### PR TITLE
Stop intermittent double Jersey requests

### DIFF
--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientAsyncTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientAsyncTest.groovy
@@ -50,7 +50,13 @@ abstract class JaxRsClientAsyncTest extends HttpClientTest {
       }).get()
 
     latch.await()
-    return response.status
+    def status = response.status
+    // Sometimes tests fail with one extra span, that is a duplicate of the server
+    // span, and there seems to be an issue with intermittent _double_ requests, and
+    // closing the response is a fix according to this:
+    // https://github.com/folkol/intermittent-duplicate-requests-from-jersey-client
+    response.close()
+    return status
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

Stops intermittent double Jersey requests by closing the response.

# Motivation

Tests sometimes fail with one extra span, that is a duplicate of the server span.

# Additional Notes
