### PR TITLE
Close last record scope when iterator indicates there are no more records

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
@@ -34,7 +34,11 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
 
   @Override
   public boolean hasNext() {
-    return delegateIterator.hasNext();
+    boolean hasNext = delegateIterator.hasNext();
+    if (!hasNext) {
+      closePrevious(true);
+    }
+    return hasNext;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
@@ -34,11 +34,12 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
 
   @Override
   public boolean hasNext() {
-    boolean hasNext = delegateIterator.hasNext();
-    if (!hasNext) {
+    boolean moreRecords = delegateIterator.hasNext();
+    if (!moreRecords) {
+      // no more records, use this as a signal to close the last iteration scope
       closePrevious(true);
     }
-    return hasNext;
+    return moreRecords;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingListIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingListIterator.java
@@ -20,11 +20,12 @@ public class TracingListIterator extends TracingIterator
 
   @Override
   public boolean hasPrevious() {
-    boolean hasPrevious = delegateIterator.hasPrevious();
-    if (!hasPrevious) {
+    boolean moreRecords = delegateIterator.hasPrevious();
+    if (!moreRecords) {
+      // no more records, use this as a signal to close the last iteration scope
       closePrevious(true);
     }
-    return hasPrevious;
+    return moreRecords;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingListIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingListIterator.java
@@ -1,5 +1,7 @@
 package datadog.trace.instrumentation.kafka_clients;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.closePrevious;
+
 import java.util.ListIterator;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
@@ -18,7 +20,11 @@ public class TracingListIterator extends TracingIterator
 
   @Override
   public boolean hasPrevious() {
-    return delegateIterator.hasPrevious();
+    boolean hasPrevious = delegateIterator.hasPrevious();
+    if (!hasPrevious) {
+      closePrevious(true);
+    }
+    return hasPrevious;
   }
 
   @Override


### PR DESCRIPTION
This is a small optimization - the last scope of the iteration will timeout if nothing closes it, but this is a good signal it can be closed early