### PR TITLE
Use correct interface matcher in slick instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/slick/src/main/java/datadog.trace.instrumentation.slick/SlickRunnableInstrumentation.java
+++ b/dd-java-agent/instrumentation/slick/src/main/java/datadog.trace.instrumentation.slick/SlickRunnableInstrumentation.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.slick;
 
-import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.hasInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
@@ -35,7 +35,7 @@ public final class SlickRunnableInstrumentation extends Instrumenter.Tracing
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
     return NameMatchers.<TypeDescription>nameStartsWith("slick.")
-        .and(hasInterface(named(Runnable.class.getName())));
+        .and(implementsInterface(named(Runnable.class.getName())));
   }
 
   @Override


### PR DESCRIPTION
`implementsInterface` should be used to match instrumented types that implement a particular interface (`hasInterface` is used to check argument/return interface types)