### PR TITLE
Small fixes to logging

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -514,7 +514,9 @@ public class Agent {
   /** Enable JMX based system access provider once it is safe to touch JMX */
   private static synchronized void initializeJmxSystemAccessProvider(
       final ClassLoader classLoader) {
-    log.debug("Initializing JMX system access provider for " + classLoader.toString());
+    if (log.isDebugEnabled()) {
+      log.debug("Initializing JMX system access provider for " + classLoader.toString());
+    }
     try {
       final Class<?> tracerInstallerClass =
           classLoader.loadClass("datadog.trace.core.util.SystemAccess");

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -244,13 +244,11 @@ public interface Instrumenter {
             if (log.isDebugEnabled()) {
               final List<Reference.Mismatch> mismatches =
                   muzzle.getMismatchedReferenceSources(classLoader);
-              if (log.isDebugEnabled()) {
-                log.debug(
-                    "Instrumentation muzzled: {} -- {} on {}",
-                    instrumentationNames,
-                    Instrumenter.Default.this.getClass().getName(),
-                    classLoader);
-              }
+              log.debug(
+                  "Instrumentation muzzled: {} -- {} on {}",
+                  instrumentationNames,
+                  Instrumenter.Default.this.getClass().getName(),
+                  classLoader);
               for (final Reference.Mismatch mismatch : mismatches) {
                 log.debug("-- {}", mismatch);
               }


### PR DESCRIPTION
# What Does This Do
Small cleanup of some of our logging code

# Motivation
Do not create objects for no reason and make the code more readable

# Additional Notes
I had a much larger change which wrapped all logging with the appropriate `isXXXEnabled()` but it seemed like overkill at this point. With this change there are no String concatenations left and all of the `log.XXX(String, Object ...)` in hot paths are properly wrapped.