### PR TITLE
Use ClassNameTrie for custom excludes

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
@@ -6,15 +6,8 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.utility.JavaModule;
 
 /**
- * Global ignores matcher used by the agent.
- *
- * <p>This matcher services two main purposes:
- *
- * <ul>
- *   <li>Ignore classes that are unsafe or pointless to transform. 'System' level classes like jvm
- *       classes or groovy classes, other tracers, debuggers, etc.
- *   <li>Ignore additional classes to minimize the number of classes we apply expensive matchers to.
- * </ul>
+ * Global ignores matcher which combines the common skipClassLoader check with other global
+ * name-based ignores and custom exclusions.
  */
 public class GlobalIgnoresMatcher implements AgentBuilder.RawMatcher {
 
@@ -41,7 +34,7 @@ public class GlobalIgnoresMatcher implements AgentBuilder.RawMatcher {
     String name = typeDescription.getActualName();
     return GlobalIgnores.isIgnored(name, skipAdditionalLibraryMatcher)
         || CustomExcludes.isExcluded(name)
-        || ProxyIgnores.isIgnored(name);
+        || ProxyClassIgnores.isIgnored(name);
   }
 
   @Override

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
@@ -1,7 +1,9 @@
 package datadog.trace.agent.tooling.bytebuddy.matcher;
 
+import java.security.ProtectionDomain;
+import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.utility.JavaModule;
 
 /**
  * Global ignores matcher used by the agent.
@@ -14,12 +16,10 @@ import net.bytebuddy.matcher.ElementMatcher;
  *   <li>Ignore additional classes to minimize the number of classes we apply expensive matchers to.
  * </ul>
  */
-public class GlobalIgnoresMatcher<T extends TypeDescription>
-    extends ElementMatcher.Junction.ForNonNullValues<T> {
+public class GlobalIgnoresMatcher implements AgentBuilder.RawMatcher {
 
-  public static <T extends TypeDescription> GlobalIgnoresMatcher<T> globalIgnoresMatcher(
-      final boolean skipAdditionalLibraryMatcher) {
-    return new GlobalIgnoresMatcher<>(skipAdditionalLibraryMatcher);
+  public static GlobalIgnoresMatcher globalIgnoresMatcher(boolean skipAdditionalLibraryMatcher) {
+    return new GlobalIgnoresMatcher(skipAdditionalLibraryMatcher);
   }
 
   private final boolean skipAdditionalLibraryMatcher;
@@ -28,53 +28,20 @@ public class GlobalIgnoresMatcher<T extends TypeDescription>
     this.skipAdditionalLibraryMatcher = skipAdditionalLibraryMatcher;
   }
 
-  /**
-   * Be very careful about the types of matchers used in this section as they are called on every
-   * class load, so they must be fast. Generally speaking try to only use name matchers as they
-   * don't have to load additional info.
-   *
-   * @see DDRediscoveryStrategy#shouldRetransformBootstrapClass(String)
-   */
   @Override
-  protected boolean doMatch(final T target) {
-    return isIgnored(target.getActualName(), skipAdditionalLibraryMatcher);
-  }
-
-  private static boolean isIgnored(String name, boolean skipAdditionalIgnores) {
-    switch (IgnoredClassNameTrie.apply(name)) {
-      case 0:
-        return false; // global allow
-      case 1:
-        return true; // system-level ignore
-      case 2:
-        return !skipAdditionalIgnores;
-      case 3:
-        return name.endsWith("Proxy");
-      case 4:
-        return !name.endsWith("HttpMessageConverter");
-      default:
-        break;
-    }
-
-    if (name.indexOf('$') > -1) {
-      if (name.contains("$JaxbAccessor")
-          || name.contains("CGLIB$$")
-          || name.contains("$__sisu")
-          || name.contains("$$EnhancerByGuice$$")
-          || name.contains("$$EnhancerByProxool$$")
-          || name.contains("$$_WeldClientProxy")) {
-        return true;
-      }
-    }
-    if (name.contains("javassist") || name.contains(".asm.")) {
+  public boolean matches(
+      TypeDescription typeDescription,
+      ClassLoader classLoader,
+      JavaModule module,
+      Class<?> classBeingRedefined,
+      ProtectionDomain protectionDomain) {
+    if (ClassLoaderMatchers.skipClassLoader(classLoader)) {
       return true;
     }
-
-    return false;
-  }
-
-  public static boolean isAdditionallyIgnored(String name) {
-    return !isIgnored(name, true) && isIgnored(name, false);
+    String name = typeDescription.getActualName();
+    return GlobalIgnores.isIgnored(name, skipAdditionalLibraryMatcher)
+        || CustomExcludes.isExcluded(name)
+        || ProxyIgnores.isIgnored(name);
   }
 
   @Override

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/CustomExcludes.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/CustomExcludes.java
@@ -2,8 +2,13 @@ package datadog.trace.agent.tooling.bytebuddy.matcher;
 
 import datadog.trace.api.Config;
 import datadog.trace.util.ClassNameTrie;
+import java.nio.file.Paths;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CustomExcludes {
+  private static final Logger log = LoggerFactory.getLogger(CustomExcludes.class);
+
   private CustomExcludes() {}
 
   private static final ClassNameTrie excludes;
@@ -12,6 +17,14 @@ public class CustomExcludes {
     ClassNameTrie.Builder builder = new ClassNameTrie.Builder();
     for (String name : Config.get().getExcludedClasses()) {
       builder.put(name, 1);
+    }
+    String excludedClassesFile = Config.get().getExcludedClassesFile();
+    if (null != excludedClassesFile) {
+      try {
+        builder.readClassNameMapping(Paths.get(excludedClassesFile));
+      } catch (Exception e) {
+        log.warn("Problem reading class excludes from {}", excludedClassesFile, e);
+      }
     }
     excludes = !builder.isEmpty() ? builder.buildTrie() : null;
   }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/CustomExcludes.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/CustomExcludes.java
@@ -6,6 +6,7 @@ import java.nio.file.Paths;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** Custom class/package excludes configured by the user. */
 public class CustomExcludes {
   private static final Logger log = LoggerFactory.getLogger(CustomExcludes.class);
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/CustomExcludes.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/CustomExcludes.java
@@ -1,0 +1,22 @@
+package datadog.trace.agent.tooling.bytebuddy.matcher;
+
+import datadog.trace.api.Config;
+import datadog.trace.util.ClassNameTrie;
+
+public class CustomExcludes {
+  private CustomExcludes() {}
+
+  private static final ClassNameTrie excludes;
+
+  static {
+    ClassNameTrie.Builder builder = new ClassNameTrie.Builder();
+    for (String name : Config.get().getExcludedClasses()) {
+      builder.put(name, 1);
+    }
+    excludes = !builder.isEmpty() ? builder.buildTrie() : null;
+  }
+
+  public static boolean isExcluded(String name) {
+    return excludes != null && excludes.apply(name) > 0;
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnores.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnores.java
@@ -1,0 +1,28 @@
+package datadog.trace.agent.tooling.bytebuddy.matcher;
+
+public class GlobalIgnores {
+  private GlobalIgnores() {}
+
+  public static boolean isIgnored(String name, boolean skipAdditionalIgnores) {
+    // ignored classes/packages are now maintained in the 'ignored_class_name.trie' resource
+    switch (IgnoredClassNameTrie.apply(name)) {
+      case 0:
+        return false; // global allow
+      case 1:
+        return true; // system-level ignore
+      case 2:
+        return !skipAdditionalIgnores;
+      case 3:
+        return name.endsWith("Proxy");
+      case 4:
+        return !name.endsWith("HttpMessageConverter");
+      default:
+        break;
+    }
+    return false;
+  }
+
+  public static boolean isAdditionallyIgnored(String name) {
+    return !isIgnored(name, true) && isIgnored(name, false);
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnores.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnores.java
@@ -1,5 +1,16 @@
 package datadog.trace.agent.tooling.bytebuddy.matcher;
 
+/**
+ * Global ignores used by the agent.
+ *
+ * <p>There are two levels of ignores:
+ *
+ * <ul>
+ *   <li>Ignore classes that are unsafe or pointless to transform. 'System' level classes like jvm
+ *       classes or groovy classes, other tracers, debuggers, etc.
+ *   <li>Ignore additional classes to minimize the number of classes we apply expensive matchers to.
+ * </ul>
+ */
 public class GlobalIgnores {
   private GlobalIgnores() {}
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ProxyClassIgnores.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ProxyClassIgnores.java
@@ -1,7 +1,8 @@
 package datadog.trace.agent.tooling.bytebuddy.matcher;
 
-public class ProxyIgnores {
-  private ProxyIgnores() {}
+/** Ignores various generated proxies based on well-known markers in their class names. */
+public class ProxyClassIgnores {
+  private ProxyClassIgnores() {}
 
   public static boolean isIgnored(String name) {
     if (name.indexOf('$') > -1) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ProxyIgnores.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ProxyIgnores.java
@@ -1,0 +1,19 @@
+package datadog.trace.agent.tooling.bytebuddy.matcher;
+
+public class ProxyIgnores {
+  private ProxyIgnores() {}
+
+  public static boolean isIgnored(String name) {
+    if (name.indexOf('$') > -1) {
+      if (name.contains("$JaxbAccessor")
+          || name.contains("CGLIB$$")
+          || name.contains("$__sisu")
+          || name.contains("$$EnhancerByGuice$$")
+          || name.contains("$$EnhancerByProxool$$")
+          || name.contains("$$_WeldClientProxy")) {
+        return true;
+      }
+    }
+    return name.contains("javassist") || name.contains(".asm.");
+  }
+}

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ClassLoaderMatchersTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ClassLoaderMatchersTest.groovy
@@ -1,6 +1,5 @@
 package datadog.trace.agent.test
 
-
 import datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers
 import datadog.trace.agent.tooling.log.LogContextScopeListener
 import datadog.trace.bootstrap.DatadogClassLoader
@@ -13,7 +12,7 @@ class ClassLoaderMatchersTest extends DDSpecification {
     setup:
     final URLClassLoader badLoader = new NonDelegatingClassLoader()
     expect:
-    ClassLoaderMatchers.skipClassLoader().matches(badLoader)
+    ClassLoaderMatchers.skipClassLoader(badLoader)
   }
 
   def "skips agent classloader"() {
@@ -21,19 +20,19 @@ class ClassLoaderMatchersTest extends DDSpecification {
     URL root = new URL("file://")
     final URLClassLoader agentLoader = new DatadogClassLoader(root, null, new DatadogClassLoader.BootstrapClassLoaderProxy(), null)
     expect:
-    ClassLoaderMatchers.skipClassLoader().matches(agentLoader)
+    ClassLoaderMatchers.skipClassLoader(agentLoader)
   }
 
   def "does not skip empty classloader"() {
     setup:
     final ClassLoader emptyLoader = new ClassLoader() {}
     expect:
-    !ClassLoaderMatchers.skipClassLoader().matches(emptyLoader)
+    !ClassLoaderMatchers.skipClassLoader(emptyLoader)
   }
 
   def "does not skip bootstrap classloader"() {
     expect:
-    !ClassLoaderMatchers.skipClassLoader().matches(null)
+    !ClassLoaderMatchers.skipClassLoader(null)
   }
 
   def "DatadogClassLoader class name is hardcoded in ClassLoaderMatcher"() {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -9,6 +9,7 @@ import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.agent.test.checkpoints.TimelineCheckpointer
 import datadog.trace.agent.test.datastreams.MockFeaturesDiscovery
 import datadog.trace.agent.test.datastreams.RecordingDatastreamsPayloadWriter
+import datadog.trace.agent.tooling.bytebuddy.matcher.GlobalIgnores
 import datadog.trace.agent.tooling.AgentInstaller
 import datadog.trace.agent.tooling.Instrumenter
 import datadog.trace.agent.tooling.TracerInstaller
@@ -56,7 +57,6 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
 
-import static datadog.trace.agent.tooling.bytebuddy.matcher.GlobalIgnoresMatcher.isAdditionallyIgnored
 import static datadog.trace.api.IdGenerationStrategy.SEQUENTIAL
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.closePrevious
 import static net.bytebuddy.matcher.ElementMatchers.named
@@ -286,7 +286,9 @@ abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.L
     // All cleanup should happen before these assertion.  If not, a failing assertion may prevent cleanup
     assert INSTRUMENTATION_ERROR_COUNT.get() == 0: INSTRUMENTATION_ERROR_COUNT.get() + " Instrumentation errors during test"
 
-    assert TRANSFORMED_CLASSES_TYPES.findAll { isAdditionallyIgnored(it.getActualName()) }.isEmpty(): "Transformed classes match global libraries ignore matcher"
+    assert TRANSFORMED_CLASSES_TYPES.findAll {
+      GlobalIgnores.isAdditionallyIgnored(it.getActualName())
+    }.isEmpty(): "Transformed classes match global libraries ignore matcher"
   }
 
   boolean useStrictTraceWrites() {

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -17,6 +17,7 @@ public final class TraceInstrumentationConfig {
   public static final String TRACE_EXECUTORS = "trace.executors";
   public static final String TRACE_METHODS = "trace.methods";
   public static final String TRACE_CLASSES_EXCLUDE = "trace.classes.exclude";
+  public static final String TRACE_CLASSES_EXCLUDE_FILE = "trace.classes.exclude.file";
   public static final String TRACE_CLASSLOADERS_EXCLUDE = "trace.classloaders.exclude";
   public static final String TRACE_TESTS_ENABLED = "trace.tests.enabled";
 

--- a/gradle/tries.gradle
+++ b/gradle/tries.gradle
@@ -19,7 +19,7 @@ def configureClassNameTrieTask(exec, sourceSetName) {
   exec.description = "Generate $sourceSetName ClassNameTries from .trie files"
   exec.inputs.files(trieFiles)
   exec.outputs.files(javaFiles)
-  exec.mainClass = 'datadog.trace.util.ClassNameTrie$Generator'
+  exec.mainClass = 'datadog.trace.util.ClassNameTrie$JavaGenerator'
   exec.classpath = sourceSets."$sourceSetName".compileClasspath
   exec.args = [trieDir, javaDir] + trieFiles
 }

--- a/internal-api/internal-api.gradle
+++ b/internal-api/internal-api.gradle
@@ -56,7 +56,7 @@ excludedClassesCoverage += [
   "datadog.trace.util.AgentThreadFactory",
   "datadog.trace.util.AgentThreadFactory.1",
   "datadog.trace.util.ClassNameTrie.Builder",
-  "datadog.trace.util.ClassNameTrie.Generator",
+  "datadog.trace.util.ClassNameTrie.JavaGenerator",
   "datadog.trace.util.CollectionUtils",
 ]
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -196,6 +196,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ROOT_C
 import static datadog.trace.api.config.TraceInstrumentationConfig.TEMP_JARS_CLEAN_ON_BOOT;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ANNOTATIONS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE_FILE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSLOADERS_EXCLUDE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_EXECUTORS;
@@ -337,6 +338,7 @@ public class Config {
   private final Map<String, String> spanTags;
   private final Map<String, String> jmxTags;
   private final List<String> excludedClasses;
+  private final String excludedClassesFile;
   private final Set<String> excludedClassLoaders;
   private final Map<String, String> requestHeaderTags;
   private final Map<String, String> responseHeaderTags;
@@ -667,6 +669,7 @@ public class Config {
     primaryTag = configProvider.getString(PRIMARY_TAG);
 
     excludedClasses = tryMakeImmutableList(configProvider.getList(TRACE_CLASSES_EXCLUDE));
+    excludedClassesFile = configProvider.getString(TRACE_CLASSES_EXCLUDE_FILE);
     excludedClassLoaders = tryMakeImmutableSet(configProvider.getList(TRACE_CLASSLOADERS_EXCLUDE));
 
     if (isEnabled(false, HEADER_TAGS, ".legacy.parsing.enabled")) {
@@ -1146,6 +1149,10 @@ public class Config {
 
   public List<String> getExcludedClasses() {
     return excludedClasses;
+  }
+
+  public String getExcludedClassesFile() {
+    return excludedClassesFile;
   }
 
   public Set<String> getExcludedClassLoaders() {
@@ -2286,6 +2293,8 @@ public class Config {
         + jmxTags
         + ", excludedClasses="
         + excludedClasses
+        + ", excludedClassesFile="
+        + excludedClassesFile
         + ", excludedClassLoaders="
         + excludedClassLoaders
         + ", requestHeaderTags="

--- a/internal-api/src/main/java/datadog/trace/util/ClassNameTrie.java
+++ b/internal-api/src/main/java/datadog/trace/util/ClassNameTrie.java
@@ -215,6 +215,7 @@ public final class ClassNameTrie {
 
   /** Builds an in-memory trie that represents a mapping of {class-name} to {number}. */
   public static class Builder {
+    private static final Pattern MAPPING_LINE = Pattern.compile("^\\s*([0-9]+)\\s+([^\\s#]+)");
 
     private final List<String> keys = new ArrayList<>();
     private final StringBuilder values = new StringBuilder();
@@ -245,6 +246,16 @@ public final class ClassNameTrie {
         keys.add(index, key);
         values.insert(index, value);
       } // else ignore class names that already exist in the trie
+    }
+
+    /** Reads a class-name mapping file into the current builder */
+    public void readClassNameMapping(Path triePath) throws IOException {
+      for (String l : Files.readAllLines(triePath, StandardCharsets.UTF_8)) {
+        Matcher m = MAPPING_LINE.matcher(l);
+        if (m.find()) {
+          put(m.group(2), Integer.parseInt(m.group(1)));
+        }
+      }
     }
 
     public ClassNameTrie buildTrie() {
@@ -379,8 +390,6 @@ public final class ClassNameTrie {
 
   /** Generates Java source for a trie described as a series of "{number} {class-name}" lines. */
   public static class JavaGenerator {
-    private static final Pattern MAPPING_LINE = Pattern.compile("^\\s*([0-9]+)\\s+([^\\s#]+)");
-
     public static void main(String[] args) throws IOException {
       if (args.length < 2) {
         throw new IllegalArgumentException("Expected: trie-dir java-dir [file.trie ...]");
@@ -423,12 +432,7 @@ public final class ClassNameTrie {
     private static void generateJavaFile(
         Path triePath, Path javaPath, String pkgName, String className) throws IOException {
       ClassNameTrie.Builder builder = new ClassNameTrie.Builder();
-      for (String l : Files.readAllLines(triePath, StandardCharsets.UTF_8)) {
-        Matcher m = MAPPING_LINE.matcher(l);
-        if (m.find()) {
-          builder.put(m.group(2), Integer.parseInt(m.group(1)));
-        }
-      }
+      builder.readClassNameMapping(triePath);
       List<String> lines = new ArrayList<>();
       if (!pkgName.isEmpty()) {
         lines.add("package " + pkgName + ';');

--- a/internal-api/src/main/java/datadog/trace/util/ClassNameTrie.java
+++ b/internal-api/src/main/java/datadog/trace/util/ClassNameTrie.java
@@ -215,7 +215,7 @@ public final class ClassNameTrie {
 
   /** Builds an in-memory trie that represents a mapping of {class-name} to {number}. */
   public static class Builder {
-    private static final Pattern MAPPING_LINE = Pattern.compile("^\\s*([0-9]+)\\s+([^\\s#]+)");
+    private static final Pattern MAPPING_LINE = Pattern.compile("^\\s*(?:([0-9]+)\\s+)?([^\\s#]+)");
 
     private final List<String> keys = new ArrayList<>();
     private final StringBuilder values = new StringBuilder();
@@ -253,7 +253,7 @@ public final class ClassNameTrie {
       for (String l : Files.readAllLines(triePath, StandardCharsets.UTF_8)) {
         Matcher m = MAPPING_LINE.matcher(l);
         if (m.find()) {
-          put(m.group(2), Integer.parseInt(m.group(1)));
+          put(m.group(2), m.group(1) != null ? Integer.parseInt(m.group(1)) : 1);
         }
       }
     }

--- a/internal-api/src/main/java/datadog/trace/util/ClassNameTrie.java
+++ b/internal-api/src/main/java/datadog/trace/util/ClassNameTrie.java
@@ -258,6 +258,10 @@ public final class ClassNameTrie {
       }
     }
 
+    public boolean isEmpty() {
+      return keys.isEmpty();
+    }
+
     public ClassNameTrie buildTrie() {
       buildSubTrie(0, 0, keys.size());
       char[] data = new char[buf.length()];

--- a/internal-api/src/main/java/datadog/trace/util/ClassNameTrie.java
+++ b/internal-api/src/main/java/datadog/trace/util/ClassNameTrie.java
@@ -378,7 +378,7 @@ public final class ClassNameTrie {
   }
 
   /** Generates Java source for a trie described as a series of "{number} {class-name}" lines. */
-  public static class Generator {
+  public static class JavaGenerator {
     private static final Pattern MAPPING_LINE = Pattern.compile("^\\s*([0-9]+)\\s+([^\\s#]+)");
 
     public static void main(String[] args) throws IOException {


### PR DESCRIPTION
# What Does This Do

* Uses `ClassNameTrie` to create a trie-based filter for custom excludes configured with
`-Ddd.trace.classes.exclude`
* Adds support for configuring a list of excluded classes/packages in an external file with
`-Ddd.trace.classes.exclude.file`
* Separates out matching of generated proxy names so we can do that (slower check) after any custom excludes
* Make `GlobalIgnoresMatcher` a `RawMatcher` and move the `skipClassLoader` check inside it (avoids creating several instances inside byte-buddy that each do part of the match - now we call these simple matches inside a single global-ignores method)
* Removes extraneous classes from the (hot) matching path where possible, preferring static methods

# Motivation

A trie should be faster than the previous approach of creating many chained `named` matchers.
