### PR TITLE
Peg the async-profiler dependency version to avoid surprises

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
@@ -23,12 +23,12 @@ excludedClassesCoverage += [
 ]
 
 def AP_VERSION = project.findProperty("dd.async_profiler")
-AP_VERSION = AP_VERSION != null ? AP_VERSION : "2.5.1-DD-SNAPSHOT"
+AP_VERSION = AP_VERSION != null ? "${AP_VERSION}" : "${versions.asyncprofiler}"
 
 dependencies {
   api project(':dd-java-agent:agent-profiling:profiling-controller')
   api project(':dd-java-agent:agent-profiling:profiling-auxiliary')
-  implementation group: "tools.profiler", name: "async-profiler", version: "${AP_VERSION}", changing: true
+  implementation group: "tools.profiler", name: "async-profiler", version: AP_VERSION, changing: AP_VERSION.toLowerCase().equals("snapshot")
 
   annotationProcessor deps.autoserviceProcessor
   compileOnly deps.autoserviceAnnotation

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -28,7 +28,8 @@ final class CachedData {
     moshi         : '1.9.2',
     testcontainers: '1.15.0-rc2',
     jmc           : "8.1.0-SNAPSHOT",
-    autoservice   : "1.0-rc7"
+    autoservice   : "1.0-rc7",
+    asyncprofiler : "2.5.1-DD-20211217"
   ]
 
   static deps = [


### PR DESCRIPTION
# What Does This Do
Uses a fixed (non-snapshot) async profiler dependency.

# Motivation
With only snapshot dependency it is hard to invoke rebuild with the update version without introducing some bogus PRs and rebuilds.
Also, the resulting build artifact will be reproducible as it will refer a pinned version.
