### PR TITLE
Force timeout on test tasks before CircleCI inactivity timeout

### DIFF
--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -1,4 +1,5 @@
 import java.time.Duration
+import java.time.temporal.ChronoUnit
 import org.gradle.jvm.toolchain.internal.SpecificInstallationToolchainSpec
 
 apply plugin: 'java-library'
@@ -319,6 +320,9 @@ def getJavaHomePath(String path) {
   return javaHome.endsWith("jre") ? javaHome.parent : javaHome
 }
 
+// Force timeout after 9 minutes (CircleCI defaults will fail after 10 minutes without output)
+def testTimeoutDuration = Duration.of(9, ChronoUnit.MINUTES)
+
 // Go through the Test tasks and configure them
 tasks.withType(Test).configureEach {
   if (project.findProperty("enableJunitPlatform") == true) {
@@ -366,4 +370,6 @@ tasks.withType(Test).configureEach {
   } else {
     exclude("**/*ForkedTest*")
   }
+
+  timeout = testTimeoutDuration
 }


### PR DESCRIPTION
# What Does This Do

Sets a hard timeout for test task to 9 minutes, so they will fail before the default CircleCI 10 minute inactivity timeout triggers.

# Motivation

Having gradle fail the test instead of CircleCI will hopefully give us more information about what was failing.

# Additional Notes
