### PR TITLE
Complete last polled JMS span when Spring JmsListener is done

### DIFF
--- a/dd-java-agent/instrumentation/spring-jms-3.1/src/main/java/datadog/trace/instrumentation/springjms/AbstractPollingMessageListenerContainerInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-jms-3.1/src/main/java/datadog/trace/instrumentation/springjms/AbstractPollingMessageListenerContainerInstrumentation.java
@@ -1,0 +1,64 @@
+package datadog.trace.instrumentation.springjms;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.closePrevious;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.jms.MessageConsumerState;
+import java.util.Map;
+import javax.jms.MessageConsumer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(Instrumenter.class)
+public class AbstractPollingMessageListenerContainerInstrumentation extends Instrumenter.Tracing {
+
+  public AbstractPollingMessageListenerContainerInstrumentation() {
+    super("spring-jms", "jms");
+  }
+
+  @Override
+  public ElementMatcher<? super TypeDescription> typeMatcher() {
+    return named("org.springframework.jms.listener.AbstractPollingMessageListenerContainer");
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return singletonMap("javax.jms.MessageConsumer", MessageConsumerState.class.getName());
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("receiveAndExecute").and(takesArgument(2, named("javax.jms.MessageConsumer"))),
+        getClass().getName() + "$CompleteMessageSpanAfterExecute");
+  }
+
+  public static class CompleteMessageSpanAfterExecute {
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void afterExecute(@Advice.Argument(2) final MessageConsumer consumer) {
+      if (null == consumer) {
+        return; // temporary consumer was created+closed during the call, need for extra clean-up
+      }
+
+      // complete the last polled message span now that we know its execution phase is complete
+      // this results in more accurate durations than if we relied on the iteration span cleaner
+      // (uses same approach as the 'beforeReceive' advice in JMSMessageConsumerInstrumentation)
+      MessageConsumerState consumerState =
+          InstrumentationContext.get(MessageConsumer.class, MessageConsumerState.class)
+              .get(consumer);
+      if (null != consumerState) {
+        boolean finishSpan = consumerState.getSessionState().isAutoAcknowledge();
+        closePrevious(finishSpan);
+        if (finishSpan) {
+          consumerState.finishTimeInQueueSpan(false);
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/spring-jms-3.1/src/test/groovy/MaxMessagesPerTaskForkedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-jms-3.1/src/test/groovy/MaxMessagesPerTaskForkedTest.groovy
@@ -1,0 +1,18 @@
+import datadog.trace.api.config.TracerConfig
+import salistener.MaxMessagesPerTaskConfig
+
+class MaxMessagesPerTaskForkedTest extends SpringSAListenerTest {
+
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+
+    // force test failure if we fall back to the iteration span cleaner
+    injectSysConfig(TracerConfig.SCOPE_ITERATION_KEEP_ALIVE, "600")
+  }
+
+  @Override
+  def configClass() {
+    return MaxMessagesPerTaskConfig
+  }
+}

--- a/dd-java-agent/instrumentation/spring-jms-3.1/src/test/groovy/SpringSAListenerTest.groovy
+++ b/dd-java-agent/instrumentation/spring-jms-3.1/src/test/groovy/SpringSAListenerTest.groovy
@@ -32,9 +32,13 @@ import javax.jms.ConnectionFactory
 
 class SpringSAListenerTest extends AgentTestRunner {
 
+  def configClass() {
+    return Config
+  }
+
   def "receiving message in spring session aware listener generates spans"() {
     setup:
-    def context = new AnnotationConfigApplicationContext(Config)
+    def context = new AnnotationConfigApplicationContext(configClass())
     def factory = context.getBean(ConnectionFactory)
     def container = context.getBean(MessageListenerContainer)
     container.start()

--- a/dd-java-agent/instrumentation/spring-jms-3.1/src/test/groovy/salistener/MaxMessagesPerTaskConfig.groovy
+++ b/dd-java-agent/instrumentation/spring-jms-3.1/src/test/groovy/salistener/MaxMessagesPerTaskConfig.groovy
@@ -1,0 +1,19 @@
+package salistener
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.jms.listener.DefaultMessageListenerContainer
+import org.springframework.jms.listener.MessageListenerContainer
+
+import javax.jms.ConnectionFactory
+
+@Configuration
+class MaxMessagesPerTaskConfig extends Config {
+
+  @Bean
+  MessageListenerContainer container(ConnectionFactory connectionFactory) {
+    def container = super.container(connectionFactory)
+    ((DefaultMessageListenerContainer) container).setMaxMessagesPerTask(1) // only call 'receive' once per task
+    return container
+  }
+}


### PR DESCRIPTION
Complete the last polled message span as soon as we know its execution phase is complete - this results in more accurate durations than if we used the iteration span cleaner fallback, as that has to rely on a timeout.