### PR TITLE
Upgrade jnr-posix dependency to avoid 'use after free' vulnerability

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-uploader/profiling-uploader.gradle
+++ b/dd-java-agent/agent-profiling/profiling-uploader/profiling-uploader.gradle
@@ -30,7 +30,7 @@ dependencies {
   implementation project(':dd-java-agent:agent-profiling:profiling-controller')
 
   implementation deps.okhttp
-  implementation group: 'com.github.jnr', name: 'jnr-posix', version: '3.0.52'
+  implementation group: 'com.github.jnr', name: 'jnr-posix', version: '3.1.15'
   implementation group: 'org.lz4', name: 'lz4-java', version: '1.7.1'
 
   testImplementation deps.junit5


### PR DESCRIPTION
# What Does This Do
Avoids this security vulnerability found in older versions of the jnr-posix package by upgrading it:
https://security.snyk.io/vuln/SNYK-JAVA-COMGITHUBJNR-1570422

This ‘use after free’ vulnerability was fixed in this diff for version 3.1.8 of jnr-posix:
https://github.com/jnr/jnr-posix/compare/jnr-posix-3.1.7...jnr-posix-3.1.8

# Motivation
Wanting to fix security vulnerabilities in our system which uses the dd-java-agent jar.