### PR TITLE
Some gradle cleanup in preparation for 7.x (take 2)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,7 +322,7 @@ jobs:
           command: >-
             MAVEN_OPTS="-Xms64M -Xmx512M"
             GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1750M -Xms512M -XX:ErrorFile=/tmp/hs_err_pid%p.log' -Ddatadog.forkedMaxHeapSize=512M -Ddatadog.forkedMinHeapSize=128M"
-            ./gradlew stagePlayBinaryDist :dd-smoke-test:<<# parameters.prefixTestTask>>testJava<</ parameters.prefixTestTask>><< parameters.testTask >>
+            ./gradlew stageMainDist :dd-smoke-test:<<# parameters.prefixTestTask>>testJava<</ parameters.prefixTestTask>><< parameters.testTask >>
             << pipeline.parameters.gradle_flags >>
             --max-workers=2
             --continue

--- a/dd-cws-tls/dd-cws-tls.gradle
+++ b/dd-cws-tls/dd-cws-tls.gradle
@@ -10,8 +10,8 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-  compile group: 'net.java.dev.jna', name: 'jna', version: '5.8.0'
-  compile group: 'net.java.dev.jna', name: 'jna-platform', version: '5.8.0'
+  implementation group: 'net.java.dev.jna', name: 'jna', version: '5.8.0'
+  implementation group: 'net.java.dev.jna', name: 'jna-platform', version: '5.8.0'
 
   implementation project(':internal-api')
   implementation project(':dd-trace-api')

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/profiling-auxiliary.gradle
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/profiling-auxiliary.gradle
@@ -16,7 +16,7 @@ dependencies {
 
   testImplementation deps.junit5
   testImplementation deps.mockito
-  testCompile deps.autoserviceAnnotation
+  testImplementation deps.autoserviceAnnotation
   testAnnotationProcessor deps.autoserviceProcessor
 }
 

--- a/dd-java-agent/agent-tooling/agent-tooling.gradle
+++ b/dd-java-agent/agent-tooling/agent-tooling.gradle
@@ -43,7 +43,7 @@ compileMain_java11Java.doFirst {
 dependencies {
   main_java11CompileOnly deps.bytebuddy
   main_java11CompileOnly sourceSets.main.output
-  runtime sourceSets.main_java11.output
+  runtimeOnly sourceSets.main_java11.output
 }
 jar {
   from sourceSets.main_java11.output

--- a/dd-java-agent/appsec/weblog/weblog-spring-app/weblog-spring-app.gradle
+++ b/dd-java-agent/appsec/weblog/weblog-spring-app/weblog-spring-app.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'org.springframework.boot:spring-boot-gradle-plugin:1.5.9.RELEASE'
+    classpath 'org.springframework.boot:spring-boot-gradle-plugin:1.5.22.RELEASE'
   }
 }
 
@@ -38,12 +38,10 @@ if (project.hasProperty('testExecutable') && project.testExecutable) {
   }
 }
 
-/* Last versions supporting Java 6
- * (this can be updated now though, because we support only 8+) */
-ext['jetty.version'] = '8.1.22.v20160922'
+ext['jetty.version'] = '9.4.44.v20210927'
 ext['jackson.version'] = '2.7.9'
 
-def groovyVersion = '2.5.8'
+def groovyVersion = '2.5.13'
 ext['groovy.version'] = groovyVersion
 
 dependencies {
@@ -55,7 +53,7 @@ dependencies {
   implementation group: 'io.sqreen', name: 'sqreen-sdk', version: '0.3'
   implementation group: 'io.sqreen', name: 'sqreen-sdk-standalone', version: '0.3.0'
 
-  implementation group: 'org.codehaus.groovy', name: 'groovy-all', version: '2.5.8'
+  implementation group: 'org.codehaus.groovy', name: 'groovy-all', version: '2.5.13'
   implementation 'org.springframework.boot:spring-boot-starter-web'
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa', {
     exclude module: 'tomcat-jdbc'
@@ -210,7 +208,7 @@ def createBundleTarget = { name, deps ->
       if (!(d instanceof List)) {
         d = [d]
       }
-      delegate."${name}Compile"(*d)
+      delegate."${name}Implementation"(*d)
     }
   }
 

--- a/dd-java-agent/benchmark-integration/README.md
+++ b/dd-java-agent/benchmark-integration/README.md
@@ -26,6 +26,6 @@ cp /tmp/perf_results.csv ~/somewhere_else/
 ```
 ./gradlew :dd-java-agent:benchmark-integration:play-perftest:dist
 # Compare a baseline (no agent) to the 0.18.0 and 0.19.0 releases.
-/usr/local/bin/bash ./run-perf-test.sh play-zip play-perftest/build/distributions/playBinary NoAgent ~/Downloads/dd-java-agent-0.18.0.jar ~/Downloads/dd-java-agent-0.19.0.jar
+/usr/local/bin/bash ./run-perf-test.sh play-zip play-perftest/build/distributions/main-*.zip NoAgent ~/Downloads/dd-java-agent-0.18.0.jar ~/Downloads/dd-java-agent-0.19.0.jar
 cp /tmp/perf_results.csv ~/somewhere_else/
 ```

--- a/dd-java-agent/benchmark-integration/play-perftest/app/controllers/HomeController.scala
+++ b/dd-java-agent/benchmark-integration/play-perftest/app/controllers/HomeController.scala
@@ -16,15 +16,16 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
   /**
     * Create an Action to perform busy wait
     */
-  def doGet(workTimeMS: Option[Long], error: Option[String]) = Action { implicit request: Request[AnyContent] =>
-    error match {
-      case Some(x) => throw new RuntimeException("some sync error")
-      case None => {
-        var workTime = workTimeMS.getOrElse(0l)
-        scheduleWork(workTime)
-        Ok("Did " + workTime + "ms of work.")
+  def doGet(workTimeMS: Option[Long], error: Option[String]) = Action {
+    implicit request: Request[AnyContent] =>
+      error match {
+        case Some(x) => throw new RuntimeException("some sync error")
+        case None => {
+          var workTime = workTimeMS.getOrElse(0L)
+          scheduleWork(workTime)
+          Ok("Did " + workTime + "ms of work.")
+        }
       }
-    }
 
   }
 

--- a/dd-java-agent/benchmark-integration/play-perftest/app/controllers/Worker.scala
+++ b/dd-java-agent/benchmark-integration/play-perftest/app/controllers/Worker.scala
@@ -15,7 +15,7 @@ object Worker {
       span.setTag("additionalInfo", "interesting stuff")
     }
     val doneTimestamp = System.nanoTime + TimeUnit.MILLISECONDS.toNanos(workTimeMS)
-    while ( {
+    while ({
       System.nanoTime < doneTimestamp
     }) {
       // busy-wait to simulate work

--- a/dd-java-agent/benchmark-integration/play-perftest/play-perftest.gradle
+++ b/dd-java-agent/benchmark-integration/play-perftest/play-perftest.gradle
@@ -1,29 +1,33 @@
 plugins {
-  id 'play'
-  // id 'idea'
+  id 'org.gradle.playframework'
 }
 
-def playVersion = "2.6.20"
-def scalaVersion = System.getProperty("scala.binary.version", /* default = */ "2.12")
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
 
-model {
-  components {
-    play {
-      platform play: playVersion, scala: scalaVersion, java: '1.8'
-      injectedRoutesGenerator = true
-    }
+def playVer = "2.6.20"
+def scalaVer = System.getProperty("scala.binary.version", /* default = */ "2.12")
+
+play {
+  platform {
+    playVersion = playVer
+    scalaVersion = scalaVer
+    javaVersion = JavaVersion.VERSION_1_8
   }
+  injectedRoutesGenerator = true
 }
 
 dependencies {
-  play "com.typesafe.play:play-guice_$scalaVersion:$playVersion"
-  play "com.typesafe.play:play-logback_$scalaVersion:$playVersion"
-  play "com.typesafe.play:filters-helpers_$scalaVersion:$playVersion"
+  implementation "com.typesafe.play:play-guice_$scalaVer:$playVer"
+  implementation "com.typesafe.play:play-logback_$scalaVer:$playVer"
+  implementation "com.typesafe.play:filters-helpers_$scalaVer:$playVer"
 
-  play project(':dd-trace-api')
-  play project(':dd-java-agent:benchmark-integration')
-  play group: 'io.opentracing', name: 'opentracing-api', version: '0.32.0'
-  play group: 'io.opentracing', name: 'opentracing-util', version: '0.32.0'
+  implementation project(':dd-trace-api')
+  implementation project(':dd-java-agent:benchmark-integration')
+  implementation group: 'io.opentracing', name: 'opentracing-api', version: '0.32.0'
+  implementation group: 'io.opentracing', name: 'opentracing-util', version: '0.32.0'
 }
 
 repositories {
@@ -37,5 +41,14 @@ repositories {
     name "lightbend-ivy-release"
     url "https://repo.lightbend.com/lightbend/ivy-releases"
     layout "ivy"
+  }
+}
+
+spotless {
+  java {
+    target "**/*.java"
+  }
+  scala {
+    target "**/*.scala"
   }
 }

--- a/dd-java-agent/benchmark-integration/run-perf-test.sh
+++ b/dd-java-agent/benchmark-integration/run-perf-test.sh
@@ -76,9 +76,9 @@ function start_server {
       unzipped_server_path=${unzip_temp}
 
       java_opts_env='JAVA_OPTS="'${javaagent_arg}'"'
-      # it appears the binary script will always be named playBinary at the time of writing
+      # it appears the binary script will always be named main at the time of writing
       # no matter what the zip file is named.
-      play_script=${unzipped_server_path}/${unzipped_dirname}/bin/playBinary
+      play_script=${unzipped_server_path}/${unzipped_dirname}/bin/main
 
       # have to use env to set JAVA_OPTS because of a gradle play plugin bug:
       # https://github.com/gradle/gradle/issues/4471

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/aws-java-sdk-1.11.0.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/aws-java-sdk-1.11.0.gradle
@@ -40,13 +40,13 @@ dependencies {
   // Include httpclient instrumentation for testing because it is a dependency for aws-sdk.
   testImplementation project(':dd-java-agent:instrumentation:apache-httpclient-4')
 
-  testCompile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '[1.11,1.11.106]'
-  testCompile group: 'com.amazonaws', name: 'aws-java-sdk-rds', version: '[1.11,1.11.106]'
-  testCompile group: 'com.amazonaws', name: 'aws-java-sdk-ec2', version: '[1.11,1.11.106]'
-  testCompile group: 'com.amazonaws', name: 'aws-java-sdk-kinesis', version: '[1.11,1.11.106]'
-  testCompile group: 'com.amazonaws', name: 'aws-java-sdk-sqs', version: '[1.11,1.11.106]'
-  testCompile group: 'com.amazonaws', name: 'aws-java-sdk-sns', version: '[1.11,1.11.106]'
-  testCompile group: 'com.amazonaws', name: 'aws-java-sdk-dynamodb', version: '[1.11,1.11.106]'
+  testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '[1.11,1.11.106]'
+  testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-rds', version: '[1.11,1.11.106]'
+  testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-ec2', version: '[1.11,1.11.106]'
+  testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-kinesis', version: '[1.11,1.11.106]'
+  testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-sqs', version: '[1.11,1.11.106]'
+  testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-sns', version: '[1.11,1.11.106]'
+  testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-dynamodb', version: '[1.11,1.11.106]'
 
   // needed for kinesis:
   testImplementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: versions.jackson

--- a/dd-java-agent/instrumentation/micronaut-http-server-netty-2/micronaut-http-server-netty-2.gradle
+++ b/dd-java-agent/instrumentation/micronaut-http-server-netty-2/micronaut-http-server-netty-2.gradle
@@ -27,9 +27,9 @@ dependencies {
   main_java8CompileOnly group: 'io.micronaut', name: 'micronaut-http-server-netty', version: '2.0.0'
 
   testImplementation project(':dd-java-agent:instrumentation:netty-4.1')
-  testCompile group: 'io.micronaut', name: 'micronaut-http-server-netty', version: '2.0.0'
+  testImplementation group: 'io.micronaut', name: 'micronaut-http-server-netty', version: '2.0.0'
 
   testAnnotationProcessor "io.micronaut:micronaut-inject-java:2.0.0"
 
-  latestDepTestCompile group: 'io.micronaut', name: 'micronaut-http-server-netty', version: '2.+'
+  latestDepTestImplementation group: 'io.micronaut', name: 'micronaut-http-server-netty', version: '2.+'
 }

--- a/dd-java-agent/instrumentation/okhttp-2/okhttp-2.gradle
+++ b/dd-java-agent/instrumentation/okhttp-2/okhttp-2.gradle
@@ -24,7 +24,7 @@ testSets {
 dependencies {
   compileOnly(group: 'com.squareup.okhttp', name: 'okhttp', version: '2.2.0')
 
-  compile(project(':dd-java-agent:agent-tooling')) {
+  implementation(project(':dd-java-agent:agent-tooling')) {
     exclude module: 'okhttp'
   }
 

--- a/dd-java-agent/instrumentation/spray-1.3/spray-1.3.gradle
+++ b/dd-java-agent/instrumentation/spray-1.3/spray-1.3.gradle
@@ -23,10 +23,10 @@ dependencies {
   compileOnly group: 'io.spray', name: "spray-can_$scalaVersion", version: '1.3.1'
   compileOnly group: 'io.spray', name: "spray-routing_$scalaVersion", version: '1.3.1'
 
-  testCompile group: 'com.typesafe.akka', name: "akka-actor_$scalaVersion", version: '2.3.14'
-  testCompile group: 'io.spray', name: "spray-can_$scalaVersion", version: '1.3.3'
-  testCompile group: 'io.spray', name: "spray-routing_$scalaVersion", version: '1.3.1'
+  testImplementation group: 'com.typesafe.akka', name: "akka-actor_$scalaVersion", version: '2.3.14'
+  testImplementation group: 'io.spray', name: "spray-can_$scalaVersion", version: '1.3.3'
+  testImplementation group: 'io.spray', name: "spray-routing_$scalaVersion", version: '1.3.1'
 
-  testCompile project(':dd-java-agent:testing')
+  testImplementation project(':dd-java-agent:testing')
 }
 

--- a/dd-smoke-tests/play-2.4/play-2.4.gradle
+++ b/dd-smoke-tests/play-2.4/play-2.4.gradle
@@ -1,27 +1,35 @@
 plugins {
-  id 'play'
+  id 'org.gradle.playframework'
 }
 
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
 }
 
-def playVersion = "2.4.11"
-def scalaVersion = System.getProperty("scala.binary.version", /* default = */ "2.11")
+apply from: "$rootDir/gradle/java.gradle"
 
-model {
-  components {
-    play {
-      platform play: playVersion, scala: scalaVersion, java: '1.8'
-      injectedRoutesGenerator = true
-    }
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+def playVer = "2.4.11"
+def scalaVer = System.getProperty("scala.binary.version", /* default = */ "2.11")
+
+play {
+  platform {
+    playVersion = playVer
+    scalaVersion = scalaVer
+    javaVersion = JavaVersion.VERSION_1_8
   }
-  distributions {
-    playBinary {
-      contents {
-        from("conf") {
-          into "conf"
-        }
+  injectedRoutesGenerator = true
+}
+
+distributions {
+  main {
+    contents {
+      from("conf") {
+        into "conf"
       }
     }
   }
@@ -41,26 +49,28 @@ repositories {
   }
 }
 
-apply from: "$rootDir/gradle/java.gradle"
-
 description = 'Play 2.4 Integration Tests.'
 
 dependencies {
-  play "com.typesafe.play:filters-helpers_$scalaVersion:$playVersion"
-  play "com.typesafe.play:play-java-ws_$scalaVersion:$playVersion"
+  implementation "com.typesafe.play:filters-helpers_$scalaVer:$playVer"
+  implementation "com.typesafe.play:play-java-ws_$scalaVer:$playVer"
   // jaxb is not there anymore in java11+
-  play "javax.xml.bind:jaxb-api:2.3.1"
+  implementation "javax.xml.bind:jaxb-api:2.3.1"
 
-  play group: 'io.opentracing', name: 'opentracing-api', version: '0.32.0'
-  play group: 'io.opentracing', name: 'opentracing-util', version: '0.32.0'
+  implementation group: 'io.opentracing', name: 'opentracing-api', version: '0.32.0'
+  implementation group: 'io.opentracing', name: 'opentracing-util', version: '0.32.0'
 
   testImplementation project(':dd-smoke-tests')
 }
 
+configurations.testImplementation {
+  exclude group:'com.typesafe.play', module:"play-test_$scalaVer"
+}
+
 tasks.named("compileTestGroovy").configure {
-  dependsOn 'stagePlayBinaryDist'
+  dependsOn 'stageMainDist'
   outputs.upToDateWhen {
-    !stagePlayBinaryDist.didWork
+    !stageMainDist.didWork
   }
 }
 

--- a/dd-smoke-tests/play-2.4/src/test/groovy/datadog/smoketest/PlayNettySmokeTest.groovy
+++ b/dd-smoke-tests/play-2.4/src/test/groovy/datadog/smoketest/PlayNettySmokeTest.groovy
@@ -14,7 +14,7 @@ import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
 class PlayNettySmokeTest extends AbstractServerSmokeTest {
 
   @Shared
-  File playDirectory = new File("${buildDirectory}/stage/playBinary")
+  File playDirectory = new File("${buildDirectory}/stage/main")
 
   @Shared
   @AutoCleanup
@@ -41,7 +41,7 @@ class PlayNettySmokeTest extends AbstractServerSmokeTest {
       runningPid.delete()
     }
     ProcessBuilder processBuilder =
-      new ProcessBuilder("${playDirectory}/bin/playBinary")
+      new ProcessBuilder("${playDirectory}/bin/main")
     processBuilder.directory(playDirectory)
     processBuilder.environment().put("JAVA_OPTS",
       defaultJavaProperties.join(" ")

--- a/dd-smoke-tests/play-2.5/play-2.5.gradle
+++ b/dd-smoke-tests/play-2.5/play-2.5.gradle
@@ -1,27 +1,35 @@
 plugins {
-  id 'play'
+  id 'org.gradle.playframework'
 }
 
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
 }
 
-def playVersion = "2.5.19"
-def scalaVersion = System.getProperty("scala.binary.version", /* default = */ "2.11")
+apply from: "$rootDir/gradle/java.gradle"
 
-model {
-  components {
-    play {
-      platform play: playVersion, scala: scalaVersion, java: '1.8'
-      injectedRoutesGenerator = true
-    }
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+def playVer = "2.5.19"
+def scalaVer = System.getProperty("scala.binary.version", /* default = */ "2.11")
+
+play {
+  platform {
+    playVersion = playVer
+    scalaVersion = scalaVer
+    javaVersion = JavaVersion.VERSION_1_8
   }
-  distributions {
-    playBinary {
-      contents {
-        from("conf") {
-          into "conf"
-        }
+  injectedRoutesGenerator = true
+}
+
+distributions {
+  main {
+    contents {
+      from("conf") {
+        into "conf"
       }
     }
   }
@@ -41,28 +49,30 @@ repositories {
   }
 }
 
-apply from: "$rootDir/gradle/java.gradle"
-
 description = 'Play 2.5 Integration Tests.'
 
 dependencies {
-  play "com.typesafe.play:play-logback_$scalaVersion:$playVersion"
-  play "com.typesafe.play:filters-helpers_$scalaVersion:$playVersion"
-  play "com.typesafe.play:play-java-ws_$scalaVersion:$playVersion"
+  implementation "com.typesafe.play:play-logback_$scalaVer:$playVer"
+  implementation "com.typesafe.play:filters-helpers_$scalaVer:$playVer"
+  implementation "com.typesafe.play:play-java-ws_$scalaVer:$playVer"
   // jaxb is not there anymore in java11+
-  play "javax.xml.bind:jaxb-api:2.3.1"
+  implementation "javax.xml.bind:jaxb-api:2.3.1"
 
-  play project(':dd-trace-api')
-  play group: 'io.opentracing', name: 'opentracing-api', version: '0.32.0'
-  play group: 'io.opentracing', name: 'opentracing-util', version: '0.32.0'
+  implementation project(':dd-trace-api')
+  implementation group: 'io.opentracing', name: 'opentracing-api', version: '0.32.0'
+  implementation group: 'io.opentracing', name: 'opentracing-util', version: '0.32.0'
 
   testImplementation project(':dd-smoke-tests')
 }
 
+configurations.testImplementation {
+  exclude group:'com.typesafe.play', module:"play-test_$scalaVer"
+}
+
 tasks.named("compileTestGroovy").configure {
-  dependsOn 'stagePlayBinaryDist'
+  dependsOn 'stageMainDist'
   outputs.upToDateWhen {
-    !stagePlayBinaryDist.didWork
+    !stageMainDist.didWork
   }
 }
 

--- a/dd-smoke-tests/play-2.5/src/test/groovy/datadog/smoketest/PlayNettySmokeTest.groovy
+++ b/dd-smoke-tests/play-2.5/src/test/groovy/datadog/smoketest/PlayNettySmokeTest.groovy
@@ -14,7 +14,7 @@ import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
 class PlayNettySmokeTest extends AbstractServerSmokeTest {
 
   @Shared
-  File playDirectory = new File("${buildDirectory}/stage/playBinary")
+  File playDirectory = new File("${buildDirectory}/stage/main")
 
   @Shared
   @AutoCleanup
@@ -41,7 +41,7 @@ class PlayNettySmokeTest extends AbstractServerSmokeTest {
       runningPid.delete()
     }
     ProcessBuilder processBuilder =
-      new ProcessBuilder("${playDirectory}/bin/playBinary")
+      new ProcessBuilder("${playDirectory}/bin/main")
     processBuilder.directory(playDirectory)
     processBuilder.environment().put("JAVA_OPTS",
       defaultJavaProperties.join(" ")

--- a/dd-smoke-tests/play-2.6/play-2.6.gradle
+++ b/dd-smoke-tests/play-2.6/play-2.6.gradle
@@ -1,27 +1,35 @@
 plugins {
-  id 'play'
+  id 'org.gradle.playframework'
 }
 
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
 }
 
-def playVersion = "2.6.25"
-def scalaVersion = System.getProperty("scala.binary.version", /* default = */ "2.12")
+apply from: "$rootDir/gradle/java.gradle"
 
-model {
-  components {
-    play {
-      platform play: playVersion, scala: scalaVersion, java: '1.8'
-      injectedRoutesGenerator = true
-    }
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+def playVer = "2.6.25"
+def scalaVer = System.getProperty("scala.binary.version", /* default = */ "2.12")
+
+play {
+  platform {
+    playVersion = playVer
+    scalaVersion = scalaVer
+    javaVersion = JavaVersion.VERSION_1_8
   }
-  distributions {
-    playBinary {
-      contents {
-        from("conf") {
-          into "conf"
-        }
+  injectedRoutesGenerator = true
+}
+
+distributions {
+  main {
+    contents {
+      from("conf") {
+        into "conf"
       }
     }
   }
@@ -41,28 +49,30 @@ repositories {
   }
 }
 
-apply from: "$rootDir/gradle/java.gradle"
-
 description = 'Play Integration 2.6 Tests.'
 
 dependencies {
-  play "com.typesafe.play:play-guice_$scalaVersion:$playVersion"
-  play "com.typesafe.play:play-logback_$scalaVersion:$playVersion"
-  play "com.typesafe.play:filters-helpers_$scalaVersion:$playVersion"
-  play "com.typesafe.play:play-netty-server_$scalaVersion:$playVersion"
-  play "com.typesafe.play:play-ahc-ws_$scalaVersion:$playVersion"
+  implementation "com.typesafe.play:play-guice_$scalaVer:$playVer"
+  implementation "com.typesafe.play:play-logback_$scalaVer:$playVer"
+  implementation "com.typesafe.play:filters-helpers_$scalaVer:$playVer"
+  implementation "com.typesafe.play:play-netty-server_$scalaVer:$playVer"
+  implementation "com.typesafe.play:play-ahc-ws_$scalaVer:$playVer"
 
-  play project(':dd-trace-api')
-  play group: 'io.opentracing', name: 'opentracing-api', version: '0.32.0'
-  play group: 'io.opentracing', name: 'opentracing-util', version: '0.32.0'
+  implementation project(':dd-trace-api')
+  implementation group: 'io.opentracing', name: 'opentracing-api', version: '0.32.0'
+  implementation group: 'io.opentracing', name: 'opentracing-util', version: '0.32.0'
 
   testImplementation project(':dd-smoke-tests')
 }
 
+configurations.testImplementation {
+  exclude group:'com.typesafe.play', module:"play-test_$scalaVer"
+}
+
 tasks.named("compileTestGroovy").configure {
-  dependsOn 'stagePlayBinaryDist'
+  dependsOn 'stageMainDist'
   outputs.upToDateWhen {
-    !stagePlayBinaryDist.didWork
+    !stageMainDist.didWork
   }
 }
 

--- a/dd-smoke-tests/play-2.6/src/test/groovy/datadog/smoketest/PlaySmokeTest.groovy
+++ b/dd-smoke-tests/play-2.6/src/test/groovy/datadog/smoketest/PlaySmokeTest.groovy
@@ -13,7 +13,7 @@ import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
 abstract class PlaySmokeTest extends AbstractServerSmokeTest {
 
   @Shared
-  File playDirectory = new File("${buildDirectory}/stage/playBinary")
+  File playDirectory = new File("${buildDirectory}/stage/main")
 
   @Shared
   @AutoCleanup
@@ -40,7 +40,7 @@ abstract class PlaySmokeTest extends AbstractServerSmokeTest {
       runningPid.delete()
     }
     ProcessBuilder processBuilder =
-      new ProcessBuilder("${playDirectory}/bin/playBinary")
+      new ProcessBuilder("${playDirectory}/bin/main")
     processBuilder.directory(playDirectory)
     processBuilder.environment().put("JAVA_OPTS",
       defaultJavaProperties.join(" ")

--- a/dd-smoke-tests/wildfly/wildfly.gradle
+++ b/dd-smoke-tests/wildfly/wildfly.gradle
@@ -23,17 +23,24 @@ apply from: "$rootDir/gradle/java.gradle"
 
 description = 'Wildfly Smoke Tests.'
 
+configurations {
+  serverFile {
+    extendsFrom implementation
+    canBeResolved = true
+  }
+}
+
 dependencies {
   // uses the ivy repository url to download the wildfly servlet zip
   // organisation = serverName, revision = serverVersion, module = serverModule, ext = serverExtension
-  compile "${serverName}:${serverModule}:${serverVersion}@${serverExtension}"
+  serverFile "${serverName}:${serverModule}:${serverVersion}@${serverExtension}"
 
   testImplementation project(':dd-smoke-tests')
 }
 
 tasks.register("unzip", Copy) {
   def zipFileNamePrefix = "servlet"
-  def zipPath = project.configurations.compile.find {
+  def zipPath = project.configurations.serverFile.find {
     it.name.startsWith(zipFileNamePrefix)
   }
   if (zipPath != null) {

--- a/dd-trace-core/dd-trace-core.gradle
+++ b/dd-trace-core/dd-trace-core.gradle
@@ -30,18 +30,18 @@ testSets {
 }
 
 dependencies {
-  compile project(':dd-trace-api')
+  api project(':dd-trace-api')
   api project(':communication')
-  compile project(':internal-api')
-  compile project(':utils:histograms')
-  compile project(':utils:container-utils')
-  compile project(':utils:socket-utils')
-  compile project(':dd-cws-tls')
+  api project(':internal-api')
+  implementation project(':utils:histograms')
+  implementation project(':utils:container-utils')
+  implementation project(':utils:socket-utils')
+  implementation project(':dd-cws-tls')
 
-  compile deps.slf4j
+  implementation deps.slf4j
   implementation deps.moshi
 
-  compile group: 'org.jctools', name: 'jctools-core', version: '3.3.0'
+  implementation group: 'org.jctools', name: 'jctools-core', version: '3.3.0'
 
   compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: '4.2.0'
 

--- a/dd-trace-java.gradle
+++ b/dd-trace-java.gradle
@@ -20,6 +20,7 @@ plugins {
 
   id "com.github.johnrengelman.shadow" version "5.2.0" apply false
   id "me.champeau.jmh" version "0.6.5" apply false
+  id 'org.gradle.playframework' version '0.12' apply false
 }
 
 description = 'dd-trace-java'

--- a/dd-trace-ot/dd-trace-ot.gradle
+++ b/dd-trace-ot/dd-trace-ot.gradle
@@ -30,19 +30,18 @@ dependencies {
   annotationProcessor deps.autoserviceProcessor
   compileOnly deps.autoserviceAnnotation
 
-  compile project(':dd-trace-api')
-  compile project(':dd-trace-core')
+  api project(':dd-trace-api')
+  api project(':dd-trace-core')
 
   // OpenTracing
-  compile group: 'io.opentracing', name: 'opentracing-api', version: '0.32.0'
-  compile group: 'io.opentracing', name: 'opentracing-noop', version: '0.32.0'
-  compile group: 'io.opentracing', name: 'opentracing-util', version: '0.32.0'
-  compile group: 'io.opentracing.contrib', name: 'opentracing-tracerresolver', version: '0.1.0'
+  api group: 'io.opentracing', name: 'opentracing-api', version: '0.32.0'
+  api group: 'io.opentracing', name: 'opentracing-noop', version: '0.32.0'
+  api group: 'io.opentracing', name: 'opentracing-util', version: '0.32.0'
+  api group: 'io.opentracing.contrib', name: 'opentracing-tracerresolver', version: '0.1.0'
 
-  compile deps.slf4j
-  compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.12.12'
-  compile deps.okio
-  compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.12.12'
+  api deps.slf4j
+  api group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.12.12'
+  api deps.okio
 
   testImplementation project(":dd-java-agent:testing")
 
@@ -55,14 +54,14 @@ dependencies {
   ot33CompatabilityTestImplementation group: 'io.opentracing', name: 'opentracing-noop', version: '0.33.0'
 }
 
-[configurations.ot31CompatabilityTestCompile, configurations.ot31CompatabilityTestRuntime].each {
+[configurations.ot31CompatabilityTestImplementation, configurations.ot31CompatabilityTestRuntime].each {
   it.resolutionStrategy {
     force group: 'io.opentracing', name: 'opentracing-api', version: '0.31.0'
     force group: 'io.opentracing', name: 'opentracing-util', version: '0.31.0'
     force group: 'io.opentracing', name: 'opentracing-noop', version: '0.31.0'
   }
 }
-[configurations.ot33CompatabilityTestCompile, configurations.ot33CompatabilityTestRuntime].each {
+[configurations.ot33CompatabilityTestImplementation, configurations.ot33CompatabilityTestRuntime].each {
   it.resolutionStrategy {
     force group: 'io.opentracing', name: 'opentracing-api', version: '0.33.0'
     force group: 'io.opentracing', name: 'opentracing-util', version: '0.33.0'

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -37,7 +37,7 @@ publishing {
             pom.withXml { xml ->
               def dependenciesNode = xml.asNode().appendNode('dependencies')
 
-              project.configurations.compile.allDependencies.each {
+              project.configurations.api.allDependencies.each {
                 if ((it instanceof ProjectDependency) || !(it instanceof SelfResolvingDependency)) {
                   def dependencyNode = dependenciesNode.appendNode('dependency')
                   dependencyNode.appendNode('groupId', it.group)

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -6,9 +6,11 @@ def configPath = rootProject.hasProperty('sharedConfigDirectory') ? sharedConfig
 boolean groovySkipJavaExclude = project.hasProperty('groovySkipJavaExclude') ? groovySkipJavaExclude : false
 
 spotless {
-  java {
-    toggleOffOn()
-    googleJavaFormat()
+  if (project.plugins.hasPlugin('java')) {
+    java {
+      toggleOffOn()
+      googleJavaFormat()
+    }
   }
 
   groovyGradle {
@@ -38,15 +40,19 @@ spotless {
     }
   }
 
-  scala {
-    toggleOffOn()
-    scalafmt("2.0.1").configFile(configPath + '/enforcement/spotless-scalafmt.conf')
+  if (project.plugins.hasPlugin('scala')) {
+    scala {
+      toggleOffOn()
+      scalafmt("2.0.1").configFile(configPath + '/enforcement/spotless-scalafmt.conf')
+    }
   }
 
-  kotlin {
-    toggleOffOn()
-    //    ktfmt() // Requires newer version of java
-    ktlint().userData(['indent_size': '2', 'continuation_indent_size': '2'])
+  if (project.plugins.hasPlugin('kotlin')) {
+    kotlin {
+      toggleOffOn()
+      //    ktfmt() // Requires newer version of java
+      ktlint().userData(['indent_size': '2', 'continuation_indent_size': '2'])
+    }
   }
 
   format 'misc', {

--- a/test-published-dependencies/all-deps-exist/build.gradle
+++ b/test-published-dependencies/all-deps-exist/build.gradle
@@ -1,0 +1,14 @@
+plugins {
+  id 'java'
+  id 'application'
+}
+
+dependencies {
+  implementation "com.datadoghq:dd-java-agent:$version"
+  implementation "com.datadoghq:dd-trace-api:$version"
+  implementation "com.datadoghq:dd-trace-ot:$version"
+}
+
+application {
+  mainClassName = 'test.published.dependencies.App'
+}

--- a/test-published-dependencies/all-deps-exist/src/main/java/test/published/dependencies/App.java
+++ b/test-published-dependencies/all-deps-exist/src/main/java/test/published/dependencies/App.java
@@ -1,0 +1,18 @@
+package test.published.dependencies;
+
+import datadog.opentracing.DDTracer;
+import datadog.trace.api.Trace;
+import io.opentracing.util.GlobalTracer;
+
+public class App {
+  public static void main(String[] args) {
+    DDTracer tracer = DDTracer.builder().serviceName("TestService").build();
+    GlobalTracer.registerIfAbsent(tracer);
+    datadog.trace.api.GlobalTracer.registerIfAbsent(tracer);
+    new App().tracedMethod();
+  }
+
+  @Trace
+  void tracedMethod() {
+  }
+}

--- a/test-published-dependencies/build.gradle
+++ b/test-published-dependencies/build.gradle
@@ -1,20 +1,10 @@
 plugins {
-  id 'java'
-  id 'application'
-
   id 'com.diffplug.spotless' version '5.12.5'
   id 'pl.allegro.tech.build.axion-release' version '1.10.3'
 }
 
-repositories {
-  mavenLocal()
-  mavenCentral()
-  gradlePluginPortal()
-}
-
 def sharedConfigDirectory = "$rootDir/../gradle"
 rootProject.ext.sharedConfigDirectory = sharedConfigDirectory
-apply from: "$sharedConfigDirectory/spotless.gradle"
 
 scmVersion {
   repository {
@@ -23,14 +13,15 @@ scmVersion {
 }
 apply from: "$sharedConfigDirectory/scm.gradle"
 
-def dd_trace_version = scmVersion.version
+allprojects {
+  group = 'com.datadoghq'
+  version = scmVersion.version
 
-dependencies {
-  implementation "com.datadoghq:dd-java-agent:${dd_trace_version}"
-  implementation "com.datadoghq:dd-trace-api:${dd_trace_version}"
-  implementation "com.datadoghq:dd-trace-ot:${dd_trace_version}"
-}
+  repositories {
+    mavenLocal()
+    mavenCentral()
+    gradlePluginPortal()
+  }
 
-application {
-  mainClassName = 'test.published.dependencies.App'
+  apply from: "$sharedConfigDirectory/spotless.gradle"
 }

--- a/test-published-dependencies/ot-pulls-in-api/build.gradle
+++ b/test-published-dependencies/ot-pulls-in-api/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+  id 'java'
+  id 'application'
+}
+
+dependencies {
+  implementation "com.datadoghq:dd-trace-ot:$version"
+}
+
+application {
+  mainClassName = 'test.published.dependencies.App'
+}

--- a/test-published-dependencies/ot-pulls-in-api/src/main/java/test/published/dependencies/App.java
+++ b/test-published-dependencies/ot-pulls-in-api/src/main/java/test/published/dependencies/App.java
@@ -1,0 +1,18 @@
+package test.published.dependencies;
+
+import datadog.opentracing.DDTracer;
+import datadog.trace.api.Trace;
+import io.opentracing.util.GlobalTracer;
+
+public class App {
+  public static void main(String[] args) {
+    DDTracer tracer = DDTracer.builder().serviceName("TestService").build();
+    GlobalTracer.registerIfAbsent(tracer);
+    datadog.trace.api.GlobalTracer.registerIfAbsent(tracer);
+    new App().tracedMethod();
+  }
+
+  @Trace
+  void tracedMethod() {
+  }
+}

--- a/test-published-dependencies/settings.gradle
+++ b/test-published-dependencies/settings.gradle
@@ -1,1 +1,4 @@
 rootProject.name = 'test-published-dependencies'
+
+include ':all-deps-exist'
+include ':ot-pulls-in-api'

--- a/test-published-dependencies/src/main/java/test/published/dependencies/App.java
+++ b/test-published-dependencies/src/main/java/test/published/dependencies/App.java
@@ -1,7 +1,0 @@
-package test.published.dependencies;
-
-public class App {
-  public static void main(String[] args) {
-    System.out.println("Test published dependencies!");
-  }
-}

--- a/utils/histograms/histograms.gradle
+++ b/utils/histograms/histograms.gradle
@@ -11,10 +11,10 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-  compile deps.slf4j
-  compile project(':internal-api')
+  implementation deps.slf4j
+  implementation project(':internal-api')
 
-  compile group: 'com.datadoghq', name: 'sketches-java', version: '0.6.1'
+  implementation group: 'com.datadoghq', name: 'sketches-java', version: '0.6.1'
 
   testImplementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.14.0'
   testImplementation project(':utils:test-utils')

--- a/utils/socket-utils/socket-utils.gradle
+++ b/utils/socket-utils/socket-utils.gradle
@@ -1,8 +1,8 @@
 apply from: "$rootDir/gradle/java.gradle"
 
 dependencies {
-  compile deps.slf4j
-  compile project(':internal-api')
+  implementation deps.slf4j
+  implementation project(':internal-api')
 
-  compile group: 'com.github.jnr', name: 'jnr-unixsocket', version: "${versions.jnr_unixsocket}"
+  implementation group: 'com.github.jnr', name: 'jnr-unixsocket', version: "${versions.jnr_unixsocket}"
 }


### PR DESCRIPTION
# What Does This Do

This is take 2 of #3330

* Adds a minimal test that check that the `dd-trace-ot` dependency pulls in `dd-trace-api` as a dependency.
* Changes all compile/runtime configurations to implementation/runtimeOnly
* Switches to the new supported play framework plugin

# Motivation

These constructs are no longer supported on gradle 7.x and would fail the build

# Additional Notes

The biggest blocker now is the muzzle `instrumentation` plugin that is beyond my current understanding of gradle, as well as the `:dd-java-agent:appsec:weblog:weblog-spring-app` that uses old versions of Spring and the Spring Boot plugin.
