### PR TITLE
Support excluding named classloaders from matching and class-file resource lookups

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -17,6 +17,7 @@ public final class TraceInstrumentationConfig {
   public static final String TRACE_EXECUTORS = "trace.executors";
   public static final String TRACE_METHODS = "trace.methods";
   public static final String TRACE_CLASSES_EXCLUDE = "trace.classes.exclude";
+  public static final String TRACE_CLASSLOADERS_EXCLUDE = "trace.classloaders.exclude";
   public static final String TRACE_TESTS_ENABLED = "trace.tests.enabled";
 
   public static final String HTTP_SERVER_TAG_QUERY_STRING = "http.server.tag.query-string";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -189,6 +189,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ROOT_C
 import static datadog.trace.api.config.TraceInstrumentationConfig.TEMP_JARS_CLEAN_ON_BOOT;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ANNOTATIONS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSLOADERS_EXCLUDE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_EXECUTORS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_EXECUTORS_ALL;
@@ -328,6 +329,7 @@ public class Config {
   private final Map<String, String> spanTags;
   private final Map<String, String> jmxTags;
   private final List<String> excludedClasses;
+  private final Set<String> excludedClassLoaders;
   private final Map<String, String> requestHeaderTags;
   private final Map<String, String> responseHeaderTags;
   private final BitSet httpServerErrorStatuses;
@@ -647,6 +649,7 @@ public class Config {
     jmxTags = configProvider.getMergedMap(JMX_TAGS);
 
     excludedClasses = tryMakeImmutableList(configProvider.getList(TRACE_CLASSES_EXCLUDE));
+    excludedClassLoaders = tryMakeImmutableSet(configProvider.getList(TRACE_CLASSLOADERS_EXCLUDE));
 
     if (isEnabled(false, HEADER_TAGS, ".legacy.parsing.enabled")) {
       requestHeaderTags = configProvider.getMergedMap(HEADER_TAGS);
@@ -1113,6 +1116,10 @@ public class Config {
 
   public List<String> getExcludedClasses() {
     return excludedClasses;
+  }
+
+  public Set<String> getExcludedClassLoaders() {
+    return excludedClassLoaders;
   }
 
   public Map<String, String> getRequestHeaderTags() {
@@ -2220,6 +2227,8 @@ public class Config {
         + jmxTags
         + ", excludedClasses="
         + excludedClasses
+        + ", excludedClassLoaders="
+        + excludedClassLoaders
         + ", requestHeaderTags="
         + requestHeaderTags
         + ", responseHeaderTags="


### PR DESCRIPTION
# What Does This Do

Adds a new flag:
```
-Ddd.trace.classloaders.exclude=name1,name2
```
to exclude named classloaders from both matching **and** class-file resource lookups

# Motivation

Gives us a way to exclude problematic classloaders from being touched by instrumentation