### PR TITLE
Add resource name priority for changes made through instrumented opentracing

### DIFF
--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.opentracing31;
 
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.instrumentation.opentracing.LogHandler;
 import io.opentracing.Span;
@@ -165,7 +166,7 @@ class OTSpan implements Span, MutableSpan {
 
   @Override
   public OTSpan setResourceName(final CharSequence resourceName) {
-    delegate.setResourceName(resourceName);
+    delegate.setResourceName(resourceName, ResourceNamePriorities.MANUAL_INSTRUMENTATION);
     return this;
   }
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.opentracing32;
 
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.instrumentation.opentracing.LogHandler;
 import io.opentracing.Span;
@@ -172,7 +173,7 @@ class OTSpan implements Span, MutableSpan {
 
   @Override
   public OTSpan setResourceName(final CharSequence resourceName) {
-    delegate.setResourceName(resourceName);
+    delegate.setResourceName(resourceName, ResourceNamePriorities.MANUAL_INSTRUMENTATION);
     return this;
   }
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -2,11 +2,13 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDId
 import datadog.trace.api.DDTags
 import datadog.trace.api.interceptor.MutableSpan
-import static datadog.trace.api.sampling.PrioritySampling.*
-import static datadog.trace.api.sampling.SamplingMechanism.*
+import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities
 import datadog.trace.context.TraceScope
 import datadog.trace.core.DDSpan
 import datadog.trace.core.propagation.ExtractedContext
+import datadog.trace.instrumentation.opentracing.DefaultLogHandler
+import datadog.trace.instrumentation.opentracing32.OTTracer
+import datadog.trace.instrumentation.opentracing32.TypeConverter
 import io.opentracing.References
 import io.opentracing.Scope
 import io.opentracing.Span
@@ -15,14 +17,25 @@ import io.opentracing.noop.NoopSpan
 import io.opentracing.propagation.Format
 import io.opentracing.propagation.TextMap
 import io.opentracing.util.GlobalTracer
+import spock.lang.Shared
 import spock.lang.Subject
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP
+import static datadog.trace.api.sampling.PrioritySampling.UNSET
+import static datadog.trace.api.sampling.PrioritySampling.USER_DROP
+import static datadog.trace.api.sampling.PrioritySampling.USER_KEEP
+import static datadog.trace.api.sampling.SamplingMechanism.DEFAULT
+import static datadog.trace.api.sampling.SamplingMechanism.MANUAL
 
 class OpenTracing32Test extends AgentTestRunner {
 
   @Subject
   def tracer = GlobalTracer.get()
+
+  @Shared
+  TypeConverter typeConverter = new TypeConverter(new DefaultLogHandler())
 
   def "test #method"() {
     setup:
@@ -318,6 +331,37 @@ class OpenTracing32Test extends AgentTestRunner {
 
     then:
     assert tracer.scopeManager().active() == null
+  }
+
+  def "test resource name assignment through MutableSpan casting"() {
+    given:
+    OTTracer.OTSpanBuilder builder = tracer.buildSpan("parent") as OTTracer.OTSpanBuilder
+    builder.delegate.withResourceName("test-resource")
+    Span testSpan = builder.start()
+    Scope testScope = tracer.activateSpan(testSpan)
+
+    when:
+    Span active = GlobalTracer.get().activeSpan()
+    Span child = GlobalTracer.get().buildSpan("child").asChildOf(active).start()
+    Scope scope = GlobalTracer.get().activateSpan(child)
+
+    MutableSpan localRootSpan = ((MutableSpan) child).getLocalRootSpan()
+    localRootSpan.setResourceName("correct-resource")
+
+    then:
+    typeConverter.toAgentSpan(testSpan).getResourceName() == "correct-resource"
+
+    when:
+    typeConverter.toAgentSpan(testSpan).setResourceName("should-be-ignored", ResourceNamePriorities.HTTP_FRAMEWORK_ROUTE)
+
+    then:
+    typeConverter.toAgentSpan(testSpan).getResourceName() == "correct-resource"
+
+    cleanup:
+    scope.close()
+    child.finish()
+    testScope.close()
+    testSpan.finish()
   }
 
   static class TextMapAdapter implements TextMap {


### PR DESCRIPTION
# What Does This Do

Complete the feature within opentracing manual instrumentation so that resource names set are not overridden

# Motivation

# Additional Notes
