### PR TITLE
Minor JMS related cleanup

### DIFF
--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
@@ -174,7 +174,9 @@ public final class JMSMessageConsumerInstrumentation extends Instrumenter.Tracin
       if (null != consumerState) {
         boolean finishSpan = consumerState.getSessionState().isAutoAcknowledge();
         closePrevious(finishSpan);
-        consumerState.finishTimeInQueueSpan(true);
+        if (finishSpan) {
+          consumerState.finishTimeInQueueSpan(true);
+        }
       }
     }
   }


### PR DESCRIPTION
* Avoid creating captured spans buffer in auto-ack mode
* Finish time-in-queue span on consumer close when using auto-ack (otherwise leave it to the session)