### PR TITLE
Remove unused Method handles from Hibernate instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/CriteriaInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/CriteriaInstrumentation.java
@@ -12,7 +12,6 @@ import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.instrumentation.hibernate.SessionMethodUtils;
 import datadog.trace.instrumentation.hibernate.SessionState;
-import java.lang.reflect.Method;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -54,14 +53,12 @@ public class CriteriaInstrumentation extends AbstractHibernateInstrumentation {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static SessionState startMethod(
         @Advice.This final Criteria criteria,
-        @Advice.Origin("hibernate.criteria.#m") final String operationName,
-        @Advice.Origin final Method origin) {
+        @Advice.Origin("hibernate.criteria.#m") final String operationName) {
 
       final ContextStore<Criteria, SessionState> contextStore =
           InstrumentationContext.get(Criteria.class, SessionState.class);
 
-      return SessionMethodUtils.startScopeFrom(
-          contextStore, criteria, origin, operationName, null, true);
+      return SessionMethodUtils.startScopeFrom(contextStore, criteria, operationName, null, true);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/QueryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/QueryInstrumentation.java
@@ -13,7 +13,6 @@ import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.instrumentation.hibernate.SessionMethodUtils;
 import datadog.trace.instrumentation.hibernate.SessionState;
-import java.lang.reflect.Method;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -59,15 +58,14 @@ public class QueryInstrumentation extends AbstractHibernateInstrumentation {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static SessionState startMethod(
         @Advice.This final Query query,
-        @Advice.Origin("hibernate.query.#m") final String operationName,
-        @Advice.Origin final Method origin) {
+        @Advice.Origin("hibernate.query.#m") final String operationName) {
 
       final ContextStore<Query, SessionState> contextStore =
           InstrumentationContext.get(Query.class, SessionState.class);
 
       // Note: We don't know what the entity is until the method is returning.
       final SessionState state =
-          SessionMethodUtils.startScopeFrom(contextStore, query, origin, operationName, null, true);
+          SessionMethodUtils.startScopeFrom(contextStore, query, operationName, null, true);
       if (state != null) {
         DECORATOR.onStatement(state.getMethodScope().span(), query.getQueryString());
       }

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionInstrumentation.java
@@ -18,7 +18,6 @@ import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.hibernate.SessionMethodUtils;
 import datadog.trace.instrumentation.hibernate.SessionState;
-import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -165,21 +164,21 @@ public class SessionInstrumentation extends AbstractHibernateInstrumentation
     public static SessionState startMethod(
         @Advice.This final Object session,
         @Advice.Origin("hibernate.#m") final String operationName,
-        @Advice.Origin final Method origin,
+        @Advice.Origin("#m") final String methodName,
         @Advice.Argument(0) final Object entity,
         @Advice.Local("startSpan") boolean startSpan) {
 
-      startSpan = !SCOPE_ONLY_METHODS.contains(origin.getName());
+      startSpan = !SCOPE_ONLY_METHODS.contains(methodName);
       if (session instanceof Session) {
         final ContextStore<Session, SessionState> contextStore =
             InstrumentationContext.get(Session.class, SessionState.class);
         return SessionMethodUtils.startScopeFrom(
-            contextStore, (Session) session, origin, operationName, entity, startSpan);
+            contextStore, (Session) session, operationName, entity, startSpan);
       } else if (session instanceof StatelessSession) {
         final ContextStore<StatelessSession, SessionState> contextStore =
             InstrumentationContext.get(StatelessSession.class, SessionState.class);
         return SessionMethodUtils.startScopeFrom(
-            contextStore, (StatelessSession) session, origin, operationName, entity, startSpan);
+            contextStore, (StatelessSession) session, operationName, entity, startSpan);
       }
       return null;
     }

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/TransactionInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/TransactionInstrumentation.java
@@ -12,7 +12,6 @@ import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.instrumentation.hibernate.SessionMethodUtils;
 import datadog.trace.instrumentation.hibernate.SessionState;
-import java.lang.reflect.Method;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -54,14 +53,13 @@ public class TransactionInstrumentation extends AbstractHibernateInstrumentation
   public static class TransactionCommitAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static SessionState startCommit(
-        @Advice.This final Transaction transaction, @Advice.Origin final Method origin) {
+    public static SessionState startCommit(@Advice.This final Transaction transaction) {
 
       final ContextStore<Transaction, SessionState> contextStore =
           InstrumentationContext.get(Transaction.class, SessionState.class);
 
       return SessionMethodUtils.startScopeFrom(
-          contextStore, transaction, origin, "hibernate.transaction.commit", null, true);
+          contextStore, transaction, "hibernate.transaction.commit", null, true);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/CriteriaInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/CriteriaInstrumentation.java
@@ -12,7 +12,6 @@ import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.instrumentation.hibernate.SessionMethodUtils;
 import datadog.trace.instrumentation.hibernate.SessionState;
-import java.lang.reflect.Method;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -53,14 +52,12 @@ public class CriteriaInstrumentation extends AbstractHibernateInstrumentation {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static SessionState startMethod(
         @Advice.This final Criteria criteria,
-        @Advice.Origin("hibernate.criteria.#m") final String operationName,
-        @Advice.Origin final Method origin) {
+        @Advice.Origin("hibernate.criteria.#m") final String operationName) {
 
       final ContextStore<Criteria, SessionState> contextStore =
           InstrumentationContext.get(Criteria.class, SessionState.class);
 
-      return SessionMethodUtils.startScopeFrom(
-          contextStore, criteria, origin, operationName, null, true);
+      return SessionMethodUtils.startScopeFrom(contextStore, criteria, operationName, null, true);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/QueryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/QueryInstrumentation.java
@@ -13,7 +13,6 @@ import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.instrumentation.hibernate.SessionMethodUtils;
 import datadog.trace.instrumentation.hibernate.SessionState;
-import java.lang.reflect.Method;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -59,15 +58,14 @@ public class QueryInstrumentation extends AbstractHibernateInstrumentation {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static SessionState startMethod(
         @Advice.This final Query query,
-        @Advice.Origin("hibernate.query.#m") final String operationName,
-        @Advice.Origin final Method origin) {
+        @Advice.Origin("hibernate.query.#m") final String operationName) {
 
       final ContextStore<Query, SessionState> contextStore =
           InstrumentationContext.get(Query.class, SessionState.class);
 
       // Note: We don't know what the entity is until the method is returning.
       final SessionState state =
-          SessionMethodUtils.startScopeFrom(contextStore, query, origin, operationName, null, true);
+          SessionMethodUtils.startScopeFrom(contextStore, query, operationName, null, true);
       if (state != null) {
         DECORATOR.onStatement(state.getMethodScope().span(), query.getQueryString());
       }

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionInstrumentation.java
@@ -18,7 +18,6 @@ import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.hibernate.SessionMethodUtils;
 import datadog.trace.instrumentation.hibernate.SessionState;
-import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -146,15 +145,15 @@ public class SessionInstrumentation extends AbstractHibernateInstrumentation {
     public static SessionState startMethod(
         @Advice.This final SharedSessionContract session,
         @Advice.Origin("hibernate.#m") final String operationName,
-        @Advice.Origin final Method origin,
+        @Advice.Origin("#m") final String methodName,
         @Advice.Argument(0) final Object entity,
         @Advice.Local("startSpan") boolean startSpan) {
 
-      startSpan = !SCOPE_ONLY_METHODS.contains(origin.getName());
+      startSpan = !SCOPE_ONLY_METHODS.contains(methodName);
       final ContextStore<SharedSessionContract, SessionState> contextStore =
           InstrumentationContext.get(SharedSessionContract.class, SessionState.class);
       return SessionMethodUtils.startScopeFrom(
-          contextStore, session, origin, operationName, entity, startSpan);
+          contextStore, session, operationName, entity, startSpan);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/TransactionInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/TransactionInstrumentation.java
@@ -12,7 +12,6 @@ import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.instrumentation.hibernate.SessionMethodUtils;
 import datadog.trace.instrumentation.hibernate.SessionState;
-import java.lang.reflect.Method;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -53,14 +52,13 @@ public class TransactionInstrumentation extends AbstractHibernateInstrumentation
   public static class TransactionCommitAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static SessionState startCommit(
-        @Advice.This final Transaction transaction, @Advice.Origin final Method origin) {
+    public static SessionState startCommit(@Advice.This final Transaction transaction) {
 
       final ContextStore<Transaction, SessionState> contextStore =
           InstrumentationContext.get(Transaction.class, SessionState.class);
 
       return SessionMethodUtils.startScopeFrom(
-          contextStore, transaction, origin, "hibernate.transaction.commit", null, true);
+          contextStore, transaction, "hibernate.transaction.commit", null, true);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_3/ProcedureCallInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_3/ProcedureCallInstrumentation.java
@@ -11,7 +11,6 @@ import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.instrumentation.hibernate.SessionMethodUtils;
 import datadog.trace.instrumentation.hibernate.SessionState;
-import java.lang.reflect.Method;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -73,15 +72,14 @@ public class ProcedureCallInstrumentation extends Instrumenter.Tracing
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static SessionState startMethod(
         @Advice.This final ProcedureCall call,
-        @Advice.Origin("hibernate.procedure.#m") final String operationName,
-        @Advice.Origin final Method origin) {
+        @Advice.Origin("hibernate.procedure.#m") final String operationName) {
 
       final ContextStore<ProcedureCall, SessionState> contextStore =
           InstrumentationContext.get(ProcedureCall.class, SessionState.class);
 
       final SessionState state =
           SessionMethodUtils.startScopeFrom(
-              contextStore, call, origin, operationName, call.getProcedureName(), true);
+              contextStore, call, operationName, call.getProcedureName(), true);
       return state;
     }
 

--- a/dd-java-agent/instrumentation/hibernate/src/main/java/datadog/trace/instrumentation/hibernate/SessionMethodUtils.java
+++ b/dd-java-agent/instrumentation/hibernate/src/main/java/datadog/trace/instrumentation/hibernate/SessionMethodUtils.java
@@ -8,7 +8,6 @@ import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -25,7 +24,6 @@ public class SessionMethodUtils {
   public static <TARGET, ENTITY> SessionState startScopeFrom(
       final ContextStore<TARGET, SessionState> contextStore,
       final TARGET spanKey,
-      final Method origin,
       final String operationName,
       final ENTITY entity,
       final boolean createSpan) {


### PR DESCRIPTION
These jlr.Method values are recreated* on every read and are not used in the decorator
(except for method name which byte-buddy makes available in cached form by using '#m')

Removing them should reduce tracer overhead on every hibernate call.

\* see warning in the [@Advice.Origin](https://javadoc.io/doc/net.bytebuddy/byte-buddy/1.12.8/net/bytebuddy/asm/Advice.Origin.html) javadoc
> Note: A constant representing a `Method` or `Constructor` is not cached but is recreated for every read