### PR TITLE
ratpack: pass converted request body / path tokens

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
@@ -29,7 +29,7 @@ public interface KnownAddresses {
    * incoming url parameters as parsed by the framework (e.g /foo/:id gives a id param that is not
    * part of the query
    */
-  Address<Map<String, Object>> REQUEST_PATH_PARAMS = new Address<>("server.request.path_params");
+  Address<Map<String, ?>> REQUEST_PATH_PARAMS = new Address<>("server.request.path_params");
 
   /** Cookies as parsed by the server */
   Address<List<StringKVPair>> REQUEST_COOKIES = new Address<>("server.request.cookies");

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -2,6 +2,7 @@ package com.datadog.appsec.gateway;
 
 import com.datadog.appsec.event.data.Address;
 import com.datadog.appsec.event.data.DataBundle;
+import com.datadog.appsec.event.data.KnownAddresses;
 import com.datadog.appsec.event.data.StringKVPair;
 import com.datadog.appsec.report.raw.events.AppSecEvent100;
 import com.datadog.appsec.util.StandardizedLogging;
@@ -66,7 +67,6 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   private boolean blocked;
 
   private boolean reqDataPublished;
-  private boolean pathParamsPublished;
   private boolean rawReqBodyPublished;
   private boolean convertedReqBodyPublished;
   private boolean respDataPublished;
@@ -282,11 +282,7 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   }
 
   public boolean isPathParamsPublished() {
-    return pathParamsPublished;
-  }
-
-  public void setPathParamsPublished(boolean pathParamsPublished) {
-    this.pathParamsPublished = pathParamsPublished;
+    return persistentData.containsKey(KnownAddresses.REQUEST_PATH_PARAMS);
   }
 
   public boolean isRawReqBodyPublished() {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -185,9 +185,9 @@ public class GatewayBridge {
           (ctx_, data) -> {
             AppSecRequestContext ctx = ctx_.getData();
             if (ctx.isPathParamsPublished()) {
+              log.debug("Second or subsequent publication of request params");
               return NoopFlow.INSTANCE;
             }
-            ctx.setPathParamsPublished(true);
 
             if (pathParamsSubInfo == null) {
               pathParamsSubInfo =

--- a/dd-java-agent/instrumentation/ratpack-1.5/ratpack-1.5.gradle
+++ b/dd-java-agent/instrumentation/ratpack-1.5/ratpack-1.5.gradle
@@ -1,7 +1,6 @@
 // Set properties before any plugins get loaded
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
-  maxJavaVersionForTests = JavaVersion.VERSION_1_8
 }
 
 muzzle {
@@ -29,5 +28,6 @@ dependencies {
 
   testImplementation project(':dd-java-agent:instrumentation:netty-4.1')
   testImplementation group: 'io.ratpack', name: 'ratpack-groovy-test', version: '1.5.0'
+  testImplementation 'com.sun.activation:jakarta.activation:1.2.2'
   latestDepTestImplementation group: 'io.ratpack', name: 'ratpack-groovy-test', version: '+'
 }

--- a/dd-java-agent/instrumentation/ratpack-1.5/ratpack-1.5.gradle
+++ b/dd-java-agent/instrumentation/ratpack-1.5/ratpack-1.5.gradle
@@ -25,6 +25,7 @@ testSets {
 
 dependencies {
   main_java8CompileOnly group: 'io.ratpack', name: 'ratpack-core', version: '1.5.0'
+  main_java8CompileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: '4.2.0'
 
   testImplementation project(':dd-java-agent:instrumentation:netty-4.1')
   testImplementation group: 'io.ratpack', name: 'ratpack-groovy-test', version: '1.5.0'

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/ContextParseInstrumentation.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/ContextParseInstrumentation.java
@@ -4,6 +4,9 @@ import static net.bytebuddy.matcher.ElementMatchers.*;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.muzzle.IReferenceMatcher;
+import datadog.trace.agent.tooling.muzzle.Reference;
+import datadog.trace.agent.tooling.muzzle.ReferenceMatcher;
 
 @AutoService(Instrumenter.class)
 public class ContextParseInstrumentation extends Instrumenter.AppSec
@@ -11,6 +14,14 @@ public class ContextParseInstrumentation extends Instrumenter.AppSec
 
   public ContextParseInstrumentation() {
     super("ratpack");
+  }
+
+  // so it doesn't apply to ratpack < 1.5
+  private static final ReferenceMatcher FILE_IO =
+      new ReferenceMatcher(new Reference.Builder("ratpack.file.FileIo").build());
+
+  private IReferenceMatcher postProcessReferenceMatcher(final ReferenceMatcher origMatcher) {
+    return new IReferenceMatcher.ConjunctionReferenceMatcher(origMatcher, FILE_IO);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/ContextParseInstrumentation.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/ContextParseInstrumentation.java
@@ -1,0 +1,30 @@
+package datadog.trace.instrumentation.ratpack;
+
+import static net.bytebuddy.matcher.ElementMatchers.*;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+
+@AutoService(Instrumenter.class)
+public class ContextParseInstrumentation extends Instrumenter.AppSec
+    implements Instrumenter.ForSingleType {
+
+  public ContextParseInstrumentation() {
+    super("ratpack");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "ratpack.handling.internal.DefaultContext";
+  }
+
+  @Override
+  public void adviceTransformations(Instrumenter.AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("parse")
+            .and(takesArguments(2))
+            .and(takesArgument(0, named("ratpack.http.TypedData")))
+            .and(takesArgument(1, named("ratpack.parse.Parse"))),
+        packageName + ".ContextParseAdvice");
+  }
+}

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/PathHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/PathHandlerInstrumentation.java
@@ -1,0 +1,58 @@
+package datadog.trace.instrumentation.ratpack;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.muzzle.IReferenceMatcher;
+import datadog.trace.agent.tooling.muzzle.Reference;
+import datadog.trace.agent.tooling.muzzle.ReferenceMatcher;
+
+@AutoService(Instrumenter.class)
+public class PathHandlerInstrumentation extends Instrumenter.AppSec
+    implements Instrumenter.ForSingleType {
+
+  public PathHandlerInstrumentation() {
+    super("ratpack");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "ratpack.path.internal.PathHandler";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".PathBindingPublishingHandler", packageName + ".TokenPathBinderInspector",
+    };
+  }
+
+  private static final ReferenceMatcher TOKEN_PATH_BINDER_TOKEN_NAMES =
+      new ReferenceMatcher(
+          new Reference.Builder("ratpack.path.internal.TokenPathBinder")
+              .withField(
+                  new String[0],
+                  Reference.EXPECTS_NON_STATIC,
+                  "tokenNames",
+                  "Lcom/google/common/collect/ImmutableList;")
+              .build());
+
+  private IReferenceMatcher postProcessReferenceMatcher(final ReferenceMatcher origMatcher) {
+    return new IReferenceMatcher.ConjunctionReferenceMatcher(
+        origMatcher, TOKEN_PATH_BINDER_TOKEN_NAMES);
+  }
+
+  @Override
+  public void adviceTransformations(Instrumenter.AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isConstructor()
+            .and(takesArguments(2))
+            .and(takesArgument(0, named("ratpack.path.PathBinder")))
+            .and(takesArgument(1, named("ratpack.handling.Handler"))),
+        packageName + ".PathHandlerAdvice");
+  }
+}

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/PathHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/PathHandlerInstrumentation.java
@@ -41,9 +41,15 @@ public class PathHandlerInstrumentation extends Instrumenter.AppSec
                   "Lcom/google/common/collect/ImmutableList;")
               .build());
 
+  // so it doesn't apply to ratpack < 1.5
+  private static final ReferenceMatcher FILE_IO =
+      new ReferenceMatcher(new Reference.Builder("ratpack.file.FileIo").build());
+
   private IReferenceMatcher postProcessReferenceMatcher(final ReferenceMatcher origMatcher) {
     return new IReferenceMatcher.ConjunctionReferenceMatcher(
-        origMatcher, TOKEN_PATH_BINDER_TOKEN_NAMES);
+        new IReferenceMatcher.ConjunctionReferenceMatcher(
+            origMatcher, TOKEN_PATH_BINDER_TOKEN_NAMES),
+        FILE_IO);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/ContextParseAdvice.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/ContextParseAdvice.java
@@ -1,0 +1,45 @@
+package datadog.trace.instrumentation.ratpack;
+
+import static datadog.trace.api.gateway.Events.EVENTS;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+
+import datadog.trace.api.function.BiFunction;
+import datadog.trace.api.gateway.CallbackProvider;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import net.bytebuddy.asm.Advice;
+import ratpack.form.Form;
+
+public class ContextParseAdvice {
+
+  // for now ignore that the parser can be configured to mix in the query string
+  @Advice.OnMethodExit(suppress = Throwable.class)
+  static void after(@Advice.Return Object obj_) {
+    Object obj = obj_;
+    if (obj == null) {
+      return;
+    }
+    if (obj instanceof Form) {
+      if (((Form) obj).isEmpty()) {
+        return;
+      }
+      obj = ((Form) obj).getAll();
+    }
+
+    AgentSpan agentSpan = activeSpan();
+    if (agentSpan == null) {
+      return;
+    }
+
+    CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
+    BiFunction<RequestContext<Object>, Object, Flow<Void>> callback =
+        cbp.getCallback(EVENTS.requestBodyProcessed());
+    RequestContext<Object> requestContext = agentSpan.getRequestContext();
+    if (requestContext == null || callback == null) {
+      return;
+    }
+    callback.apply(requestContext, obj);
+  }
+}

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/PathBindingPublishingHandler.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/PathBindingPublishingHandler.java
@@ -1,0 +1,51 @@
+package datadog.trace.instrumentation.ratpack;
+
+import static datadog.trace.api.gateway.Events.EVENTS;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+
+import datadog.trace.api.function.BiFunction;
+import datadog.trace.api.gateway.CallbackProvider;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.util.Map;
+import ratpack.handling.Context;
+import ratpack.handling.Handler;
+import ratpack.path.PathTokens;
+
+public class PathBindingPublishingHandler implements Handler {
+  public static final Handler INSTANCE = new PathBindingPublishingHandler();
+
+  @Override
+  public void handle(Context ctx) {
+    try {
+      maybePublishTokens(ctx);
+    } finally {
+      ctx.next();
+    }
+  }
+
+  private void maybePublishTokens(Context ctx) {
+    PathTokens tokens = ctx.getPathTokens();
+
+    if (tokens == null || tokens.isEmpty()) {
+      return;
+    }
+
+    AgentSpan agentSpan = activeSpan();
+    if (agentSpan == null) {
+      return;
+    }
+
+    CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
+    BiFunction<RequestContext<Object>, Map<String, ?>, Flow<Void>> callback =
+        cbp.getCallback(EVENTS.requestPathParams());
+    RequestContext<Object> requestContext = agentSpan.getRequestContext();
+    if (requestContext == null || callback == null) {
+      return;
+    }
+
+    callback.apply(requestContext, tokens);
+  }
+}

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/PathHandlerAdvice.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/PathHandlerAdvice.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.ratpack;
 
-import net.bytebuddy.asm.Advice;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import net.bytebuddy.asm.Advice;
 import ratpack.handling.Handler;
 import ratpack.handling.internal.ChainHandler;
 import ratpack.path.PathBinder;

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/PathHandlerAdvice.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/PathHandlerAdvice.java
@@ -1,0 +1,40 @@
+package datadog.trace.instrumentation.ratpack;
+
+import net.bytebuddy.asm.Advice;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import ratpack.handling.Handler;
+import ratpack.handling.internal.ChainHandler;
+import ratpack.path.PathBinder;
+import ratpack.path.internal.TokenPathBinder;
+
+/** @see ratpack.path.internal.PathBindingStorage */
+public class PathHandlerAdvice {
+
+  // limitation: we can publish tokens for more than one handler in the same request
+  // only the first one will be considered further down
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  @SuppressFBWarnings(
+      value = "UC_USELESS_OBJECT",
+      justification = "write to handler is not without effect")
+  static void before(
+      @Advice.Argument(0) PathBinder pathBinder,
+      @Advice.Argument(value = 1, readOnly = false) Handler handler) {
+    if (!(pathBinder instanceof TokenPathBinder)) {
+      return;
+    }
+
+    if (!TokenPathBinderInspector.hasTokenNames((TokenPathBinder) pathBinder)) {
+      return;
+    }
+
+    if (handler instanceof ChainHandler) {
+      Handler[] unpacked = ChainHandler.unpack(handler);
+      Handler[] withPubHandler = new Handler[unpacked.length + 1];
+      System.arraycopy(unpacked, 0, withPubHandler, 1, unpacked.length);
+      withPubHandler[0] = PathBindingPublishingHandler.INSTANCE;
+      handler = new ChainHandler(withPubHandler);
+    } else {
+      handler = new ChainHandler(PathBindingPublishingHandler.INSTANCE, handler);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/TokenPathBinderInspector.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/TokenPathBinderInspector.java
@@ -1,0 +1,28 @@
+package datadog.trace.instrumentation.ratpack;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.util.Collection;
+import ratpack.path.internal.TokenPathBinder;
+
+public class TokenPathBinderInspector {
+  private static final Field TOKEN_NAMES_FIELD;
+
+  static {
+    try {
+      TOKEN_NAMES_FIELD = TokenPathBinder.class.getDeclaredField("tokenNames");
+      TOKEN_NAMES_FIELD.setAccessible(true);
+    } catch (NoSuchFieldException e) {
+      throw new UndeclaredThrowableException(e);
+    }
+  }
+
+  public static boolean hasTokenNames(TokenPathBinder binder) {
+    try {
+      Collection<?> tokenNames = (Collection<?>) TOKEN_NAMES_FIELD.get(binder);
+      return !tokenNames.isEmpty();
+    } catch (IllegalAccessException e) {
+      throw new UndeclaredThrowableException(e);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/server/RatpackAsyncHttpServerTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/server/RatpackAsyncHttpServerTest.groovy
@@ -6,15 +6,19 @@ import io.netty.buffer.ByteBuf
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 import ratpack.exec.Promise
+import ratpack.form.Form
 import ratpack.groovy.test.embed.GroovyEmbeddedApp
 import ratpack.handling.HandlerDecorator
 
 import java.nio.charset.StandardCharsets
 
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_JSON
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_URLENCODED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.CREATED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_BOTH
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_QUERY
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
@@ -98,6 +102,44 @@ class RatpackAsyncHttpServerTest extends RatpackHttpServerTest {
             } then { HttpServerTest.ServerEndpoint endpoint ->
               controller(endpoint) {
                 context.response.status(endpoint.status).send(request.headers.get("x-forwarded-for"))
+              }
+            }
+          }
+        }
+        get('path/:id/param') {
+          Promise.sync {
+            PATH_PARAM
+          } then {endpoint ->
+            controller(endpoint) {
+              context.response.status(PATH_PARAM.status).send('text/plain', context.pathTokens['id'])
+            }
+          }
+        }
+        prefix(BODY_URLENCODED.relativeRawPath()) {
+          all {
+            Promise.sync {
+              BODY_URLENCODED
+            } then { endpoint ->
+              controller(BODY_URLENCODED) {
+                context.parse(Form).then { form ->
+                  def text = form.findAll { it.key != 'ignore' }
+                  .collectEntries { [it.key, it.value as List] } as String
+                  response.status(BODY_URLENCODED.status).send('text/plain', text)
+                }
+              }
+            }
+          }
+        }
+
+        prefix(BODY_JSON.relativeRawPath()) {
+          all {
+            Promise.sync {
+              BODY_JSON
+            } then {endpoint ->
+              controller(endpoint) {
+                context.parse(Map).then { map ->
+                  response.status(BODY_JSON.status).send('text/plain', "{\"a\":\"${map['a']}\"}")
+                }
               }
             }
           }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/server/RatpackHttpServerTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/server/RatpackHttpServerTest.groovy
@@ -1,6 +1,6 @@
 package server
 
-import com.fasterxml.jackson.databind.JsonNode
+
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
@@ -22,6 +22,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.CREATE
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_BOTH
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_QUERY
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
@@ -57,6 +58,11 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> {
                   .send('text/plain', "${CREATED.body}: ${typedData.text}")
               }
             }
+          }
+        }
+        get('path/:id/param') {
+          controller(PATH_PARAM) {
+            context.response.status(PATH_PARAM.status).send('text/plain', context.pathTokens['id'])
           }
         }
         prefix(BODY_URLENCODED.relativeRawPath()) {
@@ -150,6 +156,20 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> {
   }
 
   @Override
+  String expectedResourceName(ServerEndpoint endpoint, String method, URI address) {
+    if (endpoint == PATH_PARAM) {
+      'GET /path/:id/param'
+    } else {
+      super.expectedResourceName(endpoint, method, address)
+    }
+  }
+
+  @Override
+  Map<String, ?> expectedIGPathParams() {
+    [id: '123']
+  }
+
+  @Override
   boolean hasHandlerSpan() {
     true
   }
@@ -166,6 +186,11 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> {
 
   @Override
   boolean testBodyJson() {
+    true
+  }
+
+  @Override
+  String testPathParam() {
     true
   }
 

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateAndMatrixVariablesInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateAndMatrixVariablesInstrumentation.java
@@ -104,7 +104,7 @@ public class TemplateAndMatrixVariablesInstrumentation extends Instrumenter.AppS
 
       if (map != null && !map.isEmpty()) {
         CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-        BiFunction<RequestContext<Object>, Map<String, Object>, Flow<Void>> callback =
+        BiFunction<RequestContext<Object>, Map<String, ?>, Flow<Void>> callback =
             cbp.getCallback(EVENTS.requestPathParams());
         RequestContext<Object> requestContext = agentSpan.getRequestContext();
         if (requestContext == null || callback == null) {

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateVariablesUrlHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateVariablesUrlHandlerInstrumentation.java
@@ -78,7 +78,7 @@ public class TemplateVariablesUrlHandlerInstrumentation extends Instrumenter.App
       }
 
       CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-      BiFunction<RequestContext<Object>, Map<String, Object>, Flow<Void>> callback =
+      BiFunction<RequestContext<Object>, Map<String, ?>, Flow<Void>> callback =
           cbp.getCallback(EVENTS.requestPathParams());
       RequestContext<Object> requestContext = agentSpan.getRequestContext();
       if (requestContext == null || callback == null) {

--- a/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
@@ -79,9 +79,8 @@ public final class Events<D> {
       new ET<>("server.request.method.uri.raw", REQUEST_PATH_PARAMS_ID);
   /** The parameters the framework got from the request uri (but not the query string) */
   @SuppressWarnings("unchecked")
-  public EventType<BiFunction<RequestContext<D>, Map<String, Object>, Flow<Void>>>
-      requestPathParams() {
-    return (EventType<BiFunction<RequestContext<D>, Map<String, Object>, Flow<Void>>>)
+  public EventType<BiFunction<RequestContext<D>, Map<String, ?>, Flow<Void>>> requestPathParams() {
+    return (EventType<BiFunction<RequestContext<D>, Map<String, ?>, Flow<Void>>>)
         REQUEST_PATH_PARAMS;
   }
 


### PR DESCRIPTION
# What Does This Do

Adds support in ratpack for transmitting to the IG extract path tokens (only the first ones) as well as converted request entities.