### PR TITLE
Fix MongoDB CommandListener instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/mongo/driver-3.1-core-test/src/test/groovy/MongoCore31ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1-core-test/src/test/groovy/MongoCore31ClientTest.groovy
@@ -4,6 +4,10 @@ import com.mongodb.MongoTimeoutException
 import com.mongodb.ServerAddress
 import com.mongodb.client.MongoCollection
 import com.mongodb.client.MongoDatabase
+import com.mongodb.event.CommandFailedEvent
+import com.mongodb.event.CommandListener
+import com.mongodb.event.CommandStartedEvent
+import com.mongodb.event.CommandSucceededEvent
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -26,6 +30,17 @@ class MongoCore31ClientTest extends MongoBaseTest {
     client = new MongoClient(new ServerAddress("localhost", port),
       MongoClientOptions.builder()
       .description("some-description")
+      .addCommandListener(new CommandListener() {
+        @Override
+        void commandStarted(CommandStartedEvent event) {
+        }
+        @Override
+        void commandSucceeded(CommandSucceededEvent event) {
+        }
+        @Override
+        void commandFailed(CommandFailedEvent event) {
+        }
+      })
       .build())
   }
 

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoJava31ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoJava31ClientTest.groovy
@@ -4,6 +4,10 @@ import com.mongodb.MongoTimeoutException
 import com.mongodb.ServerAddress
 import com.mongodb.client.MongoCollection
 import com.mongodb.client.MongoDatabase
+import com.mongodb.event.CommandFailedEvent
+import com.mongodb.event.CommandListener
+import com.mongodb.event.CommandStartedEvent
+import com.mongodb.event.CommandSucceededEvent
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -26,6 +30,17 @@ class MongoJava31ClientTest extends MongoBaseTest {
     client = new MongoClient(new ServerAddress("localhost", port),
       MongoClientOptions.builder()
       .description("some-description")
+      .addCommandListener(new CommandListener() {
+        @Override
+        void commandStarted(CommandStartedEvent event) {
+        }
+        @Override
+        void commandSucceeded(CommandSucceededEvent event) {
+        }
+        @Override
+        void commandFailed(CommandFailedEvent event) {
+        }
+      })
       .build())
   }
 

--- a/dd-java-agent/instrumentation/mongo/driver-3.4/src/main/java/datadog/trace/instrumentation/mongo/MongoClient34Instrumentation.java
+++ b/dd-java-agent/instrumentation/mongo/driver-3.4/src/main/java/datadog/trace/instrumentation/mongo/MongoClient34Instrumentation.java
@@ -133,7 +133,7 @@ public final class MongoClient34Instrumentation extends Instrumenter.Tracing {
         @Advice.FieldValue("commandListeners") List<CommandListener> listeners) {
       MongoCommandListener.tryRegister(
           new MongoCommandListener(
-              1,
+              2,
               MongoDecorator34.INSTANCE,
               InstrumentationContext.get(BsonDocument.class, ByteBuf.class),
               InstrumentationContext.get(ConnectionDescription.class, CommandListener.class)),

--- a/dd-java-agent/instrumentation/mongo/driver-3.4/src/test/groovy/MongoJava34ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.4/src/test/groovy/MongoJava34ClientTest.groovy
@@ -4,6 +4,10 @@ import com.mongodb.MongoTimeoutException
 import com.mongodb.ServerAddress
 import com.mongodb.client.MongoCollection
 import com.mongodb.client.MongoDatabase
+import com.mongodb.event.CommandFailedEvent
+import com.mongodb.event.CommandListener
+import com.mongodb.event.CommandStartedEvent
+import com.mongodb.event.CommandSucceededEvent
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -26,6 +30,17 @@ class MongoJava34ClientTest extends MongoBaseTest {
     client = new MongoClient(new ServerAddress("localhost", port),
       MongoClientOptions.builder()
       .description("some-description")
+      .addCommandListener(new CommandListener() {
+        @Override
+        void commandStarted(CommandStartedEvent event) {
+        }
+        @Override
+        void commandSucceeded(CommandSucceededEvent event) {
+        }
+        @Override
+        void commandFailed(CommandFailedEvent event) {
+        }
+      })
       .build())
   }
 


### PR DESCRIPTION
# What Does This Do
Fixes the issue raised in #3361 with MongoDB Command Listeners. The tests were also updated to cover this so that in the future we will catch this type of error. Also, I fixed the mongodb 3.4 instrumentation priority for one of it's Command Listeners.

# Motivation
Fix a broken instrumentation

# Additional Notes
