### PR TITLE
Add resource name priority for changes made through dd-trace-ot

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
@@ -2,6 +2,7 @@ package datadog.opentracing;
 
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
@@ -171,7 +172,7 @@ class OTSpan implements Span, MutableSpan {
 
   @Override
   public OTSpan setResourceName(final CharSequence resourceName) {
-    delegate.setResourceName(resourceName);
+    delegate.setResourceName(resourceName, ResourceNamePriorities.MANUAL_INSTRUMENTATION);
     return this;
   }
 

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/OTSpanTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/OTSpanTest.groovy
@@ -1,0 +1,47 @@
+package datadog.opentracing
+
+import datadog.trace.api.interceptor.MutableSpan
+import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities
+import datadog.trace.test.util.DDSpecification
+import io.opentracing.Scope
+import io.opentracing.Span
+import io.opentracing.util.GlobalTracer
+import spock.lang.Shared
+
+class OTSpanTest extends DDSpecification {
+  @Shared
+  DDTracer tracer = DDTracer.builder().build()
+
+  def setup() {
+    GlobalTracer.register(tracer)
+  }
+
+  def "test resource name assignment through MutableSpan casting"() {
+    given:
+    OTSpan testSpan = tracer.buildSpan("parent").withResourceName("test-resource").start() as OTSpan
+    OTScopeManager.OTScope testScope = tracer.activateSpan(testSpan) as OTScopeManager.OTScope
+
+    when:
+    Span active = GlobalTracer.get().activeSpan()
+    Span child = GlobalTracer.get().buildSpan("child").asChildOf(active).start()
+    Scope scope = GlobalTracer.get().activateSpan(child)
+
+    MutableSpan localRootSpan = ((MutableSpan) child).getLocalRootSpan()
+    localRootSpan.setResourceName("correct-resource")
+
+    then:
+    testSpan.getResourceName() == "correct-resource"
+
+    when:
+    testSpan.delegate.setResourceName("should-be-ignored", ResourceNamePriorities.HTTP_FRAMEWORK_ROUTE)
+
+    then:
+    testSpan.getResourceName() == "correct-resource"
+
+    cleanup:
+    scope.close()
+    child.finish()
+    testScope.close()
+    testSpan.finish()
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ResourceNamePriorities.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ResourceNamePriorities.java
@@ -7,4 +7,5 @@ public class ResourceNamePriorities {
   public static final byte HTTP_FRAMEWORK_ROUTE = 3;
   public static final byte HTTP_SERVER_CONFIG_PATTERN_MATCH = 4;
   public static final byte TAG_INTERCEPTOR = 5;
+  public static final byte MANUAL_INSTRUMENTATION = 5;
 }


### PR DESCRIPTION
# What Does This Do

Adds a priority level for resource names set by users using dd-trace-ot.

# Motivation

A customer issue where instrumentation was overwriting a resource name that they were adding to the root span

# Additional Notes
