### PR TITLE
Share JMS propagation headers via the common decorator class

### DIFF
--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
@@ -34,6 +34,9 @@ public final class JMSDecorator extends MessagingClientDecorator {
 
   public static final boolean JMS_LEGACY_TRACING = Config.get().isLegacyTracingEnabled(true, "jms");
 
+  public static final String JMS_PRODUCED_KEY = "x_datadog_jms_produced";
+  public static final String JMS_BATCH_ID_KEY = "x_datadog_jms_batch_id";
+
   private static final Join QUEUE_JOINER = PrefixJoin.of("Queue ");
   private static final Join TOPIC_JOINER = PrefixJoin.of("Topic ");
 

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
@@ -59,7 +59,6 @@ public final class JMSMessageConsumerInstrumentation extends Instrumenter.Tracin
       packageName + ".JMSDecorator",
       packageName + ".MessageExtractAdapter",
       packageName + ".MessageExtractAdapter$1",
-      packageName + ".MessageInjectAdapter",
       packageName + ".DatadogMessageListener"
     };
   }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
@@ -50,12 +50,7 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Tracin
 
   @Override
   public String[] helperClassNames() {
-    return new String[] {
-      packageName + ".JMSDecorator",
-      packageName + ".MessageExtractAdapter",
-      packageName + ".MessageExtractAdapter$1",
-      packageName + ".MessageInjectAdapter"
-    };
+    return new String[] {packageName + ".JMSDecorator", packageName + ".MessageInjectAdapter"};
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageExtractAdapter.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageExtractAdapter.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.jms;
 
-import static datadog.trace.instrumentation.jms.MessageInjectAdapter.JMS_BATCH_ID_KEY;
-import static datadog.trace.instrumentation.jms.MessageInjectAdapter.JMS_PRODUCED_KEY;
+import static datadog.trace.instrumentation.jms.JMSDecorator.JMS_BATCH_ID_KEY;
+import static datadog.trace.instrumentation.jms.JMSDecorator.JMS_PRODUCED_KEY;
 
 import datadog.trace.api.Function;
 import datadog.trace.api.cache.DDCache;

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageInjectAdapter.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/MessageInjectAdapter.java
@@ -1,5 +1,8 @@
 package datadog.trace.instrumentation.jms;
 
+import static datadog.trace.instrumentation.jms.JMSDecorator.JMS_BATCH_ID_KEY;
+import static datadog.trace.instrumentation.jms.JMSDecorator.JMS_PRODUCED_KEY;
+
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.jms.MessageBatchState;
 import datadog.trace.bootstrap.instrumentation.jms.MessageProducerState;
@@ -12,9 +15,6 @@ public class MessageInjectAdapter implements AgentPropagation.Setter<Message> {
   private static final Logger log = LoggerFactory.getLogger(MessageInjectAdapter.class);
 
   public static final MessageInjectAdapter SETTER = new MessageInjectAdapter();
-
-  public static final String JMS_PRODUCED_KEY = "x_datadog_jms_produced";
-  public static final String JMS_BATCH_ID_KEY = "x_datadog_jms_batch_id";
 
   @SuppressForbidden
   @Override


### PR DESCRIPTION
Avoids having to list both injector and extractor helpers twice in the producer and consumer instrumentations.