### PR TITLE
[CIAPP-1862] Enable --logs for junitxml upload to CI Visibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 defaults: &defaults
   working_directory: ~/dd-trace-java
   docker:
-    - image: &default_container datadog/dd-trace-java-docker-build:latest
+    - image: &default_container datadog/dd-trace-java-docker-build:adrian.lopezalvo_datadog-ci-experimental-junitxml-logs
 
 # The caching setup of the build dependencies is somewhat involved because of how CircleCI works.
 # 1) Caches are immutable, so you can not reuse a cache key (the save will simply be ignored)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 defaults: &defaults
   working_directory: ~/dd-trace-java
   docker:
-    - image: &default_container datadog/dd-trace-java-docker-build:adrian.lopezalvo_datadog-ci-experimental-junitxml-logs
+    - image: &default_container datadog/dd-trace-java-docker-build:latest
 
 # The caching setup of the build dependencies is somewhat involved because of how CircleCI works.
 # 1) Caches are immutable, so you can not reuse a cache key (the save will simply be ignored)

--- a/.circleci/upload_ciapp.sh
+++ b/.circleci/upload_ciapp.sh
@@ -14,7 +14,7 @@ java_prop () {
 }
 
 # based on tracer implementation: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java#L55-L77
-datadog-ci junit upload --service $SERVICE_NAME \
+datadog-ci junit upload --service $SERVICE_NAME --logs \
     --tags "test.traits:{\"marker\":[\"$1\"]}" \
     --tags "runtime.name:$(java_prop java.runtime.name)" \
     --tags "runtime.vendor:$(java_prop java.vendor)" \


### PR DESCRIPTION
# What Does This Do
Support for the `--logs` flag added in https://github.com/DataDog/dd-trace-java-docker-build/pull/36 

This is a new feature for junitxml imports in CI Visibility where we also send texts from `<system-out>` and `<system-err>` to the logs product. This has additional cost so a flag to opt-in is required but it's not available in a standard release of datadog-ci yet.

# Motivation
We want this because the exports from dd-trace-java are the ones that we've seen the biggest load with and we do not want to make the flag and docs public to customers until we've ensured reliability with dogfooding.

# Additional Notes
Once this is working you should be able to check it out with the query `Source: junitxml` in logs. Although we are not configuring rules to ensure 100% sampling for these logs.
