### PR TITLE
Fix jakarta instrumentation dependencies

### DIFF
--- a/dd-java-agent/instrumentation/jakarta-rs-annotations-3/jakarta-rs-annotations-3.gradle
+++ b/dd-java-agent/instrumentation/jakarta-rs-annotations-3/jakarta-rs-annotations-3.gradle
@@ -21,10 +21,12 @@ testSets {
 }
 
 dependencies {
-  implementation group: 'jakarta.ws.rs', name: 'jakarta.ws.rs-api', version: '3.0.0'
+  compileOnly group: 'jakarta.ws.rs', name: 'jakarta.ws.rs-api', version: '3.0.0'
 
   testImplementation project(':dd-java-agent:instrumentation:servlet:request-3')
+  testImplementation group: 'jakarta.ws.rs', name: 'jakarta.ws.rs-api', version: '3.0.0'
   testImplementation group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '3.0.0'
 
+  latestDepTestImplementation group: 'jakarta.ws.rs', name: 'jakarta.ws.rs-api', version: '3.+'
   latestDepTestImplementation group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '3.+'
 }


### PR DESCRIPTION
# What Does This Do
Changes the `jakarta` instrumentation dependency to `compileOnly`. Otherwise, it is added to the final agent jar. Also, adds the api dependency to the `latestDepTest` configuration.

# Motivation
I noticed this issue while debugging another problem

# Additional Notes
We may think of adding custom configuration names like [open-telemetry](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/conventions/src/main/kotlin/io.opentelemetry.instrumentation.base.gradle.kts) to prevent issues like this. They have `library`, `testLibrary`, and `latestDepTestLibrary` that automatically does the right thing