### PR TITLE
[CIAPP][Agentless][Writer] Decouple common buffer+transport logic from DDAgent details

### DIFF
--- a/communication/src/main/java/datadog/communication/RemoteFeaturesDiscovery.java
+++ b/communication/src/main/java/datadog/communication/RemoteFeaturesDiscovery.java
@@ -1,0 +1,8 @@
+package datadog.communication;
+
+public interface RemoteFeaturesDiscovery {
+
+  void discover();
+
+  String getTraceEndpoint();
+}

--- a/communication/src/main/java/datadog/communication/RemoteFeaturesDiscovery.java
+++ b/communication/src/main/java/datadog/communication/RemoteFeaturesDiscovery.java
@@ -1,8 +1,0 @@
-package datadog.communication;
-
-public interface RemoteFeaturesDiscovery {
-
-  void discover();
-
-  String getTraceEndpoint();
-}

--- a/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
+++ b/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
@@ -3,7 +3,6 @@ package datadog.communication.ddagent;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
-import datadog.communication.RemoteFeaturesDiscovery;
 import datadog.communication.http.OkHttpUtils;
 import datadog.communication.monitor.DDAgentStatsDClientManager;
 import datadog.communication.monitor.Monitoring;
@@ -24,7 +23,7 @@ import okhttp3.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DDAgentFeaturesDiscovery implements RemoteFeaturesDiscovery, DroppingPolicy {
+public class DDAgentFeaturesDiscovery implements DroppingPolicy {
 
   private static final Logger log = LoggerFactory.getLogger(DDAgentFeaturesDiscovery.class);
 

--- a/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
+++ b/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
@@ -3,6 +3,7 @@ package datadog.communication.ddagent;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
+import datadog.communication.RemoteFeaturesDiscovery;
 import datadog.communication.http.OkHttpUtils;
 import datadog.communication.monitor.DDAgentStatsDClientManager;
 import datadog.communication.monitor.Monitoring;
@@ -23,7 +24,7 @@ import okhttp3.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DDAgentFeaturesDiscovery implements DroppingPolicy {
+public class DDAgentFeaturesDiscovery implements RemoteFeaturesDiscovery, DroppingPolicy {
 
   private static final Logger log = LoggerFactory.getLogger(DDAgentFeaturesDiscovery.class);
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateByServiceSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateByServiceSampler.java
@@ -5,7 +5,7 @@ import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.api.sampling.SamplingMechanism;
-import datadog.trace.common.writer.ddagent.DDAgentResponseListener;
+import datadog.trace.common.writer.RemoteResponseListener;
 import datadog.trace.core.CoreSpan;
 import java.util.HashMap;
 import java.util.Map;
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
  * <p>The configuration of (serviceName,env)->rate is configured by the core agent.
  */
 public class RateByServiceSampler<T extends CoreSpan<T>>
-    implements Sampler<T>, PrioritySampler<T>, DDAgentResponseListener {
+    implements Sampler<T>, PrioritySampler<T>, RemoteResponseListener {
 
   private static final Logger log = LoggerFactory.getLogger(RateByServiceSampler.class);
   public static final String SAMPLING_AGENT_RATE = "_dd.agent_psr";

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -18,20 +18,6 @@ import java.util.concurrent.TimeUnit;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 
-/**
- * This writer buffers traces and sends them to the provided DDApi instance. Buffering is done with
- * a distruptor to limit blocking the application threads. Internally, the trace is serialized and
- * put onto a separate disruptor that does block to decouple the CPU intensive from the IO bound
- * threads.
- *
- * <p>[Application] -> [trace processing buffer] -> [serialized trace batching buffer] -> [dd-agent]
- *
- * <p>Note: the first buffer is non-blocking and will discard if full, the second is blocking and
- * will cause back pressure on the trace processing (serializing) thread.
- *
- * <p>If the buffer is filled traces are discarded before serializing. Once serialized every effort
- * is made to keep, to avoid wasting the serialization effort.
- */
 public class DDAgentWriter extends RemoteWriter {
 
   public static DDAgentWriterBuilder builder() {

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -11,6 +11,7 @@ import datadog.communication.monitor.Monitoring;
 import datadog.trace.api.Config;
 import datadog.trace.api.StatsDClient;
 import datadog.trace.common.writer.ddagent.DDAgentApi;
+import datadog.trace.common.writer.ddagent.DDAgentMapperDiscovery;
 import datadog.trace.common.writer.ddagent.Prioritization;
 import datadog.trace.core.monitor.HealthMetrics;
 import java.util.concurrent.TimeUnit;
@@ -149,8 +150,9 @@ public class DDAgentWriter extends RemoteWriter {
             new DDAgentApi(client, agentUrl, featureDiscovery, monitoring, metricsReportingEnabled);
       }
 
+      final DDAgentMapperDiscovery mapperDiscovery = new DDAgentMapperDiscovery(featureDiscovery);
       final PayloadDispatcher dispatcher =
-          new PayloadDispatcher(featureDiscovery, agentApi, healthMetrics, monitoring);
+          new PayloadDispatcher(mapperDiscovery, agentApi, healthMetrics, monitoring);
       final TraceProcessingWorker traceProcessingWorker =
           new TraceProcessingWorker(
               traceBufferSize,
@@ -178,7 +180,7 @@ public class DDAgentWriter extends RemoteWriter {
       PayloadDispatcher dispatcher,
       TraceProcessingWorker worker,
       boolean alwaysFlush) {
-    super(api, worker, dispatcher, discovery, healthMetrics, alwaysFlush);
+    super(api, worker, dispatcher, healthMetrics, alwaysFlush);
   }
 
   private DDAgentWriter(
@@ -191,7 +193,8 @@ public class DDAgentWriter extends RemoteWriter {
         discovery,
         api,
         healthMetrics,
-        new PayloadDispatcher(discovery, api, healthMetrics, monitoring),
+        new PayloadDispatcher(
+            new DDAgentMapperDiscovery(discovery), api, healthMetrics, monitoring),
         worker,
         false);
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -4,7 +4,6 @@ import static datadog.communication.http.OkHttpUtils.buildHttpClient;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_HOST;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_TIMEOUT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_PORT;
-import static datadog.trace.api.sampling.PrioritySampling.UNSET;
 import static datadog.trace.common.writer.ddagent.Prioritization.FAST_LANE;
 
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery;
@@ -12,18 +11,11 @@ import datadog.communication.monitor.Monitoring;
 import datadog.trace.api.Config;
 import datadog.trace.api.StatsDClient;
 import datadog.trace.common.writer.ddagent.DDAgentApi;
-import datadog.trace.common.writer.ddagent.DDAgentResponseListener;
-import datadog.trace.common.writer.ddagent.PayloadDispatcher;
 import datadog.trace.common.writer.ddagent.Prioritization;
-import datadog.trace.common.writer.ddagent.TraceProcessingWorker;
-import datadog.trace.core.DDSpan;
 import datadog.trace.core.monitor.HealthMetrics;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This writer buffers traces and sends them to the provided DDApi instance. Buffering is done with
@@ -39,9 +31,7 @@ import org.slf4j.LoggerFactory;
  * <p>If the buffer is filled traces are discarded before serializing. Once serialized every effort
  * is made to keep, to avoid wasting the serialization effort.
  */
-public class DDAgentWriter implements Writer {
-
-  private static final Logger log = LoggerFactory.getLogger(DDAgentWriter.class);
+public class DDAgentWriter extends RemoteWriter {
 
   public static DDAgentWriterBuilder builder() {
     return new DDAgentWriterBuilder();
@@ -49,17 +39,8 @@ public class DDAgentWriter implements Writer {
 
   private static final int BUFFER_SIZE = 1024;
 
-  private final DDAgentApi api;
-  private final TraceProcessingWorker traceProcessingWorker;
-  private final PayloadDispatcher dispatcher;
-  private final DDAgentFeaturesDiscovery discovery;
-  private final boolean alwaysFlush;
-
-  private volatile boolean closed;
-
-  public final HealthMetrics healthMetrics;
-
   public static class DDAgentWriterBuilder {
+
     String agentHost = DEFAULT_AGENT_HOST;
     int traceAgentPort = DEFAULT_TRACE_AGENT_PORT;
     String unixDomainSocket = null;
@@ -153,69 +134,51 @@ public class DDAgentWriter implements Writer {
     }
 
     public DDAgentWriter build() {
+      final HttpUrl agentUrl = HttpUrl.get("http://" + agentHost + ":" + traceAgentPort);
+      final OkHttpClient client =
+          null == featureDiscovery || null == agentApi
+              ? buildHttpClient(agentUrl, unixDomainSocket, namedPipe, timeoutMillis)
+              : null;
+      if (null == featureDiscovery) {
+        featureDiscovery =
+            new DDAgentFeaturesDiscovery(
+                client, monitoring, agentUrl, traceAgentV05Enabled, metricsReportingEnabled);
+      }
+      if (null == agentApi) {
+        agentApi =
+            new DDAgentApi(client, agentUrl, featureDiscovery, monitoring, metricsReportingEnabled);
+      }
+
+      final PayloadDispatcher dispatcher =
+          new PayloadDispatcher(featureDiscovery, agentApi, healthMetrics, monitoring);
+      final TraceProcessingWorker traceProcessingWorker =
+          new TraceProcessingWorker(
+              traceBufferSize,
+              healthMetrics,
+              dispatcher,
+              featureDiscovery,
+              null == prioritization ? FAST_LANE : prioritization,
+              flushFrequencySeconds,
+              TimeUnit.SECONDS);
+
       return new DDAgentWriter(
-          agentApi,
-          agentHost,
-          traceAgentPort,
-          unixDomainSocket,
-          namedPipe,
-          timeoutMillis,
-          traceBufferSize,
-          healthMetrics,
-          flushFrequencySeconds,
-          prioritization,
-          monitoring,
-          traceAgentV05Enabled,
-          metricsReportingEnabled,
           featureDiscovery,
+          agentApi,
+          healthMetrics,
+          dispatcher,
+          traceProcessingWorker,
           alwaysFlush);
     }
   }
 
   private DDAgentWriter(
-      final DDAgentApi agentApi,
-      final String agentHost,
-      final int traceAgentPort,
-      final String unixDomainSocket,
-      final String namedPipe,
-      final long timeoutMillis,
-      final int traceBufferSize,
-      final HealthMetrics healthMetrics,
-      final int flushFrequencySeconds,
-      final Prioritization prioritization,
-      final Monitoring monitoring,
-      final boolean traceAgentV05Enabled,
-      boolean metricsReportingEnabled,
-      DDAgentFeaturesDiscovery featureDiscovery,
-      final boolean alwaysFlush) {
-    HttpUrl agentUrl = HttpUrl.get("http://" + agentHost + ":" + traceAgentPort);
-    OkHttpClient client =
-        null == featureDiscovery || null == agentApi
-            ? buildHttpClient(agentUrl, unixDomainSocket, namedPipe, timeoutMillis)
-            : null;
-    if (null == featureDiscovery) {
-      featureDiscovery =
-          new DDAgentFeaturesDiscovery(
-              client, monitoring, agentUrl, traceAgentV05Enabled, metricsReportingEnabled);
-    }
-    if (null == agentApi) {
-      api = new DDAgentApi(client, agentUrl, featureDiscovery, monitoring, metricsReportingEnabled);
-    } else {
-      api = agentApi;
-    }
-    discovery = featureDiscovery;
-    this.healthMetrics = healthMetrics;
-    this.dispatcher = new PayloadDispatcher(featureDiscovery, api, healthMetrics, monitoring);
-    this.alwaysFlush = alwaysFlush;
-    this.traceProcessingWorker =
-        new TraceProcessingWorker(
-            traceBufferSize,
-            healthMetrics,
-            dispatcher,
-            featureDiscovery,
-            null == prioritization ? FAST_LANE : prioritization,
-            flushFrequencySeconds,
-            TimeUnit.SECONDS);
+      DDAgentFeaturesDiscovery discovery,
+      DDAgentApi api,
+      HealthMetrics healthMetrics,
+      PayloadDispatcher dispatcher,
+      TraceProcessingWorker worker,
+      boolean alwaysFlush) {
+    super(api, worker, dispatcher, discovery, healthMetrics, alwaysFlush);
   }
 
   private DDAgentWriter(
@@ -224,12 +187,13 @@ public class DDAgentWriter implements Writer {
       HealthMetrics healthMetrics,
       Monitoring monitoring,
       TraceProcessingWorker worker) {
-    this.api = api;
-    this.discovery = discovery;
-    this.healthMetrics = healthMetrics;
-    this.traceProcessingWorker = worker;
-    this.dispatcher = new PayloadDispatcher(discovery, api, healthMetrics, monitoring);
-    this.alwaysFlush = false;
+    this(
+        discovery,
+        api,
+        healthMetrics,
+        new PayloadDispatcher(discovery, api, healthMetrics, monitoring),
+        worker,
+        false);
   }
 
   private DDAgentWriter(
@@ -238,94 +202,6 @@ public class DDAgentWriter implements Writer {
       HealthMetrics healthMetrics,
       PayloadDispatcher dispatcher,
       TraceProcessingWorker worker) {
-    this.discovery = discovery;
-    this.api = api;
-    this.healthMetrics = healthMetrics;
-    this.traceProcessingWorker = worker;
-    this.dispatcher = dispatcher;
-    this.alwaysFlush = false;
-  }
-
-  public void addResponseListener(final DDAgentResponseListener listener) {
-    api.addResponseListener(listener);
-  }
-
-  // Exposing some statistics for consumption by monitors
-  public final long getCapacity() {
-    return traceProcessingWorker.getCapacity();
-  }
-
-  @Override
-  public void write(final List<DDSpan> trace) {
-    // We can't add events after shutdown otherwise it will never complete shutting down.
-    if (!closed) {
-      if (trace.isEmpty()) {
-        handleDroppedTrace("Trace was empty", trace);
-      } else {
-        final DDSpan root = trace.get(0);
-        final int samplingPriority = root.context().getSamplingPriority();
-        if (traceProcessingWorker.publish(root, samplingPriority, trace)) {
-          healthMetrics.onPublish(trace, samplingPriority);
-        } else {
-          handleDroppedTrace("Trace written to overfilled buffer", trace, samplingPriority);
-        }
-      }
-    } else {
-      handleDroppedTrace("Trace written after shutdown.", trace);
-    }
-    if (alwaysFlush) {
-      flush();
-    }
-  }
-
-  private void handleDroppedTrace(final String reason, final List<DDSpan> trace) {
-    log.debug("{}. Counted but dropping trace: {}", reason, trace);
-    healthMetrics.onFailedPublish(UNSET);
-    incrementDropCounts(trace.size());
-  }
-
-  private void handleDroppedTrace(
-      final String reason, final List<DDSpan> trace, final int samplingPriority) {
-    log.debug("{}. Counted but dropping trace: {}", reason, trace);
-    healthMetrics.onFailedPublish(samplingPriority);
-    incrementDropCounts(trace.size());
-  }
-
-  @Override
-  public boolean flush() {
-    if (!closed) { // give up after a second
-      if (traceProcessingWorker.flush(1, TimeUnit.SECONDS)) {
-        healthMetrics.onFlush(false);
-        return true;
-      }
-    }
-    return false;
-  }
-
-  public DDAgentApi getApi() {
-    return api;
-  }
-
-  @Override
-  public void start() {
-    if (!closed) {
-      traceProcessingWorker.start();
-      healthMetrics.start();
-      healthMetrics.onStart((int) getCapacity());
-    }
-  }
-
-  @Override
-  public void close() {
-    final boolean flushed = flush();
-    closed = true;
-    traceProcessingWorker.close();
-    healthMetrics.close();
-    healthMetrics.onShutdown(flushed);
-  }
-
-  @Override
-  public void incrementDropCounts(int spanCount) {
-    dispatcher.onDroppedTrace(spanCount);
+    this(discovery, api, healthMetrics, dispatcher, worker, false);
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteApi.java
@@ -1,0 +1,78 @@
+package datadog.trace.common.writer;
+
+public interface RemoteApi {
+
+  Response sendSerializedTraces(final Payload payload);
+
+  void addResponseListener(final RemoteResponseListener listener);
+
+  /**
+   * Encapsulates an attempted response from the remote location.
+   *
+   * <p>If communication fails or times out, the Response will NOT be successful and will lack
+   * status code, but will have an exception.
+   *
+   * <p>If an communication occurs, the Response will have a status code and will be marked as
+   * success or fail in accordance with the code.
+   *
+   * <p>NOTE: A successful communication may still contain an exception if there was a problem
+   * parsing the response from the Datadog agent.
+   */
+  final class Response {
+    /** Factory method for a successful request with a trivial response body */
+    public static Response success(final int status) {
+      return new Response(true, status, null, null);
+    }
+
+    /** Factory method for a successful request with a trivial response body */
+    public static Response success(final int status, String response) {
+      return new Response(true, status, null, response);
+    }
+
+    /** Factory method for a successful request will a malformed response body */
+    public static Response success(final int status, final Throwable exception) {
+      return new Response(true, status, exception, null);
+    }
+
+    /** Factory method for a request that receive an error status in response */
+    public static Response failed(final int status) {
+      return new Response(false, status, null, null);
+    }
+
+    /** Factory method for a failed communication attempt */
+    public static Response failed(final Throwable exception) {
+      return new Response(false, null, exception, null);
+    }
+
+    private final boolean success;
+    private final Integer status;
+    private final Throwable exception;
+    private final String response;
+
+    private Response(
+        final boolean success, final Integer status, final Throwable exception, String response) {
+      this.success = success;
+      this.status = status;
+      this.exception = exception;
+      this.response = response;
+    }
+
+    public final boolean success() {
+      return success;
+    }
+
+    // TODO: DQH - In Java 8, switch to OptionalInteger
+    public final Integer status() {
+      return status;
+    }
+
+    // TODO: DQH - In Java 8, switch to Optional<Throwable>?
+    public final Throwable exception() {
+      return exception;
+    }
+
+    public final String response() {
+      return response;
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteMapperDiscovery.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteMapperDiscovery.java
@@ -1,0 +1,7 @@
+package datadog.trace.common.writer;
+
+public interface RemoteMapperDiscovery {
+  void discover();
+
+  RemoteMapper getMapper();
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteResponseListener.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteResponseListener.java
@@ -1,0 +1,8 @@
+package datadog.trace.common.writer;
+
+import java.util.Map;
+
+public interface RemoteResponseListener {
+  /** Invoked after the api receives a response from the remote service. */
+  void onResponse(String endpoint, Map<String, Map<String, Number>> responseJson);
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteWriter.java
@@ -15,7 +15,7 @@ public abstract class RemoteWriter implements Writer {
   private static final Logger log = LoggerFactory.getLogger(RemoteWriter.class);
 
   private final RemoteApi api;
-  private final TraceProcessingWorker traceProcessingWorker;
+  protected final TraceProcessingWorker traceProcessingWorker;
   private final PayloadDispatcher dispatcher;
   private final RemoteFeaturesDiscovery discovery;
   private final boolean alwaysFlush;

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteWriter.java
@@ -2,7 +2,6 @@ package datadog.trace.common.writer;
 
 import static datadog.trace.api.sampling.PrioritySampling.UNSET;
 
-import datadog.communication.RemoteFeaturesDiscovery;
 import datadog.trace.core.DDSpan;
 import datadog.trace.core.monitor.HealthMetrics;
 import java.util.List;
@@ -17,7 +16,6 @@ public abstract class RemoteWriter implements Writer {
   private final RemoteApi api;
   protected final TraceProcessingWorker traceProcessingWorker;
   private final PayloadDispatcher dispatcher;
-  private final RemoteFeaturesDiscovery discovery;
   private final boolean alwaysFlush;
 
   private volatile boolean closed;
@@ -28,13 +26,11 @@ public abstract class RemoteWriter implements Writer {
       final RemoteApi api,
       final TraceProcessingWorker traceProcessingWorker,
       final PayloadDispatcher dispatcher,
-      final RemoteFeaturesDiscovery discovery,
       final HealthMetrics healthMetrics,
       final boolean alwaysFlush) {
     this.api = api;
     this.traceProcessingWorker = traceProcessingWorker;
     this.dispatcher = dispatcher;
-    this.discovery = discovery;
     this.healthMetrics = healthMetrics;
     this.alwaysFlush = alwaysFlush;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteWriter.java
@@ -1,0 +1,124 @@
+package datadog.trace.common.writer;
+
+import static datadog.trace.api.sampling.PrioritySampling.UNSET;
+
+import datadog.communication.RemoteFeaturesDiscovery;
+import datadog.trace.core.DDSpan;
+import datadog.trace.core.monitor.HealthMetrics;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class RemoteWriter implements Writer {
+
+  private static final Logger log = LoggerFactory.getLogger(RemoteWriter.class);
+
+  private final RemoteApi api;
+  private final TraceProcessingWorker traceProcessingWorker;
+  private final PayloadDispatcher dispatcher;
+  private final RemoteFeaturesDiscovery discovery;
+  private final boolean alwaysFlush;
+
+  private volatile boolean closed;
+
+  public final HealthMetrics healthMetrics;
+
+  protected RemoteWriter(
+      final RemoteApi api,
+      final TraceProcessingWorker traceProcessingWorker,
+      final PayloadDispatcher dispatcher,
+      final RemoteFeaturesDiscovery discovery,
+      final HealthMetrics healthMetrics,
+      final boolean alwaysFlush) {
+    this.api = api;
+    this.traceProcessingWorker = traceProcessingWorker;
+    this.dispatcher = dispatcher;
+    this.discovery = discovery;
+    this.healthMetrics = healthMetrics;
+    this.alwaysFlush = alwaysFlush;
+  }
+
+  public void addResponseListener(final RemoteResponseListener listener) {
+    api.addResponseListener(listener);
+  }
+
+  public RemoteApi getApi() {
+    return api;
+  }
+
+  @Override
+  public void write(final List<DDSpan> trace) {
+    // We can't add events after shutdown otherwise it will never complete shutting down.
+    if (!closed) {
+      if (trace.isEmpty()) {
+        handleDroppedTrace("Trace was empty", trace);
+      } else {
+        final DDSpan root = trace.get(0);
+        final int samplingPriority = root.context().getSamplingPriority();
+        if (traceProcessingWorker.publish(root, samplingPriority, trace)) {
+          healthMetrics.onPublish(trace, samplingPriority);
+        } else {
+          handleDroppedTrace("Trace written to overfilled buffer", trace, samplingPriority);
+        }
+      }
+    } else {
+      handleDroppedTrace("Trace written after shutdown.", trace);
+    }
+    if (alwaysFlush) {
+      flush();
+    }
+  }
+
+  private void handleDroppedTrace(final String reason, final List<DDSpan> trace) {
+    log.debug("{}. Counted but dropping trace: {}", reason, trace);
+    healthMetrics.onFailedPublish(UNSET);
+    incrementDropCounts(trace.size());
+  }
+
+  private void handleDroppedTrace(
+      final String reason, final List<DDSpan> trace, final int samplingPriority) {
+    log.debug("{}. Counted but dropping trace: {}", reason, trace);
+    healthMetrics.onFailedPublish(samplingPriority);
+    incrementDropCounts(trace.size());
+  }
+
+  // Exposing some statistics for consumption by monitors
+  public final long getCapacity() {
+    return traceProcessingWorker.getCapacity();
+  }
+
+  @Override
+  public boolean flush() {
+    if (!closed) { // give up after a second
+      if (traceProcessingWorker.flush(1, TimeUnit.SECONDS)) {
+        healthMetrics.onFlush(false);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public void start() {
+    if (!closed) {
+      traceProcessingWorker.start();
+      healthMetrics.start();
+      healthMetrics.onStart((int) getCapacity());
+    }
+  }
+
+  @Override
+  public void close() {
+    final boolean flushed = flush();
+    closed = true;
+    traceProcessingWorker.close();
+    healthMetrics.close();
+    healthMetrics.onShutdown(flushed);
+  }
+
+  @Override
+  public void incrementDropCounts(int spanCount) {
+    dispatcher.onDroppedTrace(spanCount);
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceProcessingWorker.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceProcessingWorker.java
@@ -1,4 +1,4 @@
-package datadog.trace.common.writer.ddagent;
+package datadog.trace.common.writer;
 
 import static datadog.trace.util.AgentThreadFactory.AgentThread.TRACE_PROCESSOR;
 import static datadog.trace.util.AgentThreadFactory.THREAD_JOIN_TIMOUT_MS;
@@ -6,6 +6,9 @@ import static datadog.trace.util.AgentThreadFactory.newAgentThread;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import datadog.communication.ddagent.DroppingPolicy;
+import datadog.trace.common.writer.ddagent.FlushEvent;
+import datadog.trace.common.writer.ddagent.Prioritization;
+import datadog.trace.common.writer.ddagent.PrioritizationStrategy;
 import datadog.trace.core.CoreSpan;
 import datadog.trace.core.DDSpan;
 import datadog.trace.core.monitor.HealthMetrics;

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
@@ -15,7 +15,6 @@ import datadog.trace.api.Config;
 import datadog.trace.api.StatsDClient;
 import datadog.trace.common.sampling.Sampler;
 import datadog.trace.common.writer.ddagent.DDAgentApi;
-import datadog.trace.common.writer.ddagent.DDAgentResponseListener;
 import datadog.trace.common.writer.ddagent.Prioritization;
 import datadog.trace.core.monitor.HealthMetrics;
 import datadog.trace.util.Strings;
@@ -96,8 +95,8 @@ public class WriterFactory {
             .alwaysFlush(alwaysFlush)
             .build();
 
-    if (sampler instanceof DDAgentResponseListener) {
-      ddAgentWriter.addResponseListener((DDAgentResponseListener) sampler);
+    if (sampler instanceof RemoteResponseListener) {
+      ddAgentWriter.addResponseListener((RemoteResponseListener) sampler);
     }
 
     return ddAgentWriter;

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentMapperDiscovery.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentMapperDiscovery.java
@@ -4,6 +4,11 @@ import datadog.communication.ddagent.DDAgentFeaturesDiscovery;
 import datadog.trace.common.writer.RemoteMapper;
 import datadog.trace.common.writer.RemoteMapperDiscovery;
 
+/**
+ * Mapper discovery logic when the DDAgent is used. It leverages the {@code
+ * DDAgentFeaturesDiscovery} to select the correct {@code TraceMapper}. Typically, an instance of
+ * this class is used during the mapper lazy loading in the {@code PayloadDispatcher} class.
+ */
 public class DDAgentMapperDiscovery implements RemoteMapperDiscovery {
 
   private final DDAgentFeaturesDiscovery featuresDiscovery;

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentMapperDiscovery.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentMapperDiscovery.java
@@ -1,0 +1,38 @@
+package datadog.trace.common.writer.ddagent;
+
+import datadog.communication.ddagent.DDAgentFeaturesDiscovery;
+import datadog.trace.common.writer.RemoteMapper;
+import datadog.trace.common.writer.RemoteMapperDiscovery;
+
+public class DDAgentMapperDiscovery implements RemoteMapperDiscovery {
+
+  private final DDAgentFeaturesDiscovery featuresDiscovery;
+  private TraceMapper traceMapper;
+
+  public DDAgentMapperDiscovery(final DDAgentFeaturesDiscovery featuresDiscovery) {
+    this.featuresDiscovery = featuresDiscovery;
+  }
+
+  private void reset() {
+    this.traceMapper = null;
+  }
+
+  @Override
+  public void discover() {
+    reset();
+    if (featuresDiscovery.getTraceEndpoint() == null) {
+      featuresDiscovery.discover();
+    }
+    String tracesUrl = featuresDiscovery.getTraceEndpoint();
+    if (DDAgentFeaturesDiscovery.V5_ENDPOINT.equalsIgnoreCase(tracesUrl)) {
+      this.traceMapper = new TraceMapperV0_5();
+    } else if (null != tracesUrl) {
+      this.traceMapper = new TraceMapperV0_4();
+    }
+  }
+
+  @Override
+  public RemoteMapper getMapper() {
+    return traceMapper;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentResponseListener.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentResponseListener.java
@@ -1,8 +1,0 @@
-package datadog.trace.common.writer.ddagent;
-
-import java.util.Map;
-
-public interface DDAgentResponseListener {
-  /** Invoked after the api receives a response from the core agent. */
-  void onResponse(String endpoint, Map<String, Map<String, Number>> responseJson);
-}

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
@@ -9,7 +9,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import datadog.trace.api.IntFunction;
 import datadog.trace.api.StatsDClient;
 import datadog.trace.api.cache.RadixTreeCache;
-import datadog.trace.common.writer.ddagent.DDAgentApi;
+import datadog.trace.common.writer.RemoteApi;
 import datadog.trace.core.DDSpan;
 import datadog.trace.util.AgentTaskScheduler;
 import java.util.List;
@@ -157,17 +157,17 @@ public class HealthMetrics implements AutoCloseable {
   }
 
   public void onSend(
-      final int traceCount, final int sizeInBytes, final DDAgentApi.Response response) {
+      final int traceCount, final int sizeInBytes, final RemoteApi.Response response) {
     onSendAttempt(traceCount, sizeInBytes, response);
   }
 
   public void onFailedSend(
-      final int traceCount, final int sizeInBytes, final DDAgentApi.Response response) {
+      final int traceCount, final int sizeInBytes, final RemoteApi.Response response) {
     onSendAttempt(traceCount, sizeInBytes, response);
   }
 
   private void onSendAttempt(
-      final int traceCount, final int sizeInBytes, final DDAgentApi.Response response) {
+      final int traceCount, final int sizeInBytes, final RemoteApi.Response response) {
     statsd.incrementCounter("api.requests.total", NO_TAGS);
     statsd.count("flush.traces.total", traceCount, NO_TAGS);
     // TODO: missing queue.spans (# of spans being sent)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
@@ -12,7 +12,7 @@ import datadog.trace.common.sampling.RateByServiceSampler
 import datadog.trace.api.sampling.SamplingMechanism
 import datadog.trace.common.writer.ddagent.DDAgentApi
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery
-import datadog.trace.common.writer.ddagent.DDAgentResponseListener
+
 import datadog.trace.common.writer.ddagent.TraceMapperV0_4
 import datadog.trace.common.writer.ddagent.TraceMapperV0_5
 import datadog.trace.core.DDSpan
@@ -188,7 +188,7 @@ class DDAgentApiTest extends DDCoreSpecification {
   def "Api ResponseListeners see 200 responses"() {
     setup:
     def agentResponse = new AtomicReference<Map>(null)
-    DDAgentResponseListener responseListener = { String endpoint, Map responseJson ->
+    RemoteResponseListener responseListener = { String endpoint, Map responseJson ->
       agentResponse.set(responseJson)
     }
     def agent = httpServer {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
@@ -105,7 +105,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
 
     then:
     2 * discovery.getTraceEndpoint() >> agentVersion
-    1 * api.sendSerializedTraces({ it.traceCount() == 2 }) >> DDAgentApi.Response.success(200)
+    1 * api.sendSerializedTraces({ it.traceCount() == 2 }) >> RemoteApi.Response.success(200)
     0 * _
 
     cleanup:
@@ -137,7 +137,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
 
     then:
     2 * discovery.getTraceEndpoint() >> agentVersion
-    1 * api.sendSerializedTraces({ it.traceCount() <= traceCount }) >> DDAgentApi.Response.success(200)
+    1 * api.sendSerializedTraces({ it.traceCount() <= traceCount }) >> RemoteApi.Response.success(200)
     0 * _
 
     cleanup:
@@ -174,7 +174,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
     then:
     2 * discovery.getTraceEndpoint() >> agentVersion
     1 * healthMetrics.onSerialize(_)
-    1 * api.sendSerializedTraces({ it.traceCount() == 5 }) >> DDAgentApi.Response.success(200)
+    1 * api.sendSerializedTraces({ it.traceCount() == 5 }) >> RemoteApi.Response.success(200)
     _ * healthMetrics.onPublish(_, _)
     1 * healthMetrics.onSend(_, _, _) >> {
       phaser.arrive()
@@ -214,8 +214,8 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
 
     then:
     2 * discovery.getTraceEndpoint() >> agentVersion
-    1 * api.sendSerializedTraces({ it.traceCount() == maxedPayloadTraceCount }) >> DDAgentApi.Response.success(200)
-    1 * api.sendSerializedTraces({ it.traceCount() == 1 }) >> DDAgentApi.Response.success(200)
+    1 * api.sendSerializedTraces({ it.traceCount() == maxedPayloadTraceCount }) >> RemoteApi.Response.success(200)
+    1 * api.sendSerializedTraces({ it.traceCount() == 1 }) >> RemoteApi.Response.success(200)
     0 * _
 
     cleanup:
@@ -416,7 +416,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
     def api = Mock(DDAgentApi) {
       it.sendSerializedTraces(_) >> {
         // simulating a communication failure to a server
-        return DDAgentApi.Response.failed(new IOException("comm error"))
+        return RemoteApi.Response.failed(new IOException("comm error"))
       }
     }
 
@@ -698,7 +698,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
     def minimalTrace = createMinimalTrace()
 
     def api = apiWithVersion(agentVersion)
-    api.sendSerializedTraces(_) >> DDAgentApi.Response.failed(new IOException("comm error"))
+    api.sendSerializedTraces(_) >> RemoteApi.Response.failed(new IOException("comm error"))
 
     def statsd = Stub(StatsDClient)
     statsd.incrementCounter("api.requests.total") >> { stat ->

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
@@ -6,8 +6,6 @@ import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.api.sampling.SamplingMechanism
 import datadog.trace.common.writer.ddagent.DDAgentApi
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery
-import datadog.trace.common.writer.ddagent.PayloadDispatcher
-import datadog.trace.common.writer.ddagent.TraceProcessingWorker
 import datadog.trace.core.CoreTracer
 import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
@@ -7,7 +7,6 @@ import datadog.trace.api.sampling.SamplingMechanism
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopPathwayContext
 import datadog.trace.common.writer.ddagent.DDAgentApi
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery
-import datadog.trace.common.writer.ddagent.PayloadDispatcher
 import datadog.trace.core.CoreTracer
 import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext
@@ -37,7 +36,7 @@ class PayloadDispatcherTest extends DDSpecification {
     DDAgentApi api = Mock(DDAgentApi)
     api.sendSerializedTraces(_) >> {
       flushed.set(true)
-      return DDAgentApi.Response.success(200)
+      return RemoteApi.Response.success(200)
     }
     PayloadDispatcher dispatcher = new PayloadDispatcher(discovery, api, healthMetrics, monitoring)
     List<DDSpan> trace = [realSpan()]
@@ -68,7 +67,7 @@ class PayloadDispatcherTest extends DDSpecification {
     then:
     2 * discovery.getTraceEndpoint() >> traceEndpoint
     1 * healthMetrics.onSerialize({ it > 0 })
-    1 * api.sendSerializedTraces({ it.traceCount() == traceCount }) >> DDAgentApi.Response.success(200)
+    1 * api.sendSerializedTraces({ it.traceCount() == traceCount }) >> RemoteApi.Response.success(200)
 
     where:
     traceEndpoint | traceCount
@@ -95,7 +94,7 @@ class PayloadDispatcherTest extends DDSpecification {
     then:
     2 * discovery.getTraceEndpoint() >> traceEndpoint
     1 * healthMetrics.onSerialize({ it > 0 })
-    1 * api.sendSerializedTraces({ it.traceCount() == traceCount }) >> DDAgentApi.Response.failed(400)
+    1 * api.sendSerializedTraces({ it.traceCount() == traceCount }) >> RemoteApi.Response.failed(400)
 
     where:
     traceEndpoint | traceCount

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
@@ -7,6 +7,7 @@ import datadog.trace.api.sampling.SamplingMechanism
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopPathwayContext
 import datadog.trace.common.writer.ddagent.DDAgentApi
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery
+import datadog.trace.common.writer.ddagent.DDAgentMapperDiscovery
 import datadog.trace.core.CoreTracer
 import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext
@@ -38,7 +39,7 @@ class PayloadDispatcherTest extends DDSpecification {
       flushed.set(true)
       return RemoteApi.Response.success(200)
     }
-    PayloadDispatcher dispatcher = new PayloadDispatcher(discovery, api, healthMetrics, monitoring)
+    PayloadDispatcher dispatcher = new PayloadDispatcher(new DDAgentMapperDiscovery(discovery), api, healthMetrics, monitoring)
     List<DDSpan> trace = [realSpan()]
     when:
     while (!flushed.get()) {
@@ -57,7 +58,7 @@ class PayloadDispatcherTest extends DDSpecification {
     HealthMetrics healthMetrics = Mock(HealthMetrics)
     DDAgentFeaturesDiscovery discovery = Mock(DDAgentFeaturesDiscovery)
     DDAgentApi api = Mock(DDAgentApi)
-    PayloadDispatcher dispatcher = new PayloadDispatcher(discovery, api, healthMetrics, monitoring)
+    PayloadDispatcher dispatcher = new PayloadDispatcher(new DDAgentMapperDiscovery(discovery), api, healthMetrics, monitoring)
     List<DDSpan> trace = [realSpan()]
     when:
     for (int i = 0; i < traceCount; ++i) {
@@ -84,7 +85,7 @@ class PayloadDispatcherTest extends DDSpecification {
     HealthMetrics healthMetrics = Mock(HealthMetrics)
     DDAgentFeaturesDiscovery discovery = Mock(DDAgentFeaturesDiscovery)
     DDAgentApi api = Mock(DDAgentApi)
-    PayloadDispatcher dispatcher = new PayloadDispatcher(discovery, api, healthMetrics, monitoring)
+    PayloadDispatcher dispatcher = new PayloadDispatcher(new DDAgentMapperDiscovery(discovery), api, healthMetrics, monitoring)
     List<DDSpan> trace = [realSpan()]
     when:
     for (int i = 0; i < traceCount; ++i) {
@@ -111,7 +112,7 @@ class PayloadDispatcherTest extends DDSpecification {
     HealthMetrics healthMetrics = Mock(HealthMetrics)
     DDAgentApi api = Mock(DDAgentApi)
     DDAgentFeaturesDiscovery discovery = Mock(DDAgentFeaturesDiscovery)
-    PayloadDispatcher dispatcher = new PayloadDispatcher(discovery, api, healthMetrics, monitoring)
+    PayloadDispatcher dispatcher = new PayloadDispatcher(new DDAgentMapperDiscovery(discovery), api, healthMetrics, monitoring)
     List<DDSpan> trace = [realSpan()]
     discovery.getTraceEndpoint() >> null
     when:
@@ -127,7 +128,7 @@ class PayloadDispatcherTest extends DDSpecification {
     DDAgentFeaturesDiscovery discovery = Mock(DDAgentFeaturesDiscovery) {
       it.getTraceEndpoint() >> "v0.4/traces"
     }
-    PayloadDispatcher dispatcher = new PayloadDispatcher(discovery, api, healthMetrics, monitoring)
+    PayloadDispatcher dispatcher = new PayloadDispatcher(new DDAgentMapperDiscovery(discovery), api, healthMetrics, monitoring)
 
     when:
     dispatcher.addTrace([])

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/TraceProcessingWorkerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/TraceProcessingWorkerTest.groovy
@@ -1,8 +1,6 @@
 package datadog.trace.common.writer
 
 import datadog.trace.api.StatsDClient
-import datadog.trace.common.writer.ddagent.PayloadDispatcher
-import datadog.trace.common.writer.ddagent.TraceProcessingWorker
 import datadog.trace.core.DDSpan
 import datadog.trace.core.monitor.HealthMetrics
 import datadog.trace.core.monitor.MonitoringImpl

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
@@ -2,8 +2,8 @@ package datadog.trace.core.monitor
 
 import datadog.trace.api.StatsDClient
 import datadog.trace.api.sampling.PrioritySampling
-import datadog.trace.common.writer.DDAgentWriter
-import datadog.trace.common.writer.ddagent.DDAgentApi
+import datadog.trace.common.writer.RemoteApi
+import datadog.trace.common.writer.RemoteWriter
 import datadog.trace.test.util.DDSpecification
 import spock.lang.Ignore
 import spock.lang.Subject
@@ -18,11 +18,11 @@ class HealthMetricsTest extends DDSpecification {
   @Subject
   def healthMetrics = new HealthMetrics(statsD)
 
-  // This fails because DDAgentWriter isn't an interface and the mock doesn't prevent the call.
+  // This fails because RemoteWriter isn't an interface and the mock doesn't prevent the call.
   @Ignore
   def "test onStart"() {
     setup:
-    def writer = Mock(DDAgentWriter)
+    def writer = Mock(RemoteWriter)
 
     when:
     healthMetrics.onStart(writer)
@@ -151,10 +151,10 @@ class HealthMetricsTest extends DDSpecification {
 
     where:
     response << [
-      DDAgentApi.Response.success(ThreadLocalRandom.current().nextInt(1, 100)),
-      DDAgentApi.Response.failed(ThreadLocalRandom.current().nextInt(1, 100)),
-      DDAgentApi.Response.success(ThreadLocalRandom.current().nextInt(1, 100), new Throwable()),
-      DDAgentApi.Response.failed(new Throwable()),
+      RemoteApi.Response.success(ThreadLocalRandom.current().nextInt(1, 100)),
+      RemoteApi.Response.failed(ThreadLocalRandom.current().nextInt(1, 100)),
+      RemoteApi.Response.success(ThreadLocalRandom.current().nextInt(1, 100), new Throwable()),
+      RemoteApi.Response.failed(new Throwable()),
     ]
 
     traceCount = ThreadLocalRandom.current().nextInt(1, 100)
@@ -179,10 +179,10 @@ class HealthMetricsTest extends DDSpecification {
 
     where:
     response << [
-      DDAgentApi.Response.success(ThreadLocalRandom.current().nextInt(1, 100)),
-      DDAgentApi.Response.failed(ThreadLocalRandom.current().nextInt(1, 100)),
-      DDAgentApi.Response.success(ThreadLocalRandom.current().nextInt(1, 100), new Throwable()),
-      DDAgentApi.Response.failed(new Throwable()),
+      RemoteApi.Response.success(ThreadLocalRandom.current().nextInt(1, 100)),
+      RemoteApi.Response.failed(ThreadLocalRandom.current().nextInt(1, 100)),
+      RemoteApi.Response.success(ThreadLocalRandom.current().nextInt(1, 100), new Throwable()),
+      RemoteApi.Response.failed(new Throwable()),
     ]
 
     traceCount = ThreadLocalRandom.current().nextInt(1, 100)

--- a/dd-trace-core/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
@@ -6,8 +6,9 @@ import datadog.communication.serialization.msgpack.MsgPackWriter
 import datadog.trace.api.StatsDClient
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.common.writer.Payload
+import datadog.trace.common.writer.RemoteApi
+import datadog.trace.common.writer.RemoteResponseListener
 import datadog.trace.common.writer.ddagent.DDAgentApi
-import datadog.trace.common.writer.ddagent.DDAgentResponseListener
 
 import datadog.trace.common.writer.ddagent.TraceMapper
 import datadog.trace.common.writer.ddagent.TraceMapperV0_4
@@ -64,7 +65,7 @@ class DDApiIntegrationTest extends DDSpecification {
   def endpoint = new AtomicReference<String>(null)
   def agentResponse = new AtomicReference<Map<String, Map<String, Number>>>(null)
 
-  DDAgentResponseListener responseListener = { String receivedEndpoint, Map<String, Map<String, Number>> responseJson ->
+  RemoteResponseListener responseListener = { String receivedEndpoint, Map<String, Map<String, Number>> responseJson ->
     endpoint.set(receivedEndpoint)
     agentResponse.set(responseJson)
   }
@@ -138,7 +139,7 @@ class DDApiIntegrationTest extends DDSpecification {
     setup:
     beforeTest(enableV05)
     expect:
-    DDAgentApi.Response response = api.sendSerializedTraces(prepareRequest(traces, mapper))
+    RemoteApi.Response response = api.sendSerializedTraces(prepareRequest(traces, mapper))
     assert !response.response().isEmpty()
     assert null == response.exception()
     assert 200 == response.status()
@@ -161,7 +162,7 @@ class DDApiIntegrationTest extends DDSpecification {
     setup:
     beforeTest(enableV05)
     expect:
-    DDAgentApi.Response response = api.sendSerializedTraces(prepareRequest([[span]], mapper))
+    RemoteApi.Response response = api.sendSerializedTraces(prepareRequest([[span]], mapper))
     assert !response.response().isEmpty()
     assert null == response.exception()
     assert 200 == response.status()
@@ -178,7 +179,7 @@ class DDApiIntegrationTest extends DDSpecification {
     setup:
     beforeTest(enableV05)
     expect:
-    DDAgentApi.Response response = unixDomainSocketApi.sendSerializedTraces(prepareRequest(traces, mapper))
+    RemoteApi.Response response = unixDomainSocketApi.sendSerializedTraces(prepareRequest(traces, mapper))
     assert !response.response().isEmpty()
     assert null == response.exception()
     assert 200 == response.status()
@@ -199,7 +200,7 @@ class DDApiIntegrationTest extends DDSpecification {
     setup:
     beforeTest(enableV05)
     expect:
-    DDAgentApi.Response response = unixDomainSocketApi.sendSerializedTraces(prepareRequest([[span]], mapper))
+    RemoteApi.Response response = unixDomainSocketApi.sendSerializedTraces(prepareRequest([[span]], mapper))
     assert !response.response().isEmpty()
     assert null == response.exception()
     assert 200 == response.status()

--- a/dd-trace-core/src/traceAgentTest/groovy/TraceMapperRealAgentTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/TraceMapperRealAgentTest.groovy
@@ -3,7 +3,7 @@
 import datadog.trace.api.StatsDClient
 import datadog.trace.common.writer.ddagent.DDAgentApi
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery
-import datadog.trace.common.writer.ddagent.PayloadDispatcher
+import datadog.trace.common.writer.PayloadDispatcher
 import datadog.trace.core.CoreSpan
 import datadog.communication.http.OkHttpUtils
 import datadog.trace.core.monitor.HealthMetrics

--- a/dd-trace-core/src/traceAgentTest/groovy/TraceMapperRealAgentTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/TraceMapperRealAgentTest.groovy
@@ -4,6 +4,7 @@ import datadog.trace.api.StatsDClient
 import datadog.trace.common.writer.ddagent.DDAgentApi
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery
 import datadog.trace.common.writer.PayloadDispatcher
+import datadog.trace.common.writer.ddagent.DDAgentMapperDiscovery
 import datadog.trace.core.CoreSpan
 import datadog.communication.http.OkHttpUtils
 import datadog.trace.core.monitor.HealthMetrics
@@ -42,7 +43,7 @@ class TraceMapperRealAgentTest extends DDSpecification {
   def "send random traces"() {
     setup:
     HealthMetrics healthMetrics = Mock(HealthMetrics)
-    PayloadDispatcher dispatcher = new PayloadDispatcher(v05 ? v05Discovery : v04Discovery, v05 ? v05Api : v04Api, healthMetrics, monitoring)
+    PayloadDispatcher dispatcher = new PayloadDispatcher(new DDAgentMapperDiscovery(v05 ? v05Discovery : v04Discovery), v05 ? v05Api : v04Api, healthMetrics, monitoring)
     List<List<CoreSpan>> traces = generateRandomTraces(traceCount, lowCardinality)
     when:
     for (List<CoreSpan> trace : traces) {


### PR DESCRIPTION
As part of the initiative to transition CI Visibility to the agentless mode, the traces generated by the instrumentations need to be sent to a new HTTP public intake.

This PR refactors the code to decouple buffering + common transport logic from specific Datadog Agent implementation details. For that purpose, some common abstract classes and interfaces were created. 

The change in this PR only refactors the code and has no collateral effects on the current configuration and/or behavior. It has no changes related to the agentless mode, just the preparation.

Tested on a spring-boot application.
<img width="797" alt="image" src="https://user-images.githubusercontent.com/29516565/163981387-71b35e4f-88f7-422f-8e58-b6c3938f6d65.png">

<img width="813" alt="image" src="https://user-images.githubusercontent.com/29516565/163981454-f14d7daa-32a0-4813-984e-f30a7e78f7e6.png">

