### PR TITLE
Use AgentSpan iteration API when consuming Kafka records.

### DIFF
--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -161,6 +161,7 @@ dependencies {
 tasks.withType(Test).configureEach {
   jvmArgs "-Ddd.service.name=java-agent-tests"
   jvmArgs "-Ddd.writer.type=LoggingWriter"
+  jvmArgs "-Ddd.trace.scope.iteration.keep.alive=1"
   // Multi-threaded logging seems to be causing deadlocks with Gradle's log capture.
   //  jvmArgs "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug"
   //  jvmArgs "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -161,7 +161,7 @@ dependencies {
 tasks.withType(Test).configureEach {
   jvmArgs "-Ddd.service.name=java-agent-tests"
   jvmArgs "-Ddd.writer.type=LoggingWriter"
-  jvmArgs "-Ddd.trace.scope.iteration.keep.alive=1"
+  jvmArgs "-Ddd.trace.scope.iteration.keep.alive=1" // don't let iteration spans linger
   // Multi-threaded logging seems to be causing deadlocks with Gradle's log capture.
   //  jvmArgs "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug"
   //  jvmArgs "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingListIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingListIterator.java
@@ -18,21 +18,13 @@ public class TracingListIterator extends TracingIterator
 
   @Override
   public boolean hasPrevious() {
-    final boolean delegateHasPrevious = delegateIterator.hasPrevious();
-    if (!delegateHasPrevious) {
-      // close scope only for last iteration, because previous() most probably not going to be
-      // called.
-      // If it's not last iteration we expect scope will be closed inside previous()
-      maybeCloseCurrentScope();
-    }
-    return delegateHasPrevious;
+    return delegateIterator.hasPrevious();
   }
 
   @Override
   public ConsumerRecord<?, ?> previous() {
-    maybeCloseCurrentScope();
     final ConsumerRecord<?, ?> prev = delegateIterator.previous();
-    decorate(prev);
+    startNewRecordSpan(prev);
     return prev;
   }
 


### PR DESCRIPTION
# What Does This Do
Enables use of `AgentSpan.closePrevious` and `AgentSpan.activateNext` when consuming Kafka records.

# Motivation
Use the new shared mechanism introduced in #3194 for tracking and cleaning up Kafka iteration scopes.