### PR TITLE
Make our use of GradleRunner when testing our buildSrc 'Instrumentation' plugin more robust

### DIFF
--- a/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
+++ b/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
@@ -89,6 +89,8 @@ class InstrumentPluginTest extends Specification {
 
     when:
     BuildResult result = GradleRunner.create()
+      .withTestKitDir(new File(buildDir, '.gradle-test-kit'))  // workaround in case the global test-kit cache becomes corrupted
+      .withDebug(true)                                         // avoids starting daemon which can leave undeleted files post-cleanup
       .withProjectDir(buildDir)
       .withArguments('build')
       .withPluginClasspath()


### PR DESCRIPTION
Two changes:

1) use a local test-kit directory, in case the global one has become corrupted as discussed in Gradle issue 4506

2) enable debug mode to stop GradleRunner from launching a daemon that's still running for a while after test cleanup, leaving undeleted files

According to https://discuss.gradle.org/t/testkit-how-to-turn-off-daemon/17843 this is the only way at the moment to turn off this daemon.

PS. the global test-kit directory is usually `$TMPDIR/.gradle-test-kit-${USER}` - if you happen to see GradleRunner failures involving `InstrumentPluginTest` before this is merged then removing this directory should resolve them.
