### PR TITLE
Emit profiler setting events

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AsyncProfilerConfigEvent.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AsyncProfilerConfigEvent.java
@@ -41,9 +41,19 @@ public class AsyncProfilerConfigEvent extends Event {
   @Description("Async profiler version string")
   private final String version;
 
+  @Label("Library Path")
+  @Description("Path to async-profiler library or null")
+  private final String libPath;
+
   public AsyncProfilerConfigEvent(
-      String version, long cpuInterval, long allocInterval, long memleakInterval, int modeMask) {
+      String version,
+      String libPath,
+      long cpuInterval,
+      long allocInterval,
+      long memleakInterval,
+      int modeMask) {
     this.version = version;
+    this.libPath = libPath;
     this.cpuInterval = cpuInterval;
     this.allocInterval = allocInterval;
     this.memleakInterval = memleakInterval;

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfiler.java
@@ -70,13 +70,19 @@ final class AuxiliaryAsyncProfiler implements AuxiliaryImplementation {
     } else {
       instance = inferFromOsAndArch();
     }
-    if (configProvider.getBoolean(ProfilingConfig.PROFILING_ASYNC_ALLOC_ENABLED, false)) {
+    if (configProvider.getBoolean(
+        ProfilingConfig.PROFILING_ASYNC_ALLOC_ENABLED,
+        ProfilingConfig.PROFILING_ASYNC_ALLOC_ENABLED_DEFAULT)) {
       profilingModes.add(ProfilingMode.ALLOCATION);
     }
-    if (configProvider.getBoolean(ProfilingConfig.PROFILING_ASYNC_MEMLEAK_ENABLED, false)) {
+    if (configProvider.getBoolean(
+        ProfilingConfig.PROFILING_ASYNC_MEMLEAK_ENABLED,
+        ProfilingConfig.PROFILING_ASYNC_MEMLEAK_ENABLED_DEFAULT)) {
       profilingModes.add(ProfilingMode.MEMLEAK);
     }
-    if (configProvider.getBoolean(ProfilingConfig.PROFILING_ASYNC_CPU_ENABLED, true)) {
+    if (configProvider.getBoolean(
+        ProfilingConfig.PROFILING_ASYNC_CPU_ENABLED,
+        ProfilingConfig.PROFILING_ASYNC_CPU_ENABLED_DEFAULT)) {
       profilingModes.add(ProfilingMode.CPU);
     }
     try {
@@ -105,6 +111,7 @@ final class AuxiliaryAsyncProfiler implements AuxiliaryImplementation {
     try {
       new AsyncProfilerConfigEvent(
               asyncProfiler.getVersion(),
+              configProvider.getString(ProfilingConfig.PROFILING_ASYNC_LIBPATH),
               getCpuInterval(),
               getAllocationInterval(),
               getMemleakInterval(),

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/resources/jfr/dd.jfp
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/resources/jfr/dd.jfp
@@ -243,3 +243,4 @@ datadog.Scope#enabled=true
 datadog.Scope#threshold=10 ms
 datadog.ExceptionSample#enabled=true
 datadog.ExceptionCount#enabled=true
+datadog.ProfilerSetting#enabled=true

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/JfrProfilerSettings.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/JfrProfilerSettings.java
@@ -1,0 +1,36 @@
+package com.datadog.profiling.controller.openjdk;
+
+import com.datadog.profiling.controller.ProfilerSettingsSupport;
+import com.datadog.profiling.controller.openjdk.events.ProfilerSettingEvent;
+
+/** Capture the profiler config first and allow emitting the setting events per each recording. */
+final class JfrProfilerSettings extends ProfilerSettingsSupport {
+  public void publish() {
+    if (new ProfilerSettingEvent(null, null, null).isEnabled()) {
+      new ProfilerSettingEvent("Upload Period", String.valueOf(uploadPeriod), "seconds").commit();
+      new ProfilerSettingEvent("Upload Timeout", String.valueOf(uploadTimeout), "seconds").commit();
+      new ProfilerSettingEvent("Upload Compression", uploadCompression).commit();
+      new ProfilerSettingEvent("Allocation Profiling", String.valueOf(allocationProfilingEnabled))
+          .commit();
+      new ProfilerSettingEvent("Heap Profiling", String.valueOf(heapProfilingEnabled)).commit();
+      new ProfilerSettingEvent("Force Start-First", String.valueOf(startForceFirst)).commit();
+      new ProfilerSettingEvent("JFP Template Override Profiling", String.valueOf(templateOverride))
+          .commit();
+      new ProfilerSettingEvent(
+              "Exception Sample Rate Limit",
+              String.valueOf(exceptionSampleLimit),
+              "exceptions/second")
+          .commit();
+      new ProfilerSettingEvent(
+              "Exception Histo Report Limit", String.valueOf(exceptionHistogramTopItems))
+          .commit();
+      new ProfilerSettingEvent(
+              "Exception Histo Size Limit", String.valueOf(exceptionHistogramMaxSize))
+          .commit();
+      new ProfilerSettingEvent("Hotspots", String.valueOf(hotspotsEnabled)).commit();
+      new ProfilerSettingEvent("Checkpoints", String.valueOf(checkpointsEnabled)).commit();
+      new ProfilerSettingEvent("Endpoints", String.valueOf(endpointsEnabled)).commit();
+      new ProfilerSettingEvent("Auxiliary Profiler", auxiliaryProfiler).commit();
+    }
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecording.java
@@ -19,6 +19,8 @@ import org.slf4j.LoggerFactory;
 public class OpenJdkOngoingRecording implements OngoingRecording {
   private static final Logger log = LoggerFactory.getLogger(OpenJdkOngoingRecording.class);
 
+  private static final JfrProfilerSettings CONFIG_MEMENTO = new JfrProfilerSettings();
+
   private final Recording recording;
   private final OngoingRecording auxiliaryRecording;
   private final AuxiliaryProfiler auxiliaryProfiler;
@@ -104,6 +106,8 @@ public class OpenJdkOngoingRecording implements OngoingRecording {
     if (recording.getState() != RecordingState.RUNNING) {
       throw new IllegalStateException("Cannot stop recording that is not running");
     }
+    // dump the config to the current JFR recording
+    CONFIG_MEMENTO.publish();
 
     recording.stop();
     OpenJdkRecordingData mainData = new OpenJdkRecordingData(recording);
@@ -119,6 +123,8 @@ public class OpenJdkOngoingRecording implements OngoingRecording {
       throw new IllegalStateException("Cannot snapshot recording that is not running");
     }
 
+    // dump the config to the current JFR recording
+    CONFIG_MEMENTO.publish();
     final Recording snapshot = FlightRecorder.getFlightRecorder().takeSnapshot();
     snapshot.setName(recording.getName()); // Copy name from original recording
     // Since we just requested a snapshot, the end time of the snapshot will be

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/ProfilerSettingEvent.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/ProfilerSettingEvent.java
@@ -1,0 +1,34 @@
+package com.datadog.profiling.controller.openjdk.events;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+@Name("datadog.ProfilerSetting")
+@Label("Profiler Configuration Setting")
+@Description("Datadog profiler configuration setting")
+@Category("Datadog")
+@StackTrace(false)
+public class ProfilerSettingEvent extends Event {
+  @Label("Setting Name")
+  private final String name;
+
+  @Label("Setting Value")
+  private final String value;
+
+  @Label("Setting Unit")
+  private final String unit;
+
+  public ProfilerSettingEvent(String name, String value) {
+    this(name, value, "");
+  }
+
+  public ProfilerSettingEvent(String name, String value, String unit) {
+    this.name = name;
+    this.value = value;
+    this.unit = unit;
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-controller/profiling-controller.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller/profiling-controller.gradle
@@ -11,7 +11,9 @@ excludedClassesCoverage += [
   'com.datadog.profiling.controller.ProfilingSystem.StartRecording',
   'com.datadog.profiling.controller.ProfilingSystem.StopRecording',
   // This is almost fully abstract class so nothing to test
-  'com.datadog.profiling.controller.RecordingData'
+  'com.datadog.profiling.controller.RecordingData',
+  // A simple data holder class, nothing to test
+  'com.datadog.profiling.controller.ProfilerSettingsSupport'
 ]
 
 dependencies {

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilerSettingsSupport.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilerSettingsSupport.java
@@ -1,0 +1,78 @@
+package com.datadog.profiling.controller;
+
+import datadog.trace.api.config.ProfilingConfig;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+
+/** Capture the profiler config first and allow emitting the setting events per each recording. */
+public abstract class ProfilerSettingsSupport {
+  protected final int uploadPeriod;
+  protected final int uploadTimeout;
+  protected final String uploadCompression;
+  protected final boolean allocationProfilingEnabled;
+  protected final boolean heapProfilingEnabled;
+  protected final boolean startForceFirst;
+  protected final String templateOverride;
+  protected final int exceptionSampleLimit;
+  protected final int exceptionHistogramTopItems;
+  protected final int exceptionHistogramMaxSize;
+  protected final boolean hotspotsEnabled;
+  protected final boolean checkpointsEnabled;
+  protected final boolean endpointsEnabled;
+  protected final String auxiliaryProfiler;
+
+  protected ProfilerSettingsSupport() {
+    ConfigProvider configProvider = ConfigProvider.getInstance();
+    uploadPeriod =
+        configProvider.getInteger(
+            ProfilingConfig.PROFILING_UPLOAD_PERIOD,
+            ProfilingConfig.PROFILING_UPLOAD_PERIOD_DEFAULT);
+    uploadTimeout =
+        configProvider.getInteger(
+            ProfilingConfig.PROFILING_UPLOAD_TIMEOUT,
+            ProfilingConfig.PROFILING_UPLOAD_TIMEOUT_DEFAULT);
+    uploadCompression =
+        configProvider.getString(
+            ProfilingConfig.PROFILING_UPLOAD_COMPRESSION,
+            ProfilingConfig.PROFILING_UPLOAD_COMPRESSION_DEFAULT);
+    allocationProfilingEnabled =
+        configProvider.getBoolean(
+            ProfilingConfig.PROFILING_ALLOCATION_ENABLED,
+            ProfilingConfig.PROFILING_ALLOCATION_ENABLED_DEFAULT);
+    heapProfilingEnabled =
+        configProvider.getBoolean(
+            ProfilingConfig.PROFILING_HEAP_ENABLED, ProfilingConfig.PROFILING_HEAP_ENABLED_DEFAULT);
+    startForceFirst =
+        configProvider.getBoolean(
+            ProfilingConfig.PROFILING_START_FORCE_FIRST,
+            ProfilingConfig.PROFILING_START_FORCE_FIRST_DEFAULT);
+    templateOverride = configProvider.getString(ProfilingConfig.PROFILING_TEMPLATE_OVERRIDE_FILE);
+    exceptionSampleLimit =
+        configProvider.getInteger(
+            ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT,
+            ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT_DEFAULT);
+    exceptionHistogramTopItems =
+        configProvider.getInteger(
+            ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS,
+            ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS_DEFAULT);
+    exceptionHistogramMaxSize =
+        configProvider.getInteger(
+            ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE,
+            ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE_DEFAULT);
+    hotspotsEnabled = configProvider.getBoolean(ProfilingConfig.PROFILING_HOTSPOTS_ENABLED, false);
+    checkpointsEnabled =
+        !configProvider.getBoolean(
+            ProfilingConfig.PROFILING_LEGACY_TRACING_INTEGRATION,
+            ProfilingConfig.PROFILING_LEGACY_TRACING_INTEGRATION_DEFAULT);
+    endpointsEnabled =
+        configProvider.getBoolean(
+            ProfilingConfig.PROFILING_ENDPOINT_COLLECTION_ENABLED,
+            ProfilingConfig.PROFILING_ENDPOINT_COLLECTION_ENABLED_DEFAULT);
+    auxiliaryProfiler =
+        configProvider.getString(
+            ProfilingConfig.PROFILING_AUXILIARY_TYPE,
+            ProfilingConfig.PROFILING_AUXILIARY_TYPE_DEFAULT);
+  }
+
+  /** To be defined in controller specific way. Eg. one could emit JFR events. */
+  public abstract void publish();
+}

--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/ProfilingIntegrationTest.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/ProfilingIntegrationTest.java
@@ -500,6 +500,8 @@ class ProfilingIntegrationTest {
                     Aggregators.min("datadog.AvailableProcessorCores", cpuCountAttr)))
             .longValue();
     assertEquals(Runtime.getRuntime().availableProcessors(), val);
+
+    assertTrue(events.apply(ItemFilters.type("datadog.ProfilerSetting")).hasItems());
   }
 
   private static String getStringParameter(

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -9,7 +9,9 @@ package datadog.trace.api.config;
 public final class ProfilingConfig {
   public static final String PROFILING_ENABLED = "profiling.enabled";
   public static final String PROFILING_ALLOCATION_ENABLED = "profiling.allocation.enabled";
+  public static final boolean PROFILING_ALLOCATION_ENABLED_DEFAULT = false;
   public static final String PROFILING_HEAP_ENABLED = "profiling.heap.enabled";
+  public static final boolean PROFILING_HEAP_ENABLED_DEFAULT = false;
   @Deprecated // Use dd.site instead
   public static final String PROFILING_URL = "profiling.url";
   @Deprecated // Use dd.api-key instead
@@ -28,20 +30,27 @@ public final class ProfilingConfig {
   // Not intended for production use
   public static final String PROFILING_START_FORCE_FIRST =
       "profiling.experimental.start-force-first";
+  public static final boolean PROFILING_START_FORCE_FIRST_DEFAULT = false;
   public static final String PROFILING_UPLOAD_PERIOD = "profiling.upload.period";
+  public static final int PROFILING_UPLOAD_PERIOD_DEFAULT = 60;
   public static final String PROFILING_TEMPLATE_OVERRIDE_FILE =
       "profiling.jfr-template-override-file";
   public static final String PROFILING_UPLOAD_TIMEOUT = "profiling.upload.timeout";
+  public static final int PROFILING_UPLOAD_TIMEOUT_DEFAULT = 30;
   public static final String PROFILING_UPLOAD_COMPRESSION = "profiling.upload.compression";
+  public static final String PROFILING_UPLOAD_COMPRESSION_DEFAULT = "on";
   public static final String PROFILING_PROXY_HOST = "profiling.proxy.host";
   public static final String PROFILING_PROXY_PORT = "profiling.proxy.port";
   public static final String PROFILING_PROXY_USERNAME = "profiling.proxy.username";
   public static final String PROFILING_PROXY_PASSWORD = "profiling.proxy.password";
   public static final String PROFILING_EXCEPTION_SAMPLE_LIMIT = "profiling.exception.sample.limit";
+  public static final int PROFILING_EXCEPTION_SAMPLE_LIMIT_DEFAULT = 10_000;
   public static final String PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS =
       "profiling.exception.histogram.top-items";
+  public static final int PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS_DEFAULT = 50;
   public static final String PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE =
       "profiling.exception.histogram.max-collection-size";
+  public static final int PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE_DEFAULT = 10_000;
   public static final String PROFILING_EXCLUDE_AGENT_THREADS = "profiling.exclude.agent-threads";
   public static final String PROFILING_HOTSPOTS_ENABLED = "profiling.hotspots.enabled";
 
@@ -50,19 +59,23 @@ public final class ProfilingConfig {
 
   public static final String PROFILING_ASYNC_LIBPATH = "profiling.async.lib";
   public static final String PROFILING_ASYNC_ALLOC_ENABLED = "profiling.async.alloc.enabled";
+  public static final boolean PROFILING_ASYNC_ALLOC_ENABLED_DEFAULT = false;
   public static final String PROFILING_ASYNC_ALLOC_INTERVAL = "profiling.async.alloc.interval";
   public static final int PROFILING_ASYNC_ALLOC_INTERVAL_DEFAULT = 256 * 1024;
   public static final String PROFILING_ASYNC_CPU_ENABLED = "profiling.async.cpu.enabled";
+  public static final boolean PROFILING_ASYNC_CPU_ENABLED_DEFAULT = true;
   public static final String PROFILING_ASYNC_CPU_MODE = "profiling.async.cpu.mode";
   public static final String PROFILING_ASYNC_CPU_MODE_DEFAULT = "cpu";
   public static final String PROFILING_ASYNC_CPU_INTERVAL = "profiling.async.cpu.interval.ms";
   public static final int PROFILING_ASYNC_CPU_INTERVAL_DEFAULT = 10;
   public static final String PROFILING_ASYNC_MEMLEAK_ENABLED = "profiling.async.memleak.enabled";
+  public static final boolean PROFILING_ASYNC_MEMLEAK_ENABLED_DEFAULT = false;
   public static final String PROFILING_ASYNC_MEMLEAK_INTERVAL = "profiling.async.memleak.interval";
   public static final int PROFILING_ASYNC_MEMLEAK_INTERVAL_DEFAULT = 256 * 1024;
 
   public static final String PROFILING_LEGACY_TRACING_INTEGRATION =
       "profiling.legacy.tracing.integration";
+  public static final boolean PROFILING_LEGACY_TRACING_INTEGRATION_DEFAULT = true;
   public static final String PROFILING_CHECKPOINTS_RECORD_CPU_TIME =
       "profiling.checkpoints.record.cpu.time";
   public static final String PROFILING_CHECKPOINTS_SAMPLER_RATE_LIMIT =


### PR DESCRIPTION
# What Does This Do
Emits JFR events describing the current profiler configuration

# Motivation
We want to be able to read the profiler settings and use them in other calculations/checks

# Additional Notes
