### PR TITLE
Use correct parameter for report upload script on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,7 @@ jobs:
       - run:
           name: Upload test results to Datadog
           when: always
-          command: .circleci/upload_ciapp.sh base << parameters.testTask >> || true
+          command: .circleci/upload_ciapp.sh base << parameters.testJvm >> || true
 
   instrumentation_tests:
     <<: *base_tests
@@ -287,7 +287,7 @@ jobs:
       - run:
           name: Upload test results to Datadog
           when: always
-          command: .circleci/upload_ciapp.sh instrumentation << parameters.testTask >> || true
+          command: .circleci/upload_ciapp.sh instrumentation << parameters.testJvm >> || true
 
   smoke_tests:
     <<: *base_tests
@@ -340,7 +340,7 @@ jobs:
       - run:
           name: Upload test results to Datadog
           when: always
-          command: .circleci/upload_ciapp.sh smoke << parameters.testTask >> || true
+          command: .circleci/upload_ciapp.sh smoke << parameters.testJvm >> || true
 
   # The only way to do fan-in in CircleCI seems to have a proper job, so let's have one that
   # doesn't consume so many resources. The execution time for this including spin up seems to
@@ -471,6 +471,7 @@ build_test_jobs: &build_test_jobs
         - build
       name: z_test_8_base
       testTask: test jacocoTestReport jacocoTestCoverageVerification
+      testJvm: "8"
 
   - instrumentation_tests:
       requires:
@@ -483,12 +484,14 @@ build_test_jobs: &build_test_jobs
       requires:
         - build
       name: z_test_8_inst
+      testJvm: "8"
 
   - instrumentation_tests:
       requires:
         - build
       name: test_8_inst_latest
       testTask: latestDepTest
+      testJvm: "8"
 
   - smoke_tests:
       requires:
@@ -501,6 +504,7 @@ build_test_jobs: &build_test_jobs
       requires:
         - build
       name: z_test_8_smoke
+      testJvm: "8"
 
   - fan_in:
       requires:

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -169,6 +169,8 @@ javadoc {
   }
 }
 
+def currentJavaHomePath = getJavaHomePath(System.getProperty("java.home"))
+
 project.afterEvaluate {
   def testJvm = gradle.startParameter.projectProperties["testJvm"]
   def javaTestLauncher = null as Provider<JavaLauncher>
@@ -183,20 +185,24 @@ project.afterEvaluate {
     if (!testJvmHome) {
       throw new GradleException("Unable to find launcher for Java '$testJvm'. Have you set '$testJvmEnv'?")
     }
-    def jvmSpec = new SpecificInstallationToolchainSpec(project.getObjects(), file(testJvmHome))
-    // Not really sure why this has to be done forcefully, but if it's not then gradle will complain that
-    // javaLauncher.metadata.taskInputs.languageVersion doesn't have a configured value (even though it is
-    // populated automatically by the javaToolchainsService)
-    jvmSpec.languageVersion.set(JavaLanguageVersion.of(testJvmLanguageVersion))
-    // The provider always says that a value is present so we need to wrap it for proper error messages
-    Provider<JavaLauncher> launcher = providers.provider {
-      try {
-        return javaToolchains.launcherFor(jvmSpec).get()
-      } catch (NoSuchElementException ignored) {
-        throw new GradleException("Unable to find launcher for Java $testJvm. Does '$testJvmHome' point to a JDK?")
+    def testJvmHomePath = getJavaHomePath(testJvmHome)
+    // Only change test JVM if it's not the one we are running the gradle build with
+    if (currentJavaHomePath != testJvmHomePath) {
+      def jvmSpec = new SpecificInstallationToolchainSpec(project.getObjects(), file(testJvmHomePath))
+      // Not really sure why this has to be done forcefully, but if it's not then gradle will complain that
+      // javaLauncher.metadata.taskInputs.languageVersion doesn't have a configured value (even though it is
+      // populated automatically by the javaToolchainsService)
+      jvmSpec.languageVersion.set(JavaLanguageVersion.of(testJvmLanguageVersion))
+      // The provider always says that a value is present so we need to wrap it for proper error messages
+      Provider<JavaLauncher> launcher = providers.provider {
+        try {
+          return javaToolchains.launcherFor(jvmSpec).get()
+        } catch (NoSuchElementException ignored) {
+          throw new GradleException("Unable to find launcher for Java $testJvm. Does '$testJvmHome' point to a JDK?")
+        }
       }
+      javaTestLauncher = launcher
     }
-    javaTestLauncher = launcher
   }
 
   tasks.withType(Test).configureEach {
@@ -306,6 +312,11 @@ def isJdkExcluded(String javaName) {
 
 def isTestingInstrumentation(Project project) {
   return ["junit-4.10", "testng-6.4", "junit-5.3"].contains(project.name)
+}
+
+def getJavaHomePath(String path) {
+  def javaHome = new File(path).toPath().toRealPath()
+  return javaHome.endsWith("jre") ? javaHome.parent : javaHome
 }
 
 // Go through the Test tasks and configure them


### PR DESCRIPTION
# What Does This Do

Changes the CI test result upload script to use the correct parameter.

# Motivation

TL;DR: Wrong parameter is wrong.

The `upload_ciapp.sh` script expects the JVM name as its second parameter, and previously that was in the aptly named `testTask` parameter, which now exclusively contains the actual test task, and not a mix.

# Additional Notes

The gradle configuration has also been updated to not override the test JVM if it is the same one that is running the gradle build, in the same way it did before.