### PR TITLE
Bump async-profiler to 2.7-DD-20220303

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfiler.java
@@ -273,7 +273,9 @@ final class AuxiliaryAsyncProfiler implements AuxiliaryImplementation {
           .append(getCpuInterval())
           .append('m')
           .append(",jstackdepth=")
-          .append(getStackDepth());
+          .append(getStackDepth())
+          .append(",safemode=")
+          .append(getSafeMode());
     }
     if (profilingModes.contains(ProfilingMode.ALLOCATION)) {
       // allocation profiling is enabled
@@ -309,6 +311,12 @@ final class AuxiliaryAsyncProfiler implements AuxiliaryImplementation {
     return configProvider.getInteger(
         ProfilingConfig.PROFILING_ASYNC_CPU_STACKDEPTH,
         ProfilingConfig.PROFILING_ASYNC_CPU_STACKDEPTH_DEFAULT);
+  }
+
+  private int getSafeMode() {
+    return configProvider.getInteger(
+        ProfilingConfig.PROFILING_ASYNC_CPU_SAFEMODE,
+        ProfilingConfig.PROFILING_ASYNC_CPU_SAFEMODE_DEFAULT);
   }
 
   private String getCpuMode() {

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -72,6 +72,8 @@ public final class ProfilingConfig {
   public static final int PROFILING_ASYNC_CPU_INTERVAL_DEFAULT = 10;
   public static final String PROFILING_ASYNC_CPU_STACKDEPTH = "profiling.async.cpu.stackdepth";
   public static final int PROFILING_ASYNC_CPU_STACKDEPTH_DEFAULT = 512;
+  public static final String PROFILING_ASYNC_CPU_SAFEMODE = "profiling.async.cpu.safemode";
+  public static final int PROFILING_ASYNC_CPU_SAFEMODE_DEFAULT = 12; // POP_FRAME|SCAN_STACK
   public static final String PROFILING_ASYNC_MEMLEAK_ENABLED = "profiling.async.memleak.enabled";
   public static final boolean PROFILING_ASYNC_MEMLEAK_ENABLED_DEFAULT = false;
   public static final String PROFILING_ASYNC_MEMLEAK_INTERVAL = "profiling.async.memleak.interval";

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -29,7 +29,7 @@ final class CachedData {
     testcontainers: '1.15.0-rc2',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    asyncprofiler : "2.7-DD-20220301"
+    asyncprofiler : "2.7-DD-20220303"
   ]
 
   static deps = [

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -29,7 +29,7 @@ final class CachedData {
     testcontainers: '1.15.0-rc2',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    asyncprofiler : "2.6-DD-20220212"
+    asyncprofiler : "2.7-DD-20220301"
   ]
 
   static deps = [


### PR DESCRIPTION
Updates in async-profiler since last bump:
* Support for OpenJ9
* Dwarf stack unwinding
* Improve static analysis on CI
* Remove stacktrace field from jdk.ActiveSetting
* Logging improvements

Full diff at https://github.com/datadog/async-profiler/compare/DD-20220212...DD-20220303