### PR TITLE
Simplify instrumenter API by dropping `contextStoreForAll`

### DIFF
--- a/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
@@ -37,7 +37,7 @@ public class HttpUrlConnectionInstrumentation extends Instrumenter.Tracing
   }
 
   @Override
-  public Map<String, String> contextStoreForAll() {
+  public Map<String, String> contextStore() {
     return singletonMap("java.net.HttpURLConnection", HttpUrlState.class.getName());
   }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaExecutorInstrumentation.java
@@ -23,7 +23,7 @@ import net.bytebuddy.asm.Advice;
 public final class JavaExecutorInstrumentation extends AbstractExecutorInstrumentation {
 
   @Override
-  public Map<String, String> contextStoreForAll() {
+  public Map<String, String> contextStore() {
     return Collections.singletonMap(Runnable.class.getName(), State.class.getName());
   }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinTaskInstrumentation.java
@@ -51,7 +51,7 @@ public final class JavaForkJoinTaskInstrumentation extends Instrumenter.Tracing
   }
 
   @Override
-  public Map<String, String> contextStoreForAll() {
+  public Map<String, String> contextStore() {
     return singletonMap("java.util.concurrent.ForkJoinTask", State.class.getName());
   }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/NonStandardExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/NonStandardExecutorInstrumentation.java
@@ -18,7 +18,7 @@ public final class NonStandardExecutorInstrumentation extends AbstractExecutorIn
   }
 
   @Override
-  public Map<String, String> contextStoreForAll() {
+  public Map<String, String> contextStore() {
     return singletonMap(Runnable.class.getName(), State.class.getName());
   }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/RunnableFutureInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/RunnableFutureInstrumentation.java
@@ -53,7 +53,7 @@ public final class RunnableFutureInstrumentation extends Instrumenter.Tracing
   }
 
   @Override
-  public Map<String, String> contextStoreForAll() {
+  public Map<String, String> contextStore() {
     return singletonMap("java.util.concurrent.RunnableFuture", State.class.getName());
   }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/RunnableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/RunnableInstrumentation.java
@@ -39,7 +39,7 @@ public final class RunnableInstrumentation extends Instrumenter.Tracing
   }
 
   @Override
-  public Map<String, String> contextStoreForAll() {
+  public Map<String, String> contextStore() {
     return singletonMap(Runnable.class.getName(), State.class.getName());
   }
 

--- a/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/context/client/RmiClientContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/context/client/RmiClientContextInstrumentation.java
@@ -55,7 +55,7 @@ public class RmiClientContextInstrumentation extends Instrumenter.Tracing
   }
 
   @Override
-  public Map<String, String> contextStoreForAll() {
+  public Map<String, String> contextStore() {
     // caching if a connection can support enhanced format
     return singletonMap("sun.rmi.transport.Connection", "java.lang.Boolean");
   }

--- a/dd-java-agent/testing/src/test/java/context/FieldInjectionTestInstrumentation.java
+++ b/dd-java-agent/testing/src/test/java/context/FieldInjectionTestInstrumentation.java
@@ -48,7 +48,7 @@ public class FieldInjectionTestInstrumentation extends Instrumenter.Tracing
   }
 
   @Override
-  public Map<String, String> contextStoreForAll() {
+  public Map<String, String> contextStore() {
     final Map<String, String> store = new HashMap<>();
     String prefix = getClass().getName() + "$";
     store.put(prefix + "KeyClass", prefix + "Context");

--- a/dd-java-agent/testing/src/test/java/excludefilter/ExcludeFilterTestInstrumentation.java
+++ b/dd-java-agent/testing/src/test/java/excludefilter/ExcludeFilterTestInstrumentation.java
@@ -26,7 +26,7 @@ public class ExcludeFilterTestInstrumentation extends Instrumenter.Tracing
   public void adviceTransformations(AdviceTransformation transformation) {}
 
   @Override
-  public Map<String, String> contextStoreForAll() {
+  public Map<String, String> contextStore() {
     Map<String, String> contextStores = new HashMap<>();
     contextStores.put(Runnable.class.getName(), Object.class.getName());
     contextStores.put(Executor.class.getName(), Object.class.getName());


### PR DESCRIPTION
The only places using this method don't have custom `classLoaderMatcher`s, so it doesn't add value. It also makes the `Instrumenter` API fragile as it relies on implementers choosing the right method for a corner-case that no longer exists (where an `Instrumenter` with a narrow `classLoaderMatcher` wants to use a context store available to all) - imho if this corner-case ever comes up again it would be better to solve it in how we apply field-injection rather than leak this into the API.

For example both `JavaForkJoinTaskInstrumentation` and `JavaForkJoinPoolInstrumentation` declare a context-store for `java.util.concurrent.ForkJoinTask`, but one declared it with `contextStoreForAll` while the other used `contextStore` :)