### PR TITLE
Reuse named pipe sockets

### DIFF
--- a/utils/socket-utils/src/main/java/datadog/common/socket/NamedPipeSocketFactory.java
+++ b/utils/socket-utils/src/main/java/datadog/common/socket/NamedPipeSocketFactory.java
@@ -10,15 +10,8 @@ import javax.net.SocketFactory;
 
 public class NamedPipeSocketFactory extends SocketFactory {
   private static final String NAMED_PIPE_PREFIX = "\\\\.\\pipe\\";
+  private static final Map<File, NamedPipeSocket> fileToSocket = new HashMap<>();
   private final File pipe;
-
-  // Use enum singleton pattern.
-  // This ensures there is at most one INSTANCE per jvm
-  private enum SingletonHolder {
-    INSTANCE;
-
-    final Map<File, NamedPipeSocket> fileToSocket = new HashMap<>();
-  }
 
   public NamedPipeSocketFactory(String pipeName) {
     String pipeNameWithPrefix =
@@ -29,12 +22,12 @@ public class NamedPipeSocketFactory extends SocketFactory {
   @Override
   public Socket createSocket() throws IOException {
     // Getting a new socket is rare enough that simple synchronization is sufficient
-    synchronized (SingletonHolder.INSTANCE.fileToSocket) {
-      NamedPipeSocket socket = SingletonHolder.INSTANCE.fileToSocket.get(pipe);
+    synchronized (fileToSocket) {
+      NamedPipeSocket socket = fileToSocket.get(pipe);
 
       if (socket == null || socket.isClosed()) {
         socket = new NamedPipeSocket(pipe);
-        SingletonHolder.INSTANCE.fileToSocket.put(pipe, socket);
+        fileToSocket.put(pipe, socket);
       }
 
       return socket;


### PR DESCRIPTION
# What Does This Do
Named pipe sockets are stored in a map and reused when requesting the same named pipe.

# Motivation
Named pipes can be opened at most twice (1 client and 1 server). The previous implementation did not take that into account. Different subsystems (tracing, statsd, profiling, etc) opened their own named pipe sockets. This lead to a race where the first subsystem was able to use the named pipe and the rest were not.

# Additional Notes
This is untested because we have an inability to test on windows.