### PR TITLE
Add time-utils to list of bundled projects

### DIFF
--- a/dd-trace-ot/dd-trace-ot.gradle
+++ b/dd-trace-ot/dd-trace-ot.gradle
@@ -82,7 +82,8 @@ def bundledProjects = [
   ':internal-api',
   ':utils:container-utils',
   ':utils:histograms',
-  ':utils:socket-utils'
+  ':utils:socket-utils',
+  ':utils:time-utils'
 ]
 
 shadowJar {


### PR DESCRIPTION
# What Does This Do

Adds the `time-utils` project to the list of projects bundled for dd-trace-ot

# Motivation

The current release is missing this library. For developers attempting manual instrumentation, there's a `NoClassDefFoundError` on startup.
