### PR TITLE
Mark PendingTrace as not enqueued when queue is full

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTraceBuffer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTraceBuffer.java
@@ -49,6 +49,8 @@ public abstract class PendingTraceBuffer implements AutoCloseable {
     public void enqueue(Element pendingTrace) {
       if (pendingTrace.setEnqueued(true)) {
         if (!queue.offer(pendingTrace)) {
+          // Mark it as not in the queue
+          pendingTrace.setEnqueued(false);
           // Queue is full, so we can't buffer this trace, write it out directly instead.
           pendingTrace.write();
         }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
@@ -172,7 +172,8 @@ class PendingTraceBufferTest extends DDSpecification {
     0 * _
 
     when:
-    addContinuation(newSpanOf(factory.create(DDId.ONE))).finish()
+    def pendingTrace = factory.create(DDId.ONE)
+    addContinuation(newSpanOf(pendingTrace)).finish()
 
     then:
     1 * bufferSpy.enqueue(_)
@@ -183,6 +184,7 @@ class PendingTraceBufferTest extends DDSpecification {
     1 * tracer.onStart(_)
     1 * tracer.onFinish(_)
     0 * _
+    pendingTrace.isEnqueued == 0
   }
 
   def "continuation allows adding after root finished"() {


### PR DESCRIPTION
# What Does This Do

Marks the `PendingTrace` as not enqueued when queue is full.

# Motivation

If we don't mark the `PendingTrace` as not enqueued, it will never be reenqueued and we might miss writing out further spans.

# Additional Notes

This issue doesn't need release notes, since it was introduced by #3406 and hasn't been released yet.
