### PR TITLE
[AppSec] Report metrics for web span only

### DIFF
--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
@@ -93,6 +93,8 @@ class GatewayBridgeSpecification extends DDSpecification {
     1 * mockAppSecCtx.transferCollectedEvents() >> [event]
     1 * mockAppSecCtx.close()
     1 * traceSegment.setTagTop('manual.keep', true)
+    1 * traceSegment.setTagTop("_dd.appsec.enabled", 1)
+    1 * traceSegment.setTagTop("_dd.runtime_family", "jvm")
     1 * traceSegment.setTagTop('appsec.event', true)
     1 * traceSegment.setDataTop('appsec', new AppSecEventWrapper([event]))
     1 * traceSegment.setTagTop('http.request.headers.accept', 'header_value')

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1568,11 +1568,6 @@ public class Config {
       }
     }
 
-    if (appSecEnabled) {
-      result.put("_dd.appsec.enabled", 1);
-      result.put("_dd.runtime_family", "jvm");
-    }
-
     if (azureAppServices) {
       result.putAll(getAzureAppServicesTags());
     }


### PR DESCRIPTION
# What Does This Do
AppSec reports metrics/events for span with `web` type.  

# Motivation
Several customers reported that database services were showing up in their list of AppSec services (which is obviously wrong as we only support web services as of now).

# Additional Notes
