### PR TITLE
Ignore generated Weld (CDI) proxy class

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
@@ -61,7 +61,8 @@ public class GlobalIgnoresMatcher<T extends TypeDescription>
           || name.contains("CGLIB$$")
           || name.contains("$__sisu")
           || name.contains("$$EnhancerByGuice$$")
-          || name.contains("$$EnhancerByProxool$$")) {
+          || name.contains("$$EnhancerByProxool$$")
+          || name.contains("$$_WeldClientProxy")) {
         return true;
       }
     }


### PR DESCRIPTION
# What Does This Do

Avoids an extra proxy span appearing between the incoming request and the JAX-RS call when using Weld (CDI)
