### PR TITLE
[CIAPP] Fix span duration for skipped tests

### DIFF
--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
@@ -119,7 +119,7 @@ public class TracingListener extends RunListener {
       DECORATE.afterStart(span, version);
       DECORATE.onTestIgnored(span, description, testName, reason);
       DECORATE.beforeFinish(span);
-      span.finish(span.getStartTime());
+      span.finishWithDuration(0L);
     }
   }
 }

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
@@ -119,7 +119,9 @@ public class TracingListener extends RunListener {
       DECORATE.afterStart(span, version);
       DECORATE.onTestIgnored(span, description, testName, reason);
       DECORATE.beforeFinish(span);
-      span.finishWithDuration(0L);
+      // We set a duration of 1 ns, because a span with duration==0 has a special treatment in the
+      // tracer.
+      span.finishWithDuration(1L);
     }
   }
 }

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
@@ -90,7 +90,7 @@ class JUnit4Test extends TestFrameworkTest {
     expect:
     assertTraces(1) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags)
+        testSpan(it, 0, "org.example.TestSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
       }
     }
 
@@ -105,7 +105,7 @@ class JUnit4Test extends TestFrameworkTest {
     expect:
     assertTraces(1) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestSkippedClass", "test_class_skipped", TestDecorator.TEST_SKIP, testTags)
+        testSpan(it, 0, "org.example.TestSkippedClass", "test_class_skipped", TestDecorator.TEST_SKIP, testTags,null, true)
       }
     }
 

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java8/datadog/trace/instrumentation/junit5/TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java8/datadog/trace/instrumentation/junit5/TracingListener.java
@@ -132,7 +132,9 @@ public class TracingListener implements TestExecutionListener {
       DECORATE.afterStart(span, version);
       DECORATE.onTestIgnore(span, testSuite, testName, reason);
       DECORATE.beforeFinish(span);
-      span.finishWithDuration(0L);
+      // We set a duration of 1 ns, because a span with duration==0 has a special treatment in the
+      // tracer.
+      span.finishWithDuration(1L);
     }
   }
 
@@ -145,6 +147,8 @@ public class TracingListener implements TestExecutionListener {
     DECORATE.afterStart(span, version);
     DECORATE.onTestIgnore(span, testSuite, testName, reason);
     DECORATE.beforeFinish(span);
-    span.finishWithDuration(0L);
+    // We set a duration of 1 ns, because a span with duration==0 has a special treatment in the
+    // tracer.
+    span.finishWithDuration(1L);
   }
 }

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java8/datadog/trace/instrumentation/junit5/TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java8/datadog/trace/instrumentation/junit5/TracingListener.java
@@ -132,7 +132,7 @@ public class TracingListener implements TestExecutionListener {
       DECORATE.afterStart(span, version);
       DECORATE.onTestIgnore(span, testSuite, testName, reason);
       DECORATE.beforeFinish(span);
-      span.finish(span.getStartTime());
+      span.finishWithDuration(0L);
     }
   }
 
@@ -145,6 +145,6 @@ public class TracingListener implements TestExecutionListener {
     DECORATE.afterStart(span, version);
     DECORATE.onTestIgnore(span, testSuite, testName, reason);
     DECORATE.beforeFinish(span);
-    span.finish(span.getStartTime());
+    span.finishWithDuration(0L);
   }
 }

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
@@ -187,7 +187,7 @@ class JUnit5Test extends TestFrameworkTest {
     expect:
     assertTraces(1) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags)
+        testSpan(it, 0, "org.example.TestSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
       }
     }
 
@@ -205,7 +205,7 @@ class JUnit5Test extends TestFrameworkTest {
     expect:
     assertTraces(1) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestSkippedClass", "test_class_skipped", TestDecorator.TEST_SKIP, testTags)
+        testSpan(it, 0, "org.example.TestSkippedClass", "test_class_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
       }
     }
 

--- a/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TracingListener.java
+++ b/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TracingListener.java
@@ -86,7 +86,9 @@ public class TracingListener implements ITestListener {
 
     DECORATE.onTestIgnored(span, result);
     DECORATE.beforeFinish(span);
-    span.finishWithDuration(0L);
+    // We set a duration of 1 ns, because a span with duration==0 has a special treatment in the
+    // tracer.
+    span.finishWithDuration(1L);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TracingListener.java
+++ b/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TracingListener.java
@@ -86,7 +86,7 @@ public class TracingListener implements ITestListener {
 
     DECORATE.onTestIgnored(span, result);
     DECORATE.beforeFinish(span);
-    span.finish(span.getStartTime());
+    span.finishWithDuration(0L);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/testng-6.4/src/test/groovy/TestNGTest.groovy
+++ b/dd-java-agent/instrumentation/testng-6.4/src/test/groovy/TestNGTest.groovy
@@ -129,7 +129,7 @@ class TestNGTest extends TestFrameworkTest {
     expect:
     assertTraces(1) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags)
+        testSpan(it, 0, "org.example.TestSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
       }
     }
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/SpanAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/SpanAssert.groovy
@@ -82,6 +82,11 @@ class SpanAssert {
     checked.resourceName = true
   }
 
+  def duration(Closure<Boolean> eval) {
+    assert eval(span.durationNano)
+    checked.duration = true
+  }
+
   def spanType(String type) {
     if (null == span.spanType) {
       // code less readable makes for a better assertion message, don't want NPE

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
@@ -17,7 +17,7 @@ abstract class TestFrameworkTest extends AgentTestRunner {
     injectSysConfig("dd.civisibility.enabled", "true")
   }
 
-  void testSpan(TraceAssert trace, int index, final String testSuite, final String testName, final String testStatus, final Map<String, String> testTags = null, final Throwable exception = null) {
+  void testSpan(TraceAssert trace, int index, final String testSuite, final String testName, final String testStatus, final Map<String, String> testTags = null, final Throwable exception = null, final boolean emptyDuration = false) {
     def testFramework = expectedTestFramework()
     def testFrameworkVersion = expectedTestFrameworkVersion()
 
@@ -27,6 +27,11 @@ abstract class TestFrameworkTest extends AgentTestRunner {
       resourceName "$testSuite.$testName"
       spanType DDSpanTypes.TEST
       errored exception != null
+      if(emptyDuration) {
+        duration({it == 0L})
+      } else {
+        duration({it > 0L})
+      }
       tags {
         "$Tags.COMPONENT" component
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_TEST
@@ -38,6 +43,7 @@ abstract class TestFrameworkTest extends AgentTestRunner {
           "$Tags.TEST_FRAMEWORK_VERSION" testFrameworkVersion
         }
         "$Tags.TEST_STATUS" testStatus
+
         if (testTags) {
           testTags.each { key, val -> tag(key, val) }
         }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
@@ -28,9 +28,9 @@ abstract class TestFrameworkTest extends AgentTestRunner {
       spanType DDSpanTypes.TEST
       errored exception != null
       if(emptyDuration) {
-        duration({it == 0L})
+        duration({it == 1L})
       } else {
-        duration({it > 0L})
+        duration({it > 1L})
       }
       tags {
         "$Tags.COMPONENT" component
@@ -43,7 +43,6 @@ abstract class TestFrameworkTest extends AgentTestRunner {
           "$Tags.TEST_FRAMEWORK_VERSION" testFrameworkVersion
         }
         "$Tags.TEST_STATUS" testStatus
-
         if (testTags) {
           testTags.each { key, val -> tag(key, val) }
         }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -153,13 +153,8 @@ public class DDSpan
   }
 
   private void finishAndAddToTrace(final long durationNano) {
-    this.finishAndAddToTrace(durationNano, false);
-  }
-
-  private void finishAndAddToTrace(final long durationNano, boolean force) {
-    // ensure a min duration of 1 if !force
-    if (DURATION_NANO_UPDATER.compareAndSet(
-        this, 0, !force ? Math.max(1, durationNano) : durationNano)) {
+    // ensure a min duration of 1
+    if (DURATION_NANO_UPDATER.compareAndSet(this, 0, Math.max(1, durationNano))) {
       context.getTrace().onFinish(this);
       tracingContextTracker.deactivateContext();
       PendingTrace.PublishState publishState = context.getTrace().onPublish(this);
@@ -202,7 +197,7 @@ public class DDSpan
 
   @Override
   public final void finishWithDuration(final long durationNano) {
-    finishAndAddToTrace(durationNano, true);
+    finishAndAddToTrace(durationNano);
   }
 
   private static final boolean legacyEndToEndEnabled =

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -89,6 +89,8 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo {
 
   void finish(long finishMicros);
 
+  void finishWithDuration(long durationNanos);
+
   /** Marks the start of a message pipeline where we want to track end-to-end processing time. */
   void beginEndToEnd();
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -632,6 +632,9 @@ public class AgentTracer {
     public void finish(final long finishMicros) {}
 
     @Override
+    public void finishWithDuration(final long durationNanos) {}
+
+    @Override
     public void beginEndToEnd() {}
 
     @Override


### PR DESCRIPTION
This PR fixes the span duration for the skipped test spans instrumented by CI Visibility.

**Root cause**: The `finish(duration)` method does expect the end time in microseconds. As the `start time` is based on nanoseconds, the duration was completely wrong for skipped tests.

**Proposed solution**: Adds a new `finishWithDuration` method in the internal DDSpan API to allow us to set a fixed duration.

**Context**: In CI Visibility, the skipped tests need to have a duration of `0 ns`. This issue was not detected before because CI Visibility spans were fixed by the Datadog Agent. Now the CI Visibility traces can be sent directly to a public intake, this bug has been detected.

_**Note:**_ As the tracer has a special treatment for spans with duration == `0 ns`, for the moment let's set the duration to `1 ns` to unblock skipped tests for agentless.

Tested in staging
<img width="1198" alt="image" src="https://user-images.githubusercontent.com/29516565/167130316-0542330e-7991-48ea-87f7-c82567efecec.png">