### PR TITLE
Extract and tag Kafka consumer group

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTest.groovy
@@ -1,6 +1,8 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.Platform
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.datastreams.StatsGroup
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.KafkaConsumer
@@ -47,6 +49,7 @@ class KafkaClientTest extends AgentTestRunner {
     super.configurePreAgent()
 
     injectSysConfig("dd.kafka.e2e.duration.enabled", "true")
+    injectSysConfig("dd.data.streams.enabled", "true")
   }
 
   def "test kafka produce and consume"() {
@@ -97,7 +100,7 @@ class KafkaClientTest extends AgentTestRunner {
       }
       blockUntilChildSpansFinished(2)
     }
-
+    TEST_DATA_STREAMS_WRITER.waitForGroups(2)
 
     then:
     // check that the message was received
@@ -137,6 +140,7 @@ class KafkaClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 0
+            "$InstrumentationTags.CONSUMER_GROUP" "sender"
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             // TODO - test with and without feature enabled once Config is easier to control
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
@@ -151,6 +155,21 @@ class KafkaClientTest extends AgentTestRunner {
     headers.iterator().hasNext()
     new String(headers.headers("x-datadog-trace-id").iterator().next().value()) == "${TEST_WRITER[0][2].traceId}"
     new String(headers.headers("x-datadog-parent-id").iterator().next().value()) == "${TEST_WRITER[0][2].spanId}"
+
+    if (Platform.isJavaVersionAtLeast(8)) {
+      StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
+      verifyAll(first) {
+        type == null
+        topic == ""
+      }
+
+      StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
+      verifyAll(second) {
+        type == "kafka"
+        topic == SHARED_TOPIC
+        group == "sender"
+      }
+    }
 
     cleanup:
     producer.close()
@@ -203,7 +222,7 @@ class KafkaClientTest extends AgentTestRunner {
       })
       blockUntilChildSpansFinished(2)
     }
-
+    TEST_DATA_STREAMS_WRITER.waitForGroups(2)
 
     then:
     // check that the message was received
@@ -243,6 +262,7 @@ class KafkaClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 0
+            "$InstrumentationTags.CONSUMER_GROUP" "sender"
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             // TODO - test with and without feature enabled once Config is easier to control
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
@@ -257,6 +277,21 @@ class KafkaClientTest extends AgentTestRunner {
     headers.iterator().hasNext()
     new String(headers.headers("x-datadog-trace-id").iterator().next().value()) == "${TEST_WRITER[0][2].traceId}"
     new String(headers.headers("x-datadog-parent-id").iterator().next().value()) == "${TEST_WRITER[0][2].spanId}"
+
+    if (Platform.isJavaVersionAtLeast(8)) {
+      StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
+      verifyAll(first) {
+        type == null
+        topic == ""
+      }
+
+      StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
+      verifyAll(second) {
+        type == "kafka"
+        topic == SHARED_TOPIC
+        group == "sender"
+      }
+    }
 
     cleanup:
     producerFactory.destroy()
@@ -342,6 +377,7 @@ class KafkaClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 0
+            "$InstrumentationTags.CONSUMER_GROUP" "sender"
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "$InstrumentationTags.TOMBSTONE" true
             // TODO - test with and without feature enabled once Config is easier to control
@@ -425,6 +461,7 @@ class KafkaClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 0
+            "$InstrumentationTags.CONSUMER_GROUP" "sender"
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             // TODO - test with and without feature enabled once Config is easier to control
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
@@ -543,6 +580,7 @@ class KafkaClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 0
+            "$InstrumentationTags.CONSUMER_GROUP" "sender"
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
             defaultTags(true)
@@ -562,6 +600,7 @@ class KafkaClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 1
+            "$InstrumentationTags.CONSUMER_GROUP" "sender"
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
             defaultTags(true)
@@ -581,6 +620,7 @@ class KafkaClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 2
+            "$InstrumentationTags.CONSUMER_GROUP" "sender"
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
             defaultTags(true)
@@ -602,6 +642,7 @@ class KafkaClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 2
+            "$InstrumentationTags.CONSUMER_GROUP" "sender"
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
             defaultTags(true)
@@ -621,6 +662,7 @@ class KafkaClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 1
+            "$InstrumentationTags.CONSUMER_GROUP" "sender"
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
             defaultTags(true)
@@ -640,6 +682,7 @@ class KafkaClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 0
+            "$InstrumentationTags.CONSUMER_GROUP" "sender"
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
             defaultTags(true)
@@ -691,6 +734,7 @@ class KafkaClientTest extends AgentTestRunner {
       }
       blockUntilChildSpansFinished(2 * greetings.size())
     }
+    TEST_DATA_STREAMS_WRITER.waitForGroups(2)
 
     then:
     def receivedSet = greetings.toSet()
@@ -763,6 +807,7 @@ class KafkaClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 0
+            "$InstrumentationTags.CONSUMER_GROUP" "sender"
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
 
@@ -782,6 +827,7 @@ class KafkaClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" { it >= 0 && it < 2 }
+            "$InstrumentationTags.CONSUMER_GROUP" "sender"
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
 
@@ -801,12 +847,27 @@ class KafkaClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" { it >= 0 && it < 2 }
+            "$InstrumentationTags.CONSUMER_GROUP" "sender"
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
 
             defaultTags(true)
           }
         }
+      }
+    }
+
+    if (Platform.isJavaVersionAtLeast(8)) {
+      StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
+      verifyAll(first) {
+        type == null
+        topic == ""
+      }
+
+      StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
+      verifyAll(second) {
+        type == "kafka"
+        topic == SHARED_TOPIC
       }
     }
 

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerGroupInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerGroupInstrumentation.java
@@ -1,0 +1,93 @@
+package datadog.trace.instrumentation.kafka_clients;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.InstrumentationContext;
+import java.util.HashMap;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+/** This instrumentation saves the co */
+@AutoService(Instrumenter.class)
+public final class KafkaConsumerGroupInstrumentation extends Instrumenter.Tracing
+    implements Instrumenter.ForSingleType {
+
+  public KafkaConsumerGroupInstrumentation() {
+    super("kafka");
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    Map<String, String> contextStores = new HashMap<>();
+    contextStores.put("org.apache.kafka.clients.consumer.KafkaConsumer", "java.lang.String");
+    contextStores.put("org.apache.kafka.clients.consumer.ConsumerRecords", "java.lang.String");
+
+    return contextStores;
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.apache.kafka.clients.consumer.KafkaConsumer";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".KafkaDecorator",
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isConstructor()
+            .and(takesArgument(0, named("org.apache.kafka.clients.consumer.ConsumerConfig")))
+            .and(takesArgument(1, named("org.apache.kafka.common.serialization.Deserializer")))
+            .and(takesArgument(2, named("org.apache.kafka.common.serialization.Deserializer"))),
+        KafkaConsumerGroupInstrumentation.class.getName() + "$ConstructorAdvice");
+
+    transformation.applyAdvice(
+        isMethod()
+            .and(isPublic())
+            .and(named("poll"))
+            .and(takesArguments(1))
+            .and(returns(named("org.apache.kafka.clients.consumer.ConsumerRecords"))),
+        KafkaConsumerGroupInstrumentation.class.getName() + "$RecordsAdvice");
+  }
+
+  public static class ConstructorAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void captureGroup(
+        @Advice.This KafkaConsumer consumer, @Advice.Argument(0) ConsumerConfig consumerConfig) {
+      String consumerGroup = consumerConfig.getString(ConsumerConfig.GROUP_ID_CONFIG);
+
+      if (consumerGroup != null && !consumerGroup.isEmpty()) {
+        InstrumentationContext.get(KafkaConsumer.class, String.class).put(consumer, consumerGroup);
+      }
+    }
+  }
+
+  public static class RecordsAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void captureGroup(
+        @Advice.This KafkaConsumer consumer, @Advice.Return ConsumerRecords records) {
+      String consumerGroup =
+          InstrumentationContext.get(KafkaConsumer.class, String.class).get(consumer);
+
+      if (consumerGroup != null) {
+        InstrumentationContext.get(ConsumerRecords.class, String.class).put(records, consumerGroup);
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerGroupInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerGroupInstrumentation.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 
@@ -75,6 +76,12 @@ public final class KafkaConsumerGroupInstrumentation extends Instrumenter.Tracin
       if (consumerGroup != null && !consumerGroup.isEmpty()) {
         InstrumentationContext.get(KafkaConsumer.class, String.class).put(consumer, consumerGroup);
       }
+    }
+
+    public static void muzzleCheck(ConsumerRecord record) {
+      // KafkaConsumerInstrumentation only applies for kafka versions with headers
+      // Make an explicit call so KafkaConsumerGroupInstrumentation does the same
+      record.headers();
     }
   }
 

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInstrumentation.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.kafka_clients;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.CONSUMER_DECORATE;
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.KAFKA_CONSUME;
+import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
@@ -11,10 +12,13 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.InstrumentationContext;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 
 @AutoService(Instrumenter.class)
 public final class KafkaConsumerInstrumentation extends Instrumenter.Tracing
@@ -22,6 +26,11 @@ public final class KafkaConsumerInstrumentation extends Instrumenter.Tracing
 
   public KafkaConsumerInstrumentation() {
     super("kafka");
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return singletonMap("org.apache.kafka.clients.consumer.ConsumerRecords", "java.lang.String");
   }
 
   @Override
@@ -72,9 +81,11 @@ public final class KafkaConsumerInstrumentation extends Instrumenter.Tracing
 
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void wrap(
-        @Advice.Return(readOnly = false) Iterable<ConsumerRecord<?, ?>> iterable) {
+        @Advice.Return(readOnly = false) Iterable<ConsumerRecord<?, ?>> iterable,
+        @Advice.This ConsumerRecords records) {
       if (iterable != null) {
-        iterable = new TracingIterable(iterable, KAFKA_CONSUME, CONSUMER_DECORATE);
+        String group = InstrumentationContext.get(ConsumerRecords.class, String.class).get(records);
+        iterable = new TracingIterable(iterable, KAFKA_CONSUME, CONSUMER_DECORATE, group);
       }
     }
   }
@@ -82,9 +93,12 @@ public final class KafkaConsumerInstrumentation extends Instrumenter.Tracing
   public static class ListAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void wrap(@Advice.Return(readOnly = false) List<ConsumerRecord<?, ?>> iterable) {
+    public static void wrap(
+        @Advice.Return(readOnly = false) List<ConsumerRecord<?, ?>> iterable,
+        @Advice.This ConsumerRecords records) {
       if (iterable != null) {
-        iterable = new TracingList(iterable, KAFKA_CONSUME, CONSUMER_DECORATE);
+        String group = InstrumentationContext.get(ConsumerRecords.class, String.class).get(records);
+        iterable = new TracingList(iterable, KAFKA_CONSUME, CONSUMER_DECORATE, group);
       }
     }
   }
@@ -93,9 +107,11 @@ public final class KafkaConsumerInstrumentation extends Instrumenter.Tracing
 
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void wrap(
-        @Advice.Return(readOnly = false) Iterator<ConsumerRecord<?, ?>> iterator) {
+        @Advice.Return(readOnly = false) Iterator<ConsumerRecord<?, ?>> iterator,
+        @Advice.This ConsumerRecords records) {
       if (iterator != null) {
-        iterator = new TracingIterator(iterator, KAFKA_CONSUME, CONSUMER_DECORATE);
+        String group = InstrumentationContext.get(ConsumerRecords.class, String.class).get(records);
+        iterator = new TracingIterator(iterator, KAFKA_CONSUME, CONSUMER_DECORATE, group);
       }
     }
   }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterable.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterable.java
@@ -7,20 +7,23 @@ public class TracingIterable implements Iterable<ConsumerRecord<?, ?>>, TracingI
   private final Iterable<ConsumerRecord<?, ?>> delegate;
   private final CharSequence operationName;
   private final KafkaDecorator decorator;
+  private final String group;
 
   public TracingIterable(
       final Iterable<ConsumerRecord<?, ?>> delegate,
       final CharSequence operationName,
-      final KafkaDecorator decorator) {
+      final KafkaDecorator decorator,
+      String group) {
     this.delegate = delegate;
     this.operationName = operationName;
     this.decorator = decorator;
+    this.group = group;
   }
 
   @Override
   public Iterator<ConsumerRecord<?, ?>> iterator() {
     // every iteration will add spans. Not only the very first one
-    return new TracingIterator(delegate.iterator(), operationName, decorator);
+    return new TracingIterator(delegate.iterator(), operationName, decorator, group);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingList.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingList.java
@@ -11,14 +11,17 @@ public class TracingList implements List<ConsumerRecord<?, ?>>, TracingIterableD
   private final List<ConsumerRecord<?, ?>> delegate;
   private final CharSequence operationName;
   private final KafkaDecorator decorator;
+  private final String group;
 
   public TracingList(
       final List<ConsumerRecord<?, ?>> delegate,
       final CharSequence operationName,
-      final KafkaDecorator decorator) {
+      final KafkaDecorator decorator,
+      String group) {
     this.operationName = operationName;
     this.decorator = decorator;
     this.delegate = delegate;
+    this.group = group;
   }
 
   @Override
@@ -130,12 +133,12 @@ public class TracingList implements List<ConsumerRecord<?, ?>>, TracingIterableD
   @Override
   public ListIterator<ConsumerRecord<?, ?>> listIterator(final int index) {
     // every iteration will add spans. Not only the very first one
-    return new TracingListIterator(delegate.listIterator(index), operationName, decorator);
+    return new TracingListIterator(delegate.listIterator(index), operationName, decorator, group);
   }
 
   @Override
   public List<ConsumerRecord<?, ?>> subList(final int fromIndex, final int toIndex) {
-    return new TracingList(delegate.subList(fromIndex, toIndex), operationName, decorator);
+    return new TracingList(delegate.subList(fromIndex, toIndex), operationName, decorator, group);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingListIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingListIterator.java
@@ -13,8 +13,9 @@ public class TracingListIterator extends TracingIterator
   public TracingListIterator(
       ListIterator<ConsumerRecord<?, ?>> delegateIterator,
       CharSequence operationName,
-      KafkaDecorator decorator) {
-    super(delegateIterator, operationName, decorator);
+      KafkaDecorator decorator,
+      String group) {
+    super(delegateIterator, operationName, decorator, group);
     this.delegateIterator = delegateIterator;
   }
 

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
@@ -144,6 +144,7 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
       verifyAll(second) {
         type == "kafka"
         topic == SHARED_TOPIC
+        group == "sender"
       }
     }
 
@@ -240,6 +241,7 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
       verifyAll(second) {
         type == "kafka"
         topic == SHARED_TOPIC
+        group == "sender"
       }
     }
 
@@ -846,6 +848,7 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
         "$InstrumentationTags.PARTITION" { it >= 0 }
         "$InstrumentationTags.OFFSET" { offset.containsWithinBounds(it as int) }
+        "$InstrumentationTags.CONSUMER_GROUP" "sender"
         "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
         "$InstrumentationTags.RECORD_END_TO_END_DURATION_MS" { it >= 0 }
         if (tombstone) {

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/latestDepTest/groovy/KafkaStreamsTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/latestDepTest/groovy/KafkaStreamsTest.groovy
@@ -181,6 +181,7 @@ class KafkaStreamsTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 0
+            "$InstrumentationTags.CONSUMER_GROUP" "sender"
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "testing" 123
             defaultTags(true)

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTestBase.groovy
@@ -223,6 +223,7 @@ abstract class KafkaStreamsTestBase extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "$InstrumentationTags.PARTITION" { it >= 0 }
             "$InstrumentationTags.OFFSET" 0
+            "$InstrumentationTags.CONSUMER_GROUP" "sender"
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
             "testing" 123
             defaultTags(!hasQueueSpan)

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/MsgPackDatastreamsPayloadWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/MsgPackDatastreamsPayloadWriter.java
@@ -102,10 +102,16 @@ public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter
       if (!firstNode) {
         /* 5 */
         packer.writeUTF8(EDGE_TAGS);
-        packer.startArray(3);
-        packer.writeString("topic:" + group.getTopic(), null);
-        packer.writeString("group:" + group.getGroup(), null);
-        packer.writeString("type:" + group.getType(), null);
+        if (group.getGroup() == null) {
+          packer.startArray(2);
+          packer.writeString("topic:" + group.getTopic(), null);
+          packer.writeString("type:" + group.getType(), null);
+        } else {
+          packer.startArray(3);
+          packer.writeString("topic:" + group.getTopic(), null);
+          packer.writeString("group:" + group.getGroup(), null);
+          packer.writeString("type:" + group.getType(), null);
+        }
       }
     }
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InstrumentationTags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InstrumentationTags.java
@@ -10,6 +10,7 @@ public class InstrumentationTags {
 
   public static final String PARTITION = "partition";
   public static final String OFFSET = "offset";
+  public static final String CONSUMER_GROUP = "kafka.group";
   public static final String PROCESSOR_NAME = "processor.name";
   public static final String RECORD_QUEUE_TIME_MS = "record.queue_time_ms";
   public static final String RECORD_END_TO_END_DURATION_MS = "record.e2e_duration_ms";


### PR DESCRIPTION
# What Does This Do
This adds the Kafka consumer group as the `kafka.group` span tag and as an edge tag in data streams monitoring.

Consumer group is only available during the construction of the `KafkaConsumer`. This instrumentation:

1. Maps `KafkaConsumer` -> Group at construction
2. When a new `ConsumerRecords` is created
     a) Looks up the group of the consumer created it
     b) Maps `ConsumerRecords`-> Group
3. When the `ConsumerRecords` is iterated, the group is available to the wrapper classes

# Motivation
Consumer group is a wanted feature of data streams monitoring.

# Additional Notes
* `kafka.group` is the tag used by `dd-trace-rb`. I couldn't find any other tracers implementing consumer group as a tag. Most other tracers also use `kafka.partition` and `kafka.offset` rather than just `partition` and `offset` like the java tracer.

* The entire Kafka instrumentation can probably be simplified by wrapping `ConsumerRecords` rather than instrumenting its methods. I was not comfortable making that big of a change in something as _kafkaesque_ as the Kafka instrumentation.