### PR TITLE
Default classloading instrumentation to always on

### DIFF
--- a/dd-java-agent/instrumentation/classloading/src/main/java/datadog/trace/instrumentation/classloading/ClassloadingInstrumentation.java
+++ b/dd-java-agent/instrumentation/classloading/src/main/java/datadog/trace/instrumentation/classloading/ClassloadingInstrumentation.java
@@ -37,6 +37,11 @@ public final class ClassloadingInstrumentation extends Instrumenter.Tracing
   }
 
   @Override
+  protected boolean defaultEnabled() {
+    return true;
+  }
+
+  @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
     // just an optimization to exclude common class loaders that are known to delegate to the
     // bootstrap loader (or happen to _be_ the bootstrap loader)


### PR DESCRIPTION
even when using `-Ddd.integrations.enabled=false` because sometimes people use that to turn everything off before re-enabling selected integrations, and most (if not all) integrations rely on the classloading instrumentation. This is a stop-gap until we can declare dependencies between integrations.

Note: it can still be explicitly turned off by using `-Ddd.integration.classloading.enabled=false`
