### PR TITLE
Add primary tag and others to data streams monitoring

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -17,6 +17,7 @@ import datadog.trace.api.Config
 import datadog.trace.api.DDId
 import datadog.trace.api.Platform
 import datadog.trace.api.StatsDClient
+import datadog.trace.api.WellKnownTags
 import datadog.trace.api.config.TracerConfig
 import datadog.trace.api.time.TimeSource
 import datadog.trace.api.time.SystemTimeSource
@@ -167,11 +168,12 @@ abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.L
       try {
         // Fast enough so tests don't take forever
         long bucketDuration = TimeUnit.MILLISECONDS.toNanos(50)
+        WellKnownTags wellKnownTags = new WellKnownTags("runtimeid", "hostname", "my-env", "service", "version", "language")
 
         // Use reflection to load the class because it should only be loaded on Java 8+
         dataStreamsCheckpointer = (DataStreamsCheckpointer) Class.forName("datadog.trace.core.datastreams.DefaultDataStreamsCheckpointer")
-          .getDeclaredConstructor(Sink, DDAgentFeaturesDiscovery, TimeSource, DatastreamsPayloadWriter, long)
-          .newInstance(sink, features, SystemTimeSource.INSTANCE, TEST_DATA_STREAMS_WRITER, bucketDuration)
+          .getDeclaredConstructor(Sink, DDAgentFeaturesDiscovery, TimeSource, WellKnownTags, DatastreamsPayloadWriter, long)
+          .newInstance(sink, features, SystemTimeSource.INSTANCE, wellKnownTags, TEST_DATA_STREAMS_WRITER, bucketDuration)
       } catch (InstantiationException | InvocationTargetException | NoSuchMethodException | IllegalAccessException | ClassNotFoundException e) {
         e.printStackTrace()
       }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -21,6 +21,7 @@ public final class GeneralConfig {
   public static final String SERVICE_NAME = "service.name";
   public static final String ENV = "env";
   public static final String VERSION = "version";
+  public static final String PRIMARY_TAG = "primary.tag";
   public static final String TAGS = "tags";
   @Deprecated // Use dd.tags instead
   public static final String GLOBAL_TAGS = "trace.global.tags";

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
@@ -4,6 +4,7 @@ import com.datadoghq.sketch.ddsketch.encoding.ByteArrayInput;
 import com.datadoghq.sketch.ddsketch.encoding.GrowingByteArrayOutput;
 import com.datadoghq.sketch.ddsketch.encoding.VarEncodingHelper;
 import datadog.trace.api.Config;
+import datadog.trace.api.WellKnownTags;
 import datadog.trace.api.function.Consumer;
 import datadog.trace.api.time.TimeSource;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
@@ -11,6 +12,8 @@ import datadog.trace.bootstrap.instrumentation.api.PathwayContext;
 import datadog.trace.bootstrap.instrumentation.api.StatsPoint;
 import datadog.trace.util.FNV64Hash;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -21,6 +24,7 @@ public class DefaultPathwayContext implements PathwayContext {
   private static final Logger log = LoggerFactory.getLogger(DefaultPathwayContext.class);
   private static final String INITIALIZATION_TOPIC = "";
   private final Lock lock = new ReentrantLock();
+  private final WellKnownTags wellKnownTags;
   private final TimeSource timeSource;
   private final GrowingByteArrayOutput outputBuffer =
       GrowingByteArrayOutput.withInitialCapacity(20);
@@ -34,17 +38,20 @@ public class DefaultPathwayContext implements PathwayContext {
   private long hash;
   private boolean started;
 
-  public DefaultPathwayContext(TimeSource timeSource) {
+  public DefaultPathwayContext(TimeSource timeSource, WellKnownTags wellKnownTags) {
     this.timeSource = timeSource;
+    this.wellKnownTags = wellKnownTags;
   }
 
   private DefaultPathwayContext(
       TimeSource timeSource,
+      WellKnownTags wellKnownTags,
       long pathwayStartNanos,
       long pathwayStartNanoTicks,
       long edgeStartNanoTicks,
       long hash) {
     this.timeSource = timeSource;
+    this.wellKnownTags = wellKnownTags;
     this.pathwayStartNanos = pathwayStartNanos;
     this.pathwayStartNanoTicks = pathwayStartNanoTicks;
     this.edgeStartNanoTicks = edgeStartNanoTicks;
@@ -75,23 +82,22 @@ public class DefaultPathwayContext implements PathwayContext {
         return;
       }
 
-      String finalType;
-      String finalGroup;
-      String finalTopic;
+      List<String> edgeTags = new ArrayList<>();
 
       if (started) {
-        finalType = type;
-        finalGroup = group;
-        finalTopic = topic;
-      } else {
-        // Ignore the edge if there are no parents (ie context hasn't started yet)
-        // Initialize the context instead
-        finalType = null;
-        finalGroup = null;
-        finalTopic = INITIALIZATION_TOPIC;
-      }
+        // Only create edge tags if there's a parent (ie context has started)
+        if (type != null && !type.isEmpty()) {
+          edgeTags.add("type:" + type);
+        }
 
-      if (INITIALIZATION_TOPIC.equals(finalTopic)) {
+        if (topic != null && !topic.isEmpty()) {
+          edgeTags.add("topic:" + topic);
+        }
+
+        if (group != null && !group.isEmpty()) {
+          edgeTags.add("group:" + group);
+        }
+      } else {
         pathwayStartNanos = startNanos;
         pathwayStartNanoTicks = nanoTicks;
         edgeStartNanoTicks = nanoTicks;
@@ -100,16 +106,14 @@ public class DefaultPathwayContext implements PathwayContext {
         log.debug("Started {}", this);
       }
 
-      long newHash = generatePathwayHash(finalTopic, hash);
+      long newHash = generatePathwayHash(edgeTags, hash);
 
       long pathwayLatencyNano = nanoTicks - pathwayStartNanoTicks;
       long edgeLatencyNano = nanoTicks - edgeStartNanoTicks;
 
       StatsPoint point =
           new StatsPoint(
-              finalType,
-              finalGroup,
-              finalTopic,
+              edgeTags,
               newHash,
               hash,
               timeSource.getCurrentTimeNanos(),
@@ -187,17 +191,19 @@ public class DefaultPathwayContext implements PathwayContext {
 
   private static class PathwayContextExtractor implements AgentPropagation.BinaryKeyClassifier {
     private final TimeSource timeSource;
+    private final WellKnownTags wellKnownTags;
     private DefaultPathwayContext extractedContext;
 
-    PathwayContextExtractor(TimeSource timeSource) {
+    PathwayContextExtractor(TimeSource timeSource, WellKnownTags wellKnownTags) {
       this.timeSource = timeSource;
+      this.wellKnownTags = wellKnownTags;
     }
 
     @Override
     public boolean accept(String key, byte[] value) {
       if (PathwayContext.PROPAGATION_KEY.equalsIgnoreCase(key)) {
         try {
-          extractedContext = decode(timeSource, value);
+          extractedContext = decode(timeSource, wellKnownTags, value);
         } catch (IOException e) {
           return false;
         }
@@ -207,8 +213,12 @@ public class DefaultPathwayContext implements PathwayContext {
   }
 
   public static <C> DefaultPathwayContext extract(
-      C carrier, AgentPropagation.BinaryContextVisitor<C> getter, TimeSource timeSource) {
-    PathwayContextExtractor pathwayContextExtractor = new PathwayContextExtractor(timeSource);
+      C carrier,
+      AgentPropagation.BinaryContextVisitor<C> getter,
+      TimeSource timeSource,
+      WellKnownTags wellKnownTags) {
+    PathwayContextExtractor pathwayContextExtractor =
+        new PathwayContextExtractor(timeSource, wellKnownTags);
     getter.forEachKey(carrier, pathwayContextExtractor);
 
     if (pathwayContextExtractor.extractedContext == null) {
@@ -220,8 +230,8 @@ public class DefaultPathwayContext implements PathwayContext {
     return pathwayContextExtractor.extractedContext;
   }
 
-  public static DefaultPathwayContext decode(TimeSource timeSource, byte[] data)
-      throws IOException {
+  public static DefaultPathwayContext decode(
+      TimeSource timeSource, WellKnownTags wellKnownTags, byte[] data) throws IOException {
     ByteArrayInput input = ByteArrayInput.wrap(data);
 
     long hash = input.readLongLE();
@@ -240,15 +250,33 @@ public class DefaultPathwayContext implements PathwayContext {
         pathwayStartNanoTicks + TimeUnit.MILLISECONDS.toNanos(edgeStartMillis - pathwayStartMillis);
 
     return new DefaultPathwayContext(
-        timeSource, pathwayStartNanos, pathwayStartNanoTicks, edgeStartNanoTicks, hash);
+        timeSource,
+        wellKnownTags,
+        pathwayStartNanos,
+        pathwayStartNanoTicks,
+        edgeStartNanoTicks,
+        hash);
   }
 
-  private static long generateNodeHash(String serviceName, String edge) {
-    return FNV64Hash.generateHash(serviceName + edge, FNV64Hash.Version.v1);
+  private long generateNodeHash(List<String> edgeTags) {
+    StringBuilder builder = new StringBuilder();
+    builder.append(wellKnownTags.getService());
+    builder.append(wellKnownTags.getEnv());
+
+    String primaryTag = Config.get().getPrimaryTag();
+    if (primaryTag != null) {
+      builder.append(primaryTag);
+    }
+
+    for (String tag : edgeTags) {
+      builder.append(tag);
+    }
+
+    return FNV64Hash.generateHash(builder.toString(), FNV64Hash.Version.v1);
   }
 
-  private long generatePathwayHash(String edgeName, long parentHash) {
-    long nodeHash = generateNodeHash(Config.get().getServiceName(), edgeName);
+  private long generatePathwayHash(List<String> edgeTags, long parentHash) {
+    long nodeHash = generateNodeHash(edgeTags);
 
     lock.lock();
     try {

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/MsgPackDatastreamsPayloadWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/MsgPackDatastreamsPayloadWriter.java
@@ -6,12 +6,15 @@ import datadog.communication.serialization.GrowableBuffer;
 import datadog.communication.serialization.Writable;
 import datadog.communication.serialization.WritableFormatter;
 import datadog.communication.serialization.msgpack.MsgPackWriter;
-import datadog.trace.api.Config;
+import datadog.trace.api.WellKnownTags;
 import datadog.trace.common.metrics.Sink;
 import java.util.Collection;
 
 public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter {
   private static final byte[] ENV = "Env".getBytes(ISO_8859_1);
+  private static final byte[] PRIMARY_TAG = "PrimaryTag".getBytes(ISO_8859_1);
+  private static final byte[] LANG = "Lang".getBytes(ISO_8859_1);
+  private static final byte[] TRACER_VERSION = "TracerVersion".getBytes(ISO_8859_1);
   private static final byte[] STATS = "Stats".getBytes(ISO_8859_1);
   private static final byte[] START = "Start".getBytes(ISO_8859_1);
   private static final byte[] DURATION = "Duration".getBytes(ISO_8859_1);
@@ -27,13 +30,18 @@ public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter
   private final WritableFormatter writer;
   private final Sink sink;
   private final GrowableBuffer buffer;
-  private final byte[] envValue;
+  private final WellKnownTags wellKnownTags;
+  private final byte[] tracerVersionValue;
+  private final byte[] primaryTagValue;
 
-  public MsgPackDatastreamsPayloadWriter(Sink sink, String env) {
+  public MsgPackDatastreamsPayloadWriter(
+      Sink sink, WellKnownTags wellKnownTags, String tracerVersion, String primaryTag) {
     buffer = new GrowableBuffer(INITIAL_CAPACITY);
     writer = new MsgPackWriter(buffer);
     this.sink = sink;
-    this.envValue = env.getBytes(ISO_8859_1);
+    this.wellKnownTags = wellKnownTags;
+    tracerVersionValue = tracerVersion.getBytes(ISO_8859_1);
+    primaryTagValue = primaryTag == null ? new byte[0] : primaryTag.getBytes(ISO_8859_1);
   }
 
   public void reset() {
@@ -42,16 +50,28 @@ public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter
 
   @Override
   public void writePayload(Collection<StatsBucket> data) {
-    writer.startMap(3);
+    writer.startMap(6);
     /* 1 */
     writer.writeUTF8(ENV);
-    writer.writeUTF8(envValue);
+    writer.writeUTF8(wellKnownTags.getEnv());
 
     /* 2 */
     writer.writeUTF8(SERVICE);
-    writer.writeString(Config.get().getServiceName(), null);
+    writer.writeUTF8(wellKnownTags.getService());
 
     /* 3 */
+    writer.writeUTF8(LANG);
+    writer.writeUTF8(wellKnownTags.getLanguage());
+
+    /* 4 */
+    writer.writeUTF8(PRIMARY_TAG);
+    writer.writeUTF8(primaryTagValue);
+
+    /* 5 */
+    writer.writeUTF8(TRACER_VERSION);
+    writer.writeUTF8(tracerVersionValue);
+
+    /* 6 */
     writer.writeUTF8(STATS);
     writer.startArray(data.size());
     for (StatsBucket bucket : data) {
@@ -79,7 +99,7 @@ public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter
     Collection<StatsGroup> groups = bucket.getGroups();
     packer.startArray(groups.size());
     for (StatsGroup group : groups) {
-      boolean firstNode = "".equals(group.getTopic());
+      boolean firstNode = group.getEdgeTags().isEmpty();
 
       packer.startMap(firstNode ? 4 : 5);
 
@@ -102,15 +122,9 @@ public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter
       if (!firstNode) {
         /* 5 */
         packer.writeUTF8(EDGE_TAGS);
-        if (group.getGroup() == null) {
-          packer.startArray(2);
-          packer.writeString("topic:" + group.getTopic(), null);
-          packer.writeString("type:" + group.getType(), null);
-        } else {
-          packer.startArray(3);
-          packer.writeString("topic:" + group.getTopic(), null);
-          packer.writeString("group:" + group.getGroup(), null);
-          packer.writeString("type:" + group.getType(), null);
+        packer.startArray(group.getEdgeTags().size());
+        for (String tag : group.getEdgeTags()) {
+          packer.writeString(tag, null);
         }
       }
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/StatsBucket.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/StatsBucket.java
@@ -22,11 +22,7 @@ public class StatsBucket {
     if (statsGroup == null) {
       statsGroup =
           new StatsGroup(
-              statsPoint.getType(),
-              statsPoint.getGroup(),
-              statsPoint.getTopic(),
-              statsPoint.getHash(),
-              statsPoint.getParentHash());
+              statsPoint.getEdgeTags(), statsPoint.getHash(), statsPoint.getParentHash());
       hashToGroup.put(statsPoint.getHash(), statsGroup);
     }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/StatsGroup.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/StatsGroup.java
@@ -3,23 +3,20 @@ package datadog.trace.core.datastreams;
 import datadog.trace.core.histogram.Histogram;
 import datadog.trace.core.histogram.HistogramFactory;
 import datadog.trace.core.histogram.Histograms;
+import java.util.List;
 
 public class StatsGroup {
   private static final double NANOSECONDS_TO_SECOND = 1_000_000_000d;
   private static final HistogramFactory HISTOGRAM_FACTORY = Histograms.newHistogramFactory();
 
-  private final String type;
-  private final String group;
-  private final String topic;
+  private final List<String> edgeTags;
   private final long hash;
   private final long parentHash;
   private final Histogram pathwayLatency;
   private final Histogram edgeLatency;
 
-  public StatsGroup(String type, String group, String topic, long hash, long parentHash) {
-    this.type = type;
-    this.group = group;
-    this.topic = topic;
+  public StatsGroup(List<String> edgeTags, long hash, long parentHash) {
+    this.edgeTags = edgeTags;
     this.hash = hash;
     this.parentHash = parentHash;
     pathwayLatency = HISTOGRAM_FACTORY.newHistogram();
@@ -31,16 +28,8 @@ public class StatsGroup {
     edgeLatency.accept(((double) edgeLatencyNano) / NANOSECONDS_TO_SECOND);
   }
 
-  public String getType() {
-    return type;
-  }
-
-  public String getGroup() {
-    return group;
-  }
-
-  public String getTopic() {
-    return topic;
+  public List<String> getEdgeTags() {
+    return edgeTags;
   }
 
   public long getHash() {
@@ -62,14 +51,8 @@ public class StatsGroup {
   @Override
   public String toString() {
     return "StatsGroup{"
-        + "type='"
-        + type
-        + '\''
-        + ", group='"
-        + group
-        + '\''
-        + ", topic='"
-        + topic
+        + "edgeTags='"
+        + edgeTags
         + '\''
         + ", hash="
         + hash

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -92,6 +92,7 @@ import static datadog.trace.api.config.GeneralConfig.HEALTH_METRICS_STATSD_HOST;
 import static datadog.trace.api.config.GeneralConfig.HEALTH_METRICS_STATSD_PORT;
 import static datadog.trace.api.config.GeneralConfig.INTERNAL_EXIT_ON_FAILURE;
 import static datadog.trace.api.config.GeneralConfig.PERF_METRICS_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.PRIMARY_TAG;
 import static datadog.trace.api.config.GeneralConfig.RUNTIME_ID_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.RUNTIME_METRICS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.SERVICE_NAME;
@@ -508,6 +509,7 @@ public class Config {
 
   private String env;
   private String version;
+  private final String primaryTag;
 
   private final ConfigProvider configProvider;
 
@@ -658,6 +660,8 @@ public class Config {
 
     spanTags = configProvider.getMergedMap(SPAN_TAGS);
     jmxTags = configProvider.getMergedMap(JMX_TAGS);
+
+    primaryTag = configProvider.getString(PRIMARY_TAG);
 
     excludedClasses = tryMakeImmutableList(configProvider.getList(TRACE_CLASSES_EXCLUDE));
     excludedClassLoaders = tryMakeImmutableSet(configProvider.getList(TRACE_CLASSLOADERS_EXCLUDE));
@@ -1692,6 +1696,10 @@ public class Config {
         serviceName,
         getVersion(),
         LANGUAGE_TAG_VALUE);
+  }
+
+  public String getPrimaryTag() {
+    return primaryTag;
   }
 
   public Set<String> getMetricsIgnoredResources() {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/StatsPoint.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/StatsPoint.java
@@ -1,9 +1,9 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
+import java.util.List;
+
 public class StatsPoint {
-  private final String type;
-  private final String group;
-  private final String topic;
+  private final List<String> edgeTags;
   private final long hash;
   private final long parentHash;
   private final long timestampNanos;
@@ -11,17 +11,13 @@ public class StatsPoint {
   private final long edgeLatencyNano;
 
   public StatsPoint(
-      String type,
-      String group,
-      String topic,
+      List<String> edgeTags,
       long hash,
       long parentHash,
       long timestampNanos,
       long pathwayLatencyNano,
       long edgeLatencyNano) {
-    this.type = type;
-    this.group = group;
-    this.topic = topic;
+    this.edgeTags = edgeTags;
     this.hash = hash;
     this.parentHash = parentHash;
     this.timestampNanos = timestampNanos;
@@ -29,16 +25,8 @@ public class StatsPoint {
     this.edgeLatencyNano = edgeLatencyNano;
   }
 
-  public String getType() {
-    return type;
-  }
-
-  public String getGroup() {
-    return group;
-  }
-
-  public String getTopic() {
-    return topic;
+  public List<String> getEdgeTags() {
+    return edgeTags;
   }
 
   public long getHash() {
@@ -64,14 +52,8 @@ public class StatsPoint {
   @Override
   public String toString() {
     return "StatsPoint{"
-        + "type='"
-        + type
-        + '\''
-        + ", group='"
-        + group
-        + '\''
-        + ", topic='"
-        + topic
+        + "tags='"
+        + edgeTags
         + '\''
         + ", hash="
         + hash


### PR DESCRIPTION
# What Does This Do

* Adds primary tag, language, and tracer version to payload sent to agent
* Incorporates tags and env into calculation of pathway hash
* Small refactoring of edge tags into a `List`

# Motivation
* Primary tag (also known as the "host group" tag) is used to segment services.
* Incorporating tags and env into hash allows visualizations across envs and datacenters.
* Sending language and tracer version will help with server-side debugging
