### PR TITLE
Fix undertow runnable wrapping to avoid extending RunnableWrapper

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/RunnableWrapper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/RunnableWrapper.java
@@ -3,11 +3,15 @@ package datadog.trace.bootstrap.instrumentation.java.concurrent;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType;
 
 /**
- * This is used to wrap lambda runnables since currently we cannot instrument them
+ * This is used to wrap lambda runnables so we can apply field-injection. RunnableWrapper can be
+ * transformed to add the necessary context-store fields, while lambdas currently cannot until the
+ * issue reported in https://github.com/raphw/byte-buddy/issues/558 is addressed.
  *
- * <p>FIXME: We should remove this once https://github.com/raphw/byte-buddy/issues/558 is fixed
+ * <p>We also make this class final to stop instrumentations from extending it in their injected
+ * helper classes, because if this class is loaded during helper injection then we can miss the
+ * initial load event where we need to add the context-store fields.
  */
-public class RunnableWrapper implements Runnable {
+public final class RunnableWrapper implements Runnable {
 
   private final Runnable runnable;
 

--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingRunnableWrapper.java
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingRunnableWrapper.java
@@ -2,6 +2,8 @@ package datadog.trace.instrumentation.springscheduling;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.exclude;
 import static datadog.trace.instrumentation.springscheduling.SpringSchedulingDecorator.DECORATE;
 import static datadog.trace.instrumentation.springscheduling.SpringSchedulingDecorator.SCHEDULED_CALL;
 
@@ -37,9 +39,7 @@ public class SpringSchedulingRunnableWrapper implements Runnable {
   }
 
   public static Runnable wrapIfNeeded(final Runnable task) {
-    // We wrap only lambdas' anonymous classes and if given object has not already been wrapped.
-    // Anonymous classes have '/' in class name which is not allowed in 'normal' classes.
-    if (task instanceof SpringSchedulingRunnableWrapper) {
+    if (task instanceof SpringSchedulingRunnableWrapper || exclude(RUNNABLE, task)) {
       return task;
     }
     return new SpringSchedulingRunnableWrapper(task);

--- a/dd-java-agent/instrumentation/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/UndertowInstrumentation.java
+++ b/dd-java-agent/instrumentation/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/UndertowInstrumentation.java
@@ -1,22 +1,13 @@
 package datadog.trace.instrumentation.undertow;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static datadog.trace.instrumentation.undertow.UndertowDecorator.DD_HTTPSERVEREXCHANGE_DISPATCH;
-import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.bootstrap.ContextStore;
-import datadog.trace.bootstrap.InstrumentationContext;
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
-import datadog.trace.bootstrap.instrumentation.java.concurrent.ExecutorInstrumentationUtils;
-import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import io.undertow.server.HttpServerExchange;
-import java.util.Map;
-import java.util.concurrent.Executor;
 import net.bytebuddy.asm.Advice;
 
 @AutoService(Instrumenter.class)
@@ -33,18 +24,13 @@ public final class UndertowInstrumentation extends Instrumenter.Tracing
   }
 
   @Override
-  public Map<String, String> contextStore() {
-    return singletonMap(Runnable.class.getName(), State.class.getName());
-  }
-
-  @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(
         isMethod()
             .and(named("dispatch"))
             .and(takesArgument(0, named("java.util.concurrent.Executor")))
             .and(takesArgument(1, named("java.lang.Runnable"))),
-        getClass().getName() + "$AddListenerAdvice");
+        getClass().getName() + "$DispatchAdvice");
   }
 
   @Override
@@ -60,36 +46,15 @@ public final class UndertowInstrumentation extends Instrumenter.Tracing
     };
   }
 
-  public static class AddListenerAdvice {
+  public static class DispatchAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static State addListenerEnter(
+    public static void dispatchEnter(
         @Advice.Argument(value = 1, readOnly = false) Runnable task,
-        @Advice.Argument(0) final Executor executor,
         @Advice.This final HttpServerExchange current) {
-      final AgentScope scope = activeScope();
-      final Runnable newTask = UndertowRunnableWrapper.wrapIfNeeded(task, current, scope.span());
-      // It is important to check potentially wrapped task if we can instrument task in this
-      // executor. Some executors do not support wrapped tasks.
-      if (ExecutorInstrumentationUtils.shouldAttachStateToTask(newTask, executor)) {
-        task = newTask;
-        final ContextStore<Runnable, State> contextStore =
-            InstrumentationContext.get(Runnable.class, State.class);
-        State state = ExecutorInstrumentationUtils.setupState(contextStore, newTask, scope);
-        state.startThreadMigration();
-        // Tell the rest of the instrumentation this exchange has been dispatched so
-        // it will not be completed synchronously
-        current.putAttachment(DD_HTTPSERVEREXCHANGE_DISPATCH, true);
-        return state;
-      }
-      return null;
-    }
-
-    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-    public static void addListenerExit(
-        @Advice.Argument(0) final Executor executor,
-        @Advice.Enter final State state,
-        @Advice.Thrown final Throwable throwable) {
-      ExecutorInstrumentationUtils.cleanUpOnMethodExit(executor, state, throwable);
+      task = UndertowRunnableWrapper.wrapIfNeeded(task, current);
+      // Tell the rest of the instrumentation this exchange has been dispatched
+      // so it will not be completed synchronously
+      current.putAttachment(DD_HTTPSERVEREXCHANGE_DISPATCH, true);
     }
   }
 }

--- a/dd-java-agent/instrumentation/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/UndertowRunnableWrapper.java
+++ b/dd-java-agent/instrumentation/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/UndertowRunnableWrapper.java
@@ -1,45 +1,51 @@
 package datadog.trace.instrumentation.undertow;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.exclude;
 import static datadog.trace.instrumentation.undertow.UndertowDecorator.DECORATE;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
-import datadog.trace.bootstrap.instrumentation.java.concurrent.RunnableWrapper;
 import io.undertow.server.HttpServerExchange;
 
-public class UndertowRunnableWrapper extends RunnableWrapper {
+public class UndertowRunnableWrapper implements Runnable {
 
+  private Runnable runnable;
   private HttpServerExchange exchange;
-  private AgentSpan span;
+  private AgentScope.Continuation continuation;
 
-  public UndertowRunnableWrapper(Runnable runnable, HttpServerExchange exchange, AgentSpan span) {
-    super(runnable);
+  public UndertowRunnableWrapper(
+      Runnable runnable, HttpServerExchange exchange, AgentScope.Continuation continuation) {
+    this.runnable = runnable;
     this.exchange = exchange;
-    this.span = span;
+    this.continuation = continuation;
+    continuation.migrate();
   }
 
   @Override
   public void run() {
-    try {
-      super.run();
-      DECORATE.onResponse(span, exchange);
-      DECORATE.beforeFinish(span);
-      span.finish();
+    AgentSpan span = continuation.getSpan();
+    try (AgentScope scope = continuation.activate()) {
+      runnable.run();
     } catch (Throwable throwable) {
       DECORATE.onError(span, throwable);
+      throw throwable;
+    } finally {
       DECORATE.onResponse(span, exchange);
       DECORATE.beforeFinish(span);
       span.finish();
-      throw throwable;
     }
   }
 
-  public static Runnable wrapIfNeeded(
-      final Runnable task, HttpServerExchange exchange, AgentSpan span) {
-    if (!(task instanceof RunnableWrapper)
-        && !ExcludeFilter.exclude(ExcludeFilter.ExcludeType.RUNNABLE, task)) {
-      return new UndertowRunnableWrapper(task, exchange, span);
+  public static Runnable wrapIfNeeded(final Runnable task, HttpServerExchange exchange) {
+    if (task instanceof UndertowRunnableWrapper || exclude(RUNNABLE, task)) {
+      return task;
     }
-    return task;
+    AgentScope scope = activeScope();
+    if (null != scope) {
+      return new UndertowRunnableWrapper(task, exchange, scope.capture());
+    }
+    return task; // don't wrap unless there is a scope to propagate
   }
 }


### PR DESCRIPTION
Stop instrumentations from extending `RunnableWrapper` in their injected helper classes, because if this class is loaded during helper injection then we can miss the initial load event where we need to add the context-store fields.

Update `UndertowRunnableWrapper` to use continuations instead of extending `RunnableWrapper`.