### PR TITLE
Make mongo tests setup more robust

### DIFF
--- a/dd-java-agent/instrumentation/mongo/driver-3.1-core-test/src/test/groovy/MongoCore31ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1-core-test/src/test/groovy/MongoCore31ClientTest.groovy
@@ -20,6 +20,7 @@ import spock.lang.Shared
 import static datadog.trace.agent.test.utils.PortUtils.UNUSABLE_PORT
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
 class MongoCore31ClientTest extends MongoBaseTest {
 
@@ -108,12 +109,14 @@ class MongoCore31ClientTest extends MongoBaseTest {
 
   def "test insert"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:
@@ -136,14 +139,16 @@ class MongoCore31ClientTest extends MongoBaseTest {
 
   def "test update"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       def coll = db.getCollection(collectionName)
       coll.insertOne(new Document("password", "OLDPW"))
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:
@@ -169,14 +174,16 @@ class MongoCore31ClientTest extends MongoBaseTest {
 
   def "test delete"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       def coll = db.getCollection(collectionName)
       coll.insertOne(new Document("password", "SECRET"))
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:
@@ -200,12 +207,14 @@ class MongoCore31ClientTest extends MongoBaseTest {
 
   def "test error"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoJava31ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoJava31ClientTest.groovy
@@ -20,6 +20,7 @@ import spock.lang.Shared
 import static datadog.trace.agent.test.utils.PortUtils.UNUSABLE_PORT
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
 class MongoJava31ClientTest extends MongoBaseTest {
 
@@ -108,12 +109,14 @@ class MongoJava31ClientTest extends MongoBaseTest {
 
   def "test insert"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:
@@ -136,14 +139,16 @@ class MongoJava31ClientTest extends MongoBaseTest {
 
   def "test update"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       def coll = db.getCollection(collectionName)
       coll.insertOne(new Document("password", "OLDPW"))
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:
@@ -169,14 +174,16 @@ class MongoJava31ClientTest extends MongoBaseTest {
 
   def "test delete"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       def coll = db.getCollection(collectionName)
       coll.insertOne(new Document("password", "SECRET"))
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:
@@ -200,12 +207,14 @@ class MongoJava31ClientTest extends MongoBaseTest {
 
   def "test error"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:

--- a/dd-java-agent/instrumentation/mongo/driver-3.10-sync-test/src/test/groovy/MongoSyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.10-sync-test/src/test/groovy/MongoSyncClientTest.groovy
@@ -17,6 +17,7 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.api.Checkpointer.END
 import static datadog.trace.api.Checkpointer.SPAN
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
 class MongoSyncClientTest extends MongoBaseTest {
 
@@ -104,12 +105,14 @@ class MongoSyncClientTest extends MongoBaseTest {
 
   def "test insert"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:
@@ -140,14 +143,16 @@ class MongoSyncClientTest extends MongoBaseTest {
 
   def "test update"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       def coll = db.getCollection(collectionName)
       coll.insertOne(new Document("password", "OLDPW"))
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:
@@ -181,14 +186,16 @@ class MongoSyncClientTest extends MongoBaseTest {
 
   def "test delete"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       def coll = db.getCollection(collectionName)
       coll.insertOne(new Document("password", "SECRET"))
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:
@@ -220,12 +227,14 @@ class MongoSyncClientTest extends MongoBaseTest {
 
   def "test error"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:

--- a/dd-java-agent/instrumentation/mongo/driver-3.4/src/test/groovy/MongoJava34ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.4/src/test/groovy/MongoJava34ClientTest.groovy
@@ -20,6 +20,7 @@ import spock.lang.Shared
 import static datadog.trace.agent.test.utils.PortUtils.UNUSABLE_PORT
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
 class MongoJava34ClientTest extends MongoBaseTest {
 
@@ -108,12 +109,14 @@ class MongoJava34ClientTest extends MongoBaseTest {
 
   def "test insert"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:
@@ -136,14 +139,16 @@ class MongoJava34ClientTest extends MongoBaseTest {
 
   def "test update"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       def coll = db.getCollection(collectionName)
       coll.insertOne(new Document("password", "OLDPW"))
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:
@@ -169,14 +174,16 @@ class MongoJava34ClientTest extends MongoBaseTest {
 
   def "test delete"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       def coll = db.getCollection(collectionName)
       coll.insertOne(new Document("password", "SECRET"))
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:
@@ -200,12 +207,14 @@ class MongoJava34ClientTest extends MongoBaseTest {
 
   def "test error"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:

--- a/dd-java-agent/instrumentation/mongo/driver-3.7-core-test/src/test/groovy/MongoCore37ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.7-core-test/src/test/groovy/MongoCore37ClientTest.groovy
@@ -17,6 +17,7 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.api.Checkpointer.END
 import static datadog.trace.api.Checkpointer.SPAN
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
 class MongoCore37ClientTest extends MongoBaseTest {
 
@@ -104,12 +105,14 @@ class MongoCore37ClientTest extends MongoBaseTest {
 
   def "test insert"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:
@@ -140,14 +143,16 @@ class MongoCore37ClientTest extends MongoBaseTest {
 
   def "test update"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       def coll = db.getCollection(collectionName)
       coll.insertOne(new Document("password", "OLDPW"))
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:
@@ -181,14 +186,16 @@ class MongoCore37ClientTest extends MongoBaseTest {
 
   def "test delete"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       def coll = db.getCollection(collectionName)
       coll.insertOne(new Document("password", "SECRET"))
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:
@@ -220,12 +227,14 @@ class MongoCore37ClientTest extends MongoBaseTest {
 
   def "test error"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:

--- a/dd-java-agent/instrumentation/mongo/driver-4.0/driver-4.0.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-4.0/driver-4.0.gradle
@@ -46,8 +46,8 @@ dependencies {
   testImplementation project(':dd-java-agent:instrumentation:mongo').sourceSets.test.output
   testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '1.50.5'
 
-  testImplementation group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.0.0'
-  testImplementation group: 'org.mongodb', name: 'mongodb-driver-reactivestreams', version: '4.0.0'
+  testImplementation group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.0.1'
+  testImplementation group: 'org.mongodb', name: 'mongodb-driver-reactivestreams', version: '4.0.1'  // race condition bug in 4.0.0
   latestDepTestImplementation group: 'org.mongodb', name: 'mongodb-driver-reactivestreams', version: '4.2+'
   latestDepTestImplementation group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.2+'
 }

--- a/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/Mongo4ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/Mongo4ClientTest.groovy
@@ -17,6 +17,7 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.api.Checkpointer.END
 import static datadog.trace.api.Checkpointer.SPAN
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
 class Mongo4ClientTest extends MongoBaseTest {
 
@@ -104,12 +105,14 @@ class Mongo4ClientTest extends MongoBaseTest {
 
   def "test insert"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:
@@ -140,14 +143,16 @@ class Mongo4ClientTest extends MongoBaseTest {
 
   def "test update"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       def coll = db.getCollection(collectionName)
       coll.insertOne(new Document("password", "OLDPW"))
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:
@@ -181,14 +186,16 @@ class Mongo4ClientTest extends MongoBaseTest {
 
   def "test delete"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       def coll = db.getCollection(collectionName)
       coll.insertOne(new Document("password", "SECRET"))
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:
@@ -220,12 +227,14 @@ class Mongo4ClientTest extends MongoBaseTest {
 
   def "test error"() {
     setup:
+    DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
+      setupSpan = activeSpan() as DDSpan
       MongoDatabase db = client.getDatabase(databaseName)
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitUntilReported(setupSpan)
     TEST_WRITER.clear()
 
     when:


### PR DESCRIPTION
# What Does This Do

Tries to make test setup more robust by waiting for the actual `setup` span to be reported. Also upgrades the async test for `mongodb-driver-reactivestreams` to run against `4.0.1` as a minimum, since there was a race condition bug in earlier versions, that sometimes triggered during testing.

# Motivation

Flaky tests are flaky.

# Additional Notes

Has run this commit fully 5+ times in CI without any failures in the mongo tests. Not sure that is enough testing, but at least it doesn't seem to get worse 😉