### PR TITLE
Remove okhttp dependency from dd-trace-ot

### DIFF
--- a/dd-trace-ot/dd-trace-ot.gradle
+++ b/dd-trace-ot/dd-trace-ot.gradle
@@ -42,8 +42,6 @@ dependencies {
   api group: 'io.opentracing.contrib', name: 'opentracing-tracerresolver', version: '0.1.0'
 
   api deps.slf4j
-  api group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.12.12'
-  api deps.okio
 
   testImplementation project(":dd-java-agent:testing")
 


### PR DESCRIPTION
# What Does This Do

Remove okhttp and okio dependency from dd-trace-ot

# Motivation

We have a lambda that is currently complaining because the JAR file is too big. We depend on only dd-trace-ot and I can see it is pulling in okhttp and okio, but can't see where it is using them.

(draft PR for now as I am shamelessly using this PR to run the tests as struggling to run all the tests locally)

# Additional Notes
