### PR TITLE
Change ThreadPoolExecutorInstrumentation to avoid wrapping Runnable

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/TPEHelper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/TPEHelper.java
@@ -1,0 +1,125 @@
+package datadog.trace.bootstrap.instrumentation.java.concurrent;
+
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.exclude;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.Function;
+import datadog.trace.api.GenericClassValue;
+import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import java.util.Set;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * This class is a helper for the ThreadPoolExecutorInstrumentation. The instrumentation has two
+ * modes, where the legacy mode uses wrapping of the Runnable and the new mode uses the State
+ * context store field in the actual Runnable. The ThreadLocal below is needed to transport the
+ * AgentScope between two methods when using the context store approach. More details can be found
+ * in the ThreadPoolExecutorInstrumentation.
+ */
+public final class TPEHelper {
+  // If legacy is enabled, we will try to propagate via wrapping, if not we will try to propagate
+  // via storing the state in the existing field in the Runnable
+  private static final boolean useWrapping;
+  // A ThreadPoolExecutor with one of these types will newer be propagated/wrapped
+  private static final Set<String> excludedClasses;
+  // A ThreadLocal to store the Scope between beforeExecute and afterExecute if wrapping is not used
+  private static final ThreadLocal<AgentScope> threadLocalScope;
+
+  private static final ClassValue<Boolean> WRAP =
+      GenericClassValue.of(
+          new Function<Class<?>, Boolean>() {
+            @Override
+            public Boolean apply(Class<?> input) {
+              String className = input.getName();
+              // We should always wrap anonymous lambda classes since we can't inject fields into
+              // them, and they can never be anything more than a _pure_ Runnable. They have '/' in
+              // their class name which is not allowed in 'normal' classes.
+              return className.indexOf('/', className.lastIndexOf('.')) > 0;
+            }
+          });
+
+  static {
+    Config config = Config.get();
+    useWrapping = config.isLegacyTracingEnabled(false, "trace.thread-pool-executors");
+    excludedClasses = config.getTraceThreadPoolExecutorsExclude();
+    if (useWrapping) {
+      threadLocalScope = null;
+    } else {
+      threadLocalScope = new ThreadLocal<>();
+    }
+  }
+
+  public static boolean useWrapping(Runnable task) {
+    return useWrapping || task instanceof Wrapper || (task != null && WRAP.get(task.getClass()));
+  }
+
+  public static void setPropagate(
+      ContextStore<ThreadPoolExecutor, Boolean> contextStore, ThreadPoolExecutor executor) {
+    if (executor == null || contextStore == null || contextStore.get(executor) != null) {
+      return;
+    }
+    String executorType = executor.getClass().getName();
+    if (excludedClasses.contains(executorType)) {
+      contextStore.put(executor, Boolean.FALSE);
+    } else {
+      contextStore.put(executor, Boolean.TRUE);
+    }
+  }
+
+  public static boolean shouldPropagate(
+      ContextStore<ThreadPoolExecutor, Boolean> contextStore, ThreadPoolExecutor executor) {
+    if (executor == null || contextStore == null) {
+      return false;
+    }
+    return Boolean.TRUE.equals(contextStore.get(executor));
+  }
+
+  public static void capture(ContextStore<Runnable, State> contextStore, Runnable task) {
+    if (task != null && !exclude(RUNNABLE, task)) {
+      AdviceUtils.capture(contextStore, task, true);
+    }
+  }
+
+  public static AgentScope startScope(ContextStore<Runnable, State> contextStore, Runnable task) {
+    if (task == null || exclude(RUNNABLE, task)) {
+      return null;
+    }
+    return AdviceUtils.startTaskScope(contextStore, task);
+  }
+
+  public static void setThreadLocalScope(AgentScope scope, Runnable task) {
+    if (scope == null || task == null || exclude(RUNNABLE, task)) {
+      return;
+    }
+    AgentScope current = threadLocalScope.get();
+    if (current != null) {
+      current.close();
+    }
+    threadLocalScope.set(scope);
+  }
+
+  public static AgentScope getAndClearThreadLocalScope(Runnable task) {
+    if (task == null || exclude(RUNNABLE, task)) {
+      return null;
+    }
+    AgentScope scope = threadLocalScope.get();
+    threadLocalScope.set(null);
+    return scope;
+  }
+
+  public static void endScope(AgentScope scope, Runnable task) {
+    if (task == null || exclude(RUNNABLE, task)) {
+      return;
+    }
+    AdviceUtils.endTaskScope(scope);
+  }
+
+  public static void cancelTask(ContextStore<Runnable, State> contextStore, Runnable task) {
+    if (task == null || exclude(RUNNABLE, task)) {
+      return;
+    }
+    AdviceUtils.cancelTask(contextStore, task);
+  }
+}

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/Wrapper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/Wrapper.java
@@ -28,6 +28,10 @@ public class Wrapper<T extends Runnable> implements Runnable, AutoCloseable {
     return task;
   }
 
+  public static Runnable unwrap(Runnable task) {
+    return task instanceof Wrapper ? ((Wrapper<?>) task).unwrap() : task;
+  }
+
   protected final T delegate;
   private final AgentScope.Continuation continuation;
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorInstrumentation.java
@@ -5,6 +5,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
 import static datadog.trace.instrumentation.java.concurrent.AbstractExecutorInstrumentation.EXEC_NAME;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.not;
@@ -14,21 +15,52 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.ExcludeFilterProvider;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.TPEHelper;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.Wrapper;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ThreadPoolExecutor;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.ElementMatchers;
 
+/**
+ * The old way of doing this is to wrap the Runnable when it is added to the queue, which is scary
+ * by itself, since the queue can contain any type of object that implements Runnable, and the queue
+ * implementation can try to cast it to something that our wrapper doesn't implement. To avoid this
+ * we use the existing State field context store in the Runnable and hand off the AgentScope from
+ * beforeExecute to afterExecute via a ThreadLocal.
+ *
+ * <p>Here is a simple flow chart for the non wrapping version with + signifying added code:
+ *
+ * <pre>{@code
+ * beforeExecute -> enter
+ *                  + start AgentScope if available and pass it to exit
+ *                  normal method body
+ *                  exit
+ *               <- + store AgentScope in ThreadLocal if available
+ * normal execution of the Runnable
+ * afterExecute  -> enter
+ *                  + clear and pass ThreadLocal AgentScope if available to exit
+ *                  normal method body
+ *                  exit
+ *               <- + close AgentScope if available
+ * }</pre>
+ */
 @AutoService(Instrumenter.class)
 public final class ThreadPoolExecutorInstrumentation extends Instrumenter.Tracing
     implements Instrumenter.ForTypeHierarchy, ExcludeFilterProvider {
+
+  private static final String TPE = "java.util.concurrent.ThreadPoolExecutor";
 
   // executors which do their own wrapping before calling super,
   // leading to double wrapping, once at the child level and once
@@ -46,11 +78,20 @@ public final class ThreadPoolExecutorInstrumentation extends Instrumenter.Tracin
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
     return ElementMatchers.<TypeDescription>not(
             named("java.util.concurrent.ScheduledThreadPoolExecutor"))
-        .and(extendsClass(named("java.util.concurrent.ThreadPoolExecutor")));
+        .and(extendsClass(named(TPE)));
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    final Map<String, String> stores = new HashMap<>();
+    stores.put(TPE, Boolean.class.getName());
+    stores.put("java.lang.Runnable", State.class.getName());
+    return Collections.unmodifiableMap(stores);
   }
 
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(isConstructor(), getClass().getName() + "$Init");
     transformation.applyAdvice(
         named("execute").and(isMethod()).and(NO_WRAPPING_BEFORE_DELEGATION),
         getClass().getName() + "$Execute");
@@ -78,41 +119,97 @@ public final class ThreadPoolExecutorInstrumentation extends Instrumenter.Tracin
             "datadog.trace.bootstrap.instrumentation.java.concurrent.ComparableRunnable"));
   }
 
+  public static final class Init {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void decideWrapping(@Advice.This final ThreadPoolExecutor zis) {
+      TPEHelper.setPropagate(
+          InstrumentationContext.get(ThreadPoolExecutor.class, Boolean.class), zis);
+    }
+  }
+
   public static final class Execute {
-    @Advice.OnMethodEnter
-    public static void wrap(@Advice.Argument(readOnly = false, value = 0) Runnable task) {
-      task = Wrapper.wrap(task);
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void capture(
+        @Advice.This final ThreadPoolExecutor zis,
+        @Advice.Argument(readOnly = false, value = 0) Runnable task) {
+      if (TPEHelper.shouldPropagate(
+          InstrumentationContext.get(ThreadPoolExecutor.class, Boolean.class), zis)) {
+        if (TPEHelper.useWrapping(task)) {
+          task = Wrapper.wrap(task);
+        } else {
+          TPEHelper.capture(InstrumentationContext.get(Runnable.class, State.class), task);
+        }
+      }
     }
   }
 
   public static final class BeforeExecute {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static AgentScope beforeExecuteEnter(
+        @Advice.This final ThreadPoolExecutor zis,
+        @Advice.Argument(readOnly = false, value = 1) Runnable task) {
+      if (TPEHelper.shouldPropagate(
+          InstrumentationContext.get(ThreadPoolExecutor.class, Boolean.class), zis)) {
+        if (TPEHelper.useWrapping(task)) {
+          task = Wrapper.unwrap(task);
+        } else {
+          return TPEHelper.startScope(
+              InstrumentationContext.get(Runnable.class, State.class), task);
+        }
+      }
+      return null;
+    }
 
-    @Advice.OnMethodEnter
-    public static void unwrap(@Advice.Argument(readOnly = false, value = 1) Runnable task) {
-      if (task instanceof Wrapper) {
-        task = ((Wrapper<?>) task).unwrap();
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void beforeExecuteExit(
+        @Advice.Enter final AgentScope scope, @Advice.Argument(value = 1) Runnable task) {
+      if (scope != null) {
+        TPEHelper.setThreadLocalScope(scope, task);
       }
     }
   }
 
   public static final class AfterExecute {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static AgentScope afterExecuteEnter(
+        @Advice.This final ThreadPoolExecutor zis,
+        @Advice.Argument(readOnly = false, value = 0) Runnable task) {
+      if (TPEHelper.shouldPropagate(
+          InstrumentationContext.get(ThreadPoolExecutor.class, Boolean.class), zis)) {
+        if (TPEHelper.useWrapping(task)) {
+          task = Wrapper.unwrap(task);
+        } else {
+          return TPEHelper.getAndClearThreadLocalScope(task);
+        }
+      }
+      return null;
+    }
 
-    @Advice.OnMethodEnter
-    public static void unwrap(@Advice.Argument(readOnly = false, value = 0) Runnable task) {
-      if (task instanceof Wrapper) {
-        task = ((Wrapper<?>) task).unwrap();
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void afterExecuteExit(
+        @Advice.Enter final AgentScope scope, @Advice.Argument(value = 0) Runnable task) {
+      if (scope != null) {
+        TPEHelper.endScope(scope, task);
       }
     }
   }
 
   public static final class Remove {
-
-    @Advice.OnMethodExit
-    public static void unwrap(@Advice.Return(readOnly = false) Runnable removed) {
-      if (removed instanceof Wrapper) {
-        Wrapper<?> wrapper = ((Wrapper<?>) removed);
-        wrapper.cancel();
-        removed = wrapper.unwrap();
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void remove(
+        @Advice.This final ThreadPoolExecutor zis,
+        @Advice.Return(readOnly = false) Runnable removed) {
+      if (TPEHelper.shouldPropagate(
+          InstrumentationContext.get(ThreadPoolExecutor.class, Boolean.class), zis)) {
+        if (TPEHelper.useWrapping(removed)) {
+          if (removed instanceof Wrapper) {
+            Wrapper<?> wrapper = ((Wrapper<?>) removed);
+            wrapper.cancel();
+            removed = wrapper.unwrap();
+          }
+        } else {
+          TPEHelper.cancelTask(InstrumentationContext.get(Runnable.class, State.class), removed);
+        }
       }
     }
   }

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/java/PeriodicTask.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/java/PeriodicTask.java
@@ -1,15 +1,26 @@
 import datadog.trace.api.Trace;
 
 public class PeriodicTask implements Runnable {
-  private int runCount;
+  private volatile int runCount;
+  private boolean finished = false;
 
   public int getRunCount() {
     return runCount;
   }
 
+  public void ensureFinished() {
+    synchronized (this) {
+      this.finished = true;
+    }
+  }
+
   @Override
   public void run() {
-    periodicRun();
+    synchronized (this) {
+      if (!finished) {
+        periodicRun();
+      }
+    }
   }
 
   @Trace(operationName = "periodicRun")

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -19,6 +19,9 @@ public final class TraceInstrumentationConfig {
   public static final String TRACE_CLASSES_EXCLUDE = "trace.classes.exclude";
   public static final String TRACE_TESTS_ENABLED = "trace.tests.enabled";
 
+  public static final String TRACE_THREAD_POOL_EXECUTORS_EXCLUDE =
+      "trace.thread-pool-executors.exclude";
+
   public static final String HTTP_SERVER_TAG_QUERY_STRING = "http.server.tag.query-string";
   public static final String HTTP_SERVER_RAW_QUERY_STRING = "http.server.raw.query-string";
   public static final String HTTP_SERVER_RAW_RESOURCE = "http.server.raw.resource";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -193,6 +193,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_EXECUTORS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_EXECUTORS_ALL;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_METHODS;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_THREAD_POOL_EXECUTORS_EXCLUDE;
 import static datadog.trace.api.config.TracerConfig.AGENT_HOST;
 import static datadog.trace.api.config.TracerConfig.AGENT_NAMED_PIPE;
 import static datadog.trace.api.config.TracerConfig.AGENT_PORT_LEGACY;
@@ -391,6 +392,8 @@ public class Config {
 
   private final boolean traceExecutorsAll;
   private final List<String> traceExecutors;
+
+  private final Set<String> traceThreadPoolExecutorsExclude;
 
   private final boolean traceAnalyticsEnabled;
 
@@ -812,8 +815,10 @@ public class Config {
     traceMethods = configProvider.getString(TRACE_METHODS, DEFAULT_TRACE_METHODS);
 
     traceExecutorsAll = configProvider.getBoolean(TRACE_EXECUTORS_ALL, DEFAULT_TRACE_EXECUTORS_ALL);
-
     traceExecutors = tryMakeImmutableList(configProvider.getList(TRACE_EXECUTORS));
+
+    traceThreadPoolExecutorsExclude =
+        tryMakeImmutableSet(configProvider.getList(TRACE_THREAD_POOL_EXECUTORS_EXCLUDE));
 
     traceAnalyticsEnabled =
         configProvider.getBoolean(TRACE_ANALYTICS_ENABLED, DEFAULT_TRACE_ANALYTICS_ENABLED);
@@ -1329,6 +1334,10 @@ public class Config {
 
   public List<String> getTraceExecutors() {
     return traceExecutors;
+  }
+
+  public Set<String> getTraceThreadPoolExecutorsExclude() {
+    return traceThreadPoolExecutorsExclude;
   }
 
   public boolean isTraceAnalyticsEnabled() {


### PR DESCRIPTION
# What Does This Do

Changes the `ThreadPoolExecutorInstrumentation` to avoid wrapping the `Runnable` before it is put into the work queue.

# Motivation

Wrapping the `Runnable` is not always safe since the work queue implementation can be of a type that not only expects something that implements `Runnable` but another interface/class that it will happily try to cast to, resulting in exceptions since the internal wrapper class doesn't implement/inherit it properly.

# Additional Notes

This can change the behavior of when the scopes and spans get activated, which might lead to differences in span structure, and maybe it should be labeled a breaking change.

* A `ThreadPoolExecutor` class can be excluded from propagation by using the `dd.trace.thread-pool-executors.exclude` setting
* The old behavior can be reverted to by setting `dd.trace.thread-pool-executors.legacy.tracing.enabled=true`
