### PR TITLE
Fix Elasticsearch7RestClientTest by sorting the spans by start time

### DIFF
--- a/dd-java-agent/instrumentation/elasticsearch/rest-7/src/test/groovy/Elasticsearch7RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-7/src/test/groovy/Elasticsearch7RestClientTest.groovy
@@ -16,10 +16,8 @@ import org.elasticsearch.http.HttpServerTransport
 import org.elasticsearch.node.InternalSettingsPreparer
 import org.elasticsearch.node.Node
 import org.elasticsearch.transport.Netty4Plugin
-import spock.lang.Retry
 import spock.lang.Shared
 
-@Retry(count = 3, delay = 1000, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class Elasticsearch7RestClientTest extends AgentTestRunner {
   @Shared
   TransportAddress httpTransportAddress
@@ -68,7 +66,7 @@ class Elasticsearch7RestClientTest extends AgentTestRunner {
     }
   }
 
-  def "test elasticsearch status"() {
+  def "test elasticsearch status #nr"() {
     setup:
     Request request = new Request("GET", "_cluster/health")
     Response response = client.performRequest(request)
@@ -79,6 +77,7 @@ class Elasticsearch7RestClientTest extends AgentTestRunner {
     result.status == "green"
 
     assertTraces(1) {
+      sortSpansByStart()
       trace(2) {
         span {
           serviceName "elasticsearch"
@@ -114,5 +113,8 @@ class Elasticsearch7RestClientTest extends AgentTestRunner {
         }
       }
     }
+
+    where:
+    nr << (1..101)
   }
 }


### PR DESCRIPTION
# What Does This Do

Fixes the flaky `Elasticsearch7RestClientTest`

# Motivation

Flaky tests are flaky.

# Additional Notes

Since the finishing of the spans are done async in a callback, it's quite possible for them to finish _out of order_, so let's just sort them by start time before comparing.