### PR TITLE
Make dd.trace.header.tags apply to both request and response headers

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -56,6 +56,9 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_RA
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_RAW_RESOURCE
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_TAG_QUERY_STRING
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ASYNC_TIMEOUT_ERROR
+import static datadog.trace.api.config.TracerConfig.HEADER_TAGS
+import static datadog.trace.api.config.TracerConfig.REQUEST_HEADER_TAGS
+import static datadog.trace.api.config.TracerConfig.RESPONSE_HEADER_TAGS
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan
@@ -89,6 +92,15 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     ig.registerCallback(events.responseHeader(), callbacks.responseHeaderCb)
     ig.registerCallback(events.responseHeaderDone(), callbacks.responseHeaderDoneCb)
     ig.registerCallback(events.requestPathParams(), callbacks.requestParamsCb)
+  }
+
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+
+    injectSysConfig(HEADER_TAGS, 'x-datadog-test-both-header:both_header_tag')
+    injectSysConfig(REQUEST_HEADER_TAGS, 'x-datadog-test-request-header:request_header_tag')
+    // We don't inject a matching response header tag here since it would be always on and show up in all the tests
   }
 
   @Shared
@@ -475,6 +487,70 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     where:
     method = "GET"
     body = null
+  }
+
+  def "test success with request header #header tag mapping"() {
+    setup:
+    def request = request(SUCCESS, method, body)
+      .header(header, value)
+      .build()
+    def response = client.newCall(request).execute()
+
+    expect:
+    response.code() == SUCCESS.status
+    response.body().string() == SUCCESS.body
+
+    and:
+    assertTraces(1) {
+      trace(spanCount(SUCCESS)) {
+        sortSpansByStart()
+        serverSpan(it, null, null, method, SUCCESS, tags)
+        if (hasHandlerSpan()) {
+          handlerSpan(it)
+        }
+        controllerSpan(it)
+        if (hasResponseSpan(SUCCESS)) {
+          responseSpan(it, SUCCESS)
+        }
+      }
+    }
+
+    where:
+    method | body | header                           | value | tags
+    'GET'  | null | 'x-datadog-test-both-header'     | 'foo' | [ 'both_header_tag': 'foo' ]
+    'GET'  | null | 'x-datadog-test-request-header'  | 'bar' | [ 'request_header_tag': 'bar' ]
+  }
+
+  def "test #endpoint with response header #header tag mapping"() {
+    setup:
+    injectSysConfig(HTTP_SERVER_TAG_QUERY_STRING, "true")
+    injectSysConfig(RESPONSE_HEADER_TAGS, "$header:$mapping")
+    def request = request(endpoint, method, body)
+      .build()
+    def response = client.newCall(request).execute()
+
+    expect:
+    response.code() == endpoint.status
+    response.body().string() == endpoint.body
+
+    and:
+    assertTraces(1) {
+      trace(spanCount(endpoint)) {
+        sortSpansByStart()
+        serverSpan(it, null, null, method, endpoint, tags)
+        if (hasHandlerSpan()) {
+          handlerSpan(it, endpoint)
+        }
+        controllerSpan(it)
+        if (hasResponseSpan(endpoint)) {
+          responseSpan(it, endpoint)
+        }
+      }
+    }
+
+    where:
+    endpoint           | method | body | header             | mapping                      | tags
+    QUERY_ENCODED_BOTH | 'GET'  | null | IG_RESPONSE_HEADER | 'mapped_response_header_tag' | [ 'mapped_response_header_tag': "$IG_RESPONSE_HEADER_VALUE" ]
   }
 
   def "test tag query string for #endpoint rawQuery=#rawQuery"() {
@@ -989,7 +1065,12 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
   // If you ever feel the need to make this method non final and override it with something that is almost the
   // same, but has a slightly different behavior, then please think again, and see if you can't make that part
   // of the integrations very special behavior into something configurable here instead.
-  final void serverSpan(TraceAssert trace, BigInteger traceID = null, BigInteger parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
+  final void serverSpan(TraceAssert trace,
+    BigInteger traceID = null,
+    BigInteger parentID = null,
+    String method = "GET",
+    ServerEndpoint endpoint = SUCCESS,
+    Map<String, Serializable> extraTags = null) {
     Object expectedServerSpanRoute = expectedServerSpanRoute(endpoint)
     Map<String, Serializable> expectedExtraErrorInformation = hasExtraErrorInformation() ? expectedExtraErrorInformation(endpoint) : null
     boolean hasPeerInformation = hasPeerInformation()
@@ -1042,6 +1123,9 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
         //        }
         defaultTags(true)
         addTags(expectedExtraServerTags)
+        if (extraTags) {
+          it.addTags(extraTags)
+        }
       }
     }
   }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -38,6 +38,8 @@ public final class TracerConfig {
   public static final String TRACE_RATE_LIMIT = "trace.rate.limit";
   public static final String TRACE_REPORT_HOSTNAME = "trace.report-hostname";
   public static final String HEADER_TAGS = "trace.header.tags";
+  public static final String REQUEST_HEADER_TAGS = "trace.request_header.tags";
+  public static final String RESPONSE_HEADER_TAGS = "trace.response_header.tags";
   public static final String TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING =
       "trace.http.server.path-resource-name-mapping";
   public static final String HTTP_SERVER_ERROR_STATUSES = "http.server.error.statuses";

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -327,12 +327,12 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       sampler(Sampler.Builder.<DDSpan>forConfig(config));
       instrumentationGateway(new InstrumentationGateway());
       injector(HttpCodec.createInjector(config));
-      extractor(HttpCodec.createExtractor(config, config.getHeaderTags()));
+      extractor(HttpCodec.createExtractor(config, config.getRequestHeaderTags()));
       // Explicitly skip setting scope manager because it depends on statsDClient
       localRootSpanTags(config.getLocalRootSpanTags());
       defaultSpanTags(config.getMergedSpanTags());
       serviceNameMappings(config.getServiceMapping());
-      taggedHeaders(config.getHeaderTags());
+      taggedHeaders(config.getRequestHeaderTags());
       partialFlushMinSpans(config.getPartialFlushMinSpans());
       strictTraceWrites(config.isTraceStrictWritesEnabled());
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/TagContextExtractor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/TagContextExtractor.java
@@ -6,8 +6,7 @@ import java.util.Map;
 
 public class TagContextExtractor implements HttpCodec.Extractor {
 
-  // here to keep a legacy test happy
-  private final Map<String, String> taggedHeaders;
+  protected final Map<String, String> taggedHeaders;
   private final ThreadLocal<ContextInterpreter> ctxInterpreter;
 
   public TagContextExtractor(

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -178,9 +178,9 @@ class CoreTracerTest extends DDCoreSpecification {
     tracer.close()
 
     where:
-    mapString       | map
-    "a:1, a:2, a:3" | [a: "3"]
-    "a:b,c:d,e:"    | [a: "b", c: "d"]
+    mapString               | map
+    "a:one, a:two, a:three" | [a: "three"]
+    "a:b,c:d,e:"            | [a: "b", c: "d"]
   }
 
   def "verify overriding host"() {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
@@ -85,6 +85,11 @@ public final class ConfigProvider {
     return defaultValue;
   }
 
+  public final boolean isSet(String key) {
+    String value = getString(key);
+    return value != null && !value.isEmpty();
+  }
+
   public final Boolean getBoolean(String key) {
     return get(key, null, Boolean.class);
   }
@@ -162,7 +167,7 @@ public final class ConfigProvider {
 
   public final Map<String, String> getMergedMap(String key) {
     Map<String, String> merged = new HashMap<>();
-    // System properties take precendence over env
+    // System properties take precedence over env
     // prior art:
     // https://docs.spring.io/spring-boot/docs/1.5.6.RELEASE/reference/html/boot-features-external-config.html
     // We reverse iterate to allow overrides
@@ -175,7 +180,7 @@ public final class ConfigProvider {
 
   public final Map<String, String> getOrderedMap(String key) {
     LinkedHashMap<String, String> map = new LinkedHashMap<>();
-    // System properties take precendence over env
+    // System properties take precedence over env
     // prior art:
     // https://docs.spring.io/spring-boot/docs/1.5.6.RELEASE/reference/html/boot-features-external-config.html
     // We reverse iterate to allow overrides
@@ -184,6 +189,23 @@ public final class ConfigProvider {
       map.putAll(ConfigConverter.parseOrderedMap(value, key));
     }
     return map;
+  }
+
+  public final Map<String, String> getMergedMapWithOptionalMappings(
+      String defaultPrefix, boolean lowercaseKeys, String... keys) {
+    Map<String, String> merged = new HashMap<>();
+    // System properties take precedence over env
+    // prior art:
+    // https://docs.spring.io/spring-boot/docs/1.5.6.RELEASE/reference/html/boot-features-external-config.html
+    // We reverse iterate to allow overrides
+    for (String key : keys) {
+      for (int i = sources.length - 1; 0 <= i; i--) {
+        String value = sources[i].get(key);
+        merged.putAll(
+            ConfigConverter.parseMapWithOptionalMappings(value, key, defaultPrefix, lowercaseKeys));
+      }
+    }
+    return merged;
   }
 
   public BitSet getIntegerRange(final String key, final BitSet defaultValue) {

--- a/internal-api/src/main/java/datadog/trace/util/Strings.java
+++ b/internal-api/src/main/java/datadog/trace/util/Strings.java
@@ -189,6 +189,11 @@ public final class Strings {
     return "dd." + setting;
   }
 
+  @Nonnull
+  public static String trim(final String string) {
+    return null == string ? "" : string.trim();
+  }
+
   private static String hex(char ch) {
     return Integer.toHexString(ch).toUpperCase(Locale.ENGLISH);
   }

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -66,6 +66,8 @@ import static datadog.trace.api.config.TracerConfig.AGENT_HOST
 import static datadog.trace.api.config.TracerConfig.AGENT_PORT_LEGACY
 import static datadog.trace.api.config.TracerConfig.AGENT_UNIX_DOMAIN_SOCKET
 import static datadog.trace.api.config.TracerConfig.HEADER_TAGS
+import static datadog.trace.api.config.TracerConfig.REQUEST_HEADER_TAGS
+import static datadog.trace.api.config.TracerConfig.RESPONSE_HEADER_TAGS
 import static datadog.trace.api.config.TracerConfig.HTTP_CLIENT_ERROR_STATUSES
 import static datadog.trace.api.config.TracerConfig.HTTP_SERVER_ERROR_STATUSES
 import static datadog.trace.api.config.TracerConfig.ID_GENERATION_STRATEGY
@@ -139,7 +141,7 @@ class ConfigTest extends DDSpecification {
     prop.setProperty(GLOBAL_TAGS, "b:2")
     prop.setProperty(SPAN_TAGS, "c:3")
     prop.setProperty(JMX_TAGS, "d:4")
-    prop.setProperty(HEADER_TAGS, "e:5")
+    prop.setProperty(HEADER_TAGS, "e:five")
     prop.setProperty(HTTP_SERVER_ERROR_STATUSES, "123-456,457,124-125,122")
     prop.setProperty(HTTP_CLIENT_ERROR_STATUSES, "111")
     prop.setProperty(HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "true")
@@ -203,7 +205,7 @@ class ConfigTest extends DDSpecification {
     config.serviceMapping == [a: "1"]
     config.mergedSpanTags == [b: "2", c: "3"]
     config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName]
-    config.headerTags == [e: "5"]
+    config.requestHeaderTags == [e: "five"]
     config.httpServerErrorStatuses == toBitSet((122..457))
     config.httpClientErrorStatuses == toBitSet((111..111))
     config.httpClientSplitByDomain == true
@@ -267,7 +269,7 @@ class ConfigTest extends DDSpecification {
     System.setProperty(PREFIX + GLOBAL_TAGS, "b:2")
     System.setProperty(PREFIX + SPAN_TAGS, "c:3")
     System.setProperty(PREFIX + JMX_TAGS, "d:4")
-    System.setProperty(PREFIX + HEADER_TAGS, "e:5")
+    System.setProperty(PREFIX + HEADER_TAGS, "e:five")
     System.setProperty(PREFIX + HTTP_SERVER_ERROR_STATUSES, "123-456,457,124-125,122")
     System.setProperty(PREFIX + HTTP_CLIENT_ERROR_STATUSES, "111")
     System.setProperty(PREFIX + HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "true")
@@ -329,7 +331,7 @@ class ConfigTest extends DDSpecification {
     config.serviceMapping == [a: "1"]
     config.mergedSpanTags == [b: "2", c: "3"]
     config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName]
-    config.headerTags == [e: "5"]
+    config.requestHeaderTags == [e: "five"]
     config.httpServerErrorStatuses == toBitSet((122..457))
     config.httpClientErrorStatuses == toBitSet((111..111))
     config.httpClientSplitByDomain == true
@@ -460,7 +462,7 @@ class ConfigTest extends DDSpecification {
     config.traceResolverEnabled == true
     config.serviceMapping == [:]
     config.mergedSpanTags == [:]
-    config.headerTags == [:]
+    config.requestHeaderTags == [:]
     config.httpServerErrorStatuses == toBitSet((500..599))
     config.httpClientErrorStatuses == toBitSet((400..499))
     config.httpClientSplitByDomain == false
@@ -532,7 +534,7 @@ class ConfigTest extends DDSpecification {
     properties.setProperty(GLOBAL_TAGS, "b:2")
     properties.setProperty(SPAN_TAGS, "c:3")
     properties.setProperty(JMX_TAGS, "d:4")
-    properties.setProperty(HEADER_TAGS, "e:5")
+    properties.setProperty(HEADER_TAGS, "e:five")
     properties.setProperty(HTTP_SERVER_ERROR_STATUSES, "123-456,457,124-125,122")
     properties.setProperty(HTTP_CLIENT_ERROR_STATUSES, "111")
     properties.setProperty(HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "true")
@@ -563,7 +565,7 @@ class ConfigTest extends DDSpecification {
     config.serviceMapping == [a: "1"]
     config.mergedSpanTags == [b: "2", c: "3"]
     config.mergedJmxTags == [b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName]
-    config.headerTags == [e: "5"]
+    config.requestHeaderTags == [e: "five"]
     config.httpServerErrorStatuses == toBitSet((122..457))
     config.httpClientErrorStatuses == toBitSet((111..111))
     config.httpClientSplitByDomain == true
@@ -886,13 +888,19 @@ class ConfigTest extends DDSpecification {
 
   def "verify mapping configs on tracer for #mapString"() {
     setup:
+    System.setProperty(PREFIX + HEADER_TAGS + ".legacy.parsing.enabled", "true")
     System.setProperty(PREFIX + SERVICE_MAPPING, mapString)
     System.setProperty(PREFIX + SPAN_TAGS, mapString)
     System.setProperty(PREFIX + HEADER_TAGS, mapString)
+    System.setProperty(PREFIX + REQUEST_HEADER_TAGS, "rqh1")
+    System.setProperty(PREFIX + RESPONSE_HEADER_TAGS, "rsh1")
     def props = new Properties()
+    props.setProperty(HEADER_TAGS + ".legacy.parsing.enabled", "true")
     props.setProperty(SERVICE_MAPPING, mapString)
     props.setProperty(SPAN_TAGS, mapString)
     props.setProperty(HEADER_TAGS, mapString)
+    props.setProperty(PREFIX + REQUEST_HEADER_TAGS, "rqh1")
+    props.setProperty(PREFIX + RESPONSE_HEADER_TAGS, "rsh1")
 
     when:
     def config = new Config()
@@ -901,10 +909,12 @@ class ConfigTest extends DDSpecification {
     then:
     config.serviceMapping == map
     config.spanTags == map
-    config.headerTags == map
+    config.requestHeaderTags == map
+    config.responseHeaderTags == [:]
     propConfig.serviceMapping == map
     propConfig.spanTags == map
-    propConfig.headerTags == map
+    propConfig.requestHeaderTags == map
+    propConfig.responseHeaderTags == [:]
 
     where:
     // spotless:off
@@ -944,6 +954,71 @@ class ConfigTest extends DDSpecification {
     ":,:,:,:,"                                                    | [:]
     ": : : : "                                                    | [:]
     "::::"                                                        | [:]
+    // spotless:on
+  }
+
+  def "verify mapping header tags on tracer for #mapString"() {
+    setup:
+    Map<String, String> rqMap = map.clone()
+    rqMap.put("rqh1", "http.request.headers.rqh1")
+    System.setProperty(PREFIX + HEADER_TAGS, mapString)
+    System.setProperty(PREFIX + REQUEST_HEADER_TAGS, "rqh1")
+    System.setProperty(PREFIX + RESPONSE_HEADER_TAGS, "rsh1")
+    Map<String, String> rsMap = map.collectEntries { k, v -> [k, v.replace("http.request.headers", "http.response.headers")]}
+    rsMap.put("rsh1", "http.response.headers.rsh1")
+    def props = new Properties()
+    props.setProperty(HEADER_TAGS, mapString)
+    props.setProperty(PREFIX + REQUEST_HEADER_TAGS, "rQh1")
+    props.setProperty(PREFIX + RESPONSE_HEADER_TAGS, "rsH1")
+
+    when:
+    def config = new Config()
+    def propConfig = Config.get(props)
+
+    then:
+    config.requestHeaderTags == rqMap
+    propConfig.requestHeaderTags == rqMap
+    config.responseHeaderTags == rsMap
+    propConfig.responseHeaderTags == rsMap
+
+    where:
+    // spotless:off
+    mapString                                                     | map
+    "a:one, a:two, a:three"                                       | [a: "three"]
+    "a:b,c:d,e:"                                                  | [a: "b", c: "d"]
+    // space separated
+    "a:one  a:two  a:three"                                       | [a: "three"]
+    "a:b c:d e:"                                                  | [a: "b", c: "d"]
+    // More different string variants:
+    "a:"                                                          | [:]
+    "a:a;"                                                        | [a: "a;"]
+    "a:one, a:two, a:three"                                       | [a: "three"]
+    "a:one  a:two  a:three"                                       | [a: "three"]
+    "a:b,c:d,e:"                                                  | [a: "b", c: "d"]
+    "a:b c:d e:"                                                  | [a: "b", c: "d"]
+    "key=1!:va|ue_1,"                                             | ["key=1!": "va|ue_1"]
+    "key=1!:va|ue_1 "                                             | ["key=1!": "va|ue_1"]
+    " kEy1 :vaLue1 ,\t keY2:  valUe2"                             | [key1: "vaLue1", key2: "valUe2"]
+    "a:b,c,D"                                                     | [a: "b", c: "http.request.headers.c", d: "http.request.headers.d"]
+    "a:b,C,d,k:v"                                                 | [a: "b", c: "http.request.headers.c", d: "http.request.headers.d", k: "v"]
+    "a b c:d "                                                    | [a: "http.request.headers.a", b: "http.request.headers.b", c: "d"]
+    "dyno:web.1 dynotype:web buildpackversion:dev appname:n*****" | ["dyno": "web.1", "dynotype": "web", "buildpackversion": "dev", "appname": "n*****"]
+    "A.1,B.1"                                                     | ["a.1": "http.request.headers.a_1", "b.1": "http.request.headers.b_1"]
+    // Invalid strings:
+    ""                                                            | [:]
+    "1"                                                           | [:]
+    "a:1"                                                         | [:]
+    "a,1"                                                         | [:]
+    "in:val:id"                                                   | [:]
+    "a:b,in:val:id,x:y"                                           | [:]
+    "a:b:c:d"                                                     | [:]
+    "!a"                                                          | [:]
+    "    "                                                        | [:]
+    ",,,,"                                                        | [:]
+    ":,:,:,:,"                                                    | [:]
+    ": : : : "                                                    | [:]
+    "::::"                                                        | [:]
+    "kEy1 :value1  \t keY2:  value2"                              | [:]
     // spotless:on
   }
 
@@ -1000,7 +1075,7 @@ class ConfigTest extends DDSpecification {
     then:
     config.serviceMapping == map
     config.spanTags == map
-    config.headerTags == map
+    config.requestHeaderTags == map
 
     where:
     mapString | map
@@ -1258,7 +1333,7 @@ class ConfigTest extends DDSpecification {
     prop.setProperty(GLOBAL_TAGS, "b:2")
     prop.setProperty(SPAN_TAGS, "c:3")
     prop.setProperty(JMX_TAGS, "d:4")
-    prop.setProperty(HEADER_TAGS, "e:5")
+    prop.setProperty(HEADER_TAGS, "e:five")
     prop.setProperty(PROFILING_TAGS, "f:6")
     prop.setProperty(ENV, "eu-east")
     prop.setProperty(VERSION, "43")
@@ -1270,7 +1345,7 @@ class ConfigTest extends DDSpecification {
     config.mergedSpanTags == [a: "1", b: "2", c: "3", (ENV): "eu-east", (VERSION): "43"]
     config.mergedJmxTags == [a               : "1", b: "2", d: "4", (ENV): "eu-east", (VERSION): "43",
       (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName]
-    config.headerTags == [e: "5"]
+    config.requestHeaderTags == [e: "five"]
 
     config.mergedProfilingTags == [a            : "1", b: "2", f: "6", (ENV): "eu-east", (VERSION): "43",
       (HOST_TAG)   : config.getHostName(), (RUNTIME_ID_TAG): config.getRuntimeId(),
@@ -1283,7 +1358,7 @@ class ConfigTest extends DDSpecification {
     System.setProperty(PREFIX + GLOBAL_TAGS, "b:2")
     System.setProperty(PREFIX + SPAN_TAGS, "c:3")
     System.setProperty(PREFIX + JMX_TAGS, "d:4")
-    System.setProperty(PREFIX + HEADER_TAGS, "e:5")
+    System.setProperty(PREFIX + HEADER_TAGS, "e:five")
     System.setProperty(PREFIX + PROFILING_TAGS, "f:6")
 
     when:
@@ -1292,7 +1367,7 @@ class ConfigTest extends DDSpecification {
     then:
     config.mergedSpanTags == [a: "1", b: "2", c: "3"]
     config.mergedJmxTags == [a: "1", b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName]
-    config.headerTags == [e: "5"]
+    config.requestHeaderTags == [e: "five"]
 
     config.mergedProfilingTags == [a: "1", b: "2", f: "6", (HOST_TAG): config.getHostName(), (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
   }
@@ -1303,7 +1378,7 @@ class ConfigTest extends DDSpecification {
     environmentVariables.set(DD_GLOBAL_TAGS_ENV, "b:2")
     environmentVariables.set(DD_SPAN_TAGS_ENV, "c:3")
     environmentVariables.set(DD_JMX_TAGS_ENV, "d:4")
-    environmentVariables.set(DD_HEADER_TAGS_ENV, "e:5")
+    environmentVariables.set(DD_HEADER_TAGS_ENV, "e:five")
     environmentVariables.set(DD_PROFILING_TAGS_ENV, "f:6")
 
     when:
@@ -1312,7 +1387,7 @@ class ConfigTest extends DDSpecification {
     then:
     config.mergedSpanTags == [a: "1", b: "2", c: "3"]
     config.mergedJmxTags == [a: "1", b: "2", d: "4", (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName]
-    config.headerTags == [e: "5"]
+    config.requestHeaderTags == [e: "five"]
 
     config.mergedProfilingTags == [a: "1", b: "2", f: "6", (HOST_TAG): config.getHostName(), (RUNTIME_ID_TAG): config.getRuntimeId(), (SERVICE_TAG): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
   }


### PR DESCRIPTION
# What Does This Do

Make dd.trace.header.tags apply to both request and response headers

* Key only headers are automatically mapped to `http.request.headers.*` and `http.response.headers.*` for cross tracer consistency
* Setting of request and response header mappings separately via `dd.trace.request_header.tags` and `dd.trace.response_header.tags`
* Revert to old parsing and behavior via `dd.trace.header.tags.legacy.parsing=true`

# Motivation

The Java Tracer behavior of only mapping request header tags is inconsistent with other Datadog tracers.

# Additional Notes

- [ ] There needs to be a doc PR before this is released