### PR TITLE
[AppSec] Fixed rules file parser

### DIFF
--- a/dd-java-agent/appsec/appsec.gradle
+++ b/dd-java-agent/appsec/appsec.gradle
@@ -130,6 +130,8 @@ ext {
     'com.datadog.appsec.config.AppSecConfigServiceImpl.SubscribeFleetServiceRunnable.1',
     'com.datadog.appsec.util.StandardizedLogging',
     'com.datadog.appsec.util.AbortStartupException',
+    'com.datadog.appsec.config.AppSecConfig.AppSecConfigV1',
+    'com.datadog.appsec.config.AppSecConfig.AppSecConfigV2',
   ]
   excludedClassesBranchCoverage = [
     'com.datadog.appsec.gateway.GatewayBridge',

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
@@ -113,6 +113,11 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
       throw new IOException("Unable deserialize Json config");
     }
 
+    if (rawConfig.containsKey("version")) {
+      // in case if we have single config simulate multi-config structure
+      rawConfig = Collections.singletonMap("waf", rawConfig);
+    }
+
     Map<String, AppSecConfig> ret = new LinkedHashMap<>();
     for (Map.Entry<String, Object> entry : rawConfig.entrySet()) {
       String key = entry.getKey();
@@ -120,7 +125,7 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
       if (!(value instanceof Map)) {
         throw new IOException("Expect config to be a map");
       }
-      ret.put(key, AppSecConfig.createFromMap((Map<String, Object>) value));
+      ret.put(key, AppSecConfig.valueOf((Map<String, Object>) value));
     }
     return ret;
   }

--- a/dd-java-agent/appsec/src/main/resources/default_config.json
+++ b/dd-java-agent/appsec/src/main/resources/default_config.json
@@ -1,4897 +1,4895 @@
 {
-  "waf" : {
-    "version": "2.1",
-    "rules": [
-      {
-        "id": "crs-913-110",
-        "name": "Found request header associated with Acunetix security scanner",
-        "tags": {
-          "type": "security_scanner",
-          "crs_id": "913110",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies"
-                }
-              ],
-              "list": [
-                "acunetix-product",
-                "(acunetix web vulnerability scanner",
-                "acunetix-scanning-agreement",
-                "acunetix-user-agreement"
-              ]
-            },
-            "operator": "phrase_match"
-          }
-        ],
-        "transformers": [
-          "lowercase"
-        ]
+  "version": "2.1",
+  "rules": [
+    {
+      "id": "crs-913-110",
+      "name": "Found request header associated with Acunetix security scanner",
+      "tags": {
+        "type": "security_scanner",
+        "crs_id": "913110",
+        "category": "attack_attempt"
       },
-      {
-        "id": "crs-913-120",
-        "name": "Found request filename/argument associated with security scanner",
-        "tags": {
-          "type": "security_scanner",
-          "crs_id": "913120",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "list": [
-                "/.adsensepostnottherenonobook",
-                "/<invalid>hello.html",
-                "/actsensepostnottherenonotive",
-                "/acunetix-wvs-test-for-some-inexistent-file",
-                "/antidisestablishmentarianism",
-                "/appscan_fingerprint/mac_address",
-                "/arachni-",
-                "/cybercop",
-                "/nessus_is_probing_you_",
-                "/nessustest",
-                "/netsparker-",
-                "/rfiinc.txt",
-                "/thereisnowaythat-you-canbethere",
-                "/w3af/remotefileinclude.html",
-                "appscan_fingerprint",
-                "w00tw00t.at.isc.sans.dfind",
-                "w00tw00t.at.blackhats.romanian.anti-sec"
-              ]
-            },
-            "operator": "phrase_match"
-          }
-        ],
-        "transformers": [
-          "lowercase"
-        ]
-      },
-      {
-        "id": "crs-920-260",
-        "name": "Unicode Full/Half Width Abuse Attack Attempt",
-        "tags": {
-          "type": "http_protocol_violation",
-          "crs_id": "920260",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.uri.raw"
-                }
-              ],
-              "regex": "\\%u[fF]{2}[0-9a-fA-F]{2}",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 6
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies"
               }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-921-110",
-        "name": "HTTP Request Smuggling Attack",
-        "tags": {
-          "type": "http_protocol_violation",
-          "crs_id": "921110",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "(?:get|post|head|options|connect|put|delete|trace|track|patch|propfind|propatch|mkcol|copy|move|lock|unlock)\\s+[^\\s]+\\s+http/\\d",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 12
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "lowercase"
-        ]
-      },
-      {
-        "id": "crs-921-140",
-        "name": "HTTP Header Injection Attack via headers",
-        "tags": {
-          "type": "http_protocol_violation",
-          "crs_id": "921140",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies"
-                }
-              ],
-              "regex": "[\\n\\r]",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 1
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-921-160",
-        "name": "HTTP Header Injection Attack via payload (CR/LF and header-name detected)",
-        "tags": {
-          "type": "http_protocol_violation",
-          "crs_id": "921160",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "[\\n\\r]+(?:\\s|location|refresh|(?:set-)?cookie|(?:x-)?(?:forwarded-(?:for|host|server)|host|via|remote-ip|remote-addr|originating-IP))\\s*:",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 3
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "lowercase"
-        ]
-      },
-      {
-        "id": "crs-930-100",
-        "name": "Obfuscated Path Traversal Attack (/../)",
-        "tags": {
-          "type": "lfi",
-          "crs_id": "930100",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.uri.raw"
-                },
-                {
-                  "address": "server.request.headers.no_cookies"
-                }
-              ],
-              "regex": "(?:\\x5c|(?:%(?:c(?:0%(?:[2aq]f|5c|9v)|1%(?:[19p]c|8s|af))|2(?:5(?:c(?:0%25af|1%259c)|2f|5c)|%46|f)|(?:(?:f(?:8%8)?0%8|e)0%80%a|bg%q)f|%3(?:2(?:%(?:%6|4)6|F)|5%%63)|u(?:221[56]|002f|EFC8|F025)|1u|5c)|0x(?:2f|5c)|/))(?:%(?:(?:f(?:(?:c%80|8)%8)?0%8|e)0%80%ae|2(?:(?:5(?:c0%25a|2))?e|%45)|u(?:(?:002|ff0)e|2024)|%32(?:%(?:%6|4)5|E)|c0(?:%[256aef]e|\\.))|\\.(?:%0[01]|\\?)?|\\?\\.?|0x2e){2}(?:\\x5c|(?:%(?:c(?:0%(?:[2aq]f|5c|9v)|1%(?:[19p]c|8s|af))|2(?:5(?:c(?:0%25af|1%259c)|2f|5c)|%46|f)|(?:(?:f(?:8%8)?0%8|e)0%80%a|bg%q)f|%3(?:2(?:%(?:%6|4)6|F)|5%%63)|u(?:221[56]|002f|EFC8|F025)|1u|5c)|0x(?:2f|5c)|/))",
-              "options": {
-                "min_length": 4
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-930-110",
-        "name": "Simple Path Traversal Attack (/../)",
-        "tags": {
-          "type": "lfi",
-          "crs_id": "930110",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.uri.raw"
-                },
-                {
-                  "address": "server.request.headers.no_cookies"
-                }
-              ],
-              "regex": "(?:(?:^|[\\\\/])\\.\\.[\\\\/]|[\\\\/]\\.\\.(?:[\\\\/]|$))",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 3
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "removeNulls"
-        ]
-      },
-      {
-        "id": "crs-930-120",
-        "name": "OS File Access Attempt",
-        "tags": {
-          "type": "lfi",
-          "crs_id": "930120",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "list": [
-                ".htaccess",
-                ".htdigest",
-                ".htpasswd",
-                ".addressbook",
-                ".aptitude/config",
-                ".bash_config",
-                ".bash_history",
-                ".bash_logout",
-                ".bash_profile",
-                ".bashrc",
-                ".cache/notify-osd.log",
-                ".config/odesk/odesk team.conf",
-                ".cshrc",
-                ".dockerignore",
-                ".drush/",
-                ".eslintignore",
-                ".fbcindex",
-                ".forward",
-                ".gitattributes",
-                ".gitconfig",
-                ".gnupg/",
-                ".hplip/hplip.conf",
-                ".ksh_history",
-                ".lesshst",
-                ".lftp/",
-                ".lhistory",
-                ".lldb-history",
-                ".local/share/mc/",
-                ".lynx_cookies",
-                ".my.cnf",
-                ".mysql_history",
-                ".nano_history",
-                ".node_repl_history",
-                ".pearrc",
-                ".php_history",
-                ".pinerc",
-                ".pki/",
-                ".proclog",
-                ".procmailrc",
-                ".psql_history",
-                ".python_history",
-                ".rediscli_history",
-                ".rhistory",
-                ".rhosts",
-                ".sh_history",
-                ".sqlite_history",
-                ".ssh/authorized_keys",
-                ".ssh/config",
-                ".ssh/id_dsa",
-                ".ssh/id_dsa.pub",
-                ".ssh/id_rsa",
-                ".ssh/id_rsa.pub",
-                ".ssh/identity",
-                ".ssh/identity.pub",
-                ".ssh/known_hosts",
-                ".subversion/auth",
-                ".subversion/config",
-                ".subversion/servers",
-                ".tconn/tconn.conf",
-                ".tcshrc",
-                ".vidalia/vidalia.conf",
-                ".viminfo",
-                ".vimrc",
-                ".www_acl",
-                ".wwwacl",
-                ".xauthority",
-                ".zhistory",
-                ".zshrc",
-                ".zsh_history",
-                ".nsconfig",
-                "etc/redis.conf",
-                "etc/redis-sentinel.conf",
-                "etc/php.ini",
-                "bin/php.ini",
-                "etc/httpd/php.ini",
-                "usr/lib/php.ini",
-                "usr/lib/php/php.ini",
-                "usr/local/etc/php.ini",
-                "usr/local/lib/php.ini",
-                "usr/local/php/lib/php.ini",
-                "usr/local/php4/lib/php.ini",
-                "usr/local/php5/lib/php.ini",
-                "usr/local/apache/conf/php.ini",
-                "etc/php4.4/fcgi/php.ini",
-                "etc/php4/apache/php.ini",
-                "etc/php4/apache2/php.ini",
-                "etc/php5/apache/php.ini",
-                "etc/php5/apache2/php.ini",
-                "etc/php/php.ini",
-                "etc/php/php4/php.ini",
-                "etc/php/apache/php.ini",
-                "etc/php/apache2/php.ini",
-                "web/conf/php.ini",
-                "usr/local/zend/etc/php.ini",
-                "opt/xampp/etc/php.ini",
-                "var/local/www/conf/php.ini",
-                "etc/php/cgi/php.ini",
-                "etc/php4/cgi/php.ini",
-                "etc/php5/cgi/php.ini",
-                "home2/bin/stable/apache/php.ini",
-                "home/bin/stable/apache/php.ini",
-                "etc/httpd/conf.d/php.conf",
-                "php5/php.ini",
-                "php4/php.ini",
-                "php/php.ini",
-                "windows/php.ini",
-                "winnt/php.ini",
-                "apache/php/php.ini",
-                "xampp/apache/bin/php.ini",
-                "netserver/bin/stable/apache/php.ini",
-                "volumes/macintosh_hd1/usr/local/php/lib/php.ini",
-                "etc/mono/1.0/machine.config",
-                "etc/mono/2.0/machine.config",
-                "etc/mono/2.0/web.config",
-                "etc/mono/config",
-                "usr/local/cpanel/logs/stats_log",
-                "usr/local/cpanel/logs/access_log",
-                "usr/local/cpanel/logs/error_log",
-                "usr/local/cpanel/logs/license_log",
-                "usr/local/cpanel/logs/login_log",
-                "var/cpanel/cpanel.config",
-                "var/log/sw-cp-server/error_log",
-                "usr/local/psa/admin/logs/httpsd_access_log",
-                "usr/local/psa/admin/logs/panel.log",
-                "var/log/sso/sso.log",
-                "usr/local/psa/admin/conf/php.ini",
-                "etc/sw-cp-server/applications.d/plesk.conf",
-                "usr/local/psa/admin/conf/site_isolation_settings.ini",
-                "usr/local/sb/config",
-                "etc/sw-cp-server/applications.d/00-sso-cpserver.conf",
-                "etc/sso/sso_config.ini",
-                "etc/mysql/conf.d/old_passwords.cnf",
-                "var/log/mysql/mysql-bin.log",
-                "var/log/mysql/mysql-bin.index",
-                "var/log/mysql/data/mysql-bin.index",
-                "var/log/mysql.log",
-                "var/log/mysql.err",
-                "var/log/mysqlderror.log",
-                "var/log/mysql/mysql.log",
-                "var/log/mysql/mysql-slow.log",
-                "var/log/mysql-bin.index",
-                "var/log/data/mysql-bin.index",
-                "var/mysql.log",
-                "var/mysql-bin.index",
-                "var/data/mysql-bin.index",
-                "program files/mysql/mysql server 5.0/data/{host}.err",
-                "program files/mysql/mysql server 5.0/data/mysql.log",
-                "program files/mysql/mysql server 5.0/data/mysql.err",
-                "program files/mysql/mysql server 5.0/data/mysql-bin.log",
-                "program files/mysql/mysql server 5.0/data/mysql-bin.index",
-                "program files/mysql/data/{host}.err",
-                "program files/mysql/data/mysql.log",
-                "program files/mysql/data/mysql.err",
-                "program files/mysql/data/mysql-bin.log",
-                "program files/mysql/data/mysql-bin.index",
-                "mysql/data/{host}.err",
-                "mysql/data/mysql.log",
-                "mysql/data/mysql.err",
-                "mysql/data/mysql-bin.log",
-                "mysql/data/mysql-bin.index",
-                "usr/local/mysql/data/mysql.log",
-                "usr/local/mysql/data/mysql.err",
-                "usr/local/mysql/data/mysql-bin.log",
-                "usr/local/mysql/data/mysql-slow.log",
-                "usr/local/mysql/data/mysqlderror.log",
-                "usr/local/mysql/data/{host}.err",
-                "usr/local/mysql/data/mysql-bin.index",
-                "var/lib/mysql/my.cnf",
-                "etc/mysql/my.cnf",
-                "etc/my.cnf",
-                "program files/mysql/mysql server 5.0/my.ini",
-                "program files/mysql/mysql server 5.0/my.cnf",
-                "program files/mysql/my.ini",
-                "program files/mysql/my.cnf",
-                "mysql/my.ini",
-                "mysql/my.cnf",
-                "mysql/bin/my.ini",
-                "var/postgresql/log/postgresql.log",
-                "var/log/postgresql/postgresql.log",
-                "var/log/postgres/pg_backup.log",
-                "var/log/postgres/postgres.log",
-                "var/log/postgresql.log",
-                "var/log/pgsql/pgsql.log",
-                "var/log/postgresql/postgresql-8.1-main.log",
-                "var/log/postgresql/postgresql-8.3-main.log",
-                "var/log/postgresql/postgresql-8.4-main.log",
-                "var/log/postgresql/postgresql-9.0-main.log",
-                "var/log/postgresql/postgresql-9.1-main.log",
-                "var/log/pgsql8.log",
-                "var/log/postgresql/postgres.log",
-                "var/log/pgsql_log",
-                "var/log/postgresql/main.log",
-                "var/log/cron/var/log/postgres.log",
-                "usr/internet/pgsql/data/postmaster.log",
-                "usr/local/pgsql/data/postgresql.log",
-                "usr/local/pgsql/data/pg_log",
-                "postgresql/log/pgadmin.log",
-                "var/lib/pgsql/data/postgresql.conf",
-                "var/postgresql/db/postgresql.conf",
-                "var/nm2/postgresql.conf",
-                "usr/local/pgsql/data/postgresql.conf",
-                "usr/local/pgsql/data/pg_hba.conf",
-                "usr/internet/pgsql/data/pg_hba.conf",
-                "usr/local/pgsql/data/passwd",
-                "usr/local/pgsql/bin/pg_passwd",
-                "etc/postgresql/postgresql.conf",
-                "etc/postgresql/pg_hba.conf",
-                "home/postgres/data/postgresql.conf",
-                "home/postgres/data/pg_version",
-                "home/postgres/data/pg_ident.conf",
-                "home/postgres/data/pg_hba.conf",
-                "program files/postgresql/8.3/data/pg_hba.conf",
-                "program files/postgresql/8.3/data/pg_ident.conf",
-                "program files/postgresql/8.3/data/postgresql.conf",
-                "program files/postgresql/8.4/data/pg_hba.conf",
-                "program files/postgresql/8.4/data/pg_ident.conf",
-                "program files/postgresql/8.4/data/postgresql.conf",
-                "program files/postgresql/9.0/data/pg_hba.conf",
-                "program files/postgresql/9.0/data/pg_ident.conf",
-                "program files/postgresql/9.0/data/postgresql.conf",
-                "program files/postgresql/9.1/data/pg_hba.conf",
-                "program files/postgresql/9.1/data/pg_ident.conf",
-                "program files/postgresql/9.1/data/postgresql.conf",
-                "wamp/logs/access.log",
-                "wamp/logs/apache_error.log",
-                "wamp/logs/genquery.log",
-                "wamp/logs/mysql.log",
-                "wamp/logs/slowquery.log",
-                "wamp/bin/apache/apache2.2.22/logs/access.log",
-                "wamp/bin/apache/apache2.2.22/logs/error.log",
-                "wamp/bin/apache/apache2.2.21/logs/access.log",
-                "wamp/bin/apache/apache2.2.21/logs/error.log",
-                "wamp/bin/mysql/mysql5.5.24/data/mysql-bin.index",
-                "wamp/bin/mysql/mysql5.5.16/data/mysql-bin.index",
-                "wamp/bin/apache/apache2.2.21/conf/httpd.conf",
-                "wamp/bin/apache/apache2.2.22/conf/httpd.conf",
-                "wamp/bin/apache/apache2.2.21/wampserver.conf",
-                "wamp/bin/apache/apache2.2.22/wampserver.conf",
-                "wamp/bin/apache/apache2.2.22/conf/wampserver.conf",
-                "wamp/bin/mysql/mysql5.5.24/my.ini",
-                "wamp/bin/mysql/mysql5.5.24/wampserver.conf",
-                "wamp/bin/mysql/mysql5.5.16/my.ini",
-                "wamp/bin/mysql/mysql5.5.16/wampserver.conf",
-                "wamp/bin/php/php5.3.8/php.ini",
-                "wamp/bin/php/php5.4.3/php.ini",
-                "xampp/apache/logs/access.log",
-                "xampp/apache/logs/error.log",
-                "xampp/mysql/data/mysql-bin.index",
-                "xampp/mysql/data/mysql.err",
-                "xampp/mysql/data/{host}.err",
-                "xampp/sendmail/sendmail.log",
-                "xampp/apache/conf/httpd.conf",
-                "xampp/filezillaftp/filezilla server.xml",
-                "xampp/mercurymail/mercury.ini",
-                "xampp/php/php.ini",
-                "xampp/phpmyadmin/config.inc.php",
-                "xampp/sendmail/sendmail.ini",
-                "xampp/webalizer/webalizer.conf",
-                "opt/lampp/etc/httpd.conf",
-                "xampp/htdocs/aca.txt",
-                "xampp/htdocs/admin.php",
-                "xampp/htdocs/leer.txt",
-                "usr/local/apache/logs/audit_log",
-                "usr/local/apache2/logs/audit_log",
-                "logs/security_debug_log",
-                "logs/security_log",
-                "usr/local/apache/conf/modsec.conf",
-                "usr/local/apache2/conf/modsec.conf",
-                "winnt/system32/logfiles/msftpsvc",
-                "winnt/system32/logfiles/msftpsvc1",
-                "winnt/system32/logfiles/msftpsvc2",
-                "windows/system32/logfiles/msftpsvc",
-                "windows/system32/logfiles/msftpsvc1",
-                "windows/system32/logfiles/msftpsvc2",
-                "etc/logrotate.d/proftpd",
-                "www/logs/proftpd.system.log",
-                "var/log/proftpd",
-                "var/log/proftpd/xferlog.legacy",
-                "var/log/proftpd.access_log",
-                "var/log/proftpd.xferlog",
-                "etc/pam.d/proftpd",
-                "etc/proftp.conf",
-                "etc/protpd/proftpd.conf",
-                "etc/vhcs2/proftpd/proftpd.conf",
-                "etc/proftpd/modules.conf",
-                "var/log/vsftpd.log",
-                "etc/vsftpd.chroot_list",
-                "etc/logrotate.d/vsftpd.log",
-                "etc/vsftpd/vsftpd.conf",
-                "etc/vsftpd.conf",
-                "etc/chrootusers",
-                "var/log/xferlog",
-                "var/adm/log/xferlog",
-                "etc/wu-ftpd/ftpaccess",
-                "etc/wu-ftpd/ftphosts",
-                "etc/wu-ftpd/ftpusers",
-                "var/log/pure-ftpd/pure-ftpd.log",
-                "logs/pure-ftpd.log",
-                "var/log/pureftpd.log",
-                "usr/sbin/pure-config.pl",
-                "usr/etc/pure-ftpd.conf",
-                "etc/pure-ftpd/pure-ftpd.conf",
-                "usr/local/etc/pure-ftpd.conf",
-                "usr/local/etc/pureftpd.pdb",
-                "usr/local/pureftpd/etc/pureftpd.pdb",
-                "usr/local/pureftpd/sbin/pure-config.pl",
-                "usr/local/pureftpd/etc/pure-ftpd.conf",
-                "etc/pure-ftpd.conf",
-                "etc/pure-ftpd/pure-ftpd.pdb",
-                "etc/pureftpd.pdb",
-                "etc/pureftpd.passwd",
-                "etc/pure-ftpd/pureftpd.pdb",
-                "usr/ports/ftp/pure-ftpd/pure-ftpd.conf",
-                "usr/ports/ftp/pure-ftpd/pureftpd.pdb",
-                "usr/ports/ftp/pure-ftpd/pureftpd.passwd",
-                "usr/ports/net/pure-ftpd/pure-ftpd.conf",
-                "usr/ports/net/pure-ftpd/pureftpd.pdb",
-                "usr/ports/net/pure-ftpd/pureftpd.passwd",
-                "usr/pkgsrc/net/pureftpd/pure-ftpd.conf",
-                "usr/pkgsrc/net/pureftpd/pureftpd.pdb",
-                "usr/pkgsrc/net/pureftpd/pureftpd.passwd",
-                "usr/ports/contrib/pure-ftpd/pure-ftpd.conf",
-                "usr/ports/contrib/pure-ftpd/pureftpd.pdb",
-                "usr/ports/contrib/pure-ftpd/pureftpd.passwd",
-                "var/log/muddleftpd",
-                "usr/sbin/mudlogd",
-                "etc/muddleftpd/mudlog",
-                "etc/muddleftpd.com",
-                "etc/muddleftpd/mudlogd.conf",
-                "etc/muddleftpd/muddleftpd.conf",
-                "var/log/muddleftpd.conf",
-                "usr/sbin/mudpasswd",
-                "etc/muddleftpd/muddleftpd.passwd",
-                "etc/muddleftpd/passwd",
-                "var/log/ftp-proxy/ftp-proxy.log",
-                "var/log/ftp-proxy",
-                "var/log/ftplog",
-                "etc/logrotate.d/ftp",
-                "etc/ftpchroot",
-                "etc/ftphosts",
-                "etc/ftpusers",
-                "var/log/exim_mainlog",
-                "var/log/exim/mainlog",
-                "var/log/maillog",
-                "var/log/exim_paniclog",
-                "var/log/exim/paniclog",
-                "var/log/exim/rejectlog",
-                "var/log/exim_rejectlog",
-                "winnt/system32/logfiles/smtpsvc",
-                "winnt/system32/logfiles/smtpsvc1",
-                "winnt/system32/logfiles/smtpsvc2",
-                "winnt/system32/logfiles/smtpsvc3",
-                "winnt/system32/logfiles/smtpsvc4",
-                "winnt/system32/logfiles/smtpsvc5",
-                "windows/system32/logfiles/smtpsvc",
-                "windows/system32/logfiles/smtpsvc1",
-                "windows/system32/logfiles/smtpsvc2",
-                "windows/system32/logfiles/smtpsvc3",
-                "windows/system32/logfiles/smtpsvc4",
-                "windows/system32/logfiles/smtpsvc5",
-                "etc/osxhttpd/osxhttpd.conf",
-                "system/library/webobjects/adaptors/apache2.2/apache.conf",
-                "etc/apache2/sites-available/default",
-                "etc/apache2/sites-available/default-ssl",
-                "etc/apache2/sites-enabled/000-default",
-                "etc/apache2/sites-enabled/default",
-                "etc/apache2/apache2.conf",
-                "etc/apache2/ports.conf",
-                "usr/local/etc/apache/httpd.conf",
-                "usr/pkg/etc/httpd/httpd.conf",
-                "usr/pkg/etc/httpd/httpd-default.conf",
-                "usr/pkg/etc/httpd/httpd-vhosts.conf",
-                "etc/httpd/mod_php.conf",
-                "etc/httpd/extra/httpd-ssl.conf",
-                "etc/rc.d/rc.httpd",
-                "usr/local/apache/conf/httpd.conf.default",
-                "usr/local/apache/conf/access.conf",
-                "usr/local/apache22/conf/httpd.conf",
-                "usr/local/apache22/httpd.conf",
-                "usr/local/etc/apache22/conf/httpd.conf",
-                "usr/local/apps/apache22/conf/httpd.conf",
-                "etc/apache22/conf/httpd.conf",
-                "etc/apache22/httpd.conf",
-                "opt/apache22/conf/httpd.conf",
-                "usr/local/etc/apache2/vhosts.conf",
-                "usr/local/apache/conf/vhosts.conf",
-                "usr/local/apache2/conf/vhosts.conf",
-                "usr/local/apache/conf/vhosts-custom.conf",
-                "usr/local/apache2/conf/vhosts-custom.conf",
-                "etc/apache/default-server.conf",
-                "etc/apache2/default-server.conf",
-                "usr/local/apache2/conf/extra/httpd-ssl.conf",
-                "usr/local/apache2/conf/ssl.conf",
-                "etc/httpd/conf.d",
-                "usr/local/etc/apache22/httpd.conf",
-                "usr/local/etc/apache2/httpd.conf",
-                "etc/apache2/httpd2.conf",
-                "etc/apache2/ssl-global.conf",
-                "etc/apache2/vhosts.d/00_default_vhost.conf",
-                "apache/conf/httpd.conf",
-                "etc/apache/httpd.conf",
-                "etc/httpd/conf",
-                "http/httpd.conf",
-                "usr/local/apache1.3/conf/httpd.conf",
-                "usr/local/etc/httpd/conf",
-                "var/apache/conf/httpd.conf",
-                "var/www/conf",
-                "www/apache/conf/httpd.conf",
-                "www/conf/httpd.conf",
-                "etc/init.d",
-                "etc/apache/access.conf",
-                "etc/rc.conf",
-                "www/logs/freebsddiary-error.log",
-                "www/logs/freebsddiary-access_log",
-                "library/webserver/documents/index.html",
-                "library/webserver/documents/index.htm",
-                "library/webserver/documents/default.html",
-                "library/webserver/documents/default.htm",
-                "library/webserver/documents/index.php",
-                "library/webserver/documents/default.php",
-                "var/log/webmin/miniserv.log",
-                "usr/local/etc/webmin/miniserv.conf",
-                "etc/webmin/miniserv.conf",
-                "usr/local/etc/webmin/miniserv.users",
-                "etc/webmin/miniserv.users",
-                "winnt/system32/logfiles/w3svc/inetsvn1.log",
-                "winnt/system32/logfiles/w3svc1/inetsvn1.log",
-                "winnt/system32/logfiles/w3svc2/inetsvn1.log",
-                "winnt/system32/logfiles/w3svc3/inetsvn1.log",
-                "windows/system32/logfiles/w3svc/inetsvn1.log",
-                "windows/system32/logfiles/w3svc1/inetsvn1.log",
-                "windows/system32/logfiles/w3svc2/inetsvn1.log",
-                "windows/system32/logfiles/w3svc3/inetsvn1.log",
-                "var/log/httpd/access_log",
-                "var/log/httpd/error_log",
-                "apache/logs/error.log",
-                "apache/logs/access.log",
-                "apache2/logs/error.log",
-                "apache2/logs/access.log",
-                "logs/error.log",
-                "logs/access.log",
-                "etc/httpd/logs/access_log",
-                "etc/httpd/logs/access.log",
-                "etc/httpd/logs/error_log",
-                "etc/httpd/logs/error.log",
-                "usr/local/apache/logs/access_log",
-                "usr/local/apache/logs/access.log",
-                "usr/local/apache/logs/error_log",
-                "usr/local/apache/logs/error.log",
-                "usr/local/apache2/logs/access_log",
-                "usr/local/apache2/logs/access.log",
-                "usr/local/apache2/logs/error_log",
-                "usr/local/apache2/logs/error.log",
-                "var/www/logs/access_log",
-                "var/www/logs/access.log",
-                "var/www/logs/error_log",
-                "var/www/logs/error.log",
-                "var/log/httpd/access.log",
-                "var/log/httpd/error.log",
-                "var/log/apache/access_log",
-                "var/log/apache/access.log",
-                "var/log/apache/error_log",
-                "var/log/apache/error.log",
-                "var/log/apache2/access_log",
-                "var/log/apache2/access.log",
-                "var/log/apache2/error_log",
-                "var/log/apache2/error.log",
-                "var/log/access_log",
-                "var/log/access.log",
-                "var/log/error_log",
-                "var/log/error.log",
-                "opt/lampp/logs/access_log",
-                "opt/lampp/logs/error_log",
-                "opt/xampp/logs/access_log",
-                "opt/xampp/logs/error_log",
-                "opt/lampp/logs/access.log",
-                "opt/lampp/logs/error.log",
-                "opt/xampp/logs/access.log",
-                "opt/xampp/logs/error.log",
-                "program files/apache group/apache/logs/access.log",
-                "program files/apache group/apache/logs/error.log",
-                "program files/apache software foundation/apache2.2/logs/error.log",
-                "program files/apache software foundation/apache2.2/logs/access.log",
-                "opt/apache/apache.conf",
-                "opt/apache/conf/apache.conf",
-                "opt/apache2/apache.conf",
-                "opt/apache2/conf/apache.conf",
-                "opt/httpd/apache.conf",
-                "opt/httpd/conf/apache.conf",
-                "etc/httpd/apache.conf",
-                "etc/apache2/apache.conf",
-                "etc/httpd/conf/apache.conf",
-                "usr/local/apache/apache.conf",
-                "usr/local/apache/conf/apache.conf",
-                "usr/local/apache2/apache.conf",
-                "usr/local/apache2/conf/apache.conf",
-                "usr/local/php/apache.conf.php",
-                "usr/local/php4/apache.conf.php",
-                "usr/local/php5/apache.conf.php",
-                "usr/local/php/apache.conf",
-                "usr/local/php4/apache.conf",
-                "usr/local/php5/apache.conf",
-                "private/etc/httpd/apache.conf",
-                "opt/apache/apache2.conf",
-                "opt/apache/conf/apache2.conf",
-                "opt/apache2/apache2.conf",
-                "opt/apache2/conf/apache2.conf",
-                "opt/httpd/apache2.conf",
-                "opt/httpd/conf/apache2.conf",
-                "etc/httpd/apache2.conf",
-                "etc/httpd/conf/apache2.conf",
-                "usr/local/apache/apache2.conf",
-                "usr/local/apache/conf/apache2.conf",
-                "usr/local/apache2/apache2.conf",
-                "usr/local/apache2/conf/apache2.conf",
-                "usr/local/php/apache2.conf.php",
-                "usr/local/php4/apache2.conf.php",
-                "usr/local/php5/apache2.conf.php",
-                "usr/local/php/apache2.conf",
-                "usr/local/php4/apache2.conf",
-                "usr/local/php5/apache2.conf",
-                "private/etc/httpd/apache2.conf",
-                "usr/local/apache/conf/httpd.conf",
-                "usr/local/apache2/conf/httpd.conf",
-                "etc/httpd/conf/httpd.conf",
-                "etc/apache/apache.conf",
-                "etc/apache/conf/httpd.conf",
-                "etc/apache2/httpd.conf",
-                "usr/apache2/conf/httpd.conf",
-                "usr/apache/conf/httpd.conf",
-                "usr/local/etc/apache/conf/httpd.conf",
-                "usr/local/apache/httpd.conf",
-                "usr/local/apache2/httpd.conf",
-                "usr/local/httpd/conf/httpd.conf",
-                "usr/local/etc/apache2/conf/httpd.conf",
-                "usr/local/etc/httpd/conf/httpd.conf",
-                "usr/local/apps/apache2/conf/httpd.conf",
-                "usr/local/apps/apache/conf/httpd.conf",
-                "usr/local/php/httpd.conf.php",
-                "usr/local/php4/httpd.conf.php",
-                "usr/local/php5/httpd.conf.php",
-                "usr/local/php/httpd.conf",
-                "usr/local/php4/httpd.conf",
-                "usr/local/php5/httpd.conf",
-                "etc/apache2/conf/httpd.conf",
-                "etc/http/conf/httpd.conf",
-                "etc/httpd/httpd.conf",
-                "etc/http/httpd.conf",
-                "etc/httpd.conf",
-                "opt/apache/conf/httpd.conf",
-                "opt/apache2/conf/httpd.conf",
-                "var/www/conf/httpd.conf",
-                "private/etc/httpd/httpd.conf",
-                "private/etc/httpd/httpd.conf.default",
-                "etc/apache2/vhosts.d/default_vhost.include",
-                "etc/apache2/conf.d/charset",
-                "etc/apache2/conf.d/security",
-                "etc/apache2/envvars",
-                "etc/apache2/mods-available/autoindex.conf",
-                "etc/apache2/mods-available/deflate.conf",
-                "etc/apache2/mods-available/dir.conf",
-                "etc/apache2/mods-available/mem_cache.conf",
-                "etc/apache2/mods-available/mime.conf",
-                "etc/apache2/mods-available/proxy.conf",
-                "etc/apache2/mods-available/setenvif.conf",
-                "etc/apache2/mods-available/ssl.conf",
-                "etc/apache2/mods-enabled/alias.conf",
-                "etc/apache2/mods-enabled/deflate.conf",
-                "etc/apache2/mods-enabled/dir.conf",
-                "etc/apache2/mods-enabled/mime.conf",
-                "etc/apache2/mods-enabled/negotiation.conf",
-                "etc/apache2/mods-enabled/php5.conf",
-                "etc/apache2/mods-enabled/status.conf",
-                "program files/apache group/apache/conf/httpd.conf",
-                "program files/apache group/apache2/conf/httpd.conf",
-                "program files/xampp/apache/conf/apache.conf",
-                "program files/xampp/apache/conf/apache2.conf",
-                "program files/xampp/apache/conf/httpd.conf",
-                "program files/apache group/apache/apache.conf",
-                "program files/apache group/apache/conf/apache.conf",
-                "program files/apache group/apache2/conf/apache.conf",
-                "program files/apache group/apache/apache2.conf",
-                "program files/apache group/apache/conf/apache2.conf",
-                "program files/apache group/apache2/conf/apache2.conf",
-                "program files/apache software foundation/apache2.2/conf/httpd.conf",
-                "volumes/macintosh_hd1/opt/httpd/conf/httpd.conf",
-                "volumes/macintosh_hd1/opt/apache/conf/httpd.conf",
-                "volumes/macintosh_hd1/opt/apache2/conf/httpd.conf",
-                "volumes/macintosh_hd1/usr/local/php/httpd.conf.php",
-                "volumes/macintosh_hd1/usr/local/php4/httpd.conf.php",
-                "volumes/macintosh_hd1/usr/local/php5/httpd.conf.php",
-                "volumes/webbackup/opt/apache2/conf/httpd.conf",
-                "volumes/webbackup/private/etc/httpd/httpd.conf",
-                "volumes/webbackup/private/etc/httpd/httpd.conf.default",
-                "usr/local/etc/apache/vhosts.conf",
-                "usr/local/jakarta/tomcat/conf/jakarta.conf",
-                "usr/local/jakarta/tomcat/conf/server.xml",
-                "usr/local/jakarta/tomcat/conf/context.xml",
-                "usr/local/jakarta/tomcat/conf/workers.properties",
-                "usr/local/jakarta/tomcat/conf/logging.properties",
-                "usr/local/jakarta/dist/tomcat/conf/jakarta.conf",
-                "usr/local/jakarta/dist/tomcat/conf/server.xml",
-                "usr/local/jakarta/dist/tomcat/conf/context.xml",
-                "usr/local/jakarta/dist/tomcat/conf/workers.properties",
-                "usr/local/jakarta/dist/tomcat/conf/logging.properties",
-                "usr/share/tomcat6/conf/server.xml",
-                "usr/share/tomcat6/conf/context.xml",
-                "usr/share/tomcat6/conf/workers.properties",
-                "usr/share/tomcat6/conf/logging.properties",
-                "var/log/tomcat6/catalina.out",
-                "var/cpanel/tomcat.options",
-                "usr/local/jakarta/tomcat/logs/catalina.out",
-                "usr/local/jakarta/tomcat/logs/catalina.err",
-                "opt/tomcat/logs/catalina.out",
-                "opt/tomcat/logs/catalina.err",
-                "usr/share/logs/catalina.out",
-                "usr/share/logs/catalina.err",
-                "usr/share/tomcat/logs/catalina.out",
-                "usr/share/tomcat/logs/catalina.err",
-                "usr/share/tomcat6/logs/catalina.out",
-                "usr/share/tomcat6/logs/catalina.err",
-                "usr/local/apache/logs/mod_jk.log",
-                "usr/local/jakarta/tomcat/logs/mod_jk.log",
-                "usr/local/jakarta/dist/tomcat/logs/mod_jk.log",
-                "opt/[jboss]/server/default/conf/jboss-minimal.xml",
-                "opt/[jboss]/server/default/conf/jboss-service.xml",
-                "opt/[jboss]/server/default/conf/jndi.properties",
-                "opt/[jboss]/server/default/conf/log4j.xml",
-                "opt/[jboss]/server/default/conf/login-config.xml",
-                "opt/[jboss]/server/default/conf/standardjaws.xml",
-                "opt/[jboss]/server/default/conf/standardjboss.xml",
-                "opt/[jboss]/server/default/conf/server.log.properties",
-                "opt/[jboss]/server/default/deploy/jboss-logging.xml",
-                "usr/local/[jboss]/server/default/conf/jboss-minimal.xml",
-                "usr/local/[jboss]/server/default/conf/jboss-service.xml",
-                "usr/local/[jboss]/server/default/conf/jndi.properties",
-                "usr/local/[jboss]/server/default/conf/log4j.xml",
-                "usr/local/[jboss]/server/default/conf/login-config.xml",
-                "usr/local/[jboss]/server/default/conf/standardjaws.xml",
-                "usr/local/[jboss]/server/default/conf/standardjboss.xml",
-                "usr/local/[jboss]/server/default/conf/server.log.properties",
-                "usr/local/[jboss]/server/default/deploy/jboss-logging.xml",
-                "private/tmp/[jboss]/server/default/conf/jboss-minimal.xml",
-                "private/tmp/[jboss]/server/default/conf/jboss-service.xml",
-                "private/tmp/[jboss]/server/default/conf/jndi.properties",
-                "private/tmp/[jboss]/server/default/conf/log4j.xml",
-                "private/tmp/[jboss]/server/default/conf/login-config.xml",
-                "private/tmp/[jboss]/server/default/conf/standardjaws.xml",
-                "private/tmp/[jboss]/server/default/conf/standardjboss.xml",
-                "private/tmp/[jboss]/server/default/conf/server.log.properties",
-                "private/tmp/[jboss]/server/default/deploy/jboss-logging.xml",
-                "tmp/[jboss]/server/default/conf/jboss-minimal.xml",
-                "tmp/[jboss]/server/default/conf/jboss-service.xml",
-                "tmp/[jboss]/server/default/conf/jndi.properties",
-                "tmp/[jboss]/server/default/conf/log4j.xml",
-                "tmp/[jboss]/server/default/conf/login-config.xml",
-                "tmp/[jboss]/server/default/conf/standardjaws.xml",
-                "tmp/[jboss]/server/default/conf/standardjboss.xml",
-                "tmp/[jboss]/server/default/conf/server.log.properties",
-                "tmp/[jboss]/server/default/deploy/jboss-logging.xml",
-                "program files/[jboss]/server/default/conf/jboss-minimal.xml",
-                "program files/[jboss]/server/default/conf/jboss-service.xml",
-                "program files/[jboss]/server/default/conf/jndi.properties",
-                "program files/[jboss]/server/default/conf/log4j.xml",
-                "program files/[jboss]/server/default/conf/login-config.xml",
-                "program files/[jboss]/server/default/conf/standardjaws.xml",
-                "program files/[jboss]/server/default/conf/standardjboss.xml",
-                "program files/[jboss]/server/default/conf/server.log.properties",
-                "program files/[jboss]/server/default/deploy/jboss-logging.xml",
-                "[jboss]/server/default/conf/jboss-minimal.xml",
-                "[jboss]/server/default/conf/jboss-service.xml",
-                "[jboss]/server/default/conf/jndi.properties",
-                "[jboss]/server/default/conf/log4j.xml",
-                "[jboss]/server/default/conf/login-config.xml",
-                "[jboss]/server/default/conf/standardjaws.xml",
-                "[jboss]/server/default/conf/standardjboss.xml",
-                "[jboss]/server/default/conf/server.log.properties",
-                "[jboss]/server/default/deploy/jboss-logging.xml",
-                "opt/[jboss]/server/default/log/server.log",
-                "opt/[jboss]/server/default/log/boot.log",
-                "usr/local/[jboss]/server/default/log/server.log",
-                "usr/local/[jboss]/server/default/log/boot.log",
-                "private/tmp/[jboss]/server/default/log/server.log",
-                "private/tmp/[jboss]/server/default/log/boot.log",
-                "tmp/[jboss]/server/default/log/server.log",
-                "tmp/[jboss]/server/default/log/boot.log",
-                "program files/[jboss]/server/default/log/server.log",
-                "program files/[jboss]/server/default/log/boot.log",
-                "[jboss]/server/default/log/server.log",
-                "[jboss]/server/default/log/boot.log",
-                "var/log/lighttpd.error.log",
-                "var/log/lighttpd.access.log",
-                "var/lighttpd.log",
-                "var/logs/access.log",
-                "var/log/lighttpd/",
-                "var/log/lighttpd/error.log",
-                "var/log/lighttpd/access.www.log",
-                "var/log/lighttpd/error.www.log",
-                "var/log/lighttpd/access.log",
-                "usr/local/apache2/logs/lighttpd.error.log",
-                "usr/local/apache2/logs/lighttpd.log",
-                "usr/local/apache/logs/lighttpd.error.log",
-                "usr/local/apache/logs/lighttpd.log",
-                "usr/local/lighttpd/log/lighttpd.error.log",
-                "usr/local/lighttpd/log/access.log",
-                "var/log/lighttpd/{domain}/access.log",
-                "var/log/lighttpd/{domain}/error.log",
-                "usr/home/user/var/log/lighttpd.error.log",
-                "usr/home/user/var/log/apache.log",
-                "home/user/lighttpd/lighttpd.conf",
-                "usr/home/user/lighttpd/lighttpd.conf",
-                "etc/lighttpd/lighthttpd.conf",
-                "usr/local/etc/lighttpd.conf",
-                "usr/local/lighttpd/conf/lighttpd.conf",
-                "usr/local/etc/lighttpd.conf.new",
-                "var/www/.lighttpdpassword",
-                "var/log/nginx/access_log",
-                "var/log/nginx/error_log",
-                "var/log/nginx/access.log",
-                "var/log/nginx/error.log",
-                "var/log/nginx.access_log",
-                "var/log/nginx.error_log",
-                "logs/access_log",
-                "logs/error_log",
-                "etc/nginx/nginx.conf",
-                "usr/local/etc/nginx/nginx.conf",
-                "usr/local/nginx/conf/nginx.conf",
-                "usr/local/zeus/web/global.cfg",
-                "usr/local/zeus/web/log/errors",
-                "opt/lsws/conf/httpd_conf.xml",
-                "usr/local/lsws/conf/httpd_conf.xml",
-                "opt/lsws/logs/error.log",
-                "opt/lsws/logs/access.log",
-                "usr/local/lsws/logs/error.log",
-                "usr/local/logs/access.log",
-                "usr/local/samba/lib/log.user",
-                "usr/local/logs/samba.log",
-                "var/log/samba/log.smbd",
-                "var/log/samba/log.nmbd",
-                "var/log/samba.log",
-                "var/log/samba.log1",
-                "var/log/samba.log2",
-                "var/log/log.smb",
-                "etc/samba/netlogon",
-                "etc/smbpasswd",
-                "etc/smb.conf",
-                "etc/samba/dhcp.conf",
-                "etc/samba/smb.conf",
-                "etc/samba/samba.conf",
-                "etc/samba/smb.conf.user",
-                "etc/samba/smbpasswd",
-                "etc/samba/smbusers",
-                "etc/samba/private/smbpasswd",
-                "usr/local/etc/smb.conf",
-                "usr/local/samba/lib/smb.conf.user",
-                "etc/dhcp3/dhclient.conf",
-                "etc/dhcp3/dhcpd.conf",
-                "etc/dhcp/dhclient.conf",
-                "program files/vidalia bundle/polipo/polipo.conf",
-                "etc/tor/tor-tsocks.conf",
-                "etc/stunnel/stunnel.conf",
-                "etc/tsocks.conf",
-                "etc/tinyproxy/tinyproxy.conf",
-                "etc/miredo-server.conf",
-                "etc/miredo.conf",
-                "etc/miredo/miredo-server.conf",
-                "etc/miredo/miredo.conf",
-                "etc/wicd/dhclient.conf.template.default",
-                "etc/wicd/manager-settings.conf",
-                "etc/wicd/wired-settings.conf",
-                "etc/wicd/wireless-settings.conf",
-                "var/log/ipfw.log",
-                "var/log/ipfw",
-                "var/log/ipfw/ipfw.log",
-                "var/log/ipfw.today",
-                "etc/ipfw.rules",
-                "etc/ipfw.conf",
-                "etc/firewall.rules",
-                "winnt/system32/logfiles/firewall/pfirewall.log",
-                "winnt/system32/logfiles/firewall/pfirewall.log.old",
-                "windows/system32/logfiles/firewall/pfirewall.log",
-                "windows/system32/logfiles/firewall/pfirewall.log.old",
-                "etc/clamav/clamd.conf",
-                "etc/clamav/freshclam.conf",
-                "etc/x11/xorg.conf",
-                "etc/x11/xorg.conf-vesa",
-                "etc/x11/xorg.conf-vmware",
-                "etc/x11/xorg.conf.beforevmwaretoolsinstall",
-                "etc/x11/xorg.conf.orig",
-                "etc/bluetooth/input.conf",
-                "etc/bluetooth/main.conf",
-                "etc/bluetooth/network.conf",
-                "etc/bluetooth/rfcomm.conf",
-                "proc/self/environ",
-                "proc/self/mounts",
-                "proc/self/stat",
-                "proc/self/status",
-                "proc/self/cmdline",
-                "proc/self/fd/0",
-                "proc/self/fd/1",
-                "proc/self/fd/2",
-                "proc/self/fd/3",
-                "proc/self/fd/4",
-                "proc/self/fd/5",
-                "proc/self/fd/6",
-                "proc/self/fd/7",
-                "proc/self/fd/8",
-                "proc/self/fd/9",
-                "proc/self/fd/10",
-                "proc/self/fd/11",
-                "proc/self/fd/12",
-                "proc/self/fd/13",
-                "proc/self/fd/14",
-                "proc/self/fd/15",
-                "proc/version",
-                "proc/devices",
-                "proc/cpuinfo",
-                "proc/meminfo",
-                "proc/net/tcp",
-                "proc/net/udp",
-                "etc/bash_completion.d/debconf",
-                "root/.bash_logout",
-                "root/.bash_history",
-                "root/.bash_config",
-                "root/.bashrc",
-                "etc/bash.bashrc",
-                "var/adm/syslog",
-                "var/adm/sulog",
-                "var/adm/utmp",
-                "var/adm/utmpx",
-                "var/adm/wtmp",
-                "var/adm/wtmpx",
-                "var/adm/lastlog/username",
-                "usr/spool/lp/log",
-                "var/adm/lp/lpd-errs",
-                "usr/lib/cron/log",
-                "var/adm/loginlog",
-                "var/adm/pacct",
-                "var/adm/dtmp",
-                "var/adm/acct/sum/loginlog",
-                "var/adm/x0msgs",
-                "var/adm/crash/vmcore",
-                "var/adm/crash/unix",
-                "etc/newsyslog.conf",
-                "var/adm/qacct",
-                "var/adm/ras/errlog",
-                "var/adm/ras/bootlog",
-                "var/adm/cron/log",
-                "etc/utmp",
-                "etc/security/lastlog",
-                "etc/security/failedlogin",
-                "usr/spool/mqueue/syslog",
-                "var/adm/messages",
-                "var/adm/aculogs",
-                "var/adm/aculog",
-                "var/adm/vold.log",
-                "var/adm/log/asppp.log",
-                "var/log/poplog",
-                "var/log/authlog",
-                "var/lp/logs/lpsched",
-                "var/lp/logs/lpnet",
-                "var/lp/logs/requests",
-                "var/cron/log",
-                "var/saf/_log",
-                "var/saf/port/log",
-                "var/log/news.all",
-                "var/log/news/news.all",
-                "var/log/news/news.crit",
-                "var/log/news/news.err",
-                "var/log/news/news.notice",
-                "var/log/news/suck.err",
-                "var/log/news/suck.notice",
-                "var/log/messages",
-                "var/log/messages.1",
-                "var/log/user.log",
-                "var/log/user.log.1",
-                "var/log/auth.log",
-                "var/log/pm-powersave.log",
-                "var/log/xorg.0.log",
-                "var/log/daemon.log",
-                "var/log/daemon.log.1",
-                "var/log/kern.log",
-                "var/log/kern.log.1",
-                "var/log/mail.err",
-                "var/log/mail.info",
-                "var/log/mail.warn",
-                "var/log/ufw.log",
-                "var/log/boot.log",
-                "var/log/syslog",
-                "var/log/syslog.1",
-                "tmp/access.log",
-                "etc/sensors.conf",
-                "etc/sensors3.conf",
-                "etc/host.conf",
-                "etc/pam.conf",
-                "etc/resolv.conf",
-                "etc/apt/apt.conf",
-                "etc/inetd.conf",
-                "etc/syslog.conf",
-                "etc/sysctl.conf",
-                "etc/sysctl.d/10-console-messages.conf",
-                "etc/sysctl.d/10-network-security.conf",
-                "etc/sysctl.d/10-process-security.conf",
-                "etc/sysctl.d/wine.sysctl.conf",
-                "etc/security/access.conf",
-                "etc/security/group.conf",
-                "etc/security/limits.conf",
-                "etc/security/namespace.conf",
-                "etc/security/pam_env.conf",
-                "etc/security/sepermit.conf",
-                "etc/security/time.conf",
-                "etc/ssh/sshd_config",
-                "etc/adduser.conf",
-                "etc/deluser.conf",
-                "etc/avahi/avahi-daemon.conf",
-                "etc/ca-certificates.conf",
-                "etc/ca-certificates.conf.dpkg-old",
-                "etc/casper.conf",
-                "etc/chkrootkit.conf",
-                "etc/debconf.conf",
-                "etc/dns2tcpd.conf",
-                "etc/e2fsck.conf",
-                "etc/esound/esd.conf",
-                "etc/etter.conf",
-                "etc/fuse.conf",
-                "etc/foremost.conf",
-                "etc/hdparm.conf",
-                "etc/kernel-img.conf",
-                "etc/kernel-pkg.conf",
-                "etc/ld.so.conf",
-                "etc/ltrace.conf",
-                "etc/mail/sendmail.conf",
-                "etc/manpath.config",
-                "etc/kbd/config",
-                "etc/ldap/ldap.conf",
-                "etc/logrotate.conf",
-                "etc/mtools.conf",
-                "etc/smi.conf",
-                "etc/updatedb.conf",
-                "etc/pulse/client.conf",
-                "usr/share/adduser/adduser.conf",
-                "etc/hostname",
-                "etc/networks",
-                "etc/timezone",
-                "etc/modules",
-                "etc/passwd",
-                "etc/passwd~",
-                "etc/passwd-",
-                "etc/shadow",
-                "etc/shadow~",
-                "etc/shadow-",
-                "etc/fstab",
-                "etc/motd",
-                "etc/hosts",
-                "etc/group",
-                "etc/group-",
-                "etc/alias",
-                "etc/crontab",
-                "etc/crypttab",
-                "etc/exports",
-                "etc/mtab",
-                "etc/hosts.allow",
-                "etc/hosts.deny",
-                "etc/os-release",
-                "etc/password.master",
-                "etc/profile",
-                "etc/default/grub",
-                "etc/resolvconf/update-libc.d/sendmail",
-                "etc/inittab",
-                "etc/issue",
-                "etc/issue.net",
-                "etc/login.defs",
-                "etc/sudoers",
-                "etc/sysconfig/network-scripts/ifcfg-eth0",
-                "etc/redhat-release",
-                "etc/debian_version",
-                "etc/fedora-release",
-                "etc/mandrake-release",
-                "etc/slackware-release",
-                "etc/suse-release",
-                "etc/security/group",
-                "etc/security/passwd",
-                "etc/security/user",
-                "etc/security/environ",
-                "etc/security/limits",
-                "etc/security/opasswd",
-                "boot/grub/grub.cfg",
-                "boot/grub/menu.lst",
-                "root/.ksh_history",
-                "root/.xauthority",
-                "usr/lib/security/mkuser.default",
-                "var/log/squirrelmail.log",
-                "var/log/apache2/squirrelmail.log",
-                "var/log/apache2/squirrelmail.err.log",
-                "var/lib/squirrelmail/prefs/squirrelmail.log",
-                "var/log/mail.log",
-                "etc/squirrelmail/apache.conf",
-                "etc/squirrelmail/config_local.php",
-                "etc/squirrelmail/default_pref",
-                "etc/squirrelmail/index.php",
-                "etc/squirrelmail/config_default.php",
-                "etc/squirrelmail/config.php",
-                "etc/squirrelmail/filters_setup.php",
-                "etc/squirrelmail/sqspell_config.php",
-                "etc/squirrelmail/config/config.php",
-                "etc/httpd/conf.d/squirrelmail.conf",
-                "usr/share/squirrelmail/config/config.php",
-                "private/etc/squirrelmail/config/config.php",
-                "srv/www/htdos/squirrelmail/config/config.php",
-                "var/www/squirrelmail/config/config.php",
-                "var/www/html/squirrelmail/config/config.php",
-                "var/www/html/squirrelmail-1.2.9/config/config.php",
-                "usr/share/squirrelmail/plugins/squirrel_logger/setup.php",
-                "usr/local/squirrelmail/www/readme",
-                "windows/system32/drivers/etc/hosts",
-                "windows/system32/drivers/etc/lmhosts.sam",
-                "windows/system32/drivers/etc/networks",
-                "windows/system32/drivers/etc/protocol",
-                "windows/system32/drivers/etc/services",
-                "/boot.ini",
-                "windows/debug/netsetup.log",
-                "windows/comsetup.log",
-                "windows/repair/setup.log",
-                "windows/setupact.log",
-                "windows/setupapi.log",
-                "windows/setuperr.log",
-                "windows/updspapi.log",
-                "windows/wmsetup.log",
-                "windows/windowsupdate.log",
-                "windows/odbc.ini",
-                "usr/local/psa/admin/htdocs/domains/databases/phpmyadmin/libraries/config.default.php",
-                "etc/apache2/conf.d/phpmyadmin.conf",
-                "etc/phpmyadmin/config.inc.php",
-                "etc/openldap/ldap.conf",
-                "etc/cups/acroread.conf",
-                "etc/cups/cupsd.conf",
-                "etc/cups/cupsd.conf.default",
-                "etc/cups/pdftops.conf",
-                "etc/cups/printers.conf",
-                "windows/system32/macromed/flash/flashinstall.log",
-                "windows/system32/macromed/flash/install.log",
-                "etc/cvs-cron.conf",
-                "etc/cvs-pserver.conf",
-                "etc/subversion/config",
-                "etc/modprobe.d/vmware-tools.conf",
-                "etc/updatedb.conf.beforevmwaretoolsinstall",
-                "etc/vmware-tools/config",
-                "etc/vmware-tools/tpvmlp.conf",
-                "etc/vmware-tools/vmware-tools-libraries.conf",
-                "var/log/vmware/hostd.log",
-                "var/log/vmware/hostd-1.log",
-                "wp-config.php",
-                "wp-config.bak",
-                "wp-config.old",
-                "wp-config.temp",
-                "wp-config.tmp",
-                "wp-config.txt",
-                "config.yml",
-                "config_dev.yml",
-                "config_prod.yml",
-                "config_test.yml",
-                "parameters.yml",
-                "routing.yml",
-                "security.yml",
-                "services.yml",
-                "sites/default/default.settings.php",
-                "sites/default/settings.php",
-                "sites/default/settings.local.php",
-                "app/etc/local.xml",
-                "sftp-config.json",
-                "web.config",
-                "includes/config.php",
-                "includes/configure.php",
-                "config.inc.php",
-                "localsettings.php",
-                "inc/config.php",
-                "typo3conf/localconf.php",
-                "config/app.php",
-                "config/custom.php",
-                "config/database.php",
-                "/configuration.php",
-                "/config.php",
-                "var/mail/www-data",
-                "etc/network/",
-                "etc/init/",
-                "inetpub/wwwroot/global.asa",
-                "system32/inetsrv/config/applicationhost.config",
-                "system32/inetsrv/config/administration.config",
-                "system32/inetsrv/config/redirection.config",
-                "system32/config/default",
-                "system32/config/sam",
-                "system32/config/system",
-                "system32/config/software",
-                "winnt/repair/sam._",
-                "package.json",
-                "package-lock.json",
-                "gruntfile.js",
-                "npm-debug.log",
-                "ormconfig.json",
-                "tsconfig.json",
-                "webpack.config.js",
-                "yarn.lock"
-              ]
-            },
-            "operator": "phrase_match"
-          }
-        ],
-        "transformers": [
-          "lowercase"
-        ]
-      },
-      {
-        "id": "crs-931-110",
-        "name": "Possible Remote File Inclusion (RFI) Attack: Common RFI Vulnerable Parameter Name used w/URL Payload",
-        "tags": {
-          "type": "rfi",
-          "crs_id": "931110",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.query"
-                }
-              ],
-              "regex": "(?:\\binclude\\s*\\([^)]*|mosConfig_absolute_path|_CONF\\[path\\]|_SERVER\\[DOCUMENT_ROOT\\]|GALLERY_BASEDIR|path\\[docroot\\]|appserv_root|config\\[root_dir\\])=(?:file|ftps?|https?)://",
-              "options": {
-                "min_length": 15
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-931-120",
-        "name": "Possible Remote File Inclusion (RFI) Attack: URL Payload Used w/Trailing Question Mark Character (?)",
-        "tags": {
-          "type": "rfi",
-          "crs_id": "931120",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "^(?i:file|ftps?|https?).*?\\?+$",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 4
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-932-160",
-        "name": "Remote Command Execution: Unix Shell Code Found",
-        "tags": {
-          "type": "command_injection",
-          "crs_id": "932160",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "list": [
-                "${cdpath}",
-                "${dirstack}",
-                "${home}",
-                "${hostname}",
-                "${ifs}",
-                "${oldpwd}",
-                "${ostype}",
-                "${path}",
-                "${pwd}",
-                "$cdpath",
-                "$dirstack",
-                "$home",
-                "$hostname",
-                "$ifs",
-                "$oldpwd",
-                "$ostype",
-                "$path",
-                "$pwd",
-                "bin/bash",
-                "bin/cat",
-                "bin/csh",
-                "bin/dash",
-                "bin/du",
-                "bin/echo",
-                "bin/grep",
-                "bin/less",
-                "bin/ls",
-                "bin/mknod",
-                "bin/more",
-                "bin/nc",
-                "bin/ps",
-                "bin/rbash",
-                "bin/sh",
-                "bin/sleep",
-                "bin/su",
-                "bin/tcsh",
-                "bin/uname",
-                "dev/fd/",
-                "dev/null",
-                "dev/stderr",
-                "dev/stdin",
-                "dev/stdout",
-                "dev/tcp/",
-                "dev/udp/",
-                "dev/zero",
-                "etc/group",
-                "etc/master.passwd",
-                "etc/passwd",
-                "etc/pwd.db",
-                "etc/shadow",
-                "etc/shells",
-                "etc/spwd.db",
-                "proc/self/",
-                "usr/bin/awk",
-                "usr/bin/base64",
-                "usr/bin/cat",
-                "usr/bin/cc",
-                "usr/bin/clang",
-                "usr/bin/clang++",
-                "usr/bin/curl",
-                "usr/bin/diff",
-                "usr/bin/env",
-                "usr/bin/fetch",
-                "usr/bin/file",
-                "usr/bin/find",
-                "usr/bin/ftp",
-                "usr/bin/gawk",
-                "usr/bin/gcc",
-                "usr/bin/head",
-                "usr/bin/hexdump",
-                "usr/bin/id",
-                "usr/bin/less",
-                "usr/bin/ln",
-                "usr/bin/mkfifo",
-                "usr/bin/more",
-                "usr/bin/nc",
-                "usr/bin/ncat",
-                "usr/bin/nice",
-                "usr/bin/nmap",
-                "usr/bin/perl",
-                "usr/bin/php",
-                "usr/bin/php5",
-                "usr/bin/php7",
-                "usr/bin/php-cgi",
-                "usr/bin/printf",
-                "usr/bin/psed",
-                "usr/bin/python",
-                "usr/bin/python2",
-                "usr/bin/python3",
-                "usr/bin/ruby",
-                "usr/bin/sed",
-                "usr/bin/socat",
-                "usr/bin/tail",
-                "usr/bin/tee",
-                "usr/bin/telnet",
-                "usr/bin/top",
-                "usr/bin/uname",
-                "usr/bin/wget",
-                "usr/bin/who",
-                "usr/bin/whoami",
-                "usr/bin/xargs",
-                "usr/bin/xxd",
-                "usr/bin/yes",
-                "usr/local/bin/bash",
-                "usr/local/bin/curl",
-                "usr/local/bin/ncat",
-                "usr/local/bin/nmap",
-                "usr/local/bin/perl",
-                "usr/local/bin/php",
-                "usr/local/bin/python",
-                "usr/local/bin/python2",
-                "usr/local/bin/python3",
-                "usr/local/bin/rbash",
-                "usr/local/bin/ruby",
-                "usr/local/bin/wget"
-              ]
-            },
-            "operator": "phrase_match"
-          }
-        ],
-        "transformers": [
-          "lowercase"
-        ]
-      },
-      {
-        "id": "crs-932-171",
-        "name": "Remote Command Execution: Shellshock (CVE-2014-6271)",
-        "tags": {
-          "type": "command_injection",
-          "crs_id": "932171",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                },
-                {
-                  "address": "server.request.headers.no_cookies"
-                }
-              ],
-              "regex": "^\\(\\s*\\)\\s+{",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 4
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-932-180",
-        "name": "Restricted File Upload Attempt",
-        "tags": {
-          "type": "command_injection",
-          "crs_id": "932180",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "x-filename",
-                    "x_filename",
-                    "x-file-name"
-                  ]
-                }
-              ],
-              "list": [
-                ".htaccess",
-                ".htdigest",
-                ".htpasswd",
-                "wp-config.php",
-                "config.yml",
-                "config_dev.yml",
-                "config_prod.yml",
-                "config_test.yml",
-                "parameters.yml",
-                "routing.yml",
-                "security.yml",
-                "services.yml",
-                "default.settings.php",
-                "settings.php",
-                "settings.local.php",
-                "local.xml",
-                ".env"
-              ]
-            },
-            "operator": "phrase_match"
-          }
-        ],
-        "transformers": [
-          "lowercase"
-        ]
-      },
-      {
-        "id": "crs-933-111",
-        "name": "PHP Injection Attack: PHP Script File Upload Found",
-        "tags": {
-          "type": "unrestricted_file_upload",
-          "crs_id": "933111",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "x-filename",
-                    "x_filename",
-                    "x.filename",
-                    "x-file-name"
-                  ]
-                }
-              ],
-              "regex": ".*\\.(?:php\\d*|phtml)\\..*$",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 5
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "lowercase"
-        ]
-      },
-      {
-        "id": "crs-933-130",
-        "name": "PHP Injection Attack: Global Variables Found",
-        "tags": {
-          "type": "php_code_injection",
-          "crs_id": "933130",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "list": [
-                "$globals",
-                "$http_cookie_vars",
-                "$http_env_vars",
-                "$http_get_vars",
-                "$http_post_files",
-                "$http_post_vars",
-                "$http_raw_post_data",
-                "$http_request_vars",
-                "$http_server_vars",
-                "$_cookie",
-                "$_env",
-                "$_files",
-                "$_get",
-                "$_post",
-                "$_request",
-                "$_server",
-                "$_session",
-                "$argc",
-                "$argv"
-              ]
-            },
-            "operator": "phrase_match"
-          }
-        ],
-        "transformers": [
-          "lowercase"
-        ]
-      },
-      {
-        "id": "crs-933-131",
-        "name": "PHP Injection Attack: HTTP Headers Values Found",
-        "tags": {
-          "type": "php_code_injection",
-          "crs_id": "933131",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "(?:HTTP_(?:ACCEPT(?:_(?:ENCODING|LANGUAGE|CHARSET))?|(?:X_FORWARDED_FO|REFERE)R|(?:USER_AGEN|HOS)T|CONNECTION|KEEP_ALIVE)|PATH_(?:TRANSLATED|INFO)|ORIG_PATH_INFO|QUERY_STRING|REQUEST_URI|AUTH_TYPE)",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 9
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-933-140",
-        "name": "PHP Injection Attack: I/O Stream Found",
-        "tags": {
-          "type": "php_code_injection",
-          "crs_id": "933140",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "php://(?:std(?:in|out|err)|(?:in|out)put|fd|memory|temp|filter)",
-              "options": {
-                "min_length": 8
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-933-150",
-        "name": "PHP Injection Attack: High-Risk PHP Function Name Found",
-        "tags": {
-          "type": "php_code_injection",
-          "crs_id": "933150",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "list": [
-                "__halt_compiler",
-                "apache_child_terminate",
-                "base64_decode",
-                "bzdecompress",
-                "call_user_func",
-                "call_user_func_array",
-                "call_user_method",
-                "call_user_method_array",
-                "convert_uudecode",
-                "file_get_contents",
-                "file_put_contents",
-                "fsockopen",
-                "get_class_methods",
-                "get_class_vars",
-                "get_defined_constants",
-                "get_defined_functions",
-                "get_defined_vars",
-                "gzdecode",
-                "gzinflate",
-                "gzuncompress",
-                "include_once",
-                "invokeargs",
-                "pcntl_exec",
-                "pcntl_fork",
-                "pfsockopen",
-                "posix_getcwd",
-                "posix_getpwuid",
-                "posix_getuid",
-                "posix_uname",
-                "reflectionfunction",
-                "require_once",
-                "shell_exec",
-                "str_rot13",
-                "sys_get_temp_dir",
-                "wp_remote_fopen",
-                "wp_remote_get",
-                "wp_remote_head",
-                "wp_remote_post",
-                "wp_remote_request",
-                "wp_safe_remote_get",
-                "wp_safe_remote_head",
-                "wp_safe_remote_post",
-                "wp_safe_remote_request",
-                "zlib_decode"
-              ]
-            },
-            "operator": "phrase_match"
-          }
-        ],
-        "transformers": [
-          "lowercase"
-        ]
-      },
-      {
-        "id": "crs-933-160",
-        "name": "PHP Injection Attack: High-Risk PHP Function Call Found",
-        "tags": {
-          "type": "php_code_injection",
-          "crs_id": "933160",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "\\b(?:s(?:e(?:t(?:_(?:e(?:xception|rror)_handler|magic_quotes_runtime|include_path)|defaultstub)|ssion_s(?:et_save_handler|tart))|qlite_(?:(?:(?:unbuffered|single|array)_)?query|create_(?:aggregate|function)|p?open|exec)|tr(?:eam_(?:context_create|socket_client)|ipc?slashes|rev)|implexml_load_(?:string|file)|ocket_c(?:onnect|reate)|h(?:ow_sourc|a1_fil)e|pl_autoload_register|ystem)|p(?:r(?:eg_(?:replace(?:_callback(?:_array)?)?|match(?:_all)?|split)|oc_(?:(?:terminat|clos|nic)e|get_status|open)|int_r)|o(?:six_(?:get(?:(?:e[gu]|g)id|login|pwnam)|mk(?:fifo|nod)|ttyname|kill)|pen)|hp(?:_(?:strip_whitespac|unam)e|version|info)|g_(?:(?:execut|prepar)e|connect|query)|a(?:rse_(?:ini_file|str)|ssthru)|utenv)|r(?:unkit_(?:function_(?:re(?:defin|nam)e|copy|add)|method_(?:re(?:defin|nam)e|copy|add)|constant_(?:redefine|add))|e(?:(?:gister_(?:shutdown|tick)|name)_function|ad(?:(?:gz)?file|_exif_data|dir))|awurl(?:de|en)code)|i(?:mage(?:createfrom(?:(?:jpe|pn)g|x[bp]m|wbmp|gif)|(?:jpe|pn)g|g(?:d2?|if)|2?wbmp|xbm)|s_(?:(?:(?:execut|write?|read)ab|fi)le|dir)|ni_(?:get(?:_all)?|set)|terator_apply|ptcembed)|g(?:et(?:_(?:c(?:urrent_use|fg_va)r|meta_tags)|my(?:[gpu]id|inode)|(?:lastmo|cw)d|imagesize|env)|z(?:(?:(?:defla|wri)t|encod|fil)e|compress|open|read)|lob)|a(?:rray_(?:u(?:intersect(?:_u?assoc)?|diff(?:_u?assoc)?)|intersect_u(?:assoc|key)|diff_u(?:assoc|key)|filter|reduce|map)|ssert(?:_options)?)|h(?:tml(?:specialchars(?:_decode)?|_entity_decode|entities)|(?:ash(?:_(?:update|hmac))?|ighlight)_file|e(?:ader_register_callback|x2bin))|f(?:i(?:le(?:(?:[acm]tim|inod)e|(?:_exist|perm)s|group)?|nfo_open)|tp_(?:nb_(?:ge|pu)|connec|ge|pu)t|(?:unction_exis|pu)ts|write|open)|o(?:b_(?:get_(?:c(?:ontents|lean)|flush)|end_(?:clean|flush)|clean|flush|start)|dbc_(?:result(?:_all)?|exec(?:ute)?|connect)|pendir)|m(?:b_(?:ereg(?:_(?:replace(?:_callback)?|match)|i(?:_replace)?)?|parse_str)|(?:ove_uploaded|d5)_file|ethod_exists|ysql_query|kdir)|e(?:x(?:if_(?:t(?:humbnail|agname)|imagetype|read_data)|ec)|scapeshell(?:arg|cmd)|rror_reporting|val)|c(?:url_(?:file_create|exec|init)|onvert_uuencode|reate_function|hr)|u(?:n(?:serialize|pack)|rl(?:de|en)code|[ak]?sort)|(?:json_(?:de|en)cod|debug_backtrac|tmpfil)e|b(?:(?:son_(?:de|en)|ase64_en)code|zopen)|var_dump)(?:\\s|/\\*.*\\*/|//.*|#.*)*\\(.*\\)",
-              "options": {
-                "min_length": 5
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-933-170",
-        "name": "PHP Injection Attack: Serialized Object Injection",
-        "tags": {
-          "type": "php_code_injection",
-          "crs_id": "933170",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.headers.no_cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "[oOcC]:\\d+:\\\".+?\\\":\\d+:{[\\W\\w]*}",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 12
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-933-200",
-        "name": "PHP Injection Attack: Wrapper scheme detected",
-        "tags": {
-          "type": "php_code_injection",
-          "crs_id": "933200",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "(?i:zlib|glob|phar|ssh2|rar|ogg|expect|zip)://",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 6
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "removeNulls"
-        ]
-      },
-      {
-        "id": "crs-934-100",
-        "name": "Node.js Injection Attack",
-        "tags": {
-          "type": "js_code_injection",
-          "crs_id": "934100",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "(?:(?:_(?:\\$\\$ND_FUNC\\$\\$_|_js_function)|(?:new\\s+Function|\\beval)\\s*\\(|String\\s*\\.\\s*fromCharCode|function\\s*\\(\\s*\\)\\s*{|this\\.constructor)|module\\.exports\\s*=)",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 5
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-941-100",
-        "name": "XSS Attack Detected via libinjection",
-        "tags": {
-          "type": "xss",
-          "crs_id": "941100",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent",
-                    "referer"
-                  ]
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ]
-            },
-            "operator": "is_xss"
-          }
-        ],
-        "transformers": [
-          "removeNulls"
-        ]
-      },
-      {
-        "id": "crs-941-110",
-        "name": "XSS Filter - Category 1: Script Tag Vector",
-        "tags": {
-          "type": "xss",
-          "crs_id": "941110",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent",
-                    "referer"
-                  ]
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "<script[^>]*>[\\s\\S]*?",
-              "options": {
-                "min_length": 8
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "removeNulls"
-        ]
-      },
-      {
-        "id": "crs-941-120",
-        "name": "XSS Filter - Category 2: Event Handler Vector",
-        "tags": {
-          "type": "xss",
-          "crs_id": "941120",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent",
-                    "referer"
-                  ]
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "[\\s\\\"'`;\\/0-9=\\x0B\\x09\\x0C\\x3B\\x2C\\x28\\x3B]on[a-zA-Z]{3,25}[\\s\\x0B\\x09\\x0C\\x3B\\x2C\\x28\\x3B]*?=[^=]",
-              "options": {
-                "min_length": 8
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "removeNulls"
-        ]
-      },
-      {
-        "id": "crs-941-140",
-        "name": "XSS Filter - Category 4: Javascript URI Vector",
-        "tags": {
-          "type": "xss",
-          "crs_id": "941140",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent",
-                    "referer"
-                  ]
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "[a-z]+=(?:[^:=]+:.+;)*?[^:=]+:url\\(javascript",
-              "options": {
-                "min_length": 18
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "removeNulls"
-        ]
-      },
-      {
-        "id": "crs-941-180",
-        "name": "Node-Validator Deny List Keywords",
-        "tags": {
-          "type": "xss",
-          "crs_id": "941180",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "list": [
-                "document.cookie",
-                "document.write",
-                ".parentnode",
-                ".innerhtml",
-                "window.location",
-                "-moz-binding",
-                "<![cdata["
-              ]
-            },
-            "operator": "phrase_match"
-          }
-        ],
-        "transformers": [
-          "removeNulls",
-          "lowercase"
-        ]
-      },
-      {
-        "id": "crs-941-200",
-        "name": "IE XSS Filters - Attack Detected via vmlframe tag",
-        "tags": {
-          "type": "xss",
-          "crs_id": "941200",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "(?i:<.*[:]?vmlframe.*?[\\s/+]*?src[\\s/+]*=)",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 13
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "removeNulls"
-        ]
-      },
-      {
-        "id": "crs-941-210",
-        "name": "IE XSS Filters - Obfuscated Attack Detected via javascript injection",
-        "tags": {
-          "type": "xss",
-          "crs_id": "941210",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "(?i:(?:j|&#x?0*(?:74|4A|106|6A);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:a|&#x?0*(?:65|41|97|61);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:v|&#x?0*(?:86|56|118|76);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:a|&#x?0*(?:65|41|97|61);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:s|&#x?0*(?:83|53|115|73);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:c|&#x?0*(?:67|43|99|63);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:r|&#x?0*(?:82|52|114|72);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:i|&#x?0*(?:73|49|105|69);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:p|&#x?0*(?:80|50|112|70);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:t|&#x?0*(?:84|54|116|74);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?::|&(?:#x?0*(?:58|3A);?|colon;)).)",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 12
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "removeNulls"
-        ]
-      },
-      {
-        "id": "crs-941-220",
-        "name": "IE XSS Filters - Obfuscated Attack Detected via vbscript injection",
-        "tags": {
-          "type": "xss",
-          "crs_id": "941220",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "(?i:(?:v|&#x?0*(?:86|56|118|76);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:b|&#x?0*(?:66|42|98|62);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:s|&#x?0*(?:83|53|115|73);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:c|&#x?0*(?:67|43|99|63);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:r|&#x?0*(?:82|52|114|72);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:i|&#x?0*(?:73|49|105|69);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:p|&#x?0*(?:80|50|112|70);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:t|&#x?0*(?:84|54|116|74);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?::|&(?:#x?0*(?:58|3A);?|colon;)).)",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 10
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "removeNulls"
-        ]
-      },
-      {
-        "id": "crs-941-230",
-        "name": "IE XSS Filters - Attack Detected via embed tag",
-        "tags": {
-          "type": "xss",
-          "crs_id": "941230",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "<EMBED[\\s/+].*?(?:src|type).*?=",
-              "options": {
-                "min_length": 11
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "removeNulls"
-        ]
-      },
-      {
-        "id": "crs-941-240",
-        "name": "IE XSS Filters - Attack Detected via import tag",
-        "tags": {
-          "type": "xss",
-          "crs_id": "941240",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "<[?]?import[\\s/+\\S]*?implementation[\\s/+]*?=",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 22
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "lowercase",
-          "removeNulls"
-        ]
-      },
-      {
-        "id": "crs-941-270",
-        "name": "IE XSS Filters - Attack Detected via link tag",
-        "tags": {
-          "type": "xss",
-          "crs_id": "941270",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "<LINK[\\s/+].*?href[\\s/+]*=",
-              "options": {
-                "min_length": 11
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "removeNulls"
-        ]
-      },
-      {
-        "id": "crs-941-280",
-        "name": "IE XSS Filters - Attack Detected via base tag",
-        "tags": {
-          "type": "xss",
-          "crs_id": "941280",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "<BASE[\\s/+].*?href[\\s/+]*=",
-              "options": {
-                "min_length": 11
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "removeNulls"
-        ]
-      },
-      {
-        "id": "crs-941-290",
-        "name": "IE XSS Filters - Attack Detected via applet tag",
-        "tags": {
-          "type": "xss",
-          "crs_id": "941290",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "<APPLET[\\s/+>]",
-              "options": {
-                "min_length": 8
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "removeNulls"
-        ]
-      },
-      {
-        "id": "crs-941-300",
-        "name": "IE XSS Filters - Attack Detected via object tag",
-        "tags": {
-          "type": "xss",
-          "crs_id": "941300",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "<OBJECT[\\s/+].*?(?:type|codetype|classid|code|data)[\\s/+]*=",
-              "options": {
-                "min_length": 13
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "removeNulls"
-        ]
-      },
-      {
-        "id": "crs-941-350",
-        "name": "UTF-7 Encoding IE XSS - Attack Detected",
-        "tags": {
-          "type": "xss",
-          "crs_id": "941350",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "\\+ADw-.*(?:\\+AD4-|>)|<.*\\+AD4-",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 6
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-941-360",
-        "name": "JSFuck / Hieroglyphy obfuscation detected",
-        "tags": {
-          "type": "xss",
-          "crs_id": "941360",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "![!+ ]\\[\\]",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 4
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-942-100",
-        "name": "SQL Injection Attack Detected via libinjection",
-        "tags": {
-          "type": "sql_injection",
-          "crs_id": "942100",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ]
-            },
-            "operator": "is_sqli"
-          }
-        ],
-        "transformers": [
-          "removeNulls"
-        ]
-      },
-      {
-        "id": "crs-942-140",
-        "name": "SQL Injection Attack: Common DB Names Detected",
-        "tags": {
-          "type": "sql_injection",
-          "crs_id": "942140",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "\\b(?:(?:m(?:s(?:ys(?:ac(?:cess(?:objects|storage|xml)|es)|(?:relationship|object|querie)s|modules2?)|db)|aster\\.\\.sysdatabases|ysql\\.db)|pg_(?:catalog|toast)|information_schema|northwind|tempdb)\\b|s(?:(?:ys(?:\\.database_name|aux)|qlite(?:_temp)?_master)\\b|chema(?:_name\\b|\\W*\\())|d(?:atabas|b_nam)e\\W*\\()",
-              "options": {
-                "min_length": 4
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-942-160",
-        "name": "Detects blind sqli tests using sleep() or benchmark()",
-        "tags": {
-          "type": "sql_injection",
-          "crs_id": "942160",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "(?i:sleep\\(\\s*?\\d*?\\s*?\\)|benchmark\\(.*?\\,.*?\\))",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 7
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-942-190",
-        "name": "Detects MSSQL code execution and information gathering attempts",
-        "tags": {
-          "type": "sql_injection",
-          "crs_id": "942190",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "(?:\\b(?:(?:c(?:onnection_id|urrent_user)|database)\\s*?\\([^\\)]*?|u(?:nion(?:[\\w(?:\\s]*?select| select @)|ser\\s*?\\([^\\)]*?)|s(?:chema\\s*?\\([^\\)]*?|elect.*?\\w?user\\()|into[\\s+]+(?:dump|out)file\\s*?[\\\"'`]|from\\W+information_schema\\W|exec(?:ute)?\\s+master\\.)|[\\\"'`](?:;?\\s*?(?:union\\b\\s*?(?:(?:distin|sele)ct|all)|having|select)\\b\\s*?[^\\s]|\\s*?!\\s*?[\\\"'`\\w])|\\s*?exec(?:ute)?.*?\\Wxp_cmdshell|\\Wiif\\s*?\\()",
-              "options": {
-                "min_length": 3
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-942-220",
-        "name": "Looking for integer overflow attacks, these are taken from skipfish, except 2.2.2250738585072011e-308 is the \\\"magic number\\\" crash",
-        "tags": {
-          "type": "sql_injection",
-          "crs_id": "942220",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "^(?i:-0000023456|4294967295|4294967296|2147483648|2147483647|0000012345|-2147483648|-2147483649|0000023456|2.2250738585072007e-308|2.2250738585072011e-308|1e309)$",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 5
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-942-240",
-        "name": "Detects MySQL charset switch and MSSQL DoS attempts",
-        "tags": {
-          "type": "sql_injection",
-          "crs_id": "942240",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "(?:[\\\"'`](?:;*?\\s*?waitfor\\s+(?:delay|time)\\s+[\\\"'`]|;.*?:\\s*?goto)|alter\\s*?\\w+.*?cha(?:racte)?r\\s+set\\s+\\w+)",
-              "options": {
-                "min_length": 7
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-942-250",
-        "name": "Detects MATCH AGAINST, MERGE and EXECUTE IMMEDIATE injections",
-        "tags": {
-          "type": "sql_injection",
-          "crs_id": "942250",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "(?i:merge.*?using\\s*?\\(|execute\\s*?immediate\\s*?[\\\"'`]|match\\s*?[\\w(?:),+-]+\\s*?against\\s*?\\()",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 11
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-942-270",
-        "name": "Looking for basic sql injection. Common attack string for mysql, oracle and others",
-        "tags": {
-          "type": "sql_injection",
-          "crs_id": "942270",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "union.*?select.*?from",
-              "options": {
-                "min_length": 15
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-942-280",
-        "name": "Detects Postgres pg_sleep injection, waitfor delay attacks and database shutdown attempts",
-        "tags": {
-          "type": "sql_injection",
-          "crs_id": "942280",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "(?:;\\s*?shutdown\\s*?(?:[#;{]|\\/\\*|--)|waitfor\\s*?delay\\s?[\\\"'`]+\\s?\\d|select\\s*?pg_sleep)",
-              "options": {
-                "min_length": 10
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-942-290",
-        "name": "Finds basic MongoDB SQL injection attempts",
-        "tags": {
-          "type": "nosql_injection",
-          "crs_id": "942290",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 5
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-942-360",
-        "name": "Detects concatenated basic SQL injection and SQLLFI attempts",
-        "tags": {
-          "type": "sql_injection",
-          "crs_id": "942360",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "(?:^[\\W\\d]+\\s*?(?:alter\\s*(?:a(?:(?:pplication\\s*rol|ggregat)e|s(?:ymmetric\\s*ke|sembl)y|u(?:thorization|dit)|vailability\\s*group)|c(?:r(?:yptographic\\s*provider|edential)|o(?:l(?:latio|um)|nversio)n|ertificate|luster)|s(?:e(?:rv(?:ice|er)|curity|quence|ssion|arch)|y(?:mmetric\\s*key|nonym)|togroup|chema)|m(?:a(?:s(?:ter\\s*key|k)|terialized)|e(?:ssage\\s*type|thod)|odule)|l(?:o(?:g(?:file\\s*group|in)|ckdown)|a(?:ngua|r)ge|ibrary)|t(?:(?:abl(?:espac)?|yp)e|r(?:igger|usted)|hreshold|ext)|p(?:a(?:rtition|ckage)|ro(?:cedur|fil)e|ermission)|d(?:i(?:mension|skgroup)|atabase|efault|omain)|r(?:o(?:l(?:lback|e)|ute)|e(?:sourc|mot)e)|f(?:u(?:lltext|nction)|lashback|oreign)|e(?:xte(?:nsion|rnal)|(?:ndpoi|ve)nt)|in(?:dex(?:type)?|memory|stance)|b(?:roker\\s*priority|ufferpool)|x(?:ml\\s*schema|srobject)|w(?:ork(?:load)?|rapper)|hi(?:erarchy|stogram)|o(?:perator|utline)|(?:nicknam|queu)e|us(?:age|er)|group|java|view)\\b|(?:(?:(?:trunc|cre)at|renam)e|d(?:e(?:lete|sc)|rop)|(?:inser|selec)t|load)\\s+\\w+|u(?:nion\\s*(?:(?:distin|sele)ct|all)\\b|pdate\\s+\\w+))|\\b(?:(?:(?:(?:trunc|cre|upd)at|renam)e|(?:inser|selec)t|de(?:lete|sc)|alter|load)\\s+(?:group_concat|load_file|char)\\b\\s*\\(?|end\\s*?\\);)|[\\\"'`\\w]\\s+as\\b\\s*[\\\"'`\\w]+\\s*\\bfrom|[\\s(?:]load_file\\s*?\\(|[\\\"'`]\\s+regexp\\W)",
-              "options": {
-                "min_length": 5
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-942-500",
-        "name": "MySQL in-line comment detected",
-        "tags": {
-          "type": "sql_injection",
-          "crs_id": "942500",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "(?i:/\\*[!+](?:[\\w\\s=_\\-(?:)]+)?\\*/)",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 5
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-943-100",
-        "name": "Possible Session Fixation Attack: Setting Cookie Values in HTML",
-        "tags": {
-          "type": "http_protocol_violation",
-          "crs_id": "943100",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "(?i:\\.cookie\\b.*?;\\W*?(?:expires|domain)\\W*?=|\\bhttp-equiv\\W+set-cookie\\b)",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 15
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "crs-944-100",
-        "name": "Remote Command Execution: Suspicious Java class detected",
-        "tags": {
-          "type": "java_code_injection",
-          "crs_id": "944100",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                },
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.headers.no_cookies"
-                }
-              ],
-              "regex": "java\\.lang\\.(?:runtime|processbuilder)",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 17
-              }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "lowercase"
-        ]
-      },
-      {
-        "id": "crs-944-110",
-        "name": "Remote Command Execution: Java process spawn (CVE-2017-9805)",
-        "tags": {
-          "type": "java_code_injection",
-          "crs_id": "944110",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                },
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.headers.no_cookies"
-                }
-              ],
-              "regex": "(?:runtime|processbuilder)",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 7
-              }
-            },
-            "operator": "match_regex"
+            ],
+            "list": [
+              "acunetix-product",
+              "(acunetix web vulnerability scanner",
+              "acunetix-scanning-agreement",
+              "acunetix-user-agreement"
+            ]
           },
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                },
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.headers.no_cookies"
-                }
-              ],
-              "regex": "(?:unmarshaller|base64data|java\\.)",
-              "options": {
-                "case_sensitive": true,
-                "min_length": 5
+          "operator": "phrase_match"
+        }
+      ],
+      "transformers": [
+        "lowercase"
+      ]
+    },
+    {
+      "id": "crs-913-120",
+      "name": "Found request filename/argument associated with security scanner",
+      "tags": {
+        "type": "security_scanner",
+        "crs_id": "913120",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
               }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "lowercase"
-        ]
+            ],
+            "list": [
+              "/.adsensepostnottherenonobook",
+              "/<invalid>hello.html",
+              "/actsensepostnottherenonotive",
+              "/acunetix-wvs-test-for-some-inexistent-file",
+              "/antidisestablishmentarianism",
+              "/appscan_fingerprint/mac_address",
+              "/arachni-",
+              "/cybercop",
+              "/nessus_is_probing_you_",
+              "/nessustest",
+              "/netsparker-",
+              "/rfiinc.txt",
+              "/thereisnowaythat-you-canbethere",
+              "/w3af/remotefileinclude.html",
+              "appscan_fingerprint",
+              "w00tw00t.at.isc.sans.dfind",
+              "w00tw00t.at.blackhats.romanian.anti-sec"
+            ]
+          },
+          "operator": "phrase_match"
+        }
+      ],
+      "transformers": [
+        "lowercase"
+      ]
+    },
+    {
+      "id": "crs-920-260",
+      "name": "Unicode Full/Half Width Abuse Attack Attempt",
+      "tags": {
+        "type": "http_protocol_violation",
+        "crs_id": "920260",
+        "category": "attack_attempt"
       },
-      {
-        "id": "crs-944-130",
-        "name": "Suspicious Java class detected",
-        "tags": {
-          "type": "java_code_injection",
-          "crs_id": "944130",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                },
-                {
-                  "address": "server.request.cookies"
-                },
-                {
-                  "address": "server.request.headers.no_cookies"
-                }
-              ],
-              "list": [
-                "com.opensymphony.xwork2",
-                "com.sun.org.apache",
-                "java.io.bufferedinputstream",
-                "java.io.bufferedreader",
-                "java.io.bytearrayinputstream",
-                "java.io.bytearrayoutputstream",
-                "java.io.chararrayreader",
-                "java.io.datainputstream",
-                "java.io.file",
-                "java.io.fileoutputstream",
-                "java.io.filepermission",
-                "java.io.filewriter",
-                "java.io.filterinputstream",
-                "java.io.filteroutputstream",
-                "java.io.filterreader",
-                "java.io.inputstream",
-                "java.io.inputstreamreader",
-                "java.io.linenumberreader",
-                "java.io.objectoutputstream",
-                "java.io.outputstream",
-                "java.io.pipedoutputstream",
-                "java.io.pipedreader",
-                "java.io.printstream",
-                "java.io.pushbackinputstream",
-                "java.io.reader",
-                "java.io.stringreader",
-                "java.lang.class",
-                "java.lang.integer",
-                "java.lang.number",
-                "java.lang.object",
-                "java.lang.process",
-                "java.lang.processbuilder",
-                "java.lang.reflect",
-                "java.lang.runtime",
-                "java.lang.string",
-                "java.lang.stringbuilder",
-                "java.lang.system",
-                "javax.script.scriptenginemanager",
-                "org.apache.commons",
-                "org.apache.struts",
-                "org.apache.struts2",
-                "org.omg.corba",
-                "java.beans.xmldecode"
-              ]
-            },
-            "operator": "phrase_match"
-          }
-        ],
-        "transformers": [
-          "lowercase"
-        ]
-      },
-      {
-        "id": "sqr-000-001",
-        "name": "SSRF: Try to access the credential manager of the main cloud services",
-        "tags": {
-          "type": "ssrf",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "(?i)^\\W*((http|ftp)s?://)?\\W*((::f{4}:)?(169|(0x)?0*a9|0+251)\\.?(254|(0x)?0*fe|0+376)[0-9a-fx\\.:]+|metadata\\.google\\.internal|metadata\\.goog)\\W*/",
-              "options": {
-                "min_length": 4
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.uri.raw"
               }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "removeNulls"
-        ]
+            ],
+            "regex": "\\%u[fF]{2}[0-9a-fA-F]{2}",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 6
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-921-110",
+      "name": "HTTP Request Smuggling Attack",
+      "tags": {
+        "type": "http_protocol_violation",
+        "crs_id": "921110",
+        "category": "attack_attempt"
       },
-      {
-        "id": "sqr-000-002",
-        "name": "Server-side Javascript injection: Try to detect obvious JS injection",
-        "tags": {
-          "type": "js_code_injection",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "require\\(['\"][\\w\\.]+['\"]\\)|process\\.\\w+\\([\\w\\.]*\\)|\\.toString\\(\\)",
-              "options": {
-                "min_length": 4
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
               }
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "removeNulls"
-        ]
+            ],
+            "regex": "(?:get|post|head|options|connect|put|delete|trace|track|patch|propfind|propatch|mkcol|copy|move|lock|unlock)\\s+[^\\s]+\\s+http/\\d",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 12
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "lowercase"
+      ]
+    },
+    {
+      "id": "crs-921-140",
+      "name": "HTTP Header Injection Attack via headers",
+      "tags": {
+        "type": "http_protocol_violation",
+        "crs_id": "921140",
+        "category": "attack_attempt"
       },
-      {
-        "id": "sqr-000-007",
-        "name": "NoSQL: Detect common exploitation strategy",
-        "tags": {
-          "type": "nosql_injection",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies"
-                }
-              ],
-              "regex": "\\$(eq|ne|lte?|gte?|n?in)\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "sqr-000-008",
-        "name": "Windows: Detect attempts to exfiltrate .ini files",
-        "tags": {
-          "type": "command_injection",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                },
-                {
-                  "address": "server.request.headers.no_cookies"
-                }
-              ],
-              "regex": "(?i)[&|]\\s*type\\s+%\\w+%\\\\+\\w+\\.ini\\s*[&|]"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "sqr-000-009",
-        "name": "Linux: Detect attempts to exfiltrate passwd files",
-        "tags": {
-          "type": "command_injection",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                },
-                {
-                  "address": "server.request.headers.no_cookies"
-                }
-              ],
-              "regex": "(?i)[&|]\\s*cat\\s+\\/etc\\/[\\w\\.\\/]*passwd\\s*[&|]"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "sqr-000-010",
-        "name": "Windows: Detect attempts to timeout a shell",
-        "tags": {
-          "type": "command_injection",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                },
-                {
-                  "address": "server.request.headers.no_cookies"
-                }
-              ],
-              "regex": "(?i)[&|]\\s*timeout\\s+/t\\s+\\d+\\s*[&|]"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      },
-      {
-        "id": "sqr-000-011",
-        "name": "SSRF: Try to access internal OMI service (CVE-2021-38647)",
-        "tags": {
-          "type": "ssrf",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "operator": "match_regex",
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "http(s?):\\/\\/([A-Za-z0-9\\.\\-\\_]+|\\[[A-Fa-f0-9\\:]+\\]|):5986\\/wsman",
-              "options": {
-                "min_length": 4
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies"
               }
+            ],
+            "regex": "[\\n\\r]",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 1
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-921-160",
+      "name": "HTTP Header Injection Attack via payload (CR/LF and header-name detected)",
+      "tags": {
+        "type": "http_protocol_violation",
+        "crs_id": "921160",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "[\\n\\r]+(?:\\s|location|refresh|(?:set-)?cookie|(?:x-)?(?:forwarded-(?:for|host|server)|host|via|remote-ip|remote-addr|originating-IP))\\s*:",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 3
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "lowercase"
+      ]
+    },
+    {
+      "id": "crs-930-100",
+      "name": "Obfuscated Path Traversal Attack (/../)",
+      "tags": {
+        "type": "lfi",
+        "crs_id": "930100",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.uri.raw"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "regex": "(?:\\x5c|(?:%(?:c(?:0%(?:[2aq]f|5c|9v)|1%(?:[19p]c|8s|af))|2(?:5(?:c(?:0%25af|1%259c)|2f|5c)|%46|f)|(?:(?:f(?:8%8)?0%8|e)0%80%a|bg%q)f|%3(?:2(?:%(?:%6|4)6|F)|5%%63)|u(?:221[56]|002f|EFC8|F025)|1u|5c)|0x(?:2f|5c)|/))(?:%(?:(?:f(?:(?:c%80|8)%8)?0%8|e)0%80%ae|2(?:(?:5(?:c0%25a|2))?e|%45)|u(?:(?:002|ff0)e|2024)|%32(?:%(?:%6|4)5|E)|c0(?:%[256aef]e|\\.))|\\.(?:%0[01]|\\?)?|\\?\\.?|0x2e){2}(?:\\x5c|(?:%(?:c(?:0%(?:[2aq]f|5c|9v)|1%(?:[19p]c|8s|af))|2(?:5(?:c(?:0%25af|1%259c)|2f|5c)|%46|f)|(?:(?:f(?:8%8)?0%8|e)0%80%a|bg%q)f|%3(?:2(?:%(?:%6|4)6|F)|5%%63)|u(?:221[56]|002f|EFC8|F025)|1u|5c)|0x(?:2f|5c)|/))",
+            "options": {
+              "min_length": 4
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-930-110",
+      "name": "Simple Path Traversal Attack (/../)",
+      "tags": {
+        "type": "lfi",
+        "crs_id": "930110",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.uri.raw"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "regex": "(?:(?:^|[\\\\/])\\.\\.[\\\\/]|[\\\\/]\\.\\.(?:[\\\\/]|$))",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 3
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "removeNulls"
+      ]
+    },
+    {
+      "id": "crs-930-120",
+      "name": "OS File Access Attempt",
+      "tags": {
+        "type": "lfi",
+        "crs_id": "930120",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "list": [
+              ".htaccess",
+              ".htdigest",
+              ".htpasswd",
+              ".addressbook",
+              ".aptitude/config",
+              ".bash_config",
+              ".bash_history",
+              ".bash_logout",
+              ".bash_profile",
+              ".bashrc",
+              ".cache/notify-osd.log",
+              ".config/odesk/odesk team.conf",
+              ".cshrc",
+              ".dockerignore",
+              ".drush/",
+              ".eslintignore",
+              ".fbcindex",
+              ".forward",
+              ".gitattributes",
+              ".gitconfig",
+              ".gnupg/",
+              ".hplip/hplip.conf",
+              ".ksh_history",
+              ".lesshst",
+              ".lftp/",
+              ".lhistory",
+              ".lldb-history",
+              ".local/share/mc/",
+              ".lynx_cookies",
+              ".my.cnf",
+              ".mysql_history",
+              ".nano_history",
+              ".node_repl_history",
+              ".pearrc",
+              ".php_history",
+              ".pinerc",
+              ".pki/",
+              ".proclog",
+              ".procmailrc",
+              ".psql_history",
+              ".python_history",
+              ".rediscli_history",
+              ".rhistory",
+              ".rhosts",
+              ".sh_history",
+              ".sqlite_history",
+              ".ssh/authorized_keys",
+              ".ssh/config",
+              ".ssh/id_dsa",
+              ".ssh/id_dsa.pub",
+              ".ssh/id_rsa",
+              ".ssh/id_rsa.pub",
+              ".ssh/identity",
+              ".ssh/identity.pub",
+              ".ssh/known_hosts",
+              ".subversion/auth",
+              ".subversion/config",
+              ".subversion/servers",
+              ".tconn/tconn.conf",
+              ".tcshrc",
+              ".vidalia/vidalia.conf",
+              ".viminfo",
+              ".vimrc",
+              ".www_acl",
+              ".wwwacl",
+              ".xauthority",
+              ".zhistory",
+              ".zshrc",
+              ".zsh_history",
+              ".nsconfig",
+              "etc/redis.conf",
+              "etc/redis-sentinel.conf",
+              "etc/php.ini",
+              "bin/php.ini",
+              "etc/httpd/php.ini",
+              "usr/lib/php.ini",
+              "usr/lib/php/php.ini",
+              "usr/local/etc/php.ini",
+              "usr/local/lib/php.ini",
+              "usr/local/php/lib/php.ini",
+              "usr/local/php4/lib/php.ini",
+              "usr/local/php5/lib/php.ini",
+              "usr/local/apache/conf/php.ini",
+              "etc/php4.4/fcgi/php.ini",
+              "etc/php4/apache/php.ini",
+              "etc/php4/apache2/php.ini",
+              "etc/php5/apache/php.ini",
+              "etc/php5/apache2/php.ini",
+              "etc/php/php.ini",
+              "etc/php/php4/php.ini",
+              "etc/php/apache/php.ini",
+              "etc/php/apache2/php.ini",
+              "web/conf/php.ini",
+              "usr/local/zend/etc/php.ini",
+              "opt/xampp/etc/php.ini",
+              "var/local/www/conf/php.ini",
+              "etc/php/cgi/php.ini",
+              "etc/php4/cgi/php.ini",
+              "etc/php5/cgi/php.ini",
+              "home2/bin/stable/apache/php.ini",
+              "home/bin/stable/apache/php.ini",
+              "etc/httpd/conf.d/php.conf",
+              "php5/php.ini",
+              "php4/php.ini",
+              "php/php.ini",
+              "windows/php.ini",
+              "winnt/php.ini",
+              "apache/php/php.ini",
+              "xampp/apache/bin/php.ini",
+              "netserver/bin/stable/apache/php.ini",
+              "volumes/macintosh_hd1/usr/local/php/lib/php.ini",
+              "etc/mono/1.0/machine.config",
+              "etc/mono/2.0/machine.config",
+              "etc/mono/2.0/web.config",
+              "etc/mono/config",
+              "usr/local/cpanel/logs/stats_log",
+              "usr/local/cpanel/logs/access_log",
+              "usr/local/cpanel/logs/error_log",
+              "usr/local/cpanel/logs/license_log",
+              "usr/local/cpanel/logs/login_log",
+              "var/cpanel/cpanel.config",
+              "var/log/sw-cp-server/error_log",
+              "usr/local/psa/admin/logs/httpsd_access_log",
+              "usr/local/psa/admin/logs/panel.log",
+              "var/log/sso/sso.log",
+              "usr/local/psa/admin/conf/php.ini",
+              "etc/sw-cp-server/applications.d/plesk.conf",
+              "usr/local/psa/admin/conf/site_isolation_settings.ini",
+              "usr/local/sb/config",
+              "etc/sw-cp-server/applications.d/00-sso-cpserver.conf",
+              "etc/sso/sso_config.ini",
+              "etc/mysql/conf.d/old_passwords.cnf",
+              "var/log/mysql/mysql-bin.log",
+              "var/log/mysql/mysql-bin.index",
+              "var/log/mysql/data/mysql-bin.index",
+              "var/log/mysql.log",
+              "var/log/mysql.err",
+              "var/log/mysqlderror.log",
+              "var/log/mysql/mysql.log",
+              "var/log/mysql/mysql-slow.log",
+              "var/log/mysql-bin.index",
+              "var/log/data/mysql-bin.index",
+              "var/mysql.log",
+              "var/mysql-bin.index",
+              "var/data/mysql-bin.index",
+              "program files/mysql/mysql server 5.0/data/{host}.err",
+              "program files/mysql/mysql server 5.0/data/mysql.log",
+              "program files/mysql/mysql server 5.0/data/mysql.err",
+              "program files/mysql/mysql server 5.0/data/mysql-bin.log",
+              "program files/mysql/mysql server 5.0/data/mysql-bin.index",
+              "program files/mysql/data/{host}.err",
+              "program files/mysql/data/mysql.log",
+              "program files/mysql/data/mysql.err",
+              "program files/mysql/data/mysql-bin.log",
+              "program files/mysql/data/mysql-bin.index",
+              "mysql/data/{host}.err",
+              "mysql/data/mysql.log",
+              "mysql/data/mysql.err",
+              "mysql/data/mysql-bin.log",
+              "mysql/data/mysql-bin.index",
+              "usr/local/mysql/data/mysql.log",
+              "usr/local/mysql/data/mysql.err",
+              "usr/local/mysql/data/mysql-bin.log",
+              "usr/local/mysql/data/mysql-slow.log",
+              "usr/local/mysql/data/mysqlderror.log",
+              "usr/local/mysql/data/{host}.err",
+              "usr/local/mysql/data/mysql-bin.index",
+              "var/lib/mysql/my.cnf",
+              "etc/mysql/my.cnf",
+              "etc/my.cnf",
+              "program files/mysql/mysql server 5.0/my.ini",
+              "program files/mysql/mysql server 5.0/my.cnf",
+              "program files/mysql/my.ini",
+              "program files/mysql/my.cnf",
+              "mysql/my.ini",
+              "mysql/my.cnf",
+              "mysql/bin/my.ini",
+              "var/postgresql/log/postgresql.log",
+              "var/log/postgresql/postgresql.log",
+              "var/log/postgres/pg_backup.log",
+              "var/log/postgres/postgres.log",
+              "var/log/postgresql.log",
+              "var/log/pgsql/pgsql.log",
+              "var/log/postgresql/postgresql-8.1-main.log",
+              "var/log/postgresql/postgresql-8.3-main.log",
+              "var/log/postgresql/postgresql-8.4-main.log",
+              "var/log/postgresql/postgresql-9.0-main.log",
+              "var/log/postgresql/postgresql-9.1-main.log",
+              "var/log/pgsql8.log",
+              "var/log/postgresql/postgres.log",
+              "var/log/pgsql_log",
+              "var/log/postgresql/main.log",
+              "var/log/cron/var/log/postgres.log",
+              "usr/internet/pgsql/data/postmaster.log",
+              "usr/local/pgsql/data/postgresql.log",
+              "usr/local/pgsql/data/pg_log",
+              "postgresql/log/pgadmin.log",
+              "var/lib/pgsql/data/postgresql.conf",
+              "var/postgresql/db/postgresql.conf",
+              "var/nm2/postgresql.conf",
+              "usr/local/pgsql/data/postgresql.conf",
+              "usr/local/pgsql/data/pg_hba.conf",
+              "usr/internet/pgsql/data/pg_hba.conf",
+              "usr/local/pgsql/data/passwd",
+              "usr/local/pgsql/bin/pg_passwd",
+              "etc/postgresql/postgresql.conf",
+              "etc/postgresql/pg_hba.conf",
+              "home/postgres/data/postgresql.conf",
+              "home/postgres/data/pg_version",
+              "home/postgres/data/pg_ident.conf",
+              "home/postgres/data/pg_hba.conf",
+              "program files/postgresql/8.3/data/pg_hba.conf",
+              "program files/postgresql/8.3/data/pg_ident.conf",
+              "program files/postgresql/8.3/data/postgresql.conf",
+              "program files/postgresql/8.4/data/pg_hba.conf",
+              "program files/postgresql/8.4/data/pg_ident.conf",
+              "program files/postgresql/8.4/data/postgresql.conf",
+              "program files/postgresql/9.0/data/pg_hba.conf",
+              "program files/postgresql/9.0/data/pg_ident.conf",
+              "program files/postgresql/9.0/data/postgresql.conf",
+              "program files/postgresql/9.1/data/pg_hba.conf",
+              "program files/postgresql/9.1/data/pg_ident.conf",
+              "program files/postgresql/9.1/data/postgresql.conf",
+              "wamp/logs/access.log",
+              "wamp/logs/apache_error.log",
+              "wamp/logs/genquery.log",
+              "wamp/logs/mysql.log",
+              "wamp/logs/slowquery.log",
+              "wamp/bin/apache/apache2.2.22/logs/access.log",
+              "wamp/bin/apache/apache2.2.22/logs/error.log",
+              "wamp/bin/apache/apache2.2.21/logs/access.log",
+              "wamp/bin/apache/apache2.2.21/logs/error.log",
+              "wamp/bin/mysql/mysql5.5.24/data/mysql-bin.index",
+              "wamp/bin/mysql/mysql5.5.16/data/mysql-bin.index",
+              "wamp/bin/apache/apache2.2.21/conf/httpd.conf",
+              "wamp/bin/apache/apache2.2.22/conf/httpd.conf",
+              "wamp/bin/apache/apache2.2.21/wampserver.conf",
+              "wamp/bin/apache/apache2.2.22/wampserver.conf",
+              "wamp/bin/apache/apache2.2.22/conf/wampserver.conf",
+              "wamp/bin/mysql/mysql5.5.24/my.ini",
+              "wamp/bin/mysql/mysql5.5.24/wampserver.conf",
+              "wamp/bin/mysql/mysql5.5.16/my.ini",
+              "wamp/bin/mysql/mysql5.5.16/wampserver.conf",
+              "wamp/bin/php/php5.3.8/php.ini",
+              "wamp/bin/php/php5.4.3/php.ini",
+              "xampp/apache/logs/access.log",
+              "xampp/apache/logs/error.log",
+              "xampp/mysql/data/mysql-bin.index",
+              "xampp/mysql/data/mysql.err",
+              "xampp/mysql/data/{host}.err",
+              "xampp/sendmail/sendmail.log",
+              "xampp/apache/conf/httpd.conf",
+              "xampp/filezillaftp/filezilla server.xml",
+              "xampp/mercurymail/mercury.ini",
+              "xampp/php/php.ini",
+              "xampp/phpmyadmin/config.inc.php",
+              "xampp/sendmail/sendmail.ini",
+              "xampp/webalizer/webalizer.conf",
+              "opt/lampp/etc/httpd.conf",
+              "xampp/htdocs/aca.txt",
+              "xampp/htdocs/admin.php",
+              "xampp/htdocs/leer.txt",
+              "usr/local/apache/logs/audit_log",
+              "usr/local/apache2/logs/audit_log",
+              "logs/security_debug_log",
+              "logs/security_log",
+              "usr/local/apache/conf/modsec.conf",
+              "usr/local/apache2/conf/modsec.conf",
+              "winnt/system32/logfiles/msftpsvc",
+              "winnt/system32/logfiles/msftpsvc1",
+              "winnt/system32/logfiles/msftpsvc2",
+              "windows/system32/logfiles/msftpsvc",
+              "windows/system32/logfiles/msftpsvc1",
+              "windows/system32/logfiles/msftpsvc2",
+              "etc/logrotate.d/proftpd",
+              "www/logs/proftpd.system.log",
+              "var/log/proftpd",
+              "var/log/proftpd/xferlog.legacy",
+              "var/log/proftpd.access_log",
+              "var/log/proftpd.xferlog",
+              "etc/pam.d/proftpd",
+              "etc/proftp.conf",
+              "etc/protpd/proftpd.conf",
+              "etc/vhcs2/proftpd/proftpd.conf",
+              "etc/proftpd/modules.conf",
+              "var/log/vsftpd.log",
+              "etc/vsftpd.chroot_list",
+              "etc/logrotate.d/vsftpd.log",
+              "etc/vsftpd/vsftpd.conf",
+              "etc/vsftpd.conf",
+              "etc/chrootusers",
+              "var/log/xferlog",
+              "var/adm/log/xferlog",
+              "etc/wu-ftpd/ftpaccess",
+              "etc/wu-ftpd/ftphosts",
+              "etc/wu-ftpd/ftpusers",
+              "var/log/pure-ftpd/pure-ftpd.log",
+              "logs/pure-ftpd.log",
+              "var/log/pureftpd.log",
+              "usr/sbin/pure-config.pl",
+              "usr/etc/pure-ftpd.conf",
+              "etc/pure-ftpd/pure-ftpd.conf",
+              "usr/local/etc/pure-ftpd.conf",
+              "usr/local/etc/pureftpd.pdb",
+              "usr/local/pureftpd/etc/pureftpd.pdb",
+              "usr/local/pureftpd/sbin/pure-config.pl",
+              "usr/local/pureftpd/etc/pure-ftpd.conf",
+              "etc/pure-ftpd.conf",
+              "etc/pure-ftpd/pure-ftpd.pdb",
+              "etc/pureftpd.pdb",
+              "etc/pureftpd.passwd",
+              "etc/pure-ftpd/pureftpd.pdb",
+              "usr/ports/ftp/pure-ftpd/pure-ftpd.conf",
+              "usr/ports/ftp/pure-ftpd/pureftpd.pdb",
+              "usr/ports/ftp/pure-ftpd/pureftpd.passwd",
+              "usr/ports/net/pure-ftpd/pure-ftpd.conf",
+              "usr/ports/net/pure-ftpd/pureftpd.pdb",
+              "usr/ports/net/pure-ftpd/pureftpd.passwd",
+              "usr/pkgsrc/net/pureftpd/pure-ftpd.conf",
+              "usr/pkgsrc/net/pureftpd/pureftpd.pdb",
+              "usr/pkgsrc/net/pureftpd/pureftpd.passwd",
+              "usr/ports/contrib/pure-ftpd/pure-ftpd.conf",
+              "usr/ports/contrib/pure-ftpd/pureftpd.pdb",
+              "usr/ports/contrib/pure-ftpd/pureftpd.passwd",
+              "var/log/muddleftpd",
+              "usr/sbin/mudlogd",
+              "etc/muddleftpd/mudlog",
+              "etc/muddleftpd.com",
+              "etc/muddleftpd/mudlogd.conf",
+              "etc/muddleftpd/muddleftpd.conf",
+              "var/log/muddleftpd.conf",
+              "usr/sbin/mudpasswd",
+              "etc/muddleftpd/muddleftpd.passwd",
+              "etc/muddleftpd/passwd",
+              "var/log/ftp-proxy/ftp-proxy.log",
+              "var/log/ftp-proxy",
+              "var/log/ftplog",
+              "etc/logrotate.d/ftp",
+              "etc/ftpchroot",
+              "etc/ftphosts",
+              "etc/ftpusers",
+              "var/log/exim_mainlog",
+              "var/log/exim/mainlog",
+              "var/log/maillog",
+              "var/log/exim_paniclog",
+              "var/log/exim/paniclog",
+              "var/log/exim/rejectlog",
+              "var/log/exim_rejectlog",
+              "winnt/system32/logfiles/smtpsvc",
+              "winnt/system32/logfiles/smtpsvc1",
+              "winnt/system32/logfiles/smtpsvc2",
+              "winnt/system32/logfiles/smtpsvc3",
+              "winnt/system32/logfiles/smtpsvc4",
+              "winnt/system32/logfiles/smtpsvc5",
+              "windows/system32/logfiles/smtpsvc",
+              "windows/system32/logfiles/smtpsvc1",
+              "windows/system32/logfiles/smtpsvc2",
+              "windows/system32/logfiles/smtpsvc3",
+              "windows/system32/logfiles/smtpsvc4",
+              "windows/system32/logfiles/smtpsvc5",
+              "etc/osxhttpd/osxhttpd.conf",
+              "system/library/webobjects/adaptors/apache2.2/apache.conf",
+              "etc/apache2/sites-available/default",
+              "etc/apache2/sites-available/default-ssl",
+              "etc/apache2/sites-enabled/000-default",
+              "etc/apache2/sites-enabled/default",
+              "etc/apache2/apache2.conf",
+              "etc/apache2/ports.conf",
+              "usr/local/etc/apache/httpd.conf",
+              "usr/pkg/etc/httpd/httpd.conf",
+              "usr/pkg/etc/httpd/httpd-default.conf",
+              "usr/pkg/etc/httpd/httpd-vhosts.conf",
+              "etc/httpd/mod_php.conf",
+              "etc/httpd/extra/httpd-ssl.conf",
+              "etc/rc.d/rc.httpd",
+              "usr/local/apache/conf/httpd.conf.default",
+              "usr/local/apache/conf/access.conf",
+              "usr/local/apache22/conf/httpd.conf",
+              "usr/local/apache22/httpd.conf",
+              "usr/local/etc/apache22/conf/httpd.conf",
+              "usr/local/apps/apache22/conf/httpd.conf",
+              "etc/apache22/conf/httpd.conf",
+              "etc/apache22/httpd.conf",
+              "opt/apache22/conf/httpd.conf",
+              "usr/local/etc/apache2/vhosts.conf",
+              "usr/local/apache/conf/vhosts.conf",
+              "usr/local/apache2/conf/vhosts.conf",
+              "usr/local/apache/conf/vhosts-custom.conf",
+              "usr/local/apache2/conf/vhosts-custom.conf",
+              "etc/apache/default-server.conf",
+              "etc/apache2/default-server.conf",
+              "usr/local/apache2/conf/extra/httpd-ssl.conf",
+              "usr/local/apache2/conf/ssl.conf",
+              "etc/httpd/conf.d",
+              "usr/local/etc/apache22/httpd.conf",
+              "usr/local/etc/apache2/httpd.conf",
+              "etc/apache2/httpd2.conf",
+              "etc/apache2/ssl-global.conf",
+              "etc/apache2/vhosts.d/00_default_vhost.conf",
+              "apache/conf/httpd.conf",
+              "etc/apache/httpd.conf",
+              "etc/httpd/conf",
+              "http/httpd.conf",
+              "usr/local/apache1.3/conf/httpd.conf",
+              "usr/local/etc/httpd/conf",
+              "var/apache/conf/httpd.conf",
+              "var/www/conf",
+              "www/apache/conf/httpd.conf",
+              "www/conf/httpd.conf",
+              "etc/init.d",
+              "etc/apache/access.conf",
+              "etc/rc.conf",
+              "www/logs/freebsddiary-error.log",
+              "www/logs/freebsddiary-access_log",
+              "library/webserver/documents/index.html",
+              "library/webserver/documents/index.htm",
+              "library/webserver/documents/default.html",
+              "library/webserver/documents/default.htm",
+              "library/webserver/documents/index.php",
+              "library/webserver/documents/default.php",
+              "var/log/webmin/miniserv.log",
+              "usr/local/etc/webmin/miniserv.conf",
+              "etc/webmin/miniserv.conf",
+              "usr/local/etc/webmin/miniserv.users",
+              "etc/webmin/miniserv.users",
+              "winnt/system32/logfiles/w3svc/inetsvn1.log",
+              "winnt/system32/logfiles/w3svc1/inetsvn1.log",
+              "winnt/system32/logfiles/w3svc2/inetsvn1.log",
+              "winnt/system32/logfiles/w3svc3/inetsvn1.log",
+              "windows/system32/logfiles/w3svc/inetsvn1.log",
+              "windows/system32/logfiles/w3svc1/inetsvn1.log",
+              "windows/system32/logfiles/w3svc2/inetsvn1.log",
+              "windows/system32/logfiles/w3svc3/inetsvn1.log",
+              "var/log/httpd/access_log",
+              "var/log/httpd/error_log",
+              "apache/logs/error.log",
+              "apache/logs/access.log",
+              "apache2/logs/error.log",
+              "apache2/logs/access.log",
+              "logs/error.log",
+              "logs/access.log",
+              "etc/httpd/logs/access_log",
+              "etc/httpd/logs/access.log",
+              "etc/httpd/logs/error_log",
+              "etc/httpd/logs/error.log",
+              "usr/local/apache/logs/access_log",
+              "usr/local/apache/logs/access.log",
+              "usr/local/apache/logs/error_log",
+              "usr/local/apache/logs/error.log",
+              "usr/local/apache2/logs/access_log",
+              "usr/local/apache2/logs/access.log",
+              "usr/local/apache2/logs/error_log",
+              "usr/local/apache2/logs/error.log",
+              "var/www/logs/access_log",
+              "var/www/logs/access.log",
+              "var/www/logs/error_log",
+              "var/www/logs/error.log",
+              "var/log/httpd/access.log",
+              "var/log/httpd/error.log",
+              "var/log/apache/access_log",
+              "var/log/apache/access.log",
+              "var/log/apache/error_log",
+              "var/log/apache/error.log",
+              "var/log/apache2/access_log",
+              "var/log/apache2/access.log",
+              "var/log/apache2/error_log",
+              "var/log/apache2/error.log",
+              "var/log/access_log",
+              "var/log/access.log",
+              "var/log/error_log",
+              "var/log/error.log",
+              "opt/lampp/logs/access_log",
+              "opt/lampp/logs/error_log",
+              "opt/xampp/logs/access_log",
+              "opt/xampp/logs/error_log",
+              "opt/lampp/logs/access.log",
+              "opt/lampp/logs/error.log",
+              "opt/xampp/logs/access.log",
+              "opt/xampp/logs/error.log",
+              "program files/apache group/apache/logs/access.log",
+              "program files/apache group/apache/logs/error.log",
+              "program files/apache software foundation/apache2.2/logs/error.log",
+              "program files/apache software foundation/apache2.2/logs/access.log",
+              "opt/apache/apache.conf",
+              "opt/apache/conf/apache.conf",
+              "opt/apache2/apache.conf",
+              "opt/apache2/conf/apache.conf",
+              "opt/httpd/apache.conf",
+              "opt/httpd/conf/apache.conf",
+              "etc/httpd/apache.conf",
+              "etc/apache2/apache.conf",
+              "etc/httpd/conf/apache.conf",
+              "usr/local/apache/apache.conf",
+              "usr/local/apache/conf/apache.conf",
+              "usr/local/apache2/apache.conf",
+              "usr/local/apache2/conf/apache.conf",
+              "usr/local/php/apache.conf.php",
+              "usr/local/php4/apache.conf.php",
+              "usr/local/php5/apache.conf.php",
+              "usr/local/php/apache.conf",
+              "usr/local/php4/apache.conf",
+              "usr/local/php5/apache.conf",
+              "private/etc/httpd/apache.conf",
+              "opt/apache/apache2.conf",
+              "opt/apache/conf/apache2.conf",
+              "opt/apache2/apache2.conf",
+              "opt/apache2/conf/apache2.conf",
+              "opt/httpd/apache2.conf",
+              "opt/httpd/conf/apache2.conf",
+              "etc/httpd/apache2.conf",
+              "etc/httpd/conf/apache2.conf",
+              "usr/local/apache/apache2.conf",
+              "usr/local/apache/conf/apache2.conf",
+              "usr/local/apache2/apache2.conf",
+              "usr/local/apache2/conf/apache2.conf",
+              "usr/local/php/apache2.conf.php",
+              "usr/local/php4/apache2.conf.php",
+              "usr/local/php5/apache2.conf.php",
+              "usr/local/php/apache2.conf",
+              "usr/local/php4/apache2.conf",
+              "usr/local/php5/apache2.conf",
+              "private/etc/httpd/apache2.conf",
+              "usr/local/apache/conf/httpd.conf",
+              "usr/local/apache2/conf/httpd.conf",
+              "etc/httpd/conf/httpd.conf",
+              "etc/apache/apache.conf",
+              "etc/apache/conf/httpd.conf",
+              "etc/apache2/httpd.conf",
+              "usr/apache2/conf/httpd.conf",
+              "usr/apache/conf/httpd.conf",
+              "usr/local/etc/apache/conf/httpd.conf",
+              "usr/local/apache/httpd.conf",
+              "usr/local/apache2/httpd.conf",
+              "usr/local/httpd/conf/httpd.conf",
+              "usr/local/etc/apache2/conf/httpd.conf",
+              "usr/local/etc/httpd/conf/httpd.conf",
+              "usr/local/apps/apache2/conf/httpd.conf",
+              "usr/local/apps/apache/conf/httpd.conf",
+              "usr/local/php/httpd.conf.php",
+              "usr/local/php4/httpd.conf.php",
+              "usr/local/php5/httpd.conf.php",
+              "usr/local/php/httpd.conf",
+              "usr/local/php4/httpd.conf",
+              "usr/local/php5/httpd.conf",
+              "etc/apache2/conf/httpd.conf",
+              "etc/http/conf/httpd.conf",
+              "etc/httpd/httpd.conf",
+              "etc/http/httpd.conf",
+              "etc/httpd.conf",
+              "opt/apache/conf/httpd.conf",
+              "opt/apache2/conf/httpd.conf",
+              "var/www/conf/httpd.conf",
+              "private/etc/httpd/httpd.conf",
+              "private/etc/httpd/httpd.conf.default",
+              "etc/apache2/vhosts.d/default_vhost.include",
+              "etc/apache2/conf.d/charset",
+              "etc/apache2/conf.d/security",
+              "etc/apache2/envvars",
+              "etc/apache2/mods-available/autoindex.conf",
+              "etc/apache2/mods-available/deflate.conf",
+              "etc/apache2/mods-available/dir.conf",
+              "etc/apache2/mods-available/mem_cache.conf",
+              "etc/apache2/mods-available/mime.conf",
+              "etc/apache2/mods-available/proxy.conf",
+              "etc/apache2/mods-available/setenvif.conf",
+              "etc/apache2/mods-available/ssl.conf",
+              "etc/apache2/mods-enabled/alias.conf",
+              "etc/apache2/mods-enabled/deflate.conf",
+              "etc/apache2/mods-enabled/dir.conf",
+              "etc/apache2/mods-enabled/mime.conf",
+              "etc/apache2/mods-enabled/negotiation.conf",
+              "etc/apache2/mods-enabled/php5.conf",
+              "etc/apache2/mods-enabled/status.conf",
+              "program files/apache group/apache/conf/httpd.conf",
+              "program files/apache group/apache2/conf/httpd.conf",
+              "program files/xampp/apache/conf/apache.conf",
+              "program files/xampp/apache/conf/apache2.conf",
+              "program files/xampp/apache/conf/httpd.conf",
+              "program files/apache group/apache/apache.conf",
+              "program files/apache group/apache/conf/apache.conf",
+              "program files/apache group/apache2/conf/apache.conf",
+              "program files/apache group/apache/apache2.conf",
+              "program files/apache group/apache/conf/apache2.conf",
+              "program files/apache group/apache2/conf/apache2.conf",
+              "program files/apache software foundation/apache2.2/conf/httpd.conf",
+              "volumes/macintosh_hd1/opt/httpd/conf/httpd.conf",
+              "volumes/macintosh_hd1/opt/apache/conf/httpd.conf",
+              "volumes/macintosh_hd1/opt/apache2/conf/httpd.conf",
+              "volumes/macintosh_hd1/usr/local/php/httpd.conf.php",
+              "volumes/macintosh_hd1/usr/local/php4/httpd.conf.php",
+              "volumes/macintosh_hd1/usr/local/php5/httpd.conf.php",
+              "volumes/webbackup/opt/apache2/conf/httpd.conf",
+              "volumes/webbackup/private/etc/httpd/httpd.conf",
+              "volumes/webbackup/private/etc/httpd/httpd.conf.default",
+              "usr/local/etc/apache/vhosts.conf",
+              "usr/local/jakarta/tomcat/conf/jakarta.conf",
+              "usr/local/jakarta/tomcat/conf/server.xml",
+              "usr/local/jakarta/tomcat/conf/context.xml",
+              "usr/local/jakarta/tomcat/conf/workers.properties",
+              "usr/local/jakarta/tomcat/conf/logging.properties",
+              "usr/local/jakarta/dist/tomcat/conf/jakarta.conf",
+              "usr/local/jakarta/dist/tomcat/conf/server.xml",
+              "usr/local/jakarta/dist/tomcat/conf/context.xml",
+              "usr/local/jakarta/dist/tomcat/conf/workers.properties",
+              "usr/local/jakarta/dist/tomcat/conf/logging.properties",
+              "usr/share/tomcat6/conf/server.xml",
+              "usr/share/tomcat6/conf/context.xml",
+              "usr/share/tomcat6/conf/workers.properties",
+              "usr/share/tomcat6/conf/logging.properties",
+              "var/log/tomcat6/catalina.out",
+              "var/cpanel/tomcat.options",
+              "usr/local/jakarta/tomcat/logs/catalina.out",
+              "usr/local/jakarta/tomcat/logs/catalina.err",
+              "opt/tomcat/logs/catalina.out",
+              "opt/tomcat/logs/catalina.err",
+              "usr/share/logs/catalina.out",
+              "usr/share/logs/catalina.err",
+              "usr/share/tomcat/logs/catalina.out",
+              "usr/share/tomcat/logs/catalina.err",
+              "usr/share/tomcat6/logs/catalina.out",
+              "usr/share/tomcat6/logs/catalina.err",
+              "usr/local/apache/logs/mod_jk.log",
+              "usr/local/jakarta/tomcat/logs/mod_jk.log",
+              "usr/local/jakarta/dist/tomcat/logs/mod_jk.log",
+              "opt/[jboss]/server/default/conf/jboss-minimal.xml",
+              "opt/[jboss]/server/default/conf/jboss-service.xml",
+              "opt/[jboss]/server/default/conf/jndi.properties",
+              "opt/[jboss]/server/default/conf/log4j.xml",
+              "opt/[jboss]/server/default/conf/login-config.xml",
+              "opt/[jboss]/server/default/conf/standardjaws.xml",
+              "opt/[jboss]/server/default/conf/standardjboss.xml",
+              "opt/[jboss]/server/default/conf/server.log.properties",
+              "opt/[jboss]/server/default/deploy/jboss-logging.xml",
+              "usr/local/[jboss]/server/default/conf/jboss-minimal.xml",
+              "usr/local/[jboss]/server/default/conf/jboss-service.xml",
+              "usr/local/[jboss]/server/default/conf/jndi.properties",
+              "usr/local/[jboss]/server/default/conf/log4j.xml",
+              "usr/local/[jboss]/server/default/conf/login-config.xml",
+              "usr/local/[jboss]/server/default/conf/standardjaws.xml",
+              "usr/local/[jboss]/server/default/conf/standardjboss.xml",
+              "usr/local/[jboss]/server/default/conf/server.log.properties",
+              "usr/local/[jboss]/server/default/deploy/jboss-logging.xml",
+              "private/tmp/[jboss]/server/default/conf/jboss-minimal.xml",
+              "private/tmp/[jboss]/server/default/conf/jboss-service.xml",
+              "private/tmp/[jboss]/server/default/conf/jndi.properties",
+              "private/tmp/[jboss]/server/default/conf/log4j.xml",
+              "private/tmp/[jboss]/server/default/conf/login-config.xml",
+              "private/tmp/[jboss]/server/default/conf/standardjaws.xml",
+              "private/tmp/[jboss]/server/default/conf/standardjboss.xml",
+              "private/tmp/[jboss]/server/default/conf/server.log.properties",
+              "private/tmp/[jboss]/server/default/deploy/jboss-logging.xml",
+              "tmp/[jboss]/server/default/conf/jboss-minimal.xml",
+              "tmp/[jboss]/server/default/conf/jboss-service.xml",
+              "tmp/[jboss]/server/default/conf/jndi.properties",
+              "tmp/[jboss]/server/default/conf/log4j.xml",
+              "tmp/[jboss]/server/default/conf/login-config.xml",
+              "tmp/[jboss]/server/default/conf/standardjaws.xml",
+              "tmp/[jboss]/server/default/conf/standardjboss.xml",
+              "tmp/[jboss]/server/default/conf/server.log.properties",
+              "tmp/[jboss]/server/default/deploy/jboss-logging.xml",
+              "program files/[jboss]/server/default/conf/jboss-minimal.xml",
+              "program files/[jboss]/server/default/conf/jboss-service.xml",
+              "program files/[jboss]/server/default/conf/jndi.properties",
+              "program files/[jboss]/server/default/conf/log4j.xml",
+              "program files/[jboss]/server/default/conf/login-config.xml",
+              "program files/[jboss]/server/default/conf/standardjaws.xml",
+              "program files/[jboss]/server/default/conf/standardjboss.xml",
+              "program files/[jboss]/server/default/conf/server.log.properties",
+              "program files/[jboss]/server/default/deploy/jboss-logging.xml",
+              "[jboss]/server/default/conf/jboss-minimal.xml",
+              "[jboss]/server/default/conf/jboss-service.xml",
+              "[jboss]/server/default/conf/jndi.properties",
+              "[jboss]/server/default/conf/log4j.xml",
+              "[jboss]/server/default/conf/login-config.xml",
+              "[jboss]/server/default/conf/standardjaws.xml",
+              "[jboss]/server/default/conf/standardjboss.xml",
+              "[jboss]/server/default/conf/server.log.properties",
+              "[jboss]/server/default/deploy/jboss-logging.xml",
+              "opt/[jboss]/server/default/log/server.log",
+              "opt/[jboss]/server/default/log/boot.log",
+              "usr/local/[jboss]/server/default/log/server.log",
+              "usr/local/[jboss]/server/default/log/boot.log",
+              "private/tmp/[jboss]/server/default/log/server.log",
+              "private/tmp/[jboss]/server/default/log/boot.log",
+              "tmp/[jboss]/server/default/log/server.log",
+              "tmp/[jboss]/server/default/log/boot.log",
+              "program files/[jboss]/server/default/log/server.log",
+              "program files/[jboss]/server/default/log/boot.log",
+              "[jboss]/server/default/log/server.log",
+              "[jboss]/server/default/log/boot.log",
+              "var/log/lighttpd.error.log",
+              "var/log/lighttpd.access.log",
+              "var/lighttpd.log",
+              "var/logs/access.log",
+              "var/log/lighttpd/",
+              "var/log/lighttpd/error.log",
+              "var/log/lighttpd/access.www.log",
+              "var/log/lighttpd/error.www.log",
+              "var/log/lighttpd/access.log",
+              "usr/local/apache2/logs/lighttpd.error.log",
+              "usr/local/apache2/logs/lighttpd.log",
+              "usr/local/apache/logs/lighttpd.error.log",
+              "usr/local/apache/logs/lighttpd.log",
+              "usr/local/lighttpd/log/lighttpd.error.log",
+              "usr/local/lighttpd/log/access.log",
+              "var/log/lighttpd/{domain}/access.log",
+              "var/log/lighttpd/{domain}/error.log",
+              "usr/home/user/var/log/lighttpd.error.log",
+              "usr/home/user/var/log/apache.log",
+              "home/user/lighttpd/lighttpd.conf",
+              "usr/home/user/lighttpd/lighttpd.conf",
+              "etc/lighttpd/lighthttpd.conf",
+              "usr/local/etc/lighttpd.conf",
+              "usr/local/lighttpd/conf/lighttpd.conf",
+              "usr/local/etc/lighttpd.conf.new",
+              "var/www/.lighttpdpassword",
+              "var/log/nginx/access_log",
+              "var/log/nginx/error_log",
+              "var/log/nginx/access.log",
+              "var/log/nginx/error.log",
+              "var/log/nginx.access_log",
+              "var/log/nginx.error_log",
+              "logs/access_log",
+              "logs/error_log",
+              "etc/nginx/nginx.conf",
+              "usr/local/etc/nginx/nginx.conf",
+              "usr/local/nginx/conf/nginx.conf",
+              "usr/local/zeus/web/global.cfg",
+              "usr/local/zeus/web/log/errors",
+              "opt/lsws/conf/httpd_conf.xml",
+              "usr/local/lsws/conf/httpd_conf.xml",
+              "opt/lsws/logs/error.log",
+              "opt/lsws/logs/access.log",
+              "usr/local/lsws/logs/error.log",
+              "usr/local/logs/access.log",
+              "usr/local/samba/lib/log.user",
+              "usr/local/logs/samba.log",
+              "var/log/samba/log.smbd",
+              "var/log/samba/log.nmbd",
+              "var/log/samba.log",
+              "var/log/samba.log1",
+              "var/log/samba.log2",
+              "var/log/log.smb",
+              "etc/samba/netlogon",
+              "etc/smbpasswd",
+              "etc/smb.conf",
+              "etc/samba/dhcp.conf",
+              "etc/samba/smb.conf",
+              "etc/samba/samba.conf",
+              "etc/samba/smb.conf.user",
+              "etc/samba/smbpasswd",
+              "etc/samba/smbusers",
+              "etc/samba/private/smbpasswd",
+              "usr/local/etc/smb.conf",
+              "usr/local/samba/lib/smb.conf.user",
+              "etc/dhcp3/dhclient.conf",
+              "etc/dhcp3/dhcpd.conf",
+              "etc/dhcp/dhclient.conf",
+              "program files/vidalia bundle/polipo/polipo.conf",
+              "etc/tor/tor-tsocks.conf",
+              "etc/stunnel/stunnel.conf",
+              "etc/tsocks.conf",
+              "etc/tinyproxy/tinyproxy.conf",
+              "etc/miredo-server.conf",
+              "etc/miredo.conf",
+              "etc/miredo/miredo-server.conf",
+              "etc/miredo/miredo.conf",
+              "etc/wicd/dhclient.conf.template.default",
+              "etc/wicd/manager-settings.conf",
+              "etc/wicd/wired-settings.conf",
+              "etc/wicd/wireless-settings.conf",
+              "var/log/ipfw.log",
+              "var/log/ipfw",
+              "var/log/ipfw/ipfw.log",
+              "var/log/ipfw.today",
+              "etc/ipfw.rules",
+              "etc/ipfw.conf",
+              "etc/firewall.rules",
+              "winnt/system32/logfiles/firewall/pfirewall.log",
+              "winnt/system32/logfiles/firewall/pfirewall.log.old",
+              "windows/system32/logfiles/firewall/pfirewall.log",
+              "windows/system32/logfiles/firewall/pfirewall.log.old",
+              "etc/clamav/clamd.conf",
+              "etc/clamav/freshclam.conf",
+              "etc/x11/xorg.conf",
+              "etc/x11/xorg.conf-vesa",
+              "etc/x11/xorg.conf-vmware",
+              "etc/x11/xorg.conf.beforevmwaretoolsinstall",
+              "etc/x11/xorg.conf.orig",
+              "etc/bluetooth/input.conf",
+              "etc/bluetooth/main.conf",
+              "etc/bluetooth/network.conf",
+              "etc/bluetooth/rfcomm.conf",
+              "proc/self/environ",
+              "proc/self/mounts",
+              "proc/self/stat",
+              "proc/self/status",
+              "proc/self/cmdline",
+              "proc/self/fd/0",
+              "proc/self/fd/1",
+              "proc/self/fd/2",
+              "proc/self/fd/3",
+              "proc/self/fd/4",
+              "proc/self/fd/5",
+              "proc/self/fd/6",
+              "proc/self/fd/7",
+              "proc/self/fd/8",
+              "proc/self/fd/9",
+              "proc/self/fd/10",
+              "proc/self/fd/11",
+              "proc/self/fd/12",
+              "proc/self/fd/13",
+              "proc/self/fd/14",
+              "proc/self/fd/15",
+              "proc/version",
+              "proc/devices",
+              "proc/cpuinfo",
+              "proc/meminfo",
+              "proc/net/tcp",
+              "proc/net/udp",
+              "etc/bash_completion.d/debconf",
+              "root/.bash_logout",
+              "root/.bash_history",
+              "root/.bash_config",
+              "root/.bashrc",
+              "etc/bash.bashrc",
+              "var/adm/syslog",
+              "var/adm/sulog",
+              "var/adm/utmp",
+              "var/adm/utmpx",
+              "var/adm/wtmp",
+              "var/adm/wtmpx",
+              "var/adm/lastlog/username",
+              "usr/spool/lp/log",
+              "var/adm/lp/lpd-errs",
+              "usr/lib/cron/log",
+              "var/adm/loginlog",
+              "var/adm/pacct",
+              "var/adm/dtmp",
+              "var/adm/acct/sum/loginlog",
+              "var/adm/x0msgs",
+              "var/adm/crash/vmcore",
+              "var/adm/crash/unix",
+              "etc/newsyslog.conf",
+              "var/adm/qacct",
+              "var/adm/ras/errlog",
+              "var/adm/ras/bootlog",
+              "var/adm/cron/log",
+              "etc/utmp",
+              "etc/security/lastlog",
+              "etc/security/failedlogin",
+              "usr/spool/mqueue/syslog",
+              "var/adm/messages",
+              "var/adm/aculogs",
+              "var/adm/aculog",
+              "var/adm/vold.log",
+              "var/adm/log/asppp.log",
+              "var/log/poplog",
+              "var/log/authlog",
+              "var/lp/logs/lpsched",
+              "var/lp/logs/lpnet",
+              "var/lp/logs/requests",
+              "var/cron/log",
+              "var/saf/_log",
+              "var/saf/port/log",
+              "var/log/news.all",
+              "var/log/news/news.all",
+              "var/log/news/news.crit",
+              "var/log/news/news.err",
+              "var/log/news/news.notice",
+              "var/log/news/suck.err",
+              "var/log/news/suck.notice",
+              "var/log/messages",
+              "var/log/messages.1",
+              "var/log/user.log",
+              "var/log/user.log.1",
+              "var/log/auth.log",
+              "var/log/pm-powersave.log",
+              "var/log/xorg.0.log",
+              "var/log/daemon.log",
+              "var/log/daemon.log.1",
+              "var/log/kern.log",
+              "var/log/kern.log.1",
+              "var/log/mail.err",
+              "var/log/mail.info",
+              "var/log/mail.warn",
+              "var/log/ufw.log",
+              "var/log/boot.log",
+              "var/log/syslog",
+              "var/log/syslog.1",
+              "tmp/access.log",
+              "etc/sensors.conf",
+              "etc/sensors3.conf",
+              "etc/host.conf",
+              "etc/pam.conf",
+              "etc/resolv.conf",
+              "etc/apt/apt.conf",
+              "etc/inetd.conf",
+              "etc/syslog.conf",
+              "etc/sysctl.conf",
+              "etc/sysctl.d/10-console-messages.conf",
+              "etc/sysctl.d/10-network-security.conf",
+              "etc/sysctl.d/10-process-security.conf",
+              "etc/sysctl.d/wine.sysctl.conf",
+              "etc/security/access.conf",
+              "etc/security/group.conf",
+              "etc/security/limits.conf",
+              "etc/security/namespace.conf",
+              "etc/security/pam_env.conf",
+              "etc/security/sepermit.conf",
+              "etc/security/time.conf",
+              "etc/ssh/sshd_config",
+              "etc/adduser.conf",
+              "etc/deluser.conf",
+              "etc/avahi/avahi-daemon.conf",
+              "etc/ca-certificates.conf",
+              "etc/ca-certificates.conf.dpkg-old",
+              "etc/casper.conf",
+              "etc/chkrootkit.conf",
+              "etc/debconf.conf",
+              "etc/dns2tcpd.conf",
+              "etc/e2fsck.conf",
+              "etc/esound/esd.conf",
+              "etc/etter.conf",
+              "etc/fuse.conf",
+              "etc/foremost.conf",
+              "etc/hdparm.conf",
+              "etc/kernel-img.conf",
+              "etc/kernel-pkg.conf",
+              "etc/ld.so.conf",
+              "etc/ltrace.conf",
+              "etc/mail/sendmail.conf",
+              "etc/manpath.config",
+              "etc/kbd/config",
+              "etc/ldap/ldap.conf",
+              "etc/logrotate.conf",
+              "etc/mtools.conf",
+              "etc/smi.conf",
+              "etc/updatedb.conf",
+              "etc/pulse/client.conf",
+              "usr/share/adduser/adduser.conf",
+              "etc/hostname",
+              "etc/networks",
+              "etc/timezone",
+              "etc/modules",
+              "etc/passwd",
+              "etc/passwd~",
+              "etc/passwd-",
+              "etc/shadow",
+              "etc/shadow~",
+              "etc/shadow-",
+              "etc/fstab",
+              "etc/motd",
+              "etc/hosts",
+              "etc/group",
+              "etc/group-",
+              "etc/alias",
+              "etc/crontab",
+              "etc/crypttab",
+              "etc/exports",
+              "etc/mtab",
+              "etc/hosts.allow",
+              "etc/hosts.deny",
+              "etc/os-release",
+              "etc/password.master",
+              "etc/profile",
+              "etc/default/grub",
+              "etc/resolvconf/update-libc.d/sendmail",
+              "etc/inittab",
+              "etc/issue",
+              "etc/issue.net",
+              "etc/login.defs",
+              "etc/sudoers",
+              "etc/sysconfig/network-scripts/ifcfg-eth0",
+              "etc/redhat-release",
+              "etc/debian_version",
+              "etc/fedora-release",
+              "etc/mandrake-release",
+              "etc/slackware-release",
+              "etc/suse-release",
+              "etc/security/group",
+              "etc/security/passwd",
+              "etc/security/user",
+              "etc/security/environ",
+              "etc/security/limits",
+              "etc/security/opasswd",
+              "boot/grub/grub.cfg",
+              "boot/grub/menu.lst",
+              "root/.ksh_history",
+              "root/.xauthority",
+              "usr/lib/security/mkuser.default",
+              "var/log/squirrelmail.log",
+              "var/log/apache2/squirrelmail.log",
+              "var/log/apache2/squirrelmail.err.log",
+              "var/lib/squirrelmail/prefs/squirrelmail.log",
+              "var/log/mail.log",
+              "etc/squirrelmail/apache.conf",
+              "etc/squirrelmail/config_local.php",
+              "etc/squirrelmail/default_pref",
+              "etc/squirrelmail/index.php",
+              "etc/squirrelmail/config_default.php",
+              "etc/squirrelmail/config.php",
+              "etc/squirrelmail/filters_setup.php",
+              "etc/squirrelmail/sqspell_config.php",
+              "etc/squirrelmail/config/config.php",
+              "etc/httpd/conf.d/squirrelmail.conf",
+              "usr/share/squirrelmail/config/config.php",
+              "private/etc/squirrelmail/config/config.php",
+              "srv/www/htdos/squirrelmail/config/config.php",
+              "var/www/squirrelmail/config/config.php",
+              "var/www/html/squirrelmail/config/config.php",
+              "var/www/html/squirrelmail-1.2.9/config/config.php",
+              "usr/share/squirrelmail/plugins/squirrel_logger/setup.php",
+              "usr/local/squirrelmail/www/readme",
+              "windows/system32/drivers/etc/hosts",
+              "windows/system32/drivers/etc/lmhosts.sam",
+              "windows/system32/drivers/etc/networks",
+              "windows/system32/drivers/etc/protocol",
+              "windows/system32/drivers/etc/services",
+              "/boot.ini",
+              "windows/debug/netsetup.log",
+              "windows/comsetup.log",
+              "windows/repair/setup.log",
+              "windows/setupact.log",
+              "windows/setupapi.log",
+              "windows/setuperr.log",
+              "windows/updspapi.log",
+              "windows/wmsetup.log",
+              "windows/windowsupdate.log",
+              "windows/odbc.ini",
+              "usr/local/psa/admin/htdocs/domains/databases/phpmyadmin/libraries/config.default.php",
+              "etc/apache2/conf.d/phpmyadmin.conf",
+              "etc/phpmyadmin/config.inc.php",
+              "etc/openldap/ldap.conf",
+              "etc/cups/acroread.conf",
+              "etc/cups/cupsd.conf",
+              "etc/cups/cupsd.conf.default",
+              "etc/cups/pdftops.conf",
+              "etc/cups/printers.conf",
+              "windows/system32/macromed/flash/flashinstall.log",
+              "windows/system32/macromed/flash/install.log",
+              "etc/cvs-cron.conf",
+              "etc/cvs-pserver.conf",
+              "etc/subversion/config",
+              "etc/modprobe.d/vmware-tools.conf",
+              "etc/updatedb.conf.beforevmwaretoolsinstall",
+              "etc/vmware-tools/config",
+              "etc/vmware-tools/tpvmlp.conf",
+              "etc/vmware-tools/vmware-tools-libraries.conf",
+              "var/log/vmware/hostd.log",
+              "var/log/vmware/hostd-1.log",
+              "wp-config.php",
+              "wp-config.bak",
+              "wp-config.old",
+              "wp-config.temp",
+              "wp-config.tmp",
+              "wp-config.txt",
+              "config.yml",
+              "config_dev.yml",
+              "config_prod.yml",
+              "config_test.yml",
+              "parameters.yml",
+              "routing.yml",
+              "security.yml",
+              "services.yml",
+              "sites/default/default.settings.php",
+              "sites/default/settings.php",
+              "sites/default/settings.local.php",
+              "app/etc/local.xml",
+              "sftp-config.json",
+              "web.config",
+              "includes/config.php",
+              "includes/configure.php",
+              "config.inc.php",
+              "localsettings.php",
+              "inc/config.php",
+              "typo3conf/localconf.php",
+              "config/app.php",
+              "config/custom.php",
+              "config/database.php",
+              "/configuration.php",
+              "/config.php",
+              "var/mail/www-data",
+              "etc/network/",
+              "etc/init/",
+              "inetpub/wwwroot/global.asa",
+              "system32/inetsrv/config/applicationhost.config",
+              "system32/inetsrv/config/administration.config",
+              "system32/inetsrv/config/redirection.config",
+              "system32/config/default",
+              "system32/config/sam",
+              "system32/config/system",
+              "system32/config/software",
+              "winnt/repair/sam._",
+              "package.json",
+              "package-lock.json",
+              "gruntfile.js",
+              "npm-debug.log",
+              "ormconfig.json",
+              "tsconfig.json",
+              "webpack.config.js",
+              "yarn.lock"
+            ]
+          },
+          "operator": "phrase_match"
+        }
+      ],
+      "transformers": [
+        "lowercase"
+      ]
+    },
+    {
+      "id": "crs-931-110",
+      "name": "Possible Remote File Inclusion (RFI) Attack: Common RFI Vulnerable Parameter Name used w/URL Payload",
+      "tags": {
+        "type": "rfi",
+        "crs_id": "931110",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              }
+            ],
+            "regex": "(?:\\binclude\\s*\\([^)]*|mosConfig_absolute_path|_CONF\\[path\\]|_SERVER\\[DOCUMENT_ROOT\\]|GALLERY_BASEDIR|path\\[docroot\\]|appserv_root|config\\[root_dir\\])=(?:file|ftps?|https?)://",
+            "options": {
+              "min_length": 15
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-931-120",
+      "name": "Possible Remote File Inclusion (RFI) Attack: URL Payload Used w/Trailing Question Mark Character (?)",
+      "tags": {
+        "type": "rfi",
+        "crs_id": "931120",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "^(?i:file|ftps?|https?).*?\\?+$",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 4
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-932-160",
+      "name": "Remote Command Execution: Unix Shell Code Found",
+      "tags": {
+        "type": "command_injection",
+        "crs_id": "932160",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "list": [
+              "${cdpath}",
+              "${dirstack}",
+              "${home}",
+              "${hostname}",
+              "${ifs}",
+              "${oldpwd}",
+              "${ostype}",
+              "${path}",
+              "${pwd}",
+              "$cdpath",
+              "$dirstack",
+              "$home",
+              "$hostname",
+              "$ifs",
+              "$oldpwd",
+              "$ostype",
+              "$path",
+              "$pwd",
+              "bin/bash",
+              "bin/cat",
+              "bin/csh",
+              "bin/dash",
+              "bin/du",
+              "bin/echo",
+              "bin/grep",
+              "bin/less",
+              "bin/ls",
+              "bin/mknod",
+              "bin/more",
+              "bin/nc",
+              "bin/ps",
+              "bin/rbash",
+              "bin/sh",
+              "bin/sleep",
+              "bin/su",
+              "bin/tcsh",
+              "bin/uname",
+              "dev/fd/",
+              "dev/null",
+              "dev/stderr",
+              "dev/stdin",
+              "dev/stdout",
+              "dev/tcp/",
+              "dev/udp/",
+              "dev/zero",
+              "etc/group",
+              "etc/master.passwd",
+              "etc/passwd",
+              "etc/pwd.db",
+              "etc/shadow",
+              "etc/shells",
+              "etc/spwd.db",
+              "proc/self/",
+              "usr/bin/awk",
+              "usr/bin/base64",
+              "usr/bin/cat",
+              "usr/bin/cc",
+              "usr/bin/clang",
+              "usr/bin/clang++",
+              "usr/bin/curl",
+              "usr/bin/diff",
+              "usr/bin/env",
+              "usr/bin/fetch",
+              "usr/bin/file",
+              "usr/bin/find",
+              "usr/bin/ftp",
+              "usr/bin/gawk",
+              "usr/bin/gcc",
+              "usr/bin/head",
+              "usr/bin/hexdump",
+              "usr/bin/id",
+              "usr/bin/less",
+              "usr/bin/ln",
+              "usr/bin/mkfifo",
+              "usr/bin/more",
+              "usr/bin/nc",
+              "usr/bin/ncat",
+              "usr/bin/nice",
+              "usr/bin/nmap",
+              "usr/bin/perl",
+              "usr/bin/php",
+              "usr/bin/php5",
+              "usr/bin/php7",
+              "usr/bin/php-cgi",
+              "usr/bin/printf",
+              "usr/bin/psed",
+              "usr/bin/python",
+              "usr/bin/python2",
+              "usr/bin/python3",
+              "usr/bin/ruby",
+              "usr/bin/sed",
+              "usr/bin/socat",
+              "usr/bin/tail",
+              "usr/bin/tee",
+              "usr/bin/telnet",
+              "usr/bin/top",
+              "usr/bin/uname",
+              "usr/bin/wget",
+              "usr/bin/who",
+              "usr/bin/whoami",
+              "usr/bin/xargs",
+              "usr/bin/xxd",
+              "usr/bin/yes",
+              "usr/local/bin/bash",
+              "usr/local/bin/curl",
+              "usr/local/bin/ncat",
+              "usr/local/bin/nmap",
+              "usr/local/bin/perl",
+              "usr/local/bin/php",
+              "usr/local/bin/python",
+              "usr/local/bin/python2",
+              "usr/local/bin/python3",
+              "usr/local/bin/rbash",
+              "usr/local/bin/ruby",
+              "usr/local/bin/wget"
+            ]
+          },
+          "operator": "phrase_match"
+        }
+      ],
+      "transformers": [
+        "lowercase"
+      ]
+    },
+    {
+      "id": "crs-932-171",
+      "name": "Remote Command Execution: Shellshock (CVE-2014-6271)",
+      "tags": {
+        "type": "command_injection",
+        "crs_id": "932171",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "regex": "^\\(\\s*\\)\\s+{",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 4
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-932-180",
+      "name": "Restricted File Upload Attempt",
+      "tags": {
+        "type": "command_injection",
+        "crs_id": "932180",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "x-filename",
+                  "x_filename",
+                  "x-file-name"
+                ]
+              }
+            ],
+            "list": [
+              ".htaccess",
+              ".htdigest",
+              ".htpasswd",
+              "wp-config.php",
+              "config.yml",
+              "config_dev.yml",
+              "config_prod.yml",
+              "config_test.yml",
+              "parameters.yml",
+              "routing.yml",
+              "security.yml",
+              "services.yml",
+              "default.settings.php",
+              "settings.php",
+              "settings.local.php",
+              "local.xml",
+              ".env"
+            ]
+          },
+          "operator": "phrase_match"
+        }
+      ],
+      "transformers": [
+        "lowercase"
+      ]
+    },
+    {
+      "id": "crs-933-111",
+      "name": "PHP Injection Attack: PHP Script File Upload Found",
+      "tags": {
+        "type": "unrestricted_file_upload",
+        "crs_id": "933111",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "x-filename",
+                  "x_filename",
+                  "x.filename",
+                  "x-file-name"
+                ]
+              }
+            ],
+            "regex": ".*\\.(?:php\\d*|phtml)\\..*$",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 5
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "lowercase"
+      ]
+    },
+    {
+      "id": "crs-933-130",
+      "name": "PHP Injection Attack: Global Variables Found",
+      "tags": {
+        "type": "php_code_injection",
+        "crs_id": "933130",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "list": [
+              "$globals",
+              "$http_cookie_vars",
+              "$http_env_vars",
+              "$http_get_vars",
+              "$http_post_files",
+              "$http_post_vars",
+              "$http_raw_post_data",
+              "$http_request_vars",
+              "$http_server_vars",
+              "$_cookie",
+              "$_env",
+              "$_files",
+              "$_get",
+              "$_post",
+              "$_request",
+              "$_server",
+              "$_session",
+              "$argc",
+              "$argv"
+            ]
+          },
+          "operator": "phrase_match"
+        }
+      ],
+      "transformers": [
+        "lowercase"
+      ]
+    },
+    {
+      "id": "crs-933-131",
+      "name": "PHP Injection Attack: HTTP Headers Values Found",
+      "tags": {
+        "type": "php_code_injection",
+        "crs_id": "933131",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "(?:HTTP_(?:ACCEPT(?:_(?:ENCODING|LANGUAGE|CHARSET))?|(?:X_FORWARDED_FO|REFERE)R|(?:USER_AGEN|HOS)T|CONNECTION|KEEP_ALIVE)|PATH_(?:TRANSLATED|INFO)|ORIG_PATH_INFO|QUERY_STRING|REQUEST_URI|AUTH_TYPE)",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 9
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-933-140",
+      "name": "PHP Injection Attack: I/O Stream Found",
+      "tags": {
+        "type": "php_code_injection",
+        "crs_id": "933140",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "php://(?:std(?:in|out|err)|(?:in|out)put|fd|memory|temp|filter)",
+            "options": {
+              "min_length": 8
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-933-150",
+      "name": "PHP Injection Attack: High-Risk PHP Function Name Found",
+      "tags": {
+        "type": "php_code_injection",
+        "crs_id": "933150",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "list": [
+              "__halt_compiler",
+              "apache_child_terminate",
+              "base64_decode",
+              "bzdecompress",
+              "call_user_func",
+              "call_user_func_array",
+              "call_user_method",
+              "call_user_method_array",
+              "convert_uudecode",
+              "file_get_contents",
+              "file_put_contents",
+              "fsockopen",
+              "get_class_methods",
+              "get_class_vars",
+              "get_defined_constants",
+              "get_defined_functions",
+              "get_defined_vars",
+              "gzdecode",
+              "gzinflate",
+              "gzuncompress",
+              "include_once",
+              "invokeargs",
+              "pcntl_exec",
+              "pcntl_fork",
+              "pfsockopen",
+              "posix_getcwd",
+              "posix_getpwuid",
+              "posix_getuid",
+              "posix_uname",
+              "reflectionfunction",
+              "require_once",
+              "shell_exec",
+              "str_rot13",
+              "sys_get_temp_dir",
+              "wp_remote_fopen",
+              "wp_remote_get",
+              "wp_remote_head",
+              "wp_remote_post",
+              "wp_remote_request",
+              "wp_safe_remote_get",
+              "wp_safe_remote_head",
+              "wp_safe_remote_post",
+              "wp_safe_remote_request",
+              "zlib_decode"
+            ]
+          },
+          "operator": "phrase_match"
+        }
+      ],
+      "transformers": [
+        "lowercase"
+      ]
+    },
+    {
+      "id": "crs-933-160",
+      "name": "PHP Injection Attack: High-Risk PHP Function Call Found",
+      "tags": {
+        "type": "php_code_injection",
+        "crs_id": "933160",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "\\b(?:s(?:e(?:t(?:_(?:e(?:xception|rror)_handler|magic_quotes_runtime|include_path)|defaultstub)|ssion_s(?:et_save_handler|tart))|qlite_(?:(?:(?:unbuffered|single|array)_)?query|create_(?:aggregate|function)|p?open|exec)|tr(?:eam_(?:context_create|socket_client)|ipc?slashes|rev)|implexml_load_(?:string|file)|ocket_c(?:onnect|reate)|h(?:ow_sourc|a1_fil)e|pl_autoload_register|ystem)|p(?:r(?:eg_(?:replace(?:_callback(?:_array)?)?|match(?:_all)?|split)|oc_(?:(?:terminat|clos|nic)e|get_status|open)|int_r)|o(?:six_(?:get(?:(?:e[gu]|g)id|login|pwnam)|mk(?:fifo|nod)|ttyname|kill)|pen)|hp(?:_(?:strip_whitespac|unam)e|version|info)|g_(?:(?:execut|prepar)e|connect|query)|a(?:rse_(?:ini_file|str)|ssthru)|utenv)|r(?:unkit_(?:function_(?:re(?:defin|nam)e|copy|add)|method_(?:re(?:defin|nam)e|copy|add)|constant_(?:redefine|add))|e(?:(?:gister_(?:shutdown|tick)|name)_function|ad(?:(?:gz)?file|_exif_data|dir))|awurl(?:de|en)code)|i(?:mage(?:createfrom(?:(?:jpe|pn)g|x[bp]m|wbmp|gif)|(?:jpe|pn)g|g(?:d2?|if)|2?wbmp|xbm)|s_(?:(?:(?:execut|write?|read)ab|fi)le|dir)|ni_(?:get(?:_all)?|set)|terator_apply|ptcembed)|g(?:et(?:_(?:c(?:urrent_use|fg_va)r|meta_tags)|my(?:[gpu]id|inode)|(?:lastmo|cw)d|imagesize|env)|z(?:(?:(?:defla|wri)t|encod|fil)e|compress|open|read)|lob)|a(?:rray_(?:u(?:intersect(?:_u?assoc)?|diff(?:_u?assoc)?)|intersect_u(?:assoc|key)|diff_u(?:assoc|key)|filter|reduce|map)|ssert(?:_options)?)|h(?:tml(?:specialchars(?:_decode)?|_entity_decode|entities)|(?:ash(?:_(?:update|hmac))?|ighlight)_file|e(?:ader_register_callback|x2bin))|f(?:i(?:le(?:(?:[acm]tim|inod)e|(?:_exist|perm)s|group)?|nfo_open)|tp_(?:nb_(?:ge|pu)|connec|ge|pu)t|(?:unction_exis|pu)ts|write|open)|o(?:b_(?:get_(?:c(?:ontents|lean)|flush)|end_(?:clean|flush)|clean|flush|start)|dbc_(?:result(?:_all)?|exec(?:ute)?|connect)|pendir)|m(?:b_(?:ereg(?:_(?:replace(?:_callback)?|match)|i(?:_replace)?)?|parse_str)|(?:ove_uploaded|d5)_file|ethod_exists|ysql_query|kdir)|e(?:x(?:if_(?:t(?:humbnail|agname)|imagetype|read_data)|ec)|scapeshell(?:arg|cmd)|rror_reporting|val)|c(?:url_(?:file_create|exec|init)|onvert_uuencode|reate_function|hr)|u(?:n(?:serialize|pack)|rl(?:de|en)code|[ak]?sort)|(?:json_(?:de|en)cod|debug_backtrac|tmpfil)e|b(?:(?:son_(?:de|en)|ase64_en)code|zopen)|var_dump)(?:\\s|/\\*.*\\*/|//.*|#.*)*\\(.*\\)",
+            "options": {
+              "min_length": 5
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-933-170",
+      "name": "PHP Injection Attack: Serialized Object Injection",
+      "tags": {
+        "type": "php_code_injection",
+        "crs_id": "933170",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "[oOcC]:\\d+:\\\".+?\\\":\\d+:{[\\W\\w]*}",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 12
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-933-200",
+      "name": "PHP Injection Attack: Wrapper scheme detected",
+      "tags": {
+        "type": "php_code_injection",
+        "crs_id": "933200",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "(?i:zlib|glob|phar|ssh2|rar|ogg|expect|zip)://",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 6
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "removeNulls"
+      ]
+    },
+    {
+      "id": "crs-934-100",
+      "name": "Node.js Injection Attack",
+      "tags": {
+        "type": "js_code_injection",
+        "crs_id": "934100",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "(?:(?:_(?:\\$\\$ND_FUNC\\$\\$_|_js_function)|(?:new\\s+Function|\\beval)\\s*\\(|String\\s*\\.\\s*fromCharCode|function\\s*\\(\\s*\\)\\s*{|this\\.constructor)|module\\.exports\\s*=)",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 5
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-941-100",
+      "name": "XSS Attack Detected via libinjection",
+      "tags": {
+        "type": "xss",
+        "crs_id": "941100",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent",
+                  "referer"
+                ]
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ]
+          },
+          "operator": "is_xss"
+        }
+      ],
+      "transformers": [
+        "removeNulls"
+      ]
+    },
+    {
+      "id": "crs-941-110",
+      "name": "XSS Filter - Category 1: Script Tag Vector",
+      "tags": {
+        "type": "xss",
+        "crs_id": "941110",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent",
+                  "referer"
+                ]
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "<script[^>]*>[\\s\\S]*?",
+            "options": {
+              "min_length": 8
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "removeNulls"
+      ]
+    },
+    {
+      "id": "crs-941-120",
+      "name": "XSS Filter - Category 2: Event Handler Vector",
+      "tags": {
+        "type": "xss",
+        "crs_id": "941120",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent",
+                  "referer"
+                ]
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "[\\s\\\"'`;\\/0-9=\\x0B\\x09\\x0C\\x3B\\x2C\\x28\\x3B]on[a-zA-Z]{3,25}[\\s\\x0B\\x09\\x0C\\x3B\\x2C\\x28\\x3B]*?=[^=]",
+            "options": {
+              "min_length": 8
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "removeNulls"
+      ]
+    },
+    {
+      "id": "crs-941-140",
+      "name": "XSS Filter - Category 4: Javascript URI Vector",
+      "tags": {
+        "type": "xss",
+        "crs_id": "941140",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent",
+                  "referer"
+                ]
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "[a-z]+=(?:[^:=]+:.+;)*?[^:=]+:url\\(javascript",
+            "options": {
+              "min_length": 18
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "removeNulls"
+      ]
+    },
+    {
+      "id": "crs-941-180",
+      "name": "Node-Validator Deny List Keywords",
+      "tags": {
+        "type": "xss",
+        "crs_id": "941180",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "list": [
+              "document.cookie",
+              "document.write",
+              ".parentnode",
+              ".innerhtml",
+              "window.location",
+              "-moz-binding",
+              "<![cdata["
+            ]
+          },
+          "operator": "phrase_match"
+        }
+      ],
+      "transformers": [
+        "removeNulls",
+        "lowercase"
+      ]
+    },
+    {
+      "id": "crs-941-200",
+      "name": "IE XSS Filters - Attack Detected via vmlframe tag",
+      "tags": {
+        "type": "xss",
+        "crs_id": "941200",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "(?i:<.*[:]?vmlframe.*?[\\s/+]*?src[\\s/+]*=)",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 13
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "removeNulls"
+      ]
+    },
+    {
+      "id": "crs-941-210",
+      "name": "IE XSS Filters - Obfuscated Attack Detected via javascript injection",
+      "tags": {
+        "type": "xss",
+        "crs_id": "941210",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "(?i:(?:j|&#x?0*(?:74|4A|106|6A);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:a|&#x?0*(?:65|41|97|61);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:v|&#x?0*(?:86|56|118|76);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:a|&#x?0*(?:65|41|97|61);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:s|&#x?0*(?:83|53|115|73);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:c|&#x?0*(?:67|43|99|63);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:r|&#x?0*(?:82|52|114|72);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:i|&#x?0*(?:73|49|105|69);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:p|&#x?0*(?:80|50|112|70);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:t|&#x?0*(?:84|54|116|74);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?::|&(?:#x?0*(?:58|3A);?|colon;)).)",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 12
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "removeNulls"
+      ]
+    },
+    {
+      "id": "crs-941-220",
+      "name": "IE XSS Filters - Obfuscated Attack Detected via vbscript injection",
+      "tags": {
+        "type": "xss",
+        "crs_id": "941220",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "(?i:(?:v|&#x?0*(?:86|56|118|76);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:b|&#x?0*(?:66|42|98|62);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:s|&#x?0*(?:83|53|115|73);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:c|&#x?0*(?:67|43|99|63);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:r|&#x?0*(?:82|52|114|72);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:i|&#x?0*(?:73|49|105|69);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:p|&#x?0*(?:80|50|112|70);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:t|&#x?0*(?:84|54|116|74);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?::|&(?:#x?0*(?:58|3A);?|colon;)).)",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 10
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "removeNulls"
+      ]
+    },
+    {
+      "id": "crs-941-230",
+      "name": "IE XSS Filters - Attack Detected via embed tag",
+      "tags": {
+        "type": "xss",
+        "crs_id": "941230",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "<EMBED[\\s/+].*?(?:src|type).*?=",
+            "options": {
+              "min_length": 11
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "removeNulls"
+      ]
+    },
+    {
+      "id": "crs-941-240",
+      "name": "IE XSS Filters - Attack Detected via import tag",
+      "tags": {
+        "type": "xss",
+        "crs_id": "941240",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "<[?]?import[\\s/+\\S]*?implementation[\\s/+]*?=",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 22
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "lowercase",
+        "removeNulls"
+      ]
+    },
+    {
+      "id": "crs-941-270",
+      "name": "IE XSS Filters - Attack Detected via link tag",
+      "tags": {
+        "type": "xss",
+        "crs_id": "941270",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "<LINK[\\s/+].*?href[\\s/+]*=",
+            "options": {
+              "min_length": 11
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "removeNulls"
+      ]
+    },
+    {
+      "id": "crs-941-280",
+      "name": "IE XSS Filters - Attack Detected via base tag",
+      "tags": {
+        "type": "xss",
+        "crs_id": "941280",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "<BASE[\\s/+].*?href[\\s/+]*=",
+            "options": {
+              "min_length": 11
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "removeNulls"
+      ]
+    },
+    {
+      "id": "crs-941-290",
+      "name": "IE XSS Filters - Attack Detected via applet tag",
+      "tags": {
+        "type": "xss",
+        "crs_id": "941290",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "<APPLET[\\s/+>]",
+            "options": {
+              "min_length": 8
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "removeNulls"
+      ]
+    },
+    {
+      "id": "crs-941-300",
+      "name": "IE XSS Filters - Attack Detected via object tag",
+      "tags": {
+        "type": "xss",
+        "crs_id": "941300",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "<OBJECT[\\s/+].*?(?:type|codetype|classid|code|data)[\\s/+]*=",
+            "options": {
+              "min_length": 13
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "removeNulls"
+      ]
+    },
+    {
+      "id": "crs-941-350",
+      "name": "UTF-7 Encoding IE XSS - Attack Detected",
+      "tags": {
+        "type": "xss",
+        "crs_id": "941350",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "\\+ADw-.*(?:\\+AD4-|>)|<.*\\+AD4-",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 6
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-941-360",
+      "name": "JSFuck / Hieroglyphy obfuscation detected",
+      "tags": {
+        "type": "xss",
+        "crs_id": "941360",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "![!+ ]\\[\\]",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 4
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-942-100",
+      "name": "SQL Injection Attack Detected via libinjection",
+      "tags": {
+        "type": "sql_injection",
+        "crs_id": "942100",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ]
+          },
+          "operator": "is_sqli"
+        }
+      ],
+      "transformers": [
+        "removeNulls"
+      ]
+    },
+    {
+      "id": "crs-942-140",
+      "name": "SQL Injection Attack: Common DB Names Detected",
+      "tags": {
+        "type": "sql_injection",
+        "crs_id": "942140",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "\\b(?:(?:m(?:s(?:ys(?:ac(?:cess(?:objects|storage|xml)|es)|(?:relationship|object|querie)s|modules2?)|db)|aster\\.\\.sysdatabases|ysql\\.db)|pg_(?:catalog|toast)|information_schema|northwind|tempdb)\\b|s(?:(?:ys(?:\\.database_name|aux)|qlite(?:_temp)?_master)\\b|chema(?:_name\\b|\\W*\\())|d(?:atabas|b_nam)e\\W*\\()",
+            "options": {
+              "min_length": 4
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-942-160",
+      "name": "Detects blind sqli tests using sleep() or benchmark()",
+      "tags": {
+        "type": "sql_injection",
+        "crs_id": "942160",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "(?i:sleep\\(\\s*?\\d*?\\s*?\\)|benchmark\\(.*?\\,.*?\\))",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 7
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-942-190",
+      "name": "Detects MSSQL code execution and information gathering attempts",
+      "tags": {
+        "type": "sql_injection",
+        "crs_id": "942190",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "(?:\\b(?:(?:c(?:onnection_id|urrent_user)|database)\\s*?\\([^\\)]*?|u(?:nion(?:[\\w(?:\\s]*?select| select @)|ser\\s*?\\([^\\)]*?)|s(?:chema\\s*?\\([^\\)]*?|elect.*?\\w?user\\()|into[\\s+]+(?:dump|out)file\\s*?[\\\"'`]|from\\W+information_schema\\W|exec(?:ute)?\\s+master\\.)|[\\\"'`](?:;?\\s*?(?:union\\b\\s*?(?:(?:distin|sele)ct|all)|having|select)\\b\\s*?[^\\s]|\\s*?!\\s*?[\\\"'`\\w])|\\s*?exec(?:ute)?.*?\\Wxp_cmdshell|\\Wiif\\s*?\\()",
+            "options": {
+              "min_length": 3
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-942-220",
+      "name": "Looking for integer overflow attacks, these are taken from skipfish, except 2.2.2250738585072011e-308 is the \\\"magic number\\\" crash",
+      "tags": {
+        "type": "sql_injection",
+        "crs_id": "942220",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "^(?i:-0000023456|4294967295|4294967296|2147483648|2147483647|0000012345|-2147483648|-2147483649|0000023456|2.2250738585072007e-308|2.2250738585072011e-308|1e309)$",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 5
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-942-240",
+      "name": "Detects MySQL charset switch and MSSQL DoS attempts",
+      "tags": {
+        "type": "sql_injection",
+        "crs_id": "942240",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "(?:[\\\"'`](?:;*?\\s*?waitfor\\s+(?:delay|time)\\s+[\\\"'`]|;.*?:\\s*?goto)|alter\\s*?\\w+.*?cha(?:racte)?r\\s+set\\s+\\w+)",
+            "options": {
+              "min_length": 7
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-942-250",
+      "name": "Detects MATCH AGAINST, MERGE and EXECUTE IMMEDIATE injections",
+      "tags": {
+        "type": "sql_injection",
+        "crs_id": "942250",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "(?i:merge.*?using\\s*?\\(|execute\\s*?immediate\\s*?[\\\"'`]|match\\s*?[\\w(?:),+-]+\\s*?against\\s*?\\()",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 11
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-942-270",
+      "name": "Looking for basic sql injection. Common attack string for mysql, oracle and others",
+      "tags": {
+        "type": "sql_injection",
+        "crs_id": "942270",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "union.*?select.*?from",
+            "options": {
+              "min_length": 15
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-942-280",
+      "name": "Detects Postgres pg_sleep injection, waitfor delay attacks and database shutdown attempts",
+      "tags": {
+        "type": "sql_injection",
+        "crs_id": "942280",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "(?:;\\s*?shutdown\\s*?(?:[#;{]|\\/\\*|--)|waitfor\\s*?delay\\s?[\\\"'`]+\\s?\\d|select\\s*?pg_sleep)",
+            "options": {
+              "min_length": 10
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-942-290",
+      "name": "Finds basic MongoDB SQL injection attempts",
+      "tags": {
+        "type": "nosql_injection",
+        "crs_id": "942290",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 5
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-942-360",
+      "name": "Detects concatenated basic SQL injection and SQLLFI attempts",
+      "tags": {
+        "type": "sql_injection",
+        "crs_id": "942360",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "(?:^[\\W\\d]+\\s*?(?:alter\\s*(?:a(?:(?:pplication\\s*rol|ggregat)e|s(?:ymmetric\\s*ke|sembl)y|u(?:thorization|dit)|vailability\\s*group)|c(?:r(?:yptographic\\s*provider|edential)|o(?:l(?:latio|um)|nversio)n|ertificate|luster)|s(?:e(?:rv(?:ice|er)|curity|quence|ssion|arch)|y(?:mmetric\\s*key|nonym)|togroup|chema)|m(?:a(?:s(?:ter\\s*key|k)|terialized)|e(?:ssage\\s*type|thod)|odule)|l(?:o(?:g(?:file\\s*group|in)|ckdown)|a(?:ngua|r)ge|ibrary)|t(?:(?:abl(?:espac)?|yp)e|r(?:igger|usted)|hreshold|ext)|p(?:a(?:rtition|ckage)|ro(?:cedur|fil)e|ermission)|d(?:i(?:mension|skgroup)|atabase|efault|omain)|r(?:o(?:l(?:lback|e)|ute)|e(?:sourc|mot)e)|f(?:u(?:lltext|nction)|lashback|oreign)|e(?:xte(?:nsion|rnal)|(?:ndpoi|ve)nt)|in(?:dex(?:type)?|memory|stance)|b(?:roker\\s*priority|ufferpool)|x(?:ml\\s*schema|srobject)|w(?:ork(?:load)?|rapper)|hi(?:erarchy|stogram)|o(?:perator|utline)|(?:nicknam|queu)e|us(?:age|er)|group|java|view)\\b|(?:(?:(?:trunc|cre)at|renam)e|d(?:e(?:lete|sc)|rop)|(?:inser|selec)t|load)\\s+\\w+|u(?:nion\\s*(?:(?:distin|sele)ct|all)\\b|pdate\\s+\\w+))|\\b(?:(?:(?:(?:trunc|cre|upd)at|renam)e|(?:inser|selec)t|de(?:lete|sc)|alter|load)\\s+(?:group_concat|load_file|char)\\b\\s*\\(?|end\\s*?\\);)|[\\\"'`\\w]\\s+as\\b\\s*[\\\"'`\\w]+\\s*\\bfrom|[\\s(?:]load_file\\s*?\\(|[\\\"'`]\\s+regexp\\W)",
+            "options": {
+              "min_length": 5
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-942-500",
+      "name": "MySQL in-line comment detected",
+      "tags": {
+        "type": "sql_injection",
+        "crs_id": "942500",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "(?i:/\\*[!+](?:[\\w\\s=_\\-(?:)]+)?\\*/)",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 5
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-943-100",
+      "name": "Possible Session Fixation Attack: Setting Cookie Values in HTML",
+      "tags": {
+        "type": "http_protocol_violation",
+        "crs_id": "943100",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "(?i:\\.cookie\\b.*?;\\W*?(?:expires|domain)\\W*?=|\\bhttp-equiv\\W+set-cookie\\b)",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 15
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "crs-944-100",
+      "name": "Remote Command Execution: Suspicious Java class detected",
+      "tags": {
+        "type": "java_code_injection",
+        "crs_id": "944100",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "regex": "java\\.lang\\.(?:runtime|processbuilder)",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 17
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "lowercase"
+      ]
+    },
+    {
+      "id": "crs-944-110",
+      "name": "Remote Command Execution: Java process spawn (CVE-2017-9805)",
+      "tags": {
+        "type": "java_code_injection",
+        "crs_id": "944110",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "regex": "(?:runtime|processbuilder)",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 7
+            }
+          },
+          "operator": "match_regex"
+        },
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "regex": "(?:unmarshaller|base64data|java\\.)",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 5
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "lowercase"
+      ]
+    },
+    {
+      "id": "crs-944-130",
+      "name": "Suspicious Java class detected",
+      "tags": {
+        "type": "java_code_injection",
+        "crs_id": "944130",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "server.request.cookies"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "list": [
+              "com.opensymphony.xwork2",
+              "com.sun.org.apache",
+              "java.io.bufferedinputstream",
+              "java.io.bufferedreader",
+              "java.io.bytearrayinputstream",
+              "java.io.bytearrayoutputstream",
+              "java.io.chararrayreader",
+              "java.io.datainputstream",
+              "java.io.file",
+              "java.io.fileoutputstream",
+              "java.io.filepermission",
+              "java.io.filewriter",
+              "java.io.filterinputstream",
+              "java.io.filteroutputstream",
+              "java.io.filterreader",
+              "java.io.inputstream",
+              "java.io.inputstreamreader",
+              "java.io.linenumberreader",
+              "java.io.objectoutputstream",
+              "java.io.outputstream",
+              "java.io.pipedoutputstream",
+              "java.io.pipedreader",
+              "java.io.printstream",
+              "java.io.pushbackinputstream",
+              "java.io.reader",
+              "java.io.stringreader",
+              "java.lang.class",
+              "java.lang.integer",
+              "java.lang.number",
+              "java.lang.object",
+              "java.lang.process",
+              "java.lang.processbuilder",
+              "java.lang.reflect",
+              "java.lang.runtime",
+              "java.lang.string",
+              "java.lang.stringbuilder",
+              "java.lang.system",
+              "javax.script.scriptenginemanager",
+              "org.apache.commons",
+              "org.apache.struts",
+              "org.apache.struts2",
+              "org.omg.corba",
+              "java.beans.xmldecode"
+            ]
+          },
+          "operator": "phrase_match"
+        }
+      ],
+      "transformers": [
+        "lowercase"
+      ]
+    },
+    {
+      "id": "sqr-000-001",
+      "name": "SSRF: Try to access the credential manager of the main cloud services",
+      "tags": {
+        "type": "ssrf",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "(?i)^\\W*((http|ftp)s?://)?\\W*((::f{4}:)?(169|(0x)?0*a9|0+251)\\.?(254|(0x)?0*fe|0+376)[0-9a-fx\\.:]+|metadata\\.google\\.internal|metadata\\.goog)\\W*/",
+            "options": {
+              "min_length": 4
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "removeNulls"
+      ]
+    },
+    {
+      "id": "sqr-000-002",
+      "name": "Server-side Javascript injection: Try to detect obvious JS injection",
+      "tags": {
+        "type": "js_code_injection",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "require\\(['\"][\\w\\.]+['\"]\\)|process\\.\\w+\\([\\w\\.]*\\)|\\.toString\\(\\)",
+            "options": {
+              "min_length": 4
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "removeNulls"
+      ]
+    },
+    {
+      "id": "sqr-000-007",
+      "name": "NoSQL: Detect common exploitation strategy",
+      "tags": {
+        "type": "nosql_injection",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "regex": "\\$(eq|ne|lte?|gte?|n?in)\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "sqr-000-008",
+      "name": "Windows: Detect attempts to exfiltrate .ini files",
+      "tags": {
+        "type": "command_injection",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "regex": "(?i)[&|]\\s*type\\s+%\\w+%\\\\+\\w+\\.ini\\s*[&|]"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "sqr-000-009",
+      "name": "Linux: Detect attempts to exfiltrate passwd files",
+      "tags": {
+        "type": "command_injection",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "regex": "(?i)[&|]\\s*cat\\s+\\/etc\\/[\\w\\.\\/]*passwd\\s*[&|]"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "sqr-000-010",
+      "name": "Windows: Detect attempts to timeout a shell",
+      "tags": {
+        "type": "command_injection",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "regex": "(?i)[&|]\\s*timeout\\s+/t\\s+\\d+\\s*[&|]"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "sqr-000-011",
+      "name": "SSRF: Try to access internal OMI service (CVE-2021-38647)",
+      "tags": {
+        "type": "ssrf",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "operator": "match_regex",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "http(s?):\\/\\/([A-Za-z0-9\\.\\-\\_]+|\\[[A-Fa-f0-9\\:]+\\]|):5986\\/wsman",
+            "options": {
+              "min_length": 4
             }
           }
-        ],
-        "transformers": []
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "sqr-000-012",
+      "name": "SSRF: Detect SSRF attempt on internal service",
+      "tags": {
+        "type": "ssrf",
+        "category": "attack_attempt"
       },
-      {
-        "id": "sqr-000-012",
-        "name": "SSRF: Detect SSRF attempt on internal service",
-        "tags": {
-          "type": "ssrf",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "^(jar:)?(http|https):\\/\\/([0-9oq]{1,5}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}|[0-9]{1,10}|localhost)(:[0-9]{1,5})?(\\/.*|)$"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "lowercase"
-        ]
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "^(jar:)?(http|https):\\/\\/([0-9oq]{1,5}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}|[0-9]{1,10}|localhost)(:[0-9]{1,5})?(\\/.*|)$"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "lowercase"
+      ]
+    },
+    {
+      "id": "sqr-000-013",
+      "name": "SSRF: Detect SSRF attempts using IPv6 or octal/hexdecimal obfuscation",
+      "tags": {
+        "type": "ssrf",
+        "category": "attack_attempt"
       },
-      {
-        "id": "sqr-000-013",
-        "name": "SSRF: Detect SSRF attempts using IPv6 or octal/hexdecimal obfuscation",
-        "tags": {
-          "type": "ssrf",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                }
-              ],
-              "regex": "^(jar:)?(http|https):\\/\\/((\\[)?[:0-9a-f\\.x]{2,}(\\])?)(:[0-9]{1,5})?(\\/.*)?$"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "lowercase"
-        ]
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "regex": "^(jar:)?(http|https):\\/\\/((\\[)?[:0-9a-f\\.x]{2,}(\\])?)(:[0-9]{1,5})?(\\/.*)?$"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "lowercase"
+      ]
+    },
+    {
+      "id": "sqr-000-014",
+      "name": "SSRF: Detect SSRF domain redirection bypass",
+      "tags": {
+        "type": "ssrf",
+        "category": "attack_attempt"
       },
-      {
-        "id": "sqr-000-014",
-        "name": "SSRF: Detect SSRF domain redirection bypass",
-        "tags": {
-          "type": "ssrf",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                },
-                {
-                  "address": "server.request.headers.no_cookies"
-                }
-              ],
-              "regex": "^(http|https):\\/\\/(.*burpcollaborator\\.net|localtest\\.me|mail\\.ebc\\.apple\\.com|bugbounty\\.dod\\.network|.*\\.[nx]ip\\.io)"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "lowercase"
-        ]
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "regex": "^(http|https):\\/\\/(.*burpcollaborator\\.net|localtest\\.me|mail\\.ebc\\.apple\\.com|bugbounty\\.dod\\.network|.*\\.[nx]ip\\.io)"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "lowercase"
+      ]
+    },
+    {
+      "id": "sqr-000-015",
+      "name": "SSRF: Detect SSRF attempt using non HTTP protocol",
+      "tags": {
+        "type": "ssrf",
+        "category": "attack_attempt"
       },
-      {
-        "id": "sqr-000-015",
-        "name": "SSRF: Detect SSRF attempt using non HTTP protocol",
-        "tags": {
-          "type": "ssrf",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.query"
-                },
-                {
-                  "address": "server.request.body"
-                },
-                {
-                  "address": "server.request.path_params"
-                },
-                {
-                  "address": "server.request.headers.no_cookies"
-                }
-              ],
-              "regex": "^(jar:)?((file|netdoc):\\/\\/[\\\\\\/]+|(dict|gopher|ldap|sftp|tftp):\\/\\/.*:[0-9]{1,5})"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": [
-          "lowercase"
-        ]
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "regex": "^(jar:)?((file|netdoc):\\/\\/[\\\\\\/]+|(dict|gopher|ldap|sftp|tftp):\\/\\/.*:[0-9]{1,5})"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "lowercase"
+      ]
+    },
+    {
+      "id": "ua0-600-0xx",
+      "name": "Joomla exploitation tool",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-0xx",
-        "name": "Joomla exploitation tool",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "JDatabaseDriverMysqli"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "JDatabaseDriverMysqli"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-10x",
+      "name": "Nessus",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-10x",
-        "name": "Nessus",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)^Nessus(/|([ :]+SOAP))"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)^Nessus(/|([ :]+SOAP))"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-12x",
+      "name": "Arachni",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-12x",
-        "name": "Arachni",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "^Arachni\\/v"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "^Arachni\\/v"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-13x",
+      "name": "Jorgee",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-13x",
-        "name": "Jorgee",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bJorgee\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bJorgee\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-14x",
+      "name": "Probely",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-14x",
-        "name": "Probely",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bProbely\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bProbely\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-15x",
+      "name": "Metis",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-15x",
-        "name": "Metis",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bmetis\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bmetis\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-16x",
+      "name": "SQL power injector",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-16x",
-        "name": "SQL power injector",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "sql power injector"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "sql power injector"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-18x",
+      "name": "N-Stealth",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-18x",
-        "name": "N-Stealth",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bn-stealth\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bn-stealth\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-19x",
+      "name": "Brutus",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-19x",
-        "name": "Brutus",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bbrutus\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bbrutus\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-1xx",
+      "name": "Shellshock exploitation tool",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-1xx",
-        "name": "Shellshock exploitation tool",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "\\(\\) \\{ :; *\\}"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "\\(\\) \\{ :; *\\}"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-20x",
+      "name": "Netsparker",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-20x",
-        "name": "Netsparker",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)(<script>netsparker\\(0x0|ns:netsparker.*=vuln)"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)(<script>netsparker\\(0x0|ns:netsparker.*=vuln)"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-22x",
+      "name": "JAASCois",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-22x",
-        "name": "JAASCois",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bjaascois\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bjaascois\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-23x",
+      "name": "PMAFind",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-23x",
-        "name": "PMAFind",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bpmafind\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bpmafind\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-25x",
+      "name": "Webtrends",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-25x",
-        "name": "Webtrends",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "webtrends security analyzer"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "webtrends security analyzer"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-26x",
+      "name": "Nsauditor",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-26x",
-        "name": "Nsauditor",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bnsauditor\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bnsauditor\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-27x",
+      "name": "Paros",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-27x",
-        "name": "Paros",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)Mozilla/.* Paros/"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)Mozilla/.* Paros/"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-28x",
+      "name": "DirBuster",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-28x",
-        "name": "DirBuster",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bdirbuster\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bdirbuster\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-29x",
+      "name": "Pangolin",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-29x",
-        "name": "Pangolin",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bpangolin\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bpangolin\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-2xx",
+      "name": "Qualys",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-2xx",
-        "name": "Qualys",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bqualys\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bqualys\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-30x",
+      "name": "SQLNinja",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-30x",
-        "name": "SQLNinja",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bsqlninja\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bsqlninja\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-31x",
+      "name": "Nikto",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-31x",
-        "name": "Nikto",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "\\(Nikto/[\\d\\.]+\\)"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "\\(Nikto/[\\d\\.]+\\)"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-32x",
+      "name": "WebInspect",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-32x",
-        "name": "WebInspect",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bwebinspect\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bwebinspect\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-33x",
+      "name": "BlackWidow",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-33x",
-        "name": "BlackWidow",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bblack\\s?widow\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bblack\\s?widow\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-34x",
+      "name": "Grendel-Scan",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-34x",
-        "name": "Grendel-Scan",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bgrendel-scan\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bgrendel-scan\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-35x",
+      "name": "Havij",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-35x",
-        "name": "Havij",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bhavij\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bhavij\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-36x",
+      "name": "w3af",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-36x",
-        "name": "w3af",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bw3af\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bw3af\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-37x",
+      "name": "Nmap",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-37x",
-        "name": "Nmap",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "nmap (nse|scripting engine)"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "nmap (nse|scripting engine)"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-39x",
+      "name": "Nessus Scripted",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-39x",
-        "name": "Nessus Scripted",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)^'?[a-z0-9]+\\.nasl'?$"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)^'?[a-z0-9]+\\.nasl'?$"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-3xx",
+      "name": "Evil Scanner",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-3xx",
-        "name": "Evil Scanner",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bevilScanner\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bevilScanner\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-40x",
+      "name": "WebFuck",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-40x",
-        "name": "WebFuck",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bWebFuck\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bWebFuck\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-41x",
+      "name": "Acunetix",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-41x",
-        "name": "Acunetix",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "md5\\(acunetix_wvs_security_test\\)"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "md5\\(acunetix_wvs_security_test\\)"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-42x",
+      "name": "OpenVAS",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-42x",
-        "name": "OpenVAS",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)OpenVAS\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)OpenVAS\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-43x",
+      "name": "Spider-Pig",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-43x",
-        "name": "Spider-Pig",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "Powered by Spider-Pig by tinfoilsecurity\\.com"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "Powered by Spider-Pig by tinfoilsecurity\\.com"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-44x",
+      "name": "Zgrab",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-44x",
-        "name": "Zgrab",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "Mozilla/\\d+.\\d+ zgrab"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "Mozilla/\\d+.\\d+ zgrab"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-45x",
+      "name": "Zmeu",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-45x",
-        "name": "Zmeu",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bZmEu\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bZmEu\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-46x",
+      "name": "Crowdstrike",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-46x",
-        "name": "Crowdstrike",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bcrowdstrike\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bcrowdstrike\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-47x",
+      "name": "GoogleSecurityScanner",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-47x",
-        "name": "GoogleSecurityScanner",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bGoogleSecurityScanner\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bGoogleSecurityScanner\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-48x",
+      "name": "Commix",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-48x",
-        "name": "Commix",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "^commix\\/"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "^commix\\/"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-49x",
+      "name": "Gobuster",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-49x",
-        "name": "Gobuster",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "^gobuster\\/"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "^gobuster\\/"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-4xx",
+      "name": "CGIchk",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-4xx",
-        "name": "CGIchk",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bcgichk\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bcgichk\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-51x",
+      "name": "FFUF",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-51x",
-        "name": "FFUF",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)^Fuzz Faster U Fool\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)^Fuzz Faster U Fool\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-52x",
+      "name": "Nuclei is a fast tool for configurable targeted scanning based on templates offering massive extensibility and ease of use",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-52x",
-        "name": "Nuclei is a fast tool for configurable targeted scanning based on templates offering massive extensibility and ease of use",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)^Nuclei\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)^Nuclei\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-53x",
+      "name": "Tsunami is a general purpose network security scanner with an extensible plugin system for detecting high severity vulnerabilities with high confidence",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-53x",
-        "name": "Tsunami is a general purpose network security scanner with an extensible plugin system for detecting high severity vulnerabilities with high confidence",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bTsunamiSecurityScanner\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bTsunamiSecurityScanner\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-54x",
+      "name": "Nimbostratus is a vulnerability scanner that scan websites unprompted",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-54x",
-        "name": "Nimbostratus is a vulnerability scanner that scan websites unprompted",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bnimbostratus-bot\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bnimbostratus-bot\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-5xx",
+      "name": "Blind Sql Injection Brute Forcer",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-5xx",
-        "name": "Blind Sql Injection Brute Forcer",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)\\bbsqlbf\\b"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)\\bbsqlbf\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-6xx",
+      "name": "Suspicious user agent",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-6xx",
-        "name": "Suspicious user agent",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "mozilla/4\\.0 \\(compatible(; msie 6\\.0; win32)?\\)"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "mozilla/4\\.0 \\(compatible(; msie 6\\.0; win32)?\\)"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-7xx",
+      "name": "SQLmap",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-7xx",
-        "name": "SQLmap",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "^sqlmap/"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "^sqlmap/"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-9xx",
+      "name": "Skipfish",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
       },
-      {
-        "id": "ua0-600-9xx",
-        "name": "Skipfish",
-        "tags": {
-          "type": "security_scanner",
-          "category": "attack_attempt"
-        },
-        "conditions": [
-          {
-            "parameters": {
-              "inputs": [
-                {
-                  "address": "server.request.headers.no_cookies",
-                  "key_path": [
-                    "user-agent"
-                  ]
-                }
-              ],
-              "regex": "(?i)mozilla/5\\.0 sf/"
-            },
-            "operator": "match_regex"
-          }
-        ],
-        "transformers": []
-      }
-    ]
-  }
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "(?i)mozilla/5\\.0 sf/"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    }
+  ]
 }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/test/StubAppSecConfigService.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/test/StubAppSecConfigService.groovy
@@ -3,7 +3,6 @@ package com.datadog.appsec.test
 import com.datadog.appsec.config.AppSecConfig
 import com.datadog.appsec.config.AppSecConfigService
 import com.datadog.appsec.config.AppSecConfigServiceImpl
-import com.squareup.moshi.Moshi
 import okio.Okio
 
 class StubAppSecConfigService implements AppSecConfigService {
@@ -14,7 +13,7 @@ class StubAppSecConfigService implements AppSecConfigService {
 
   private final Map hardcodedConfig
 
-  StubAppSecConfigService(String location = AppSecConfigServiceImpl.DEFAULT_CONFIG_LOCATION) {
+  StubAppSecConfigService(String location = "test_multi_config.json") {
     this.location = location
   }
 

--- a/dd-java-agent/appsec/src/test/resources/test_multi_config.json
+++ b/dd-java-agent/appsec/src/test/resources/test_multi_config.json
@@ -1,0 +1,4897 @@
+{
+  "waf": {
+    "version": "2.1",
+    "rules": [
+      {
+        "id": "crs-913-110",
+        "name": "Found request header associated with Acunetix security scanner",
+        "tags": {
+          "type": "security_scanner",
+          "crs_id": "913110",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies"
+                }
+              ],
+              "list": [
+                "acunetix-product",
+                "(acunetix web vulnerability scanner",
+                "acunetix-scanning-agreement",
+                "acunetix-user-agreement"
+              ]
+            },
+            "operator": "phrase_match"
+          }
+        ],
+        "transformers": [
+          "lowercase"
+        ]
+      },
+      {
+        "id": "crs-913-120",
+        "name": "Found request filename/argument associated with security scanner",
+        "tags": {
+          "type": "security_scanner",
+          "crs_id": "913120",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "list": [
+                "/.adsensepostnottherenonobook",
+                "/<invalid>hello.html",
+                "/actsensepostnottherenonotive",
+                "/acunetix-wvs-test-for-some-inexistent-file",
+                "/antidisestablishmentarianism",
+                "/appscan_fingerprint/mac_address",
+                "/arachni-",
+                "/cybercop",
+                "/nessus_is_probing_you_",
+                "/nessustest",
+                "/netsparker-",
+                "/rfiinc.txt",
+                "/thereisnowaythat-you-canbethere",
+                "/w3af/remotefileinclude.html",
+                "appscan_fingerprint",
+                "w00tw00t.at.isc.sans.dfind",
+                "w00tw00t.at.blackhats.romanian.anti-sec"
+              ]
+            },
+            "operator": "phrase_match"
+          }
+        ],
+        "transformers": [
+          "lowercase"
+        ]
+      },
+      {
+        "id": "crs-920-260",
+        "name": "Unicode Full/Half Width Abuse Attack Attempt",
+        "tags": {
+          "type": "http_protocol_violation",
+          "crs_id": "920260",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.uri.raw"
+                }
+              ],
+              "regex": "\\%u[fF]{2}[0-9a-fA-F]{2}",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 6
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-921-110",
+        "name": "HTTP Request Smuggling Attack",
+        "tags": {
+          "type": "http_protocol_violation",
+          "crs_id": "921110",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "(?:get|post|head|options|connect|put|delete|trace|track|patch|propfind|propatch|mkcol|copy|move|lock|unlock)\\s+[^\\s]+\\s+http/\\d",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 12
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "lowercase"
+        ]
+      },
+      {
+        "id": "crs-921-140",
+        "name": "HTTP Header Injection Attack via headers",
+        "tags": {
+          "type": "http_protocol_violation",
+          "crs_id": "921140",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies"
+                }
+              ],
+              "regex": "[\\n\\r]",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 1
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-921-160",
+        "name": "HTTP Header Injection Attack via payload (CR/LF and header-name detected)",
+        "tags": {
+          "type": "http_protocol_violation",
+          "crs_id": "921160",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "[\\n\\r]+(?:\\s|location|refresh|(?:set-)?cookie|(?:x-)?(?:forwarded-(?:for|host|server)|host|via|remote-ip|remote-addr|originating-IP))\\s*:",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 3
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "lowercase"
+        ]
+      },
+      {
+        "id": "crs-930-100",
+        "name": "Obfuscated Path Traversal Attack (/../)",
+        "tags": {
+          "type": "lfi",
+          "crs_id": "930100",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.uri.raw"
+                },
+                {
+                  "address": "server.request.headers.no_cookies"
+                }
+              ],
+              "regex": "(?:\\x5c|(?:%(?:c(?:0%(?:[2aq]f|5c|9v)|1%(?:[19p]c|8s|af))|2(?:5(?:c(?:0%25af|1%259c)|2f|5c)|%46|f)|(?:(?:f(?:8%8)?0%8|e)0%80%a|bg%q)f|%3(?:2(?:%(?:%6|4)6|F)|5%%63)|u(?:221[56]|002f|EFC8|F025)|1u|5c)|0x(?:2f|5c)|/))(?:%(?:(?:f(?:(?:c%80|8)%8)?0%8|e)0%80%ae|2(?:(?:5(?:c0%25a|2))?e|%45)|u(?:(?:002|ff0)e|2024)|%32(?:%(?:%6|4)5|E)|c0(?:%[256aef]e|\\.))|\\.(?:%0[01]|\\?)?|\\?\\.?|0x2e){2}(?:\\x5c|(?:%(?:c(?:0%(?:[2aq]f|5c|9v)|1%(?:[19p]c|8s|af))|2(?:5(?:c(?:0%25af|1%259c)|2f|5c)|%46|f)|(?:(?:f(?:8%8)?0%8|e)0%80%a|bg%q)f|%3(?:2(?:%(?:%6|4)6|F)|5%%63)|u(?:221[56]|002f|EFC8|F025)|1u|5c)|0x(?:2f|5c)|/))",
+              "options": {
+                "min_length": 4
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-930-110",
+        "name": "Simple Path Traversal Attack (/../)",
+        "tags": {
+          "type": "lfi",
+          "crs_id": "930110",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.uri.raw"
+                },
+                {
+                  "address": "server.request.headers.no_cookies"
+                }
+              ],
+              "regex": "(?:(?:^|[\\\\/])\\.\\.[\\\\/]|[\\\\/]\\.\\.(?:[\\\\/]|$))",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 3
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "removeNulls"
+        ]
+      },
+      {
+        "id": "crs-930-120",
+        "name": "OS File Access Attempt",
+        "tags": {
+          "type": "lfi",
+          "crs_id": "930120",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "list": [
+                ".htaccess",
+                ".htdigest",
+                ".htpasswd",
+                ".addressbook",
+                ".aptitude/config",
+                ".bash_config",
+                ".bash_history",
+                ".bash_logout",
+                ".bash_profile",
+                ".bashrc",
+                ".cache/notify-osd.log",
+                ".config/odesk/odesk team.conf",
+                ".cshrc",
+                ".dockerignore",
+                ".drush/",
+                ".eslintignore",
+                ".fbcindex",
+                ".forward",
+                ".gitattributes",
+                ".gitconfig",
+                ".gnupg/",
+                ".hplip/hplip.conf",
+                ".ksh_history",
+                ".lesshst",
+                ".lftp/",
+                ".lhistory",
+                ".lldb-history",
+                ".local/share/mc/",
+                ".lynx_cookies",
+                ".my.cnf",
+                ".mysql_history",
+                ".nano_history",
+                ".node_repl_history",
+                ".pearrc",
+                ".php_history",
+                ".pinerc",
+                ".pki/",
+                ".proclog",
+                ".procmailrc",
+                ".psql_history",
+                ".python_history",
+                ".rediscli_history",
+                ".rhistory",
+                ".rhosts",
+                ".sh_history",
+                ".sqlite_history",
+                ".ssh/authorized_keys",
+                ".ssh/config",
+                ".ssh/id_dsa",
+                ".ssh/id_dsa.pub",
+                ".ssh/id_rsa",
+                ".ssh/id_rsa.pub",
+                ".ssh/identity",
+                ".ssh/identity.pub",
+                ".ssh/known_hosts",
+                ".subversion/auth",
+                ".subversion/config",
+                ".subversion/servers",
+                ".tconn/tconn.conf",
+                ".tcshrc",
+                ".vidalia/vidalia.conf",
+                ".viminfo",
+                ".vimrc",
+                ".www_acl",
+                ".wwwacl",
+                ".xauthority",
+                ".zhistory",
+                ".zshrc",
+                ".zsh_history",
+                ".nsconfig",
+                "etc/redis.conf",
+                "etc/redis-sentinel.conf",
+                "etc/php.ini",
+                "bin/php.ini",
+                "etc/httpd/php.ini",
+                "usr/lib/php.ini",
+                "usr/lib/php/php.ini",
+                "usr/local/etc/php.ini",
+                "usr/local/lib/php.ini",
+                "usr/local/php/lib/php.ini",
+                "usr/local/php4/lib/php.ini",
+                "usr/local/php5/lib/php.ini",
+                "usr/local/apache/conf/php.ini",
+                "etc/php4.4/fcgi/php.ini",
+                "etc/php4/apache/php.ini",
+                "etc/php4/apache2/php.ini",
+                "etc/php5/apache/php.ini",
+                "etc/php5/apache2/php.ini",
+                "etc/php/php.ini",
+                "etc/php/php4/php.ini",
+                "etc/php/apache/php.ini",
+                "etc/php/apache2/php.ini",
+                "web/conf/php.ini",
+                "usr/local/zend/etc/php.ini",
+                "opt/xampp/etc/php.ini",
+                "var/local/www/conf/php.ini",
+                "etc/php/cgi/php.ini",
+                "etc/php4/cgi/php.ini",
+                "etc/php5/cgi/php.ini",
+                "home2/bin/stable/apache/php.ini",
+                "home/bin/stable/apache/php.ini",
+                "etc/httpd/conf.d/php.conf",
+                "php5/php.ini",
+                "php4/php.ini",
+                "php/php.ini",
+                "windows/php.ini",
+                "winnt/php.ini",
+                "apache/php/php.ini",
+                "xampp/apache/bin/php.ini",
+                "netserver/bin/stable/apache/php.ini",
+                "volumes/macintosh_hd1/usr/local/php/lib/php.ini",
+                "etc/mono/1.0/machine.config",
+                "etc/mono/2.0/machine.config",
+                "etc/mono/2.0/web.config",
+                "etc/mono/config",
+                "usr/local/cpanel/logs/stats_log",
+                "usr/local/cpanel/logs/access_log",
+                "usr/local/cpanel/logs/error_log",
+                "usr/local/cpanel/logs/license_log",
+                "usr/local/cpanel/logs/login_log",
+                "var/cpanel/cpanel.config",
+                "var/log/sw-cp-server/error_log",
+                "usr/local/psa/admin/logs/httpsd_access_log",
+                "usr/local/psa/admin/logs/panel.log",
+                "var/log/sso/sso.log",
+                "usr/local/psa/admin/conf/php.ini",
+                "etc/sw-cp-server/applications.d/plesk.conf",
+                "usr/local/psa/admin/conf/site_isolation_settings.ini",
+                "usr/local/sb/config",
+                "etc/sw-cp-server/applications.d/00-sso-cpserver.conf",
+                "etc/sso/sso_config.ini",
+                "etc/mysql/conf.d/old_passwords.cnf",
+                "var/log/mysql/mysql-bin.log",
+                "var/log/mysql/mysql-bin.index",
+                "var/log/mysql/data/mysql-bin.index",
+                "var/log/mysql.log",
+                "var/log/mysql.err",
+                "var/log/mysqlderror.log",
+                "var/log/mysql/mysql.log",
+                "var/log/mysql/mysql-slow.log",
+                "var/log/mysql-bin.index",
+                "var/log/data/mysql-bin.index",
+                "var/mysql.log",
+                "var/mysql-bin.index",
+                "var/data/mysql-bin.index",
+                "program files/mysql/mysql server 5.0/data/{host}.err",
+                "program files/mysql/mysql server 5.0/data/mysql.log",
+                "program files/mysql/mysql server 5.0/data/mysql.err",
+                "program files/mysql/mysql server 5.0/data/mysql-bin.log",
+                "program files/mysql/mysql server 5.0/data/mysql-bin.index",
+                "program files/mysql/data/{host}.err",
+                "program files/mysql/data/mysql.log",
+                "program files/mysql/data/mysql.err",
+                "program files/mysql/data/mysql-bin.log",
+                "program files/mysql/data/mysql-bin.index",
+                "mysql/data/{host}.err",
+                "mysql/data/mysql.log",
+                "mysql/data/mysql.err",
+                "mysql/data/mysql-bin.log",
+                "mysql/data/mysql-bin.index",
+                "usr/local/mysql/data/mysql.log",
+                "usr/local/mysql/data/mysql.err",
+                "usr/local/mysql/data/mysql-bin.log",
+                "usr/local/mysql/data/mysql-slow.log",
+                "usr/local/mysql/data/mysqlderror.log",
+                "usr/local/mysql/data/{host}.err",
+                "usr/local/mysql/data/mysql-bin.index",
+                "var/lib/mysql/my.cnf",
+                "etc/mysql/my.cnf",
+                "etc/my.cnf",
+                "program files/mysql/mysql server 5.0/my.ini",
+                "program files/mysql/mysql server 5.0/my.cnf",
+                "program files/mysql/my.ini",
+                "program files/mysql/my.cnf",
+                "mysql/my.ini",
+                "mysql/my.cnf",
+                "mysql/bin/my.ini",
+                "var/postgresql/log/postgresql.log",
+                "var/log/postgresql/postgresql.log",
+                "var/log/postgres/pg_backup.log",
+                "var/log/postgres/postgres.log",
+                "var/log/postgresql.log",
+                "var/log/pgsql/pgsql.log",
+                "var/log/postgresql/postgresql-8.1-main.log",
+                "var/log/postgresql/postgresql-8.3-main.log",
+                "var/log/postgresql/postgresql-8.4-main.log",
+                "var/log/postgresql/postgresql-9.0-main.log",
+                "var/log/postgresql/postgresql-9.1-main.log",
+                "var/log/pgsql8.log",
+                "var/log/postgresql/postgres.log",
+                "var/log/pgsql_log",
+                "var/log/postgresql/main.log",
+                "var/log/cron/var/log/postgres.log",
+                "usr/internet/pgsql/data/postmaster.log",
+                "usr/local/pgsql/data/postgresql.log",
+                "usr/local/pgsql/data/pg_log",
+                "postgresql/log/pgadmin.log",
+                "var/lib/pgsql/data/postgresql.conf",
+                "var/postgresql/db/postgresql.conf",
+                "var/nm2/postgresql.conf",
+                "usr/local/pgsql/data/postgresql.conf",
+                "usr/local/pgsql/data/pg_hba.conf",
+                "usr/internet/pgsql/data/pg_hba.conf",
+                "usr/local/pgsql/data/passwd",
+                "usr/local/pgsql/bin/pg_passwd",
+                "etc/postgresql/postgresql.conf",
+                "etc/postgresql/pg_hba.conf",
+                "home/postgres/data/postgresql.conf",
+                "home/postgres/data/pg_version",
+                "home/postgres/data/pg_ident.conf",
+                "home/postgres/data/pg_hba.conf",
+                "program files/postgresql/8.3/data/pg_hba.conf",
+                "program files/postgresql/8.3/data/pg_ident.conf",
+                "program files/postgresql/8.3/data/postgresql.conf",
+                "program files/postgresql/8.4/data/pg_hba.conf",
+                "program files/postgresql/8.4/data/pg_ident.conf",
+                "program files/postgresql/8.4/data/postgresql.conf",
+                "program files/postgresql/9.0/data/pg_hba.conf",
+                "program files/postgresql/9.0/data/pg_ident.conf",
+                "program files/postgresql/9.0/data/postgresql.conf",
+                "program files/postgresql/9.1/data/pg_hba.conf",
+                "program files/postgresql/9.1/data/pg_ident.conf",
+                "program files/postgresql/9.1/data/postgresql.conf",
+                "wamp/logs/access.log",
+                "wamp/logs/apache_error.log",
+                "wamp/logs/genquery.log",
+                "wamp/logs/mysql.log",
+                "wamp/logs/slowquery.log",
+                "wamp/bin/apache/apache2.2.22/logs/access.log",
+                "wamp/bin/apache/apache2.2.22/logs/error.log",
+                "wamp/bin/apache/apache2.2.21/logs/access.log",
+                "wamp/bin/apache/apache2.2.21/logs/error.log",
+                "wamp/bin/mysql/mysql5.5.24/data/mysql-bin.index",
+                "wamp/bin/mysql/mysql5.5.16/data/mysql-bin.index",
+                "wamp/bin/apache/apache2.2.21/conf/httpd.conf",
+                "wamp/bin/apache/apache2.2.22/conf/httpd.conf",
+                "wamp/bin/apache/apache2.2.21/wampserver.conf",
+                "wamp/bin/apache/apache2.2.22/wampserver.conf",
+                "wamp/bin/apache/apache2.2.22/conf/wampserver.conf",
+                "wamp/bin/mysql/mysql5.5.24/my.ini",
+                "wamp/bin/mysql/mysql5.5.24/wampserver.conf",
+                "wamp/bin/mysql/mysql5.5.16/my.ini",
+                "wamp/bin/mysql/mysql5.5.16/wampserver.conf",
+                "wamp/bin/php/php5.3.8/php.ini",
+                "wamp/bin/php/php5.4.3/php.ini",
+                "xampp/apache/logs/access.log",
+                "xampp/apache/logs/error.log",
+                "xampp/mysql/data/mysql-bin.index",
+                "xampp/mysql/data/mysql.err",
+                "xampp/mysql/data/{host}.err",
+                "xampp/sendmail/sendmail.log",
+                "xampp/apache/conf/httpd.conf",
+                "xampp/filezillaftp/filezilla server.xml",
+                "xampp/mercurymail/mercury.ini",
+                "xampp/php/php.ini",
+                "xampp/phpmyadmin/config.inc.php",
+                "xampp/sendmail/sendmail.ini",
+                "xampp/webalizer/webalizer.conf",
+                "opt/lampp/etc/httpd.conf",
+                "xampp/htdocs/aca.txt",
+                "xampp/htdocs/admin.php",
+                "xampp/htdocs/leer.txt",
+                "usr/local/apache/logs/audit_log",
+                "usr/local/apache2/logs/audit_log",
+                "logs/security_debug_log",
+                "logs/security_log",
+                "usr/local/apache/conf/modsec.conf",
+                "usr/local/apache2/conf/modsec.conf",
+                "winnt/system32/logfiles/msftpsvc",
+                "winnt/system32/logfiles/msftpsvc1",
+                "winnt/system32/logfiles/msftpsvc2",
+                "windows/system32/logfiles/msftpsvc",
+                "windows/system32/logfiles/msftpsvc1",
+                "windows/system32/logfiles/msftpsvc2",
+                "etc/logrotate.d/proftpd",
+                "www/logs/proftpd.system.log",
+                "var/log/proftpd",
+                "var/log/proftpd/xferlog.legacy",
+                "var/log/proftpd.access_log",
+                "var/log/proftpd.xferlog",
+                "etc/pam.d/proftpd",
+                "etc/proftp.conf",
+                "etc/protpd/proftpd.conf",
+                "etc/vhcs2/proftpd/proftpd.conf",
+                "etc/proftpd/modules.conf",
+                "var/log/vsftpd.log",
+                "etc/vsftpd.chroot_list",
+                "etc/logrotate.d/vsftpd.log",
+                "etc/vsftpd/vsftpd.conf",
+                "etc/vsftpd.conf",
+                "etc/chrootusers",
+                "var/log/xferlog",
+                "var/adm/log/xferlog",
+                "etc/wu-ftpd/ftpaccess",
+                "etc/wu-ftpd/ftphosts",
+                "etc/wu-ftpd/ftpusers",
+                "var/log/pure-ftpd/pure-ftpd.log",
+                "logs/pure-ftpd.log",
+                "var/log/pureftpd.log",
+                "usr/sbin/pure-config.pl",
+                "usr/etc/pure-ftpd.conf",
+                "etc/pure-ftpd/pure-ftpd.conf",
+                "usr/local/etc/pure-ftpd.conf",
+                "usr/local/etc/pureftpd.pdb",
+                "usr/local/pureftpd/etc/pureftpd.pdb",
+                "usr/local/pureftpd/sbin/pure-config.pl",
+                "usr/local/pureftpd/etc/pure-ftpd.conf",
+                "etc/pure-ftpd.conf",
+                "etc/pure-ftpd/pure-ftpd.pdb",
+                "etc/pureftpd.pdb",
+                "etc/pureftpd.passwd",
+                "etc/pure-ftpd/pureftpd.pdb",
+                "usr/ports/ftp/pure-ftpd/pure-ftpd.conf",
+                "usr/ports/ftp/pure-ftpd/pureftpd.pdb",
+                "usr/ports/ftp/pure-ftpd/pureftpd.passwd",
+                "usr/ports/net/pure-ftpd/pure-ftpd.conf",
+                "usr/ports/net/pure-ftpd/pureftpd.pdb",
+                "usr/ports/net/pure-ftpd/pureftpd.passwd",
+                "usr/pkgsrc/net/pureftpd/pure-ftpd.conf",
+                "usr/pkgsrc/net/pureftpd/pureftpd.pdb",
+                "usr/pkgsrc/net/pureftpd/pureftpd.passwd",
+                "usr/ports/contrib/pure-ftpd/pure-ftpd.conf",
+                "usr/ports/contrib/pure-ftpd/pureftpd.pdb",
+                "usr/ports/contrib/pure-ftpd/pureftpd.passwd",
+                "var/log/muddleftpd",
+                "usr/sbin/mudlogd",
+                "etc/muddleftpd/mudlog",
+                "etc/muddleftpd.com",
+                "etc/muddleftpd/mudlogd.conf",
+                "etc/muddleftpd/muddleftpd.conf",
+                "var/log/muddleftpd.conf",
+                "usr/sbin/mudpasswd",
+                "etc/muddleftpd/muddleftpd.passwd",
+                "etc/muddleftpd/passwd",
+                "var/log/ftp-proxy/ftp-proxy.log",
+                "var/log/ftp-proxy",
+                "var/log/ftplog",
+                "etc/logrotate.d/ftp",
+                "etc/ftpchroot",
+                "etc/ftphosts",
+                "etc/ftpusers",
+                "var/log/exim_mainlog",
+                "var/log/exim/mainlog",
+                "var/log/maillog",
+                "var/log/exim_paniclog",
+                "var/log/exim/paniclog",
+                "var/log/exim/rejectlog",
+                "var/log/exim_rejectlog",
+                "winnt/system32/logfiles/smtpsvc",
+                "winnt/system32/logfiles/smtpsvc1",
+                "winnt/system32/logfiles/smtpsvc2",
+                "winnt/system32/logfiles/smtpsvc3",
+                "winnt/system32/logfiles/smtpsvc4",
+                "winnt/system32/logfiles/smtpsvc5",
+                "windows/system32/logfiles/smtpsvc",
+                "windows/system32/logfiles/smtpsvc1",
+                "windows/system32/logfiles/smtpsvc2",
+                "windows/system32/logfiles/smtpsvc3",
+                "windows/system32/logfiles/smtpsvc4",
+                "windows/system32/logfiles/smtpsvc5",
+                "etc/osxhttpd/osxhttpd.conf",
+                "system/library/webobjects/adaptors/apache2.2/apache.conf",
+                "etc/apache2/sites-available/default",
+                "etc/apache2/sites-available/default-ssl",
+                "etc/apache2/sites-enabled/000-default",
+                "etc/apache2/sites-enabled/default",
+                "etc/apache2/apache2.conf",
+                "etc/apache2/ports.conf",
+                "usr/local/etc/apache/httpd.conf",
+                "usr/pkg/etc/httpd/httpd.conf",
+                "usr/pkg/etc/httpd/httpd-default.conf",
+                "usr/pkg/etc/httpd/httpd-vhosts.conf",
+                "etc/httpd/mod_php.conf",
+                "etc/httpd/extra/httpd-ssl.conf",
+                "etc/rc.d/rc.httpd",
+                "usr/local/apache/conf/httpd.conf.default",
+                "usr/local/apache/conf/access.conf",
+                "usr/local/apache22/conf/httpd.conf",
+                "usr/local/apache22/httpd.conf",
+                "usr/local/etc/apache22/conf/httpd.conf",
+                "usr/local/apps/apache22/conf/httpd.conf",
+                "etc/apache22/conf/httpd.conf",
+                "etc/apache22/httpd.conf",
+                "opt/apache22/conf/httpd.conf",
+                "usr/local/etc/apache2/vhosts.conf",
+                "usr/local/apache/conf/vhosts.conf",
+                "usr/local/apache2/conf/vhosts.conf",
+                "usr/local/apache/conf/vhosts-custom.conf",
+                "usr/local/apache2/conf/vhosts-custom.conf",
+                "etc/apache/default-server.conf",
+                "etc/apache2/default-server.conf",
+                "usr/local/apache2/conf/extra/httpd-ssl.conf",
+                "usr/local/apache2/conf/ssl.conf",
+                "etc/httpd/conf.d",
+                "usr/local/etc/apache22/httpd.conf",
+                "usr/local/etc/apache2/httpd.conf",
+                "etc/apache2/httpd2.conf",
+                "etc/apache2/ssl-global.conf",
+                "etc/apache2/vhosts.d/00_default_vhost.conf",
+                "apache/conf/httpd.conf",
+                "etc/apache/httpd.conf",
+                "etc/httpd/conf",
+                "http/httpd.conf",
+                "usr/local/apache1.3/conf/httpd.conf",
+                "usr/local/etc/httpd/conf",
+                "var/apache/conf/httpd.conf",
+                "var/www/conf",
+                "www/apache/conf/httpd.conf",
+                "www/conf/httpd.conf",
+                "etc/init.d",
+                "etc/apache/access.conf",
+                "etc/rc.conf",
+                "www/logs/freebsddiary-error.log",
+                "www/logs/freebsddiary-access_log",
+                "library/webserver/documents/index.html",
+                "library/webserver/documents/index.htm",
+                "library/webserver/documents/default.html",
+                "library/webserver/documents/default.htm",
+                "library/webserver/documents/index.php",
+                "library/webserver/documents/default.php",
+                "var/log/webmin/miniserv.log",
+                "usr/local/etc/webmin/miniserv.conf",
+                "etc/webmin/miniserv.conf",
+                "usr/local/etc/webmin/miniserv.users",
+                "etc/webmin/miniserv.users",
+                "winnt/system32/logfiles/w3svc/inetsvn1.log",
+                "winnt/system32/logfiles/w3svc1/inetsvn1.log",
+                "winnt/system32/logfiles/w3svc2/inetsvn1.log",
+                "winnt/system32/logfiles/w3svc3/inetsvn1.log",
+                "windows/system32/logfiles/w3svc/inetsvn1.log",
+                "windows/system32/logfiles/w3svc1/inetsvn1.log",
+                "windows/system32/logfiles/w3svc2/inetsvn1.log",
+                "windows/system32/logfiles/w3svc3/inetsvn1.log",
+                "var/log/httpd/access_log",
+                "var/log/httpd/error_log",
+                "apache/logs/error.log",
+                "apache/logs/access.log",
+                "apache2/logs/error.log",
+                "apache2/logs/access.log",
+                "logs/error.log",
+                "logs/access.log",
+                "etc/httpd/logs/access_log",
+                "etc/httpd/logs/access.log",
+                "etc/httpd/logs/error_log",
+                "etc/httpd/logs/error.log",
+                "usr/local/apache/logs/access_log",
+                "usr/local/apache/logs/access.log",
+                "usr/local/apache/logs/error_log",
+                "usr/local/apache/logs/error.log",
+                "usr/local/apache2/logs/access_log",
+                "usr/local/apache2/logs/access.log",
+                "usr/local/apache2/logs/error_log",
+                "usr/local/apache2/logs/error.log",
+                "var/www/logs/access_log",
+                "var/www/logs/access.log",
+                "var/www/logs/error_log",
+                "var/www/logs/error.log",
+                "var/log/httpd/access.log",
+                "var/log/httpd/error.log",
+                "var/log/apache/access_log",
+                "var/log/apache/access.log",
+                "var/log/apache/error_log",
+                "var/log/apache/error.log",
+                "var/log/apache2/access_log",
+                "var/log/apache2/access.log",
+                "var/log/apache2/error_log",
+                "var/log/apache2/error.log",
+                "var/log/access_log",
+                "var/log/access.log",
+                "var/log/error_log",
+                "var/log/error.log",
+                "opt/lampp/logs/access_log",
+                "opt/lampp/logs/error_log",
+                "opt/xampp/logs/access_log",
+                "opt/xampp/logs/error_log",
+                "opt/lampp/logs/access.log",
+                "opt/lampp/logs/error.log",
+                "opt/xampp/logs/access.log",
+                "opt/xampp/logs/error.log",
+                "program files/apache group/apache/logs/access.log",
+                "program files/apache group/apache/logs/error.log",
+                "program files/apache software foundation/apache2.2/logs/error.log",
+                "program files/apache software foundation/apache2.2/logs/access.log",
+                "opt/apache/apache.conf",
+                "opt/apache/conf/apache.conf",
+                "opt/apache2/apache.conf",
+                "opt/apache2/conf/apache.conf",
+                "opt/httpd/apache.conf",
+                "opt/httpd/conf/apache.conf",
+                "etc/httpd/apache.conf",
+                "etc/apache2/apache.conf",
+                "etc/httpd/conf/apache.conf",
+                "usr/local/apache/apache.conf",
+                "usr/local/apache/conf/apache.conf",
+                "usr/local/apache2/apache.conf",
+                "usr/local/apache2/conf/apache.conf",
+                "usr/local/php/apache.conf.php",
+                "usr/local/php4/apache.conf.php",
+                "usr/local/php5/apache.conf.php",
+                "usr/local/php/apache.conf",
+                "usr/local/php4/apache.conf",
+                "usr/local/php5/apache.conf",
+                "private/etc/httpd/apache.conf",
+                "opt/apache/apache2.conf",
+                "opt/apache/conf/apache2.conf",
+                "opt/apache2/apache2.conf",
+                "opt/apache2/conf/apache2.conf",
+                "opt/httpd/apache2.conf",
+                "opt/httpd/conf/apache2.conf",
+                "etc/httpd/apache2.conf",
+                "etc/httpd/conf/apache2.conf",
+                "usr/local/apache/apache2.conf",
+                "usr/local/apache/conf/apache2.conf",
+                "usr/local/apache2/apache2.conf",
+                "usr/local/apache2/conf/apache2.conf",
+                "usr/local/php/apache2.conf.php",
+                "usr/local/php4/apache2.conf.php",
+                "usr/local/php5/apache2.conf.php",
+                "usr/local/php/apache2.conf",
+                "usr/local/php4/apache2.conf",
+                "usr/local/php5/apache2.conf",
+                "private/etc/httpd/apache2.conf",
+                "usr/local/apache/conf/httpd.conf",
+                "usr/local/apache2/conf/httpd.conf",
+                "etc/httpd/conf/httpd.conf",
+                "etc/apache/apache.conf",
+                "etc/apache/conf/httpd.conf",
+                "etc/apache2/httpd.conf",
+                "usr/apache2/conf/httpd.conf",
+                "usr/apache/conf/httpd.conf",
+                "usr/local/etc/apache/conf/httpd.conf",
+                "usr/local/apache/httpd.conf",
+                "usr/local/apache2/httpd.conf",
+                "usr/local/httpd/conf/httpd.conf",
+                "usr/local/etc/apache2/conf/httpd.conf",
+                "usr/local/etc/httpd/conf/httpd.conf",
+                "usr/local/apps/apache2/conf/httpd.conf",
+                "usr/local/apps/apache/conf/httpd.conf",
+                "usr/local/php/httpd.conf.php",
+                "usr/local/php4/httpd.conf.php",
+                "usr/local/php5/httpd.conf.php",
+                "usr/local/php/httpd.conf",
+                "usr/local/php4/httpd.conf",
+                "usr/local/php5/httpd.conf",
+                "etc/apache2/conf/httpd.conf",
+                "etc/http/conf/httpd.conf",
+                "etc/httpd/httpd.conf",
+                "etc/http/httpd.conf",
+                "etc/httpd.conf",
+                "opt/apache/conf/httpd.conf",
+                "opt/apache2/conf/httpd.conf",
+                "var/www/conf/httpd.conf",
+                "private/etc/httpd/httpd.conf",
+                "private/etc/httpd/httpd.conf.default",
+                "etc/apache2/vhosts.d/default_vhost.include",
+                "etc/apache2/conf.d/charset",
+                "etc/apache2/conf.d/security",
+                "etc/apache2/envvars",
+                "etc/apache2/mods-available/autoindex.conf",
+                "etc/apache2/mods-available/deflate.conf",
+                "etc/apache2/mods-available/dir.conf",
+                "etc/apache2/mods-available/mem_cache.conf",
+                "etc/apache2/mods-available/mime.conf",
+                "etc/apache2/mods-available/proxy.conf",
+                "etc/apache2/mods-available/setenvif.conf",
+                "etc/apache2/mods-available/ssl.conf",
+                "etc/apache2/mods-enabled/alias.conf",
+                "etc/apache2/mods-enabled/deflate.conf",
+                "etc/apache2/mods-enabled/dir.conf",
+                "etc/apache2/mods-enabled/mime.conf",
+                "etc/apache2/mods-enabled/negotiation.conf",
+                "etc/apache2/mods-enabled/php5.conf",
+                "etc/apache2/mods-enabled/status.conf",
+                "program files/apache group/apache/conf/httpd.conf",
+                "program files/apache group/apache2/conf/httpd.conf",
+                "program files/xampp/apache/conf/apache.conf",
+                "program files/xampp/apache/conf/apache2.conf",
+                "program files/xampp/apache/conf/httpd.conf",
+                "program files/apache group/apache/apache.conf",
+                "program files/apache group/apache/conf/apache.conf",
+                "program files/apache group/apache2/conf/apache.conf",
+                "program files/apache group/apache/apache2.conf",
+                "program files/apache group/apache/conf/apache2.conf",
+                "program files/apache group/apache2/conf/apache2.conf",
+                "program files/apache software foundation/apache2.2/conf/httpd.conf",
+                "volumes/macintosh_hd1/opt/httpd/conf/httpd.conf",
+                "volumes/macintosh_hd1/opt/apache/conf/httpd.conf",
+                "volumes/macintosh_hd1/opt/apache2/conf/httpd.conf",
+                "volumes/macintosh_hd1/usr/local/php/httpd.conf.php",
+                "volumes/macintosh_hd1/usr/local/php4/httpd.conf.php",
+                "volumes/macintosh_hd1/usr/local/php5/httpd.conf.php",
+                "volumes/webbackup/opt/apache2/conf/httpd.conf",
+                "volumes/webbackup/private/etc/httpd/httpd.conf",
+                "volumes/webbackup/private/etc/httpd/httpd.conf.default",
+                "usr/local/etc/apache/vhosts.conf",
+                "usr/local/jakarta/tomcat/conf/jakarta.conf",
+                "usr/local/jakarta/tomcat/conf/server.xml",
+                "usr/local/jakarta/tomcat/conf/context.xml",
+                "usr/local/jakarta/tomcat/conf/workers.properties",
+                "usr/local/jakarta/tomcat/conf/logging.properties",
+                "usr/local/jakarta/dist/tomcat/conf/jakarta.conf",
+                "usr/local/jakarta/dist/tomcat/conf/server.xml",
+                "usr/local/jakarta/dist/tomcat/conf/context.xml",
+                "usr/local/jakarta/dist/tomcat/conf/workers.properties",
+                "usr/local/jakarta/dist/tomcat/conf/logging.properties",
+                "usr/share/tomcat6/conf/server.xml",
+                "usr/share/tomcat6/conf/context.xml",
+                "usr/share/tomcat6/conf/workers.properties",
+                "usr/share/tomcat6/conf/logging.properties",
+                "var/log/tomcat6/catalina.out",
+                "var/cpanel/tomcat.options",
+                "usr/local/jakarta/tomcat/logs/catalina.out",
+                "usr/local/jakarta/tomcat/logs/catalina.err",
+                "opt/tomcat/logs/catalina.out",
+                "opt/tomcat/logs/catalina.err",
+                "usr/share/logs/catalina.out",
+                "usr/share/logs/catalina.err",
+                "usr/share/tomcat/logs/catalina.out",
+                "usr/share/tomcat/logs/catalina.err",
+                "usr/share/tomcat6/logs/catalina.out",
+                "usr/share/tomcat6/logs/catalina.err",
+                "usr/local/apache/logs/mod_jk.log",
+                "usr/local/jakarta/tomcat/logs/mod_jk.log",
+                "usr/local/jakarta/dist/tomcat/logs/mod_jk.log",
+                "opt/[jboss]/server/default/conf/jboss-minimal.xml",
+                "opt/[jboss]/server/default/conf/jboss-service.xml",
+                "opt/[jboss]/server/default/conf/jndi.properties",
+                "opt/[jboss]/server/default/conf/log4j.xml",
+                "opt/[jboss]/server/default/conf/login-config.xml",
+                "opt/[jboss]/server/default/conf/standardjaws.xml",
+                "opt/[jboss]/server/default/conf/standardjboss.xml",
+                "opt/[jboss]/server/default/conf/server.log.properties",
+                "opt/[jboss]/server/default/deploy/jboss-logging.xml",
+                "usr/local/[jboss]/server/default/conf/jboss-minimal.xml",
+                "usr/local/[jboss]/server/default/conf/jboss-service.xml",
+                "usr/local/[jboss]/server/default/conf/jndi.properties",
+                "usr/local/[jboss]/server/default/conf/log4j.xml",
+                "usr/local/[jboss]/server/default/conf/login-config.xml",
+                "usr/local/[jboss]/server/default/conf/standardjaws.xml",
+                "usr/local/[jboss]/server/default/conf/standardjboss.xml",
+                "usr/local/[jboss]/server/default/conf/server.log.properties",
+                "usr/local/[jboss]/server/default/deploy/jboss-logging.xml",
+                "private/tmp/[jboss]/server/default/conf/jboss-minimal.xml",
+                "private/tmp/[jboss]/server/default/conf/jboss-service.xml",
+                "private/tmp/[jboss]/server/default/conf/jndi.properties",
+                "private/tmp/[jboss]/server/default/conf/log4j.xml",
+                "private/tmp/[jboss]/server/default/conf/login-config.xml",
+                "private/tmp/[jboss]/server/default/conf/standardjaws.xml",
+                "private/tmp/[jboss]/server/default/conf/standardjboss.xml",
+                "private/tmp/[jboss]/server/default/conf/server.log.properties",
+                "private/tmp/[jboss]/server/default/deploy/jboss-logging.xml",
+                "tmp/[jboss]/server/default/conf/jboss-minimal.xml",
+                "tmp/[jboss]/server/default/conf/jboss-service.xml",
+                "tmp/[jboss]/server/default/conf/jndi.properties",
+                "tmp/[jboss]/server/default/conf/log4j.xml",
+                "tmp/[jboss]/server/default/conf/login-config.xml",
+                "tmp/[jboss]/server/default/conf/standardjaws.xml",
+                "tmp/[jboss]/server/default/conf/standardjboss.xml",
+                "tmp/[jboss]/server/default/conf/server.log.properties",
+                "tmp/[jboss]/server/default/deploy/jboss-logging.xml",
+                "program files/[jboss]/server/default/conf/jboss-minimal.xml",
+                "program files/[jboss]/server/default/conf/jboss-service.xml",
+                "program files/[jboss]/server/default/conf/jndi.properties",
+                "program files/[jboss]/server/default/conf/log4j.xml",
+                "program files/[jboss]/server/default/conf/login-config.xml",
+                "program files/[jboss]/server/default/conf/standardjaws.xml",
+                "program files/[jboss]/server/default/conf/standardjboss.xml",
+                "program files/[jboss]/server/default/conf/server.log.properties",
+                "program files/[jboss]/server/default/deploy/jboss-logging.xml",
+                "[jboss]/server/default/conf/jboss-minimal.xml",
+                "[jboss]/server/default/conf/jboss-service.xml",
+                "[jboss]/server/default/conf/jndi.properties",
+                "[jboss]/server/default/conf/log4j.xml",
+                "[jboss]/server/default/conf/login-config.xml",
+                "[jboss]/server/default/conf/standardjaws.xml",
+                "[jboss]/server/default/conf/standardjboss.xml",
+                "[jboss]/server/default/conf/server.log.properties",
+                "[jboss]/server/default/deploy/jboss-logging.xml",
+                "opt/[jboss]/server/default/log/server.log",
+                "opt/[jboss]/server/default/log/boot.log",
+                "usr/local/[jboss]/server/default/log/server.log",
+                "usr/local/[jboss]/server/default/log/boot.log",
+                "private/tmp/[jboss]/server/default/log/server.log",
+                "private/tmp/[jboss]/server/default/log/boot.log",
+                "tmp/[jboss]/server/default/log/server.log",
+                "tmp/[jboss]/server/default/log/boot.log",
+                "program files/[jboss]/server/default/log/server.log",
+                "program files/[jboss]/server/default/log/boot.log",
+                "[jboss]/server/default/log/server.log",
+                "[jboss]/server/default/log/boot.log",
+                "var/log/lighttpd.error.log",
+                "var/log/lighttpd.access.log",
+                "var/lighttpd.log",
+                "var/logs/access.log",
+                "var/log/lighttpd/",
+                "var/log/lighttpd/error.log",
+                "var/log/lighttpd/access.www.log",
+                "var/log/lighttpd/error.www.log",
+                "var/log/lighttpd/access.log",
+                "usr/local/apache2/logs/lighttpd.error.log",
+                "usr/local/apache2/logs/lighttpd.log",
+                "usr/local/apache/logs/lighttpd.error.log",
+                "usr/local/apache/logs/lighttpd.log",
+                "usr/local/lighttpd/log/lighttpd.error.log",
+                "usr/local/lighttpd/log/access.log",
+                "var/log/lighttpd/{domain}/access.log",
+                "var/log/lighttpd/{domain}/error.log",
+                "usr/home/user/var/log/lighttpd.error.log",
+                "usr/home/user/var/log/apache.log",
+                "home/user/lighttpd/lighttpd.conf",
+                "usr/home/user/lighttpd/lighttpd.conf",
+                "etc/lighttpd/lighthttpd.conf",
+                "usr/local/etc/lighttpd.conf",
+                "usr/local/lighttpd/conf/lighttpd.conf",
+                "usr/local/etc/lighttpd.conf.new",
+                "var/www/.lighttpdpassword",
+                "var/log/nginx/access_log",
+                "var/log/nginx/error_log",
+                "var/log/nginx/access.log",
+                "var/log/nginx/error.log",
+                "var/log/nginx.access_log",
+                "var/log/nginx.error_log",
+                "logs/access_log",
+                "logs/error_log",
+                "etc/nginx/nginx.conf",
+                "usr/local/etc/nginx/nginx.conf",
+                "usr/local/nginx/conf/nginx.conf",
+                "usr/local/zeus/web/global.cfg",
+                "usr/local/zeus/web/log/errors",
+                "opt/lsws/conf/httpd_conf.xml",
+                "usr/local/lsws/conf/httpd_conf.xml",
+                "opt/lsws/logs/error.log",
+                "opt/lsws/logs/access.log",
+                "usr/local/lsws/logs/error.log",
+                "usr/local/logs/access.log",
+                "usr/local/samba/lib/log.user",
+                "usr/local/logs/samba.log",
+                "var/log/samba/log.smbd",
+                "var/log/samba/log.nmbd",
+                "var/log/samba.log",
+                "var/log/samba.log1",
+                "var/log/samba.log2",
+                "var/log/log.smb",
+                "etc/samba/netlogon",
+                "etc/smbpasswd",
+                "etc/smb.conf",
+                "etc/samba/dhcp.conf",
+                "etc/samba/smb.conf",
+                "etc/samba/samba.conf",
+                "etc/samba/smb.conf.user",
+                "etc/samba/smbpasswd",
+                "etc/samba/smbusers",
+                "etc/samba/private/smbpasswd",
+                "usr/local/etc/smb.conf",
+                "usr/local/samba/lib/smb.conf.user",
+                "etc/dhcp3/dhclient.conf",
+                "etc/dhcp3/dhcpd.conf",
+                "etc/dhcp/dhclient.conf",
+                "program files/vidalia bundle/polipo/polipo.conf",
+                "etc/tor/tor-tsocks.conf",
+                "etc/stunnel/stunnel.conf",
+                "etc/tsocks.conf",
+                "etc/tinyproxy/tinyproxy.conf",
+                "etc/miredo-server.conf",
+                "etc/miredo.conf",
+                "etc/miredo/miredo-server.conf",
+                "etc/miredo/miredo.conf",
+                "etc/wicd/dhclient.conf.template.default",
+                "etc/wicd/manager-settings.conf",
+                "etc/wicd/wired-settings.conf",
+                "etc/wicd/wireless-settings.conf",
+                "var/log/ipfw.log",
+                "var/log/ipfw",
+                "var/log/ipfw/ipfw.log",
+                "var/log/ipfw.today",
+                "etc/ipfw.rules",
+                "etc/ipfw.conf",
+                "etc/firewall.rules",
+                "winnt/system32/logfiles/firewall/pfirewall.log",
+                "winnt/system32/logfiles/firewall/pfirewall.log.old",
+                "windows/system32/logfiles/firewall/pfirewall.log",
+                "windows/system32/logfiles/firewall/pfirewall.log.old",
+                "etc/clamav/clamd.conf",
+                "etc/clamav/freshclam.conf",
+                "etc/x11/xorg.conf",
+                "etc/x11/xorg.conf-vesa",
+                "etc/x11/xorg.conf-vmware",
+                "etc/x11/xorg.conf.beforevmwaretoolsinstall",
+                "etc/x11/xorg.conf.orig",
+                "etc/bluetooth/input.conf",
+                "etc/bluetooth/main.conf",
+                "etc/bluetooth/network.conf",
+                "etc/bluetooth/rfcomm.conf",
+                "proc/self/environ",
+                "proc/self/mounts",
+                "proc/self/stat",
+                "proc/self/status",
+                "proc/self/cmdline",
+                "proc/self/fd/0",
+                "proc/self/fd/1",
+                "proc/self/fd/2",
+                "proc/self/fd/3",
+                "proc/self/fd/4",
+                "proc/self/fd/5",
+                "proc/self/fd/6",
+                "proc/self/fd/7",
+                "proc/self/fd/8",
+                "proc/self/fd/9",
+                "proc/self/fd/10",
+                "proc/self/fd/11",
+                "proc/self/fd/12",
+                "proc/self/fd/13",
+                "proc/self/fd/14",
+                "proc/self/fd/15",
+                "proc/version",
+                "proc/devices",
+                "proc/cpuinfo",
+                "proc/meminfo",
+                "proc/net/tcp",
+                "proc/net/udp",
+                "etc/bash_completion.d/debconf",
+                "root/.bash_logout",
+                "root/.bash_history",
+                "root/.bash_config",
+                "root/.bashrc",
+                "etc/bash.bashrc",
+                "var/adm/syslog",
+                "var/adm/sulog",
+                "var/adm/utmp",
+                "var/adm/utmpx",
+                "var/adm/wtmp",
+                "var/adm/wtmpx",
+                "var/adm/lastlog/username",
+                "usr/spool/lp/log",
+                "var/adm/lp/lpd-errs",
+                "usr/lib/cron/log",
+                "var/adm/loginlog",
+                "var/adm/pacct",
+                "var/adm/dtmp",
+                "var/adm/acct/sum/loginlog",
+                "var/adm/x0msgs",
+                "var/adm/crash/vmcore",
+                "var/adm/crash/unix",
+                "etc/newsyslog.conf",
+                "var/adm/qacct",
+                "var/adm/ras/errlog",
+                "var/adm/ras/bootlog",
+                "var/adm/cron/log",
+                "etc/utmp",
+                "etc/security/lastlog",
+                "etc/security/failedlogin",
+                "usr/spool/mqueue/syslog",
+                "var/adm/messages",
+                "var/adm/aculogs",
+                "var/adm/aculog",
+                "var/adm/vold.log",
+                "var/adm/log/asppp.log",
+                "var/log/poplog",
+                "var/log/authlog",
+                "var/lp/logs/lpsched",
+                "var/lp/logs/lpnet",
+                "var/lp/logs/requests",
+                "var/cron/log",
+                "var/saf/_log",
+                "var/saf/port/log",
+                "var/log/news.all",
+                "var/log/news/news.all",
+                "var/log/news/news.crit",
+                "var/log/news/news.err",
+                "var/log/news/news.notice",
+                "var/log/news/suck.err",
+                "var/log/news/suck.notice",
+                "var/log/messages",
+                "var/log/messages.1",
+                "var/log/user.log",
+                "var/log/user.log.1",
+                "var/log/auth.log",
+                "var/log/pm-powersave.log",
+                "var/log/xorg.0.log",
+                "var/log/daemon.log",
+                "var/log/daemon.log.1",
+                "var/log/kern.log",
+                "var/log/kern.log.1",
+                "var/log/mail.err",
+                "var/log/mail.info",
+                "var/log/mail.warn",
+                "var/log/ufw.log",
+                "var/log/boot.log",
+                "var/log/syslog",
+                "var/log/syslog.1",
+                "tmp/access.log",
+                "etc/sensors.conf",
+                "etc/sensors3.conf",
+                "etc/host.conf",
+                "etc/pam.conf",
+                "etc/resolv.conf",
+                "etc/apt/apt.conf",
+                "etc/inetd.conf",
+                "etc/syslog.conf",
+                "etc/sysctl.conf",
+                "etc/sysctl.d/10-console-messages.conf",
+                "etc/sysctl.d/10-network-security.conf",
+                "etc/sysctl.d/10-process-security.conf",
+                "etc/sysctl.d/wine.sysctl.conf",
+                "etc/security/access.conf",
+                "etc/security/group.conf",
+                "etc/security/limits.conf",
+                "etc/security/namespace.conf",
+                "etc/security/pam_env.conf",
+                "etc/security/sepermit.conf",
+                "etc/security/time.conf",
+                "etc/ssh/sshd_config",
+                "etc/adduser.conf",
+                "etc/deluser.conf",
+                "etc/avahi/avahi-daemon.conf",
+                "etc/ca-certificates.conf",
+                "etc/ca-certificates.conf.dpkg-old",
+                "etc/casper.conf",
+                "etc/chkrootkit.conf",
+                "etc/debconf.conf",
+                "etc/dns2tcpd.conf",
+                "etc/e2fsck.conf",
+                "etc/esound/esd.conf",
+                "etc/etter.conf",
+                "etc/fuse.conf",
+                "etc/foremost.conf",
+                "etc/hdparm.conf",
+                "etc/kernel-img.conf",
+                "etc/kernel-pkg.conf",
+                "etc/ld.so.conf",
+                "etc/ltrace.conf",
+                "etc/mail/sendmail.conf",
+                "etc/manpath.config",
+                "etc/kbd/config",
+                "etc/ldap/ldap.conf",
+                "etc/logrotate.conf",
+                "etc/mtools.conf",
+                "etc/smi.conf",
+                "etc/updatedb.conf",
+                "etc/pulse/client.conf",
+                "usr/share/adduser/adduser.conf",
+                "etc/hostname",
+                "etc/networks",
+                "etc/timezone",
+                "etc/modules",
+                "etc/passwd",
+                "etc/passwd~",
+                "etc/passwd-",
+                "etc/shadow",
+                "etc/shadow~",
+                "etc/shadow-",
+                "etc/fstab",
+                "etc/motd",
+                "etc/hosts",
+                "etc/group",
+                "etc/group-",
+                "etc/alias",
+                "etc/crontab",
+                "etc/crypttab",
+                "etc/exports",
+                "etc/mtab",
+                "etc/hosts.allow",
+                "etc/hosts.deny",
+                "etc/os-release",
+                "etc/password.master",
+                "etc/profile",
+                "etc/default/grub",
+                "etc/resolvconf/update-libc.d/sendmail",
+                "etc/inittab",
+                "etc/issue",
+                "etc/issue.net",
+                "etc/login.defs",
+                "etc/sudoers",
+                "etc/sysconfig/network-scripts/ifcfg-eth0",
+                "etc/redhat-release",
+                "etc/debian_version",
+                "etc/fedora-release",
+                "etc/mandrake-release",
+                "etc/slackware-release",
+                "etc/suse-release",
+                "etc/security/group",
+                "etc/security/passwd",
+                "etc/security/user",
+                "etc/security/environ",
+                "etc/security/limits",
+                "etc/security/opasswd",
+                "boot/grub/grub.cfg",
+                "boot/grub/menu.lst",
+                "root/.ksh_history",
+                "root/.xauthority",
+                "usr/lib/security/mkuser.default",
+                "var/log/squirrelmail.log",
+                "var/log/apache2/squirrelmail.log",
+                "var/log/apache2/squirrelmail.err.log",
+                "var/lib/squirrelmail/prefs/squirrelmail.log",
+                "var/log/mail.log",
+                "etc/squirrelmail/apache.conf",
+                "etc/squirrelmail/config_local.php",
+                "etc/squirrelmail/default_pref",
+                "etc/squirrelmail/index.php",
+                "etc/squirrelmail/config_default.php",
+                "etc/squirrelmail/config.php",
+                "etc/squirrelmail/filters_setup.php",
+                "etc/squirrelmail/sqspell_config.php",
+                "etc/squirrelmail/config/config.php",
+                "etc/httpd/conf.d/squirrelmail.conf",
+                "usr/share/squirrelmail/config/config.php",
+                "private/etc/squirrelmail/config/config.php",
+                "srv/www/htdos/squirrelmail/config/config.php",
+                "var/www/squirrelmail/config/config.php",
+                "var/www/html/squirrelmail/config/config.php",
+                "var/www/html/squirrelmail-1.2.9/config/config.php",
+                "usr/share/squirrelmail/plugins/squirrel_logger/setup.php",
+                "usr/local/squirrelmail/www/readme",
+                "windows/system32/drivers/etc/hosts",
+                "windows/system32/drivers/etc/lmhosts.sam",
+                "windows/system32/drivers/etc/networks",
+                "windows/system32/drivers/etc/protocol",
+                "windows/system32/drivers/etc/services",
+                "/boot.ini",
+                "windows/debug/netsetup.log",
+                "windows/comsetup.log",
+                "windows/repair/setup.log",
+                "windows/setupact.log",
+                "windows/setupapi.log",
+                "windows/setuperr.log",
+                "windows/updspapi.log",
+                "windows/wmsetup.log",
+                "windows/windowsupdate.log",
+                "windows/odbc.ini",
+                "usr/local/psa/admin/htdocs/domains/databases/phpmyadmin/libraries/config.default.php",
+                "etc/apache2/conf.d/phpmyadmin.conf",
+                "etc/phpmyadmin/config.inc.php",
+                "etc/openldap/ldap.conf",
+                "etc/cups/acroread.conf",
+                "etc/cups/cupsd.conf",
+                "etc/cups/cupsd.conf.default",
+                "etc/cups/pdftops.conf",
+                "etc/cups/printers.conf",
+                "windows/system32/macromed/flash/flashinstall.log",
+                "windows/system32/macromed/flash/install.log",
+                "etc/cvs-cron.conf",
+                "etc/cvs-pserver.conf",
+                "etc/subversion/config",
+                "etc/modprobe.d/vmware-tools.conf",
+                "etc/updatedb.conf.beforevmwaretoolsinstall",
+                "etc/vmware-tools/config",
+                "etc/vmware-tools/tpvmlp.conf",
+                "etc/vmware-tools/vmware-tools-libraries.conf",
+                "var/log/vmware/hostd.log",
+                "var/log/vmware/hostd-1.log",
+                "wp-config.php",
+                "wp-config.bak",
+                "wp-config.old",
+                "wp-config.temp",
+                "wp-config.tmp",
+                "wp-config.txt",
+                "config.yml",
+                "config_dev.yml",
+                "config_prod.yml",
+                "config_test.yml",
+                "parameters.yml",
+                "routing.yml",
+                "security.yml",
+                "services.yml",
+                "sites/default/default.settings.php",
+                "sites/default/settings.php",
+                "sites/default/settings.local.php",
+                "app/etc/local.xml",
+                "sftp-config.json",
+                "web.config",
+                "includes/config.php",
+                "includes/configure.php",
+                "config.inc.php",
+                "localsettings.php",
+                "inc/config.php",
+                "typo3conf/localconf.php",
+                "config/app.php",
+                "config/custom.php",
+                "config/database.php",
+                "/configuration.php",
+                "/config.php",
+                "var/mail/www-data",
+                "etc/network/",
+                "etc/init/",
+                "inetpub/wwwroot/global.asa",
+                "system32/inetsrv/config/applicationhost.config",
+                "system32/inetsrv/config/administration.config",
+                "system32/inetsrv/config/redirection.config",
+                "system32/config/default",
+                "system32/config/sam",
+                "system32/config/system",
+                "system32/config/software",
+                "winnt/repair/sam._",
+                "package.json",
+                "package-lock.json",
+                "gruntfile.js",
+                "npm-debug.log",
+                "ormconfig.json",
+                "tsconfig.json",
+                "webpack.config.js",
+                "yarn.lock"
+              ]
+            },
+            "operator": "phrase_match"
+          }
+        ],
+        "transformers": [
+          "lowercase"
+        ]
+      },
+      {
+        "id": "crs-931-110",
+        "name": "Possible Remote File Inclusion (RFI) Attack: Common RFI Vulnerable Parameter Name used w/URL Payload",
+        "tags": {
+          "type": "rfi",
+          "crs_id": "931110",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.query"
+                }
+              ],
+              "regex": "(?:\\binclude\\s*\\([^)]*|mosConfig_absolute_path|_CONF\\[path\\]|_SERVER\\[DOCUMENT_ROOT\\]|GALLERY_BASEDIR|path\\[docroot\\]|appserv_root|config\\[root_dir\\])=(?:file|ftps?|https?)://",
+              "options": {
+                "min_length": 15
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-931-120",
+        "name": "Possible Remote File Inclusion (RFI) Attack: URL Payload Used w/Trailing Question Mark Character (?)",
+        "tags": {
+          "type": "rfi",
+          "crs_id": "931120",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "^(?i:file|ftps?|https?).*?\\?+$",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 4
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-932-160",
+        "name": "Remote Command Execution: Unix Shell Code Found",
+        "tags": {
+          "type": "command_injection",
+          "crs_id": "932160",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "list": [
+                "${cdpath}",
+                "${dirstack}",
+                "${home}",
+                "${hostname}",
+                "${ifs}",
+                "${oldpwd}",
+                "${ostype}",
+                "${path}",
+                "${pwd}",
+                "$cdpath",
+                "$dirstack",
+                "$home",
+                "$hostname",
+                "$ifs",
+                "$oldpwd",
+                "$ostype",
+                "$path",
+                "$pwd",
+                "bin/bash",
+                "bin/cat",
+                "bin/csh",
+                "bin/dash",
+                "bin/du",
+                "bin/echo",
+                "bin/grep",
+                "bin/less",
+                "bin/ls",
+                "bin/mknod",
+                "bin/more",
+                "bin/nc",
+                "bin/ps",
+                "bin/rbash",
+                "bin/sh",
+                "bin/sleep",
+                "bin/su",
+                "bin/tcsh",
+                "bin/uname",
+                "dev/fd/",
+                "dev/null",
+                "dev/stderr",
+                "dev/stdin",
+                "dev/stdout",
+                "dev/tcp/",
+                "dev/udp/",
+                "dev/zero",
+                "etc/group",
+                "etc/master.passwd",
+                "etc/passwd",
+                "etc/pwd.db",
+                "etc/shadow",
+                "etc/shells",
+                "etc/spwd.db",
+                "proc/self/",
+                "usr/bin/awk",
+                "usr/bin/base64",
+                "usr/bin/cat",
+                "usr/bin/cc",
+                "usr/bin/clang",
+                "usr/bin/clang++",
+                "usr/bin/curl",
+                "usr/bin/diff",
+                "usr/bin/env",
+                "usr/bin/fetch",
+                "usr/bin/file",
+                "usr/bin/find",
+                "usr/bin/ftp",
+                "usr/bin/gawk",
+                "usr/bin/gcc",
+                "usr/bin/head",
+                "usr/bin/hexdump",
+                "usr/bin/id",
+                "usr/bin/less",
+                "usr/bin/ln",
+                "usr/bin/mkfifo",
+                "usr/bin/more",
+                "usr/bin/nc",
+                "usr/bin/ncat",
+                "usr/bin/nice",
+                "usr/bin/nmap",
+                "usr/bin/perl",
+                "usr/bin/php",
+                "usr/bin/php5",
+                "usr/bin/php7",
+                "usr/bin/php-cgi",
+                "usr/bin/printf",
+                "usr/bin/psed",
+                "usr/bin/python",
+                "usr/bin/python2",
+                "usr/bin/python3",
+                "usr/bin/ruby",
+                "usr/bin/sed",
+                "usr/bin/socat",
+                "usr/bin/tail",
+                "usr/bin/tee",
+                "usr/bin/telnet",
+                "usr/bin/top",
+                "usr/bin/uname",
+                "usr/bin/wget",
+                "usr/bin/who",
+                "usr/bin/whoami",
+                "usr/bin/xargs",
+                "usr/bin/xxd",
+                "usr/bin/yes",
+                "usr/local/bin/bash",
+                "usr/local/bin/curl",
+                "usr/local/bin/ncat",
+                "usr/local/bin/nmap",
+                "usr/local/bin/perl",
+                "usr/local/bin/php",
+                "usr/local/bin/python",
+                "usr/local/bin/python2",
+                "usr/local/bin/python3",
+                "usr/local/bin/rbash",
+                "usr/local/bin/ruby",
+                "usr/local/bin/wget"
+              ]
+            },
+            "operator": "phrase_match"
+          }
+        ],
+        "transformers": [
+          "lowercase"
+        ]
+      },
+      {
+        "id": "crs-932-171",
+        "name": "Remote Command Execution: Shellshock (CVE-2014-6271)",
+        "tags": {
+          "type": "command_injection",
+          "crs_id": "932171",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                },
+                {
+                  "address": "server.request.headers.no_cookies"
+                }
+              ],
+              "regex": "^\\(\\s*\\)\\s+{",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 4
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-932-180",
+        "name": "Restricted File Upload Attempt",
+        "tags": {
+          "type": "command_injection",
+          "crs_id": "932180",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "x-filename",
+                    "x_filename",
+                    "x-file-name"
+                  ]
+                }
+              ],
+              "list": [
+                ".htaccess",
+                ".htdigest",
+                ".htpasswd",
+                "wp-config.php",
+                "config.yml",
+                "config_dev.yml",
+                "config_prod.yml",
+                "config_test.yml",
+                "parameters.yml",
+                "routing.yml",
+                "security.yml",
+                "services.yml",
+                "default.settings.php",
+                "settings.php",
+                "settings.local.php",
+                "local.xml",
+                ".env"
+              ]
+            },
+            "operator": "phrase_match"
+          }
+        ],
+        "transformers": [
+          "lowercase"
+        ]
+      },
+      {
+        "id": "crs-933-111",
+        "name": "PHP Injection Attack: PHP Script File Upload Found",
+        "tags": {
+          "type": "unrestricted_file_upload",
+          "crs_id": "933111",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "x-filename",
+                    "x_filename",
+                    "x.filename",
+                    "x-file-name"
+                  ]
+                }
+              ],
+              "regex": ".*\\.(?:php\\d*|phtml)\\..*$",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 5
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "lowercase"
+        ]
+      },
+      {
+        "id": "crs-933-130",
+        "name": "PHP Injection Attack: Global Variables Found",
+        "tags": {
+          "type": "php_code_injection",
+          "crs_id": "933130",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "list": [
+                "$globals",
+                "$http_cookie_vars",
+                "$http_env_vars",
+                "$http_get_vars",
+                "$http_post_files",
+                "$http_post_vars",
+                "$http_raw_post_data",
+                "$http_request_vars",
+                "$http_server_vars",
+                "$_cookie",
+                "$_env",
+                "$_files",
+                "$_get",
+                "$_post",
+                "$_request",
+                "$_server",
+                "$_session",
+                "$argc",
+                "$argv"
+              ]
+            },
+            "operator": "phrase_match"
+          }
+        ],
+        "transformers": [
+          "lowercase"
+        ]
+      },
+      {
+        "id": "crs-933-131",
+        "name": "PHP Injection Attack: HTTP Headers Values Found",
+        "tags": {
+          "type": "php_code_injection",
+          "crs_id": "933131",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "(?:HTTP_(?:ACCEPT(?:_(?:ENCODING|LANGUAGE|CHARSET))?|(?:X_FORWARDED_FO|REFERE)R|(?:USER_AGEN|HOS)T|CONNECTION|KEEP_ALIVE)|PATH_(?:TRANSLATED|INFO)|ORIG_PATH_INFO|QUERY_STRING|REQUEST_URI|AUTH_TYPE)",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 9
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-933-140",
+        "name": "PHP Injection Attack: I/O Stream Found",
+        "tags": {
+          "type": "php_code_injection",
+          "crs_id": "933140",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "php://(?:std(?:in|out|err)|(?:in|out)put|fd|memory|temp|filter)",
+              "options": {
+                "min_length": 8
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-933-150",
+        "name": "PHP Injection Attack: High-Risk PHP Function Name Found",
+        "tags": {
+          "type": "php_code_injection",
+          "crs_id": "933150",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "list": [
+                "__halt_compiler",
+                "apache_child_terminate",
+                "base64_decode",
+                "bzdecompress",
+                "call_user_func",
+                "call_user_func_array",
+                "call_user_method",
+                "call_user_method_array",
+                "convert_uudecode",
+                "file_get_contents",
+                "file_put_contents",
+                "fsockopen",
+                "get_class_methods",
+                "get_class_vars",
+                "get_defined_constants",
+                "get_defined_functions",
+                "get_defined_vars",
+                "gzdecode",
+                "gzinflate",
+                "gzuncompress",
+                "include_once",
+                "invokeargs",
+                "pcntl_exec",
+                "pcntl_fork",
+                "pfsockopen",
+                "posix_getcwd",
+                "posix_getpwuid",
+                "posix_getuid",
+                "posix_uname",
+                "reflectionfunction",
+                "require_once",
+                "shell_exec",
+                "str_rot13",
+                "sys_get_temp_dir",
+                "wp_remote_fopen",
+                "wp_remote_get",
+                "wp_remote_head",
+                "wp_remote_post",
+                "wp_remote_request",
+                "wp_safe_remote_get",
+                "wp_safe_remote_head",
+                "wp_safe_remote_post",
+                "wp_safe_remote_request",
+                "zlib_decode"
+              ]
+            },
+            "operator": "phrase_match"
+          }
+        ],
+        "transformers": [
+          "lowercase"
+        ]
+      },
+      {
+        "id": "crs-933-160",
+        "name": "PHP Injection Attack: High-Risk PHP Function Call Found",
+        "tags": {
+          "type": "php_code_injection",
+          "crs_id": "933160",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "\\b(?:s(?:e(?:t(?:_(?:e(?:xception|rror)_handler|magic_quotes_runtime|include_path)|defaultstub)|ssion_s(?:et_save_handler|tart))|qlite_(?:(?:(?:unbuffered|single|array)_)?query|create_(?:aggregate|function)|p?open|exec)|tr(?:eam_(?:context_create|socket_client)|ipc?slashes|rev)|implexml_load_(?:string|file)|ocket_c(?:onnect|reate)|h(?:ow_sourc|a1_fil)e|pl_autoload_register|ystem)|p(?:r(?:eg_(?:replace(?:_callback(?:_array)?)?|match(?:_all)?|split)|oc_(?:(?:terminat|clos|nic)e|get_status|open)|int_r)|o(?:six_(?:get(?:(?:e[gu]|g)id|login|pwnam)|mk(?:fifo|nod)|ttyname|kill)|pen)|hp(?:_(?:strip_whitespac|unam)e|version|info)|g_(?:(?:execut|prepar)e|connect|query)|a(?:rse_(?:ini_file|str)|ssthru)|utenv)|r(?:unkit_(?:function_(?:re(?:defin|nam)e|copy|add)|method_(?:re(?:defin|nam)e|copy|add)|constant_(?:redefine|add))|e(?:(?:gister_(?:shutdown|tick)|name)_function|ad(?:(?:gz)?file|_exif_data|dir))|awurl(?:de|en)code)|i(?:mage(?:createfrom(?:(?:jpe|pn)g|x[bp]m|wbmp|gif)|(?:jpe|pn)g|g(?:d2?|if)|2?wbmp|xbm)|s_(?:(?:(?:execut|write?|read)ab|fi)le|dir)|ni_(?:get(?:_all)?|set)|terator_apply|ptcembed)|g(?:et(?:_(?:c(?:urrent_use|fg_va)r|meta_tags)|my(?:[gpu]id|inode)|(?:lastmo|cw)d|imagesize|env)|z(?:(?:(?:defla|wri)t|encod|fil)e|compress|open|read)|lob)|a(?:rray_(?:u(?:intersect(?:_u?assoc)?|diff(?:_u?assoc)?)|intersect_u(?:assoc|key)|diff_u(?:assoc|key)|filter|reduce|map)|ssert(?:_options)?)|h(?:tml(?:specialchars(?:_decode)?|_entity_decode|entities)|(?:ash(?:_(?:update|hmac))?|ighlight)_file|e(?:ader_register_callback|x2bin))|f(?:i(?:le(?:(?:[acm]tim|inod)e|(?:_exist|perm)s|group)?|nfo_open)|tp_(?:nb_(?:ge|pu)|connec|ge|pu)t|(?:unction_exis|pu)ts|write|open)|o(?:b_(?:get_(?:c(?:ontents|lean)|flush)|end_(?:clean|flush)|clean|flush|start)|dbc_(?:result(?:_all)?|exec(?:ute)?|connect)|pendir)|m(?:b_(?:ereg(?:_(?:replace(?:_callback)?|match)|i(?:_replace)?)?|parse_str)|(?:ove_uploaded|d5)_file|ethod_exists|ysql_query|kdir)|e(?:x(?:if_(?:t(?:humbnail|agname)|imagetype|read_data)|ec)|scapeshell(?:arg|cmd)|rror_reporting|val)|c(?:url_(?:file_create|exec|init)|onvert_uuencode|reate_function|hr)|u(?:n(?:serialize|pack)|rl(?:de|en)code|[ak]?sort)|(?:json_(?:de|en)cod|debug_backtrac|tmpfil)e|b(?:(?:son_(?:de|en)|ase64_en)code|zopen)|var_dump)(?:\\s|/\\*.*\\*/|//.*|#.*)*\\(.*\\)",
+              "options": {
+                "min_length": 5
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-933-170",
+        "name": "PHP Injection Attack: Serialized Object Injection",
+        "tags": {
+          "type": "php_code_injection",
+          "crs_id": "933170",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.headers.no_cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "[oOcC]:\\d+:\\\".+?\\\":\\d+:{[\\W\\w]*}",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 12
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-933-200",
+        "name": "PHP Injection Attack: Wrapper scheme detected",
+        "tags": {
+          "type": "php_code_injection",
+          "crs_id": "933200",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "(?i:zlib|glob|phar|ssh2|rar|ogg|expect|zip)://",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 6
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "removeNulls"
+        ]
+      },
+      {
+        "id": "crs-934-100",
+        "name": "Node.js Injection Attack",
+        "tags": {
+          "type": "js_code_injection",
+          "crs_id": "934100",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "(?:(?:_(?:\\$\\$ND_FUNC\\$\\$_|_js_function)|(?:new\\s+Function|\\beval)\\s*\\(|String\\s*\\.\\s*fromCharCode|function\\s*\\(\\s*\\)\\s*{|this\\.constructor)|module\\.exports\\s*=)",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 5
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-941-100",
+        "name": "XSS Attack Detected via libinjection",
+        "tags": {
+          "type": "xss",
+          "crs_id": "941100",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent",
+                    "referer"
+                  ]
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ]
+            },
+            "operator": "is_xss"
+          }
+        ],
+        "transformers": [
+          "removeNulls"
+        ]
+      },
+      {
+        "id": "crs-941-110",
+        "name": "XSS Filter - Category 1: Script Tag Vector",
+        "tags": {
+          "type": "xss",
+          "crs_id": "941110",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent",
+                    "referer"
+                  ]
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "<script[^>]*>[\\s\\S]*?",
+              "options": {
+                "min_length": 8
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "removeNulls"
+        ]
+      },
+      {
+        "id": "crs-941-120",
+        "name": "XSS Filter - Category 2: Event Handler Vector",
+        "tags": {
+          "type": "xss",
+          "crs_id": "941120",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent",
+                    "referer"
+                  ]
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "[\\s\\\"'`;\\/0-9=\\x0B\\x09\\x0C\\x3B\\x2C\\x28\\x3B]on[a-zA-Z]{3,25}[\\s\\x0B\\x09\\x0C\\x3B\\x2C\\x28\\x3B]*?=[^=]",
+              "options": {
+                "min_length": 8
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "removeNulls"
+        ]
+      },
+      {
+        "id": "crs-941-140",
+        "name": "XSS Filter - Category 4: Javascript URI Vector",
+        "tags": {
+          "type": "xss",
+          "crs_id": "941140",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent",
+                    "referer"
+                  ]
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "[a-z]+=(?:[^:=]+:.+;)*?[^:=]+:url\\(javascript",
+              "options": {
+                "min_length": 18
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "removeNulls"
+        ]
+      },
+      {
+        "id": "crs-941-180",
+        "name": "Node-Validator Deny List Keywords",
+        "tags": {
+          "type": "xss",
+          "crs_id": "941180",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "list": [
+                "document.cookie",
+                "document.write",
+                ".parentnode",
+                ".innerhtml",
+                "window.location",
+                "-moz-binding",
+                "<![cdata["
+              ]
+            },
+            "operator": "phrase_match"
+          }
+        ],
+        "transformers": [
+          "removeNulls",
+          "lowercase"
+        ]
+      },
+      {
+        "id": "crs-941-200",
+        "name": "IE XSS Filters - Attack Detected via vmlframe tag",
+        "tags": {
+          "type": "xss",
+          "crs_id": "941200",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "(?i:<.*[:]?vmlframe.*?[\\s/+]*?src[\\s/+]*=)",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 13
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "removeNulls"
+        ]
+      },
+      {
+        "id": "crs-941-210",
+        "name": "IE XSS Filters - Obfuscated Attack Detected via javascript injection",
+        "tags": {
+          "type": "xss",
+          "crs_id": "941210",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "(?i:(?:j|&#x?0*(?:74|4A|106|6A);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:a|&#x?0*(?:65|41|97|61);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:v|&#x?0*(?:86|56|118|76);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:a|&#x?0*(?:65|41|97|61);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:s|&#x?0*(?:83|53|115|73);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:c|&#x?0*(?:67|43|99|63);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:r|&#x?0*(?:82|52|114|72);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:i|&#x?0*(?:73|49|105|69);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:p|&#x?0*(?:80|50|112|70);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:t|&#x?0*(?:84|54|116|74);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?::|&(?:#x?0*(?:58|3A);?|colon;)).)",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 12
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "removeNulls"
+        ]
+      },
+      {
+        "id": "crs-941-220",
+        "name": "IE XSS Filters - Obfuscated Attack Detected via vbscript injection",
+        "tags": {
+          "type": "xss",
+          "crs_id": "941220",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "(?i:(?:v|&#x?0*(?:86|56|118|76);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:b|&#x?0*(?:66|42|98|62);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:s|&#x?0*(?:83|53|115|73);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:c|&#x?0*(?:67|43|99|63);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:r|&#x?0*(?:82|52|114|72);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:i|&#x?0*(?:73|49|105|69);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:p|&#x?0*(?:80|50|112|70);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:t|&#x?0*(?:84|54|116|74);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?::|&(?:#x?0*(?:58|3A);?|colon;)).)",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 10
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "removeNulls"
+        ]
+      },
+      {
+        "id": "crs-941-230",
+        "name": "IE XSS Filters - Attack Detected via embed tag",
+        "tags": {
+          "type": "xss",
+          "crs_id": "941230",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "<EMBED[\\s/+].*?(?:src|type).*?=",
+              "options": {
+                "min_length": 11
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "removeNulls"
+        ]
+      },
+      {
+        "id": "crs-941-240",
+        "name": "IE XSS Filters - Attack Detected via import tag",
+        "tags": {
+          "type": "xss",
+          "crs_id": "941240",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "<[?]?import[\\s/+\\S]*?implementation[\\s/+]*?=",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 22
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "lowercase",
+          "removeNulls"
+        ]
+      },
+      {
+        "id": "crs-941-270",
+        "name": "IE XSS Filters - Attack Detected via link tag",
+        "tags": {
+          "type": "xss",
+          "crs_id": "941270",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "<LINK[\\s/+].*?href[\\s/+]*=",
+              "options": {
+                "min_length": 11
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "removeNulls"
+        ]
+      },
+      {
+        "id": "crs-941-280",
+        "name": "IE XSS Filters - Attack Detected via base tag",
+        "tags": {
+          "type": "xss",
+          "crs_id": "941280",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "<BASE[\\s/+].*?href[\\s/+]*=",
+              "options": {
+                "min_length": 11
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "removeNulls"
+        ]
+      },
+      {
+        "id": "crs-941-290",
+        "name": "IE XSS Filters - Attack Detected via applet tag",
+        "tags": {
+          "type": "xss",
+          "crs_id": "941290",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "<APPLET[\\s/+>]",
+              "options": {
+                "min_length": 8
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "removeNulls"
+        ]
+      },
+      {
+        "id": "crs-941-300",
+        "name": "IE XSS Filters - Attack Detected via object tag",
+        "tags": {
+          "type": "xss",
+          "crs_id": "941300",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "<OBJECT[\\s/+].*?(?:type|codetype|classid|code|data)[\\s/+]*=",
+              "options": {
+                "min_length": 13
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "removeNulls"
+        ]
+      },
+      {
+        "id": "crs-941-350",
+        "name": "UTF-7 Encoding IE XSS - Attack Detected",
+        "tags": {
+          "type": "xss",
+          "crs_id": "941350",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "\\+ADw-.*(?:\\+AD4-|>)|<.*\\+AD4-",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 6
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-941-360",
+        "name": "JSFuck / Hieroglyphy obfuscation detected",
+        "tags": {
+          "type": "xss",
+          "crs_id": "941360",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "![!+ ]\\[\\]",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 4
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-942-100",
+        "name": "SQL Injection Attack Detected via libinjection",
+        "tags": {
+          "type": "sql_injection",
+          "crs_id": "942100",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ]
+            },
+            "operator": "is_sqli"
+          }
+        ],
+        "transformers": [
+          "removeNulls"
+        ]
+      },
+      {
+        "id": "crs-942-140",
+        "name": "SQL Injection Attack: Common DB Names Detected",
+        "tags": {
+          "type": "sql_injection",
+          "crs_id": "942140",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "\\b(?:(?:m(?:s(?:ys(?:ac(?:cess(?:objects|storage|xml)|es)|(?:relationship|object|querie)s|modules2?)|db)|aster\\.\\.sysdatabases|ysql\\.db)|pg_(?:catalog|toast)|information_schema|northwind|tempdb)\\b|s(?:(?:ys(?:\\.database_name|aux)|qlite(?:_temp)?_master)\\b|chema(?:_name\\b|\\W*\\())|d(?:atabas|b_nam)e\\W*\\()",
+              "options": {
+                "min_length": 4
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-942-160",
+        "name": "Detects blind sqli tests using sleep() or benchmark()",
+        "tags": {
+          "type": "sql_injection",
+          "crs_id": "942160",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "(?i:sleep\\(\\s*?\\d*?\\s*?\\)|benchmark\\(.*?\\,.*?\\))",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 7
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-942-190",
+        "name": "Detects MSSQL code execution and information gathering attempts",
+        "tags": {
+          "type": "sql_injection",
+          "crs_id": "942190",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "(?:\\b(?:(?:c(?:onnection_id|urrent_user)|database)\\s*?\\([^\\)]*?|u(?:nion(?:[\\w(?:\\s]*?select| select @)|ser\\s*?\\([^\\)]*?)|s(?:chema\\s*?\\([^\\)]*?|elect.*?\\w?user\\()|into[\\s+]+(?:dump|out)file\\s*?[\\\"'`]|from\\W+information_schema\\W|exec(?:ute)?\\s+master\\.)|[\\\"'`](?:;?\\s*?(?:union\\b\\s*?(?:(?:distin|sele)ct|all)|having|select)\\b\\s*?[^\\s]|\\s*?!\\s*?[\\\"'`\\w])|\\s*?exec(?:ute)?.*?\\Wxp_cmdshell|\\Wiif\\s*?\\()",
+              "options": {
+                "min_length": 3
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-942-220",
+        "name": "Looking for integer overflow attacks, these are taken from skipfish, except 2.2.2250738585072011e-308 is the \\\"magic number\\\" crash",
+        "tags": {
+          "type": "sql_injection",
+          "crs_id": "942220",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "^(?i:-0000023456|4294967295|4294967296|2147483648|2147483647|0000012345|-2147483648|-2147483649|0000023456|2.2250738585072007e-308|2.2250738585072011e-308|1e309)$",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 5
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-942-240",
+        "name": "Detects MySQL charset switch and MSSQL DoS attempts",
+        "tags": {
+          "type": "sql_injection",
+          "crs_id": "942240",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "(?:[\\\"'`](?:;*?\\s*?waitfor\\s+(?:delay|time)\\s+[\\\"'`]|;.*?:\\s*?goto)|alter\\s*?\\w+.*?cha(?:racte)?r\\s+set\\s+\\w+)",
+              "options": {
+                "min_length": 7
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-942-250",
+        "name": "Detects MATCH AGAINST, MERGE and EXECUTE IMMEDIATE injections",
+        "tags": {
+          "type": "sql_injection",
+          "crs_id": "942250",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "(?i:merge.*?using\\s*?\\(|execute\\s*?immediate\\s*?[\\\"'`]|match\\s*?[\\w(?:),+-]+\\s*?against\\s*?\\()",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 11
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-942-270",
+        "name": "Looking for basic sql injection. Common attack string for mysql, oracle and others",
+        "tags": {
+          "type": "sql_injection",
+          "crs_id": "942270",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "union.*?select.*?from",
+              "options": {
+                "min_length": 15
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-942-280",
+        "name": "Detects Postgres pg_sleep injection, waitfor delay attacks and database shutdown attempts",
+        "tags": {
+          "type": "sql_injection",
+          "crs_id": "942280",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "(?:;\\s*?shutdown\\s*?(?:[#;{]|\\/\\*|--)|waitfor\\s*?delay\\s?[\\\"'`]+\\s?\\d|select\\s*?pg_sleep)",
+              "options": {
+                "min_length": 10
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-942-290",
+        "name": "Finds basic MongoDB SQL injection attempts",
+        "tags": {
+          "type": "nosql_injection",
+          "crs_id": "942290",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 5
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-942-360",
+        "name": "Detects concatenated basic SQL injection and SQLLFI attempts",
+        "tags": {
+          "type": "sql_injection",
+          "crs_id": "942360",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "(?:^[\\W\\d]+\\s*?(?:alter\\s*(?:a(?:(?:pplication\\s*rol|ggregat)e|s(?:ymmetric\\s*ke|sembl)y|u(?:thorization|dit)|vailability\\s*group)|c(?:r(?:yptographic\\s*provider|edential)|o(?:l(?:latio|um)|nversio)n|ertificate|luster)|s(?:e(?:rv(?:ice|er)|curity|quence|ssion|arch)|y(?:mmetric\\s*key|nonym)|togroup|chema)|m(?:a(?:s(?:ter\\s*key|k)|terialized)|e(?:ssage\\s*type|thod)|odule)|l(?:o(?:g(?:file\\s*group|in)|ckdown)|a(?:ngua|r)ge|ibrary)|t(?:(?:abl(?:espac)?|yp)e|r(?:igger|usted)|hreshold|ext)|p(?:a(?:rtition|ckage)|ro(?:cedur|fil)e|ermission)|d(?:i(?:mension|skgroup)|atabase|efault|omain)|r(?:o(?:l(?:lback|e)|ute)|e(?:sourc|mot)e)|f(?:u(?:lltext|nction)|lashback|oreign)|e(?:xte(?:nsion|rnal)|(?:ndpoi|ve)nt)|in(?:dex(?:type)?|memory|stance)|b(?:roker\\s*priority|ufferpool)|x(?:ml\\s*schema|srobject)|w(?:ork(?:load)?|rapper)|hi(?:erarchy|stogram)|o(?:perator|utline)|(?:nicknam|queu)e|us(?:age|er)|group|java|view)\\b|(?:(?:(?:trunc|cre)at|renam)e|d(?:e(?:lete|sc)|rop)|(?:inser|selec)t|load)\\s+\\w+|u(?:nion\\s*(?:(?:distin|sele)ct|all)\\b|pdate\\s+\\w+))|\\b(?:(?:(?:(?:trunc|cre|upd)at|renam)e|(?:inser|selec)t|de(?:lete|sc)|alter|load)\\s+(?:group_concat|load_file|char)\\b\\s*\\(?|end\\s*?\\);)|[\\\"'`\\w]\\s+as\\b\\s*[\\\"'`\\w]+\\s*\\bfrom|[\\s(?:]load_file\\s*?\\(|[\\\"'`]\\s+regexp\\W)",
+              "options": {
+                "min_length": 5
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-942-500",
+        "name": "MySQL in-line comment detected",
+        "tags": {
+          "type": "sql_injection",
+          "crs_id": "942500",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "(?i:/\\*[!+](?:[\\w\\s=_\\-(?:)]+)?\\*/)",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 5
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-943-100",
+        "name": "Possible Session Fixation Attack: Setting Cookie Values in HTML",
+        "tags": {
+          "type": "http_protocol_violation",
+          "crs_id": "943100",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "(?i:\\.cookie\\b.*?;\\W*?(?:expires|domain)\\W*?=|\\bhttp-equiv\\W+set-cookie\\b)",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 15
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "crs-944-100",
+        "name": "Remote Command Execution: Suspicious Java class detected",
+        "tags": {
+          "type": "java_code_injection",
+          "crs_id": "944100",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                },
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.headers.no_cookies"
+                }
+              ],
+              "regex": "java\\.lang\\.(?:runtime|processbuilder)",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 17
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "lowercase"
+        ]
+      },
+      {
+        "id": "crs-944-110",
+        "name": "Remote Command Execution: Java process spawn (CVE-2017-9805)",
+        "tags": {
+          "type": "java_code_injection",
+          "crs_id": "944110",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                },
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.headers.no_cookies"
+                }
+              ],
+              "regex": "(?:runtime|processbuilder)",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 7
+              }
+            },
+            "operator": "match_regex"
+          },
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                },
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.headers.no_cookies"
+                }
+              ],
+              "regex": "(?:unmarshaller|base64data|java\\.)",
+              "options": {
+                "case_sensitive": true,
+                "min_length": 5
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "lowercase"
+        ]
+      },
+      {
+        "id": "crs-944-130",
+        "name": "Suspicious Java class detected",
+        "tags": {
+          "type": "java_code_injection",
+          "crs_id": "944130",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                },
+                {
+                  "address": "server.request.cookies"
+                },
+                {
+                  "address": "server.request.headers.no_cookies"
+                }
+              ],
+              "list": [
+                "com.opensymphony.xwork2",
+                "com.sun.org.apache",
+                "java.io.bufferedinputstream",
+                "java.io.bufferedreader",
+                "java.io.bytearrayinputstream",
+                "java.io.bytearrayoutputstream",
+                "java.io.chararrayreader",
+                "java.io.datainputstream",
+                "java.io.file",
+                "java.io.fileoutputstream",
+                "java.io.filepermission",
+                "java.io.filewriter",
+                "java.io.filterinputstream",
+                "java.io.filteroutputstream",
+                "java.io.filterreader",
+                "java.io.inputstream",
+                "java.io.inputstreamreader",
+                "java.io.linenumberreader",
+                "java.io.objectoutputstream",
+                "java.io.outputstream",
+                "java.io.pipedoutputstream",
+                "java.io.pipedreader",
+                "java.io.printstream",
+                "java.io.pushbackinputstream",
+                "java.io.reader",
+                "java.io.stringreader",
+                "java.lang.class",
+                "java.lang.integer",
+                "java.lang.number",
+                "java.lang.object",
+                "java.lang.process",
+                "java.lang.processbuilder",
+                "java.lang.reflect",
+                "java.lang.runtime",
+                "java.lang.string",
+                "java.lang.stringbuilder",
+                "java.lang.system",
+                "javax.script.scriptenginemanager",
+                "org.apache.commons",
+                "org.apache.struts",
+                "org.apache.struts2",
+                "org.omg.corba",
+                "java.beans.xmldecode"
+              ]
+            },
+            "operator": "phrase_match"
+          }
+        ],
+        "transformers": [
+          "lowercase"
+        ]
+      },
+      {
+        "id": "sqr-000-001",
+        "name": "SSRF: Try to access the credential manager of the main cloud services",
+        "tags": {
+          "type": "ssrf",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "(?i)^\\W*((http|ftp)s?://)?\\W*((::f{4}:)?(169|(0x)?0*a9|0+251)\\.?(254|(0x)?0*fe|0+376)[0-9a-fx\\.:]+|metadata\\.google\\.internal|metadata\\.goog)\\W*/",
+              "options": {
+                "min_length": 4
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "removeNulls"
+        ]
+      },
+      {
+        "id": "sqr-000-002",
+        "name": "Server-side Javascript injection: Try to detect obvious JS injection",
+        "tags": {
+          "type": "js_code_injection",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "require\\(['\"][\\w\\.]+['\"]\\)|process\\.\\w+\\([\\w\\.]*\\)|\\.toString\\(\\)",
+              "options": {
+                "min_length": 4
+              }
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "removeNulls"
+        ]
+      },
+      {
+        "id": "sqr-000-007",
+        "name": "NoSQL: Detect common exploitation strategy",
+        "tags": {
+          "type": "nosql_injection",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies"
+                }
+              ],
+              "regex": "\\$(eq|ne|lte?|gte?|n?in)\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "sqr-000-008",
+        "name": "Windows: Detect attempts to exfiltrate .ini files",
+        "tags": {
+          "type": "command_injection",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                },
+                {
+                  "address": "server.request.headers.no_cookies"
+                }
+              ],
+              "regex": "(?i)[&|]\\s*type\\s+%\\w+%\\\\+\\w+\\.ini\\s*[&|]"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "sqr-000-009",
+        "name": "Linux: Detect attempts to exfiltrate passwd files",
+        "tags": {
+          "type": "command_injection",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                },
+                {
+                  "address": "server.request.headers.no_cookies"
+                }
+              ],
+              "regex": "(?i)[&|]\\s*cat\\s+\\/etc\\/[\\w\\.\\/]*passwd\\s*[&|]"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "sqr-000-010",
+        "name": "Windows: Detect attempts to timeout a shell",
+        "tags": {
+          "type": "command_injection",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                },
+                {
+                  "address": "server.request.headers.no_cookies"
+                }
+              ],
+              "regex": "(?i)[&|]\\s*timeout\\s+/t\\s+\\d+\\s*[&|]"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "sqr-000-011",
+        "name": "SSRF: Try to access internal OMI service (CVE-2021-38647)",
+        "tags": {
+          "type": "ssrf",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "operator": "match_regex",
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "http(s?):\\/\\/([A-Za-z0-9\\.\\-\\_]+|\\[[A-Fa-f0-9\\:]+\\]|):5986\\/wsman",
+              "options": {
+                "min_length": 4
+              }
+            }
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "sqr-000-012",
+        "name": "SSRF: Detect SSRF attempt on internal service",
+        "tags": {
+          "type": "ssrf",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "^(jar:)?(http|https):\\/\\/([0-9oq]{1,5}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}|[0-9]{1,10}|localhost)(:[0-9]{1,5})?(\\/.*|)$"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "lowercase"
+        ]
+      },
+      {
+        "id": "sqr-000-013",
+        "name": "SSRF: Detect SSRF attempts using IPv6 or octal/hexdecimal obfuscation",
+        "tags": {
+          "type": "ssrf",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                }
+              ],
+              "regex": "^(jar:)?(http|https):\\/\\/((\\[)?[:0-9a-f\\.x]{2,}(\\])?)(:[0-9]{1,5})?(\\/.*)?$"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "lowercase"
+        ]
+      },
+      {
+        "id": "sqr-000-014",
+        "name": "SSRF: Detect SSRF domain redirection bypass",
+        "tags": {
+          "type": "ssrf",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                },
+                {
+                  "address": "server.request.headers.no_cookies"
+                }
+              ],
+              "regex": "^(http|https):\\/\\/(.*burpcollaborator\\.net|localtest\\.me|mail\\.ebc\\.apple\\.com|bugbounty\\.dod\\.network|.*\\.[nx]ip\\.io)"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "lowercase"
+        ]
+      },
+      {
+        "id": "sqr-000-015",
+        "name": "SSRF: Detect SSRF attempt using non HTTP protocol",
+        "tags": {
+          "type": "ssrf",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.query"
+                },
+                {
+                  "address": "server.request.body"
+                },
+                {
+                  "address": "server.request.path_params"
+                },
+                {
+                  "address": "server.request.headers.no_cookies"
+                }
+              ],
+              "regex": "^(jar:)?((file|netdoc):\\/\\/[\\\\\\/]+|(dict|gopher|ldap|sftp|tftp):\\/\\/.*:[0-9]{1,5})"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": [
+          "lowercase"
+        ]
+      },
+      {
+        "id": "ua0-600-0xx",
+        "name": "Joomla exploitation tool",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "JDatabaseDriverMysqli"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-10x",
+        "name": "Nessus",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)^Nessus(/|([ :]+SOAP))"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-12x",
+        "name": "Arachni",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "^Arachni\\/v"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-13x",
+        "name": "Jorgee",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bJorgee\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-14x",
+        "name": "Probely",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bProbely\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-15x",
+        "name": "Metis",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bmetis\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-16x",
+        "name": "SQL power injector",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "sql power injector"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-18x",
+        "name": "N-Stealth",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bn-stealth\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-19x",
+        "name": "Brutus",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bbrutus\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-1xx",
+        "name": "Shellshock exploitation tool",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "\\(\\) \\{ :; *\\}"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-20x",
+        "name": "Netsparker",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)(<script>netsparker\\(0x0|ns:netsparker.*=vuln)"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-22x",
+        "name": "JAASCois",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bjaascois\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-23x",
+        "name": "PMAFind",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bpmafind\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-25x",
+        "name": "Webtrends",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "webtrends security analyzer"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-26x",
+        "name": "Nsauditor",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bnsauditor\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-27x",
+        "name": "Paros",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)Mozilla/.* Paros/"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-28x",
+        "name": "DirBuster",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bdirbuster\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-29x",
+        "name": "Pangolin",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bpangolin\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-2xx",
+        "name": "Qualys",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bqualys\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-30x",
+        "name": "SQLNinja",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bsqlninja\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-31x",
+        "name": "Nikto",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "\\(Nikto/[\\d\\.]+\\)"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-32x",
+        "name": "WebInspect",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bwebinspect\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-33x",
+        "name": "BlackWidow",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bblack\\s?widow\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-34x",
+        "name": "Grendel-Scan",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bgrendel-scan\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-35x",
+        "name": "Havij",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bhavij\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-36x",
+        "name": "w3af",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bw3af\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-37x",
+        "name": "Nmap",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "nmap (nse|scripting engine)"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-39x",
+        "name": "Nessus Scripted",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)^'?[a-z0-9]+\\.nasl'?$"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-3xx",
+        "name": "Evil Scanner",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bevilScanner\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-40x",
+        "name": "WebFuck",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bWebFuck\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-41x",
+        "name": "Acunetix",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "md5\\(acunetix_wvs_security_test\\)"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-42x",
+        "name": "OpenVAS",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)OpenVAS\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-43x",
+        "name": "Spider-Pig",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "Powered by Spider-Pig by tinfoilsecurity\\.com"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-44x",
+        "name": "Zgrab",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "Mozilla/\\d+.\\d+ zgrab"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-45x",
+        "name": "Zmeu",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bZmEu\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-46x",
+        "name": "Crowdstrike",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bcrowdstrike\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-47x",
+        "name": "GoogleSecurityScanner",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bGoogleSecurityScanner\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-48x",
+        "name": "Commix",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "^commix\\/"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-49x",
+        "name": "Gobuster",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "^gobuster\\/"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-4xx",
+        "name": "CGIchk",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bcgichk\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-51x",
+        "name": "FFUF",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)^Fuzz Faster U Fool\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-52x",
+        "name": "Nuclei is a fast tool for configurable targeted scanning based on templates offering massive extensibility and ease of use",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)^Nuclei\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-53x",
+        "name": "Tsunami is a general purpose network security scanner with an extensible plugin system for detecting high severity vulnerabilities with high confidence",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bTsunamiSecurityScanner\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-54x",
+        "name": "Nimbostratus is a vulnerability scanner that scan websites unprompted",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bnimbostratus-bot\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-5xx",
+        "name": "Blind Sql Injection Brute Forcer",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)\\bbsqlbf\\b"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-6xx",
+        "name": "Suspicious user agent",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "mozilla/4\\.0 \\(compatible(; msie 6\\.0; win32)?\\)"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-7xx",
+        "name": "SQLmap",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "^sqlmap/"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      },
+      {
+        "id": "ua0-600-9xx",
+        "name": "Skipfish",
+        "tags": {
+          "type": "security_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies",
+                  "key_path": [
+                    "user-agent"
+                  ]
+                }
+              ],
+              "regex": "(?i)mozilla/5\\.0 sf/"
+            },
+            "operator": "match_regex"
+          }
+        ],
+        "transformers": []
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# What Does This Do
Fixed AppSec rules file parser.
Added support fo both rules formats `1.x` and `2.x`

# Motivation
Using rules file, downloaded from dashboard, caused an exception at AppSec startup, because of inconsistent rules file format. This been preventing AppSec to protect customers application, when they are trying to use external rules file.

# Additional Notes