### PR TITLE
Rename profiling pid tag to process_id to align with other products

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/util/PidHelper.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/util/PidHelper.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
 public class PidHelper {
   private static final Logger log = LoggerFactory.getLogger(PidHelper.class);
 
-  public static final String PID_TAG = "pid";
+  public static final String PID_TAG = "process_id";
   public static final Long PID = getPid();
 
   private static Long getPid() {


### PR DESCRIPTION
In the UX, tracing is using process_id (automatically mapped) and the processes product will also work with process_id.
