### PR TITLE
[AppSec] Added response status code analysis

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -193,10 +193,10 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, CARRIER
       if (null != cbp) {
         RequestContext<Object> ctx = span.getRequestContext();
         if (ctx != null) {
-          BiConsumer<RequestContext<Object>, Integer> addrCallback =
+          BiFunction<RequestContext<Object>, Integer, Flow<Void>> addrCallback =
               cbp.getCallback(EVENTS.responseStarted());
           if (null != addrCallback) {
-            addrCallback.accept(ctx, status);
+            addrCallback.apply(ctx, status);
           }
         }
       }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
@@ -51,10 +51,10 @@ public interface KnownAddresses {
   Address<List<StringKVPair>> REQUEST_COOKIES = new Address<>("server.request.cookies");
 
   /** Same as server transport related field. */
-  Address<String> REQUEST_TRANSPORT = new Address<String>("server.request.transport");
+  Address<String> REQUEST_TRANSPORT = new Address<>("server.request.transport");
 
   /** status code of HTTP response */
-  Address<Integer> RESPONSE_STATUS = new Address<>("server.response.status");
+  Address<String> RESPONSE_STATUS = new Address<>("server.response.status");
 
   /** First chars of HTTP response body */
   Address<String> RESPONSE_BODY_RAW = new Address<>("server.response.body.raw");
@@ -96,7 +96,7 @@ public interface KnownAddresses {
    * <p>TODO: It will be possible to satisfy the spec with other servers. So this parsing should
    * then be moved to the Servlet HttpContext impl.
    */
-  Address<Map<String, List<String>>> REQUEST_QUERY = new Address("server.request.query");
+  Address<Map<String, List<String>>> REQUEST_QUERY = new Address<>("server.request.query");
 
   /** Headers with the cookie fields excluded. */
   Address<CaseInsensitiveMap<List<String>>> HEADERS_NO_COOKIES =

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -87,6 +87,7 @@ public class PowerWAFModule implements AppSecModule {
     ADDRESSES_OF_INTEREST.add(KnownAddresses.REQUEST_COOKIES);
     ADDRESSES_OF_INTEREST.add(KnownAddresses.REQUEST_PATH_PARAMS);
     ADDRESSES_OF_INTEREST.add(KnownAddresses.REQUEST_BODY_RAW);
+    ADDRESSES_OF_INTEREST.add(KnownAddresses.RESPONSE_STATUS);
 
     EVENTS_OF_INTEREST = new HashSet<>();
     EVENTS_OF_INTEREST.add(EventType.REQUEST_START);
@@ -279,22 +280,19 @@ public class PowerWAFModule implements AppSecModule {
 
     RuleInfo ruleInfo = rulesInfoMap.get(wafResult.rule.id);
 
-    AppSecEvent100 event =
-        new AppSecEvent100.AppSecEvent100Builder()
-            .withRule(
-                new Rule.RuleBuilder()
-                    .withId(wafResult.rule.id)
-                    .withName(ruleInfo.name)
-                    .withTags(
-                        new Tags.TagsBuilder()
-                            .withType(ruleInfo.tags.get("type"))
-                            .withCategory(ruleInfo.tags.get("category"))
-                            .build())
-                    .build())
-            .withRuleMatches(ruleMatchList)
-            .build();
-
-    return event;
+    return new AppSecEvent100.AppSecEvent100Builder()
+        .withRule(
+            new Rule.RuleBuilder()
+                .withId(wafResult.rule.id)
+                .withName(ruleInfo.name)
+                .withTags(
+                    new Tags.TagsBuilder()
+                        .withType(ruleInfo.tags.get("type"))
+                        .withCategory(ruleInfo.tags.get("category"))
+                        .build())
+                .build())
+        .withRuleMatches(ruleMatchList)
+        .build();
   }
 
   private static final class DataBundleMapWrapper implements Map<String, Object> {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -8,7 +8,6 @@ import datadog.trace.api.DDTags
 import datadog.trace.api.Function
 import datadog.trace.api.config.GeneralConfig
 import datadog.trace.api.env.CapturedEnvironment
-import datadog.trace.api.function.BiConsumer
 import datadog.trace.api.function.BiFunction
 import datadog.trace.api.function.Supplier
 import datadog.trace.api.function.TriConsumer
@@ -1056,10 +1055,11 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
       Flow.ResultFlow.empty()
     } as BiFunction<RequestContext<Context>, StoredBodySupplier, Flow<Void>>)
 
-    final BiConsumer<RequestContext<Context>, Integer> responseStartedCb =
+    final BiFunction<RequestContext<Context>, Integer, Flow<Void>> responseStartedCb =
     { RequestContext<Context> rqCtxt, Integer resultCode ->
       def context = rqCtxt.data
       context.tags.put(IG_RESPONSE_STATUS, String.valueOf(resultCode))
-    } as BiConsumer<RequestContext<Context>, Integer>
+      Flow.ResultFlow.empty()
+    } as BiFunction<RequestContext<Context>, Integer, Flow<Void>>
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
@@ -115,8 +115,8 @@ public final class Events<D> {
       new ET<>("response.started", RESPONSE_STARTED_ID);
   /** A response started */
   @SuppressWarnings("unchecked")
-  public EventType<BiConsumer<RequestContext<D>, Integer>> responseStarted() {
-    return (EventType<BiConsumer<RequestContext<D>, Integer>>) RESPONSE_STARTED;
+  public EventType<BiFunction<RequestContext<D>, Integer, Flow<Void>>> responseStarted() {
+    return (EventType<BiFunction<RequestContext<D>, Integer, Flow<Void>>>) RESPONSE_STARTED;
   }
 
   static final int MAX_EVENTS = nextId.get();

--- a/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
@@ -206,13 +206,15 @@ public class InstrumentationGateway implements CallbackProvider, SubscriptionSer
             };
       case RESPONSE_STARTED_ID:
         return (C)
-            new BiConsumer<RequestContext, Integer>() {
+            new BiFunction<RequestContext, Integer, Flow<Void>>() {
               @Override
-              public void accept(RequestContext ctx, Integer status) {
+              public Flow<Void> apply(RequestContext ctx, Integer status) {
                 try {
-                  ((BiConsumer<RequestContext, Integer>) callback).accept(ctx, status);
+                  return ((BiFunction<RequestContext, Integer, Flow<Void>>) callback)
+                      .apply(ctx, status);
                 } catch (Throwable t) {
                   log.warn("Callback for {} threw.", eventType, t);
+                  return Flow.ResultFlow.empty();
                 }
               }
             };

--- a/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
@@ -141,7 +141,7 @@ public class InstrumentationGatewayTest {
     assertThat(gateway.getCallback(events.requestBodyDone()).apply(null, null).getAction())
         .isEqualTo(Flow.Action.Noop.INSTANCE);
     gateway.registerCallback(events.responseStarted(), callback);
-    gateway.getCallback(events.responseStarted()).accept(null, null);
+    gateway.getCallback(events.responseStarted()).apply(null, null);
     assertThat(callback.count).isEqualTo(Events.MAX_EVENTS);
   }
 
@@ -173,7 +173,7 @@ public class InstrumentationGatewayTest {
     assertThat(gateway.getCallback(events.requestBodyDone()).apply(null, null).getAction())
         .isEqualTo(Flow.Action.Noop.INSTANCE);
     gateway.registerCallback(events.responseStarted(), throwback);
-    gateway.getCallback(events.responseStarted()).accept(null, null);
+    gateway.getCallback(events.responseStarted()).apply(null, null);
     assertThat(throwback.count).isEqualTo(Events.MAX_EVENTS);
   }
 


### PR DESCRIPTION
# What Does This Do
Implemented support for HTTP response code analysis - required for Rule 404.
Reading and analysis of the response status happens at the beginning of http response, BEFORE actual data will be committed.

# Motivation

# Additional Notes
Status code type in KnownAddresses changed to String, because of WAF currently able to process only strings.