### PR TITLE
Don't overwrite the shadow jar with the shared shadow jar

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/profiling-auxiliary-async.gradle
@@ -49,7 +49,6 @@ shadowJar {
     // TODO: modify the filter to include other OS/arch combinations once the overhead is evaluated
     rslt |= it.path == "native-libs" || it.path.startsWith("native-libs/linux-x64") || it.path.startsWith("native-libs/linux-musl-x64")
     rslt |= (it.path.contains("ap-tools") && it.path.endsWith(".jar"))
-    println ">>> ${it.path}: ${rslt}"
     return rslt
   }
 }

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -86,6 +86,12 @@ includeSubprojShadowJar ':dd-java-agent:appsec', 'appsec'
 
 def sharedShadowJar = tasks.register('sharedShadowJar', ShadowJar) {
   configurations = [project.configurations.sharedShadowInclude]
+  // Put the jar in a different directory so we don't overwrite the normal shadow jar and
+  // break caching, and also to not interfere with CI scripts that copy everything in the
+  // libs directory
+  it.destinationDirectory.set(file("${project.buildDir}/shared-lib"))
+  // Add a classifier so we don't confuse the jar file with the normal shadow jar
+  archiveClassifier = 'shared'
   it.dependencies {
     exclude(project(':dd-java-agent:agent-bootstrap'))
     exclude(project(':dd-java-agent:agent-logging'))


### PR DESCRIPTION
# What Does This Do

Ensures that the `shadowJar` file in the `dd-java-agent` directory doesn't get overwritten by the `sharedShadowJar` in the same project.

# Motivation

Having two jar files writing to the same name, where one depends on the other leads the gradle being unable to cache the results causing the two build steps to be repeated on every run that depends on the `:dd-java-agen:shadowJar` 

# Additional Notes

Completely unscientific measurements on my laptop got the time for being ready to run the tests of a smoke test down from 25s to 10s, if all the files had been compiled before.