### PR TITLE
Remove incorrect check that meant 'trace.config' location was never logged

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
@@ -111,7 +111,7 @@ public final class StatusLogger extends JsonAdapter<Config>
     writer.name("health_checks_enabled");
     writer.value(config.isHealthMetricsEnabled());
     writer.name("configuration_file");
-    writer.value(config.getConfigFile());
+    writer.value(config.getConfigFileStatus());
     writer.name("runtime_id");
     writer.value(config.getRuntimeId());
     writer.name("logging_settings");

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
@@ -22,10 +22,23 @@ public final class ConfigProvider {
   }
 
   private static final Logger log = LoggerFactory.getLogger(ConfigProvider.class);
+
   protected final ConfigProvider.Source[] sources;
 
   private ConfigProvider(ConfigProvider.Source... sources) {
     this.sources = sources;
+  }
+
+  public final String getConfigFileStatus() {
+    for (ConfigProvider.Source source : sources) {
+      if (source instanceof PropertiesConfigSource) {
+        String configFileStatus = ((PropertiesConfigSource) source).getConfigFileStatus();
+        if (null != configFileStatus) {
+          return configFileStatus;
+        }
+      }
+    }
+    return "no config file present";
   }
 
   public final String getString(String key) {
@@ -249,6 +262,8 @@ public final class ConfigProvider {
       log.error(
           "Configuration file '{}' cannot be accessed or correctly parsed.", configurationFilePath);
     }
+
+    properties.setProperty(PropertiesConfigSource.CONFIG_FILE_STATUS, configurationFilePath);
 
     return properties;
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/PropertiesConfigSource.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/PropertiesConfigSource.java
@@ -5,6 +5,9 @@ import static datadog.trace.util.Strings.propertyNameToSystemPropertyName;
 import java.util.Properties;
 
 final class PropertiesConfigSource extends ConfigProvider.Source {
+  // start key with underscore, so it isn't visible using the public 'get' method
+  static final String CONFIG_FILE_STATUS = "_dd.config.file.status";
+
   private final Properties props;
   private final boolean useSystemPropertyFormat;
 
@@ -12,6 +15,10 @@ final class PropertiesConfigSource extends ConfigProvider.Source {
     assert props != null;
     this.props = props;
     this.useSystemPropertyFormat = useSystemPropertyFormat;
+  }
+
+  public String getConfigFileStatus() {
+    return props.getProperty(CONFIG_FILE_STATUS);
   }
 
   @Override

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -187,6 +187,7 @@ class ConfigTest extends DDSpecification {
     Config config = Config.get(prop)
 
     then:
+    config.configFileStatus == "no config file present"
     config.apiKey == "new api key" // we can still override via internal properties object
     config.site == "new site"
     config.serviceName == "something else"
@@ -1057,6 +1058,7 @@ class ConfigTest extends DDSpecification {
     def config = new Config()
 
     then:
+    config.configFileStatus == "src/test/resources/dd-java-tracer.properties"
     config.serviceName == "set-in-properties"
   }
 
@@ -1069,6 +1071,7 @@ class ConfigTest extends DDSpecification {
     def config = new Config()
 
     then:
+    config.configFileStatus == "src/test/resources/dd-java-tracer.properties"
     config.serviceName == "set-in-system"
   }
 
@@ -1081,6 +1084,7 @@ class ConfigTest extends DDSpecification {
     def config = new Config()
 
     then:
+    config.configFileStatus == "src/test/resources/dd-java-tracer.properties"
     config.serviceName == "set-in-env"
   }
 


### PR DESCRIPTION
Replace it with the actual path which ConfigProvider loaded properties from