### PR TITLE
[Serverless] add cleanup in tests

### DIFF
--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/LambdaContextTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/LambdaContextTest.groovy
@@ -1,8 +1,8 @@
 package datadog.trace.core.propagation
 
-import spock.lang.Specification
+import datadog.trace.test.util.DDSpecification
 
-class LambdaContextTest extends Specification {
+class LambdaContextTest extends DDSpecification {
 
   def "test constructor"(){
     when:

--- a/dd-trace-core/src/test/groovy/datadog/trace/lambda/LambdaHandlerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/lambda/LambdaHandlerTest.groovy
@@ -39,6 +39,9 @@ class LambdaHandlerTest extends DDCoreSpecification {
     objTest.getTraceId().toString() == traceId
     objTest.getSpanId().toString() == spanId
 
+    cleanup:
+    server.close()
+
     where:
     traceId    | spanId      | obj
     "1234"     | "5678"      | new TestObject()
@@ -62,6 +65,9 @@ class LambdaHandlerTest extends DDCoreSpecification {
 
     then:
     objTest == expected
+
+    cleanup:
+    server.close()
 
     where:
     expected    | obj
@@ -88,6 +94,9 @@ class LambdaHandlerTest extends DDCoreSpecification {
     then:
     result == expected
 
+    cleanup:
+    server.close()
+
     where:
     expected  | headerValue     | boolValue
     true      | "true"          | true
@@ -113,6 +122,9 @@ class LambdaHandlerTest extends DDCoreSpecification {
     then:
     result == expected
     server.lastRequest.headers.get("x-datadog-invocation-error") == headerValue
+
+    cleanup:
+    server.close()
 
     where:
     expected  | headerValue     | boolValue


### PR DESCRIPTION
# What Does This Do

Add the cleanup step to close the test server in `dd-trace-core/src/test/groovy/datadog/trace/lambda/LambdaHandlerTest.groovy`
