### PR TITLE
Add system tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -500,7 +500,7 @@ jobs:
           name: Run
           command: |
             cd system-tests
-            DD_API_KEY=$DATADOG_API_KEY ./run.sh
+            DD_API_KEY=$SYSTEM_TESTS_DD_API_KEY ./run.sh
 
       - store_artifacts:
           path: system-tests/logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -469,6 +469,18 @@ jobs:
           <<: *cache_keys
 
       - run:
+          name: Install good version of docker-compose
+          command: |
+            sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+            sudo chmod +x /usr/local/bin/docker-compose
+
+      - run:
+          name: versions
+          command: |
+            docker --version
+            docker-compose --version
+
+      - run:
           name: Clone System Tests repo
           command: git clone https://github.com/DataDog/system-tests.git
 
@@ -488,7 +500,7 @@ jobs:
           name: Run
           command: |
             cd system-tests
-            DD_API_KEY=todo ./run.sh
+            DD_API_KEY=$DATADOG_API_KEY ./run.sh
 
       - store_artifacts:
           path: system-tests/logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -456,6 +456,44 @@ jobs:
 
       - display_memory_usage
 
+  system-tests:
+    machine:
+      # https://support.circleci.com/hc/en-us/articles/360007324514-How-can-I-use-Docker-volume-mounting-on-CircleCI-
+      image: ubuntu-2004:current
+    resource_class: large
+    steps:
+
+      - setup_code
+
+      - restore_cache:
+          <<: *cache_keys
+
+      - run:
+          name: Clone System Tests repo
+          command: git clone https://github.com/DataDog/system-tests.git
+
+      - run:
+          name: Copy jar file to system test binaries folder
+          command: |
+            ls -la workspace/dd-java-agent/build/libs
+            cp workspace/dd-java-agent/build/libs/*.jar system-tests/binaries/
+
+      - run:
+          name: Build
+          command: |
+            cd system-tests
+            ./build.sh java
+
+      - run:
+          name: Run
+          command: |
+            cd system-tests
+            DD_API_KEY=todo ./run.sh
+
+      - store_artifacts:
+          path: system-tests/logs
+          destination: system-tests.tar.gz
+
 build_test_jobs: &build_test_jobs
   - build
 
@@ -541,6 +579,10 @@ build_test_jobs: &build_test_jobs
             - master
             - project/*
             - release/*
+
+  - system-tests:
+      requires:
+        - build
 
 workflows:
   build_test:


### PR DESCRIPTION
# What Does This Do

Add system tests in CI

# Motivation

System tests in a functional test workbench that perform black box testing across all tracers. More info here : https://github.com/DataDog/system-tests/tree/main/docs

## How it can helps ? 

* Validate that feature implementation are consistent across all tracers
* catch integration issues
* perform end-to-end testing
* Quite fast, adding new tests does not add noticeable CI time (well, actually, on java tracer, the build step is terribly long 😞 . The test phase itself takes 4mn )

## What are the non-goals

* unit test with test isolation
* provides good explanation about issues. It use black box testing, so even if you're trying to give good feedback, we are not able to dig inside components, so the information is often very poor.

## Flakynes ?

System tests are pretty stable. The build phase can be flaky if the third party service we rely on are not stable (and in case of java, sometimes very slow). But the tests phase is, as now, 99.99% stable. The only known source of flakiness is the missing configuration of WAF timeout on AppSec (the component is flaky, so the test is flaky), but the default value is quite high, so it's not an issue as now.   

## CI conf

As now, the CI is configured to run on all PR, and nightly. Feel free to change it to whatever you need, but please, just keep the nightly run, as we need it to display result on dashboards.