### PR TITLE
Remove jcenter from projects where it is possible

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -20,7 +20,7 @@ gradlePlugin {
 repositories {
   mavenLocal()
   mavenCentral()
-  jcenter()
+  gradlePluginPortal()
 }
 
 dependencies {

--- a/dd-java-agent/benchmark-integration/benchmark-integration.gradle
+++ b/dd-java-agent/benchmark-integration/benchmark-integration.gradle
@@ -1,6 +1,7 @@
 buildscript {
   repositories {
-    jcenter()
+    mavenCentral()
+    gradlePluginPortal()
   }
   dependencies {
     classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.1'

--- a/dd-java-agent/benchmark-integration/play-perftest/play-perftest.gradle
+++ b/dd-java-agent/benchmark-integration/play-perftest/play-perftest.gradle
@@ -28,7 +28,7 @@ dependencies {
 
 repositories {
   mavenCentral()
-  jcenter()
+  gradlePluginPortal()
   maven {
     name "lightbend-maven-releases"
     url "https://repo.lightbend.com/lightbend/maven-release"

--- a/dd-java-agent/instrumentation/apache-httpclient-4/apache-httpclient-4.gradle
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/apache-httpclient-4.gradle
@@ -4,6 +4,7 @@ muzzle {
     module = "commons-httpclient"
     versions = "[,4.0)"
     skipVersions += '3.1-jenkins-1'
+    skipVersions += '2.0-final' // broken metadata on maven central
   }
   pass {
     group = "org.apache.httpcomponents"

--- a/dd-java-agent/instrumentation/commons-httpclient-2/commons-httpclient-2.gradle
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/commons-httpclient-2.gradle
@@ -5,6 +5,7 @@ muzzle {
     versions = "[2.0,]"
     skipVersions += "3.1-jenkins-1" // odd version in jcenter
     skipVersions += "20020423" // ancient pre-release version
+    skipVersions += '2.0-final' // broken metadata on maven central
     assertInverse = true
   }
 }

--- a/dd-java-agent/instrumentation/glassfish/glassfish.gradle
+++ b/dd-java-agent/instrumentation/glassfish/glassfish.gradle
@@ -14,6 +14,10 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
+repositories {
+  jcenter() // maven central has broken metadata right now
+}
+
 apply plugin: 'org.unbroken-dome.test-sets'
 
 testSets {

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/grizzly-http-2.3.20.gradle
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/grizzly-http-2.3.20.gradle
@@ -9,6 +9,10 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
+repositories {
+  jcenter() // maven central has broken metadata right now
+}
+
 apply plugin: 'org.unbroken-dome.test-sets'
 
 testSets {

--- a/dd-java-agent/instrumentation/guava-10/guava-10.gradle
+++ b/dd-java-agent/instrumentation/guava-10/guava-10.gradle
@@ -3,6 +3,7 @@ muzzle {
     group = "com.google.guava"
     module = "guava"
     versions = "[10.0,]"
+    skipVersions += '13.0-final' // not on maven central
     assertInverse = true
   }
 }

--- a/dd-java-agent/instrumentation/jms/jms.gradle
+++ b/dd-java-agent/instrumentation/jms/jms.gradle
@@ -13,6 +13,10 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
+repositories {
+  jcenter() // only place that has org.jboss.naming:jnpserver:5.0.3.GA publically accessible
+}
+
 apply plugin: 'org.unbroken-dome.test-sets'
 
 testSets {

--- a/dd-java-agent/instrumentation/play-2.3/play-2.3.gradle
+++ b/dd-java-agent/instrumentation/play-2.3/play-2.3.gradle
@@ -24,6 +24,11 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
+
+repositories {
+  jcenter() // only place that has 'com.typesafe.netty:netty-http-pipelining:1.1.2' publically accessible
+}
+
 apply from: "$rootDir/gradle/test-with-scala.gradle"
 
 apply plugin: 'org.unbroken-dome.test-sets'

--- a/dd-java-agent/instrumentation/play-2.4/play-2.4.gradle
+++ b/dd-java-agent/instrumentation/play-2.4/play-2.4.gradle
@@ -24,6 +24,9 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
+repositories {
+  jcenter() // only place that has 'com.typesafe.netty:netty-http-pipelining:1.1.2' publically accessible (muzzle)
+}
 
 apply plugin: 'org.unbroken-dome.test-sets'
 

--- a/dd-java-agent/instrumentation/play-2.6/play-2.6.gradle
+++ b/dd-java-agent/instrumentation/play-2.6/play-2.6.gradle
@@ -30,6 +30,10 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
+repositories {
+  jcenter() // only place that has 'com.typesafe.netty:netty-http-pipelining:1.1.2' publically accessible (muzzle)
+}
+
 apply plugin: 'org.unbroken-dome.test-sets'
 
 testSets {

--- a/dd-java-agent/instrumentation/restlet-2.2/restlet-2.2.gradle
+++ b/dd-java-agent/instrumentation/restlet-2.2/restlet-2.2.gradle
@@ -9,6 +9,10 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
+repositories {
+  jcenter() // only place that has 'org.restlet.jse:org.restlet' publically accessible
+}
+
 apply plugin: 'org.unbroken-dome.test-sets'
 
 testSets {

--- a/dd-java-agent/instrumentation/servlet/request-2/request-2.gradle
+++ b/dd-java-agent/instrumentation/servlet/request-2/request-2.gradle
@@ -3,6 +3,7 @@ muzzle {
     group = "javax.servlet"
     module = "servlet-api"
     versions = "[2.2, 3.0)"
+    skipVersions += '0' // broken version on jcenter
     assertInverse = true
   }
 

--- a/dd-java-agent/instrumentation/servlet/request-3/request-3.gradle
+++ b/dd-java-agent/instrumentation/servlet/request-3/request-3.gradle
@@ -9,6 +9,7 @@ muzzle {
     group = "javax.servlet"
     module = 'servlet-api'
     versions = "[,]"
+    skipVersions += '0' // broken version on jcenter
   }
 }
 

--- a/dd-java-agent/instrumentation/testng-6.4/testng-6.4.gradle
+++ b/dd-java-agent/instrumentation/testng-6.4/testng-6.4.gradle
@@ -8,6 +8,10 @@ muzzle {
   }
 }
 
+repositories {
+  jcenter() // only needed for muzzle
+}
+
 dependencies {
   compileOnly group: 'org.testng', name: 'testng', version: '6.4'
 

--- a/dd-java-agent/instrumentation/tomcat-5.5/tomcat-5.5.gradle
+++ b/dd-java-agent/instrumentation/tomcat-5.5/tomcat-5.5.gradle
@@ -33,6 +33,10 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
+repositories {
+  jcenter() // only needed for muzzle
+}
+
 apply plugin: 'org.unbroken-dome.test-sets'
 
 testSets {

--- a/dd-smoke-tests/play-2.4/play-2.4.gradle
+++ b/dd-smoke-tests/play-2.4/play-2.4.gradle
@@ -29,7 +29,7 @@ model {
 
 repositories {
   mavenCentral()
-  jcenter()
+  gradlePluginPortal()
   maven {
     name "lightbend-maven-releases"
     url "https://repo.lightbend.com/lightbend/maven-release"

--- a/dd-smoke-tests/play-2.5/play-2.5.gradle
+++ b/dd-smoke-tests/play-2.5/play-2.5.gradle
@@ -29,7 +29,7 @@ model {
 
 repositories {
   mavenCentral()
-  jcenter()
+  gradlePluginPortal()
   maven {
     name "lightbend-maven-releases"
     url "https://repo.lightbend.com/lightbend/maven-release"

--- a/dd-smoke-tests/play-2.6/play-2.6.gradle
+++ b/dd-smoke-tests/play-2.6/play-2.6.gradle
@@ -29,7 +29,7 @@ model {
 
 repositories {
   mavenCentral()
-  jcenter()
+  gradlePluginPortal()
   maven {
     name "lightbend-maven-releases"
     url "https://repo.lightbend.com/lightbend/maven-release"

--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -50,7 +50,7 @@ allprojects {
 repositories {
   mavenLocal()
   mavenCentral()
-  jcenter()
+  gradlePluginPortal()
 }
 
 tasks.register("latestDepTest")

--- a/test-published-dependencies/build.gradle
+++ b/test-published-dependencies/build.gradle
@@ -9,7 +9,7 @@ plugins {
 repositories {
   mavenLocal()
   mavenCentral()
-  jcenter()
+  gradlePluginPortal()
 }
 
 def sharedConfigDirectory = "$rootDir/../gradle"


### PR DESCRIPTION
# What Does This Do

Removes the JCenter repository in all places where it's possible

# Motivation

Make our JCenter dependencies explicit and minimize impact of JCenter service disruptions

# Additional Notes
