### PR TITLE
Exclude Elasticsearch 8.0.0 since we don't support it yet

### DIFF
--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/transport-6.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/transport-6.gradle
@@ -7,14 +7,14 @@ muzzle {
   pass {
     group = "org.elasticsearch.client"
     module = "transport"
-    versions = "[6.0.0,]"
+    versions = "[6.0.0,8.0.0)"
     skipVersions = ["7.11.0"]
     assertInverse = true
   }
   pass {
     group = "org.elasticsearch"
     module = "elasticsearch"
-    versions = "[6.0.0,]"
+    versions = "[6.0.0,8.0.0)"
     skipVersions = ["7.11.0"]
     assertInverse = true
   }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-7.3/transport-7.3.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-7.3/transport-7.3.gradle
@@ -7,14 +7,14 @@ muzzle {
   pass {
     group = "org.elasticsearch.client"
     module = "transport"
-    versions = "[7.3,]"
+    versions = "[7.3,8.0.0)"
     assertInverse = true
     skipVersions = ["7.11.0"]
   }
   pass {
     group = "org.elasticsearch"
     module = "elasticsearch"
-    versions = "[7.3,]"
+    versions = "[7.3,8.0.0)"
     assertInverse = true
     skipVersions = ["7.11.0"]
   }


### PR DESCRIPTION
# What Does This Do

Excludes `elasticsearch` version `8.+` from the _accepted_ versions since we don't support it yet.

# Motivation

# Additional Notes
