### PR TITLE
Separate out proxy class 'contains' checks from the global ignores matcher…

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentTransformerBuilder.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentTransformerBuilder.java
@@ -2,7 +2,7 @@ package datadog.trace.agent.tooling;
 
 import static datadog.trace.agent.tooling.bytebuddy.DDTransformers.defaultTransformers;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.ANY_CLASS_LOADER;
-import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.NOT_DECORATOR_MATCHER;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.notProxyOrDecorator;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isSynthetic;
 import static net.bytebuddy.matcher.ElementMatchers.not;
@@ -58,7 +58,7 @@ public class AgentTransformerBuilder
     adviceBuilder =
         agentBuilder
             .type(matcher)
-            .and(NOT_DECORATOR_MATCHER)
+            .and(notProxyOrDecorator())
             .and(
                 new AgentBuilder.RawMatcher() {
                   @Override
@@ -166,7 +166,7 @@ public class AgentTransformerBuilder
 
     ignoreMatcher = isSynthetic();
     adviceBuilder =
-        agentBuilder.type(matcher).and(NOT_DECORATOR_MATCHER).transform(defaultTransformers());
+        agentBuilder.type(matcher).and(notProxyOrDecorator()).transform(defaultTransformers());
 
     instrumenter.adviceTransformations(this);
 

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextProvider.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextProvider.java
@@ -1,6 +1,6 @@
 package datadog.trace.agent.tooling.context;
 
-import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.NOT_DECORATOR_MATCHER;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.notProxyOrDecorator;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers.safeHasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
@@ -131,7 +131,7 @@ public final class FieldBackedContextProvider implements InstrumentationContextP
                 builder
                     .type(safeHasSuperType(named(keyClassName)), classLoaderMatcher)
                     .and(new ShouldInjectFieldsRawMatcher(keyClassName, contextClassName))
-                    .and(NOT_DECORATOR_MATCHER)
+                    .and(notProxyOrDecorator())
                     .transform(
                         wrapVisitor(
                             new FieldBackedContextInjector(keyClassName, contextClassName)));

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/DDElementMatchers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/DDElementMatchers.java
@@ -6,7 +6,6 @@ import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import de.thetaphi.forbiddenapis.SuppressForbidden;
-import net.bytebuddy.description.annotation.AnnotationSource;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDefinition;
 import net.bytebuddy.description.type.TypeDescription;
@@ -20,8 +19,12 @@ public class DDElementMatchers {
 
   // Added here instead of byte-buddy's ignores because it's relatively
   // expensive. https://github.com/DataDog/dd-trace-java/pull/1045
-  public static final ElementMatcher.Junction<AnnotationSource> NOT_DECORATOR_MATCHER =
-      not(isAnnotatedWith(named("javax.decorator.Decorator")));
+  private static final ElementMatcher.Junction<TypeDescription> NOT_PROXY_OR_DECORATOR_MATCHER =
+      not(new ProxyClassMatcher<>().or(isAnnotatedWith(named("javax.decorator.Decorator"))));
+
+  public static ElementMatcher.Junction<TypeDescription> notProxyOrDecorator() {
+    return NOT_PROXY_OR_DECORATOR_MATCHER;
+  }
 
   public static <T extends TypeDescription> ElementMatcher.Junction<T> extendsClass(
       final ElementMatcher<? super TypeDescription> matcher) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
@@ -178,6 +178,9 @@ public class GlobalIgnoresMatcher<T extends TypeDescription>
             if (springClassLoaderIgnores.matches(target)) {
               return true;
             }
+            if (name.startsWith("org.springframework.core.$Proxy")) {
+              return true;
+            }
           }
         }
         break;
@@ -200,21 +203,6 @@ public class GlobalIgnoresMatcher<T extends TypeDescription>
         }
         break;
       default:
-    }
-
-    final int firstDollar = name.indexOf('$');
-    if (firstDollar > -1) {
-      if (name.contains("$JaxbAccessor")
-          || name.contains("CGLIB$$")
-          || name.contains("$__sisu")
-          || name.contains("$$EnhancerByGuice$$")
-          || name.contains("$$EnhancerByProxool$$")
-          || name.startsWith("org.springframework.core.$Proxy")) {
-        return true;
-      }
-    }
-    if (name.contains("javassist") || name.contains(".asm.")) {
-      return true;
     }
 
     return !skipAdditionalLibraryMatcher && additionalLibraryIgnoreMatcher.matches(target);

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ProxyClassMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ProxyClassMatcher.java
@@ -1,0 +1,29 @@
+package datadog.trace.agent.tooling.bytebuddy.matcher;
+
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+/**
+ * An element matcher that matches generated proxy classes that shouldn't be transformed.
+ *
+ * <p>Separate from the global ignores matcher because it uses non-trivial 'contains' checks.
+ */
+class ProxyClassMatcher<T extends TypeDescription>
+    extends ElementMatcher.Junction.ForNonNullValues<T> {
+
+  @Override
+  protected boolean doMatch(final T target) {
+    final String name = target.getActualName();
+    final int firstDollar = name.indexOf('$');
+    if (firstDollar > -1) {
+      if (name.contains("$JaxbAccessor")
+          || name.contains("CGLIB$$")
+          || name.contains("$__sisu")
+          || name.contains("$$EnhancerByGuice$$")
+          || name.contains("$$EnhancerByProxool$$")) {
+        return true;
+      }
+    }
+    return name.contains("javassist") || name.contains(".asm.");
+  }
+}


### PR DESCRIPTION
…and use it to filter out proxy classes only once we have a transform match

This is based on the assumption that proxy classes which match instrumentations are less frequent than all the non-proxy classes (plus proxy classes that do match) so it makes sense to defer this filter rather than have all classes incur its cost.