### PR TITLE
Test java 17 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ save_cache_paths: &save_cache_paths
 
 test_matrix: &test_matrix
   parameters:
-    testJvm: [ "7", "IBM8", "ZULU8","ORACLE8", "11", "ZULU11", "ZULU13", "15" ]
+    testJvm: [ "7", "IBM8", "ZULU8","ORACLE8", "11", "ZULU11", "ZULU13", "15", "17" ]
 
 parameters:
   gradle_flags:

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -380,7 +380,9 @@ public class AgentInstaller {
         final JavaModule javaModule,
         final boolean b) {
       final List<Runnable> callbacks;
-      if ("java.util.logging.LogManager".equals(typeName)) {
+      // On Java 17 java.util.logging.LogManager is loaded early even though it's not initialized,
+      // so wait for the LoggerContext to be initialized before the callbacks are processed.
+      if ("java.util.logging.LogManager$LoggerContext".equals(typeName)) {
         callbacks = LOG_MANAGER_CALLBACKS;
       } else if ("javax.management.MBeanServerBuilder".equals(typeName)) {
         callbacks = MBEAN_SERVER_BUILDER_CALLBACKS;

--- a/dd-java-agent/instrumentation/classloading/jboss-testing/jboss-testing.gradle
+++ b/dd-java-agent/instrumentation/classloading/jboss-testing/jboss-testing.gradle
@@ -1,3 +1,8 @@
+ext {
+  // TODO Java 17: This version of jboss-modules doesn't support Java 17
+  //  __redirected.__SAXParserFactory can't access com.sun.org.apache.xerces.internal.jaxp
+  maxJavaVersionForTests = JavaVersion.VERSION_15
+}
 apply from: "$rootDir/gradle/java.gradle"
 
 dependencies {

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
@@ -10,6 +10,7 @@ import com.couchbase.client.java.view.DesignDocument
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.data.repository.CrudRepository
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Unroll
 import util.AbstractCouchbaseTest
@@ -18,6 +19,10 @@ import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
+@IgnoreIf({
+  // TODO Java 17: This version of spring-data doesn't support Java 17
+  new BigDecimal(System.getProperty("java.specification.version")).isAtLeast(17.0)
+})
 @Unroll
 class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
   static final Closure<Doc> FIND

--- a/dd-java-agent/instrumentation/datastax-cassandra-4/datastax-cassandra-4.gradle
+++ b/dd-java-agent/instrumentation/datastax-cassandra-4/datastax-cassandra-4.gradle
@@ -1,5 +1,8 @@
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
+  // TODO Java 17: The embedded cassandra deadlocks on start every time on Java 17
+  //  This can be changed to use test-containers
+  maxJavaVersionForTests = JavaVersion.VERSION_15
 }
 
 muzzle {

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/rest-5.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/rest-5.gradle
@@ -1,6 +1,9 @@
 // Set properties before any plugins get loaded
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
+  // TODO Java 17: The embedded elastic search server doesn't work on Java 17
+  //  This can be changed to use test-containers
+  maxJavaVersionForTests = JavaVersion.VERSION_15
 }
 
 muzzle {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/transport-5.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/transport-5.gradle
@@ -1,6 +1,9 @@
 // Set properties before any plugins get loaded
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
+  // TODO Java 17: The embedded elastic search server doesn't work on Java 17
+  //  This can be changed to use test-containers
+  maxJavaVersionForTests = JavaVersion.VERSION_15
 }
 
 muzzle {

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -3,7 +3,7 @@ import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.bootstrap.instrumentation.httpurlconnection.HttpUrlConnectionDecorator
 import spock.lang.Ignore
-import spock.lang.Requires
+import spock.lang.IgnoreIf
 import spock.lang.Timeout
 import sun.net.www.protocol.https.HttpsURLConnectionImpl
 
@@ -362,7 +362,10 @@ class HttpUrlConnectionTest extends HttpClientTest {
   }
 
   // This test makes no sense on IBM JVM because there is no HttpsURLConnectionImpl class there
-  @Requires({ !System.getProperty("java.vm.name").contains("IBM J9 VM") })
+  @IgnoreIf({
+    System.getProperty("java.vm.name").contains("IBM J9 VM") ||
+      // TODO Java 17: we can't access HttpsURLConnectionImpl on Java 17
+      new BigDecimal(System.getProperty("java.specification.version")).isAtLeast(17.0) })
   def "Make sure we can load HttpsURLConnectionImpl"() {
     when:
     def instance = new HttpsURLConnectionImpl(null, null, null)

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/CustomThreadPoolExecutor.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/CustomThreadPoolExecutor.java
@@ -1,0 +1,112 @@
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.TimeUnit;
+
+public class CustomThreadPoolExecutor extends AbstractExecutorService {
+
+  private volatile Boolean running = true;
+  private LinkedBlockingQueue<Runnable> workQueue = new LinkedBlockingQueue<Runnable>(10);
+  private Runnable worker =
+      new Runnable() {
+        public void run() {
+          try {
+            while (getRunning()) {
+              Runnable runnable = ((LinkedBlockingQueue<Runnable>) getWorkQueue()).take();
+              runnable.run();
+            }
+
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          } catch (Exception e) {
+            e.printStackTrace();
+          }
+        }
+      };
+  private Thread workerThread = new Thread(worker, "ExecutorTestThread");
+
+  public CustomThreadPoolExecutor() {
+    workerThread.start();
+  }
+
+  @Override
+  public void shutdown() {
+    running = false;
+    workerThread.interrupt();
+  }
+
+  @Override
+  public List<Runnable> shutdownNow() {
+    running = false;
+    workerThread.interrupt();
+    return new ArrayList<Runnable>();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return !running;
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return workerThread.isAlive();
+  }
+
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    workerThread.join(unit.toMillis(timeout));
+    return true;
+  }
+
+  @Override
+  public Future<?> submit(Runnable task) {
+    RunnableFuture<Object> future = super.newTaskFor(task, null);
+    execute(future);
+    return ((Future<?>) (future));
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    try {
+      workQueue.put(command);
+    } catch (Throwable t) {
+      throw new RejectedExecutionException(t);
+    }
+  }
+
+  public Boolean getRunning() {
+    return running;
+  }
+
+  public void setRunning(Boolean running) {
+    this.running = running;
+  }
+
+  public LinkedBlockingQueue<Runnable> getWorkQueue() {
+    return workQueue;
+  }
+
+  public void setWorkQueue(LinkedBlockingQueue<Runnable> workQueue) {
+    this.workQueue = workQueue;
+  }
+
+  public Runnable getWorker() {
+    return worker;
+  }
+
+  public void setWorker(Runnable worker) {
+    this.worker = worker;
+  }
+
+  public Thread getWorkerThread() {
+    return workerThread;
+  }
+
+  public void setWorkerThread(Thread workerThread) {
+    this.workerThread = workerThread;
+  }
+}

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/FutureTaskContinuationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/FutureTaskContinuationTest.groovy
@@ -7,24 +7,6 @@ import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 class FutureTaskContinuationTest extends AgentTestRunner {
-  class SettableFuture extends FutureTask<String> {
-    SettableFuture() {
-      super({ "async result" })
-    }
-
-    @SuppressWarnings('UnnecessaryOverridingMethod')
-    @Override
-    void set(String value) {
-      super.set(value)
-    }
-
-    @SuppressWarnings('UnnecessaryOverridingMethod')
-    @Override
-    void setException(Throwable cause) {
-      super.setException(cause)
-    }
-  }
-
   SettableFuture future
 
   @Override

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/SettableFuture.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/SettableFuture.java
@@ -1,0 +1,22 @@
+import java.util.concurrent.Callable;
+import java.util.concurrent.FutureTask;
+
+public class SettableFuture extends FutureTask<String> {
+  SettableFuture() {
+    super(
+        new Callable<String>() {
+          @Override
+          public String call() throws Exception {
+            return "async result";
+          }
+        });
+  }
+
+  public void set(String value) {
+    super.set(value);
+  }
+
+  public void setException(Throwable cause) {
+    super.setException(cause);
+  }
+}

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientAsyncTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientAsyncTest.groovy
@@ -7,6 +7,7 @@ import org.glassfish.jersey.client.ClientConfig
 import org.glassfish.jersey.client.ClientProperties
 import org.glassfish.jersey.client.JerseyClientBuilder
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder
+import spock.lang.IgnoreIf
 import spock.lang.Timeout
 
 import javax.ws.rs.client.AsyncInvoker
@@ -97,6 +98,11 @@ class ResteasyClientAsyncTest extends JaxRsClientAsyncTest {
 }
 
 @Timeout(5)
+@IgnoreIf({
+  // TODO Java 17: This version of apache-cxf doesn't work on Java 17
+  //  exception in org.apache.cxf.common.util.ReflectionUtil
+  new BigDecimal(System.getProperty("java.specification.version")).isAtLeast(17.0)
+})
 class CxfClientAsyncTest extends JaxRsClientAsyncTest {
 
   @Override

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientTest.groovy
@@ -5,6 +5,7 @@ import org.glassfish.jersey.client.ClientConfig
 import org.glassfish.jersey.client.ClientProperties
 import org.glassfish.jersey.client.JerseyClientBuilder
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder
+import spock.lang.IgnoreIf
 import spock.lang.Timeout
 
 import javax.ws.rs.client.Client
@@ -77,6 +78,11 @@ class ResteasyClientTest extends JaxRsClientTest {
 }
 
 @Timeout(5)
+@IgnoreIf({
+  // TODO Java 17: This version of apache-cxf doesn't work on Java 17
+  //  exception in org.apache.cxf.common.util.ReflectionUtil
+  new BigDecimal(System.getProperty("java.specification.version")).isAtLeast(17.0)
+})
 class CxfClientTest extends JaxRsClientTest {
 
   @Override

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPTestBase.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPTestBase.groovy
@@ -5,6 +5,7 @@ import datadog.trace.agent.test.utils.PortUtils
 import net.bytebuddy.utility.JavaModule
 import okhttp3.OkHttpClient
 import org.apache.catalina.Context
+import org.apache.catalina.LifecycleException
 import org.apache.catalina.startup.Tomcat
 import spock.lang.Shared
 
@@ -64,8 +65,17 @@ abstract class JSPTestBase extends AgentTestRunner {
   }
 
   def cleanupSpec() {
-    tomcatServer.stop()
-    tomcatServer.destroy()
+    try {
+      tomcatServer.stop()
+      tomcatServer.destroy()
+    } catch (LifecycleException e) {
+      // TODO Java 17: Failure during Catalina shutdown on JDK17
+      if (new BigDecimal(System.getProperty("java.specification.version")).isAtLeast(17.0)) {
+        e.printStackTrace(System.out)
+      } else {
+        throw e
+      }
+    }
   }
 
   @Override

--- a/dd-java-agent/instrumentation/mule-4/mule-4.gradle
+++ b/dd-java-agent/instrumentation/mule-4/mule-4.gradle
@@ -1,5 +1,7 @@
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
+  // TODO Java 17: Mule 4 doesn't support Java 17
+  maxJavaVersionForTests = JavaVersion.VERSION_15
 }
 
 muzzle {

--- a/dd-java-agent/instrumentation/rmi/rmi.gradle
+++ b/dd-java-agent/instrumentation/rmi/rmi.gradle
@@ -1,6 +1,8 @@
 ext {
   // need access to sun.rmi package
   skipSettingCompilerRelease = true
+  // TODO Java 17: The necessary packages are not opened on Java 17
+  maxJavaVersionForTests = JavaVersion.VERSION_15
 }
 
 muzzle {

--- a/dd-java-agent/instrumentation/spring-data-1.8/spring-data-1.8.gradle
+++ b/dd-java-agent/instrumentation/spring-data-1.8/spring-data-1.8.gradle
@@ -1,3 +1,8 @@
+ext {
+  // TODO Java 17: This version of spring-data doesn't support Java 17
+  maxJavaVersionForTests = JavaVersion.VERSION_15
+}
+
 // This file includes software developed at SignalFx
 
 muzzle {

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/client/VertxHttpClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/client/VertxHttpClientForkedTest.groovy
@@ -9,11 +9,10 @@ import io.vertx.core.http.HttpClientResponse
 import io.vertx.core.http.HttpMethod
 import spock.lang.AutoCleanup
 import spock.lang.Shared
-import spock.lang.Timeout
 
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
 
-@Timeout(10)
 class VertxHttpClientForkedTest extends HttpClientTest {
 
   @Override
@@ -47,7 +46,7 @@ class VertxHttpClientForkedTest extends HttpClientTest {
     }
     request.end()
 
-    return future.get().statusCode()
+    return future.get(10, TimeUnit.SECONDS).statusCode()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/vertx-web-3.4/vertx-web-3.4.gradle
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/vertx-web-3.4.gradle
@@ -1,6 +1,8 @@
 // Set properties before any plugins get loaded
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
+  // TODO Java 17: This version of vertx-web doesn't support Java 17
+  maxJavaVersionForTests = JavaVersion.VERSION_15
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/appsec/springboot-grpc/springboot-grpc.gradle
+++ b/dd-smoke-tests/appsec/springboot-grpc/springboot-grpc.gradle
@@ -4,6 +4,8 @@ plugins {
 
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
+  // TODO Java 17: This version of spring-boot doesn't support Java 17
+  maxJavaVersionForTests = JavaVersion.VERSION_15
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/osgi/osgi.gradle
+++ b/dd-smoke-tests/osgi/osgi.gradle
@@ -27,7 +27,7 @@ dependencies {
   compileOnly group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
 
   equinox 'org.eclipse.platform:org.eclipse.osgi:3.15.300'
-  felix 'org.apache.felix:org.apache.felix.framework:6.0.4'
+  felix 'org.apache.felix:org.apache.felix.framework:6.0.5'
 
   bundles 'org.ops4j.pax.logging:pax-logging-api:1.11.0'
   bundles 'com.google.guava:guava:20.0'

--- a/dd-smoke-tests/play-2.4/play-2.4.gradle
+++ b/dd-smoke-tests/play-2.4/play-2.4.gradle
@@ -4,6 +4,8 @@ plugins {
 
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
+  // TODO Java 17: This version of play doesn't support Java 17
+  maxJavaVersionForTests = JavaVersion.VERSION_15
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/play-2.4/src/test/groovy/datadog/smoketest/PlayNettySmokeTest.groovy
+++ b/dd-smoke-tests/play-2.4/src/test/groovy/datadog/smoketest/PlayNettySmokeTest.groovy
@@ -36,7 +36,7 @@ class PlayNettySmokeTest extends AbstractServerSmokeTest {
   ProcessBuilder createProcessBuilder() {
     // If the server is not shut down correctly, this file can be left there and will block
     // the start of a new test
-    def runningPid = new File("RUNNING_PID", playDirectory)
+    def runningPid = new File(playDirectory.getPath(), "RUNNING_PID")
     if (runningPid.exists()) {
       runningPid.delete()
     }

--- a/dd-smoke-tests/play-2.5/play-2.5.gradle
+++ b/dd-smoke-tests/play-2.5/play-2.5.gradle
@@ -4,6 +4,8 @@ plugins {
 
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
+  // TODO Java 17: This version of play doesn't support Java 17
+  maxJavaVersionForTests = JavaVersion.VERSION_15
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/play-2.5/src/test/groovy/datadog/smoketest/PlayNettySmokeTest.groovy
+++ b/dd-smoke-tests/play-2.5/src/test/groovy/datadog/smoketest/PlayNettySmokeTest.groovy
@@ -36,7 +36,7 @@ class PlayNettySmokeTest extends AbstractServerSmokeTest {
   ProcessBuilder createProcessBuilder() {
     // If the server is not shut down correctly, this file can be left there and will block
     // the start of a new test
-    def runningPid = new File("RUNNING_PID", playDirectory)
+    def runningPid = new File(playDirectory.getPath(), "RUNNING_PID")
     if (runningPid.exists()) {
       runningPid.delete()
     }

--- a/dd-smoke-tests/play-2.6/play-2.6.gradle
+++ b/dd-smoke-tests/play-2.6/play-2.6.gradle
@@ -4,6 +4,8 @@ plugins {
 
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
+  // TODO Java 17: This version of play doesn't support Java 17
+  maxJavaVersionForTests = JavaVersion.VERSION_15
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/play-2.6/src/test/groovy/datadog/smoketest/PlaySmokeTest.groovy
+++ b/dd-smoke-tests/play-2.6/src/test/groovy/datadog/smoketest/PlaySmokeTest.groovy
@@ -35,7 +35,7 @@ abstract class PlaySmokeTest extends AbstractServerSmokeTest {
   ProcessBuilder createProcessBuilder() {
     // If the server is not shut down correctly, this file can be left there and will block
     // the start of a new test
-    def runningPid = new File("RUNNING_PID", playDirectory)
+    def runningPid = new File(playDirectory.getPath(), "RUNNING_PID")
     if (runningPid.exists()) {
       runningPid.delete()
     }

--- a/dd-smoke-tests/play-2.7/play-2.7.gradle
+++ b/dd-smoke-tests/play-2.7/play-2.7.gradle
@@ -4,6 +4,8 @@ plugins {
 
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
+  // TODO Java 17: This version of play doesn't support Java 17
+  maxJavaVersionForTests = JavaVersion.VERSION_15
 }
 
 apply from: "$rootDir/gradle/java.gradle"
@@ -13,7 +15,7 @@ java {
   targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-def playVer = "2.7.5"
+def playVer = "2.7.9"
 def scalaVer = System.getProperty("scala.version", /* default = */ "2.13")
 
 play {

--- a/dd-smoke-tests/play-2.7/src/test/groovy/datadog/smoketest/PlaySmokeTest.groovy
+++ b/dd-smoke-tests/play-2.7/src/test/groovy/datadog/smoketest/PlaySmokeTest.groovy
@@ -35,7 +35,7 @@ abstract class PlaySmokeTest extends AbstractServerSmokeTest {
   ProcessBuilder createProcessBuilder() {
     // If the server is not shut down correctly, this file can be left there and will block
     // the start of a new test
-    def runningPid = new File("RUNNING_PID", playDirectory)
+    def runningPid = new File(playDirectory.getPath(), "RUNNING_PID")
     if (runningPid.exists()) {
       runningPid.delete()
     }

--- a/dd-smoke-tests/play-2.8/play-2.8.gradle
+++ b/dd-smoke-tests/play-2.8/play-2.8.gradle
@@ -13,7 +13,7 @@ java {
   targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-def playVer = "2.8.2"
+def playVer = "2.8.15"
 def scalaVer = System.getProperty("scala.version", /* default = */ "2.13")
 
 play {
@@ -57,6 +57,10 @@ dependencies {
   implementation "com.typesafe.play:filters-helpers_$scalaVer:$playVer"
   implementation "com.typesafe.play:play-netty-server_$scalaVer:$playVer"
   implementation "com.typesafe.play:play-ahc-ws_$scalaVer:$playVer"
+
+  // Needed for Java17
+  implementation "com.google.inject:guice:5.1.0"
+  implementation "com.google.inject.extensions:guice-assistedinject:5.1.0"
 
   implementation project(':dd-trace-api')
   implementation group: 'io.opentracing', name: 'opentracing-api', version: '0.32.0'

--- a/dd-smoke-tests/play-2.8/src/test/groovy/datadog/smoketest/PlaySmokeTest.groovy
+++ b/dd-smoke-tests/play-2.8/src/test/groovy/datadog/smoketest/PlaySmokeTest.groovy
@@ -35,7 +35,7 @@ abstract class PlaySmokeTest extends AbstractServerSmokeTest {
   ProcessBuilder createProcessBuilder() {
     // If the server is not shut down correctly, this file can be left there and will block
     // the start of a new test
-    def runningPid = new File("RUNNING_PID", playDirectory)
+    def runningPid = new File(playDirectory.getPath(), "RUNNING_PID")
     if (runningPid.exists()) {
       runningPid.delete()
     }

--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/ProfilingIntegrationTest.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/ProfilingIntegrationTest.java
@@ -19,6 +19,7 @@ import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
@@ -51,6 +52,7 @@ import org.slf4j.LoggerFactory;
 
 class ProfilingIntegrationTest {
   private static final Logger log = LoggerFactory.getLogger(ProfilingIntegrationTest.class);
+  private static final Duration ONE_NANO = Duration.ofNanos(1);
 
   @FunctionalInterface
   private interface TestBody {
@@ -207,7 +209,9 @@ class ProfilingIntegrationTest {
       IItemCollection events = JfrLoaderToolkit.loadEvents(new ByteArrayInputStream(rawJfr.get()));
       assertTrue(events.hasItems());
       Pair<Instant, Instant> rangeStartAndEnd = getRangeStartAndEnd(events);
-      final Instant firstRangeStart = rangeStartAndEnd.getLeft();
+      // This nano-second compensates for the added nano second in
+      // ProfilingSystem.SnapshotRecording.snapshot()
+      final Instant firstRangeStart = rangeStartAndEnd.getLeft().plus(ONE_NANO);
       final Instant firstRangeEnd = rangeStartAndEnd.getRight();
       assertTrue(
           firstStartTime.compareTo(firstRangeStart) <= 0,
@@ -254,7 +258,9 @@ class ProfilingIntegrationTest {
       events = JfrLoaderToolkit.loadEvents(new ByteArrayInputStream(rawJfr.get()));
       assertTrue(events.hasItems());
       rangeStartAndEnd = getRangeStartAndEnd(events);
-      final Instant secondRangeStart = rangeStartAndEnd.getLeft();
+      // This nano-second compensates for the added nano second in
+      // ProfilingSystem.SnapshotRecording.snapshot()
+      final Instant secondRangeStart = rangeStartAndEnd.getLeft().plus(ONE_NANO);
       final Instant secondRangeEnd = rangeStartAndEnd.getRight();
       // So the OracleJdkOngoingRecording and underlying recording seems to
       // either lose precision in the reported times, or filter a bit differently

--- a/dd-smoke-tests/springboot-grpc/springboot-grpc.gradle
+++ b/dd-smoke-tests/springboot-grpc/springboot-grpc.gradle
@@ -5,6 +5,8 @@ plugins {
 
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
+  // TODO Java 17: This version of spring-boot doesn't support Java 17
+  maxJavaVersionForTests = JavaVersion.VERSION_15
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-smoke-tests/springboot/springboot.gradle
+++ b/dd-smoke-tests/springboot/springboot.gradle
@@ -1,6 +1,11 @@
 plugins {
   id "com.github.johnrengelman.shadow"
 }
+
+ext {
+  maxJavaVersionForTests = JavaVersion.VERSION_15
+}
+
 apply from: "$rootDir/gradle/java.gradle"
 description = 'SpringBoot Smoke Tests.'
 

--- a/dd-trace-core/dd-trace-core.gradle
+++ b/dd-trace-core/dd-trace-core.gradle
@@ -30,6 +30,11 @@ testSets {
   traceAgentTest
 }
 
+tasks.withType(Test).findByName('forkedTest').configure {
+  // Needed for FootprintForkedTest on Java 17
+  jvmArgs += ['-Djol.magicFieldOffset=true']
+}
+
 dependencies {
   api project(':dd-trace-api')
   api project(':communication')
@@ -54,7 +59,7 @@ dependencies {
   testImplementation project(":dd-java-agent:testing")
   testImplementation group: 'org.msgpack', name: 'msgpack-core', version: '0.8.20'
   testImplementation group: 'org.msgpack', name: 'jackson-dataformat-msgpack', version: '0.8.20'
-  testImplementation group: 'org.openjdk.jol', name: 'jol-core', version: '0.14'
+  testImplementation group: 'org.openjdk.jol', name: 'jol-core', version: '0.16'
 
   traceAgentTestImplementation deps.testcontainers
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintForkedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintForkedTest.groovy
@@ -17,7 +17,7 @@ import static java.util.concurrent.TimeUnit.SECONDS
 @Requires({
   !System.getProperty("java.vendor").toUpperCase().contains("IBM") && isJavaVersionAtLeast(8)
 })
-class FootprintTest extends DDSpecification {
+class FootprintForkedTest extends DDSpecification {
 
   @Shared
   Random random = new Random(0)

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -24,7 +24,7 @@ final class CachedData {
     dogstatsd     : "4.0.0",
     jnr_unixsocket: "0.28",
     commons       : "3.2",
-    mockito       : '3.5.10',
+    mockito       : '4.4.0',
     moshi         : '1.9.2',
     testcontainers: '1.15.0-rc2',
     jmc           : "8.1.0-SNAPSHOT",

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -362,6 +362,7 @@ tasks.withType(Test).configureEach {
     forkEvery 1
     // Limit the number of concurrent forked tests
     usesService(forkedTestLimit)
+    onlyIf { !project.rootProject.hasProperty("skipForkedTests") }
   } else {
     exclude("**/*ForkedTest*")
   }


### PR DESCRIPTION
# What Does This Do

Adds Java 17 as one of the tested versions in CI.

# Motivation

Test on the latest LTS release

# Additional Notes

The RMI instrumentation won't work on Java 17 right now since it inherits across modules in an unsupported way. This needs to be fixed.