### PR TITLE
Add '-Ddd.message.broker.split-by-destination=true' flag

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/MessageConsumerState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/MessageConsumerState.java
@@ -1,5 +1,6 @@
 package datadog.trace.bootstrap.instrumentation.jms;
 
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 
 /** Tracks message spans when consuming messages with {@code receive}. */
@@ -21,12 +22,16 @@ public final class MessageConsumerState {
     this.consumerResourceName = consumerResourceName;
     this.propagationDisabled = propagationDisabled;
 
-    // use the destination as the service name, with no prefix
-    String brokerServiceName = brokerResourceName.toString();
-    if (brokerServiceName.startsWith("Queue ") || brokerServiceName.startsWith("Topic ")) {
-      this.brokerServiceName = brokerServiceName.substring(6);
+    if (Config.get().isMessageBrokerSplitByDestination()) {
+      // use the destination as the service name, with no prefix
+      String brokerServiceName = brokerResourceName.toString();
+      if (brokerServiceName.startsWith("Queue ") || brokerServiceName.startsWith("Topic ")) {
+        this.brokerServiceName = brokerServiceName.substring(6);
+      } else {
+        this.brokerServiceName = brokerServiceName;
+      }
     } else {
-      this.brokerServiceName = brokerServiceName;
+      this.brokerServiceName = "jms";
     }
   }
 

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
@@ -74,7 +74,7 @@ public final class JMSDecorator extends MessagingClientDecorator {
           "",
           Tags.SPAN_KIND_BROKER,
           DDSpanTypes.MESSAGE_BROKER,
-          null /* will be set per-queue or topic */);
+          null /* service name will be set later on */);
 
   public JMSDecorator(
       String resourcePrefix, String spanKind, CharSequence spanType, String serviceName) {

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/TimeInQueueForkedTest.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/TimeInQueueForkedTest.groovy
@@ -42,6 +42,7 @@ class TimeInQueueForkedTest extends AgentTestRunner {
     super.configurePreAgent()
 
     injectSysConfig("jms.legacy.tracing.enabled", 'false')
+    injectSysConfig("message.broker.split-by-destination", 'true')
     injectSysConfig(GeneralConfig.SERVICE_NAME, 'myService')
   }
 

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/TimeInQueueForkedTest.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/TimeInQueueForkedTest.groovy
@@ -13,7 +13,7 @@ import javax.jms.Connection
 import javax.jms.Session
 import javax.jms.TextMessage
 
-class TimeInQueueForkedTest extends AgentTestRunner {
+abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
   @Shared
   EmbeddedActiveMQBroker broker = new EmbeddedActiveMQBroker()
   @Shared
@@ -42,9 +42,10 @@ class TimeInQueueForkedTest extends AgentTestRunner {
     super.configurePreAgent()
 
     injectSysConfig("jms.legacy.tracing.enabled", 'false')
-    injectSysConfig("message.broker.split-by-destination", 'true')
     injectSysConfig(GeneralConfig.SERVICE_NAME, 'myService')
   }
+
+  abstract boolean splitByDestination()
 
   def setupSpec() {
     broker.start()
@@ -536,13 +537,13 @@ class TimeInQueueForkedTest extends AgentTestRunner {
     session.createTemporaryTopic()   | "Temporary Topic"
   }
 
-  static producerTrace(ListWriterAssert writer, String jmsResourceName) {
+  def producerTrace(ListWriterAssert writer, String jmsResourceName) {
     writer.trace(1) {
       producerSpan(it, jmsResourceName)
     }
   }
 
-  static producerSpan(TraceAssert traceAssert, String jmsResourceName) {
+  def producerSpan(TraceAssert traceAssert, String jmsResourceName) {
     return traceAssert.span {
       serviceName "myService"
       operationName "jms.produce"
@@ -560,14 +561,14 @@ class TimeInQueueForkedTest extends AgentTestRunner {
     }
   }
 
-  static consumerTrace(ListWriterAssert writer, String jmsResourceName, DDSpan parentSpan, boolean isTimestampDisabled = false) {
+  def consumerTrace(ListWriterAssert writer, String jmsResourceName, DDSpan parentSpan, boolean isTimestampDisabled = false) {
     writer.trace(2) {
       timeInQueueSpan(it, jmsResourceName, parentSpan)
       consumerSpan(it, jmsResourceName, span(0), isTimestampDisabled)
     }
   }
 
-  static consumerSpan(TraceAssert traceAssert, String jmsResourceName, DDSpan parentSpan, boolean isTimestampDisabled = false) {
+  def consumerSpan(TraceAssert traceAssert, String jmsResourceName, DDSpan parentSpan, boolean isTimestampDisabled = false) {
     return traceAssert.span {
       serviceName "myService"
       operationName "jms.consume"
@@ -588,9 +589,9 @@ class TimeInQueueForkedTest extends AgentTestRunner {
     }
   }
 
-  static timeInQueueSpan(TraceAssert traceAssert, String jmsResourceName, DDSpan parentSpan) {
+  def timeInQueueSpan(TraceAssert traceAssert, String jmsResourceName, DDSpan parentSpan) {
     return traceAssert.span {
-      serviceName "${jmsResourceName.replaceFirst(/(Queue |Topic )/,'')}"
+      serviceName splitByDestination() ? "${jmsResourceName.replaceFirst(/(Queue |Topic )/,'')}" : "jms"
       operationName "jms.deliver"
       resourceName "$jmsResourceName"
       spanType DDSpanTypes.MESSAGE_BROKER
@@ -602,5 +603,25 @@ class TimeInQueueForkedTest extends AgentTestRunner {
         defaultTags(true)
       }
     }
+  }
+}
+
+class TimeInQueueForkedTest extends TimeInQueueForkedTestBase {
+  @Override
+  boolean splitByDestination() {
+    return false
+  }
+}
+
+class TimeInQueueSplitByDestinationForkedTest extends TimeInQueueForkedTestBase {
+  @Override
+  void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("dd.message.broker.split-by-destination", "true")
+  }
+
+  @Override
+  boolean splitByDestination() {
+    return true
   }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -55,6 +55,9 @@ public final class TraceInstrumentationConfig {
   public static final String RABBIT_PROPAGATION_DISABLED_EXCHANGES =
       "rabbit.propagation.disabled.exchanges";
 
+  public static final String MESSAGE_BROKER_SPLIT_BY_DESTINATION =
+      "message.broker.split-by-destination";
+
   public static final String GRPC_IGNORED_INBOUND_METHODS = "trace.grpc.ignored.inbound.methods";
   public static final String GRPC_IGNORED_OUTBOUND_METHODS = "trace.grpc.ignored.outbound.methods";
   public static final String GRPC_SERVER_TRIM_PACKAGE_RESOURCE =

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -170,6 +170,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.KAFKA_CLIENT_B
 import static datadog.trace.api.config.TraceInstrumentationConfig.KAFKA_CLIENT_PROPAGATION_DISABLED_TOPICS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_INJECTION_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_MDC_TAGS_INJECTION_ENABLED;
+import static datadog.trace.api.config.TraceInstrumentationConfig.MESSAGE_BROKER_SPLIT_BY_DESTINATION;
 import static datadog.trace.api.config.TraceInstrumentationConfig.OSGI_SEARCH_DEPTH;
 import static datadog.trace.api.config.TraceInstrumentationConfig.PLAY_REPORT_HTTP_STATUS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGATION_DISABLED_EXCHANGES;
@@ -431,6 +432,8 @@ public class Config {
   private final boolean rabbitPropagationEnabled;
   private final Set<String> rabbitPropagationDisabledQueues;
   private final Set<String> rabbitPropagationDisabledExchanges;
+
+  private final boolean messageBrokerSplitByDestination;
 
   private final boolean hystrixTagsEnabled;
   private final boolean hystrixMeasuredEnabled;
@@ -904,6 +907,9 @@ public class Config {
         tryMakeImmutableSet(configProvider.getList(RABBIT_PROPAGATION_DISABLED_QUEUES));
     rabbitPropagationDisabledExchanges =
         tryMakeImmutableSet(configProvider.getList(RABBIT_PROPAGATION_DISABLED_EXCHANGES));
+
+    messageBrokerSplitByDestination =
+        configProvider.getBoolean(MESSAGE_BROKER_SPLIT_BY_DESTINATION, false);
 
     grpcIgnoredInboundMethods =
         tryMakeImmutableSet(configProvider.getList(GRPC_IGNORED_INBOUND_METHODS));
@@ -1431,6 +1437,10 @@ public class Config {
     return null != queueOrExchange
         && (rabbitPropagationDisabledQueues.contains(queueOrExchange)
             || rabbitPropagationDisabledExchanges.contains(queueOrExchange));
+  }
+
+  public boolean isMessageBrokerSplitByDestination() {
+    return messageBrokerSplitByDestination;
   }
 
   public boolean isHystrixTagsEnabled() {
@@ -2306,6 +2316,8 @@ public class Config {
         + rabbitPropagationDisabledQueues
         + ", rabbitPropagationDisabledExchanges="
         + rabbitPropagationDisabledExchanges
+        + ", messageBrokerSplitByDestination="
+        + messageBrokerSplitByDestination
         + ", hystrixTagsEnabled="
         + hystrixTagsEnabled
         + ", hystrixMeasuredEnabled="


### PR DESCRIPTION
Setting this flag makes messaging integrations use a different broker service name according to the destination.

The new system property is
```
-Ddd.message.broker.split-by-destination=true
```
You can also set this environment variable:
```
DD_MESSAGE_BROKER_SPLIT_BY_DESTINATION=true
```
Also note that this only applies when legacy tracing is turned off for the messaging integration since it relies on the new "time-in-queue" trace structure, ie:
```
-Ddd.jms.legacy.tracing.enabled=false
```