### PR TITLE
Upgrade JMXFetch to 0.44.5 even though we exclude log4j

### DIFF
--- a/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
+++ b/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
@@ -4,7 +4,7 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 
 dependencies {
-  api('com.datadoghq:jmxfetch:0.44.1') {
+  api('com.datadoghq:jmxfetch:0.44.5') {
     exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
     exclude group: 'org.apache.logging.log4j', module: 'log4j-core'
     exclude group: 'org.slf4j', module: 'slf4j-api'


### PR DESCRIPTION
# What Does This Do

Upgrades JMXFetch to `0.44.5` that has upgraded the `log4j` dependency to `2.12.2` which has fixed the vulnerability.

# Motivation

Ease fears of `dd-trace-java` possibly being affected by the `log4j` vulnerability, which wasn't the case since the build explicitly excludes the `log4j` artefacts and never use or ship them.

# Additional Notes
