### PR TITLE
Don't treat wrapped broken pipe exceptions as errors

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -392,7 +392,9 @@ public class DDSpan
   public DDSpan addThrowable(final Throwable error) {
     if (null != error) {
       String message = error.getMessage();
-      if (!"broken pipe".equalsIgnoreCase(message)) {
+      if (!"broken pipe".equalsIgnoreCase(message)
+          && (error.getCause() == null
+              || !"broken pipe".equalsIgnoreCase(error.getCause().getMessage()))) {
         // broken pipes happen when clients abort connections,
         // which might happen because the application is overloaded
         // or warming up - capturing the stack trace and keeping

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -436,6 +436,16 @@ class DDSpanTest extends DDCoreSpecification {
     span.getTag(DDTags.ERROR_MSG) == "Broken pipe"
   }
 
+  def "wrapped broken pipe exception does not create error span"() {
+    when:
+    def span = tracer.buildSpan("root").start()
+    span.addThrowable(new RuntimeException(new IOException("Broken pipe")))
+    then:
+    !span.isError()
+    span.getTag(DDTags.ERROR_STACK) == null
+    span.getTag(DDTags.ERROR_MSG) == "java.io.IOException: Broken pipe"
+  }
+
   def "null exception safe to add"() {
     when:
     def span = tracer.buildSpan("root").start()


### PR DESCRIPTION
# What Does This Do

This widens the check introduced in #2754 by one level of wrapping, so broken pipe exceptions wrapped inside another exception are also not treated as errors.

# Motivation

Broken pipe `IOExceptions` are checked exceptions which may be wrapped inside unchecked exceptions or more web-app-friendly exceptions.

# Additional Notes

I decided to avoid widening this to the entire exception chain as usually there's only one level of wrapping, and checking one extra level shouldn't add much cost.

An alternative approach would be to do a `contains` check of the outer exception's message, since the outer exception often sets its message to be `cause.toString()`. Unfortunately though there's no `containsIgnoreCase` and changing the case of the message would involve allocating a new string. It's also possible that the outer exception sets a more user-friendly message, in which case we'd need to check `cause.getMessage()` anyway.