### PR TITLE
Update the async-profiler version

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
@@ -28,7 +28,7 @@ AP_VERSION = AP_VERSION != null ? "${AP_VERSION}" : "${versions.asyncprofiler}"
 dependencies {
   api project(':dd-java-agent:agent-profiling:profiling-controller')
   api project(':dd-java-agent:agent-profiling:profiling-auxiliary')
-  implementation group: "tools.profiler", name: "async-profiler", version: AP_VERSION, changing: AP_VERSION.toLowerCase().equals("snapshot")
+  implementation group: "tools.profiler", name: "async-profiler", version: AP_VERSION, changing: AP_VERSION.toLowerCase().contains("snapshot")
 
   annotationProcessor deps.autoserviceProcessor
   compileOnly deps.autoserviceAnnotation

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfiler.java
@@ -273,7 +273,9 @@ final class AuxiliaryAsyncProfiler implements AuxiliaryImplementation {
           .append(getCpuMode())
           .append(",interval=")
           .append(getCpuInterval())
-          .append('m');
+          .append('m')
+          .append(",jstackdepth=")
+          .append(getStackDepth());
     }
     if (profilingModes.contains(ProfilingMode.ALLOCATION)) {
       // allocation profiling is enabled
@@ -283,7 +285,9 @@ final class AuxiliaryAsyncProfiler implements AuxiliaryImplementation {
       // memleak profiling is enabled
       cmd.append(",memleak=").append(getMemleakInterval()).append('b');
     }
-    return cmd.toString();
+    String cmdString = cmd.toString();
+    log.debug("Async profiler command line: {}", cmdString);
+    return cmdString;
   }
 
   private int getAllocationInterval() {
@@ -296,6 +300,12 @@ final class AuxiliaryAsyncProfiler implements AuxiliaryImplementation {
     return configProvider.getInteger(
         ProfilingConfig.PROFILING_ASYNC_CPU_INTERVAL,
         ProfilingConfig.PROFILING_ASYNC_CPU_INTERVAL_DEFAULT);
+  }
+
+  private int getStackDepth() {
+    return configProvider.getInteger(
+        ProfilingConfig.PROFILING_ASYNC_CPU_STACKDEPTH,
+        ProfilingConfig.PROFILING_ASYNC_CPU_STACKDEPTH_DEFAULT);
   }
 
   private String getCpuMode() {

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -68,6 +68,8 @@ public final class ProfilingConfig {
   public static final String PROFILING_ASYNC_CPU_MODE_DEFAULT = "cpu";
   public static final String PROFILING_ASYNC_CPU_INTERVAL = "profiling.async.cpu.interval.ms";
   public static final int PROFILING_ASYNC_CPU_INTERVAL_DEFAULT = 10;
+  public static final String PROFILING_ASYNC_CPU_STACKDEPTH = "profiling.async.cpu.stackdepth";
+  public static final int PROFILING_ASYNC_CPU_STACKDEPTH_DEFAULT = 512;
   public static final String PROFILING_ASYNC_MEMLEAK_ENABLED = "profiling.async.memleak.enabled";
   public static final boolean PROFILING_ASYNC_MEMLEAK_ENABLED_DEFAULT = false;
   public static final String PROFILING_ASYNC_MEMLEAK_INTERVAL = "profiling.async.memleak.interval";

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -29,7 +29,7 @@ final class CachedData {
     testcontainers: '1.15.0-rc2',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    asyncprofiler : "2.5.1-DD-20211217"
+    asyncprofiler : "2.6-DD-20220115"
   ]
 
   static deps = [


### PR DESCRIPTION
# What Does This Do
Updates the async-profiler version to 2.6-DD-20220115

# Motivation
Get the latest fixes and improvements:
- using perf to deliver sampling signals (on linux)
- properly mark hidden frames
- and more

# Additional Notes
