### PR TITLE
Fix bad cast in vertx redis send handling

### DIFF
--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_redis_client/RedisAPIImplSendAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java8/datadog/trace/instrumentation/vertx_redis_client/RedisAPIImplSendAdvice.java
@@ -1,33 +1,41 @@
 package datadog.trace.instrumentation.vertx_redis_client;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan;
+
 import datadog.trace.bootstrap.InstrumentationContext;
-import io.vertx.core.AsyncResult;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import io.vertx.core.Future;
 import io.vertx.redis.RedisClient;
 import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.RedisAPI;
+import io.vertx.redis.client.Response;
 import net.bytebuddy.asm.Advice;
 
 public class RedisAPIImplSendAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
-  public static void afterSend(@Advice.This RedisAPI self, @Advice.Return Future future) {
+  public static void afterSend(@Advice.This RedisAPI self, @Advice.Return Future<Response> future) {
     /*
     Here we can safely set the handler for a command related Future instance.
     We need to take some precautions due to a non-existent operation which would allow setting the handler
     and in case the Future is complete immediately calling it.
      */
 
-    // Get the handler from the context, set by RedisAPICallAdvice
-    ResponseHandlerWrapper handler =
-        InstrumentationContext.get(RedisAPI.class, ResponseHandlerWrapper.class).get(self);
-    if (handler != null && !future.isComplete()) {
-      // Add the handler only when the future is not already completed
-      future.setHandler(handler);
-    }
-    if (handler != null && future.isComplete()) {
-      // Check whether the future has completed some time when adding the handler.
-      // This might lead to executing the handler twice so the handler must be able to deal with it.
-      handler.handle(((AsyncResult) future.result()));
+    // Note that we should not _leak_ the active scope to the handler if it gets executed directly
+    try (AgentScope scope = activateSpan(noopSpan())) {
+      // Get the handler from the context, set by RedisAPICallAdvice
+      ResponseHandlerWrapper handler =
+          InstrumentationContext.get(RedisAPI.class, ResponseHandlerWrapper.class).get(self);
+      if (handler != null && !future.isComplete()) {
+        // Add the handler only when the future is not already completed
+        future.setHandler(handler);
+      }
+      if (handler != null && future.isComplete()) {
+        // Check whether the future has completed some time when adding the handler.
+        // This might lead to executing the handler twice so the handler must be able to deal with
+        // it.
+        handler.handle(future);
+      }
     }
   }
 


### PR DESCRIPTION
# What Does This Do

Removes a bad cast in the `RedisAPISendAdvice`, that could throw exceptions, and also wraps the possible direct calls to the handler with a noop span, to not _leak_ the active scope for trace consistency between the different paths.

# Motivation

It was broken and threw exceptions if the `Future` was completed fast enough that the `Handler` was executed directly.

# Additional Notes
