### PR TITLE
[CIAPP][Agentless] Allow setting host URL via configuration

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
@@ -5,6 +5,7 @@ public final class CiVisibilityConfig {
 
   public static final String CIVISIBILITY_ENABLED = "civisibility.enabled";
   public static final String CIVISIBILITY_AGENTLESS_ENABLED = "civisibility.agentless.enabled";
+  public static final String CIVISIBILITY_AGENTLESS_URL = "civisibility.agentless.url";
 
   private CiVisibilityConfig() {}
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
@@ -22,6 +22,7 @@ import datadog.trace.common.writer.ddintake.DDIntakeApi;
 import datadog.trace.common.writer.ddintake.DDIntakeTrackTypeResolver;
 import datadog.trace.core.monitor.HealthMetrics;
 import datadog.trace.util.Strings;
+import okhttp3.HttpUrl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,8 +72,19 @@ public class WriterFactory {
         return new PrintingWriter(System.out, true);
       }
 
+      HttpUrl hostUrl = null;
+      if (config.getCiVisibilityAgentlessUrl() != null) {
+        hostUrl = HttpUrl.get(config.getCiVisibilityAgentlessUrl());
+        log.info(
+            "Using host URL '" + hostUrl + "' to report CI Visibility traces in Agentless mode.");
+      }
+
       final DDIntakeApi ddIntakeApi =
-          DDIntakeApi.builder().apiKey(config.getApiKey()).trackType(trackType).build();
+          DDIntakeApi.builder()
+              .hostUrl(hostUrl)
+              .apiKey(config.getApiKey())
+              .trackType(trackType)
+              .build();
 
       remoteWriter =
           DDIntakeWriter.builder()

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDIntakeApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDIntakeApi.java
@@ -71,7 +71,7 @@ public class DDIntakeApi implements RemoteApi {
       return this;
     }
 
-    DDIntakeApiBuilder hostUrl(final HttpUrl hostUrl) {
+    public DDIntakeApiBuilder hostUrl(final HttpUrl hostUrl) {
       this.hostUrl = hostUrl;
       return this;
     }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -966,18 +966,17 @@ public class Config {
         configProvider.getBoolean(
             CIVISIBILITY_AGENTLESS_ENABLED, DEFAULT_CIVISIBILITY_AGENTLESS_ENABLED);
 
-    final String ciVisibilityAgentlessUrlStr =
-        configProvider.getString(CIVISIBILITY_AGENTLESS_URL, null);
-    URL parsedCiVisibilityUrl = null;
+    final String ciVisibilityAgentlessUrlStr = configProvider.getString(CIVISIBILITY_AGENTLESS_URL);
+    URI parsedCiVisibilityUri = null;
     if (ciVisibilityAgentlessUrlStr != null && !ciVisibilityAgentlessUrlStr.isEmpty()) {
       try {
-        parsedCiVisibilityUrl = new URL(ciVisibilityAgentlessUrlStr);
-      } catch (MalformedURLException ex) {
+        parsedCiVisibilityUri = new URL(ciVisibilityAgentlessUrlStr).toURI();
+      } catch (MalformedURLException | URISyntaxException ex) {
         log.error(
             "Cannot parse CI Visibility agentless URL '{}', skipping", ciVisibilityAgentlessUrlStr);
       }
     }
-    if (parsedCiVisibilityUrl != null) {
+    if (parsedCiVisibilityUri != null) {
       ciVisibilityAgentlessUrl = ciVisibilityAgentlessUrlStr;
     } else {
       ciVisibilityAgentlessUrl = null;

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -75,6 +75,7 @@ import static datadog.trace.api.config.AppSecConfig.APPSEC_RULES_FILE;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_TRACE_RATE_LIMIT;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_WAF_METRICS;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_AGENTLESS_ENABLED;
+import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_AGENTLESS_URL;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_ENABLED;
 import static datadog.trace.api.config.CwsConfig.CWS_ENABLED;
 import static datadog.trace.api.config.CwsConfig.CWS_TLS_REFRESH;
@@ -261,8 +262,10 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.InetAddress;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -450,6 +453,7 @@ public class Config {
 
   private final boolean ciVisibilityEnabled;
   private final boolean ciVisibilityAgentlessEnabled;
+  private final String ciVisibilityAgentlessUrl;
 
   private final boolean awsPropagationEnabled;
   private final boolean sqsPropagationEnabled;
@@ -961,6 +965,23 @@ public class Config {
     ciVisibilityAgentlessEnabled =
         configProvider.getBoolean(
             CIVISIBILITY_AGENTLESS_ENABLED, DEFAULT_CIVISIBILITY_AGENTLESS_ENABLED);
+
+    final String ciVisibilityAgentlessUrlStr =
+        configProvider.getString(CIVISIBILITY_AGENTLESS_URL, null);
+    URL parsedCiVisibilityUrl = null;
+    if (ciVisibilityAgentlessUrlStr != null && !ciVisibilityAgentlessUrlStr.isEmpty()) {
+      try {
+        parsedCiVisibilityUrl = new URL(ciVisibilityAgentlessUrlStr);
+      } catch (MalformedURLException ex) {
+        log.error(
+            "Cannot parse CI Visibility agentless URL '{}', skipping", ciVisibilityAgentlessUrlStr);
+      }
+    }
+    if (parsedCiVisibilityUrl != null) {
+      ciVisibilityAgentlessUrl = ciVisibilityAgentlessUrlStr;
+    } else {
+      ciVisibilityAgentlessUrl = null;
+    }
 
     jdbcPreparedStatementClassName =
         configProvider.getString(JDBC_PREPARED_STATEMENT_CLASS_NAME, "");
@@ -1524,6 +1545,10 @@ public class Config {
 
   public boolean isCiVisibilityAgentlessEnabled() {
     return ciVisibilityAgentlessEnabled;
+  }
+
+  public String getCiVisibilityAgentlessUrl() {
+    return ciVisibilityAgentlessUrl;
   }
 
   public String getAppSecRulesFile() {


### PR DESCRIPTION
This PR adds the `dd.civisibility.agentless.url` config property (or environment variable equivalent) to allow configuring the Intake host URL externally. This will be particularly useful for configuring e2e tests on CI Visibility agentless mode.

The change in this PR is a feature used only by CI Visibility. It has no changes that might affect customers in production mode for APM Java.