### PR TITLE
Remove uses of Objects.hash()

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfig.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfig.java
@@ -99,7 +99,11 @@ public interface AppSecConfig {
 
     @Override
     public int hashCode() {
-      return Objects.hash(version, events, rawConfig);
+      int hash = 1;
+      hash = 31 * hash + (version == null ? 0 : version.hashCode());
+      hash = 31 * hash + (events == null ? 0 : events.hashCode());
+      hash = 31 * hash + (rawConfig == null ? 0 : rawConfig.hashCode());
+      return hash;
     }
   }
 
@@ -136,7 +140,11 @@ public interface AppSecConfig {
 
     @Override
     public int hashCode() {
-      return Objects.hash(version, rules, rawConfig);
+      int hash = 1;
+      hash = 31 * hash + (version == null ? 0 : version.hashCode());
+      hash = 31 * hash + (rules == null ? 0 : rules.hashCode());
+      hash = 31 * hash + (rawConfig == null ? 0 : rawConfig.hashCode());
+      return hash;
     }
   }
 }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/StringKVPair.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/StringKVPair.java
@@ -41,7 +41,11 @@ public class StringKVPair implements List<String> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(key, value);
+    int hash = 1;
+    // key and value can not be NULL
+    hash = 31 * hash + key.hashCode();
+    hash = 31 * hash + value.hashCode();
+    return hash;
   }
 
   // List implementation follows

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/report/AppSecEventWrapper.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/report/AppSecEventWrapper.java
@@ -27,12 +27,12 @@ public class AppSecEventWrapper {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     AppSecEventWrapper that = (AppSecEventWrapper) o;
-    return Objects.equals(triggers, that.triggers) && Objects.equals(json, that.json);
+    return Objects.equals(triggers, that.triggers);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(triggers, json);
+    return triggers.hashCode();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixDecorator.java
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixDecorator.java
@@ -12,7 +12,6 @@ import datadog.trace.api.cache.DDCaches;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
-import java.util.Objects;
 
 public class HystrixDecorator extends BaseDecorator {
   public static HystrixDecorator DECORATE = new HystrixDecorator();
@@ -64,7 +63,11 @@ public class HystrixDecorator extends BaseDecorator {
 
     @Override
     public int hashCode() {
-      return Objects.hash(group, command, methodName);
+      int hash = 1;
+      hash = 31 * hash + group.hashCode();
+      hash = 31 * hash + command.hashCode();
+      hash = 31 * hash + methodName.hashCode();
+      return hash;
     }
   }
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
@@ -7,7 +7,6 @@ import datadog.trace.instrumentation.opentracing.LogHandler;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * This class should be castable to MutableSpan since that is the way we've encouraged users to
@@ -225,6 +224,6 @@ class OTSpan implements Span, MutableSpan {
 
   @Override
   public int hashCode() {
-    return Objects.hash(delegate);
+    return delegate.hashCode();
   }
 }

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
@@ -8,7 +8,6 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.tag.Tag;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * This class should be castable to MutableSpan since that is the way we've encouraged users to
@@ -232,6 +231,6 @@ class OTSpan implements Span, MutableSpan {
 
   @Override
   public int hashCode() {
-    return Objects.hash(delegate);
+    return delegate.hashCode();
   }
 }

--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/JFRCheckpointer.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/JFRCheckpointer.java
@@ -57,7 +57,14 @@ public class JFRCheckpointer implements Checkpointer, ProfilingListener<Profilin
 
     @Override
     public int hashCode() {
-      return Objects.hash(windowSize, samplesPerWindow, averageLookback, budgetLookback);
+      // Removed Objects.hash() since it will allocate an array for its parameters
+      // and it will box the 3 ints
+      int hash = 1;
+      hash = 31 * hash + windowSize.hashCode();
+      hash = 31 * hash + samplesPerWindow;
+      hash = 31 * hash + averageLookback;
+      hash = 31 * hash + budgetLookback;
+      return hash;
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateByServiceSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateByServiceSampler.java
@@ -9,7 +9,6 @@ import datadog.trace.common.writer.ddagent.DDAgentResponseListener;
 import datadog.trace.core.CoreSpan;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -165,7 +164,10 @@ public class RateByServiceSampler<T extends CoreSpan<T>>
 
     @Override
     public int hashCode() {
-      return Objects.hash(env, service);
+      int hash = 1;
+      hash = 31 * hash + env.hashCode();
+      hash = 31 * hash + service.hashCode();
+      return hash;
     }
   }
 }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTScopeManager.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTScopeManager.java
@@ -8,7 +8,6 @@ import datadog.trace.context.TraceScope;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
-import java.util.Objects;
 
 /** One of the two possible scope managers. See CustomScopeManagerWrapper */
 class OTScopeManager implements ScopeManager {
@@ -89,7 +88,7 @@ class OTScopeManager implements ScopeManager {
 
     @Override
     public int hashCode() {
-      return Objects.hash(delegate);
+      return delegate.hashCode();
     }
 
     @Override

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
@@ -7,7 +7,6 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.tag.Tag;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * This class should be castable to MutableSpan since that is the way we've encouraged users to
@@ -231,6 +230,6 @@ class OTSpan implements Span, MutableSpan {
 
   @Override
   public int hashCode() {
-    return Objects.hash(delegate);
+    return delegate.hashCode();
   }
 }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTSpanContext.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTSpanContext.java
@@ -3,7 +3,6 @@ package datadog.opentracing;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import io.opentracing.SpanContext;
 import java.util.Map;
-import java.util.Objects;
 
 class OTSpanContext implements SpanContext {
   private final AgentSpan.Context delegate;
@@ -45,6 +44,6 @@ class OTSpanContext implements SpanContext {
 
   @Override
   public int hashCode() {
-    return Objects.hash(delegate);
+    return delegate.hashCode();
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/CIProviderInfo.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/CIProviderInfo.java
@@ -559,16 +559,17 @@ public abstract class CIProviderInfo {
 
     @Override
     public int hashCode() {
-      return Objects.hash(
-          ciProviderName,
-          ciPipelineId,
-          ciPipelineName,
-          ciStageName,
-          ciJobName,
-          ciPipelineNumber,
-          ciPipelineUrl,
-          ciJobUrl,
-          ciWorkspace);
+      int hash = 1;
+      hash = 31 * hash + (ciProviderName == null ? 0 : ciProviderName.hashCode());
+      hash = 31 * hash + (ciPipelineId == null ? 0 : ciPipelineId.hashCode());
+      hash = 31 * hash + (ciPipelineName == null ? 0 : ciPipelineName.hashCode());
+      hash = 31 * hash + (ciStageName == null ? 0 : ciStageName.hashCode());
+      hash = 31 * hash + (ciJobName == null ? 0 : ciJobName.hashCode());
+      hash = 31 * hash + (ciPipelineNumber == null ? 0 : ciPipelineNumber.hashCode());
+      hash = 31 * hash + (ciPipelineUrl == null ? 0 : ciPipelineUrl.hashCode());
+      hash = 31 * hash + (ciJobUrl == null ? 0 : ciJobUrl.hashCode());
+      hash = 31 * hash + (ciWorkspace == null ? 0 : ciWorkspace.hashCode());
+      return hash;
     }
 
     @Override

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/git/CommitInfo.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/git/CommitInfo.java
@@ -60,7 +60,12 @@ public class CommitInfo {
 
   @Override
   public int hashCode() {
-    return Objects.hash(sha, author, committer, fullMessage);
+    int hash = 1;
+    hash = 31 * hash + (sha == null ? 0 : sha.hashCode());
+    hash = 31 * hash + (author == null ? 0 : author.hashCode());
+    hash = 31 * hash + (committer == null ? 0 : committer.hashCode());
+    hash = 31 * hash + (fullMessage == null ? 0 : fullMessage.hashCode());
+    return hash;
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/git/GitInfo.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/git/GitInfo.java
@@ -59,6 +59,11 @@ public class GitInfo {
 
   @Override
   public int hashCode() {
-    return Objects.hash(repositoryURL, branch, tag, commit);
+    int hash = 1;
+    hash = 31 * hash + (repositoryURL == null ? 0 : repositoryURL.hashCode());
+    hash = 31 * hash + (branch == null ? 0 : branch.hashCode());
+    hash = 31 * hash + (tag == null ? 0 : tag.hashCode());
+    hash = 31 * hash + (commit == null ? 0 : commit.hashCode());
+    return hash;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/git/GitObject.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/git/GitObject.java
@@ -1,7 +1,6 @@
 package datadog.trace.bootstrap.instrumentation.ci.git;
 
 import java.util.Arrays;
-import java.util.Objects;
 
 public final class GitObject {
 
@@ -49,13 +48,15 @@ public final class GitObject {
     }
     final GitObject gitObject = (GitObject) o;
     return size == gitObject.size
-        && Objects.equals(type, gitObject.type)
+        && type == gitObject.type
         && Arrays.equals(content, gitObject.content);
   }
 
   @Override
   public int hashCode() {
-    int result = Objects.hash(type, size);
+    int result = 1;
+    result = 31 * result + (int) type;
+    result = 31 * result + size;
     result = 31 * result + Arrays.hashCode(content);
     return result;
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/git/PersonInfo.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/git/PersonInfo.java
@@ -59,7 +59,11 @@ public class PersonInfo {
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, email, ISO8601Date);
+    int hash = 1;
+    hash = 31 * hash + (name == null ? 0 : name.hashCode());
+    hash = 31 * hash + (email == null ? 0 : email.hashCode());
+    hash = 31 * hash + (ISO8601Date == null ? 0 : ISO8601Date.hashCode());
+    return hash;
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do
Remove all instances of `Objects.hash()` since it is poorly optimized by the JVM. 

# Motivation
Calls to `Objects.hash()` will allocate an array to hold the parameters and all primitive parameters will be autoboxed. There are some caches for primitives in the JVM but they are limited and common values for things like a web server port will not be in the cache. This causes unneeded object allocations. 

# Additional Notes
I will add some JMH results comparing the results for an inline version of `Objects.hash()` (like this change) and calling `Objects.hash()` for different sets of parameters.
