### PR TITLE
Finish captured JMS spans when a client-ack session is recovered

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/SessionState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/SessionState.java
@@ -142,6 +142,10 @@ public final class SessionState {
     finishCapturedSpans();
   }
 
+  public void onRecover() {
+    finishCapturedSpans();
+  }
+
   public void onCommitOrRollback() {
     COMMIT_SEQUENCE.incrementAndGet(this);
     finishCapturedSpans();

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/SessionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/SessionInstrumentation.java
@@ -76,6 +76,8 @@ public class SessionInstrumentation extends Instrumenter.Tracing {
             .and(takesArgument(0, named("javax.jms.Destination"))),
         getClass().getName() + "$CreateConsumer");
     transformation.applyAdvice(
+        namedOneOf("recover").and(takesNoArguments()), getClass().getName() + "$Recover");
+    transformation.applyAdvice(
         namedOneOf("commit", "rollback").and(takesNoArguments()), getClass().getName() + "$Commit");
     transformation.applyAdvice(
         named("close").and(takesNoArguments()), getClass().getName() + "$Close");
@@ -162,6 +164,17 @@ public class SessionInstrumentation extends Instrumenter.Tracing {
             consumer,
             new MessageConsumerState(
                 sessionState, brokerResourceName, consumerResourceName, propagationDisabled));
+      }
+    }
+  }
+
+  public static final class Recover {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void recover(@Advice.This Session session) {
+      SessionState sessionState =
+          InstrumentationContext.get(Session.class, SessionState.class).get(session);
+      if (null != sessionState && sessionState.isClientAcknowledge()) {
+        sessionState.onRecover();
       }
     }
   }


### PR DESCRIPTION
like we do for `rollback` in a transacted session - recovered messages will be re-delivered and new spans will be generated.

(note: historically rolled-back message spans have not been marked with 'error', so we leave recovered spans alone as well)