### PR TITLE
Introduce SamplingMechanism param to setSamplingPriority

### DIFF
--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -2,7 +2,8 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDId
 import datadog.trace.api.DDTags
 import datadog.trace.api.interceptor.MutableSpan
-import datadog.trace.api.sampling.PrioritySampling
+import static datadog.trace.api.sampling.PrioritySampling.*
+import static datadog.trace.api.sampling.SamplingMechanism.*
 import datadog.trace.context.TraceScope
 import datadog.trace.core.DDSpan
 import datadog.trace.core.propagation.ExtractedContext
@@ -33,7 +34,8 @@ class OpenTracing31Test extends AgentTestRunner {
         .withTag("boolean", true)
     }
     if (addReference) {
-      builder.addReference(addReference, tracer.tracer.converter.toSpanContext(new ExtractedContext(DDId.ONE, DDId.from(2), 0, null, 0, [:], [:])))
+      def ctx = new ExtractedContext(DDId.ONE, DDId.from(2), SAMPLER_DROP, DEFAULT, null, 0, [:], [:])
+      builder.addReference(addReference, tracer.tracer.converter.toSpanContext(ctx))
     }
     def result = builder.start()
     if (tagSpan) {
@@ -261,7 +263,7 @@ class OpenTracing31Test extends AgentTestRunner {
     def adapter = new TextMapAdapter(textMap)
 
     when:
-    context.delegate.samplingPriority = contextPriority
+    context.delegate.setSamplingPriority(contextPriority, samplingMechanism)
     tracer.inject(context, Format.Builtin.TEXT_MAP, adapter)
 
     then:
@@ -280,12 +282,12 @@ class OpenTracing31Test extends AgentTestRunner {
     extract.delegate.samplingPriority == propagatedPriority
 
     where:
-    contextPriority               | propagatedPriority
-    PrioritySampling.SAMPLER_DROP | PrioritySampling.SAMPLER_DROP
-    PrioritySampling.SAMPLER_KEEP | PrioritySampling.SAMPLER_KEEP
-    PrioritySampling.UNSET        | PrioritySampling.SAMPLER_KEEP
-    PrioritySampling.USER_KEEP    | PrioritySampling.USER_KEEP
-    PrioritySampling.USER_DROP    | PrioritySampling.USER_DROP
+    contextPriority | samplingMechanism | propagatedPriority
+    SAMPLER_DROP    | DEFAULT           | SAMPLER_DROP
+    SAMPLER_KEEP    | DEFAULT           | SAMPLER_KEEP
+    UNSET           | DEFAULT           | SAMPLER_KEEP
+    USER_KEEP       | MANUAL            | USER_KEEP
+    USER_DROP       | MANUAL            | USER_DROP
   }
 
   def "tolerate null span activation"() {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
@@ -6,8 +6,8 @@ import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString
 import datadog.trace.common.sampling.RateByServiceSampler
+import datadog.trace.common.writer.ddagent.TraceMapper
 import datadog.trace.core.DDSpan
-import datadog.trace.core.DDSpanContext
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 
@@ -43,7 +43,7 @@ class TagsAssert {
     assertedTags.add(DDTags.RUNTIME_ID_TAG)
     assertedTags.add(DDTags.LANGUAGE_TAG_KEY)
     assertedTags.add(RateByServiceSampler.SAMPLING_AGENT_RATE)
-    assertedTags.add(DDSpanContext.PRIORITY_SAMPLING_KEY)
+    assertedTags.add(TraceMapper.SAMPLING_PRIORITY_KEY.toString())
     assertedTags.add("_sample_rate")
 
     assert tags["thread.name"] != null

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -58,6 +58,8 @@ public final class TracerConfig {
   public static final String PROPAGATION_STYLE_INJECT = "propagation.style.inject";
 
   public static final String ENABLE_TRACE_AGENT_V05 = "trace.agent.v0.5.enabled";
+  public static final String SAMPLING_MECHANISM_VALIDATION_DISABLED =
+      "trace.sampling.mechanism.validation.disabled";
 
   private TracerConfig() {}
 }

--- a/dd-trace-core/src/jmh/java/datadog/trace/core/PendingTraceWrite.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/PendingTraceWrite.java
@@ -1,6 +1,8 @@
 package datadog.trace.core;
 
 import datadog.trace.api.DDId;
+import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.api.sampling.SamplingMechanism;
 import java.util.Collections;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Level;
@@ -46,7 +48,8 @@ public class PendingTraceWrite {
                 "service",
                 "operation",
                 "resource",
-                1,
+                PrioritySampling.SAMPLER_KEEP,
+                SamplingMechanism.DEFAULT,
                 null,
                 Collections.<String, String>emptyMap(),
                 false,
@@ -65,7 +68,8 @@ public class PendingTraceWrite {
                 "service",
                 "operation",
                 "resource",
-                1,
+                PrioritySampling.SAMPLER_KEEP,
+                SamplingMechanism.DEFAULT,
                 null,
                 Collections.<String, String>emptyMap(),
                 false,

--- a/dd-trace-core/src/jmh/java/datadog/trace/core/PendingTraceWrite.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/PendingTraceWrite.java
@@ -56,7 +56,8 @@ public class PendingTraceWrite {
                 "type",
                 0,
                 trace,
-                null));
+                null,
+                false));
     span =
         DDSpan.create(
             System.currentTimeMillis() * 1000,
@@ -76,7 +77,8 @@ public class PendingTraceWrite {
                 "type",
                 0,
                 trace,
-                null));
+                null,
+                false));
   }
 
   @Threads(4)

--- a/dd-trace-core/src/jmh/java/datadog/trace/core/TracerMapperMap.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/TracerMapperMap.java
@@ -114,6 +114,7 @@ public class TracerMapperMap {
             "type",
             0,
             trace,
-            null));
+            null,
+            false));
   }
 }

--- a/dd-trace-core/src/jmh/java/datadog/trace/core/TracerMapperMap.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/TracerMapperMap.java
@@ -3,6 +3,7 @@ package datadog.trace.core;
 import datadog.communication.serialization.msgpack.MsgPackWriter;
 import datadog.trace.api.DDId;
 import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.api.sampling.SamplingMechanism;
 import datadog.trace.common.writer.LoggingWriter;
 import datadog.trace.common.writer.ddagent.TraceMapperV0_4;
 import datadog.trace.common.writer.ddagent.TraceMapperV0_5;
@@ -106,6 +107,7 @@ public class TracerMapperMap {
             "operation",
             "resource",
             PrioritySampling.SAMPLER_KEEP,
+            SamplingMechanism.DEFAULT,
             origin,
             Collections.<String, String>emptyMap(),
             false,

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/ForcePrioritySampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/ForcePrioritySampler.java
@@ -9,9 +9,11 @@ public class ForcePrioritySampler<T extends CoreSpan<T>> implements Sampler<T>, 
 
   private static final Logger log = LoggerFactory.getLogger(ForcePrioritySampler.class);
   private final int prioritySampling;
+  private final int samplingMechanism;
 
-  public ForcePrioritySampler(final int prioritySampling) {
+  public ForcePrioritySampler(final int prioritySampling, final int samplingMechanism) {
     this.prioritySampling = prioritySampling;
+    this.samplingMechanism = samplingMechanism;
   }
 
   @Override
@@ -21,6 +23,6 @@ public class ForcePrioritySampler<T extends CoreSpan<T>> implements Sampler<T>, 
 
   @Override
   public void setSamplingPriority(final T span) {
-    span.setSamplingPriority(prioritySampling);
+    span.setSamplingPriority(prioritySampling, samplingMechanism);
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateByServiceSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateByServiceSampler.java
@@ -4,6 +4,7 @@ import datadog.trace.api.Function;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
 import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.api.sampling.SamplingMechanism;
 import datadog.trace.common.writer.ddagent.DDAgentResponseListener;
 import datadog.trace.core.CoreSpan;
 import java.util.HashMap;
@@ -46,10 +47,16 @@ public class RateByServiceSampler<T extends CoreSpan<T>>
 
     if (sampler.sample(span)) {
       span.setSamplingPriority(
-          PrioritySampling.SAMPLER_KEEP, SAMPLING_AGENT_RATE, sampler.getSampleRate());
+          PrioritySampling.SAMPLER_KEEP,
+          SAMPLING_AGENT_RATE,
+          sampler.getSampleRate(),
+          SamplingMechanism.AGENT_RATE);
     } else {
       span.setSamplingPriority(
-          PrioritySampling.SAMPLER_DROP, SAMPLING_AGENT_RATE, sampler.getSampleRate());
+          PrioritySampling.SAMPLER_DROP,
+          SAMPLING_AGENT_RATE,
+          sampler.getSampleRate(),
+          SamplingMechanism.AGENT_RATE);
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/RuleBasedSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/RuleBasedSampler.java
@@ -1,6 +1,7 @@
 package datadog.trace.common.sampling;
 
 import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.api.sampling.SamplingMechanism;
 import datadog.trace.common.sampling.SamplingRule.AlwaysMatchesSamplingRule;
 import datadog.trace.common.sampling.SamplingRule.OperationSamplingRule;
 import datadog.trace.common.sampling.SamplingRule.ServiceSamplingRule;
@@ -103,19 +104,22 @@ public class RuleBasedSampler<T extends CoreSpan<T>> implements Sampler<T>, Prio
           span.setSamplingPriority(
               PrioritySampling.USER_KEEP,
               SAMPLING_RULE_RATE,
-              matchedRule.getSampler().getSampleRate());
+              matchedRule.getSampler().getSampleRate(),
+              SamplingMechanism.RULE);
         } else {
           span.setSamplingPriority(
               PrioritySampling.USER_DROP,
               SAMPLING_RULE_RATE,
-              matchedRule.getSampler().getSampleRate());
+              matchedRule.getSampler().getSampleRate(),
+              SamplingMechanism.RULE);
         }
         span.setMetric(SAMPLING_LIMIT_RATE, rateLimit);
       } else {
         span.setSamplingPriority(
             PrioritySampling.USER_DROP,
             SAMPLING_RULE_RATE,
-            matchedRule.getSampler().getSampleRate());
+            matchedRule.getSampler().getSampleRate(),
+            SamplingMechanism.RULE);
       }
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/Sampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/Sampler.java
@@ -4,6 +4,8 @@ import static datadog.trace.bootstrap.instrumentation.api.SamplerConstants.DROP;
 import static datadog.trace.bootstrap.instrumentation.api.SamplerConstants.KEEP;
 
 import datadog.trace.api.Config;
+import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.api.sampling.SamplingMechanism;
 import datadog.trace.core.CoreSpan;
 import java.util.Map;
 import java.util.Properties;
@@ -48,10 +50,14 @@ public interface Sampler<T extends CoreSpan<T>> {
         } else if (config.isPrioritySamplingEnabled()) {
           if (KEEP.equalsIgnoreCase(config.getPrioritySamplingForce())) {
             log.debug("Force Sampling Priority to: SAMPLER_KEEP.");
-            sampler = new ForcePrioritySampler<>(PrioritySampling.SAMPLER_KEEP);
+            sampler =
+                new ForcePrioritySampler<>(
+                    PrioritySampling.SAMPLER_KEEP, SamplingMechanism.DEFAULT);
           } else if (DROP.equalsIgnoreCase(config.getPrioritySamplingForce())) {
             log.debug("Force Sampling Priority to: SAMPLER_DROP.");
-            sampler = new ForcePrioritySampler<>(PrioritySampling.SAMPLER_DROP);
+            sampler =
+                new ForcePrioritySampler<>(
+                    PrioritySampling.SAMPLER_DROP, SamplingMechanism.DEFAULT);
           } else {
             sampler = new RateByServiceSampler<>();
           }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapper.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapper.java
@@ -5,6 +5,7 @@ import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.core.CoreSpan;
+import datadog.trace.core.DDSpanContext;
 import java.util.List;
 
 public interface TraceMapper extends Mapper<List<? extends CoreSpan<?>>> {
@@ -12,7 +13,8 @@ public interface TraceMapper extends Mapper<List<? extends CoreSpan<?>>> {
   UTF8BytesString HTTP_STATUS = UTF8BytesString.create(Tags.HTTP_STATUS);
   UTF8BytesString THREAD_NAME = UTF8BytesString.create(DDTags.THREAD_NAME);
   UTF8BytesString THREAD_ID = UTF8BytesString.create(DDTags.THREAD_ID);
-  UTF8BytesString SAMPLING_PRIORITY_KEY = UTF8BytesString.create("_sampling_priority_v1");
+  UTF8BytesString SAMPLING_PRIORITY_KEY =
+      UTF8BytesString.create(DDSpanContext.PRIORITY_SAMPLING_KEY);
   UTF8BytesString ORIGIN_KEY = UTF8BytesString.create(DDTags.ORIGIN_KEY);
 
   Payload newPayload();

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
@@ -69,9 +69,10 @@ public interface CoreSpan<T extends CoreSpan<T>> {
 
   void processTagsAndBaggage(MetadataConsumer consumer);
 
-  T setSamplingPriority(int samplingPriority);
+  T setSamplingPriority(int samplingPriority, int samplingMechanism);
 
-  T setSamplingPriority(int samplingPriority, CharSequence rate, double sampleRate);
+  T setSamplingPriority(
+      int samplingPriority, CharSequence rate, double sampleRate, int samplingMechanism);
 
   T setMetric(CharSequence name, int value);
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -23,6 +23,7 @@ import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.api.interceptor.TraceInterceptor;
 import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.api.sampling.SamplingMechanism;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentScopeManager;
@@ -978,6 +979,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       final Map<String, String> baggage;
       final PendingTrace parentTrace;
       final int samplingPriority;
+      final int samplingMechanism;
       final String origin;
       final Map<String, String> coreTags;
       final Map<String, ?> rootSpanTags;
@@ -1008,6 +1010,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         baggage = ddsc.getBaggageItems();
         parentTrace = ddsc.getTrace();
         samplingPriority = PrioritySampling.UNSET;
+        samplingMechanism = SamplingMechanism.UNKNOWN;
         origin = null;
         coreTags = null;
         rootSpanTags = null;
@@ -1026,6 +1029,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
           traceId = extractedContext.getTraceId();
           parentSpanId = extractedContext.getSpanId();
           samplingPriority = extractedContext.getSamplingPriority();
+          samplingMechanism = extractedContext.getSamplingMechanism();
           endToEndStartTime = extractedContext.getEndToEndStartTime();
           baggage = extractedContext.getBaggage();
         } else {
@@ -1033,6 +1037,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
           traceId = IdGenerationStrategy.RANDOM.generate();
           parentSpanId = DDId.ZERO;
           samplingPriority = PrioritySampling.UNSET;
+          samplingMechanism = SamplingMechanism.UNKNOWN;
           endToEndStartTime = 0;
           baggage = null;
         }
@@ -1081,6 +1086,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
               operationName,
               resourceName,
               samplingPriority,
+              samplingMechanism,
               origin,
               baggage,
               errorFlag,

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -115,6 +115,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   private final PendingTrace.Factory pendingTraceFactory;
   private final SamplingCheckpointer checkpointer;
   private final ExternalAgentLauncher externalAgentLauncher;
+  private boolean disableSamplingMechanismValidation;
 
   /**
    * JVM shutdown callback, keeping a reference to it to remove this if DDTracer gets destroyed
@@ -429,6 +430,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     }
 
     this.externalAgentLauncher = new ExternalAgentLauncher(config);
+
+    this.disableSamplingMechanismValidation = config.isSamplingMechanismValidationDisabled();
 
     if (sharedCommunicationObjects == null) {
       sharedCommunicationObjects = new SharedCommunicationObjects();
@@ -1093,7 +1096,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
               spanType,
               tagsSize,
               parentTrace,
-              requestContextData);
+              requestContextData,
+              disableSamplingMechanismValidation);
 
       // By setting the tags on the context we apply decorators to any tags that have been set via
       // the builder. This is the order that the tags were added previously, but maybe the `tags`

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -14,6 +14,7 @@ import datadog.trace.api.DDId;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.api.sampling.SamplingMechanism;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
 import datadog.trace.core.util.Clock;
@@ -528,20 +529,28 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan> {
     return context.getRequestContext();
   }
 
+  @Deprecated
+  @Override
+  public final DDSpan setSamplingPriority(final int newPriority) {
+    // this method exist only to satisfy MutableSpan. It will be removed in 1.0
+    return setSamplingPriority(newPriority, SamplingMechanism.UNKNOWN);
+  }
+
   /**
    * Set the sampling priority of the root span of this span's trace
    *
    * <p>Has no effect if the span priority has been propagated (injected or extracted).
    */
   @Override
-  public final DDSpan setSamplingPriority(final int newPriority) {
-    context.setSamplingPriority(newPriority);
+  public final DDSpan setSamplingPriority(final int newPriority, int samplingMechanism) {
+    context.setSamplingPriority(newPriority, samplingMechanism);
     return this;
   }
 
   @Override
-  public DDSpan setSamplingPriority(int samplingPriority, CharSequence rate, double sampleRate) {
-    if (context.setSamplingPriority(samplingPriority)) {
+  public DDSpan setSamplingPriority(
+      int samplingPriority, CharSequence rate, double sampleRate, int samplingMechanism) {
+    if (context.setSamplingPriority(samplingPriority, samplingMechanism)) {
       setMetric(rate, sampleRate);
     }
     return this;

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -1,8 +1,6 @@
 package datadog.trace.core;
 
 import static datadog.trace.api.cache.RadixTreeCache.HTTP_STATUSES;
-import static datadog.trace.api.sampling.PrioritySampling.UNSET;
-import static datadog.trace.api.sampling.PrioritySampling.USER_KEEP;
 
 import datadog.trace.api.DDId;
 import datadog.trace.api.DDTags;
@@ -11,6 +9,7 @@ import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.api.sampling.SamplingMechanism;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -89,21 +88,38 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext<Object> 
   private volatile boolean measured;
 
   private volatile boolean topLevel;
-  /**
-   * When true, the samplingPriority cannot be changed. This prevents the sampling flag from
-   * changing after the context has propagated.
-   *
-   * <p>For thread safety, this boolean is only modified or accessed under instance lock.
-   */
-  private static final AtomicIntegerFieldUpdater<DDSpanContext> SAMPLING_PRIORITY_UPDATER =
-      AtomicIntegerFieldUpdater.newUpdater(DDSpanContext.class, "samplingPriorityV1");
 
-  private volatile int samplingPriorityV1 = PrioritySampling.UNSET;
+  private static final AtomicIntegerFieldUpdater<DDSpanContext> SAMPLING_DECISION_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(DDSpanContext.class, "samplingDecision");
+
+  private volatile int samplingDecision = SamplingDecision.UNSET_UNKNOWN;
+
   /** The origin of the trace. (eg. Synthetics, CI App) */
   private volatile CharSequence origin;
 
   /** RequestContext data for the InstrumentationGateway */
   private final Object requestContextData;
+
+  /** Aims to pack sampling priority and sampling mechanism into one value */
+  protected static class SamplingDecision {
+
+    public static final int UNSET_UNKNOWN =
+        create(PrioritySampling.UNSET, SamplingMechanism.UNKNOWN);
+
+    public static int create(int priority, int mechanism) {
+      return priority << 16 | (byte) mechanism & 0xFFFF;
+    }
+
+    public static int priority(int samplingDecision) {
+      return samplingDecision >> 16;
+    }
+
+    public static int mechanism(int samplingDecision) {
+      return (byte) samplingDecision;
+    }
+
+    private SamplingDecision() {}
+  }
 
   public DDSpanContext(
       final DDId traceId,
@@ -114,6 +130,7 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext<Object> 
       final CharSequence operationName,
       final CharSequence resourceName,
       final int samplingPriority,
+      final int samplingMechanism,
       final CharSequence origin,
       final Map<String, String> baggageItems,
       final boolean errorFlag,
@@ -153,8 +170,9 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext<Object> 
     this.spanType = spanType;
     this.origin = origin;
 
-    if (samplingPriority != PrioritySampling.UNSET) {
-      setSamplingPriority(samplingPriority);
+    long samplingParams = SamplingDecision.create(samplingPriority, samplingMechanism);
+    if (samplingParams != SamplingDecision.UNSET_UNKNOWN) {
+      setSamplingPriority(samplingPriority, samplingMechanism);
     }
 
     // Additional Metadata
@@ -265,29 +283,45 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext<Object> 
       }
     }
     // if the user really wants to keep this trace chunk, we will let them,
-    // even if the old sampling priority has already propagated
-    SAMPLING_PRIORITY_UPDATER.set(this, USER_KEEP);
+    // even if the old sampling priority and mechanism have already propagated
+    int newSamplingPriorityAndMechanism =
+        SamplingDecision.create(PrioritySampling.USER_KEEP, SamplingMechanism.MANUAL);
+    SAMPLING_DECISION_UPDATER.set(this, newSamplingPriorityAndMechanism);
   }
 
   /** @return if sampling priority was set by this method invocation */
-  public boolean setSamplingPriority(final int newPriority) {
+  public boolean setSamplingPriority(final int newPriority, final int newMechanism) {
     if (newPriority == PrioritySampling.UNSET) {
       log.debug("{}: Refusing to set samplingPriority to UNSET", this);
+      return false;
+    }
+
+    if (!SamplingMechanism.validateWithSamplingPriority(newMechanism, newPriority)) {
+      log.debug(
+          "{}: Refusing to set samplingMechanism to {}. Provided samplingPriority {} is not allowed.",
+          this,
+          newMechanism,
+          newPriority);
       return false;
     }
 
     if (trace != null) {
       final DDSpan rootSpan = trace.getRootSpan();
       if (null != rootSpan && rootSpan.context() != this) {
-        return rootSpan.context().setSamplingPriority(newPriority);
+        return rootSpan.context().setSamplingPriority(newPriority, newMechanism);
       }
     }
-    if (!SAMPLING_PRIORITY_UPDATER.compareAndSet(this, UNSET, newPriority)) {
+
+    int newSamplingDecision = SamplingDecision.create(newPriority, newMechanism);
+    if (!SAMPLING_DECISION_UPDATER.compareAndSet(
+        this, SamplingDecision.UNSET_UNKNOWN, newSamplingDecision)) {
       if (log.isDebugEnabled()) {
         log.debug(
-            "samplingPriority locked at {}. Refusing to set to {}",
-            samplingPriorityV1,
-            newPriority);
+            "samplingPriority locked at priority: {} mechanism: {}. Refusing to set to priority: {} mechanism: {}",
+            SamplingDecision.priority(samplingDecision),
+            SamplingDecision.mechanism(samplingDecision),
+            SamplingDecision.priority(newSamplingDecision),
+            SamplingDecision.mechanism(newSamplingDecision));
       }
       return false;
     }
@@ -296,12 +330,13 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext<Object> 
 
   /** @return the sampling priority of this span's trace, or null if no priority has been set */
   public int getSamplingPriority() {
+    // TODO find usages and see whether returning SamplingDecision is needed @YG
     final DDSpan rootSpan = trace.getRootSpan();
     if (null != rootSpan && rootSpan.context() != this) {
       return rootSpan.context().getSamplingPriority();
     }
 
-    return samplingPriorityV1;
+    return SamplingDecision.priority(samplingDecision);
   }
 
   /**
@@ -316,14 +351,14 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext<Object> 
   @Deprecated
   public boolean lockSamplingPriority() {
     // this is now effectively a no-op - there is no locking.
-    // the priority is just CAS'd against UNSET, unless it's forced to USER_KEEP
-    // but is maintained for backwards compatability, and returns false when it used to
+    // the priority is just CAS'd against UNSET/UNKNOWN, unless it's forced to USER_KEEP/MANUAL
+    // but is maintained for backwards compatibility, and returns false when it used to
     final DDSpan rootSpan = trace.getRootSpan();
     if (null != rootSpan && rootSpan.context() != this) {
       return rootSpan.context().lockSamplingPriority();
     }
 
-    return SAMPLING_PRIORITY_UPDATER.get(this) != UNSET;
+    return SAMPLING_DECISION_UPDATER.get(this) != SamplingDecision.UNSET_UNKNOWN;
   }
 
   public CharSequence getOrigin() {
@@ -467,8 +502,8 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext<Object> 
       Map<String, Object> tags = new HashMap<>(unsafeTags);
       tags.put(DDTags.THREAD_ID, threadId);
       tags.put(DDTags.THREAD_NAME, threadName.toString());
-      if (samplingPriorityV1 != UNSET) {
-        tags.put(SAMPLE_RATE_KEY, samplingPriorityV1);
+      if (samplingDecision != SamplingDecision.UNSET_UNKNOWN) {
+        tags.put(SAMPLE_RATE_KEY, SamplingDecision.priority(samplingDecision));
       }
       if (httpStatusCode != 0) {
         tags.put(Tags.HTTP_STATUS, (int) httpStatusCode);
@@ -485,7 +520,8 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext<Object> 
               threadName,
               unsafeTags,
               baggageItems,
-              samplingPriorityV1,
+              SamplingDecision.priority(samplingDecision),
+              // TODO do we also need to pass samplingMechanism in there? @YG
               measured,
               topLevel,
               httpStatusCode == 0 ? null : HTTP_STATUSES.get(httpStatusCode),

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -12,6 +12,7 @@ import datadog.trace.api.Functions;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
 import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.api.sampling.SamplingMechanism;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.ForwardedTagContext;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
@@ -26,6 +27,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
   protected DDId traceId;
   protected DDId spanId;
   protected int samplingPriority;
+  protected int samplingMechanism;
   protected Map<String, String> tags;
   protected Map<String, String> baggage;
   protected String origin;
@@ -107,6 +109,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
     traceId = DDId.ZERO;
     spanId = DDId.ZERO;
     samplingPriority = defaultSamplingPriority();
+    samplingMechanism = defaultSamplingMechanism();
     origin = null;
     endToEndStartTime = 0;
     hasForwarded = false;
@@ -131,6 +134,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
                   traceId,
                   spanId,
                   samplingPriority,
+                  samplingMechanism,
                   origin,
                   endToEndStartTime,
                   forwarded,
@@ -143,7 +147,14 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
         } else {
           context =
               new ExtractedContext(
-                  traceId, spanId, samplingPriority, origin, endToEndStartTime, baggage, tags);
+                  traceId,
+                  spanId,
+                  samplingPriority,
+                  samplingMechanism,
+                  origin,
+                  endToEndStartTime,
+                  baggage,
+                  tags);
         }
         return context;
       } else if (hasForwarded) {
@@ -162,5 +173,9 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
 
   protected int defaultSamplingPriority() {
     return PrioritySampling.UNSET;
+  }
+
+  protected int defaultSamplingMechanism() {
+    return SamplingMechanism.UNKNOWN;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
@@ -11,6 +11,7 @@ public class ExtractedContext extends TagContext {
   private final DDId traceId;
   private final DDId spanId;
   private final int samplingPriority;
+  private final int samplingMechanism;
   private final long endToEndStartTime;
   private final Map<String, String> baggage;
 
@@ -18,6 +19,7 @@ public class ExtractedContext extends TagContext {
       final DDId traceId,
       final DDId spanId,
       final int samplingPriority,
+      final int samplingMechanism,
       final String origin,
       final long endToEndStartTime,
       final Map<String, String> baggage,
@@ -26,6 +28,7 @@ public class ExtractedContext extends TagContext {
     this.traceId = traceId;
     this.spanId = spanId;
     this.samplingPriority = samplingPriority;
+    this.samplingMechanism = samplingMechanism;
     this.endToEndStartTime = endToEndStartTime;
     this.baggage = baggage;
   }
@@ -47,6 +50,10 @@ public class ExtractedContext extends TagContext {
 
   public final int getSamplingPriority() {
     return samplingPriority;
+  }
+
+  public final int getSamplingMechanism() {
+    return samplingMechanism;
   }
 
   public final long getEndToEndStartTime() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ForwardedExtractedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ForwardedExtractedContext.java
@@ -16,6 +16,7 @@ public final class ForwardedExtractedContext extends ExtractedContext {
       final DDId traceId,
       final DDId spanId,
       final int samplingPriority,
+      final int samplingMechanism,
       final String origin,
       final long endToEndStartTime,
       final String forwarded,
@@ -25,7 +26,15 @@ public final class ForwardedExtractedContext extends ExtractedContext {
       final String forwardedPort,
       final Map<String, String> baggage,
       final Map<String, String> tags) {
-    super(traceId, spanId, samplingPriority, origin, endToEndStartTime, baggage, tags);
+    super(
+        traceId,
+        spanId,
+        samplingPriority,
+        samplingMechanism,
+        origin,
+        endToEndStartTime,
+        baggage,
+        tags);
     this.forwarded = forwarded;
     this.forwardedProto = forwardedProto;
     this.forwardedHost = forwardedHost;

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HaystackHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HaystackHttpCodec.java
@@ -4,6 +4,7 @@ import static datadog.trace.core.propagation.HttpCodec.firstHeaderValue;
 
 import datadog.trace.api.DDId;
 import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.api.sampling.SamplingMechanism;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.core.DDSpanContext;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
@@ -232,6 +233,11 @@ class HaystackHttpCodec {
     @Override
     protected int defaultSamplingPriority() {
       return PrioritySampling.SAMPLER_KEEP;
+    }
+
+    @Override
+    protected int defaultSamplingMechanism() {
+      return SamplingMechanism.DEFAULT;
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/TagInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/TagInterceptor.java
@@ -15,6 +15,7 @@ import datadog.trace.api.ConfigDefaults;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.config.GeneralConfig;
 import datadog.trace.api.env.CapturedEnvironment;
+import datadog.trace.api.sampling.SamplingMechanism;
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -67,7 +68,8 @@ public class TagInterceptor {
         }
         return false;
       case DDTags.MANUAL_DROP:
-        return interceptSamplingPriority(FORCE_MANUAL_DROP, USER_DROP, span, value);
+        return interceptSamplingPriority(
+            FORCE_MANUAL_DROP, USER_DROP, SamplingMechanism.MANUAL, span, value);
       case InstrumentationTags.SERVLET_CONTEXT:
         return interceptServletContext(span, value);
       case SPAN_TYPE:
@@ -148,10 +150,14 @@ public class TagInterceptor {
   }
 
   private boolean interceptSamplingPriority(
-      RuleFlags.Feature feature, int priority, DDSpanContext span, Object value) {
+      RuleFlags.Feature feature,
+      int samplingPriority,
+      int samplingMechanism,
+      DDSpanContext span,
+      Object value) {
     if (ruleFlags.isEnabled(feature)) {
       if (asBoolean(value)) {
-        span.setSamplingPriority(priority);
+        span.setSamplingPriority(samplingPriority, samplingMechanism);
       }
       return true;
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
@@ -200,12 +200,12 @@ class SimpleSpan implements CoreSpan<SimpleSpan> {
   }
 
   @Override
-  SimpleSpan setSamplingPriority(int samplingPriority) {
+  SimpleSpan setSamplingPriority(int samplingPriority, int samplingMechanism) {
     return this
   }
 
   @Override
-  SimpleSpan setSamplingPriority(int samplingPriority, CharSequence rate, double sampleRate) {
+  SimpleSpan setSamplingPriority(int samplingPriority, CharSequence rate, double sampleRate, int samplingMechanism) {
     return this
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/RateByServiceSamplerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/RateByServiceSamplerTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.common.sampling
 
 import datadog.trace.api.DDTags
+import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.common.writer.LoggingWriter
 import datadog.trace.common.writer.ddagent.DDAgentApi

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
@@ -439,7 +439,8 @@ class DDAgentApiTest extends DDCoreSpecification {
       "fakeType",
       0,
       tracer.pendingTraceFactory.create(DDId.from(1)),
-      null)
+      null,
+      false)
 
     def span = DDSpan.create(timestamp, context)
     span.setTag(tag, value)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
@@ -8,6 +8,7 @@ import datadog.trace.api.StatsDClient
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.common.sampling.RateByServiceSampler
+import datadog.trace.api.sampling.SamplingMechanism
 import datadog.trace.common.writer.ddagent.DDAgentApi
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery
 import datadog.trace.common.writer.ddagent.DDAgentResponseListener
@@ -27,7 +28,6 @@ import okhttp3.OkHttpClient
 import org.msgpack.jackson.dataformat.MessagePackFactory
 import spock.lang.Shared
 import spock.lang.Timeout
-
 import java.nio.ByteBuffer
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
@@ -432,6 +432,7 @@ class DDAgentApiTest extends DDCoreSpecification {
       "fakeOperation",
       "fakeResource",
       PrioritySampling.UNSET,
+      SamplingMechanism.UNKNOWN,
       null,
       [:],
       false,

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
@@ -3,6 +3,7 @@ package datadog.trace.common.writer
 import datadog.trace.api.DDId
 import datadog.trace.api.StatsDClient
 import datadog.trace.api.sampling.PrioritySampling
+import datadog.trace.api.sampling.SamplingMechanism
 import datadog.trace.common.writer.ddagent.DDAgentApi
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery
 import datadog.trace.common.writer.ddagent.TraceMapperV0_4
@@ -275,6 +276,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
       "",
       "",
       PrioritySampling.UNSET,
+      SamplingMechanism.UNKNOWN,
       "",
       [:],
       false,

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
@@ -283,7 +283,8 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
       "",
       0,
       trace,
-      null)
+      null,
+      false)
   }
 
   def createMinimalTrace() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
@@ -3,6 +3,7 @@ package datadog.trace.common.writer
 import datadog.trace.api.DDId
 import datadog.trace.api.StatsDClient
 import datadog.trace.api.sampling.PrioritySampling
+import datadog.trace.api.sampling.SamplingMechanism
 import datadog.trace.common.writer.ddagent.DDAgentApi
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery
 import datadog.trace.common.writer.ddagent.PayloadDispatcher
@@ -176,6 +177,7 @@ class DDAgentWriterTest extends DDCoreSpecification {
       "",
       "",
       PrioritySampling.UNSET,
+      SamplingMechanism.UNKNOWN,
       "",
       [:],
       false,

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
@@ -184,6 +184,7 @@ class DDAgentWriterTest extends DDCoreSpecification {
       "",
       0,
       trace,
-      null))
+      null,
+      false))
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
@@ -167,6 +167,7 @@ class PayloadDispatcherTest extends DDSpecification {
       "",
       0,
       trace,
-      null))
+      null,
+      false))
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
@@ -3,6 +3,7 @@ package datadog.trace.common.writer
 import datadog.trace.api.DDId
 import datadog.trace.api.StatsDClient
 import datadog.trace.api.sampling.PrioritySampling
+import datadog.trace.api.sampling.SamplingMechanism
 import datadog.trace.common.writer.ddagent.DDAgentApi
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery
 import datadog.trace.common.writer.ddagent.Payload
@@ -159,6 +160,7 @@ class PayloadDispatcherTest extends DDSpecification {
       "",
       "",
       PrioritySampling.UNSET,
+      SamplingMechanism.UNKNOWN,
       "",
       [:],
       false,

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
@@ -308,12 +308,12 @@ class TraceGenerator {
     }
 
     @Override
-    PojoSpan setSamplingPriority(int samplingPriority) {
+    PojoSpan setSamplingPriority(int samplingPriority, int samplingMechanism) {
       return this
     }
 
     @Override
-    PojoSpan setSamplingPriority(int samplingPriority, CharSequence rate, double sampleRate) {
+    PojoSpan setSamplingPriority(int samplingPriority, CharSequence rate, double sampleRate, int samplingMechanism) {
       return this
     }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -2,6 +2,8 @@ package datadog.trace.core
 
 import datadog.trace.api.Config
 import datadog.trace.api.DDId
+import datadog.trace.api.sampling.PrioritySampling
+import datadog.trace.api.sampling.SamplingMechanism
 import datadog.trace.bootstrap.instrumentation.api.AgentScope
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.common.writer.ListWriter
@@ -319,9 +321,9 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
     span.getTag(THREAD_NAME) == thread.name
 
     where:
-    extractedContext                                                                                                                       | _
-    new ExtractedContext(DDId.ONE, DDId.from(2), 0, null, 0, [:], [:])                                                                     | _
-    new ExtractedContext(DDId.from(3), DDId.from(4), 1, "some-origin", 0, ["asdf": "qwer"], [(ORIGIN_KEY): "some-origin", "zxcv": "1234"]) | _
+    extractedContext                                                                                                                                                                              | _
+    new ExtractedContext(DDId.ONE, DDId.from(2), PrioritySampling.SAMPLER_DROP, SamplingMechanism.DEFAULT, null, 0, [:], [:])                                                                     | _
+    new ExtractedContext(DDId.from(3), DDId.from(4), PrioritySampling.SAMPLER_KEEP, SamplingMechanism.DEFAULT, "some-origin", 0, ["asdf": "qwer"], [(ORIGIN_KEY): "some-origin", "zxcv": "1234"]) | _
   }
 
   def "TagContext should populate default span details"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -8,6 +8,7 @@ import datadog.trace.common.sampling.AllSampler
 import datadog.trace.common.sampling.PrioritySampler
 import datadog.trace.common.sampling.RateByServiceSampler
 import datadog.trace.common.sampling.Sampler
+import datadog.trace.api.sampling.SamplingMechanism
 import datadog.trace.common.writer.DDAgentWriter
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.common.writer.LoggingWriter
@@ -382,7 +383,7 @@ class ControllableSampler<T extends CoreSpan<T>> implements Sampler<T>, Priority
 
   @Override
   void setSamplingPriority(T span) {
-    span.setSamplingPriority(nextSamplingPriority)
+    span.setSamplingPriority(nextSamplingPriority, SamplingMechanism.DEFAULT)
   }
 
   @Override

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
@@ -4,9 +4,8 @@ import datadog.trace.api.DDTags
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.test.DDCoreSpecification
 
-import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP
-import static datadog.trace.api.sampling.PrioritySampling.USER_DROP
-import static datadog.trace.api.sampling.PrioritySampling.USER_KEEP
+import static datadog.trace.api.sampling.PrioritySampling.*
+import static datadog.trace.api.sampling.SamplingMechanism.*
 
 class DDSpanContextTest extends DDCoreSpecification {
 
@@ -145,14 +144,14 @@ class DDSpanContextTest extends DDCoreSpecification {
       .start()
     def context = span.context()
     when:
-    context.setSamplingPriority(SAMPLER_DROP)
+    context.setSamplingPriority(SAMPLER_DROP, DEFAULT)
     then: "priority should be set"
     context.getSamplingPriority() == SAMPLER_DROP
 
     when: "sampling priority locked"
     context.lockSamplingPriority()
     then: "override ignored"
-    !context.setSamplingPriority(USER_DROP)
+    !context.setSamplingPriority(USER_DROP, MANUAL)
     context.getSamplingPriority() == SAMPLER_DROP
 
     when:
@@ -162,6 +161,63 @@ class DDSpanContextTest extends DDCoreSpecification {
 
     cleanup:
     span.finish()
+  }
+
+  def "test sampling decision pack/unpack"() {
+    expect:
+    def decision = DDSpanContext.SamplingDecision.create(priority, mechanism)
+    DDSpanContext.SamplingDecision.priority(decision) == priority2
+    DDSpanContext.SamplingDecision.mechanism(decision) == mechanism2
+
+    where:
+    mechanism        | priority     | mechanism2       | priority2
+    UNKNOWN          | UNSET        | UNKNOWN          | UNSET
+    UNKNOWN          | SAMPLER_DROP | UNKNOWN          | SAMPLER_DROP
+    UNKNOWN          | SAMPLER_KEEP | UNKNOWN          | SAMPLER_KEEP
+    UNKNOWN          | USER_DROP    | UNKNOWN          | USER_DROP
+    UNKNOWN          | USER_KEEP    | UNKNOWN          | USER_KEEP
+
+    DEFAULT          | UNSET        | DEFAULT          | UNSET
+    DEFAULT          | SAMPLER_DROP | DEFAULT          | SAMPLER_DROP
+    DEFAULT          | SAMPLER_KEEP | DEFAULT          | SAMPLER_KEEP
+    DEFAULT          | USER_DROP    | DEFAULT          | USER_DROP
+    DEFAULT          | USER_KEEP    | DEFAULT          | USER_KEEP
+
+    AGENT_RATE       | UNSET        | AGENT_RATE       | UNSET
+    AGENT_RATE       | SAMPLER_DROP | AGENT_RATE       | SAMPLER_DROP
+    AGENT_RATE       | SAMPLER_KEEP | AGENT_RATE       | SAMPLER_KEEP
+    AGENT_RATE       | USER_DROP    | AGENT_RATE       | USER_DROP
+    AGENT_RATE       | USER_KEEP    | AGENT_RATE       | USER_KEEP
+
+    REMOTE_AUTO_RATE | UNSET        | REMOTE_AUTO_RATE | UNSET
+    REMOTE_AUTO_RATE | SAMPLER_DROP | REMOTE_AUTO_RATE | SAMPLER_DROP
+    REMOTE_AUTO_RATE | SAMPLER_KEEP | REMOTE_AUTO_RATE | SAMPLER_KEEP
+    REMOTE_AUTO_RATE | USER_DROP    | REMOTE_AUTO_RATE | USER_DROP
+    REMOTE_AUTO_RATE | USER_KEEP    | REMOTE_AUTO_RATE | USER_KEEP
+
+    RULE             | UNSET        | RULE             | UNSET
+    RULE             | SAMPLER_DROP | RULE             | SAMPLER_DROP
+    RULE             | SAMPLER_KEEP | RULE             | SAMPLER_KEEP
+    RULE             | USER_DROP    | RULE             | USER_DROP
+    RULE             | USER_KEEP    | RULE             | USER_KEEP
+
+    MANUAL           | UNSET        | MANUAL           | UNSET
+    MANUAL           | SAMPLER_DROP | MANUAL           | SAMPLER_DROP
+    MANUAL           | SAMPLER_KEEP | MANUAL           | SAMPLER_KEEP
+    MANUAL           | USER_DROP    | MANUAL           | USER_DROP
+    MANUAL           | USER_KEEP    | MANUAL           | USER_KEEP
+
+    REMOTE_USER_RATE | UNSET        |REMOTE_USER_RATE | UNSET
+    REMOTE_USER_RATE | SAMPLER_DROP |REMOTE_USER_RATE | SAMPLER_DROP
+    REMOTE_USER_RATE | SAMPLER_KEEP |REMOTE_USER_RATE | SAMPLER_KEEP
+    REMOTE_USER_RATE | USER_DROP    |REMOTE_USER_RATE | USER_DROP
+    REMOTE_USER_RATE | USER_KEEP    |REMOTE_USER_RATE | USER_KEEP
+
+    APPSEC           | UNSET        |APPSEC           | UNSET
+    APPSEC           | SAMPLER_DROP |APPSEC           | SAMPLER_DROP
+    APPSEC           | SAMPLER_KEEP |APPSEC           | SAMPLER_KEEP
+    APPSEC           | USER_DROP    |APPSEC           | USER_DROP
+    APPSEC           | USER_KEEP    |APPSEC           | USER_KEEP
   }
 
   static void assertTagmap(Map source, Map comparison) {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
@@ -146,7 +146,8 @@ class DDSpanSerializationTest extends DDCoreSpecification {
       null,
       tags.size(),
       tracer.pendingTraceFactory.create(DDId.ONE),
-      null)
+      null,
+      false)
     context.setAllTags(tags)
     def span = DDSpan.create(0, context)
     CaptureBuffer capture = new CaptureBuffer()
@@ -214,7 +215,8 @@ class DDSpanSerializationTest extends DDCoreSpecification {
       null,
       tags.size(),
       tracer.pendingTraceFactory.create(DDId.ONE),
-      null)
+      null,
+      false)
     context.setAllTags(tags)
     def span = DDSpan.create(0, context)
     CaptureBuffer capture = new CaptureBuffer()
@@ -292,7 +294,8 @@ class DDSpanSerializationTest extends DDCoreSpecification {
       spanType,
       1,
       tracer.pendingTraceFactory.create(DDId.ONE),
-      null)
+      null,
+      false)
     ctx.setAllTags(["k1": "v1"])
     return ctx
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
@@ -2,6 +2,7 @@ package datadog.trace.core
 
 import datadog.trace.api.DDId
 import datadog.trace.api.sampling.PrioritySampling
+import datadog.trace.api.sampling.SamplingMechanism
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.common.writer.ddagent.TraceMapperV0_4
 import datadog.trace.common.writer.ddagent.TraceMapperV0_5
@@ -138,6 +139,7 @@ class DDSpanSerializationTest extends DDCoreSpecification {
       "fakeOperation",
       "fakeResource",
       PrioritySampling.UNSET,
+      SamplingMechanism.UNKNOWN,
       null,
       baggage,
       false,
@@ -205,6 +207,7 @@ class DDSpanSerializationTest extends DDCoreSpecification {
       "fakeOperation",
       "fakeResource",
       PrioritySampling.UNSET,
+      SamplingMechanism.UNKNOWN,
       null,
       baggage,
       false,
@@ -282,6 +285,7 @@ class DDSpanSerializationTest extends DDCoreSpecification {
       "fakeOperation",
       "fakeResource",
       PrioritySampling.UNSET,
+      SamplingMechanism.UNKNOWN,
       null,
       ["a-baggage": "value"],
       false,

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -331,7 +331,8 @@ class DDSpanTest extends DDCoreSpecification {
       "fakeType",
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
-      null)
+      null,
+      false)
     then:
     context.isTopLevel() == expectTopLevel
 
@@ -366,7 +367,8 @@ class DDSpanTest extends DDCoreSpecification {
       "fakeType",
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
-      null)
+      null,
+      false)
 
     def span = null
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -7,6 +7,7 @@ import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString
 import datadog.trace.common.sampling.RateByServiceSampler
+import datadog.trace.api.sampling.SamplingMechanism
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.propagation.ExtractedContext
 import datadog.trace.bootstrap.instrumentation.api.TagContext
@@ -265,9 +266,9 @@ class DDSpanTest extends DDCoreSpecification {
     child.@origin == null // Access field directly instead of getter.
 
     where:
-    extractedContext                                                            | _
-    new TagContext("some-origin", [:])                                          | _
-    new ExtractedContext(DDId.ONE, DDId.from(2), 0, "some-origin", 0, [:], [:]) | _
+    extractedContext                                                                                                                | _
+    new TagContext("some-origin", [:])                                                                                              | _
+    new ExtractedContext(DDId.ONE, DDId.from(2), PrioritySampling.SAMPLER_DROP, SamplingMechanism.DEFAULT, "some-origin", 0, [:], [:]) | _
   }
 
   def "isRootSpan() in and not in the context of distributed tracing"() {
@@ -284,9 +285,9 @@ class DDSpanTest extends DDCoreSpecification {
     root.finish()
 
     where:
-    extractedContext                                                            | isTraceRootSpan
-    null                                                                        | true
-    new ExtractedContext(DDId.from(123), DDId.from(456), 1, "789", 0, [:], [:]) | false
+    extractedContext                                                                                                                   | isTraceRootSpan
+    null                                                                                                                               | true
+    new ExtractedContext(DDId.from(123), DDId.from(456), PrioritySampling.SAMPLER_KEEP, SamplingMechanism.DEFAULT, "789", 0, [:], [:]) | false
   }
 
   def "getApplicationRootSpan() in and not in the context of distributed tracing"() {
@@ -306,9 +307,9 @@ class DDSpanTest extends DDCoreSpecification {
     root.finish()
 
     where:
-    extractedContext                                                            | isTraceRootSpan
-    null                                                                        | true
-    new ExtractedContext(DDId.from(123), DDId.from(456), 1, "789", 0, [:], [:]) | false
+    extractedContext                                                                                                                   | isTraceRootSpan
+    null                                                                                                                               | true
+    new ExtractedContext(DDId.from(123), DDId.from(456), PrioritySampling.SAMPLER_KEEP, SamplingMechanism.DEFAULT, "789", 0, [:], [:]) | false
   }
 
   def "infer top level from parent service name"() {
@@ -323,6 +324,7 @@ class DDSpanTest extends DDCoreSpecification {
       "fakeOperation",
       "fakeResource",
       PrioritySampling.UNSET,
+      SamplingMechanism.UNKNOWN,
       null,
       Collections.<String, String> emptyMap(),
       false,
@@ -357,6 +359,7 @@ class DDSpanTest extends DDCoreSpecification {
       "fakeOperation",
       "fakeResource",
       PrioritySampling.UNSET,
+      SamplingMechanism.UNKNOWN,
       null,
       Collections.<String, String> emptyMap(),
       false,

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
@@ -318,7 +318,8 @@ class PendingTraceBufferTest extends DDSpecification {
       "fakeType",
       0,
       trace,
-      null)
+      null,
+      false)
     return DDSpan.create(0, context)
   }
 
@@ -340,7 +341,8 @@ class PendingTraceBufferTest extends DDSpecification {
       "fakeType",
       0,
       trace,
-      null)
+      null,
+      false)
     return DDSpan.create(0, context)
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
@@ -5,6 +5,7 @@ import datadog.trace.api.DDId
 import datadog.trace.api.StatsDClient
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource
+import datadog.trace.api.sampling.SamplingMechanism
 import datadog.trace.context.TraceScope
 import datadog.trace.core.scopemanager.ContinuableScopeManager
 import datadog.trace.test.util.DDSpecification
@@ -310,6 +311,7 @@ class PendingTraceBufferTest extends DDSpecification {
       "fakeOperation",
       "fakeResource",
       PrioritySampling.UNSET,
+      SamplingMechanism.UNKNOWN,
       null,
       Collections.emptyMap(),
       false,
@@ -331,6 +333,7 @@ class PendingTraceBufferTest extends DDSpecification {
       "fakeOperation",
       "fakeResource",
       PrioritySampling.UNSET,
+      SamplingMechanism.UNKNOWN,
       null,
       Collections.emptyMap(),
       false,

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpInjectorTest.groovy
@@ -1,8 +1,9 @@
 package datadog.trace.core.propagation
 
 import datadog.trace.api.DDId
+import static datadog.trace.api.sampling.PrioritySampling.*
+import static datadog.trace.api.sampling.SamplingMechanism.*
 import datadog.trace.bootstrap.instrumentation.api.TagContext
-import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.ContextVisitors
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.DDSpanContext
@@ -32,6 +33,7 @@ class B3HttpInjectorTest extends DDCoreSpecification {
       "fakeOperation",
       "fakeResource",
       samplingPriority,
+      samplingMechanism,
       "fakeOrigin",
       ["k1": "v1", "k2": "v2"],
       false,
@@ -60,14 +62,14 @@ class B3HttpInjectorTest extends DDCoreSpecification {
     tracer.close()
 
     where:
-    traceId          | spanId           | samplingPriority              | expectedSamplingPriority
-    1G               | 2G               | PrioritySampling.UNSET        | null
-    2G               | 3G               | PrioritySampling.SAMPLER_KEEP | 1
-    4G               | 5G               | PrioritySampling.SAMPLER_DROP | 0
-    5G               | 6G               | PrioritySampling.USER_KEEP    | 1
-    6G               | 7G               | PrioritySampling.USER_DROP    | 0
-    TRACE_ID_MAX     | TRACE_ID_MAX - 1 | PrioritySampling.UNSET        | null
-    TRACE_ID_MAX - 1 | TRACE_ID_MAX     | PrioritySampling.SAMPLER_KEEP | 1
+    traceId          | spanId           | samplingPriority | samplingMechanism | expectedSamplingPriority
+    1G               | 2G               | UNSET            | UNKNOWN           | null
+    2G               | 3G               | SAMPLER_KEEP     | DEFAULT           | SAMPLER_KEEP
+    4G               | 5G               | SAMPLER_DROP     | DEFAULT           | SAMPLER_DROP
+    5G               | 6G               | USER_KEEP        | MANUAL            | SAMPLER_KEEP
+    6G               | 7G               | USER_DROP        | MANUAL            | SAMPLER_DROP
+    TRACE_ID_MAX     | TRACE_ID_MAX - 1 | UNSET            | UNKNOWN           | null
+    TRACE_ID_MAX - 1 | TRACE_ID_MAX     | SAMPLER_KEEP     | DEFAULT           | SAMPLER_KEEP
   }
 
   def "inject http headers with extracted original"() {
@@ -89,7 +91,8 @@ class B3HttpInjectorTest extends DDCoreSpecification {
       "fakeService",
       "fakeOperation",
       "fakeResource",
-      PrioritySampling.UNSET,
+      UNSET,
+      UNKNOWN,
       "fakeOrigin",
       ["k1": "v1", "k2": "v2"],
       false,

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpInjectorTest.groovy
@@ -40,7 +40,8 @@ class B3HttpInjectorTest extends DDCoreSpecification {
       "fakeType",
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
-      null)
+      null,
+      false)
 
     final Map<String, String> carrier = Mock()
 
@@ -99,7 +100,8 @@ class B3HttpInjectorTest extends DDCoreSpecification {
       "fakeType",
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
-      null)
+      null,
+      false)
     final Map<String, String> carrier = Mock()
 
     when:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpInjectorTest.groovy
@@ -1,17 +1,14 @@
 package datadog.trace.core.propagation
 
 import datadog.trace.api.DDId
-import datadog.trace.api.sampling.PrioritySampling
+import static datadog.trace.api.sampling.PrioritySampling.*
+import static datadog.trace.api.sampling.SamplingMechanism.*
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.DDSpanContext
 import datadog.trace.core.test.DDCoreSpecification
 
 import static datadog.trace.core.CoreTracer.TRACE_ID_MAX
-import static datadog.trace.core.propagation.DatadogHttpCodec.ORIGIN_KEY
-import static datadog.trace.core.propagation.DatadogHttpCodec.OT_BAGGAGE_PREFIX
-import static datadog.trace.core.propagation.DatadogHttpCodec.SAMPLING_PRIORITY_KEY
-import static datadog.trace.core.propagation.DatadogHttpCodec.SPAN_ID_KEY
-import static datadog.trace.core.propagation.DatadogHttpCodec.TRACE_ID_KEY
+import static datadog.trace.core.propagation.DatadogHttpCodec.*
 
 class DatadogHttpInjectorTest extends DDCoreSpecification {
 
@@ -31,6 +28,7 @@ class DatadogHttpInjectorTest extends DDCoreSpecification {
       "fakeOperation",
       "fakeResource",
       samplingPriority,
+      samplingMechanism,
       origin,
       ["k1" : "v1", "k2" : "v2"],
       false,
@@ -47,7 +45,7 @@ class DatadogHttpInjectorTest extends DDCoreSpecification {
     then:
     1 * carrier.put(TRACE_ID_KEY, traceId.toString())
     1 * carrier.put(SPAN_ID_KEY, spanId.toString())
-    if (samplingPriority != PrioritySampling.UNSET) {
+    if (samplingPriority != UNSET) {
       1 * carrier.put(SAMPLING_PRIORITY_KEY, "$samplingPriority")
     }
     if (origin) {
@@ -61,11 +59,11 @@ class DatadogHttpInjectorTest extends DDCoreSpecification {
     tracer.close()
 
     where:
-    traceId               | spanId                | samplingPriority              | origin
-    "1"                   | "2"                   | PrioritySampling.UNSET        | null
-    "1"                   | "2"                   | PrioritySampling.SAMPLER_KEEP | "saipan"
-    "$TRACE_ID_MAX"       | "${TRACE_ID_MAX - 1}" | PrioritySampling.UNSET        | "saipan"
-    "${TRACE_ID_MAX - 1}" | "$TRACE_ID_MAX"       | PrioritySampling.SAMPLER_KEEP | null
+    traceId               | spanId                | samplingPriority | samplingMechanism | origin
+    "1"                   | "2"                   | UNSET            | UNKNOWN           | null
+    "1"                   | "2"                   | SAMPLER_KEEP     | DEFAULT           | "saipan"
+    "$TRACE_ID_MAX"       | "${TRACE_ID_MAX - 1}" | UNSET            | UNKNOWN           | "saipan"
+    "${TRACE_ID_MAX - 1}" | "$TRACE_ID_MAX"       | SAMPLER_KEEP     | DEFAULT           | null
   }
 
   def "inject http headers with end-to-end"() {
@@ -81,7 +79,8 @@ class DatadogHttpInjectorTest extends DDCoreSpecification {
       "fakeService",
       "fakeOperation",
       "fakeResource",
-      PrioritySampling.UNSET,
+      UNSET,
+      UNKNOWN,
       "fakeOrigin",
       ["k1" : "v1", "k2" : "v2"],
       false,

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpInjectorTest.groovy
@@ -35,7 +35,8 @@ class DatadogHttpInjectorTest extends DDCoreSpecification {
       "fakeType",
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
-      null)
+      null,
+      false)
 
     final Map<String, String> carrier = Mock()
 
@@ -87,7 +88,8 @@ class DatadogHttpInjectorTest extends DDCoreSpecification {
       "fakeType",
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
-      null)
+      null,
+      false)
 
     mockedContext.beginEndToEnd()
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpInjectorTest.groovy
@@ -1,19 +1,14 @@
 package datadog.trace.core.propagation
 
 import datadog.trace.api.DDId
-import datadog.trace.api.sampling.PrioritySampling
+import static datadog.trace.api.sampling.PrioritySampling.*
+import static datadog.trace.api.sampling.SamplingMechanism.*
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.DDSpanContext
 import datadog.trace.core.test.DDCoreSpecification
 
 import static datadog.trace.core.CoreTracer.TRACE_ID_MAX
-import static datadog.trace.core.propagation.HaystackHttpCodec.DD_PARENT_ID_BAGGAGE_KEY
-import static datadog.trace.core.propagation.HaystackHttpCodec.DD_SPAN_ID_BAGGAGE_KEY
-import static datadog.trace.core.propagation.HaystackHttpCodec.DD_TRACE_ID_BAGGAGE_KEY
-import static datadog.trace.core.propagation.HaystackHttpCodec.HAYSTACK_TRACE_ID_BAGGAGE_KEY
-import static datadog.trace.core.propagation.HaystackHttpCodec.OT_BAGGAGE_PREFIX
-import static datadog.trace.core.propagation.HaystackHttpCodec.SPAN_ID_KEY
-import static datadog.trace.core.propagation.HaystackHttpCodec.TRACE_ID_KEY
+import static datadog.trace.core.propagation.HaystackHttpCodec.*
 
 class HaystackHttpInjectorTest extends DDCoreSpecification {
 
@@ -33,6 +28,7 @@ class HaystackHttpInjectorTest extends DDCoreSpecification {
       "fakeOperation",
       "fakeResource",
       samplingPriority,
+      samplingMechanism,
       origin,
       ["k1" : "v1", "k2" : "v2"],
       false,
@@ -60,11 +56,11 @@ class HaystackHttpInjectorTest extends DDCoreSpecification {
     tracer.close()
 
     where:
-    traceId               | spanId                | samplingPriority              | origin | traceUuid                              | spanUuid
-    "1"                   | "2"                   | PrioritySampling.SAMPLER_KEEP | null   | "44617461-646f-6721-0000-000000000001" | "44617461-646f-6721-0000-000000000002"
-    "1"                   | "2"                   | PrioritySampling.SAMPLER_KEEP | null   | "44617461-646f-6721-0000-000000000001" | "44617461-646f-6721-0000-000000000002"
-    "$TRACE_ID_MAX"       | "${TRACE_ID_MAX - 1}" | PrioritySampling.SAMPLER_KEEP | null   | "44617461-646f-6721-ffff-ffffffffffff" | "44617461-646f-6721-ffff-fffffffffffe"
-    "${TRACE_ID_MAX - 1}" | "$TRACE_ID_MAX"       | PrioritySampling.SAMPLER_KEEP | null   | "44617461-646f-6721-ffff-fffffffffffe" | "44617461-646f-6721-ffff-ffffffffffff"
+    traceId               | spanId                | samplingPriority | samplingMechanism | origin | traceUuid                              | spanUuid
+    "1"                   | "2"                   | SAMPLER_KEEP     | DEFAULT           | null   | "44617461-646f-6721-0000-000000000001" | "44617461-646f-6721-0000-000000000002"
+    "1"                   | "2"                   | SAMPLER_KEEP     | DEFAULT           | null   | "44617461-646f-6721-0000-000000000001" | "44617461-646f-6721-0000-000000000002"
+    "$TRACE_ID_MAX"       | "${TRACE_ID_MAX - 1}" | SAMPLER_KEEP     | DEFAULT           | null   | "44617461-646f-6721-ffff-ffffffffffff" | "44617461-646f-6721-ffff-fffffffffffe"
+    "${TRACE_ID_MAX - 1}" | "$TRACE_ID_MAX"       | SAMPLER_KEEP     | DEFAULT           | null   | "44617461-646f-6721-ffff-fffffffffffe" | "44617461-646f-6721-ffff-ffffffffffff"
   }
 
   def "inject http headers with haystack traceId in baggage"() {
@@ -82,6 +78,7 @@ class HaystackHttpInjectorTest extends DDCoreSpecification {
       "fakeOperation",
       "fakeResource",
       samplingPriority,
+      samplingMechanism,
       origin,
       ["k1" : "v1", "k2" : "v2", (HAYSTACK_TRACE_ID_BAGGAGE_KEY) : haystackUuid],
       false,
@@ -107,10 +104,10 @@ class HaystackHttpInjectorTest extends DDCoreSpecification {
     tracer.close()
 
     where:
-    traceId               | spanId                | samplingPriority              | origin | traceUuid                              | spanUuid
-    "1"                   | "2"                   | PrioritySampling.SAMPLER_KEEP | null   | "54617461-646f-6721-0000-000000000001" | "44617461-646f-6721-0000-000000000002"
-    "1"                   | "2"                   | PrioritySampling.SAMPLER_KEEP | null   | "54617461-646f-6721-0000-000000000001" | "44617461-646f-6721-0000-000000000002"
-    "$TRACE_ID_MAX"       | "${TRACE_ID_MAX - 1}" | PrioritySampling.SAMPLER_KEEP | null   | "54617461-646f-6721-ffff-ffffffffffff" | "44617461-646f-6721-ffff-fffffffffffe"
-    "${TRACE_ID_MAX - 1}" | "$TRACE_ID_MAX"       | PrioritySampling.SAMPLER_KEEP | null   | "54617461-646f-6721-ffff-fffffffffffe" | "44617461-646f-6721-ffff-ffffffffffff"
+    traceId               | spanId                | samplingPriority | samplingMechanism | origin | traceUuid                              | spanUuid
+    "1"                   | "2"                   | SAMPLER_KEEP     | DEFAULT           | null   | "54617461-646f-6721-0000-000000000001" | "44617461-646f-6721-0000-000000000002"
+    "1"                   | "2"                   | SAMPLER_KEEP     | DEFAULT           | null   | "54617461-646f-6721-0000-000000000001" | "44617461-646f-6721-0000-000000000002"
+    "$TRACE_ID_MAX"       | "${TRACE_ID_MAX - 1}" | SAMPLER_KEEP     | DEFAULT           | null   | "54617461-646f-6721-ffff-ffffffffffff" | "44617461-646f-6721-ffff-fffffffffffe"
+    "${TRACE_ID_MAX - 1}" | "$TRACE_ID_MAX"       | SAMPLER_KEEP     | DEFAULT           | null   | "54617461-646f-6721-ffff-fffffffffffe" | "44617461-646f-6721-ffff-ffffffffffff"
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpInjectorTest.groovy
@@ -35,7 +35,8 @@ class HaystackHttpInjectorTest extends DDCoreSpecification {
       "fakeType",
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
-      null)
+      null,
+      false)
 
     final Map<String, String> carrier = Mock()
 
@@ -85,7 +86,8 @@ class HaystackHttpInjectorTest extends DDCoreSpecification {
       "fakeType",
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
-      null)
+      null,
+      false)
 
     final Map<String, String> carrier = Mock()
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
@@ -2,7 +2,8 @@ package datadog.trace.core.propagation
 
 import datadog.trace.api.Config
 import datadog.trace.api.DDId
-import datadog.trace.api.sampling.PrioritySampling
+import static datadog.trace.api.sampling.PrioritySampling.*
+import static datadog.trace.api.sampling.SamplingMechanism.*
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.DDSpanContext
 import datadog.trace.core.test.DDCoreSpecification
@@ -35,6 +36,7 @@ class HttpInjectorTest extends DDCoreSpecification {
       "fakeOperation",
       "fakeResource",
       samplingPriority,
+      samplingMechanism,
       origin,
       ["k1": "v1", "k2": "v2"],
       false,
@@ -54,7 +56,7 @@ class HttpInjectorTest extends DDCoreSpecification {
       1 * carrier.put(DatadogHttpCodec.SPAN_ID_KEY, spanId.toString())
       1 * carrier.put(DatadogHttpCodec.OT_BAGGAGE_PREFIX + "k1", "v1")
       1 * carrier.put(DatadogHttpCodec.OT_BAGGAGE_PREFIX + "k2", "v2")
-      if (samplingPriority != PrioritySampling.UNSET) {
+      if (samplingPriority != UNSET) {
         1 * carrier.put(DatadogHttpCodec.SAMPLING_PRIORITY_KEY, "$samplingPriority")
       }
       if (origin) {
@@ -64,7 +66,7 @@ class HttpInjectorTest extends DDCoreSpecification {
     if (styles.contains(B3)) {
       1 * carrier.put(B3HttpCodec.TRACE_ID_KEY, traceId.toString())
       1 * carrier.put(B3HttpCodec.SPAN_ID_KEY, spanId.toString())
-      if (samplingPriority != PrioritySampling.UNSET) {
+      if (samplingPriority != UNSET) {
         1 * carrier.put(B3HttpCodec.SAMPLING_PRIORITY_KEY, "1")
         1 * carrier.put(B3_KEY, traceId.toString() + "-" + spanId.toString() + "-1")
       } else {
@@ -78,14 +80,14 @@ class HttpInjectorTest extends DDCoreSpecification {
 
     where:
     // spotless:off
-    styles        | samplingPriority              | origin
-    [DATADOG, B3] | PrioritySampling.UNSET        | null
-    [DATADOG, B3] | PrioritySampling.SAMPLER_KEEP | "saipan"
-    [DATADOG]     | PrioritySampling.UNSET        | null
-    [DATADOG]     | PrioritySampling.SAMPLER_KEEP | "saipan"
-    [B3]          | PrioritySampling.UNSET        | null
-    [B3]          | PrioritySampling.SAMPLER_KEEP | "saipan"
-    [B3, DATADOG] | PrioritySampling.SAMPLER_KEEP | "saipan"
+    styles        | samplingPriority | samplingMechanism | origin
+    [DATADOG, B3] | UNSET            | UNKNOWN           | null
+    [DATADOG, B3] | SAMPLER_KEEP     | DEFAULT           | "saipan"
+    [DATADOG]     | UNSET            | UNKNOWN           | null
+    [DATADOG]     | SAMPLER_KEEP     | DEFAULT           | "saipan"
+    [B3]          | UNSET            | UNKNOWN           | null
+    [B3]          | SAMPLER_KEEP     | DEFAULT           | "saipan"
+    [B3, DATADOG] | SAMPLER_KEEP     | DEFAULT           | "saipan"
     // spotless:on
   }
 
@@ -106,6 +108,7 @@ class HttpInjectorTest extends DDCoreSpecification {
       "fakeOperation",
       "fakeResource",
       samplingPriority,
+      samplingMechanism,
       origin,
       ["k1": "v1", "k2": "v2"],
       false,
@@ -125,7 +128,7 @@ class HttpInjectorTest extends DDCoreSpecification {
       1 * carrier.put(DatadogHttpCodec.SPAN_ID_KEY, spanId.toString())
       1 * carrier.put(DatadogHttpCodec.OT_BAGGAGE_PREFIX + "k1", "v1")
       1 * carrier.put(DatadogHttpCodec.OT_BAGGAGE_PREFIX + "k2", "v2")
-      if (samplingPriority != PrioritySampling.UNSET) {
+      if (samplingPriority != UNSET) {
         1 * carrier.put(DatadogHttpCodec.SAMPLING_PRIORITY_KEY, "$samplingPriority")
       }
       if (origin) {
@@ -134,7 +137,7 @@ class HttpInjectorTest extends DDCoreSpecification {
     } else if (style == B3) {
       1 * carrier.put(B3HttpCodec.TRACE_ID_KEY, traceId.toString())
       1 * carrier.put(B3HttpCodec.SPAN_ID_KEY, spanId.toString())
-      if (samplingPriority != PrioritySampling.UNSET) {
+      if (samplingPriority != UNSET) {
         1 * carrier.put(B3HttpCodec.SAMPLING_PRIORITY_KEY, "1")
         1 * carrier.put(B3_KEY, traceId.toString() + "-" + spanId.toString() + "-1")
       } else {
@@ -148,13 +151,13 @@ class HttpInjectorTest extends DDCoreSpecification {
 
     where:
     // spotless:off
-    style   | samplingPriority              | origin
-    DATADOG | PrioritySampling.UNSET        | null
-    DATADOG | PrioritySampling.SAMPLER_KEEP | null
-    DATADOG | PrioritySampling.SAMPLER_KEEP | "saipan"
-    B3      | PrioritySampling.UNSET        | null
-    B3      | PrioritySampling.SAMPLER_KEEP | null
-    B3      | PrioritySampling.SAMPLER_KEEP | "saipan"
+    style   | samplingPriority | samplingMechanism | origin
+    DATADOG | UNSET            | UNKNOWN           | null
+    DATADOG | SAMPLER_KEEP     | DEFAULT           | null
+    DATADOG | SAMPLER_KEEP     | DEFAULT           | "saipan"
+    B3      | UNSET            | UNKNOWN           | null
+    B3      | SAMPLER_KEEP     | DEFAULT           | null
+    B3      | SAMPLER_KEEP     | DEFAULT           | "saipan"
     // spotless:on
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
@@ -43,7 +43,8 @@ class HttpInjectorTest extends DDCoreSpecification {
       "fakeType",
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
-      null)
+      null,
+      false)
 
     final Map<String, String> carrier = Mock()
 
@@ -115,7 +116,8 @@ class HttpInjectorTest extends DDCoreSpecification {
       "fakeType",
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
-      null)
+      null,
+      false)
 
     final Map<String, String> carrier = Mock()
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/XRayHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/XRayHttpInjectorTest.groovy
@@ -36,7 +36,8 @@ class XRayHttpInjectorTest extends DDCoreSpecification {
       "fakeType",
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
-      null)
+      null,
+      false)
 
     final Map<String, String> carrier = Mock()
 
@@ -87,7 +88,8 @@ class XRayHttpInjectorTest extends DDCoreSpecification {
       "fakeType",
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
-      null)
+      null,
+      false)
     final Map<String, String> carrier = Mock()
 
     when:
@@ -131,7 +133,8 @@ class XRayHttpInjectorTest extends DDCoreSpecification {
       "fakeType",
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
-      null)
+      null,
+      false)
 
     mockedContext.beginEndToEnd()
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/XRayHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/XRayHttpInjectorTest.groovy
@@ -1,7 +1,8 @@
 package datadog.trace.core.propagation
 
 import datadog.trace.api.DDId
-import datadog.trace.api.sampling.PrioritySampling
+import static datadog.trace.api.sampling.PrioritySampling.*
+import static datadog.trace.api.sampling.SamplingMechanism.*
 import datadog.trace.bootstrap.instrumentation.api.ContextVisitors
 import datadog.trace.bootstrap.instrumentation.api.TagContext
 import datadog.trace.common.writer.ListWriter
@@ -28,6 +29,7 @@ class XRayHttpInjectorTest extends DDCoreSpecification {
       "fakeOperation",
       "fakeResource",
       samplingPriority,
+      samplingMechanism,
       "fakeOrigin",
       ["k": "v"],
       false,
@@ -49,14 +51,14 @@ class XRayHttpInjectorTest extends DDCoreSpecification {
     tracer.close()
 
     where:
-    traceId          | spanId           | samplingPriority              | expectedTraceHeader
-    1G               | 2G               | PrioritySampling.UNSET        | 'Root=1-00000000-000000000000000000000001;Parent=0000000000000002;_dd.origin=fakeOrigin;k=v'
-    2G               | 3G               | PrioritySampling.SAMPLER_KEEP | 'Root=1-00000000-000000000000000000000002;Parent=0000000000000003;Sampled=1;_dd.origin=fakeOrigin;k=v'
-    4G               | 5G               | PrioritySampling.SAMPLER_DROP | 'Root=1-00000000-000000000000000000000004;Parent=0000000000000005;Sampled=0;_dd.origin=fakeOrigin;k=v'
-    5G               | 6G               | PrioritySampling.USER_KEEP    | 'Root=1-00000000-000000000000000000000005;Parent=0000000000000006;Sampled=1;_dd.origin=fakeOrigin;k=v'
-    6G               | 7G               | PrioritySampling.USER_DROP    | 'Root=1-00000000-000000000000000000000006;Parent=0000000000000007;Sampled=0;_dd.origin=fakeOrigin;k=v'
-    TRACE_ID_MAX     | TRACE_ID_MAX - 1 | PrioritySampling.UNSET        | 'Root=1-00000000-00000000ffffffffffffffff;Parent=fffffffffffffffe;_dd.origin=fakeOrigin;k=v'
-    TRACE_ID_MAX - 1 | TRACE_ID_MAX     | PrioritySampling.SAMPLER_KEEP | 'Root=1-00000000-00000000fffffffffffffffe;Parent=ffffffffffffffff;Sampled=1;_dd.origin=fakeOrigin;k=v'
+    traceId          | spanId           | samplingPriority | samplingMechanism | expectedTraceHeader
+    1G               | 2G               | UNSET            | UNKNOWN           | 'Root=1-00000000-000000000000000000000001;Parent=0000000000000002;_dd.origin=fakeOrigin;k=v'
+    2G               | 3G               | SAMPLER_KEEP     | DEFAULT           | 'Root=1-00000000-000000000000000000000002;Parent=0000000000000003;Sampled=1;_dd.origin=fakeOrigin;k=v'
+    4G               | 5G               | SAMPLER_DROP     | DEFAULT           | 'Root=1-00000000-000000000000000000000004;Parent=0000000000000005;Sampled=0;_dd.origin=fakeOrigin;k=v'
+    5G               | 6G               | USER_KEEP        | MANUAL            | 'Root=1-00000000-000000000000000000000005;Parent=0000000000000006;Sampled=1;_dd.origin=fakeOrigin;k=v'
+    6G               | 7G               | USER_DROP        | MANUAL            | 'Root=1-00000000-000000000000000000000006;Parent=0000000000000007;Sampled=0;_dd.origin=fakeOrigin;k=v'
+    TRACE_ID_MAX     | TRACE_ID_MAX - 1 | UNSET            | UNKNOWN           | 'Root=1-00000000-00000000ffffffffffffffff;Parent=fffffffffffffffe;_dd.origin=fakeOrigin;k=v'
+    TRACE_ID_MAX - 1 | TRACE_ID_MAX     | SAMPLER_KEEP     | DEFAULT           | 'Root=1-00000000-00000000fffffffffffffffe;Parent=ffffffffffffffff;Sampled=1;_dd.origin=fakeOrigin;k=v'
   }
 
   def "inject http headers with extracted original"() {
@@ -77,7 +79,8 @@ class XRayHttpInjectorTest extends DDCoreSpecification {
       "fakeService",
       "fakeOperation",
       "fakeResource",
-      PrioritySampling.UNSET,
+      UNSET,
+      UNKNOWN,
       "fakeOrigin",
       ["k": "v"],
       false,
@@ -120,7 +123,8 @@ class XRayHttpInjectorTest extends DDCoreSpecification {
       "fakeService",
       "fakeOperation",
       "fakeResource",
-      PrioritySampling.UNSET,
+      UNSET,
+      UNKNOWN,
       "fakeOrigin",
       ["k": "v"],
       false,

--- a/dd-trace-core/src/traceAgentTest/groovy/TraceGenerator.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/TraceGenerator.groovy
@@ -300,12 +300,12 @@ class TraceGenerator {
     }
 
     @Override
-    PojoSpan setSamplingPriority(int samplingPriority) {
+    PojoSpan setSamplingPriority(int samplingPriority, int samplingMechanism) {
       return this
     }
 
     @Override
-    PojoSpan setSamplingPriority(int samplingPriority, CharSequence rate, double sampleRate) {
+    PojoSpan setSamplingPriority(int samplingPriority, CharSequence rate, double sampleRate, int samplingMechanism) {
       return this
     }
 

--- a/dd-trace-ot/src/ot31CompatabilityTest/groovy/OT31ApiTest.groovy
+++ b/dd-trace-ot/src/ot31CompatabilityTest/groovy/OT31ApiTest.groovy
@@ -1,5 +1,6 @@
 import datadog.opentracing.DDTracer
-import datadog.trace.api.sampling.PrioritySampling
+import static datadog.trace.api.sampling.PrioritySampling.*
+import static datadog.trace.api.sampling.SamplingMechanism.*
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.DDSpan
 import datadog.trace.test.util.DDSpecification
@@ -78,7 +79,7 @@ class OT31ApiTest extends DDSpecification {
     def adapter = new TextMapAdapter(textMap)
 
     when:
-    context.delegate.samplingPriority = contextPriority
+    context.delegate.setSamplingPriority(contextPriority, samplingMechanism)
     tracer.inject(context, Format.Builtin.TEXT_MAP, adapter)
 
     then:
@@ -97,12 +98,12 @@ class OT31ApiTest extends DDSpecification {
     extract.delegate.samplingPriority == propagatedPriority
 
     where:
-    contextPriority               | propagatedPriority
-    PrioritySampling.SAMPLER_DROP | PrioritySampling.SAMPLER_DROP
-    PrioritySampling.SAMPLER_KEEP | PrioritySampling.SAMPLER_KEEP
-    PrioritySampling.UNSET        | PrioritySampling.SAMPLER_KEEP
-    PrioritySampling.USER_KEEP    | PrioritySampling.USER_KEEP
-    PrioritySampling.USER_DROP    | PrioritySampling.USER_DROP
+    contextPriority | samplingMechanism | propagatedPriority
+    SAMPLER_DROP    | DEFAULT           | SAMPLER_DROP
+    SAMPLER_KEEP    | DEFAULT           | SAMPLER_KEEP
+    UNSET           | DEFAULT           | SAMPLER_KEEP
+    USER_KEEP       | MANUAL            | USER_KEEP
+    USER_DROP       | MANUAL            | USER_DROP
   }
 
   static class TextMapAdapter implements TextMap {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1841,6 +1841,10 @@ public class Config {
     return isEnabled(Arrays.asList(integrationNames), "", ".analytics.enabled", defaultEnabled);
   }
 
+  public boolean isSamplingMechanismValidationDisabled() {
+    return configProvider.getBoolean(TracerConfig.SAMPLING_MECHANISM_VALIDATION_DISABLED, false);
+  }
+
   public <T extends Enum<T>> T getEnumValue(
       final String name, final Class<T> type, final T defaultValue) {
     return configProvider.getEnum(name, type, defaultValue);

--- a/internal-api/src/main/java/datadog/trace/api/sampling/SamplingMechanism.java
+++ b/internal-api/src/main/java/datadog/trace/api/sampling/SamplingMechanism.java
@@ -1,0 +1,45 @@
+package datadog.trace.api.sampling;
+
+import static datadog.trace.api.sampling.PrioritySampling.*;
+
+public class SamplingMechanism {
+  /** Not encouraged to use */
+  public static final byte UNKNOWN = -1;
+  /** Used before the tracer receives any rates from agent and there are no rules configured */
+  public static final byte DEFAULT = 0;
+  /** The sampling rate received in the agent's http response */
+  public static final byte AGENT_RATE = 1;
+  /** Auto; reserved for future use */
+  public static final byte REMOTE_AUTO_RATE = 2;
+  /** Sampling rule or sampling rate based on tracer config */
+  public static final byte RULE = 3;
+  /** User directly sets sampling priority via code using span.SetTag(ManualKeep) or similar API */
+  public static final byte MANUAL = 4;
+  /** AppSec */
+  public static final byte APPSEC = 5;
+  /** User-defined target; reserved for future use */
+  public static final byte REMOTE_USER_RATE = 6;
+
+  public static boolean validateWithSamplingPriority(int mechanism, int priority) {
+    switch (mechanism) {
+      case UNKNOWN:
+        return priority >= USER_DROP && priority <= USER_KEEP || priority == UNSET;
+
+      case DEFAULT:
+      case AGENT_RATE:
+      case REMOTE_AUTO_RATE:
+        return priority == SAMPLER_DROP || priority == SAMPLER_KEEP;
+
+      case RULE:
+      case MANUAL:
+      case REMOTE_USER_RATE:
+        return priority == USER_DROP || priority == USER_KEEP;
+
+      case APPSEC:
+        return priority == PrioritySampling.USER_KEEP;
+    }
+    return true;
+  }
+
+  private SamplingMechanism() {}
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/sampling/SamplingMechanismTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/sampling/SamplingMechanismTest.groovy
@@ -1,0 +1,63 @@
+package datadog.trace.api.sampling
+
+import spock.lang.Specification
+import static datadog.trace.api.sampling.PrioritySampling.*
+import static datadog.trace.api.sampling.SamplingMechanism.*
+
+class SamplingMechanismTest extends Specification {
+
+  def "test validation"() {
+    expect:
+    validateWithSamplingPriority(mechanism, priority) == valid
+
+    where:
+    mechanism        | priority     | valid
+    UNKNOWN          | UNSET        | true
+    UNKNOWN          | SAMPLER_DROP | true
+    UNKNOWN          | SAMPLER_KEEP | true
+    UNKNOWN          | USER_DROP    | true
+    UNKNOWN          | USER_KEEP    | true
+
+    DEFAULT          | UNSET        | false
+    DEFAULT          | SAMPLER_DROP | true
+    DEFAULT          | SAMPLER_KEEP | true
+    DEFAULT          | USER_DROP    | false
+    DEFAULT          | USER_KEEP    | false
+
+    AGENT_RATE       | UNSET        | false
+    AGENT_RATE       | SAMPLER_DROP | true
+    AGENT_RATE       | SAMPLER_KEEP | true
+    AGENT_RATE       | USER_DROP    | false
+    AGENT_RATE       | USER_KEEP    | false
+
+    REMOTE_AUTO_RATE | UNSET        | false
+    REMOTE_AUTO_RATE | SAMPLER_DROP | true
+    REMOTE_AUTO_RATE | SAMPLER_KEEP | true
+    REMOTE_AUTO_RATE | USER_DROP    | false
+    REMOTE_AUTO_RATE | USER_KEEP    | false
+
+    RULE             | UNSET        | false
+    RULE             | SAMPLER_DROP | false
+    RULE             | SAMPLER_KEEP | false
+    RULE             | USER_DROP    | true
+    RULE             | USER_KEEP    | true
+
+    MANUAL           | UNSET        | false
+    MANUAL           | SAMPLER_DROP | false
+    MANUAL           | SAMPLER_KEEP | false
+    MANUAL           | USER_DROP    | true
+    MANUAL           | USER_KEEP    | true
+
+    REMOTE_USER_RATE | UNSET        | false
+    REMOTE_USER_RATE | SAMPLER_DROP | false
+    REMOTE_USER_RATE | SAMPLER_KEEP | false
+    REMOTE_USER_RATE | USER_DROP    | true
+    REMOTE_USER_RATE | USER_KEEP    | true
+
+    APPSEC           | UNSET        | false
+    APPSEC           | SAMPLER_DROP | false
+    APPSEC           | SAMPLER_KEEP | false
+    APPSEC           | USER_DROP    | false
+    APPSEC           | USER_KEEP    | true
+  }
+}


### PR DESCRIPTION
# What Does This Do
Modifies DDSpanContext::setSamplingPriority to have a new parameter to track the mechanism which is setting/changing the sampling priority. 

# Motivation
Trace Tags Propagation in Distributed Traces RFC introduces sampling mechanism.

# Additional Notes
[Implementation plan](https://docs.google.com/document/d/1eBOz7BwCEDc6yuM58yMsNN3Ov0jbjRnZcXgYs2zjuTw)
See “Sampling Mechanisms” section of [the RFC](https://docs.google.com/document/d/1zeO6LGnvxk5XweObHAwJbK3SfK23z7jQzp7ozWJTa2A).