### PR TITLE
[AppSec] Fixed double calling

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/AppSecModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/AppSecModule.java
@@ -13,6 +13,8 @@ public interface AppSecModule {
 
   String getName();
 
+  String getInfo();
+
   Collection<EventSubscription> getEventSubscriptions();
 
   Collection<DataSubscription> getDataSubscriptions();

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/AppSecSystem.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/AppSecSystem.java
@@ -16,10 +16,8 @@ import datadog.trace.api.Config;
 import datadog.trace.api.gateway.SubscriptionService;
 import datadog.trace.api.time.SystemTimeSource;
 import datadog.trace.util.AgentThreadFactory;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.ServiceLoader;
+import datadog.trace.util.Strings;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,7 +26,7 @@ public class AppSecSystem {
 
   private static final Logger log = LoggerFactory.getLogger(AppSecSystem.class);
   private static final AtomicBoolean STARTED = new AtomicBoolean();
-  private static final List<String> STARTED_MODULE_NAMES = new ArrayList<>();
+  private static final Map<String, String> STARTED_MODULES_INFO = new HashMap<String, String>();
   private static AppSecConfigService APP_SEC_CONFIG_SERVICE;
 
   public static void start(SubscriptionService gw, SharedCommunicationObjects sco) {
@@ -48,7 +46,7 @@ public class AppSecSystem {
       log.debug("AppSec: disabled");
       return;
     }
-    log.info("AppSec has started");
+    log.debug("AppSec has started");
 
     //  TODO: FleetService should be shared with other components
     FleetService fleetService =
@@ -71,6 +69,9 @@ public class AppSecSystem {
     gatewayBridge.init();
 
     STARTED.set(true);
+
+    String startedAppSecModules = Strings.join(", ", STARTED_MODULES_INFO.values());
+    log.info("AppSec has started with {}", startedAppSecModules);
   }
 
   private static RateLimiter getRateLimiter(Config config, Monitoring monitoring) {
@@ -102,7 +103,7 @@ public class AppSecSystem {
     ServiceLoader<AppSecModule> modules =
         ServiceLoader.load(AppSecModule.class, AppSecSystem.class.getClassLoader());
     for (AppSecModule module : modules) {
-      log.info("Starting appsec module {}", module.getName());
+      log.debug("Starting appsec module {}", module.getName());
       try {
         module.config(APP_SEC_CONFIG_SERVICE);
       } catch (RuntimeException | AppSecModule.AppSecModuleActivationException t) {
@@ -120,7 +121,7 @@ public class AppSecSystem {
         dataSubscriptionSet.addSubscription(sub.getSubscribedAddresses(), sub);
       }
 
-      STARTED_MODULE_NAMES.add(module.getName());
+      STARTED_MODULES_INFO.put(module.getName(), module.getInfo());
     }
 
     eventDispatcher.subscribeEvents(eventSubscriptionSet);
@@ -131,11 +132,11 @@ public class AppSecSystem {
     return STARTED.get();
   }
 
-  public static List<String> getStartedModuleNames() {
+  public static Set<String> getStartedModulesInfo() {
     if (isStarted()) {
-      return Collections.unmodifiableList(STARTED_MODULE_NAMES);
+      return Collections.unmodifiableSet(STARTED_MODULES_INFO.keySet());
     } else {
-      return Collections.emptyList();
+      return Collections.emptySet();
     }
   }
 }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -64,7 +64,11 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   private int responseStatus;
   private boolean blocked;
 
+  private boolean reqDataPublished;
+  private boolean pathParamsPublished;
+  private boolean rawReqBodyPublished;
   private boolean convertedReqBodyPublished;
+  private boolean respDataPublished;
 
   private Additive additive;
 
@@ -251,12 +255,44 @@ public class AppSecRequestContext implements DataBundle, Closeable {
     this.blocked = blocked;
   }
 
+  public boolean isReqDataPublished() {
+    return reqDataPublished;
+  }
+
+  public void setReqDataPublished(boolean reqDataPublished) {
+    this.reqDataPublished = reqDataPublished;
+  }
+
+  public boolean isPathParamsPublished() {
+    return pathParamsPublished;
+  }
+
+  public void setPathParamsPublished(boolean pathParamsPublished) {
+    this.pathParamsPublished = pathParamsPublished;
+  }
+
+  public boolean isRawReqBodyPublished() {
+    return rawReqBodyPublished;
+  }
+
+  public void setRawReqBodyPublished(boolean rawReqBodyPublished) {
+    this.rawReqBodyPublished = rawReqBodyPublished;
+  }
+
   public boolean isConvertedReqBodyPublished() {
     return convertedReqBodyPublished;
   }
 
   public void setConvertedReqBodyPublished(boolean convertedReqBodyPublished) {
     this.convertedReqBodyPublished = convertedReqBodyPublished;
+  }
+
+  public boolean isRespDataPublished() {
+    return respDataPublished;
+  }
+
+  public void setRespDataPublished(boolean respDataPublished) {
+    this.respDataPublished = respDataPublished;
   }
 
   @Override

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -116,7 +116,9 @@ public class PowerWAFModule implements AppSecModule {
   }
 
   private void applyConfig(AppSecConfig config) throws AppSecModuleActivationException {
-    log.info("Configuring WAF");
+    if (log.isDebugEnabled()) {
+      log.info("Configuring WAF");
+    }
 
     CtxAndAddresses prevContextAndAddresses = this.ctxAndAddresses.get();
     CtxAndAddresses newContextAndAddresses;
@@ -151,6 +153,15 @@ public class PowerWAFModule implements AppSecModule {
   @Override
   public String getName() {
     return "powerwaf";
+  }
+
+  @Override
+  public String getInfo() {
+    return "powerwaf(libddwaf: "
+        + Powerwaf.LIB_VERSION
+        + ") loaded "
+        + rulesInfoMap.size()
+        + " rules";
   }
 
   @Override
@@ -241,7 +252,9 @@ public class PowerWAFModule implements AppSecModule {
       StandardizedLogging.inAppWafReturn(log, actionWithData);
 
       if (actionWithData.action != Powerwaf.Action.OK) {
-        log.warn("WAF signalled action {}: {}", actionWithData.action, actionWithData.data);
+        if (log.isDebugEnabled()) {
+          log.warn("WAF signalled action {}: {}", actionWithData.action, actionWithData.data);
+        }
         flow.setAction(new Flow.Action.Throw(new RuntimeException("WAF wants to block")));
 
         reqCtx.setBlocked(actionWithData.action == Powerwaf.Action.BLOCK);

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/util/StandardizedLogging.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/util/StandardizedLogging.java
@@ -141,7 +141,9 @@ public class StandardizedLogging {
       }
     }
 
-    logger.info("Detecting an attack from rule {}", ruleId);
+    if (logger.isDebugEnabled()) {
+      logger.info("Detecting an attack from rule {}", ruleId);
+    }
     logger.debug("Detecting an attack from rule {}: {}", ruleId, event.getRuleMatches());
   }
 
@@ -183,13 +185,19 @@ public class StandardizedLogging {
    * The following nonstandard alternative was instead chosen.
    */
   public static void _initialConfigSourceAndLibddwafVersion(Logger logger, String source) {
-    logger.info(
-        "AppSec initial configuration from {}, libddwaf version: {}", source, Powerwaf.LIB_VERSION);
+    if (logger.isDebugEnabled()) {
+      logger.info(
+          "AppSec initial configuration from {}, libddwaf version: {}",
+          source,
+          Powerwaf.LIB_VERSION);
+    }
   }
 
   // I2
   public static void numLoadedRules(Logger logger, String source, int numRules) {
-    logger.info("AppSec loaded {} rules from file {}", numRules, source);
+    if (logger.isDebugEnabled()) {
+      logger.info("AppSec loaded {} rules from file {}", numRules, source);
+    }
   }
 
   // I3: high volume; should really not be at info level

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/AppSecSystemSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/AppSecSystemSpecification.groovy
@@ -33,7 +33,7 @@ class AppSecSystemSpecification extends DDSpecification {
     AppSecSystem.start(subService, sharedCommunicationObjects())
 
     then:
-    'powerwaf' in AppSecSystem.startedModuleNames
+    'powerwaf' in AppSecSystem.startedModulesInfo
   }
 
   void 'throws if custom config does not exist'() {
@@ -115,7 +115,7 @@ class AppSecSystemSpecification extends DDSpecification {
 
   void 'when not started returns empty list for started modules'() {
     expect:
-    AppSecSystem.startedModuleNames.empty
+    AppSecSystem.startedModulesInfo.empty
   }
 
   private SharedCommunicationObjects sharedCommunicationObjects() {


### PR DESCRIPTION
# What Does This Do
Added checkers to avoid double calling of AppSec.

# Motivation
Some combinations of instrumentations can cause events’ reduplication. Customer reported the application built based on Ratpack produces exceptions. In sample RatPack app, I discovered there are `HttpServerDecorator.onRequest()` and  `HttpServerDecorator.onResponse()`, are called twice per request. First time from `netty-4.1` instrumentation and the second time from `ratpack-1.5`. Overall this looks reasonable, but in terms of AppSec, doubling events results in redundant analysis iteration (calling WAF).

# Additional Notes
