### PR TITLE
Update statsd client to the latest

### DIFF
--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/JMXFetchTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/JMXFetchTest.groovy
@@ -9,15 +9,14 @@ import spock.lang.Timeout
 
 @Timeout(30)
 class JMXFetchTest extends Specification {
-  @Shared
   DatagramSocket jmxStatsSocket
 
-  def setupSpec() {
+  def setup() {
     jmxStatsSocket = new DatagramSocket(0)
     jmxStatsSocket.setSoTimeout(30 * 1000)
   }
 
-  def cleanupSpec() {
+  def cleanup() {
     jmxStatsSocket.close()
   }
 
@@ -49,7 +48,7 @@ class JMXFetchTest extends Specification {
   }
 
   def "Agent loads when JmxFetch is misconfigured"() {
-    setup:
+    when:
     // verify the agent starts up correctly with a bogus address.
     def returnCode = IntegrationTestUtils.runOnSeparateJvm(AgentLoadedChecker.getName()
       , [
@@ -61,7 +60,7 @@ class JMXFetchTest extends Specification {
       , [:]
       , true)
 
-    expect:
+    then:
     returnCode == 0
   }
 
@@ -71,6 +70,8 @@ class JMXFetchTest extends Specification {
       "-Ddd.jmxfetch.${it}.enabled=${enable}"
     }
     def testOutput = new ByteArrayOutputStream()
+
+    when:
     def returnCode = IntegrationTestUtils.runOnSeparateJvm(JmxStartedChecker.getName()
       , [
         "-Ddd.jmxfetch.enabled=true",
@@ -92,7 +93,7 @@ class JMXFetchTest extends Specification {
       }
     }
 
-    expect:
+    then:
     returnCode == 0
     actualConfig as Set == expectedConfig as Set
 

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/JMXFetchTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/JMXFetchTest.groovy
@@ -3,7 +3,6 @@ package datadog.trace.agent
 import datadog.trace.agent.test.IntegrationTestUtils
 import jvmbootstraptest.AgentLoadedChecker
 import jvmbootstraptest.JmxStartedChecker
-import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Timeout
 

--- a/dd-java-agent/src/test/java/jvmbootstraptest/JmxStartedChecker.java
+++ b/dd-java-agent/src/test/java/jvmbootstraptest/JmxStartedChecker.java
@@ -17,6 +17,6 @@ public class JmxStartedChecker {
     }
 
     // Give time for metrics to flush
-    Thread.sleep(200);
+    Thread.sleep(500);
   }
 }

--- a/dd-java-agent/src/test/java/jvmbootstraptest/JmxStartedChecker.java
+++ b/dd-java-agent/src/test/java/jvmbootstraptest/JmxStartedChecker.java
@@ -8,11 +8,15 @@ public class JmxStartedChecker {
     for (Thread t : Thread.getAllStackTraces().keySet()) {
       if ("dd-jmx-collector".equals(t.getName())) {
         jmxStarted = true;
+        break;
       }
     }
 
     if (!jmxStarted) {
       throw new IllegalStateException("JMXFetch did not start");
     }
+
+    // Give time for metrics to flush
+    Thread.sleep(200);
   }
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -21,7 +21,7 @@ final class CachedData {
     scala213      : "2.13.4",
     kotlin        : "1.3.72",
     coroutines    : "1.3.0",
-    dogstatsd     : "2.13.0",
+    dogstatsd     : "4.0.0",
     jnr_unixsocket: "0.28",
     commons       : "3.2",
     mockito       : '3.5.10',


### PR DESCRIPTION
# What Does This Do

Updates the internal statsd client to the latest version: 4.0.0

# Motivation
The updated version is required for windows named pipe support

# Additional Notes
`JMXFetchTest` initially failed. Adding a sleep in `JmxStartedChecker` fixed the issue. Since I was already looking at the code, I cleaned up the test class a bit:
- Added a socket timeout so a failing test doesn't hang the build forever
- Created a new socket instance per test so that they are isolated
- Cleaned up some of the `setup`/`when`/`then` statements