### PR TITLE
Set connect timeout for apache http client 5 tests

### DIFF
--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpClientResponseHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpClientResponseHandlerTest.groovy
@@ -20,7 +20,7 @@ class ApacheHttpClientResponseHandlerTest extends HttpClientTest {
   def client = HttpClients.custom()
   .setConnectionManager(new BasicHttpClientConnectionManager())
   .setDefaultRequestConfig(RequestConfig.custom()
-  .setConnectionRequestTimeout(CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+  .setConnectTimeout(CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
   .build()).build()
 
   @Shared

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpClientTest.groovy
@@ -21,7 +21,7 @@ abstract class ApacheHttpClientTest<T extends HttpRequest> extends HttpClientTes
   def client = HttpClients.custom()
   .setConnectionManager(new BasicHttpClientConnectionManager())
   .setDefaultRequestConfig(RequestConfig.custom()
-  .setConnectionRequestTimeout(CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+  .setConnectTimeout(CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
   .build()).build()
 
   @Override


### PR DESCRIPTION
# What Does This Do

This sets the `ConnectTimeout` instead of the `ConnectionRequestTimeout` timeout (which is the connection lease request timeout from the internal pool).

# Motivation

Each `"connection error non routable address"` test for the apache http client 5 tests took ~2 minutes, instead of the supposed ~3 seconds.

# Additional Notes
