### PR TITLE
Introduce API to decouple custom transformers from AgentBuilder

### DIFF
--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/ServletRequestBodyInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/ServletRequestBodyInstrumentation.java
@@ -32,7 +32,6 @@ import javax.servlet.ServletInputStream;
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import net.bytebuddy.ByteBuddy;
-import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.ClassFileLocator;
@@ -100,9 +99,9 @@ public class ServletRequestBodyInstrumentation extends Instrumenter.AppSec
       };
 
   @Override
-  public AgentBuilder.Transformer transformer() {
+  public AdviceTransformer transformer() {
     // transformer possible adding extra 3 methods to ServletInputStreamWrapper
-    return new AgentBuilder.Transformer() {
+    return new AdviceTransformer() {
       private final Map<ClassLoader, Boolean> injectedClassLoaders =
           Collections.synchronizedMap(new WeakHashMap<ClassLoader, Boolean>());
 

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RequestImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RequestImplInstrumentation.java
@@ -5,7 +5,6 @@ import static net.bytebuddy.matcher.ElementMatchers.none;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import java.util.Arrays;
-import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.AsmVisitorWrapper;
 import net.bytebuddy.description.field.FieldDescription;
 import net.bytebuddy.description.field.FieldList;
@@ -39,10 +38,10 @@ public class RequestImplInstrumentation extends Instrumenter.Tracing
   }
 
   @Override
-  public AgentBuilder.Transformer transformer() {
+  public AdviceTransformer transformer() {
     // This Transformer will add the Cloneable interface to RequestImpl, as well as a clone method
     // that calls the protected shallow clone method in Object
-    return new AgentBuilder.Transformer() {
+    return new AdviceTransformer() {
       @Override
       public DynamicType.Builder<?> transform(
           DynamicType.Builder<?> builder,


### PR DESCRIPTION
Another step towards fully decoupling `Instrumenter`s from `AgentBuilder` so we can try different agent approaches