### PR TITLE
Bump async-profiler to DD-2.6-20220211

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -29,7 +29,7 @@ final class CachedData {
     testcontainers: '1.15.0-rc2',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    asyncprofiler : "2.6-DD-20220210"
+    asyncprofiler : "2.6-DD-20220211"
   ]
 
   static deps = [


### PR DESCRIPTION
# Motivation

* Relax CallTraceStorage locking to cover only necessary code