### PR TITLE
Ignore Spring Boot example unmatched packages

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -32,11 +32,16 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
         || name.startsWith("com.github.mustachejava.")
         || name.startsWith("com.jayway.jsonpath.")
         || name.startsWith("com.lightbend.lagom.")
+        || name.startsWith("com.netflix.graphql.")
         || name.startsWith("javax.el.")
         || name.startsWith("net.sf.cglib.")
+        || name.startsWith("org.antlr.")
+        || name.startsWith("org.apache.ibatis.")
         || name.startsWith("org.apache.lucene.")
         || name.startsWith("org.apache.tartarus.")
+        || name.startsWith("org.hibernate.validator.")
         || name.startsWith("org.json.simple.")
+        || name.startsWith("org.flywaydb.")
         || name.startsWith("org.yaml.snakeyaml.")) {
       return true;
     }
@@ -59,6 +64,12 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
           || name.startsWith("org.springframework.orm.")
           || name.startsWith("org.springframework.remoting.")
           || name.startsWith("org.springframework.scripting.")
+          || (name.startsWith("org.springframework.security.config.")
+              // Runnables
+              && !name.startsWith(
+                  "org.springframework.security.config.annotation.web.builders.WebSecurity$")
+              && !name.startsWith(
+                  "org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter$"))
           || name.startsWith("org.springframework.stereotype.")
           || name.startsWith("org.springframework.transaction.")
           || name.startsWith("org.springframework.ui.")


### PR DESCRIPTION
# What Does This Do

Filters out some Spring Boot sample app libraries "com.netflix.graphql.", "org.antlr.", "org.apache.ibatis.", "org.hibernate.validator.", "org.flywaydb." and "org.springframework.security.config."

# Motivation

This provides instrumentation time improvement around: 0.26s

<img width="1255" alt="image" src="https://user-images.githubusercontent.com/4147346/155239755-db465f49-bc15-4cab-827e-b129e777b507.png">

# Additional Notes

| package | classes | time (s) |
|---------|---------|---------|
| com.netflix.graphql | 102 | 0.032134 |
| org.antlr.v4 | 137 | 0.029614 |
| org.hibernate.validator | 451 | 0.160034 |
| org.apache.ibatis | 303 | 0.058716 |
| org.flywaydb.core | 222 | 0.040988 |
| org.springframework.security.config | 110 | 0.051863 |

