### PR TITLE
Use lazy initialization for HandlerMappingResourceNameFilter

### DIFF
--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerMappingResourceNameFilter.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerMappingResourceNameFilter.java
@@ -92,6 +92,7 @@ public class HandlerMappingResourceNameFilter extends OncePerRequestFilter imple
       super(HandlerMappingResourceNameFilter.class);
       setBeanClassName(HandlerMappingResourceNameFilter.class.getName());
       setScope(SCOPE_SINGLETON);
+      setLazyInit(true);
     }
   }
 }


### PR DESCRIPTION
as the bean processor may not have access to all dependencies at configure time, for example when using Spring with OSGi