### PR TITLE
[AppSec] Report multiple events per request (legacy)

### DIFF
--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
@@ -165,25 +165,25 @@ class PowerWAFModuleSpecification extends DDSpecification {
   void 'bad ActionWithData - empty list'() {
     def waf = new PowerWAFModule()
     Powerwaf.ActionWithData actionWithData = new Powerwaf.ActionWithData(null, "[]")
-    Optional ret
+    Collection ret
 
     when:
-    ret = waf.buildEvent(actionWithData)
+    ret = waf.buildEvents(actionWithData)
 
     then:
-    !ret.isPresent()
+    ret.isEmpty()
   }
 
   void 'bad ActionWithData - empty object'() {
     def waf = new PowerWAFModule()
     Powerwaf.ActionWithData actionWithData = new Powerwaf.ActionWithData(null, "[{}]")
-    Optional ret
+    Collection ret
 
     when:
-    ret = waf.buildEvent(actionWithData)
+    ret = waf.buildEvents(actionWithData)
 
     then:
-    !ret.isPresent()
+    ret.isEmpty()
   }
 
   private Map<String, Object> getDefaultConfig() {


### PR DESCRIPTION
# What Does This Do
Fixed AppSec events reporting issue. (same as #3280 but for legacy reporting system)

# Motivation
In case of multiple attacks in request, were reported only the first one (all remaining were missed).

# Additional Notes
