### PR TITLE
Turn off checkpoints for JMS 'time-in-q' spans…

### DIFF
--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/DatadogMessageListener.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/DatadogMessageListener.java
@@ -48,7 +48,8 @@ public class DatadogMessageListener implements MessageListener {
       long batchId = GETTER.extractMessageBatchId(message);
       AgentSpan timeInQueue = consumerState.getTimeInQueueSpan(batchId);
       if (null == timeInQueue) {
-        timeInQueue = startSpan(JMS_DELIVER, propagatedContext, MILLISECONDS.toMicros(startMillis));
+        timeInQueue =
+            startSpan(JMS_DELIVER, propagatedContext, MILLISECONDS.toMicros(startMillis), false);
         BROKER_DECORATE.afterStart(timeInQueue);
         BROKER_DECORATE.onTimeInQueue(
             timeInQueue,

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
@@ -134,7 +134,7 @@ public final class JMSMessageConsumerInstrumentation extends Instrumenter.Tracin
         AgentSpan timeInQueue = consumerState.getTimeInQueueSpan(batchId);
         if (null == timeInQueue) {
           timeInQueue =
-              startSpan(JMS_DELIVER, propagatedContext, MILLISECONDS.toMicros(startMillis));
+              startSpan(JMS_DELIVER, propagatedContext, MILLISECONDS.toMicros(startMillis), false);
           BROKER_DECORATE.afterStart(timeInQueue);
           BROKER_DECORATE.onTimeInQueue(
               timeInQueue,


### PR DESCRIPTION
…since it's a synthetic span not associated with CPU work (this aligns JMS with other 'time-in-q' implementations)