### PR TITLE
Adjust Apache/Drill tracing to cover the shared superclass from Apache/Calcite that the Drill class delegates to

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
@@ -60,8 +60,9 @@ public class ConnectionInstrumentation extends AbstractConnectionInstrumentation
     "net.snowflake.client.jdbc.SnowflakeConnectionV1",
     // vertica
     "com.vertica.jdbc.common.SConnection",
-    // apache drill
-    "org.apache.drill.jdbc.impl.DrillConnectionImpl",
+    // this covers apache calcite/drill plus the drill-all uber-jar
+    "org.apache.calcite.avatica.AvaticaConnection",
+    "oadd.org.apache.calcite.avatica.AvaticaConnection",
     // jtds (for SQL Server and Sybase)
     "net.sourceforge.jtds.jdbc.JtdsConnection",
     // SAP HANA in-memory DB

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -95,8 +95,9 @@ public final class PreparedStatementInstrumentation extends AbstractPreparedStat
     "net.snowflake.client.jdbc.SnowflakePreparedStatementV1",
     // vertica
     "com.vertica.jdbc.common.SPreparedStatement",
-    // apache drill
-    "org.apache.drill.jdbc.impl.DrillPreparedStatementImpl",
+    // this covers apache calcite/drill plus the drill-all uber-jar
+    "org.apache.calcite.avatica.AvaticaPreparedStatement",
+    "oadd.org.apache.calcite.avatica.AvaticaPreparedStatement",
     // jtds (for SQL Server and Sybase)
     "net.sourceforge.jtds.jdbc.JtdsPreparedStatement",
     "net.sourceforge.jtds.jdbc.JtdsCallableStatement",


### PR DESCRIPTION
`DrillPreparedStatementImpl` extends `AvaticaPreparedStatement` and while it does override most of its methods it doesn’t override `executeQuery` - this means we need to move up to trace `AvaticaPreparedStatement` to catch that call

Tracing the super-class is safe here because `DrillPreparedStatementImpl` ends up calling the `AvaticaPreparedStatement` methods to do the actual work of talking to the database - the `DrillPreparedStatementImpl` sub-class just adds some pre/post-condition checks that we don’t need to cover with tracing, as well as some non-JDBC methods specific to Apache/Drill

This is slightly complicated by the fact that drill-jdbc-all-1.15.0.jar refactors its copy of `AvaticaPreparedStatement` under the `oadd` prefix, so we need to add it twice - once with and once without the prefix
