### PR TITLE
Appsec: basic grpc support

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
@@ -86,6 +86,8 @@ public interface KnownAddresses {
   Address<CaseInsensitiveMap<List<String>>> HEADERS_NO_COOKIES =
       new Address<>("server.request.headers.no_cookies");
 
+  Address<Object> GRPC_SERVER_REQUEST_MESSAGE = new Address<>("grpc.server.request.message");
+
   static Address<?> forName(String name) {
     switch (name) {
       case "server.request.body":
@@ -124,6 +126,8 @@ public interface KnownAddresses {
         return REQUEST_QUERY;
       case "server.request.headers.no_cookies":
         return HEADERS_NO_COOKIES;
+      case "grpc.server.request.message":
+        return GRPC_SERVER_REQUEST_MESSAGE;
       default:
         return null;
     }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecification.groovy
@@ -27,12 +27,13 @@ class KnownAddressesSpecification extends Specification {
       "server.request.body.combined_file_size",
       "server.request.query",
       "server.request.headers.no_cookies",
+      "grpc.server.request.message"
     ]
   }
 
   void 'number of known addresses is expected number'() {
     expect:
-    Address.instanceCount() == 18
-    KnownAddresses.HEADERS_NO_COOKIES.serial == Address.instanceCount() - 1
+    Address.instanceCount() == 19
+    KnownAddresses.GRPC_SERVER_REQUEST_MESSAGE.serial == Address.instanceCount() - 1
   }
 }

--- a/dd-smoke-tests/appsec/springboot-grpc/springboot-grpc.gradle
+++ b/dd-smoke-tests/appsec/springboot-grpc/springboot-grpc.gradle
@@ -1,0 +1,31 @@
+plugins {
+  id "com.github.johnrengelman.shadow"
+}
+
+ext {
+  minJavaVersionForTests = JavaVersion.VERSION_1_8
+}
+
+apply from: "$rootDir/gradle/java.gradle"
+
+// The standard spring-boot plugin doesn't play nice with our project
+// so we'll build a fat jar instead
+jar {
+  manifest {
+    attributes('Main-Class': 'datadog.smoketest.appsec.springboot.SpringbootApplication')
+  }
+}
+
+dependencies {
+  testImplementation project(':dd-smoke-tests:appsec')
+  testImplementation project(':dd-smoke-tests:springboot-grpc')
+}
+
+tasks.withType(Test).configureEach {
+  evaluationDependsOn ':dd-smoke-tests:springboot-grpc'
+  dependsOn ':dd-smoke-tests:springboot-grpc:shadowJar'
+
+  Task shadowJarTask = project(':dd-smoke-tests:springboot-grpc').tasks['shadowJar']
+
+  jvmArgs "-Ddatadog.smoketest.appsec.springboot-grpc.shadowJar.path=${shadowJarTask.archivePath}"
+}

--- a/dd-smoke-tests/appsec/springboot-grpc/src/test/groovy/datadog/smoketest/appsec/SpringBootWithGRPCAppSecTest.groovy
+++ b/dd-smoke-tests/appsec/springboot-grpc/src/test/groovy/datadog/smoketest/appsec/SpringBootWithGRPCAppSecTest.groovy
@@ -1,0 +1,52 @@
+package datadog.smoketest.appsec
+
+
+import okhttp3.Request
+
+class SpringBootWithGRPCAppSecTest extends AbstractAppSecServerSmokeTest {
+
+  @Override
+  ProcessBuilder createProcessBuilder() {
+    String springBootShadowJar = System.getProperty("datadog.smoketest.appsec.springboot-grpc.shadowJar.path")
+    assert springBootShadowJar != null
+
+    List<String> command = [
+      javaPath(),
+      *defaultJavaProperties,
+      *defaultAppSecProperties,
+      "-jar",
+      springBootShadowJar,
+      "--server.port=${httpPort}"
+    ].collect { it as String }
+
+    ProcessBuilder processBuilder = new ProcessBuilder(command)
+    processBuilder.directory(new File(buildDirectory))
+  }
+
+  static final String ROUTE = 'async_annotation_greeting'
+
+  def greeter() {
+    setup:
+    String url = "http://localhost:${httpPort}/${ROUTE}"
+    def request = new Request.Builder()
+      .url("${url}?message=${'.htaccess'.bytes.encodeBase64()}")
+      .get().build()
+
+    when:
+    def response = client.newCall(request).execute()
+
+    then:
+    def responseBodyStr = response.body().string()
+    responseBodyStr != null
+    responseBodyStr.contains("bye")
+    response.body().contentType().toString().contains("text/plain")
+    response.code() == 200
+
+    and:
+    waitForTraceCount(2) == 2
+    rootSpans.size() == 2
+    def grpcRootSpan = rootSpans.find { it.triggers }
+    grpcRootSpan.triggers[0]['rule']['tags']['type'] == 'lfi'
+    grpcRootSpan.triggers[0]['rule_matches'][0]['parameters']['address'][0] == 'grpc.server.request.message'
+  }
+}

--- a/dd-smoke-tests/springboot-grpc/src/main_java8/java/datadog/smoketest/springboot/AsyncTask.java
+++ b/dd-smoke-tests/springboot-grpc/src/main_java8/java/datadog/smoketest/springboot/AsyncTask.java
@@ -13,7 +13,7 @@ public class AsyncTask {
   }
 
   @Async
-  public CompletableFuture<String> greet() {
-    return CompletableFuture.completedFuture(greeter.greet());
+  public CompletableFuture<String> greet(String message) {
+    return CompletableFuture.completedFuture(greeter.greet(message));
   }
 }

--- a/dd-smoke-tests/springboot-grpc/src/main_java8/java/datadog/smoketest/springboot/controller/WebController.java
+++ b/dd-smoke-tests/springboot-grpc/src/main_java8/java/datadog/smoketest/springboot/controller/WebController.java
@@ -3,13 +3,15 @@ package datadog.smoketest.springboot.controller;
 import datadog.smoketest.springboot.AsyncTask;
 import datadog.smoketest.springboot.grpc.AsynchronousGreeter;
 import datadog.smoketest.springboot.spanner.SpannerTask;
-import java.util.concurrent.Callable;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -35,31 +37,28 @@ public class WebController {
   }
 
   @RequestMapping("/async_cf_greeting")
-  public String asyncCompleteableFutureGreeting() {
+  public String asyncCompleteableFutureGreeting(
+      @RequestParam(value = "message", defaultValue = "aGVsbG8=" /*hello*/) final String message) {
+    final String decodedMsg = decodeBase64(message);
     CompletableFuture<String>[] cfs = new CompletableFuture[20];
     for (int i = 0; i < cfs.length; ++i) {
       cfs[i] =
           CompletableFuture.supplyAsync(() -> "something", pool)
-              .thenApplyAsync(x -> asyncGreeter.greet(), pool);
+              .thenApplyAsync(x -> asyncGreeter.greet(decodedMsg), pool);
     }
     return CompletableFuture.allOf(cfs).thenApply(x -> "bye").join();
   }
 
   @RequestMapping("/async_concurrent_greeting")
   @SuppressWarnings("unchecked")
-  public String asyncConcurrentGreeting() throws Exception {
+  public String asyncConcurrentGreeting(
+      @RequestParam(value = "message", defaultValue = "aGVsbG8=") final String message)
+      throws Exception {
     // more tasks than threads to force some parallel activity
     // onto the same threads
     Future[] futures = new Future[20];
     for (int i = 0; i < futures.length; ++i) {
-      futures[i] =
-          pool.submit(
-              new Callable<String>() {
-                @Override
-                public String call() {
-                  return asyncGreeter.greet();
-                }
-              });
+      futures[i] = pool.submit(() -> asyncGreeter.greet(decodeBase64(message)));
     }
     String response = "";
     for (Future<String> f : futures) {
@@ -69,7 +68,12 @@ public class WebController {
   }
 
   @RequestMapping("async_annotation_greeting")
-  public String asyncAnnotationGreeting() {
-    return asyncTask.greet().join();
+  public String asyncAnnotationGreeting(
+      @RequestParam(value = "message", defaultValue = "aGVsbG8=") final String message) {
+    return asyncTask.greet(decodeBase64(message)).join();
+  }
+
+  private static String decodeBase64(String str) {
+    return new String(Base64.getDecoder().decode(str), StandardCharsets.US_ASCII);
   }
 }

--- a/dd-smoke-tests/springboot-grpc/src/main_java8/java/datadog/smoketest/springboot/grpc/AsynchronousGreeter.java
+++ b/dd-smoke-tests/springboot-grpc/src/main_java8/java/datadog/smoketest/springboot/grpc/AsynchronousGreeter.java
@@ -17,7 +17,7 @@ public class AsynchronousGreeter implements AutoCloseable {
     this.impl = GreeterGrpc.newStub(channel);
   }
 
-  public String greet() {
+  public String greet(String message) {
     final AtomicReference<String> response = new AtomicReference<>();
     final CountDownLatch latch = new CountDownLatch(1);
     StreamObserver<Response> observer =
@@ -37,7 +37,7 @@ public class AsynchronousGreeter implements AutoCloseable {
             latch.countDown();
           }
         };
-    impl.hello(Request.newBuilder().setMessage("hello").build(), observer);
+    impl.hello(Request.newBuilder().setMessage(message).build(), observer);
     try {
       latch.await(30, TimeUnit.SECONDS);
       return response.get();

--- a/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
@@ -166,6 +166,18 @@ public final class Events<D> {
     return (EventType<Function<RequestContext<D>, Flow<Void>>>) RESPONSE_HEADER_DONE;
   }
 
+  static final int GRPC_SERVER_REQUEST_MESSAGE_ID = 13;
+
+  @SuppressWarnings("rawtypes")
+  private static final EventType GRPC_SERVER_REQUEST_MESSAGE =
+      new ET<>("grpc.server.request.message", GRPC_SERVER_REQUEST_MESSAGE_ID);
+  /** All response headers have been provided */
+  @SuppressWarnings("unchecked")
+  public EventType<BiFunction<RequestContext<D>, Object, Flow<Void>>> grpcServerRequestMessage() {
+    return (EventType<BiFunction<RequestContext<D>, Object, Flow<Void>>>)
+        GRPC_SERVER_REQUEST_MESSAGE;
+  }
+
   static final int MAX_EVENTS = nextId.get();
 
   private static final class ET<T> extends EventType<T> {

--- a/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
@@ -226,6 +226,7 @@ public class InstrumentationGateway implements CallbackProvider, SubscriptionSer
                 }
               }
             };
+      case GRPC_SERVER_REQUEST_MESSAGE_ID:
       case REQUEST_BODY_CONVERTED_ID:
         return (C)
             new BiFunction<RequestContext, Object, Flow<Void>>() {

--- a/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
@@ -145,6 +145,9 @@ public class InstrumentationGatewayTest {
     gateway.registerCallback(events.requestBodyProcessed(), callback);
     assertThat(gateway.getCallback(events.requestBodyProcessed()).apply(null, null).getAction())
         .isEqualTo(Flow.Action.Noop.INSTANCE);
+    gateway.registerCallback(events.grpcServerRequestMessage(), callback);
+    assertThat(gateway.getCallback(events.grpcServerRequestMessage()).apply(null, null).getAction())
+        .isEqualTo(Flow.Action.Noop.INSTANCE);
     gateway.registerCallback(events.responseStarted(), callback);
     gateway.getCallback(events.responseStarted()).apply(null, null);
     gateway.registerCallback(events.responseHeader(), callback);
@@ -186,6 +189,9 @@ public class InstrumentationGatewayTest {
         .isEqualTo(Flow.Action.Noop.INSTANCE);
     gateway.registerCallback(events.requestBodyProcessed(), throwback);
     assertThat(gateway.getCallback(events.requestBodyProcessed()).apply(null, null).getAction())
+        .isEqualTo(Flow.Action.Noop.INSTANCE);
+    gateway.registerCallback(events.grpcServerRequestMessage(), throwback);
+    assertThat(gateway.getCallback(events.grpcServerRequestMessage()).apply(null, null).getAction())
         .isEqualTo(Flow.Action.Noop.INSTANCE);
     gateway.registerCallback(events.responseStarted(), throwback);
     gateway.getCallback(events.responseStarted()).apply(null, null);

--- a/settings.gradle
+++ b/settings.gradle
@@ -93,6 +93,7 @@ include ':dd-smoke-tests:vertx-3.9-resteasy'
 include ':dd-smoke-tests:wildfly'
 include ':dd-smoke-tests:appsec'
 include ':dd-smoke-tests:appsec:springboot'
+include ':dd-smoke-tests:appsec:springboot-grpc'
 
 // instrumentation:
 include ':dd-java-agent:instrumentation:aerospike-4'


### PR DESCRIPTION
Basic implementation of interception of server received GRPC messages and their delivery to the instrumentation gateway and the appsec subsystem. Because there might me multiple messages per grpc server span (which creates an appsec request context), the grpc message is not saved along with other appsec data, and the WAF run is one-shot as well (no accumulation of data).

A limitation is that these messages are all reported in the grpc server span and for long running requests there may be many of them.
