### PR TITLE
jakarta-rs-annotations 3.1.x requires Java 11 for testing

### DIFF
--- a/dd-java-agent/instrumentation/jakarta-rs-annotations-3/jakarta-rs-annotations-3.gradle
+++ b/dd-java-agent/instrumentation/jakarta-rs-annotations-3/jakarta-rs-annotations-3.gradle
@@ -18,6 +18,20 @@ testSets {
   latestDepTest {
     dirName = 'test'
   }
+  latestDepJava11Test {
+    extendsFrom latestDepTest
+    dirName = 'test'
+  }
+}
+
+tasks.named("compileLatestDepJava11TestJava").configure {
+  setJavaVersion(it, 11)
+}
+tasks.named("compileLatestDepJava11TestGroovy").configure {
+  javaLauncher = getJavaLauncherFor(11)
+}
+tasks.named("latestDepJava11Test").configure {
+  javaLauncher = getJavaLauncherFor(11)
 }
 
 dependencies {
@@ -27,6 +41,9 @@ dependencies {
   testImplementation group: 'jakarta.ws.rs', name: 'jakarta.ws.rs-api', version: '3.0.0'
   testImplementation group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '3.0.0'
 
-  latestDepTestImplementation group: 'jakarta.ws.rs', name: 'jakarta.ws.rs-api', version: '3.+'
-  latestDepTestImplementation group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '3.+'
+  latestDepTestImplementation group: 'jakarta.ws.rs', name: 'jakarta.ws.rs-api', version: '3.0.+'
+  latestDepTestImplementation group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '3.0.+'
+
+  latestDepJava11TestImplementation group: 'jakarta.ws.rs', name: 'jakarta.ws.rs-api', version: '3.+'
+  latestDepJava11TestImplementation group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '3.+'
 }


### PR DESCRIPTION
The gradle changes were cribbed from the jdbc module - if any of this can be simplified let me know :)