### PR TITLE
[AppSec] Fixed double status assignment

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -196,8 +196,6 @@ public class GatewayBridge {
               MapDataBundle.of(
                   KnownAddresses.RESPONSE_STATUS, String.valueOf(ctx.getResponseStatus()));
 
-          ctx.addAll(bundle);
-
           if (responseStatusSubInfo == null) {
             responseStatusSubInfo =
                 producerService.getDataSubscribers(KnownAddresses.RESPONSE_STATUS);


### PR DESCRIPTION
# What Does This Do
Removed code duplication

# Motivation
Customers discovered in logs warning message `Illegal attempt to replace context value for Address{key='server.response.status'}`

# Additional Notes
