### PR TITLE
Add '-Ddd.trace.codesources.exclude=example-1.jar' flag to exclude named code-sources from matching

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
@@ -34,6 +34,7 @@ public class GlobalIgnoresMatcher implements AgentBuilder.RawMatcher {
     String name = typeDescription.getActualName();
     return GlobalIgnores.isIgnored(name, skipAdditionalLibraryMatcher)
         || CustomExcludes.isExcluded(name)
+        || CodeSourceExcludes.isExcluded(protectionDomain)
         || ProxyClassIgnores.isIgnored(name);
   }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/CodeSourceExcludes.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/CodeSourceExcludes.java
@@ -1,0 +1,56 @@
+package datadog.trace.agent.tooling.bytebuddy.matcher;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.cache.DDCache;
+import datadog.trace.api.cache.DDCaches;
+import datadog.trace.api.function.Function;
+import java.net.URL;
+import java.security.CodeSource;
+import java.security.ProtectionDomain;
+import java.util.List;
+
+/**
+ * Custom {@link java.security.CodeSource} excludes configured by the user.
+ *
+ * <p>Matches any code source location that contains one of the configured strings.
+ */
+public class CodeSourceExcludes {
+  private CodeSourceExcludes() {}
+
+  private static final List<String> excludes = Config.get().getExcludedCodeSources();
+
+  private static final DDCache<String, Boolean> excludedCodeSources;
+
+  static {
+    if (!excludes.isEmpty()) {
+      excludedCodeSources = DDCaches.newFixedSizeCache(64);
+    } else {
+      excludedCodeSources = null;
+    }
+  }
+
+  public static boolean isExcluded(ProtectionDomain protectionDomain) {
+    if (null != excludedCodeSources && null != protectionDomain) {
+      CodeSource codeSource = protectionDomain.getCodeSource();
+      if (null != codeSource) {
+        // avoid hashing on the URL because that can be a blocking operation
+        URL location = codeSource.getLocation();
+        return null != location
+            && excludedCodeSources.computeIfAbsent(
+                location.getPath(),
+                new Function<String, Boolean>() {
+                  @Override
+                  public Boolean apply(String path) {
+                    for (String name : excludes) {
+                      if (path.contains(name)) {
+                        return true;
+                      }
+                    }
+                    return false;
+                  }
+                });
+      }
+    }
+    return false;
+  }
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -19,6 +19,7 @@ public final class TraceInstrumentationConfig {
   public static final String TRACE_CLASSES_EXCLUDE = "trace.classes.exclude";
   public static final String TRACE_CLASSES_EXCLUDE_FILE = "trace.classes.exclude.file";
   public static final String TRACE_CLASSLOADERS_EXCLUDE = "trace.classloaders.exclude";
+  public static final String TRACE_CODESOURCES_EXCLUDE = "trace.codesources.exclude";
   public static final String TRACE_TESTS_ENABLED = "trace.tests.enabled";
 
   public static final String TRACE_THREAD_POOL_EXECUTORS_EXCLUDE =

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -200,6 +200,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ANNOTATI
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE_FILE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSLOADERS_EXCLUDE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CODESOURCES_EXCLUDE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_EXECUTORS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_EXECUTORS_ALL;
@@ -342,6 +343,7 @@ public class Config {
   private final List<String> excludedClasses;
   private final String excludedClassesFile;
   private final Set<String> excludedClassLoaders;
+  private final List<String> excludedCodeSources;
   private final Map<String, String> requestHeaderTags;
   private final Map<String, String> responseHeaderTags;
   private final BitSet httpServerErrorStatuses;
@@ -675,6 +677,7 @@ public class Config {
     excludedClasses = tryMakeImmutableList(configProvider.getList(TRACE_CLASSES_EXCLUDE));
     excludedClassesFile = configProvider.getString(TRACE_CLASSES_EXCLUDE_FILE);
     excludedClassLoaders = tryMakeImmutableSet(configProvider.getList(TRACE_CLASSLOADERS_EXCLUDE));
+    excludedCodeSources = tryMakeImmutableList(configProvider.getList(TRACE_CODESOURCES_EXCLUDE));
 
     if (isEnabled(false, HEADER_TAGS, ".legacy.parsing.enabled")) {
       requestHeaderTags = configProvider.getMergedMap(HEADER_TAGS);
@@ -1164,6 +1167,10 @@ public class Config {
 
   public Set<String> getExcludedClassLoaders() {
     return excludedClassLoaders;
+  }
+
+  public List<String> getExcludedCodeSources() {
+    return excludedCodeSources;
   }
 
   public Map<String, String> getRequestHeaderTags() {
@@ -2308,6 +2315,8 @@ public class Config {
         + excludedClassesFile
         + ", excludedClassLoaders="
         + excludedClassLoaders
+        + ", excludedCodeSources="
+        + excludedCodeSources
         + ", requestHeaderTags="
         + requestHeaderTags
         + ", responseHeaderTags="


### PR DESCRIPTION
# What Does This Do

Excludes any code-source location that contains one of the configured strings somewhere in its path.

# Motivation

This lets users exclude specific named jars or directories from being instrumented, this could be useful when all jars are loaded using the same classloader (so we can't exclude by classloader) and excluding each class in the jar would be too verbose.

# Example
```
-Ddd.trace.codesources.exclude=/classes,/antlr-2.7.7.jar
```

# Notes

The matching is just a simple `contains` check, so you should avoid using short words that could appear elsewhere in the code-source location (this is also a feature, because you can then exclude several code-sources with similar locations.)