### PR TITLE
User attribution (identify) API (AppSec)

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/GlobalTracer.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/GlobalTracer.java
@@ -31,6 +31,11 @@ public class GlobalTracer {
 
         @Override
         public void addScopeListener(ScopeListener listener) {}
+
+        @Override
+        public UserDetails addUserDetails(String userId) {
+          return NoopUserDetails.INSTANCE;
+        }
       };
 
   private static final Collection<Callback> installationCallbacks = new ArrayList<>();

--- a/dd-trace-api/src/main/java/datadog/trace/api/Tracer.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Tracer.java
@@ -29,4 +29,78 @@ public interface Tracer {
    * @param listener listener to attach
    */
   void addScopeListener(ScopeListener listener);
+
+  /**
+   * Add tags identifying the user associated with the request.
+   *
+   * <p>Only an arbitrary (but unique) user id is required. The remaining data can be set by calling
+   * the <code>withXXX</code> methods on the returned {@link UserDetails} object.
+   *
+   * <p>The information is transmitted in tags of the local root span. All the tags are prefixed by
+   * <code>usr.</code> (e.g. <code>usr.id</code>).
+   *
+   * <p>This is a noop in case there is no active trace.
+   *
+   * @param userId an arbitrary string identifying the user, or null/empty string to remove the tag
+   *     <code>usr.id</code>
+   * @return an object that allows setting further tags.
+   */
+  UserDetails addUserDetails(String userId);
+
+  /** Object used to set <code>usr.*</code> tags in the local root span. */
+  interface UserDetails {
+    String ID_TAG = "usr.id";
+    String NAME_TAG = "usr.name";
+    String EMAIL_TAG = "usr.email";
+    String SESSION_ID_TAG = "usr.session_id";
+    String ROLE_TAG = "usr.role";
+
+    UserDetails withEmail(String email);
+
+    UserDetails withName(String name);
+
+    UserDetails withSessionId(String sessionId);
+
+    UserDetails withRole(String role);
+
+    /**
+     * Sets a tag in the local root span to associate arbitrary data with the user.
+     *
+     * @param tagSuffix the suffix of the tag, after <code>usr.</code>
+     * @param value the value of the tag. If null, the call is a noop
+     * @return this object, for setting further tags
+     */
+    UserDetails withCustomData(String tagSuffix, String value);
+  }
+
+  class NoopUserDetails implements UserDetails {
+    public static final UserDetails INSTANCE = new NoopUserDetails();
+
+    private NoopUserDetails() {}
+
+    @Override
+    public UserDetails withEmail(String email) {
+      return this;
+    }
+
+    @Override
+    public UserDetails withName(String name) {
+      return this;
+    }
+
+    @Override
+    public UserDetails withSessionId(String sessionId) {
+      return this;
+    }
+
+    @Override
+    public UserDetails withRole(String role) {
+      return this;
+    }
+
+    @Override
+    public UserDetails withCustomData(String tagSuffix, String value) {
+      return this;
+    }
+  }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpanUserDetails.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpanUserDetails.java
@@ -1,0 +1,42 @@
+package datadog.trace.api.interceptor;
+
+import datadog.trace.api.Tracer;
+
+public final class MutableSpanUserDetails implements Tracer.UserDetails {
+  private final MutableSpan rootSpan;
+
+  public MutableSpanUserDetails(MutableSpan agentSpan) {
+    rootSpan = agentSpan;
+  }
+
+  @Override
+  public Tracer.UserDetails withEmail(String email) {
+    rootSpan.setTag(EMAIL_TAG, email);
+    return this;
+  }
+
+  @Override
+  public Tracer.UserDetails withName(String name) {
+    rootSpan.setTag(NAME_TAG, name);
+    return this;
+  }
+
+  @Override
+  public Tracer.UserDetails withSessionId(String sessionId) {
+    rootSpan.setTag(SESSION_ID_TAG, sessionId);
+    return this;
+  }
+
+  @Override
+  public Tracer.UserDetails withRole(String role) {
+    rootSpan.setTag(ROLE_TAG, role);
+    return this;
+  }
+
+  @Override
+  public Tracer.UserDetails withCustomData(String tagSuffix, String value) {
+    String tag = "usr." + tagSuffix;
+    rootSpan.setTag(tag, value);
+    return this;
+  }
+}

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/interceptor/MutableSpanUserDetailsTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/interceptor/MutableSpanUserDetailsTest.groovy
@@ -1,0 +1,33 @@
+package datadog.trace.api.interceptor
+
+import spock.lang.Specification
+
+class MutableSpanUserDetailsTest extends Specification {
+  MutableSpan span = Mock()
+  MutableSpanUserDetails userDetails = new MutableSpanUserDetails(span)
+
+  void '#method method set the correct tag'() {
+    when:
+    def ret = userDetails."$method"('foobar')
+
+    then:
+    1 * span.setTag(tagName, 'foobar')
+    ret.is(userDetails)
+
+    where:
+    method          | tagName
+    'withEmail'     | 'usr.email'
+    'withName'      | 'usr.name'
+    'withSessionId' | 'usr.session_id'
+    'withRole'      | 'usr.role'
+  }
+
+  void 'withCustomData correctly prefixes the tag'() {
+    when:
+    def ret = userDetails.withCustomData('foo', 'bar')
+
+    then:
+    ret.is(userDetails)
+    1 * span.setTag('usr.foo', 'bar')
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -21,6 +21,7 @@ import datadog.trace.api.config.GeneralConfig;
 import datadog.trace.api.gateway.InstrumentationGateway;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.interceptor.MutableSpan;
+import datadog.trace.api.interceptor.MutableSpanUserDetails;
 import datadog.trace.api.interceptor.TraceInterceptor;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.api.sampling.SamplingMechanism;
@@ -790,6 +791,18 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     if (scopeManager instanceof ContinuableScopeManager) {
       ((ContinuableScopeManager) scopeManager).addScopeListener(listener);
     }
+  }
+
+  @Override
+  public UserDetails addUserDetails(String userId) {
+    AgentSpan agentSpan = scopeManager.activeSpan();
+    if (agentSpan == null) {
+      return NoopUserDetails.INSTANCE;
+    }
+
+    AgentSpan rootSpan = agentSpan.getLocalRootSpan();
+    rootSpan.setTag(UserDetails.ID_TAG, userId);
+    return new MutableSpanUserDetails(rootSpan);
   }
 
   @Override

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -4,6 +4,8 @@ import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.GlobalTracer;
 import datadog.trace.api.StatsDClient;
+import datadog.trace.api.interceptor.MutableSpan;
+import datadog.trace.api.interceptor.MutableSpanUserDetails;
 import datadog.trace.api.interceptor.TraceInterceptor;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -432,6 +434,18 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer {
   @Override
   public void addScopeListener(final ScopeListener listener) {
     tracer.addScopeListener(listener);
+  }
+
+  @Override
+  public UserDetails addUserDetails(String userId) {
+    Span span = activeSpan();
+    if (!(span instanceof MutableSpan)) {
+      return NoopUserDetails.INSTANCE;
+    }
+
+    MutableSpan rootSpan = ((MutableSpan) span).getLocalRootSpan();
+    rootSpan.setTag(UserDetails.ID_TAG, userId);
+    return new MutableSpanUserDetails(rootSpan);
   }
 
   @Override

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DDTracerAPITest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DDTracerAPITest.groovy
@@ -1,9 +1,12 @@
 package datadog.opentracing
 
-
+import datadog.trace.api.interceptor.MutableSpan
+import datadog.trace.common.sampling.AllSampler
 import datadog.trace.common.sampling.RateByServiceSampler
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.test.util.DDSpecification
+import io.opentracing.Scope
+import io.opentracing.Span
 
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME
 import static datadog.trace.api.DDTags.LANGUAGE_TAG_KEY
@@ -26,6 +29,45 @@ class DDTracerAPITest extends DDSpecification {
     tracer.writer == writer
     tracer.localRootSpanTags[RUNTIME_ID_TAG].size() > 0 // not null or empty
     tracer.localRootSpanTags[LANGUAGE_TAG_KEY] == LANGUAGE_TAG_VALUE
+
+    cleanup:
+    tracer.close()
+  }
+
+
+  def 'tracer reports user details on the top span'() {
+    setup:
+    List<MutableSpan> spans
+    datadog.trace.common.writer.Writer writer = Mock()
+    DDTracer tracer = new DDTracer(DEFAULT_SERVICE_NAME, writer, new AllSampler())
+
+    when:
+    Span root = tracer.buildSpan('operation').start()
+    Scope scopeRoot = tracer.activateSpan(root)
+    Span child = tracer.buildSpan('my_child').asChildOf(root).start()
+    Scope scopeChild = tracer.activateSpan(child)
+    tracer.addUserDetails('my-user-id')
+      .withName('John Smith')
+      .withEmail('foo@example.com')
+      .withRole('admin')
+      .withSessionId('the-session-id')
+      .withCustomData('custom', 'data')
+    scopeChild.close()
+    child.finish()
+    scopeRoot.close()
+    root.finish()
+
+    then:
+    1 * writer.write(_) >> { spans = it[0] }
+    spans[0].operationName == 'operation'
+    spans[0].tags.findAll { it.key.startsWith('usr.') } == [
+      'usr.id': 'my-user-id',
+      'usr.name': 'John Smith',
+      'usr.email': 'foo@example.com',
+      'usr.role': 'admin',
+      'usr.session_id': 'the-session-id',
+      'usr.custom': 'data'
+    ]
 
     cleanup:
     tracer.close()

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -309,6 +309,11 @@ public class AgentTracer {
     public void addScopeListener(final ScopeListener listener) {}
 
     @Override
+    public UserDetails addUserDetails(String userId) {
+      return NoopUserDetails.INSTANCE;
+    }
+
+    @Override
     public void registerCheckpointer(Checkpointer checkpointer) {}
 
     @Override

--- a/internal-api/src/test/groovy/datadog/trace/api/WithGlobalTracerForkedTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/WithGlobalTracerForkedTest.groovy
@@ -35,6 +35,11 @@ class WithGlobalTracerForkedTest extends DDSpecification {
     @Override
     void addScopeListener(ScopeListener listener) {
     }
+
+    @Override
+    Tracer.UserDetails addUserDetails(String userId) {
+      Tracer.NoopUserDetails.INSTANCE
+    }
   }
 
   def "should call the callback at the right time"() {


### PR DESCRIPTION
# What Does This Do

Implements the "User attribution (identify)" spec. It provides an API for the application programmer to specify user data associated with a request. This information is added in the form of tags to the root span.

# Additional Notes

See the spec on Google Docs.
