### PR TITLE
Fix issues with features discovery

### DIFF
--- a/communication/src/test/groovy/datadog/communication/ddagent/DDAgentFeaturesDiscoveryTest.groovy
+++ b/communication/src/test/groovy/datadog/communication/ddagent/DDAgentFeaturesDiscoveryTest.groovy
@@ -30,6 +30,8 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
   static final String INFO_WITH_CLIENT_DROPPING_RESPONSE = loadJsonFile("agent-info-with-client-dropping.json")
   static final String INFO_WITHOUT_METRICS_RESPONSE = loadJsonFile("agent-info-without-metrics.json")
 
+  def state = "a"
+
   def "test parse /info response"() {
     setup:
     OkHttpClient client = Mock(OkHttpClient)
@@ -40,10 +42,12 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
 
     then:
     1 * client.newCall(_) >> { Request request -> infoResponse(request, INFO_RESPONSE) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> success(request) }
     features.getMetricsEndpoint() == V6_METRICS_ENDPOINT
     features.supportsMetrics()
     features.getTraceEndpoint() == "v0.5/traces"
     !features.supportsDropping()
+    features.state() == "a"
   }
 
   def "test parse /info response with client dropping"() {
@@ -56,10 +60,12 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
 
     then:
     1 * client.newCall(_) >> { Request request -> infoResponse(request, INFO_WITH_CLIENT_DROPPING_RESPONSE) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> success(request) }
     features.getMetricsEndpoint() == V6_METRICS_ENDPOINT
     features.supportsMetrics()
     features.getTraceEndpoint() == "v0.5/traces"
     features.supportsDropping()
+    features.state() == "a"
   }
 
   def "test fallback when /info not found"() {
@@ -191,22 +197,28 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     !(features as DroppingPolicy).active()
 
     when: "/info available and agent allows dropping"
+    state = "b"
     features.discover()
 
     then: "metrics and dropping not supported"
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> infoResponse(request, INFO_WITH_CLIENT_DROPPING_RESPONSE) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> success(request) }
     !features.supportsMetrics()
     !features.supportsDropping()
     !(features as DroppingPolicy).active()
+    features.state() == "b"
 
     when: "/info available and agent does not allow dropping"
+    state = "c"
     features.discover()
 
     then: "metrics and dropping not supported"
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> infoResponse(request, INFO_RESPONSE) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> success(request) }
     !features.supportsMetrics()
     !features.supportsDropping()
     !(features as DroppingPolicy).active()
+    features.state() == "c"
   }
 
   def "discovery of metrics endpoint after agent upgrade enables dropping and metrics"() {
@@ -226,13 +238,16 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     !(features as DroppingPolicy).active()
 
     when: "/info and v0.6/stats become available to an already configured tracer"
+    state = "b"
     features.discover()
 
     then: "metrics endpoint not probed, metrics and dropping enabled"
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> infoResponse(request, INFO_WITH_CLIENT_DROPPING_RESPONSE) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> success(request) }
     features.supportsDropping()
     features.supportsMetrics()
     (features as DroppingPolicy).active()
+    features.state() == "b"
   }
 
   def "disappearance of info endpoint after agent downgrade disables metrics and dropping"() {
@@ -243,19 +258,22 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     when: "/info available"
     features.discover()
 
-    then: "no probing, metrics and dropping supported"
+    then: "metrics and dropping supported"
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> infoResponse(request, INFO_WITH_CLIENT_DROPPING_RESPONSE) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> success(request) }
     0 * client.newCall(_)
     features.supportsDropping()
     features.supportsMetrics()
     (features as DroppingPolicy).active()
+    features.state() == "a"
 
     when: "/info and v0.6/stats become unavailable to an already configured tracer"
     features.discover()
 
-    then: "no probing, metrics and dropping not supported"
+    then: "metrics and dropping not supported"
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> notFound(request) }
-    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> success(request) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> success(request) }
+    0 * client.newCall(_)
     !features.supportsDropping()
     !features.supportsMetrics()
     !(features as DroppingPolicy).active()
@@ -269,24 +287,29 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     when: "/info available"
     features.discover()
 
-    then: "no probing, metrics and dropping supported"
+    then: "metrics and dropping supported"
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> infoResponse(request, INFO_WITH_CLIENT_DROPPING_RESPONSE) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> success(request) }
     0 * client.newCall(_)
     features.supportsDropping()
     features.supportsMetrics()
     (features as DroppingPolicy).active()
+    features.state() == "a"
 
     when: "/info and v0.6/stats become unavailable to an already configured tracer"
+    state = "b"
     features.discover()
 
-    then: "no probing, metrics and dropping not supported"
+    then: "metrics and dropping not supported"
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> infoResponse(request, INFO_WITHOUT_METRICS_RESPONSE) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> success(request) }
     0 * client.newCall(_)
     // misconfigured agent allows dropping but not metrics
     features.supportsDropping()
     !features.supportsMetrics()
     // but we don't permit dropping anyway
     !(features as DroppingPolicy).active()
+    features.state() == "b"
   }
 
   def countingNotFound(Request request, CountDownLatch latch) {
@@ -330,6 +353,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
         .request(request)
         .protocol(Protocol.HTTP_1_1)
         .message("")
+        .header(DDAgentFeaturesDiscovery.DATADOG_AGENT_STATE, state)
         .body(ResponseBody.create(MediaType.get("application/msgpack"), ""))
         .build()
     }
@@ -342,6 +366,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
         .request(request)
         .protocol(Protocol.HTTP_1_1)
         .message("")
+        .header(DDAgentFeaturesDiscovery.DATADOG_AGENT_STATE, state)
         .body(ResponseBody.create(MediaType.get("application/msgpack"), ""))
         .build()
     }


### PR DESCRIPTION
# What Does This Do

1) Simplify the features discovery logic by removing needlessly complicated reverse iteration
2) Fix a bug where feature discovery was invoked after every trace request

The agent returns `Datadog-Agent-State` (a hash of the info endpoint) for all endpoints _except_ the info endpoint. Previous to this PR, if the `/info` endpoint exists on the agent, the `state==null` **always**. With trace requests, `state!=null` **always**. As a result, after ever trace request `DDAgentApi.handleAgentChange()` would always call `discover()`.

This PR changes that behavior by probing the discovered trace endpoint once even if the endpoint was found via `/info`

# Motivation

I discovered these issue while adding another discovery endpoint

# Additional Notes

The behavior when dealing Datadog agents that do not return `Datadog-Agent-State` remains unchanged. They will still be feature probed after every trace request.
