### PR TITLE
[CIAPP] Add `library_version` root tag for CI Visibility traces

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
@@ -3,6 +3,7 @@ package datadog.trace.agent.test.base
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.bootstrap.instrumentation.decorator.TestDecorator
 import spock.lang.Shared
@@ -61,6 +62,7 @@ abstract class TestFrameworkTest extends AgentTestRunner {
         "$Tags.RUNTIME_VENDOR" String
         "$Tags.RUNTIME_NAME" String
         "$Tags.RUNTIME_VERSION" String
+        "$DDTags.LIBRARY_VERSION_TAG_KEY" String
 
         defaultTags()
       }

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -37,4 +37,5 @@ public class DDTags {
   public static final String LANGUAGE_TAG_KEY = "language";
   public static final String LANGUAGE_TAG_VALUE = "jvm";
   public static final String ORIGIN_KEY = "_dd.origin";
+  public static final String LIBRARY_VERSION_TAG_KEY = "library_version";
 }

--- a/dd-trace-core/src/main/java/datadog/trace/civisibility/CiVisibilityTraceInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/civisibility/CiVisibilityTraceInterceptor.java
@@ -1,9 +1,11 @@
 package datadog.trace.civisibility;
 
+import datadog.trace.api.DDTags;
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.api.interceptor.TraceInterceptor;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.core.DDSpan;
+import datadog.trace.core.DDTraceCoreInfo;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -36,6 +38,7 @@ public class CiVisibilityTraceInterceptor implements TraceInterceptor {
     // `ciapp-test`.
     for (MutableSpan span : trace) {
       ((DDSpan) span).context().setOrigin(CIAPP_TEST_ORIGIN);
+      span.setTag(DDTags.LIBRARY_VERSION_TAG_KEY, DDTraceCoreInfo.VERSION);
     }
 
     return trace;

--- a/dd-trace-core/src/test/groovy/datadog/trace/civisibility/CiVisibilityTraceInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/civisibility/CiVisibilityTraceInterceptorTest.groovy
@@ -1,5 +1,6 @@
 package datadog.trace.civisibility
 
+import datadog.trace.api.DDTags
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.test.DDCoreSpecification
 import spock.lang.Timeout
@@ -22,7 +23,7 @@ class CiVisibilityTraceInterceptorTest extends DDCoreSpecification {
     writer.size() == 0
   }
 
-  def "add ciapp origin the context origin to all spans"() {
+  def "add ciapp origin and tracer version to all spans"() {
     setup:
     tracer.addTraceInterceptor(CiVisibilityTraceInterceptor.INSTANCE)
 
@@ -36,5 +37,6 @@ class CiVisibilityTraceInterceptorTest extends DDCoreSpecification {
     def span = trace[0]
 
     span.context().origin == CiVisibilityTraceInterceptor.CIAPP_TEST_ORIGIN
+    span.getTag(DDTags.LIBRARY_VERSION_TAG_KEY) != null
   }
 }


### PR DESCRIPTION
This PR adds the `library_version` root tag for CI Visibility traces leveraging the `CIVisibilityTraceInterceptor`.