### PR TITLE
Skip probing agent trace endpoints when info is available

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
+++ b/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
@@ -1,5 +1,7 @@
 package datadog.communication.ddagent;
 
+import static datadog.communication.serialization.msgpack.MsgPackWriter.FIXARRAY;
+
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
@@ -7,8 +9,10 @@ import datadog.communication.http.OkHttpUtils;
 import datadog.communication.monitor.DDAgentStatsDClientManager;
 import datadog.communication.monitor.Monitoring;
 import datadog.communication.monitor.Recording;
+import datadog.trace.util.Strings;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -30,6 +34,12 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
           .build()
           .adapter(Types.newParameterizedType(Map.class, String.class, Object.class));
 
+  // Currently all the endpoints that we probe expect a msgpack body of an array of arrays, v3/v4
+  // arbitrary size and v5 two elements, so let's give them a two element array of empty arrays
+  private static final byte[] PROBE_MESSAGE = {
+    (byte) FIXARRAY | 2, (byte) FIXARRAY, (byte) FIXARRAY
+  };
+
   public static final String V3_ENDPOINT = "v0.3/traces";
   public static final String V4_ENDPOINT = "v0.4/traces";
   public static final String V5_ENDPOINT = "v0.5/traces";
@@ -48,7 +58,6 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
   private volatile String traceEndpoint;
   private volatile String metricsEndpoint;
   private volatile boolean supportsDropping;
-
   private volatile String state;
 
   public DDAgentFeaturesDiscovery(
@@ -67,7 +76,15 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
     this.discoveryTimer = monitoring.newTimer("trace.agent.discovery.time");
   }
 
+  private void reset() {
+    traceEndpoint = null;
+    metricsEndpoint = null;
+    supportsDropping = false;
+    state = null;
+  }
+
   public void discover() {
+    reset();
     // 1. try to fetch info about the agent, if the endpoint is there
     // 2. try to parse the response, if it can be parsed, finish
     // 3. fallback if the endpoint couldn't be found or the response couldn't be parsed
@@ -84,18 +101,18 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
         errorQueryingEndpoint("info", error);
       }
       if (fallback) {
-        this.supportsDropping = false;
+        supportsDropping = false;
         log.debug("Falling back to probing, client dropping will be disabled");
         // disable metrics unless the info endpoint is present, which prevents
         // sending metrics to 7.26.0, which has a bug in reporting metric origin
-        this.metricsEndpoint = null;
+        metricsEndpoint = null;
       }
 
       // don't want to rewire the traces pipeline
       if (null == traceEndpoint) {
-        this.traceEndpoint = probeTracesEndpoint(traceEndpoints);
-      } else {
-        // Still need to probe so that this.state is correctly assigned
+        traceEndpoint = probeTracesEndpoint(traceEndpoints);
+      } else if (state == null || state.isEmpty()) {
+        // Still need to probe so that state is correctly assigned
         probeTracesEndpoint(new String[] {traceEndpoint});
       }
     }
@@ -115,12 +132,14 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
           client
               .newCall(
                   new Request.Builder()
-                      .put(OkHttpUtils.msgpackRequestBodyOf(Collections.<ByteBuffer>emptyList()))
+                      .put(
+                          OkHttpUtils.msgpackRequestBodyOf(
+                              Collections.singletonList(ByteBuffer.wrap(PROBE_MESSAGE))))
                       .url(agentBaseUrl.resolve(candidate))
                       .build())
               .execute()) {
-        if (response.code() != 404) {
-          this.state = response.header(DATADOG_AGENT_STATE);
+        if (response.code() == 200) {
+          state = response.header(DATADOG_AGENT_STATE);
           return candidate;
         }
       } catch (IOException e) {
@@ -159,10 +178,15 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
 
       if (metricsEnabled) {
         Object canDrop = map.get("client_drop_p0s");
-        this.supportsDropping =
+        supportsDropping =
             null != canDrop
                 && ("true".equalsIgnoreCase(String.valueOf(canDrop))
                     || Boolean.TRUE.equals(canDrop));
+      }
+      try {
+        state = Strings.sha256(response);
+      } catch (NoSuchAlgorithmException ex) {
+        log.debug("Failed to hash trace agent /info response. Will probe {}", traceEndpoint, ex);
       }
       return true;
     } catch (Throwable error) {

--- a/communication/src/test/groovy/datadog/communication/ddagent/DDAgentFeaturesDiscoveryTest.groovy
+++ b/communication/src/test/groovy/datadog/communication/ddagent/DDAgentFeaturesDiscoveryTest.groovy
@@ -2,6 +2,7 @@ package datadog.communication.ddagent
 
 import datadog.communication.monitor.Monitoring
 import datadog.trace.test.util.DDSpecification
+import datadog.trace.util.Strings
 import okhttp3.Call
 import okhttp3.HttpUrl
 import okhttp3.MediaType
@@ -27,10 +28,12 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
   HttpUrl agentUrl = HttpUrl.get("http://localhost:8125")
 
   static final String INFO_RESPONSE = loadJsonFile("agent-info.json")
+  static final String INFO_STATE = Strings.sha256(INFO_RESPONSE)
   static final String INFO_WITH_CLIENT_DROPPING_RESPONSE = loadJsonFile("agent-info-with-client-dropping.json")
+  static final String INFO_WITH_CLIENT_DROPPING_STATE = Strings.sha256(INFO_WITH_CLIENT_DROPPING_RESPONSE)
   static final String INFO_WITHOUT_METRICS_RESPONSE = loadJsonFile("agent-info-without-metrics.json")
-
-  def state = "a"
+  static final String INFO_WITHOUT_METRICS_STATE = Strings.sha256(INFO_WITHOUT_METRICS_RESPONSE)
+  static final String PROBE_STATE = "probestate"
 
   def "test parse /info response"() {
     setup:
@@ -42,12 +45,11 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
 
     then:
     1 * client.newCall(_) >> { Request request -> infoResponse(request, INFO_RESPONSE) }
-    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> success(request) }
     features.getMetricsEndpoint() == V6_METRICS_ENDPOINT
     features.supportsMetrics()
     features.getTraceEndpoint() == "v0.5/traces"
     !features.supportsDropping()
-    features.state() == "a"
+    features.state() == INFO_STATE
   }
 
   def "test parse /info response with client dropping"() {
@@ -60,12 +62,11 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
 
     then:
     1 * client.newCall(_) >> { Request request -> infoResponse(request, INFO_WITH_CLIENT_DROPPING_RESPONSE) }
-    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> success(request) }
     features.getMetricsEndpoint() == V6_METRICS_ENDPOINT
     features.supportsMetrics()
     features.getTraceEndpoint() == "v0.5/traces"
     features.supportsDropping()
-    features.state() == "a"
+    features.state() == INFO_WITH_CLIENT_DROPPING_STATE
   }
 
   def "test fallback when /info not found"() {
@@ -79,11 +80,14 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     then:
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> notFound(request) }
     0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.6/stats" }) >> { Request request -> clientError(request) }
-    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> clientError(request) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> success(request) }
+    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> success(request) }
+    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.3/traces" }) >> { Request request -> success(request) }
     features.getMetricsEndpoint() == null
     !features.supportsMetrics()
     features.getTraceEndpoint() == "v0.5/traces"
     !features.supportsDropping()
+    features.state() == PROBE_STATE
   }
 
   def "test fallback when /info not found and agent returns ok"() {
@@ -102,6 +106,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     !features.supportsMetrics()
     features.getTraceEndpoint() == "v0.5/traces"
     !features.supportsDropping()
+    features.state() == PROBE_STATE
   }
 
   def "test fallback when /info not found and v0.5 disabled"() {
@@ -115,11 +120,14 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     then:
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> notFound(request) }
     0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.6/stats" }) >> { Request request -> clientError(request) }
-    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> clientError(request) }
+    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> success(request) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> success(request) }
+    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.3/traces" }) >> { Request request -> success(request) }
     features.getMetricsEndpoint() == null
     !features.supportsMetrics()
     features.getTraceEndpoint() == "v0.4/traces"
     !features.supportsDropping()
+    features.state() == PROBE_STATE
   }
 
   def "test fallback when /info not found and v0.5 unavailable agent side"() {
@@ -134,30 +142,13 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> notFound(request) }
     0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.6/stats" }) >> { Request request -> clientError(request) }
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> notFound(request) }
-    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> clientError(request) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> success(request) }
+    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.3/traces" }) >> { Request request -> success(request) }
     features.getMetricsEndpoint() == null
     !features.supportsMetrics()
     features.getTraceEndpoint() == "v0.4/traces"
     !features.supportsDropping()
-  }
-
-  def "test fallback on old agent"() {
-    setup:
-    OkHttpClient client = Mock(OkHttpClient)
-    DDAgentFeaturesDiscovery features = new DDAgentFeaturesDiscovery(client, monitoring, agentUrl, true, true)
-
-    when: "/info unavailable"
-    features.discover()
-
-    then:
-    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> notFound(request) }
-    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.6/stats" }) >> { Request request -> notFound(request) }
-    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> notFound(request) }
-    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> clientError(request) }
-    features.getMetricsEndpoint() == null
-    !features.supportsMetrics()
-    features.getTraceEndpoint() == "v0.4/traces"
-    !features.supportsDropping()
+    features.state() == PROBE_STATE
   }
 
   def "test fallback on very old agent"() {
@@ -173,11 +164,12 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.6/stats" }) >> { Request request -> notFound(request) }
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> notFound(request) }
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> notFound(request) }
-    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.3/traces" }) >> { Request request -> clientError(request) }
+    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.3/traces" }) >> { Request request -> success(request) }
     features.getMetricsEndpoint() == null
     !features.supportsMetrics()
     features.getTraceEndpoint() == "v0.3/traces"
     !features.supportsDropping()
+    features.state() == PROBE_STATE
   }
 
   def "disabling metrics disables metrics and dropping"() {
@@ -195,30 +187,27 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     !features.supportsMetrics()
     !features.supportsDropping()
     !(features as DroppingPolicy).active()
+    features.state() == PROBE_STATE
 
     when: "/info available and agent allows dropping"
-    state = "b"
     features.discover()
 
     then: "metrics and dropping not supported"
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> infoResponse(request, INFO_WITH_CLIENT_DROPPING_RESPONSE) }
-    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> success(request) }
     !features.supportsMetrics()
     !features.supportsDropping()
     !(features as DroppingPolicy).active()
-    features.state() == "b"
+    features.state() == INFO_WITH_CLIENT_DROPPING_STATE
 
     when: "/info available and agent does not allow dropping"
-    state = "c"
     features.discover()
 
     then: "metrics and dropping not supported"
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> infoResponse(request, INFO_RESPONSE) }
-    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.5/traces" }) >> { Request request -> success(request) }
     !features.supportsMetrics()
     !features.supportsDropping()
     !(features as DroppingPolicy).active()
-    features.state() == "c"
+    features.state() == INFO_STATE
   }
 
   def "discovery of metrics endpoint after agent upgrade enables dropping and metrics"() {
@@ -236,18 +225,18 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     !features.supportsDropping()
     !features.supportsMetrics()
     !(features as DroppingPolicy).active()
+    features.state() == PROBE_STATE
 
     when: "/info and v0.6/stats become available to an already configured tracer"
-    state = "b"
     features.discover()
 
     then: "metrics endpoint not probed, metrics and dropping enabled"
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> infoResponse(request, INFO_WITH_CLIENT_DROPPING_RESPONSE) }
-    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> success(request) }
+    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> success(request) }
     features.supportsDropping()
     features.supportsMetrics()
     (features as DroppingPolicy).active()
-    features.state() == "b"
+    features.state() == INFO_WITH_CLIENT_DROPPING_STATE
   }
 
   def "disappearance of info endpoint after agent downgrade disables metrics and dropping"() {
@@ -260,12 +249,12 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
 
     then: "metrics and dropping supported"
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> infoResponse(request, INFO_WITH_CLIENT_DROPPING_RESPONSE) }
-    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> success(request) }
+    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> success(request) }
     0 * client.newCall(_)
     features.supportsDropping()
     features.supportsMetrics()
     (features as DroppingPolicy).active()
-    features.state() == "a"
+    features.state() == INFO_WITH_CLIENT_DROPPING_STATE
 
     when: "/info and v0.6/stats become unavailable to an already configured tracer"
     features.discover()
@@ -277,6 +266,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     !features.supportsDropping()
     !features.supportsMetrics()
     !(features as DroppingPolicy).active()
+    features.state() == PROBE_STATE
   }
 
   def "disappearance of metrics endpoint after agent downgrade disables metrics and dropping"() {
@@ -289,27 +279,25 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
 
     then: "metrics and dropping supported"
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> infoResponse(request, INFO_WITH_CLIENT_DROPPING_RESPONSE) }
-    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> success(request) }
+    0 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> success(request) }
     0 * client.newCall(_)
     features.supportsDropping()
     features.supportsMetrics()
     (features as DroppingPolicy).active()
-    features.state() == "a"
+    features.state() == INFO_WITH_CLIENT_DROPPING_STATE
 
     when: "/info and v0.6/stats become unavailable to an already configured tracer"
-    state = "b"
     features.discover()
 
     then: "metrics and dropping not supported"
     1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/info" }) >> { Request request -> infoResponse(request, INFO_WITHOUT_METRICS_RESPONSE) }
-    1 * client.newCall({ Request request -> request.url().toString() == "http://localhost:8125/v0.4/traces" }) >> { Request request -> success(request) }
     0 * client.newCall(_)
     // misconfigured agent allows dropping but not metrics
     features.supportsDropping()
     !features.supportsMetrics()
     // but we don't permit dropping anyway
     !(features as DroppingPolicy).active()
-    features.state() == "b"
+    features.state() == INFO_WITHOUT_METRICS_STATE
   }
 
   def countingNotFound(Request request, CountDownLatch latch) {
@@ -341,6 +329,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
         .request(request)
         .protocol(Protocol.HTTP_1_1)
         .message("")
+        .header(DDAgentFeaturesDiscovery.DATADOG_AGENT_STATE, PROBE_STATE)
         .body(ResponseBody.create(MediaType.get("application/json"), ""))
         .build()
     }
@@ -353,7 +342,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
         .request(request)
         .protocol(Protocol.HTTP_1_1)
         .message("")
-        .header(DDAgentFeaturesDiscovery.DATADOG_AGENT_STATE, state)
+        .header(DDAgentFeaturesDiscovery.DATADOG_AGENT_STATE, PROBE_STATE)
         .body(ResponseBody.create(MediaType.get("application/msgpack"), ""))
         .build()
     }
@@ -366,7 +355,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
         .request(request)
         .protocol(Protocol.HTTP_1_1)
         .message("")
-        .header(DDAgentFeaturesDiscovery.DATADOG_AGENT_STATE, state)
+        .header(DDAgentFeaturesDiscovery.DATADOG_AGENT_STATE, PROBE_STATE)
         .body(ResponseBody.create(MediaType.get("application/msgpack"), ""))
         .build()
     }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -131,7 +131,9 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
 
   @Override
   public void start() {
-    features.discover();
+    if (features.getMetricsEndpoint() == null) {
+      features.discover();
+    }
     if (features.supportsMetrics()) {
       sink.register(this);
       thread.start();

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/PayloadDispatcher.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/PayloadDispatcher.java
@@ -69,7 +69,9 @@ public class PayloadDispatcher implements ByteBufferConsumer {
 
   private void selectTraceMapper() {
     if (null == traceMapper) {
-      featuresDiscovery.discover();
+      if (featuresDiscovery.getTraceEndpoint() == null) {
+        featuresDiscovery.discover();
+      }
       String tracesUrl = featuresDiscovery.getTraceEndpoint();
       if (DDAgentFeaturesDiscovery.V5_ENDPOINT.equalsIgnoreCase(tracesUrl)) {
         this.traceMapper = new TraceMapperV0_5();

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
@@ -103,8 +103,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
     writer.flush()
 
     then:
-    1 * discovery.discover()
-    1 * discovery.getTraceEndpoint() >> agentVersion
+    2 * discovery.getTraceEndpoint() >> agentVersion
     1 * api.sendSerializedTraces({ it.traceCount() == 2 }) >> DDAgentApi.Response.success(200)
     0 * _
 
@@ -136,8 +135,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
     writer.flush()
 
     then:
-    1 * discovery.discover()
-    1 * discovery.getTraceEndpoint() >> agentVersion
+    2 * discovery.getTraceEndpoint() >> agentVersion
     1 * api.sendSerializedTraces({ it.traceCount() <= traceCount }) >> DDAgentApi.Response.success(200)
     0 * _
 
@@ -173,8 +171,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
     phaser.awaitAdvanceInterruptibly(phaser.arriveAndDeregister())
 
     then:
-    1 * discovery.getTraceEndpoint() >> agentVersion
-    1 * discovery.discover()
+    2 * discovery.getTraceEndpoint() >> agentVersion
     1 * healthMetrics.onSerialize(_)
     1 * api.sendSerializedTraces({ it.traceCount() == 5 }) >> DDAgentApi.Response.success(200)
     _ * healthMetrics.onPublish(_, _)
@@ -215,8 +212,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
     writer.flush()
 
     then:
-    1 * discovery.getTraceEndpoint() >> agentVersion
-    1 * discovery.discover()
+    2 * discovery.getTraceEndpoint() >> agentVersion
     1 * api.sendSerializedTraces({ it.traceCount() == maxedPayloadTraceCount }) >> DDAgentApi.Response.success(200)
     1 * api.sendSerializedTraces({ it.traceCount() == 1 }) >> DDAgentApi.Response.success(200)
     0 * _

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
@@ -66,7 +66,7 @@ class PayloadDispatcherTest extends DDSpecification {
     }
     dispatcher.flush()
     then:
-    1 * discovery.getTraceEndpoint() >> traceEndpoint
+    2 * discovery.getTraceEndpoint() >> traceEndpoint
     1 * healthMetrics.onSerialize({ it > 0 })
     1 * api.sendSerializedTraces({ it.traceCount() == traceCount }) >> DDAgentApi.Response.success(200)
 
@@ -93,8 +93,8 @@ class PayloadDispatcherTest extends DDSpecification {
     }
     dispatcher.flush()
     then:
+    2 * discovery.getTraceEndpoint() >> traceEndpoint
     1 * healthMetrics.onSerialize({ it > 0 })
-    1 * discovery.getTraceEndpoint() >> traceEndpoint
     1 * api.sendSerializedTraces({ it.traceCount() == traceCount }) >> DDAgentApi.Response.failed(400)
 
     where:

--- a/internal-api/src/main/java/datadog/trace/util/Strings.java
+++ b/internal-api/src/main/java/datadog/trace/util/Strings.java
@@ -1,5 +1,8 @@
 package datadog.trace.util;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Iterator;
 import java.util.Locale;
 import javax.annotation.Nonnull;
@@ -196,5 +199,19 @@ public final class Strings {
 
   private static String hex(char ch) {
     return Integer.toHexString(ch).toUpperCase(Locale.ENGLISH);
+  }
+
+  public static String sha256(String input) throws NoSuchAlgorithmException {
+    MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+    StringBuilder hexString = new StringBuilder(2 * hash.length);
+    for (int i = 0; i < hash.length; i++) {
+      String hex = Integer.toHexString(0xFF & hash[i]);
+      if (hex.length() == 1) {
+        hexString.append('0');
+      }
+      hexString.append(hex);
+    }
+    return hexString.toString();
   }
 }

--- a/internal-api/src/test/groovy/datadog/trace/util/StringsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/util/StringsTest.groovy
@@ -98,4 +98,17 @@ class StringsTest extends DDSpecification {
     "\u000b"|"\\u000B"
     "a"|"a"
   }
+
+  def "test sha256"() {
+    when:
+    String sha256 = Strings.sha256(input)
+
+    then:
+    sha256 == expected
+
+    where:
+    input | expected
+    'the quick brown fox jumps over the lazy dog'    | '05c6e08f1d9fdafa03147fcb8f82f124c76d2f70e3d989dc8aadb5e7d7450bec'
+    'det kommer bli bättre, du kommer andas lättare' | '9e6215a16fc8968bf3ba29d81f028f7d4bbf22ccc59ae87a0e36a8085f1c2968'
+  }
 }


### PR DESCRIPTION
# What Does This Do

Takes the result of the Datadog agent `/info` endpoint and avoids probing the endpoints by computing the state hash of the response.

# Motivation

Avoid probing the Datadog agent with incomplete requests that show up as a failure to decode in the agent logs, that might confuse customers/support.

# Additional Notes

I also changed the probing to send valid but empty payloads to the Datadog agent, but that broke the old `test-agent` that's used in some smoke tests, so it was changed back. Replacing the `test-agent` is a bigger task.