### PR TITLE
Cancel continuation when FutureTask value/exception is set directly

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/RunnableFutureInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/RunnableFutureInstrumentation.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.java.concurrent;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.extendsClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.nameEndsWith;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.cancelTask;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.capture;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.endTaskScope;
@@ -74,7 +75,9 @@ public final class RunnableFutureInstrumentation extends Instrumenter.Tracing
         getClass().getName() + "$Construct");
     transformation.applyAdvice(isConstructor(), getClass().getName() + "$Construct");
     transformation.applyAdvice(isMethod().and(named("run")), getClass().getName() + "$Run");
-    transformation.applyAdvice(isMethod().and(named("cancel")), getClass().getName() + "$Cancel");
+    transformation.applyAdvice(
+        isMethod().and(namedOneOf("cancel", "set", "setException")),
+        getClass().getName() + "$Cancel");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/FutureTaskContinuationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/FutureTaskContinuationTest.groovy
@@ -1,0 +1,92 @@
+import datadog.trace.agent.test.AgentTestRunner
+
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.FutureTask
+
+import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+
+class FutureTaskContinuationTest extends AgentTestRunner {
+  class SettableFuture extends FutureTask<String> {
+    SettableFuture() {
+      super({ "async result" })
+    }
+
+    @SuppressWarnings('UnnecessaryOverridingMethod')
+    @Override
+    void set(String value) {
+      super.set(value)
+    }
+
+    @SuppressWarnings('UnnecessaryOverridingMethod')
+    @Override
+    void setException(Throwable cause) {
+      super.setException(cause)
+    }
+  }
+
+  SettableFuture future
+
+  @Override
+  def setup() {
+    runUnderTrace("parent") {
+      future = new SettableFuture()
+    }
+  }
+
+  def "test continuation activated when FutureTask runs"() {
+    when:
+    future.run()
+
+    then:
+    future.get() == "async result"
+    assertTraces(1) {
+      trace(1) {
+        basicSpan(it, "parent")
+      }
+    }
+  }
+
+  def "test continuation canceled when FutureTask is canceled"() {
+    when:
+    future.cancel(true)
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        basicSpan(it, "parent")
+      }
+    }
+  }
+
+  def "test continuation canceled when FutureTask value is set without running"() {
+    when:
+    future.set("set result")
+
+    then:
+    future.get() == "set result"
+    assertTraces(1) {
+      trace(1) {
+        basicSpan(it, "parent")
+      }
+    }
+  }
+
+  def "test continuation canceled when FutureTask exception is set without running"() {
+    when:
+    future.setException(new RuntimeException("expected"))
+
+    and:
+    future.get()
+
+    then:
+    ExecutionException e = thrown()
+    e.getCause().message == "expected"
+
+    assertTraces(1) {
+      trace(1) {
+        basicSpan(it, "parent")
+      }
+    }
+  }
+}


### PR DESCRIPTION
(ie. without running the task)

Some libraries implement settable futures by extending `FutureTask`, like Spring's `SettableListenableFuture`. When this is used in `KafkaTemplate` the future value is set directly without actually running the task, so we need to cancel the continuation to stop if from keeping the surrounding span alive indefinitely.