### PR TITLE
Explicitly set classFileVersion of auxiliary types to avoid byte-buddy warning

### DIFF
--- a/buildSrc/src/main/groovy/InstrumentPlugin.groovy
+++ b/buildSrc/src/main/groovy/InstrumentPlugin.groovy
@@ -1,3 +1,4 @@
+import net.bytebuddy.ClassFileVersion
 import net.bytebuddy.build.EntryPoint
 import net.bytebuddy.build.gradle.ByteBuddyTask
 import net.bytebuddy.build.gradle.Discovery
@@ -38,6 +39,7 @@ class InstrumentPlugin implements Plugin<Project> {
           byteBuddyTask.extendedParsing = false
           byteBuddyTask.discovery = Discovery.NONE
           byteBuddyTask.threads = 0
+          byteBuddyTask.classFileVersion = ClassFileVersion.JAVA_V7
 
           byteBuddyTask.incrementalResolver = IncrementalResolver.ForChangedFiles.INSTANCE
 


### PR DESCRIPTION
byte-buddy 1.12.3 added support for explicitly setting the classfile version of auxiliary types in the byte-buddy gradle task. Previously this was deduced from the gradle project. It also added a warning when this task property was not set to let users know that it was now implicitly using the classfile version of the JDK running the build:

  Could not locate Java target version, build is JDK dependant: 8

We don't currently use auxiliary types so this doesn't alter the final build output, but it's better to explicitly set the classfile version to the current minimum of Java 7 - this also avoids the above warning from appearing multiple times during the build