### PR TITLE
Added extra parsing for property/env

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -552,7 +552,6 @@ public class Agent {
 
   private static void maybeStartAppSec(Class<?> scoClass, Object o) {
     if (APPSEC_CLASSLOADER == null) {
-      log.warn("AppSec ClassLoader has not been created");
       return;
     }
 
@@ -772,10 +771,10 @@ public class Agent {
 
     if (feature.isEnabledByDefault()) {
       // true unless it's explicitly set to "false"
-      return !"false".equalsIgnoreCase(featureEnabled);
+      return !("false".equalsIgnoreCase(featureEnabled) || "0".equals(featureEnabled));
     } else {
       // false unless it's explicitly set to "true"
-      return "true".equalsIgnoreCase(featureEnabled);
+      return Boolean.parseBoolean(featureEnabled) || "1".equals(featureEnabled);
     }
   }
 


### PR DESCRIPTION
# What Does This Do
Added extra parsing properties/env variables, in case if customer tries to enable feature(modules) with "0", "1".

# Motivation
In case, if try to enable module with value `1`, it will be displayed as enabled, but nothing in practice module will not be started.
For example if customer tries to enable AppSec with environment variable `DD_APPSEC_ENABLED=1`, the AppSec module will not be loaded, however in logs we will be able to see:
`DATADOG TRACER CONFIGURATION {... "appsec_enabled":true ...}`

# Additional Notes
The problem exist because of property/env reading happens in two places: in `Agent::isFeatureEnabled(...)` and in `Config` but with the different logic.
