### PR TITLE
[Appsec] Move to libsqreen w/ finalizers; add guardrails

### DIFF
--- a/dd-java-agent/appsec/appsec.gradle
+++ b/dd-java-agent/appsec/appsec.gradle
@@ -23,7 +23,7 @@ dependencies {
   api deps.slf4j
   implementation project(':internal-api')
   implementation project(':communication')
-  implementation group: 'io.sqreen', name: 'libsqreen', version: '3.0.7'
+  implementation group: 'io.sqreen', name: 'libsqreen', version: '3.0.8'
   implementation group: 'com.squareup.moshi', name: 'moshi', version: versions.moshi
 
   annotationProcessor deps.autoserviceProcessor

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -96,6 +96,13 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   }
 
   public void setAdditive(Additive additive) {
+    Additive curAdditive = this.additive;
+    // the better check would be if the curAdditive has been closed,
+    // but this is behind a private field
+    if (curAdditive != null && additive != null) {
+      log.warn("Replacing WAF object. This is a bug");
+      curAdditive.close();
+    }
     this.additive = additive;
   }
 
@@ -297,7 +304,11 @@ public class AppSecRequestContext implements DataBundle, Closeable {
 
   @Override
   public void close() {
-    // currently no-op
+    if (additive != null) {
+      log.warn("WAF object had not been closed (probably missed request-end event)");
+      additive.close();
+      additive = null;
+    }
   }
 
   /* end interface for GatewayBridge */

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/AppSecRequestContextSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/AppSecRequestContextSpecification.groovy
@@ -1,17 +1,22 @@
 package com.datadog.appsec.gateway
 
+import com.datadog.appsec.config.AppSecConfig
 import com.datadog.appsec.event.data.DataBundle
 import com.datadog.appsec.event.data.KnownAddresses
 import com.datadog.appsec.event.data.MapDataBundle
 import com.datadog.appsec.event.data.StringKVPair
 import com.datadog.appsec.report.raw.events.AppSecEvent100
+import com.datadog.appsec.test.StubAppSecConfigService
 import datadog.trace.test.util.DDSpecification
+import io.sqreen.powerwaf.Additive
+import io.sqreen.powerwaf.Powerwaf
+import io.sqreen.powerwaf.PowerwafContext
 
 class AppSecRequestContextSpecification extends DDSpecification {
 
-  void 'implements DataBundle'() {
-    DataBundle ctx = new AppSecRequestContext()
+  AppSecRequestContext ctx = new AppSecRequestContext()
 
+  void 'implements DataBundle'() {
     when:
     ctx.addAll(MapDataBundle.of(KnownAddresses.REQUEST_URI_RAW, '/a'))
 
@@ -36,8 +41,6 @@ class AppSecRequestContextSpecification extends DDSpecification {
   }
 
   void 'it is closeable'() {
-    def ctx = new AppSecRequestContext()
-
     expect:
     assert ctx.respondsTo('close')
 
@@ -49,8 +52,6 @@ class AppSecRequestContextSpecification extends DDSpecification {
   }
 
   void 'adding headers after they are said to be finished is forbidden'() {
-    AppSecRequestContext ctx = new AppSecRequestContext()
-
     when:
     ctx.finishRequestHeaders()
 
@@ -69,8 +70,6 @@ class AppSecRequestContextSpecification extends DDSpecification {
   }
 
   void 'adding uri a second time is forbidden'() {
-    AppSecRequestContext ctx = new AppSecRequestContext()
-
     when:
     ctx.rawURI = '/a'
     ctx.rawURI = '/b'
@@ -81,8 +80,6 @@ class AppSecRequestContextSpecification extends DDSpecification {
   }
 
   void 'saves cookies and other headers'() {
-    AppSecRequestContext ctx = new AppSecRequestContext()
-
     when:
     ctx.addCookie(new StringKVPair('a', 'c'))
     ctx.addRequestHeader('user-agent', 'foo')
@@ -93,8 +90,6 @@ class AppSecRequestContextSpecification extends DDSpecification {
   }
 
   void 'can save the URI'() {
-    AppSecRequestContext ctx = new AppSecRequestContext()
-
     when:
     ctx.savedRawURI = '/a'
 
@@ -103,8 +98,6 @@ class AppSecRequestContextSpecification extends DDSpecification {
   }
 
   void 'can collect events'() {
-    AppSecRequestContext ctx = new AppSecRequestContext()
-
     when:
     ctx.reportEvents([new AppSecEvent100(), new AppSecEvent100()], null)
     def events = ctx.transferCollectedEvents()
@@ -122,10 +115,7 @@ class AppSecRequestContextSpecification extends DDSpecification {
   }
 
   void 'collect events when none reported'() {
-    when:
-    AppSecRequestContext ctx = new AppSecRequestContext()
-
-    then:
+    expect:
     ctx.transferCollectedEvents().empty
   }
 
@@ -137,9 +127,6 @@ class AppSecRequestContextSpecification extends DDSpecification {
   }
 
   void 'basic headers collection test'() {
-    given:
-    def ctx = new AppSecRequestContext()
-
     when:
     ctx.addRequestHeader('Host', '127.0.0.1')
     ctx.addRequestHeader('Content-Type', 'text/html; charset=UTF-8')
@@ -155,9 +142,6 @@ class AppSecRequestContextSpecification extends DDSpecification {
   }
 
   void 'null headers should be ignored'() {
-    given:
-    def ctx = new AppSecRequestContext()
-
     when:
     ctx.addRequestHeader(null, 'value')
     ctx.addRequestHeader('key', null)
@@ -167,9 +151,6 @@ class AppSecRequestContextSpecification extends DDSpecification {
   }
 
   void 'concat multiple values for same header'() {
-    given:
-    def ctx = new AppSecRequestContext()
-
     when:
     ctx.addRequestHeader('Custom-Header', 'value1')
     ctx.addRequestHeader('CUSTOM-HEADER', 'value2')
@@ -180,5 +161,45 @@ class AppSecRequestContextSpecification extends DDSpecification {
     ctx.requestHeaders == [
       'custom-header': ['value1', 'value2'],
       'accept': ['application/json', 'application/xml']] as Map
+  }
+
+  private Additive createAdditive() {
+    Powerwaf.initialize false
+    def service = new StubAppSecConfigService()
+    service.init false
+    AppSecConfig config = service.lastConfig['waf']
+    String uniqueId = UUID.randomUUID() as String
+    PowerwafContext context = Powerwaf.createContext(uniqueId, config.rawConfig)
+    new Additive(context)
+  }
+
+  void 'replacing the additive closes the previous one'() {
+    setup:
+    def additive1 = createAdditive()
+    def additive2 = createAdditive()
+
+    when:
+    ctx.additive = additive1
+    ctx.additive = additive2
+
+    then:
+    additive1.online == false
+    additive2.online == true
+
+    cleanup:
+    [additive1, additive2].findAll {it.online }*.close()
+  }
+
+  void 'close closes the additive'() {
+    setup:
+    def additive = createAdditive()
+
+    when:
+    ctx.additive = additive
+    ctx.close()
+
+    then:
+    ctx.additive == null
+    additive.online == false
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -47,6 +47,8 @@ import datadog.trace.core.scopemanager.ContinuableScopeManager;
 import datadog.trace.core.taginterceptor.RuleFlags;
 import datadog.trace.core.taginterceptor.TagInterceptor;
 import datadog.trace.util.AgentTaskScheduler;
+import java.io.Closeable;
+import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -731,6 +733,17 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       }
       if (null != rootSpan) {
         onRootSpanFinished(rootSpan, published);
+
+        // request context is propagated to contexts in child spans
+        // Assume here that if present it will be so starting in the top span
+        RequestContext<Object> requestContext = rootSpan.getRequestContext();
+        if (requestContext != null && requestContext.getData() instanceof Closeable) {
+          try {
+            ((Closeable) requestContext.getData()).close();
+          } catch (IOException e) {
+            log.warn("Error closing request context data", e);
+          }
+        }
       }
     }
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -312,6 +312,30 @@ class DDSpanTest extends DDCoreSpecification {
     new ExtractedContext(DDId.from(123), DDId.from(456), PrioritySampling.SAMPLER_KEEP, SamplingMechanism.DEFAULT, "789", 0, [:], [:], null) | false
   }
 
+  def 'publishing of root span closes the request context data'() {
+    setup:
+    def reqContextData = Mock(Closeable)
+    def context = new TagContext().withRequestContextData(reqContextData)
+    def root = tracer.buildSpan("root").asChildOf(context).start()
+    def child = tracer.buildSpan("child").asChildOf(root).start()
+
+    expect:
+    root.requestContext.data.is(reqContextData)
+    child.requestContext.data.is(reqContextData)
+
+    when:
+    child.finish()
+
+    then:
+    0 * reqContextData.close()
+
+    when:
+    root.finish()
+
+    then:
+    1 * reqContextData.close()
+  }
+
   def "infer top level from parent service name"() {
     when:
     DDSpanContext context =


### PR DESCRIPTION
# What Does This Do

Moves to libsqreen to version 3.0.8, which removes `finalize()` implementations. Adds extra checks to make it more likely that `Additive` objects are closed and don't leak memory.

# Motivation

So that we don't pay the performance penalty of having `finalize()` methods.

# Additional Notes

Perhaps different strategies for calling `close()` when the root span finishes are more appropriate, like using `TraceInterceptor`.