### PR TITLE
 Slow down ProcessSupervisorTest a bit for code coverage

### DIFF
--- a/internal-api/src/main/java/datadog/trace/util/ProcessSupervisor.java
+++ b/internal-api/src/main/java/datadog/trace/util/ProcessSupervisor.java
@@ -44,7 +44,7 @@ public class ProcessSupervisor implements Closeable {
                 continue;
               }
 
-              log.debug("Starting process: {}", name);
+              log.debug("Starting process: [{}]", name);
               nextRestartTime = System.currentTimeMillis() + MIN_RESTART_INTERVAL_MS;
               currentProcess = processBuilder.start();
             }
@@ -57,7 +57,7 @@ public class ProcessSupervisor implements Closeable {
             currentProcess = null;
           } catch (InterruptedException ignored) {
           } catch (IOException e) {
-            log.error("Exception starting process: {}", name, e);
+            log.error("Exception starting process: [{}]", name, e);
           }
         }
       } finally {

--- a/internal-api/src/test/groovy/datadog/trace/util/ProcessSupervisorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/util/ProcessSupervisorTest.groovy
@@ -28,6 +28,12 @@ class ProcessSupervisorTest extends DDSpecification {
     }
 
     when:
+    // code coverage: give the supervisor thread a reasonable chance to start waiting for the exit code
+    Thread.sleep(1000)
+    // code coverage: make sure that the supervisor thread loops around once
+    processSupervisor.supervisorThread.interrupt()
+    // code coverage: give the supervisor thread a reasonable chance to start waiting for the exit code
+    Thread.sleep(1000)
     def oldProcess = processSupervisor.currentProcess
     processSupervisor.close()
 
@@ -53,18 +59,29 @@ class ProcessSupervisorTest extends DDSpecification {
     }
 
     when:
+    // code coverage: give the supervisor thread a reasonable chance to start waiting for the exit code
+    Thread.sleep(1000)
     def oldProcess = processSupervisor.currentProcess
     oldProcess.destroyForcibly()
 
     then:
     conditions.eventually {
       !oldProcess.isAlive()
-      processSupervisor.currentProcess != null
       processSupervisor.currentProcess != oldProcess
+      processSupervisor.currentProcess != null
       processSupervisor.currentProcess.isAlive()
     }
 
-    cleanup:
+    when:
+    // code coverage: give the supervisor thread a reasonable chance to start waiting for the exit code
+    Thread.sleep(1000)
+    oldProcess = processSupervisor.currentProcess
     processSupervisor.close()
+
+    then:
+    conditions.eventually {
+      !oldProcess.isAlive()
+      processSupervisor.currentProcess == null || !processSupervisor.currentProcess.isAlive()
+    }
   }
 }


### PR DESCRIPTION
# What Does This Do

Slow down `ProcessSupervisorTest` a bit for more reliable code coverage.

# Motivation

The `ProcessSupervisorTest` sometimes fails the code coverage checks, since the test code manages to close `ProcessSuperVisor` before the code under test has run all the relevant code paths.

# Additional Notes
