### PR TITLE
Cleanup servlet matchers

### DIFF
--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Instrumentation.java
@@ -36,7 +36,7 @@ public final class Servlet2Instrumentation extends Instrumenter.Tracing
 
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
-    return safeHasSuperType(
+    return safeHasSuperType( // search both interfaces (FilterChain) and superclasses (HttpServlet)
         namedOneOf("javax.servlet.FilterChain", "javax.servlet.http.HttpServlet"));
   }
 

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2ResponseStatusInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2ResponseStatusInstrumentation.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.servlet2;
 
-import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.safeHasSuperType;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static java.util.Collections.singletonMap;
@@ -26,7 +26,7 @@ public final class Servlet2ResponseStatusInstrumentation extends Instrumenter.Tr
 
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
-    return safeHasSuperType(named("javax.servlet.http.HttpServletResponse"));
+    return implementsInterface(named("javax.servlet.http.HttpServletResponse"));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Instrumentation.java
@@ -30,7 +30,7 @@ public final class Servlet3Instrumentation extends Instrumenter.Tracing
 
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
-    return safeHasSuperType(
+    return safeHasSuperType( // search both interfaces (FilterChain) and superclasses (HttpServlet)
         namedOneOf("javax.servlet.FilterChain", "javax.servlet.http.HttpServlet"));
   }
 


### PR DESCRIPTION
`HttpServletResponse` is an interface, so we only need `implementsInterface` rather than `safeHasSuperType` (as that searches both interfaces and superclasses)

Also document how certain servlet instrumentations use `safeHasSuperType` to search for both `FilterChain` (an interface) and `HttpServlet` (a superclass) rather than have separate matchers