### PR TITLE
Add registry to use same keys across class loaders

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/FieldBackedContextStore.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/FieldBackedContextStore.java
@@ -89,14 +89,14 @@ public final class FieldBackedContextStore implements ContextStore<Object, Objec
   }
 
   // only create WeakMap-based fall-back when we need it
-  private volatile WeakMapContextStore weakStore;
+  private volatile WeakMapContextStore<Object, Object> weakStore;
   private final Object synchronizationInstance = new Object();
 
-  WeakMapContextStore weakStore() {
+  WeakMapContextStore<Object, Object> weakStore() {
     if (null == weakStore) {
       synchronized (synchronizationInstance) {
         if (null == weakStore) {
-          weakStore = new WeakMapContextStore();
+          weakStore = new WeakMapContextStore<>();
         }
       }
     }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InstanceStore.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InstanceStore.java
@@ -1,0 +1,30 @@
+package datadog.trace.bootstrap;
+
+import datadog.trace.api.Function;
+import datadog.trace.api.GenericClassValue;
+
+/**
+ * An {@code InstanceStore} is a class global map for registering instances. This can be useful when
+ * helper classes are injected into multiple class loaders but need to share unique keys of a type
+ * from a common parent class loader.
+ *
+ * <p>The {@code InstanceStore} is backed by a {@code WeakMapContextStore} that has a max size of
+ * 100 keys.
+ */
+public final class InstanceStore {
+  private InstanceStore() {}
+
+  private static final ClassValue<? super ContextStore<String, ?>> classInstanceStore =
+      GenericClassValue.of(
+          new Function<Class<?>, ContextStore<String, ?>>() {
+            @Override
+            public ContextStore<String, ?> apply(Class<?> input) {
+              return new WeakMapContextStore<>(100);
+            }
+          });
+
+  @SuppressWarnings("unchecked")
+  public static <T> ContextStore<String, T> of(Class<T> type) {
+    return (ContextStore<String, T>) classInstanceStore.get(type);
+  }
+}

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/InstanceStoreTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/InstanceStoreTest.groovy
@@ -1,0 +1,147 @@
+package datadog.trace.bootstrap
+
+import datadog.trace.agent.tooling.WeakMaps
+import datadog.trace.test.util.DDSpecification
+import spock.lang.Shared
+
+import java.util.concurrent.atomic.AtomicInteger
+
+class InstanceStoreTest extends DDSpecification {
+  static {
+    WeakMaps.registerAsSupplier()
+  }
+
+  @Shared
+  private AtomicInteger counter = new AtomicInteger()
+
+  // Since the InstanceStore is a per Class singleton, every test case needs new keys
+  String nextKey() {
+    "key-${counter.incrementAndGet()}"
+  }
+
+  def "test empty InstanceStore"() {
+    setup:
+    WeakMapContextStore<String, Some> someStore = InstanceStore.of(Some) as WeakMapContextStore<String, Some>
+
+    expect:
+    someStore.size() == 0
+  }
+
+  def "test returns existing value"() {
+    setup:
+    def someStore = InstanceStore.of(Some)
+    def some1 = new Some()
+    def some2 = new Some()
+    def key = nextKey()
+    someStore.put(key, some1)
+
+    when:
+    def current = someStore.putIfAbsent(key, some2)
+
+    then:
+    current == some1
+    current != some2
+
+    when:
+    current = someStore.putIfAbsent(key, some2)
+
+    then:
+    current == some1
+    current != some2
+  }
+
+  def "test returns existing store"() {
+    setup:
+    def some1 = new Some()
+    def key = nextKey()
+    InstanceStore.of(Some).put(key, some1)
+
+    when:
+    def current = InstanceStore.of(Some).putIfAbsent(key, new Some())
+
+    then:
+    current == some1
+
+    when:
+    current = InstanceStore.of(Some).putIfAbsent(key, new Some())
+
+    then:
+    current == some1
+  }
+
+  def "test conditionally set first value"() {
+    def someStore = InstanceStore.of(Some)
+    def some1 = new Some()
+    def key = nextKey()
+
+    when:
+    def current = someStore.putIfAbsent(key, some1)
+
+    then:
+    current == some1
+
+    when:
+    current = someStore.putIfAbsent(key, new Some())
+
+    then:
+    current == some1
+  }
+
+  def "test factory is not called when value exists"() {
+    def someStore = InstanceStore.of(Some)
+    def some1 = new Some()
+    def invocations = new AtomicInteger()
+    def key = nextKey()
+    someStore.put(key, some1)
+
+    when:
+    def current = someStore.putIfAbsent(key, new Creator(invocations))
+
+    then:
+    current == some1
+    invocations.get() == 0
+  }
+
+  def "test factory is called only once for multiple invocations"() {
+    def someStore = InstanceStore.of(Some)
+    def some1 = new Some()
+    def invocations = new AtomicInteger()
+    def key = nextKey()
+
+    when:
+    def current = someStore.putIfAbsent(key, new Creator(invocations, some1))
+
+    then:
+    current == some1
+    invocations.get() == 1
+
+    when:
+    current = someStore.putIfAbsent(key, new Creator(invocations))
+
+    then:
+    current == some1
+    invocations.get() == 1
+  }
+
+  static class Some {}
+
+  static class Creator implements ContextStore.Factory<Some> {
+    private AtomicInteger invocations
+    private Some some
+
+    Creator(AtomicInteger invocations, Some some) {
+      this.invocations = invocations
+      this.some = some
+    }
+
+    Creator(AtomicInteger invocations) {
+      this(invocations, new Some())
+    }
+
+    @Override
+    Some create() {
+      invocations.incrementAndGet()
+      return some
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/UndertowDecorator.java
+++ b/dd-java-agent/instrumentation/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/UndertowDecorator.java
@@ -1,5 +1,7 @@
 package datadog.trace.instrumentation.undertow;
 
+import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.InstanceStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
@@ -16,11 +18,21 @@ public class UndertowDecorator
   public static final CharSequence SERVLET_REQUEST = UTF8BytesString.create("servlet.request");
   public static final CharSequence UNDERTOW_HTTP_SERVER =
       UTF8BytesString.create("undertow-http-server");
-  public static final UndertowDecorator DECORATE = new UndertowDecorator();
+
+  @SuppressWarnings("rawtypes")
+  private static final ContextStore<String, AttachmentKey> attachmentStore =
+      InstanceStore.of(AttachmentKey.class);
+
+  @SuppressWarnings("unchecked")
   public static final AttachmentKey<Boolean> DD_HTTPSERVEREXCHANGE_DISPATCH =
-      AttachmentKey.create(Boolean.class);
+      attachmentStore.putIfAbsent(
+          "DD_HTTPSERVEREXCHANGE_DISPATCH", AttachmentKey.create(Boolean.class));
+
+  @SuppressWarnings("unchecked")
   public static final AttachmentKey<AgentSpan> DD_UNDERTOW_SPAN =
-      AttachmentKey.create(AgentSpan.class);
+      attachmentStore.putIfAbsent("DD_UNDERTOW_SPAN", AttachmentKey.create(AgentSpan.class));
+
+  public static final UndertowDecorator DECORATE = new UndertowDecorator();
 
   @Override
   protected String[] instrumentationNames() {


### PR DESCRIPTION
# What Does This Do

Creates a class global instance registry for things like keys used to attach information to HTTP Requests/Responses.

# Motivation

Part of the Undertow instrumentation is based on classes implementing a certain interface, which means that the helper classes can get injected into multiple class loaders, while the main Undertow code lives in another class loader. While looking at a reported issue @ValentinZakharov noticed that this can lead to our helper classes being injected multiple times, and the `AttachmentKey` instances being different across multiple classes in the same server, leading to doubling of calls.

# Additional Notes
