### PR TITLE
Use AgentSpan iteration API when consuming JMS messages

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/MessageConsumerState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/MessageConsumerState.java
@@ -1,9 +1,8 @@
 package datadog.trace.bootstrap.instrumentation.jms;
 
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 
-/** Tracks message scopes and spans when consuming messages with {@code receive}. */
+/** Tracks message spans when consuming messages with {@code receive}. */
 public final class MessageConsumerState {
 
   private final SessionState sessionState;
@@ -49,16 +48,6 @@ public final class MessageConsumerState {
 
   public boolean isPropagationDisabled() {
     return propagationDisabled;
-  }
-
-  /** Closes the given message scope when the next message is consumed or the consumer is closed. */
-  public void closeOnIteration(AgentScope newScope) {
-    sessionState.closeOnIteration(newScope); // tracked per-session-thread
-  }
-
-  /** Closes the scope previously registered by closeOnIteration, assumes same calling thread. */
-  public void closePreviousMessageScope() {
-    sessionState.closePreviousMessageScope(); // tracked per-session-thread
   }
 
   /** Gets the current time-in-queue span; returns {@code null} if this is a new batch. */

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -43,6 +43,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.AdditionalLibraryIgnoresMatcher.additionalLibraryIgnoresMatcher
 import static datadog.trace.api.IdGenerationStrategy.SEQUENTIAL
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.closePrevious
 import static net.bytebuddy.matcher.ElementMatchers.named
 import static net.bytebuddy.matcher.ElementMatchers.none
 
@@ -197,6 +198,7 @@ abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.L
 
     assertThreadsEachCleanup = false
 
+    closePrevious(true) // in case the previous test left a lingering iteration span
     assert TEST_TRACER.activeSpan() == null: "Span is active before test has started: " + TEST_TRACER.activeSpan()
 
     // Config is reset before each test. Thus, configurePreAgent() has to be called before each test


### PR DESCRIPTION
# What Does This Do
Enables use of `AgentSpan.closePrevious` and `AgentSpan.activateNext` when consuming JMS messages.

# Motivation
This replaces the previous JMS specific approach with the new shared mechanism introduced in #3194

# Additional Notes
Also made a change to cleanup iteration scopes before each test (for when tests run immediately afterwards)