### PR TITLE
[AppSec] Play/Akka double instrumentation

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -84,7 +84,9 @@ public class AppSecRequestContext implements DataBundle, Closeable {
         continue;
       }
       Object prev = persistentData.putIfAbsent(address, value);
-      if (prev != null) {
+      if (prev == value) {
+        continue;
+      } else if (prev != null) {
         log.warn("Illegal attempt to replace context value for {}", address);
       }
       if (log.isDebugEnabled()) {
@@ -167,8 +169,9 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   }
 
   void setRawURI(String savedRawURI) {
-    if (this.savedRawURI != null) {
-      throw new IllegalStateException("Raw URI set already");
+    if (this.savedRawURI != null && this.savedRawURI.compareToIgnoreCase(savedRawURI) != 0) {
+      throw new IllegalStateException(
+          "Forbidden attempt to set different raw URI for given request context");
     }
     this.savedRawURI = savedRawURI;
   }


### PR DESCRIPTION
# What Does This Do
When setting the same data in the context of the request, the same data will be ignored for further analysis using AppSec WAF.

# Motivation
Issue reported by customer: #3484 

# Additional Notes
Different instrumentations (Play and Akka) populate same data to distinct spans, but all of them consolidates in same AppSecRequestContext, which cause forbidden data replacement. As a workaround we ignores replacement if the values are the same.