### PR TITLE
Move jcenter to last in repo list (pending removal)

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -19,8 +19,8 @@ gradlePlugin {
 
 repositories {
   mavenLocal()
-  jcenter()
   mavenCentral()
+  jcenter()
 }
 
 dependencies {

--- a/gradle/repositories.gradle
+++ b/gradle/repositories.gradle
@@ -1,7 +1,6 @@
 repositories {
   mavenLocal()
   mavenCentral()
-  jcenter()
   maven {
     url "https://adoptopenjdk.jfrog.io/adoptopenjdk/jmc-libs-snapshots"
     content {
@@ -16,4 +15,5 @@ repositories {
     url 'https://raw.githubusercontent.com/DataDog/async-profiler/maven2'
     name "GitHub - DD AsyncProfiler"
   }
+  jcenter()
 }


### PR DESCRIPTION
This should help avoid timeouts when checking jcenter for artifacts that we know live elsewhere.