### PR TITLE
Ignore Guice generated proxy classes

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
@@ -208,6 +208,7 @@ public class GlobalIgnoresMatcher<T extends TypeDescription>
       if (name.contains("$JaxbAccessor")
           || name.contains("CGLIB$$")
           || name.contains("$__sisu")
+          || name.contains("$$EnhancerByGuice$$")
           || name.contains("$$EnhancerByProxool$$")
           || name.startsWith("org.springframework.core.$Proxy")) {
         return true;


### PR DESCRIPTION
Classes with names that include `$$EnhancerByGuice$$` are proxy (sub)classes generated by Guice at runtime and can safely be ignored because we'll instrument their superclass. Ignoring them also means we can avoid creating duplicate spans, ie. one for the proxy and one for the real class.