### PR TITLE
Fix computation overflow

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AsyncProfilerConfigEvent.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AsyncProfilerConfigEvent.java
@@ -33,6 +33,10 @@ public class AsyncProfilerConfigEvent extends Event {
   @DataAmount
   private final long memleakInterval;
 
+  @Label("MemLeak Sampling Capacity")
+  @Description("Number of objects to track")
+  private final long memleakCapacity;
+
   @Label("Profiling Mode")
   @Description("Profiling mode bitmask")
   private final int modeMask;
@@ -51,12 +55,14 @@ public class AsyncProfilerConfigEvent extends Event {
       long cpuInterval,
       long allocInterval,
       long memleakInterval,
+      long memleakCapacity,
       int modeMask) {
     this.version = version;
     this.libPath = libPath;
     this.cpuInterval = cpuInterval;
     this.allocInterval = allocInterval;
     this.memleakInterval = memleakInterval;
+    this.memleakCapacity = memleakCapacity;
     this.modeMask = modeMask;
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfiler.java
@@ -32,7 +32,7 @@ final class AuxiliaryAsyncProfiler implements AuxiliaryImplementation {
 
   public static final String TYPE = "async";
 
-  private final int memleakIntervalDefault;
+  private final long memleakIntervalDefault;
 
   @AutoService(AuxiliaryImplementation.Provider.class)
   public static final class ImplementerProvider implements AuxiliaryImplementation.Provider {
@@ -99,7 +99,7 @@ final class AuxiliaryAsyncProfiler implements AuxiliaryImplementation {
       FlightRecorder.addPeriodicEvent(AsyncProfilerConfigEvent.class, this::emitConfiguration);
     }
 
-    int maxheap = (int) ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax();
+    long maxheap = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax();
     this.memleakIntervalDefault =
         maxheap <= 0 ? 1 * 1024 * 1024 : maxheap / Math.max(1, getMemleakCapacity());
   }
@@ -112,6 +112,7 @@ final class AuxiliaryAsyncProfiler implements AuxiliaryImplementation {
               getCpuInterval(),
               getAllocationInterval(),
               getMemleakInterval(),
+              getMemleakCapacity(),
               ProfilingMode.mask(profilingModes))
           .commit();
     } catch (Throwable t) {
@@ -315,8 +316,8 @@ final class AuxiliaryAsyncProfiler implements AuxiliaryImplementation {
         ProfilingConfig.PROFILING_ASYNC_CPU_MODE, ProfilingConfig.PROFILING_ASYNC_CPU_MODE_DEFAULT);
   }
 
-  private int getMemleakInterval() {
-    return configProvider.getInteger(
+  private long getMemleakInterval() {
+    return configProvider.getLong(
         ProfilingConfig.PROFILING_ASYNC_MEMLEAK_INTERVAL, memleakIntervalDefault);
   }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
@@ -105,6 +105,18 @@ public final class ConfigProvider {
     return get(key, defaultValue, Integer.class, aliases);
   }
 
+  public final Long getLong(String key) {
+    return get(key, null, Long.class);
+  }
+
+  public final Long getLong(String key, String... aliases) {
+    return get(key, null, Long.class, aliases);
+  }
+
+  public final long getLong(String key, long defaultValue, String... aliases) {
+    return get(key, defaultValue, Long.class, aliases);
+  }
+
   public final Float getFloat(String key, String... aliases) {
     return get(key, null, Float.class, aliases);
   }


### PR DESCRIPTION
# What Does This Do

When heaps are non-trivial (bigger than 2g), it would overflow an int
leading to non-sensical value for maxheap, leading to interval of 1M.
