### PR TITLE
Hibernate 6.0.0.Final removed the Criteria query API

### DIFF
--- a/dd-java-agent/instrumentation/hibernate/core-4.0/core-4.0.gradle
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/core-4.0.gradle
@@ -2,7 +2,7 @@ muzzle {
   pass {
     group = "org.hibernate"
     module = "hibernate-core"
-    versions = "[4.0.0.Final,)"
+    versions = "[4.0.0.Final,6.0.0)"
     assertInverse = true
   }
 }


### PR DESCRIPTION
Update the muzzle range to match the new expectation that the 4.0 instrumentation will no longer match the 6.0 API

https://github.com/hibernate/hibernate-orm/blob/main/migration-guide.adoc#legacy-hibernate-criteria-api