### PR TITLE
Build fixes: configureondemand=true and jfr issue

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
@@ -2,6 +2,8 @@ plugins {
   id "com.github.johnrengelman.shadow"
 }
 
+ext.skipSettingCompilerRelease = true
+
 apply from: "$rootDir/gradle/java.gradle"
 apply plugin: 'idea'
 

--- a/dd-smoke-tests/dd-smoke-tests.gradle
+++ b/dd-smoke-tests/dd-smoke-tests.gradle
@@ -19,6 +19,7 @@ subprojects { Project subProj ->
   // Don't need javadoc task run for internal projects.
   subProj.tasks.withType(Javadoc).configureEach { enabled = false }
 
+  subProj.evaluationDependsOn ':dd-java-agent'
   subProj.tasks.withType(Test).configureEach { subTask ->
     dependsOn project(':dd-java-agent').tasks.named("shadowJar")
 


### PR DESCRIPTION
# What Does This Do

Adds an evaluation dependency to fix the build when `configureondemand=true` and removes `--release 8` from the build of `profiling-auxiliary-async`, so that JFR packages become available. See https://gist.githubusercontent.com/cataphract/4f745e6f811a0e2c26f841047a40b62f/raw/af25a75332ac3e1b4e3002999f6b7cfb6154f2c5/profiling_compilation_failure.txt
