### PR TITLE
Avoid calling `Scope.span()` which was removed in OT 0.33.0

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
@@ -55,7 +55,7 @@ class CustomScopeManagerWrapper implements AgentScopeManager {
   public AgentScope activate(final AgentSpan agentSpan, final ScopeSource source) {
     final Span span = converter.toSpan(agentSpan);
     final Scope scope = delegate.activate(span);
-    return converter.toAgentScope(scope);
+    return converter.toAgentScope(span, scope);
   }
 
   @Override
@@ -63,14 +63,14 @@ class CustomScopeManagerWrapper implements AgentScopeManager {
       final AgentSpan agentSpan, final ScopeSource source, boolean isAsyncPropagating) {
     final Span span = converter.toSpan(agentSpan);
     final Scope scope = delegate.activate(span);
-    final AgentScope agentScope = converter.toAgentScope(scope);
+    final AgentScope agentScope = converter.toAgentScope(span, scope);
     agentScope.setAsyncPropagation(isAsyncPropagating);
     return agentScope;
   }
 
   @Override
   public AgentScope active() {
-    return converter.toAgentScope(delegate.active());
+    return converter.toAgentScope(delegate.activeSpan(), delegate.active());
   }
 
   @Override
@@ -111,7 +111,7 @@ class CustomScopeManagerWrapper implements AgentScopeManager {
     if (iterationKeepAlive > 0) {
       scheduleIterationSpanCleanup(agentSpan);
     }
-    return converter.toAgentScope(scope);
+    return converter.toAgentScope(span, scope);
   }
 
   private void scheduleIterationSpanCleanup(final AgentSpan span) {

--- a/dd-trace-ot/src/main/java/datadog/opentracing/TypeConverter.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/TypeConverter.java
@@ -36,7 +36,7 @@ class TypeConverter {
     return new OTSpan(agentSpan, this, logHandler);
   }
 
-  public AgentScope toAgentScope(final Scope scope) {
+  public AgentScope toAgentScope(final Span span, final Scope scope) {
     if (scope == null) {
       return null;
     } else if (scope instanceof OTScopeManager.OTScope) {
@@ -47,7 +47,7 @@ class TypeConverter {
         return wrapper.unwrap();
       }
     } else {
-      return new CustomScope(scope);
+      return new CustomScope(span, scope);
     }
   }
 
@@ -145,9 +145,11 @@ class TypeConverter {
 
   /** Wraps an external {@link Scope} to look like an internal {@link AgentScope} */
   final class CustomScope implements AgentScope {
+    private final Span span;
     private final Scope delegate;
 
-    private CustomScope(final Scope delegate) {
+    private CustomScope(final Span span, final Scope delegate) {
+      this.span = span;
       this.delegate = delegate;
     }
 
@@ -158,7 +160,7 @@ class TypeConverter {
 
     @Override
     public AgentSpan span() {
-      return toAgentSpan(delegate.span());
+      return toAgentSpan(span);
     }
 
     @Override


### PR DESCRIPTION
# What Does This Do

Avoids code in `TypeConverter` calling a method in the OpenTracing API that was deprecated and later removed

# Motivation

Fixes a third-party build issue where the GraalVM step fails due to use of the missing method (this particular call is not used for 0.33.0 because we don't support custom scope managers with 0.33.0 but the existence of this call in the bytecode is tripping a check during GraalVM's static analysis)

# Additional Notes

Note that `CustomScopeManagerWrapper` still calls the removed method - but it also calls `ScopeManager.active()` which was also removed in 0.33.0. This wrapper class is only ever used when someone installs a custom scope manager, so it doesn't cause the same GraalVM failure as the call in `TypeConverter`. It would only be an issue if someone installed a custom scope manager when using OpenTracing 0.33.0 - this isn't a new issue, so is not a regression.