### PR TITLE
Avoid double decode in HaystackHttpCodec

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HaystackHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HaystackHttpCodec.java
@@ -185,14 +185,14 @@ class HaystackHttpCodec {
             switch (classification) {
               case TRACE_ID:
                 traceId = convertUUIDToBigInt(value);
-                addBaggageItem(HAYSTACK_TRACE_ID_BAGGAGE_KEY, HttpCodec.decode(value));
+                addBaggageItem(HAYSTACK_TRACE_ID_BAGGAGE_KEY, value);
                 break;
               case SPAN_ID:
                 spanId = convertUUIDToBigInt(value);
-                addBaggageItem(HAYSTACK_SPAN_ID_BAGGAGE_KEY, HttpCodec.decode(value));
+                addBaggageItem(HAYSTACK_SPAN_ID_BAGGAGE_KEY, value);
                 break;
               case PARENT_ID:
-                addBaggageItem(HAYSTACK_PARENT_ID_BAGGAGE_KEY, HttpCodec.decode(value));
+                addBaggageItem(HAYSTACK_PARENT_ID_BAGGAGE_KEY, value);
                 break;
               case TAGS:
                 {
@@ -207,8 +207,7 @@ class HaystackHttpCodec {
                 }
               case BAGGAGE:
                 {
-                  addBaggageItem(
-                      lowerCaseKey.substring(BAGGAGE_PREFIX_LC.length()), HttpCodec.decode(value));
+                  addBaggageItem(lowerCaseKey.substring(BAGGAGE_PREFIX_LC.length()), value);
                   break;
                 }
               default:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
@@ -27,7 +27,8 @@ class HaystackHttpExtractorTest extends DDSpecification {
       (TRACE_ID_KEY.toUpperCase())            : traceUuid,
       (SPAN_ID_KEY.toUpperCase())             : spanUuid,
       (OT_BAGGAGE_PREFIX.toUpperCase() + "k1"): "v1",
-      (OT_BAGGAGE_PREFIX.toUpperCase() + "k2"): "v2",
+      (OT_BAGGAGE_PREFIX.toUpperCase() + "k2"): "%76%32",             // v2 encoded once
+      (OT_BAGGAGE_PREFIX.toUpperCase() + "k3"): "%25%37%36%25%33%33", // v3 encoded twice
       SOME_HEADER                             : "my-interesting-info",
     ]
 
@@ -37,7 +38,9 @@ class HaystackHttpExtractorTest extends DDSpecification {
     then:
     context.traceId == DDId.from(traceId)
     context.spanId == DDId.from(spanId)
-    context.baggage == ["k1": "v1", "k2": "v2", "Haystack-Trace-ID": traceUuid, "Haystack-Span-ID": spanUuid]
+    context.baggage == ["k1": "v1", "k2": "v2",
+      "k3": "%76%33", // expect value decoded only once
+      "Haystack-Trace-ID": traceUuid, "Haystack-Span-ID": spanUuid]
     context.tags == ["some-tag": "my-interesting-info"]
     context.samplingPriority == samplingPriority
     context.origin == origin


### PR DESCRIPTION
HaystackHttpCodec's addBaggageItem method decodes the given value, so no need to decode before calling it