### PR TITLE
Drop redundant classLoaderMatchers

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSClientInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.aws.v0;
 
-import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.declaresField;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
@@ -23,14 +22,6 @@ public final class AWSClientInstrumentation extends Instrumenter.Tracing
 
   public AWSClientInstrumentation() {
     super("aws-sdk");
-  }
-
-  static final ElementMatcher<ClassLoader> CLASS_LOADER_MATCHER =
-      hasClassesNamed("com.amazonaws.AmazonWebServiceRequest");
-
-  @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
-    return CLASS_LOADER_MATCHER;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSHttpClientInstrumentation.java
@@ -1,7 +1,6 @@
 package datadog.trace.instrumentation.aws.v0;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static datadog.trace.instrumentation.aws.v0.AWSClientInstrumentation.CLASS_LOADER_MATCHER;
 import static datadog.trace.instrumentation.aws.v0.OnErrorDecorator.DECORATE;
 import static datadog.trace.instrumentation.aws.v0.OnErrorDecorator.SCOPE_CONTEXT_KEY;
 import static net.bytebuddy.matcher.ElementMatchers.isAbstract;
@@ -16,7 +15,6 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import net.bytebuddy.asm.Advice;
-import net.bytebuddy.matcher.ElementMatcher;
 
 /**
  * This is additional 'helper' to catch cases when HTTP request throws exception different from
@@ -29,11 +27,6 @@ public class AWSHttpClientInstrumentation extends Instrumenter.Tracing
 
   public AWSHttpClientInstrumentation() {
     super("aws-sdk");
-  }
-
-  @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
-    return CLASS_LOADER_MATCHER;
   }
 
   @Override
@@ -78,11 +71,6 @@ public class AWSHttpClientInstrumentation extends Instrumenter.Tracing
    */
   @AutoService(Instrumenter.class)
   public static final class RequestExecutorInstrumentation extends AWSHttpClientInstrumentation {
-
-    @Override
-    public ElementMatcher<ClassLoader> classLoaderMatcher() {
-      return CLASS_LOADER_MATCHER;
-    }
 
     @Override
     public String instrumentedType() {

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsJmsMessageInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsJmsMessageInstrumentation.java
@@ -1,7 +1,6 @@
 package datadog.trace.instrumentation.aws.v1.sqs;
 
 import static com.amazon.sqs.javamessaging.SQSMessagingClientConstants.STRING;
-import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -14,7 +13,6 @@ import datadog.trace.api.Config;
 import java.util.Map;
 import javax.jms.JMSException;
 import net.bytebuddy.asm.Advice;
-import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(Instrumenter.class)
 public class SqsJmsMessageInstrumentation extends Instrumenter.Tracing
@@ -26,11 +24,6 @@ public class SqsJmsMessageInstrumentation extends Instrumenter.Tracing
   @Override
   protected boolean defaultEnabled() {
     return super.defaultEnabled() && Config.get().isSqsPropagationEnabled();
-  }
-
-  @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
-    return hasClassesNamed("com.amazon.sqs.javamessaging.message.SQSMessage");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsReceiveRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsReceiveRequestInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.aws.v1.sqs;
 
-import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static java.util.Arrays.asList;
@@ -14,7 +13,6 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.Config;
 import java.util.List;
 import net.bytebuddy.asm.Advice;
-import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(Instrumenter.class)
 public class SqsReceiveRequestInstrumentation extends Instrumenter.Tracing
@@ -26,11 +24,6 @@ public class SqsReceiveRequestInstrumentation extends Instrumenter.Tracing
   @Override
   protected boolean defaultEnabled() {
     return super.defaultEnabled() && Config.get().isSqsPropagationEnabled();
-  }
-
-  @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
-    return hasClassesNamed("com.amazonaws.services.sqs.model.ReceiveMessageRequest");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/guava-10/src/main/java/datadog/trace/instrumentation/guava10/ListenableFutureInstrumentation.java
+++ b/dd-java-agent/instrumentation/guava-10/src/main/java/datadog/trace/instrumentation/guava10/ListenableFutureInstrumentation.java
@@ -33,6 +33,9 @@ public class ListenableFutureInstrumentation extends Instrumenter.Tracing
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    // prevents Runnable from being instrumented unless this
+    // instrumentation would take effect (unless something else
+    // instruments it).
     return CLASS_LOADER_MATCHER;
   }
 

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/client/WebClientFilterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/client/WebClientFilterInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.springwebflux.client;
 
-import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -8,7 +7,6 @@ import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(Instrumenter.class)
 public class WebClientFilterInstrumentation extends Instrumenter.Tracing
@@ -16,12 +14,6 @@ public class WebClientFilterInstrumentation extends Instrumenter.Tracing
 
   public WebClientFilterInstrumentation() {
     super("spring-webflux", "spring-webflux-client");
-  }
-
-  @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
-    // Optimization for expensive typeMatcher.
-    return hasClassesNamed("org.springframework.web.reactive.function.client.WebClient");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/tomcat-appsec-6/src/main/java/datadog/trace/instrumentation/tomcat6/ParsedBodyParametersInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-appsec-6/src/main/java/datadog/trace/instrumentation/tomcat6/ParsedBodyParametersInstrumentation.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.tomcat6;
 
-import static datadog.trace.agent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static datadog.trace.api.gateway.Events.EVENTS;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static net.bytebuddy.matcher.ElementMatchers.*;
@@ -34,11 +33,6 @@ public class ParsedBodyParametersInstrumentation extends Instrumenter.AppSec
 
   public ParsedBodyParametersInstrumentation() {
     super("tomcat");
-  }
-
-  @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
-    return hasClassesNamed("org.apache.tomcat.util.http.Parameters");
   }
 
   @Override


### PR DESCRIPTION
These instrumentations match on class names and have no context-stores so they don't need class-loader filtering.

Also document that the class-loader matcher in ListenableFutureInstrumentation helps avoid Runnable instrumentation when Guava is not on the classpath.