### PR TITLE
Put the vendor, version, and runtime name in log message

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ControllerFactory.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ControllerFactory.java
@@ -67,41 +67,48 @@ public final class ControllerFactory {
         if (e.getCause() != null && e.getCause() instanceof ConfigurationException) {
           throw (ConfigurationException) e.getCause();
         }
-        final String message = "Not enabling profiling" + getFixProposalMessage();
-        throw new UnsupportedEnvironmentException(message, e);
+        throw new UnsupportedEnvironmentException(getFixProposalMessage(), e);
       }
     }
-    throw new UnsupportedEnvironmentException("Not enabling profiling" + getFixProposalMessage());
+    throw new UnsupportedEnvironmentException(getFixProposalMessage());
   }
 
   private static String getFixProposalMessage() {
+    final String javaVendor = System.getProperty("java.vendor");
+    final String javaVersion = System.getProperty("java.version");
+    final String javaRuntimeName = System.getProperty("java.runtime.name");
+    final String message =
+        "Not enabling profiling for vendor="
+            + javaVendor
+            + ", version="
+            + javaVersion
+            + ", runtimeName="
+            + javaRuntimeName;
     try {
-      final String javaVersion = System.getProperty("java.version");
       if (javaVersion == null) {
-        return "";
+        return message;
       }
-      final String javaVendor = System.getProperty("java.vendor", "");
       if (javaVersion.startsWith("1.8")) {
         if (javaVendor.startsWith("Azul Systems")) {
-          return "; it requires Zulu Java 8 (1.8.0_212+).";
+          return message + "; it requires Zulu Java 8 (1.8.0_212+).";
         }
-        final String javaRuntimeName = System.getProperty("java.runtime.name", "");
         if (javaVendor.startsWith("Oracle")) {
           if (javaRuntimeName.startsWith("OpenJDK")) {
             // this is a upstream build from openjdk docker repository for example
-            return "; it requires 1.8.0_272+ OpenJDK builds (upstream)";
+            return message + "; it requires 1.8.0_272+ OpenJDK builds (upstream)";
           } else {
             // this is a proprietary Oracle JRE/JDK 8
-            return "; it requires Oracle JRE/JDK 8u40+";
+            return message + "; it requires Oracle JRE/JDK 8u40+";
           }
         }
         if (javaRuntimeName.startsWith("OpenJDK")) {
-          return "; it requires 1.8.0_272+ OpenJDK builds from the following vendors: AdoptOpenJDK, Amazon Corretto, Azul Zulu, BellSoft Liberica";
+          return message
+              + "; it requires 1.8.0_272+ OpenJDK builds from the following vendors: AdoptOpenJDK, Eclipse Temurin, Amazon Corretto, Azul Zulu, BellSoft Liberica.";
         }
       }
-      return "; it requires OpenJDK 11+, Oracle Java 11+, or Zulu Java 8 (1.8.0_212+).";
+      return message + "; it requires OpenJDK 11+, Oracle Java 11+, or Zulu Java 8 (1.8.0_212+).";
     } catch (final Exception ex) {
-      return "";
+      return message;
     }
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ControllerFactoryTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ControllerFactoryTest.java
@@ -26,21 +26,29 @@ public class ControllerFactoryTest {
             () -> {
               ControllerFactory.createController(config);
             });
-    String expected =
-        "Not enabling profiling; it requires OpenJDK 11+, Oracle Java 11+, or Zulu Java 8 (1.8.0_212+).";
     final String javaVendor = System.getProperty("java.vendor");
     final String javaRuntimeName = System.getProperty("java.runtime.name");
     final String javaVersion = System.getProperty("java.version");
+    String expected =
+        "Not enabling profiling for vendor="
+            + javaVendor
+            + ", version="
+            + javaVersion
+            + ", runtimeName="
+            + javaRuntimeName
+            + "; it requires ";
     if ("Azul Systems, Inc.".equals(javaVendor)) {
-      expected = "Not enabling profiling; it requires Zulu Java 8 (1.8.0_212+).";
+      expected += "Zulu Java 8 (1.8.0_212+).";
     } else if ("Java(TM) SE Runtime Environment".equals(javaRuntimeName)
         && "Oracle Corporation".equals(javaVendor)
         && javaVersion.startsWith("1.8")) {
       // condition for OracleJRE8 (with proprietary JFR inside)
-      expected = "Not enabling profiling; it requires Oracle JRE/JDK 8u40+";
+      expected += "Oracle JRE/JDK 8u40+";
     } else if ("OpenJDK Runtime Environment".equals(javaRuntimeName)) {
-      expected =
-          "Not enabling profiling; it requires 1.8.0_272+ OpenJDK builds from the following vendors: AdoptOpenJDK, Amazon Corretto, Azul Zulu, BellSoft Liberica";
+      expected +=
+          "1.8.0_272+ OpenJDK builds from the following vendors: AdoptOpenJDK, Eclipse Temurin, Amazon Corretto, Azul Zulu, BellSoft Liberica.";
+    } else {
+      expected += "OpenJDK 11+, Oracle Java 11+, or Zulu Java 8 (1.8.0_212+).";
     }
     assertEquals(
         expected,


### PR DESCRIPTION
# What Does This Do

Dumps the java.vendor, java.version and java.runtime.name in the log message.

# Motivation

It's regularly an issue during escalations that we don't know the version of the runtime and we have to ask customers to provide it to us manually when the "; it requires ..." message shows up. Instead, let's dump the information along the log.

# Additional Notes
