### PR TITLE
Support long running spans

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -90,5 +90,8 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_CWS_ENABLED = false;
   static final int DEFAULT_CWS_TLS_REFRESH = 5000;
 
+  static final boolean DEFAULT_LONG_RUNNING_TRACE_ENABLED = false;
+  static final long DEFAULT_LONG_RUNNING_TRACE_FLUSH_INTERVAL = 300; // seconds -> 5 minutes
+
   private ConfigDefaults() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -37,4 +37,5 @@ public class DDTags {
   public static final String LANGUAGE_TAG_KEY = "language";
   public static final String LANGUAGE_TAG_VALUE = "jvm";
   public static final String ORIGIN_KEY = "_dd.origin";
+  public static final String DD_PARTIAL_VERSION = "_dd.partial_version";
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -62,9 +62,9 @@ public final class TracerConfig {
   public static final String ENABLE_TRACE_AGENT_V05 = "trace.agent.v0.5.enabled";
   public static final String SAMPLING_MECHANISM_VALIDATION_DISABLED =
       "trace.sampling.mechanism.validation.disabled";
-  public static final String LONG_RUNNING_TRACE_ENABLED = "trace.longrunning.enabled";
+  public static final String LONG_RUNNING_TRACE_ENABLED = "longrunning.enabled";
 
-  public static final String LONG_RUNNING_TRACE_FLUSH_INTERVAL = "trace.longrunning.flush.interval";
+  public static final String LONG_RUNNING_TRACE_FLUSH_INTERVAL = "longrunning.flush.interval";
 
   public static final String CLOCK_SYNC_PERIOD = "trace.clock.sync.period";
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -62,6 +62,9 @@ public final class TracerConfig {
   public static final String ENABLE_TRACE_AGENT_V05 = "trace.agent.v0.5.enabled";
   public static final String SAMPLING_MECHANISM_VALIDATION_DISABLED =
       "trace.sampling.mechanism.validation.disabled";
+  public static final String LONG_RUNNING_TRACE_ENABLED = "trace.longrunning.enabled";
+
+  public static final String LONG_RUNNING_TRACE_FLUSH_INTERVAL = "trace.longrunning.flush.interval";
 
   public static final String CLOCK_SYNC_PERIOD = "trace.clock.sync.period";
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -62,9 +62,9 @@ public final class TracerConfig {
   public static final String ENABLE_TRACE_AGENT_V05 = "trace.agent.v0.5.enabled";
   public static final String SAMPLING_MECHANISM_VALIDATION_DISABLED =
       "trace.sampling.mechanism.validation.disabled";
-  public static final String LONG_RUNNING_TRACE_ENABLED = "longrunning.enabled";
+  public static final String LONG_RUNNING_TRACE_ENABLED = "trace.longrunning.enabled";
 
-  public static final String LONG_RUNNING_TRACE_FLUSH_INTERVAL = "longrunning.flush.interval";
+  public static final String LONG_RUNNING_TRACE_FLUSH_INTERVAL = "trace.longrunning.flush.interval";
 
   public static final String CLOCK_SYNC_PERIOD = "trace.clock.sync.period";
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -169,8 +169,9 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
     boolean forceKeep = false;
     if (features.supportsMetrics()) {
       for (CoreSpan<?> span : trace) {
+        boolean isPartial = span.getPartialVersion() != null;
         boolean isTopLevel = span.isTopLevel();
-        if (isTopLevel || span.isMeasured()) {
+        if (!isPartial && (isTopLevel || span.isMeasured())) {
           if (ignoredResources.contains(span.getResourceName().toString())) {
             // skip publishing all children
             return false;

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
@@ -85,4 +85,6 @@ public interface CoreSpan<T extends CoreSpan<T>> {
   T setFlag(CharSequence name, boolean value);
 
   int samplingPriority();
+
+  Long getPartialVersion();
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -560,7 +560,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     return null == mapped ? serviceName : mapped;
   }
 
-  boolean isDisableSamplingMechanismValidation() {
+  boolean   isDisableSamplingMechanismValidation() {
     return disableSamplingMechanismValidation;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -516,7 +516,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     this.instrumentationGateway = instrumentationGateway;
 
     if (config.isTraceLongRunningEnabled()) {
-      this.traceKeepAlive = new TraceKeepAlive(config.getTraceLongRunningFlushInterval());
+      this.traceKeepAlive = new TraceKeepAlive(config.getTraceLongRunningFlushInterval() * 1000);
       traceKeepAlive.start();
     } else {
       this.traceKeepAlive = null;

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1221,9 +1221,6 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     public void run() {
       final CoreTracer tracer = reference.get();
       if (tracer != null) {
-        if (tracer.traceKeepAlive != null) {
-          tracer.traceKeepAlive.stop();
-        }
         tracer.close();
       }
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -560,7 +560,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     return null == mapped ? serviceName : mapped;
   }
 
-  boolean   isDisableSamplingMechanismValidation() {
+  boolean isDisableSamplingMechanismValidation() {
     return disableSamplingMechanismValidation;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -63,7 +63,7 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan>, AttachableWrapper {
    * combination of millisecond-precision clock and nanosecond-precision offset from start of the
    * trace. See {@link PendingTrace} for details.
    */
-  private long startTimeNano;
+  private final long startTimeNano;
 
   /** Mark as incomplete (long running span). */
   private Long partialVersion;

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -63,7 +63,10 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan>, AttachableWrapper {
    * combination of millisecond-precision clock and nanosecond-precision offset from start of the
    * trace. See {@link PendingTrace} for details.
    */
-  private final long startTimeNano;
+  private long startTimeNano;
+
+  /** Mark as incomplete (long running span). */
+  private Long partialVersion;
 
   private static final AtomicLongFieldUpdater<DDSpan> DURATION_NANO_UPDATER =
       AtomicLongFieldUpdater.newUpdater(DDSpan.class, "durationNano");
@@ -119,6 +122,14 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan>, AttachableWrapper {
 
   public boolean isFinished() {
     return durationNano != 0;
+  }
+
+  public Long getPartialVersion() {
+    return partialVersion;
+  }
+
+  public void setPartialVersion(Long partialVersion) {
+    this.partialVersion = partialVersion;
   }
 
   private void finishAndAddToTrace(final long durationNano) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -531,6 +531,7 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext<Object>,
 
   public void processTagsAndBaggage(final MetadataConsumer consumer) {
     synchronized (unsafeTags) {
+      final boolean incomplete = unsafeTags.containsKey(DDTags.DD_PARTIAL_VERSION);
       consumer.accept(
           new Metadata(
               threadId,
@@ -541,8 +542,8 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext<Object>,
                   ? SamplingDecision.priority(samplingDecision)
                   : getSamplingPriority()),
               // TODO do we also need to pass samplingMechanism in there? @YG
-              measured,
-              topLevel,
+              measured && !incomplete,
+              topLevel && !incomplete,
               httpStatusCode == 0 ? null : HTTP_STATUSES.get(httpStatusCode),
               getOrigin())); // Get origin from rootSpan.context
     }
@@ -615,5 +616,13 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext<Object>,
   private DDSpanContext getTopContext() {
     DDSpan span = trace.getRootSpan();
     return null != span ? span.context() : this;
+  }
+
+  String getParentServiceName() {
+    return parentServiceName;
+  }
+
+  int getSamplingDecision() {
+    return samplingDecision;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/TraceKeepAlive.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/TraceKeepAlive.java
@@ -1,0 +1,73 @@
+package datadog.trace.core;
+
+import datadog.trace.api.config.TracerConfig;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A monitor thread scheduled on a regular basis. It triggers keep-alive spans to be sent for
+ * long-running traces.
+ */
+public class TraceKeepAlive extends TimerTask {
+  public TraceKeepAlive(long keepAlivePeriod) {
+    if (keepAlivePeriod <= 0) {
+      throw new IllegalArgumentException(
+          TracerConfig.LONG_RUNNING_TRACE_FLUSH_INTERVAL + " property should be strictly positive");
+    }
+    this.keepAlivePeriod = keepAlivePeriod;
+  }
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TraceKeepAlive.class);
+
+  private final Object dummy = new Object();
+
+  private final Timer timer = new Timer(true);
+  private final ConcurrentMap<WeakReference<PendingTrace>, Object> pendingTraces =
+      new ConcurrentHashMap<>();
+
+  private final long keepAlivePeriod;
+
+  @Override
+  public void run() {
+    final long now = System.currentTimeMillis();
+    final List<WeakReference<PendingTrace>> garbaged = new ArrayList<>();
+    for (final WeakReference<PendingTrace> ref : pendingTraces.keySet()) {
+      final PendingTrace pt = ref.get();
+      if (pt != null) {
+        pt.keepAliveUnfinished(now, keepAlivePeriod);
+      } else {
+        garbaged.add(ref);
+      }
+    }
+    for (final WeakReference<PendingTrace> ref : garbaged) {
+      pendingTraces.remove(ref);
+    }
+  }
+
+  public void start() {
+    LOGGER.debug(
+        "Starting long running keepalive monitor. It will flush pending thread each {} millis",
+        keepAlivePeriod);
+    timer.scheduleAtFixedRate(this, 0L, keepAlivePeriod);
+  }
+
+  public void stop() {
+    timer.cancel();
+    LOGGER.debug("Long running keepalive monitor stopped");
+  }
+
+  public void onPendingTraceBegins(final PendingTrace pendingTrace) {
+    pendingTraces.put(new WeakReference<>(pendingTrace), dummy);
+  }
+
+  public void onPendingTraceEnds(final PendingTrace pendingTrace) {
+    pendingTraces.remove(new WeakReference<>(pendingTrace));
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
@@ -238,4 +238,9 @@ class SimpleSpan implements CoreSpan<SimpleSpan> {
   int samplingPriority() {
     return 0
   }
+
+  @Override
+  Long getPartialVersion() {
+    return null
+  }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceGenerator.groovy
@@ -364,6 +364,11 @@ class TraceGenerator {
     }
 
     @Override
+    Long getPartialVersion() {
+      return null
+    }
+
+    @Override
     <U> U getTag(CharSequence name, U defaultValue) {
       U value = getTag(name)
       return null == value ? defaultValue : value

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
@@ -83,6 +83,7 @@ class PendingTraceBufferTest extends DDSpecification {
     _ * tracer.getPartialFlushMinSpans() >> 10
     1 * tracer.getTimeWithNanoTicks(_)
     1 * tracer.onFinish(span)
+    _ * tracer.getTraceKeepAlive()
     0 * _
 
     when:
@@ -93,6 +94,7 @@ class PendingTraceBufferTest extends DDSpecification {
     1 * tracer.write({ it.size() == 1 })
     1 * tracer.writeTimer() >> Monitoring.DISABLED.newTimer("")
     _ * tracer.getPartialFlushMinSpans() >> 10
+    _ * tracer.getTraceKeepAlive()
     0 * _
   }
 
@@ -115,6 +117,7 @@ class PendingTraceBufferTest extends DDSpecification {
     _ * tracer.getPartialFlushMinSpans() >> 10
     1 * tracer.getTimeWithNanoTicks(_)
     1 * tracer.onFinish(parent)
+    _ * tracer.getTraceKeepAlive()
     0 * _
 
     when:
@@ -128,6 +131,7 @@ class PendingTraceBufferTest extends DDSpecification {
     _ * tracer.getPartialFlushMinSpans() >> 10
     1 * tracer.getTimeWithNanoTicks(_)
     1 * tracer.onFinish(child)
+    _ * tracer.getTraceKeepAlive()
     0 * _
   }
 
@@ -152,6 +156,7 @@ class PendingTraceBufferTest extends DDSpecification {
     1 * tracer.write(_) >> { List<List<DDSpan>> spans ->
       spans.first().first().processTagsAndBaggage(metadataChecker)
     }
+    _ * tracer.getTraceKeepAlive()
     0 *  _
     metadataChecker.hasSamplingPriority
 
@@ -175,6 +180,7 @@ class PendingTraceBufferTest extends DDSpecification {
     _ * tracer.onStart(_)
     _ * tracer.getTimeWithNanoTicks(_)
     _ * tracer.onFinish(_)
+    _ * tracer.getTraceKeepAlive()
     0 * _
 
     when:
@@ -190,6 +196,7 @@ class PendingTraceBufferTest extends DDSpecification {
     1 * tracer.onStart(_)
     2 * tracer.getTimeWithNanoTicks(_)
     1 * tracer.onFinish(_)
+    _ * tracer.getTraceKeepAlive()
     0 * _
     pendingTrace.isEnqueued == 0
   }
@@ -216,6 +223,7 @@ class PendingTraceBufferTest extends DDSpecification {
     _ * tracer.getPartialFlushMinSpans() >> 10
     1 * tracer.getTimeWithNanoTicks(_)
     1 * tracer.onFinish(parent)
+    _ * tracer.getTraceKeepAlive()
     0 * _
 
     when:
@@ -241,6 +249,7 @@ class PendingTraceBufferTest extends DDSpecification {
       latch.countDown()
     }
     _ * tracer.getPartialFlushMinSpans() >> 10
+    _ * tracer.getTraceKeepAlive()
     0 * _
   }
 
@@ -266,6 +275,7 @@ class PendingTraceBufferTest extends DDSpecification {
       parentLatch.countDown()
     }
     _ * tracer.getPartialFlushMinSpans() >> 10
+    _ * tracer.getTraceKeepAlive()
     1 * tracer.getTimeWithNanoTicks(_)
     1 * tracer.onFinish(parent)
     0 * _
@@ -286,6 +296,7 @@ class PendingTraceBufferTest extends DDSpecification {
       childLatch.countDown()
     }
     _ * tracer.mapServiceName(_)
+    _ * tracer.getTraceKeepAlive()
     1 * tracer.onStart(_)
     2 * tracer.getTimeWithNanoTicks(_)
     1 * tracer.onFinish(_)
@@ -359,6 +370,7 @@ class PendingTraceBufferTest extends DDSpecification {
     1 * tracer.onStart(_)
     2 * tracer.getTimeWithNanoTicks(_)
     1 * tracer.onFinish(_)
+    _ * tracer.getTraceKeepAlive()
     0 * _
 
     when: "fail to fill the buffer"
@@ -375,6 +387,7 @@ class PendingTraceBufferTest extends DDSpecification {
     _ * tracer.onStart(_)
     _ * tracer.getTimeWithNanoTicks(_)
     _ * tracer.onFinish(_)
+    _ * tracer.getTraceKeepAlive()
     0 * _
 
     when: "process the buffer"

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
@@ -35,4 +35,81 @@ class PendingTraceTest extends PendingTraceTestBase {
     writer == [[rootSpan]]
     writer.traceCount.get() == 1
   }
+
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
+  def "traces keep alive are sent for long running spans"() {
+    given:
+    def keepalive = new TraceKeepAlive(1)
+    when: "Open a long running spans"
+    def scope = tracer.activateSpan(rootSpan)
+    keepalive.onPendingTraceBegins(trace)
+
+    then:
+    trace.pendingReferenceCount == 1
+    trace.finishedSpans.empty
+    trace.unfinishedSpans.asList() == [rootSpan]
+    keepalive.pendingTraces.size() == 1
+    keepalive.pendingTraces.containsKey(trace)
+    writer == []
+
+    when: "keepAlive tasks sweeps #1"
+    sleep(10)
+    keepalive.run(null)
+
+    then:
+    trace.pendingReferenceCount == 1
+    trace.finishedSpans.size() == 0
+    trace.unfinishedSpans.asList() == [rootSpan]
+    writer.traceCount.get() == 1
+    writer.firstTrace().size() == 1
+    writer.firstTrace().first().partialVersion > 0
+
+    when: "keepAlive tasks sweeps #2"
+    sleep(10)
+    keepalive.run(null)
+
+    then:
+    trace.pendingReferenceCount == 1
+    trace.finishedSpans.size() == 0
+    trace.unfinishedSpans.asList() == [rootSpan]
+    writer.traceCount.get() == 2
+    writer[0].size() == 1
+    writer[1].size() == 1
+    writer[0].first().partialVersion < writer[1].first().partialVersion
+
+    when: "open a child on a long running span"
+    def child = tracer.startSpan("child", rootSpan.context(),false)
+    sleep(10)
+    child.finish()
+    keepalive.run(null)
+
+    then:
+    trace.pendingReferenceCount == 1
+    trace.finishedSpans.size() == 0 // should already have been flushed at this point
+    trace.unfinishedSpans.asList() == [rootSpan]
+    writer.traceCount.get() == 3
+    writer[2].size() == 2
+    writer[2][1] == child
+    writer[2][0].partialVersion > writer[1][0].partialVersion
+
+    when: "close pending long running spans"
+    rootSpan.finish()
+
+    then:
+    trace.pendingReferenceCount == 0
+    trace.finishedSpans.size() == 0 //already flushed to the writer at this point also
+    trace.unfinishedSpans.size() == 0
+    writer.traceCount.get() == 4
+    writer[3].size() == 1
+    writer[3][0] == rootSpan
+    writer[3][0].partialVersion == null
+
+    when: "nothing more to keep alive"
+    keepalive.run(null)
+
+    then:
+    trace.finishedSpans.size() == 0
+    trace.unfinishedSpans.size() == 0
+    writer.traceCount.get() == 4
+  }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
@@ -93,6 +93,7 @@ class PendingTraceTest extends PendingTraceTestBase {
     writer[2][0].partialVersion > writer[1][0].partialVersion
 
     when: "close pending long running spans"
+    scope.close()
     rootSpan.finish()
 
     then:

--- a/dd-trace-core/src/traceAgentTest/groovy/TraceGenerator.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/TraceGenerator.groovy
@@ -351,6 +351,11 @@ class TraceGenerator {
     }
 
     @Override
+    Long getPartialVersion() {
+      return null
+    }
+
+    @Override
     <U> U getTag(CharSequence name, U defaultValue) {
       U value = getTag(name)
       return null == value ? defaultValue : value

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1027,7 +1027,8 @@ public class Config {
 
     boolean longRunningEnabled =
         configProvider.getBoolean(
-            TracerConfig.LONG_RUNNING_TRACE_ENABLED, ConfigDefaults.DEFAULT_LONG_RUNNING_TRACE_ENABLED);
+            TracerConfig.LONG_RUNNING_TRACE_ENABLED,
+            ConfigDefaults.DEFAULT_LONG_RUNNING_TRACE_ENABLED);
     this.traceLongRunningFlushInterval =
         configProvider.getLong(
             TracerConfig.LONG_RUNNING_TRACE_FLUSH_INTERVAL,

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -498,6 +498,11 @@ public class Config {
   private final String dogStatsDPath;
   private final List<String> dogStatsDArgs;
 
+  /** Are long running spans supported */
+  private final boolean traceLongRunningEnabled;
+  /** The flush interval in millis of span still not finished. */
+  private final long traceLongRunningFlushInterval;
+
   private String env;
   private String version;
 
@@ -1019,6 +1024,12 @@ public class Config {
           Collections.unmodifiableList(
               new ArrayList<>(parseStringIntoSetOfNonEmptyStrings(dogStatsDArgsString)));
     }
+
+    traceLongRunningEnabled =
+        configProvider.getBoolean(TracerConfig.LONG_RUNNING_TRACE_ENABLED, false);
+    traceLongRunningFlushInterval =
+        configProvider.getLong(TracerConfig.LONG_RUNNING_TRACE_FLUSH_INTERVAL, 5 * 60)
+            * 1000; // defaults to 5 minutes
 
     // Setting this last because we have a few places where this can come from
     apiKey = tmpApiKey;
@@ -1633,6 +1644,14 @@ public class Config {
 
   public BitSet getGrpcClientErrorStatuses() {
     return grpcClientErrorStatuses;
+  }
+
+  public boolean isTraceLongRunningEnabled() {
+    return traceLongRunningEnabled;
+  }
+
+  public long getTraceLongRunningFlushInterval() {
+    return traceLongRunningFlushInterval;
   }
 
   /** @return A map of tags to be applied only to the local application root span. */


### PR DESCRIPTION
# What Does This Do

Add support for long running spans. Allows incomplete spans to be reported to datadog and partial results to be displayed into the live view. 
As well, this PR enables collecting complete traces for spans lasting more than 15 minutes.

The feature is released behind a configuration flag and it's disabled by default.

# How does it work

Pending traces are scanned on a scheduled basis and if a long lasting span is found:
* A copy of this span (same span_id, parent_it, trace_id) is added to the buffer. The span is tagged as partial (metrics[_dd.partial_version] with an incrementing number)
* All finished spans also buffered on the same pending traces are flushed (similar to partial flush scenario)


# Motivation

Today, due to internal datadog architecture, spans lasting more than 15 minutes may result in incomplete tracing. Additionally to this, spans are sent only when all pending ones are closed. Hence, live view won't display those ones.


# Additional Notes
