### PR TITLE
Update the async profiler packaging to the new artifact name

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
@@ -53,7 +53,8 @@ if (apUrl != null) {
 dependencies {
   api project(':dd-java-agent:agent-profiling:profiling-controller')
   api project(':dd-java-agent:agent-profiling:profiling-auxiliary')
-  implementation apDependency
+  //  implementation group: "com.datadoghq", name: "ap-tools", version: "2.6-DD-20220208", changing: true
+  implementation deps.asyncprofiler
 
   annotationProcessor deps.autoserviceProcessor
   compileOnly deps.autoserviceAnnotation
@@ -76,7 +77,7 @@ shadowJar {
     rslt |= it.path == "META-INF" || it.path == "META-INF/services" || it.path.startsWith("META-INF/services/")
     // TODO: modify the filter to include other OS/arch combinations once the overhead is evaluated
     rslt |= it.path == "native-libs" || it.path.startsWith("native-libs/linux-x64") || it.path.startsWith("native-libs/linux-musl-x64")
-    rslt |= (it.path.contains("async-profiler") && it.path.endsWith(".jar"))
+    rslt |= (it.path.contains("ap-tools") && it.path.endsWith(".jar"))
     return rslt
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
@@ -31,7 +31,7 @@ def apFileName = "async-profiler-DD.jar"
 def apDownloadDir = "$rootDir/build/agent-snapshot"
 def apDownloadPath = "$apDownloadDir/$apFileName"
 def apUrl = System.env.get('AP_TOOLS_URL')
-// AP_TOOLS_URL environment variable has always precedency over the configured dependency
+// AP_TOOLS_URL environment variable has always precedence over the configured dependency
 if (apUrl == null && (apDependency instanceof java.net.URL)) {
   // if the dependency is defined as URL make sure it is downloaded
   apUrl = apDependency
@@ -53,8 +53,7 @@ if (apUrl != null) {
 dependencies {
   api project(':dd-java-agent:agent-profiling:profiling-controller')
   api project(':dd-java-agent:agent-profiling:profiling-auxiliary')
-  //  implementation group: "com.datadoghq", name: "ap-tools", version: "2.6-DD-20220208", changing: true
-  implementation deps.asyncprofiler
+  implementation apDependency
 
   annotationProcessor deps.autoserviceProcessor
   compileOnly deps.autoserviceAnnotation


### PR DESCRIPTION
# What Does This Do
Updates the shadowJar configuration to the new async profiler artifact name

# Motivation
The datadog specific async profiler artifact was renamed to reduce the potential confusion. However, the shadow gradle plugin needs to match the jars and since the jar name is now different no async profiler content gets included.

# Additional Notes
