### PR TITLE
Really remove jcenter from the default repositories

### DIFF
--- a/gradle/repositories.gradle
+++ b/gradle/repositories.gradle
@@ -15,5 +15,4 @@ repositories {
     url 'https://raw.githubusercontent.com/DataDog/async-profiler/maven2'
     name "GitHub - DD AsyncProfiler"
   }
-  jcenter()
 }


### PR DESCRIPTION
# What Does This Do

Really removes jcenter from the default repositories, which was missed in #3325 due to a bad merge.
