### PR TITLE
Fix the custom ap-tools jar support

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
@@ -1,13 +1,9 @@
 plugins {
   id "com.github.johnrengelman.shadow"
-  id "de.undercouch.download" version "5.0.1"
 }
 
 apply from: "$rootDir/gradle/java.gradle"
 apply plugin: 'idea'
-apply plugin: 'de.undercouch.download'
-
-import de.undercouch.gradle.tasks.download.Download
 
 def osName = System.getProperty('os.name', '').toLowerCase()
 // currently, only linux binaries are included
@@ -26,34 +22,10 @@ excludedClassesCoverage += [
   'com.datadog.profiling.auxiliary.async.AsyncProfilerConfigEvent'
 ]
 
-def apDependency = deps.asyncprofiler
-def apFileName = "async-profiler-DD.jar"
-def apDownloadDir = "$rootDir/build/agent-snapshot"
-def apDownloadPath = "$apDownloadDir/$apFileName"
-def apUrl = System.env.get('AP_TOOLS_URL')
-// AP_TOOLS_URL environment variable has always precedence over the configured dependency
-if (apUrl == null && (apDependency instanceof java.net.URL)) {
-  // if the dependency is defined as URL make sure it is downloaded
-  apUrl = apDependency
-}
-if (apUrl != null) {
-  task downloadApTools(type: Download) {
-    mkdir(apDownloadDir)
-    src(apUrl)
-    dest(apDownloadPath)
-    overwrite(true)
-    onlyIfModified(true)
-  }
-
-  compileJava.dependsOn downloadApTools
-  apDependency = files(apDownloadPath)
-}
-
-
 dependencies {
   api project(':dd-java-agent:agent-profiling:profiling-controller')
   api project(':dd-java-agent:agent-profiling:profiling-auxiliary')
-  implementation apDependency
+  implementation project.hasProperty('ap.tools.jar') ? files(project.getProperty('ap.tools.jar')) : deps.asyncprofiler
 
   annotationProcessor deps.autoserviceProcessor
   compileOnly deps.autoserviceAnnotation
@@ -77,6 +49,7 @@ shadowJar {
     // TODO: modify the filter to include other OS/arch combinations once the overhead is evaluated
     rslt |= it.path == "native-libs" || it.path.startsWith("native-libs/linux-x64") || it.path.startsWith("native-libs/linux-musl-x64")
     rslt |= (it.path.contains("ap-tools") && it.path.endsWith(".jar"))
+    println ">>> ${it.path}: ${rslt}"
     return rslt
   }
 }


### PR DESCRIPTION
# What Does This Do
The PR fixes the custom ap-tools jar support because the current version is not working reliably.
Everything boils down to the fact that downloading a jar and adding it as a dependency seems to mess up the gradle model and the build results can be quite surprising eg. `shadowJar` step not seeing the dependency at all most of the time.

Another surprising issue was the inability to read an environment variable set at the `gradlew` command line - so using the project property instead.