### PR TITLE
3143 add support for vertx web 4

### DIFF
--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/HttpServerResponseEndHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/HttpServerResponseEndHandlerInstrumentation.java
@@ -7,12 +7,18 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.muzzle.Reference;
 
 @AutoService(Instrumenter.class)
 public class HttpServerResponseEndHandlerInstrumentation extends Instrumenter.Tracing
     implements Instrumenter.ForKnownTypes {
   public HttpServerResponseEndHandlerInstrumentation() {
     super("vertx", "vertx-4.0");
+  }
+
+  @Override
+  public Reference[] additionalMuzzleReferences() {
+    return new Reference[] {VertxVersionMatcher.HTTP_1X_SERVER_RESPONSE};
   }
 
   @Override

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/HttpServerResponseEndHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/HttpServerResponseEndHandlerInstrumentation.java
@@ -26,12 +26,11 @@ public class HttpServerResponseEndHandlerInstrumentation extends Instrumenter.Tr
   }
 
   @Override
-  public String[] instrumentedType() {
-    return {
+  public String[] knownMatchingTypes() {
+    return new String[] {
       "io.vertx.core.http.impl.Http1xServerResponse",
       "io.vertx.core.http.impl.Http2ServerResponse "
-
-    }
+    };
   }
 
   @Override

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/HttpServerResponseEndHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/HttpServerResponseEndHandlerInstrumentation.java
@@ -1,0 +1,46 @@
+package datadog.trace.instrumentation.vertx_4_0.server;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+
+@AutoService(Instrumenter.class)
+public class HttpServerResponseEndHandlerInstrumentation extends Instrumenter.Tracing
+    implements Instrumenter.ForKnownTypes {
+  public HttpServerResponseEndHandlerInstrumentation() {
+    super("vertx", "vertx-4.2");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".EndHandlerWrapper",
+      packageName + ".RouteHandlerWrapper",
+      packageName + ".VertxDecorator",
+      packageName + ".VertxDecorator$VertxURIDataAdapter",
+    };
+  }
+
+  @Override
+  public String[] instrumentedType() {
+    return {
+      "io.vertx.core.http.impl.Http1xServerResponse",
+      "io.vertx.core.http.impl.Http2ServerResponse "
+
+    }
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod()
+            .and(named("endHandler"))
+            .and(isPublic())
+            .and(takesArgument(0, named("io.vertx.core.Handler"))),
+        packageName + ".EndHandlerWrapperAdvice");
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/HttpServerResponseEndHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/HttpServerResponseEndHandlerInstrumentation.java
@@ -28,8 +28,7 @@ public class HttpServerResponseEndHandlerInstrumentation extends Instrumenter.Tr
   @Override
   public String[] knownMatchingTypes() {
     return new String[] {
-      "io.vertx.core.http.impl.Http1xServerResponse",
-      "io.vertx.core.http.impl.Http2ServerResponse "
+      "io.vertx.core.http.impl.Http1xServerResponse", "io.vertx.core.http.impl.Http2ServerResponse "
     };
   }
 

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/HttpServerResponseEndHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/HttpServerResponseEndHandlerInstrumentation.java
@@ -12,7 +12,7 @@ import datadog.trace.agent.tooling.Instrumenter;
 public class HttpServerResponseEndHandlerInstrumentation extends Instrumenter.Tracing
     implements Instrumenter.ForKnownTypes {
   public HttpServerResponseEndHandlerInstrumentation() {
-    super("vertx", "vertx-4.2");
+    super("vertx", "vertx-4.0");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerInstrumentation.java
@@ -7,12 +7,18 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.muzzle.Reference;
 
 @AutoService(Instrumenter.class)
 public class RouteHandlerInstrumentation extends Instrumenter.Tracing
     implements Instrumenter.ForSingleType {
   public RouteHandlerInstrumentation() {
     super("vertx", "vertx-4.0");
+  }
+
+  @Override
+  public Reference[] additionalMuzzleReferences() {
+    return new Reference[] {VertxVersionMatcher.HTTP_1X_SERVER_RESPONSE};
   }
 
   @Override

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerInstrumentation.java
@@ -12,7 +12,7 @@ import datadog.trace.agent.tooling.Instrumenter;
 public class RouteHandlerInstrumentation extends Instrumenter.Tracing
     implements Instrumenter.ForSingleType {
   public RouteHandlerInstrumentation() {
-    super("vertx", "vertx-4.2");
+    super("vertx", "vertx-4.0");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerInstrumentation.java
@@ -1,0 +1,42 @@
+package datadog.trace.instrumentation.vertx_4_0.server;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+
+@AutoService(Instrumenter.class)
+public class RouteHandlerInstrumentation extends Instrumenter.Tracing
+    implements Instrumenter.ForSingleType {
+  public RouteHandlerInstrumentation() {
+    super("vertx", "vertx-4.2");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".EndHandlerWrapper",
+      packageName + ".RouteHandlerWrapper",
+      packageName + ".VertxDecorator",
+      packageName + ".VertxDecorator$VertxURIDataAdapter",
+    };
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "io.vertx.ext.web.impl.RouteImpl";
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod()
+            .and(named("handler"))
+            .and(isPublic())
+            .and(takesArgument(0, named("io.vertx.core.Handler"))),
+        packageName + ".RouteHandlerWrapperAdvice");
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteImplInstrumentation.java
@@ -8,8 +8,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.agent.tooling.muzzle.IReferenceMatcher;
-import datadog.trace.agent.tooling.muzzle.ReferenceMatcher;
+import datadog.trace.agent.tooling.muzzle.Reference;
 
 @AutoService(Instrumenter.class)
 public class RouteImplInstrumentation extends Instrumenter.AppSec
@@ -19,9 +18,9 @@ public class RouteImplInstrumentation extends Instrumenter.AppSec
     super("vertx", "vertx-4.0");
   }
 
-  private IReferenceMatcher postProcessReferenceMatcher(final ReferenceMatcher origMatcher) {
-    return new IReferenceMatcher.ConjunctionReferenceMatcher(
-        origMatcher, VertxVersionMatcher.INSTANCE);
+  @Override
+  public Reference[] additionalMuzzleReferences() {
+    return new Reference[] {VertxVersionMatcher.HTTP_1X_SERVER_RESPONSE};
   }
 
   @Override

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteImplInstrumentation.java
@@ -1,0 +1,66 @@
+package datadog.trace.instrumentation.vertx_4_0.server;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.muzzle.IReferenceMatcher;
+import datadog.trace.agent.tooling.muzzle.ReferenceMatcher;
+
+@AutoService(Instrumenter.class)
+public class RouteImplInstrumentation extends Instrumenter.AppSec
+    implements Instrumenter.ForKnownTypes {
+
+  public RouteImplInstrumentation() {
+    super("vertx", "vertx-4.2");
+  }
+
+  private IReferenceMatcher postProcessReferenceMatcher(final ReferenceMatcher origMatcher) {
+    return new IReferenceMatcher.ConjunctionReferenceMatcher(
+        origMatcher, VertxVersionMatcher.INSTANCE);
+  }
+
+  @Override
+  public String[] knownMatchingTypes() {
+    return new String[] {
+      "io.vertx.ext.web.impl.RouteImpl", "io.vertx.ext.web.impl.RouteState",
+    };
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".PathParameterPublishingHelper",
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("matches")
+            .and(takesArguments(3))
+            .and(takesArgument(0, named("io.vertx.ext.web.impl.RoutingContextImplBase")))
+            .and(takesArgument(1, String.class))
+            .and(takesArgument(2, boolean.class))
+            .and(isPublic())
+            .and(returns(int.class)),
+        packageName + ".RouteMatchesAdvice");
+
+    transformation.applyAdvice(
+        named("matches")
+            .and(takesArguments(3))
+            .and(
+                takesArgument(
+                    0,
+                    named("io.vertx.ext.web.impl.RoutingContextImplBase")
+                        .or(named("io.vertx.ext.web.RoutingContext"))))
+            .and(takesArgument(1, String.class))
+            .and(takesArgument(2, boolean.class))
+            .and(returns(boolean.class)),
+        packageName + ".RouteMatchesAdvice$BooleanReturnVariant");
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteImplInstrumentation.java
@@ -16,7 +16,7 @@ public class RouteImplInstrumentation extends Instrumenter.AppSec
     implements Instrumenter.ForKnownTypes {
 
   public RouteImplInstrumentation() {
-    super("vertx", "vertx-4.2");
+    super("vertx", "vertx-4.0");
   }
 
   private IReferenceMatcher postProcessReferenceMatcher(final ReferenceMatcher origMatcher) {

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextImplInstrumentation.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.vertx_4_0.server;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextImplInstrumentation.java
@@ -6,8 +6,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.agent.tooling.muzzle.IReferenceMatcher;
-import datadog.trace.agent.tooling.muzzle.ReferenceMatcher;
+import datadog.trace.agent.tooling.muzzle.Reference;
 
 @AutoService(Instrumenter.class)
 public class RoutingContextImplInstrumentation extends Instrumenter.AppSec
@@ -18,13 +17,13 @@ public class RoutingContextImplInstrumentation extends Instrumenter.AppSec
   }
 
   @Override
-  public String instrumentedType() {
-    return "io.vertx.ext.web.impl.RoutingContextImpl";
+  public Reference[] additionalMuzzleReferences() {
+    return new Reference[] {VertxVersionMatcher.HTTP_1X_SERVER_RESPONSE};
   }
 
-  private IReferenceMatcher postProcessReferenceMatcher(final ReferenceMatcher origMatcher) {
-    return new IReferenceMatcher.ConjunctionReferenceMatcher(
-        origMatcher, VertxVersionMatcher.INSTANCE);
+  @Override
+  public String instrumentedType() {
+    return "io.vertx.ext.web.impl.RoutingContextImpl";
   }
 
   @Override

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextImplInstrumentation.java
@@ -1,0 +1,35 @@
+package datadog.trace.instrumentation.vertx_4_0.server;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.muzzle.IReferenceMatcher;
+import datadog.trace.agent.tooling.muzzle.ReferenceMatcher;
+
+@AutoService(Instrumenter.class)
+public class RoutingContextImplInstrumentation extends Instrumenter.AppSec
+    implements Instrumenter.ForSingleType {
+
+  public RoutingContextImplInstrumentation() {
+    super("vertx", "vertx-4.2");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "io.vertx.ext.web.impl.RoutingContextImpl";
+  }
+
+  private IReferenceMatcher postProcessReferenceMatcher(final ReferenceMatcher origMatcher) {
+    return new IReferenceMatcher.ConjunctionReferenceMatcher(
+        origMatcher, VertxVersionMatcher.INSTANCE);
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("getBodyAsJson").or(named("getBodyAsJsonArray")).and(takesArguments(0)),
+        packageName + ".RoutingContextJsonAdvice");
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextImplInstrumentation.java
@@ -29,9 +29,10 @@ public class RoutingContextImplInstrumentation extends Instrumenter.AppSec
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(
-      named("getBodyAsJson")
-        .or(named("getBodyAsJsonArray"))
-        .and(takesArguments(1).and(takesArgument(0, int.class))),
-      packageName + ".RoutingContextJsonAdvice");
+        named("getBodyAsJson")
+            .or(named("getBodyAsJsonArray"))
+            .and(takesArguments(1))
+            .and(takesArgument(0, int.class)),
+        packageName + ".RoutingContextJsonAdvice");
   }
 }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextImplInstrumentation.java
@@ -29,7 +29,9 @@ public class RoutingContextImplInstrumentation extends Instrumenter.AppSec
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(
-        named("getBodyAsJson").or(named("getBodyAsJsonArray")).and(takesArguments(0)),
-        packageName + ".RoutingContextJsonAdvice");
+      named("getBodyAsJson")
+        .or(named("getBodyAsJsonArray"))
+        .and(takesArguments(1).and(takesArgument(0, int.class))),
+      packageName + ".RoutingContextJsonAdvice");
   }
 }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextImplInstrumentation.java
@@ -13,7 +13,7 @@ public class RoutingContextImplInstrumentation extends Instrumenter.AppSec
     implements Instrumenter.ForSingleType {
 
   public RoutingContextImplInstrumentation() {
-    super("vertx", "vertx-4.2");
+    super("vertx", "vertx-4.0");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/VertxVersionMatcher.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/VertxVersionMatcher.java
@@ -7,5 +7,6 @@ import datadog.trace.agent.tooling.muzzle.ReferenceMatcher;
 public class VertxVersionMatcher {
   // added in 4.0
   static final ReferenceMatcher INSTANCE =
-      new ReferenceMatcher(new Reference.Builder("io.vertx.core.http.impl.Http1xServerResponse").build());
+      new ReferenceMatcher(
+          new Reference.Builder("io.vertx.core.http.impl.Http1xServerResponse").build());
 }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/VertxVersionMatcher.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/VertxVersionMatcher.java
@@ -1,12 +1,10 @@
 package datadog.trace.instrumentation.vertx_4_0.server;
 
 import datadog.trace.agent.tooling.muzzle.Reference;
-import datadog.trace.agent.tooling.muzzle.ReferenceMatcher;
 
 // checks for vertx > 4
 public class VertxVersionMatcher {
   // added in 4.0
-  static final ReferenceMatcher INSTANCE =
-      new ReferenceMatcher(
-          new Reference.Builder("io.vertx.core.http.impl.Http1xServerResponse").build());
+  static final Reference HTTP_1X_SERVER_RESPONSE =
+      new Reference.Builder("io.vertx.core.http.impl.Http1xServerResponse").build();
 }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/VertxVersionMatcher.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/VertxVersionMatcher.java
@@ -1,0 +1,11 @@
+package datadog.trace.instrumentation.vertx_4_0.server;
+
+import datadog.trace.agent.tooling.muzzle.Reference;
+import datadog.trace.agent.tooling.muzzle.ReferenceMatcher;
+
+// checks for vertx > 4
+public class VertxVersionMatcher {
+  // added in 4.0
+  static final ReferenceMatcher INSTANCE =
+      new ReferenceMatcher(new Reference.Builder("io.vertx.core.http.impl.Http1xServerResponse").build());
+}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/EndHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/EndHandlerWrapper.java
@@ -1,0 +1,41 @@
+package datadog.trace.instrumentation.vertx_4_0.server;
+
+import static datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourceDecorator.HTTP_RESOURCE_DECORATOR;
+import static datadog.trace.instrumentation.vertx_4_0.server.RouteHandlerWrapper.HANDLER_SPAN_CONTEXT_KEY;
+import static datadog.trace.instrumentation.vertx_4_0.server.RouteHandlerWrapper.PARENT_SPAN_CONTEXT_KEY;
+import static datadog.trace.instrumentation.vertx_4_0.server.RouteHandlerWrapper.ROUTE_CONTEXT_KEY;
+import static datadog.trace.instrumentation.vertx_4_0.server.VertxDecorator.DECORATE;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+public class EndHandlerWrapper implements Handler<Void> {
+  private final RoutingContext routingContext;
+
+  Handler<Void> actual;
+
+  EndHandlerWrapper(RoutingContext routingContext) {
+    this.routingContext = routingContext;
+  }
+
+  @Override
+  public void handle(final Void event) {
+    AgentSpan span = routingContext.get(HANDLER_SPAN_CONTEXT_KEY);
+    AgentSpan parentSpan = routingContext.get(PARENT_SPAN_CONTEXT_KEY);
+    String path = routingContext.get(ROUTE_CONTEXT_KEY);
+    try {
+      span.finishThreadMigration();
+      if (actual != null) {
+        actual.handle(event);
+      }
+    } finally {
+      if (path != null) {
+        HTTP_RESOURCE_DECORATOR.withRoute(
+            parentSpan, routingContext.request().rawMethod(), path, true);
+      }
+      DECORATE.onResponse(span, routingContext.response());
+      span.finish();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/EndHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/EndHandlerWrapper.java
@@ -32,7 +32,7 @@ public class EndHandlerWrapper implements Handler<Void> {
     } finally {
       if (path != null) {
         HTTP_RESOURCE_DECORATOR.withRoute(
-            parentSpan, routingContext.request().rawMethod(), path, true);
+            parentSpan, routingContext.request().method().name(), path, true);
       }
       DECORATE.onResponse(span, routingContext.response());
       span.finish();

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/EndHandlerWrapperAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/EndHandlerWrapperAdvice.java
@@ -1,0 +1,27 @@
+package datadog.trace.instrumentation.vertx_4_0.server;
+
+import io.vertx.core.Handler;
+import net.bytebuddy.asm.Advice;
+
+public class EndHandlerWrapperAdvice {
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  public static void wrapHandler(
+      @Advice.FieldValue(value = "endHandler", readOnly = false) final Handler<Void> endHandler,
+      @Advice.Argument(value = 0, readOnly = false) Handler<Void> handler) {
+    // In case the handler instrumentation executes twice on the same response
+    if (endHandler instanceof EndHandlerWrapper && handler instanceof EndHandlerWrapper) {
+      return;
+    }
+    // If an end handler was already registered when our wrapper is registered, we save the one that
+    // existed before
+    if (handler instanceof EndHandlerWrapper && endHandler != null) {
+      ((EndHandlerWrapper) handler).actual = endHandler;
+
+      // If the user registers an end handler and ours has already been registered then we wrap the
+      // users handler and swap the function argument for the wrapper
+    } else if (endHandler instanceof EndHandlerWrapper) {
+      ((EndHandlerWrapper) endHandler).actual = handler;
+      handler = endHandler;
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/PathParameterPublishingHelper.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/PathParameterPublishingHelper.java
@@ -1,0 +1,31 @@
+package datadog.trace.instrumentation.vertx_4_0.server;
+
+import static datadog.trace.api.gateway.Events.EVENTS;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+
+import datadog.trace.api.function.BiFunction;
+import datadog.trace.api.gateway.CallbackProvider;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.util.Map;
+
+public class PathParameterPublishingHelper {
+  public static void publishParams(Map<String, String> params) {
+    AgentSpan agentSpan = activeSpan();
+    if (agentSpan == null) {
+      return;
+    }
+
+    CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
+    BiFunction<RequestContext<Object>, Map<String, ?>, Flow<Void>> callback =
+        cbp.getCallback(EVENTS.requestPathParams());
+    RequestContext<Object> requestContext = agentSpan.getRequestContext();
+    if (requestContext == null || callback == null) {
+      return;
+    }
+
+    callback.apply(requestContext, params);
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapper.java
@@ -65,6 +65,7 @@ public class RouteHandlerWrapper implements Handler<RoutingContext> {
     String path = routingContext.currentRoute().getPath();
     if (mountPoint != null) {
       path = mountPoint + path;
+      path = path.replaceAll("//", "/");
     }
     if (method != null && path != null) {
       routingContext.put(ROUTE_CONTEXT_KEY, path);

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapper.java
@@ -62,10 +62,15 @@ public class RouteHandlerWrapper implements Handler<RoutingContext> {
   private void updateRoutingContextWithRoute(RoutingContext routingContext) {
     final String method = routingContext.request().method().name();
     final String mountPoint = routingContext.mountPoint();
+
     String path = routingContext.currentRoute().getPath();
+
     if (mountPoint != null) {
-      path = mountPoint + path;
-      path = path.replaceAll("//", "/");
+      final String noBackslashhMountPoint =
+          mountPoint.endsWith("/")
+              ? mountPoint.substring(0, mountPoint.lastIndexOf("/"))
+              : mountPoint;
+      path = noBackslashhMountPoint + path;
     }
     if (method != null && path != null) {
       routingContext.put(ROUTE_CONTEXT_KEY, path);

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapper.java
@@ -1,0 +1,73 @@
+package datadog.trace.instrumentation.vertx_4_0.server;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.vertx_4_0.server.VertxDecorator.DECORATE;
+import static datadog.trace.instrumentation.vertx_4_0.server.VertxDecorator.INSTRUMENTATION_NAME;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RouteHandlerWrapper implements Handler<RoutingContext> {
+  private static final Logger log = LoggerFactory.getLogger(RouteHandlerWrapper.class);
+  static final String PARENT_SPAN_CONTEXT_KEY = AgentSpan.class.getName() + ".parent";
+  static final String HANDLER_SPAN_CONTEXT_KEY = AgentSpan.class.getName() + ".handler";
+  static final String ROUTE_CONTEXT_KEY = "dd." + Tags.HTTP_ROUTE;
+
+  private final Handler<RoutingContext> actual;
+
+  public RouteHandlerWrapper(final Handler<RoutingContext> handler) {
+    actual = handler;
+  }
+
+  @Override
+  public void handle(final RoutingContext routingContext) {
+    AgentSpan span = routingContext.get(HANDLER_SPAN_CONTEXT_KEY);
+    if (span == null) {
+      AgentSpan parentSpan = activeSpan();
+      routingContext.put(PARENT_SPAN_CONTEXT_KEY, parentSpan);
+
+      span = startSpan(INSTRUMENTATION_NAME);
+      routingContext.put(HANDLER_SPAN_CONTEXT_KEY, span);
+      // span is stored in the context and the span related work may proceed on any thread
+      span.startThreadMigration();
+
+      routingContext.response().endHandler(new EndHandlerWrapper(routingContext));
+      DECORATE.afterStart(span);
+      span.setResourceName(DECORATE.className(actual.getClass()));
+    } else {
+      // the span was retrieved from the context in 'suspended' state - need to be resumed
+      span.finishThreadMigration();
+    }
+
+    updateRoutingContextWithRoute(routingContext);
+
+    try (final AgentScope scope = activateSpan(span)) {
+      scope.setAsyncPropagation(true);
+      try {
+        actual.handle(routingContext);
+      } catch (final Throwable t) {
+        DECORATE.onError(span, t);
+        throw t;
+      }
+    }
+  }
+
+  private void updateRoutingContextWithRoute(RoutingContext routingContext) {
+    final String method = routingContext.request().rawMethod();
+    final String mountPoint = routingContext.mountPoint();
+    String path = routingContext.currentRoute().getPath();
+    if (mountPoint != null) {
+      path = mountPoint + path;
+    }
+    if (method != null && path != null) {
+      routingContext.put(ROUTE_CONTEXT_KEY, path);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapper.java
@@ -60,7 +60,7 @@ public class RouteHandlerWrapper implements Handler<RoutingContext> {
   }
 
   private void updateRoutingContextWithRoute(RoutingContext routingContext) {
-    final String method = routingContext.request().rawMethod();
+    final String method = routingContext.request().method().name();
     final String mountPoint = routingContext.mountPoint();
     String path = routingContext.currentRoute().getPath();
     if (mountPoint != null) {

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapperAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapperAdvice.java
@@ -2,7 +2,7 @@ package datadog.trace.instrumentation.vertx_4_0.server;
 
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.impl.RouterImpl;
+import io.vertx.ext.web.impl.RouteImpl;
 import net.bytebuddy.asm.Advice;
 
 public class RouteHandlerWrapperAdvice {
@@ -13,7 +13,7 @@ public class RouteHandlerWrapperAdvice {
     // method this skips that. This prevents routers from creating a span during handling. In the
     // event a route is not found, without this code, a span would be created for the router when
     // it shouldn't
-    if (!handler.getClass().getName().startsWith(RouterImpl.class.getName())) {
+    if (!handler.getClass().getName().startsWith(RouteImpl.class.getName())) {
       handler = new RouteHandlerWrapper(handler);
     }
   }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapperAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapperAdvice.java
@@ -1,0 +1,20 @@
+package datadog.trace.instrumentation.vertx_4_0.server;
+
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.impl.RouterImpl;
+import net.bytebuddy.asm.Advice;
+
+public class RouteHandlerWrapperAdvice {
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  public static void wrapHandler(
+      @Advice.Argument(value = 0, readOnly = false) Handler<RoutingContext> handler) {
+    // When mounting a sub router, the handler is a method reference to the routers handleContext
+    // method this skips that. This prevents routers from creating a span during handling. In the
+    // event a route is not found, without this code, a span would be created for the router when
+    // it shouldn't
+    if (!handler.getClass().getName().startsWith(RouterImpl.class.getName())) {
+      handler = new RouteHandlerWrapper(handler);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/RouteMatchesAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/RouteMatchesAdvice.java
@@ -1,0 +1,35 @@
+package datadog.trace.instrumentation.vertx_4_0.server;
+
+import io.vertx.ext.web.RoutingContext;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+
+class RouteMatchesAdvice {
+  @Advice.OnMethodExit(suppress = Throwable.class)
+  static void after(@Advice.Return int ret, @Advice.Argument(0) final RoutingContext ctx) {
+    if (ret != 0) {
+      return;
+    }
+    Map<String, String> params = ctx.pathParams();
+    if (params.isEmpty()) {
+      return;
+    }
+
+    PathParameterPublishingHelper.publishParams(params);
+  }
+
+  static class BooleanReturnVariant {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    static void after(@Advice.Return boolean ret, @Advice.Argument(0) final RoutingContext ctx) {
+      if (!ret) {
+        return;
+      }
+      Map<String, String> params = ctx.pathParams();
+      if (params.isEmpty()) {
+        return;
+      }
+
+      PathParameterPublishingHelper.publishParams(params);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextJsonAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextJsonAdvice.java
@@ -1,0 +1,40 @@
+package datadog.trace.instrumentation.vertx_4_0.server;
+
+import static datadog.trace.api.gateway.Events.EVENTS;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+
+import datadog.trace.api.function.BiFunction;
+import datadog.trace.api.gateway.CallbackProvider;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import io.vertx.core.json.JsonObject;
+import net.bytebuddy.asm.Advice;
+
+class RoutingContextJsonAdvice {
+  @Advice.OnMethodExit(suppress = Throwable.class)
+  static void after(@Advice.Return Object obj_) {
+    if (obj_ == null) {
+      return;
+    }
+    Object obj = obj_;
+    if (obj instanceof JsonObject) {
+      obj = ((JsonObject) obj).getMap();
+    }
+
+    AgentSpan agentSpan = activeSpan();
+    if (agentSpan == null) {
+      return;
+    }
+    CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
+    BiFunction<RequestContext<Object>, Object, Flow<Void>> callback =
+        cbp.getCallback(EVENTS.requestBodyProcessed());
+    RequestContext<Object> requestContext = agentSpan.getRequestContext();
+    if (requestContext == null || callback == null) {
+      return;
+    }
+
+    callback.apply(requestContext, obj);
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/VertxDecorator.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/VertxDecorator.java
@@ -44,7 +44,7 @@ public class VertxDecorator
 
   @Override
   protected String method(final RoutingContext routingContext) {
-    return routingContext.request().rawMethod();
+    return routingContext.request().method().name();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/VertxDecorator.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/VertxDecorator.java
@@ -1,0 +1,131 @@
+package datadog.trace.instrumentation.vertx_4_0.server;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapterBase;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+
+public class VertxDecorator
+    extends HttpServerDecorator<RoutingContext, RoutingContext, HttpServerResponse, Void> {
+  static final CharSequence INSTRUMENTATION_NAME = UTF8BytesString.create("vertx.route-handler");
+
+  private static final CharSequence COMPONENT_NAME = UTF8BytesString.create("vertx");
+
+  static final VertxDecorator DECORATE = new VertxDecorator();
+
+  @Override
+  protected String[] instrumentationNames() {
+    return new String[] {INSTRUMENTATION_NAME.toString()};
+  }
+
+  @Override
+  protected CharSequence component() {
+    return COMPONENT_NAME;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<Void> getter() {
+    return null;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<HttpServerResponse> responseGetter() {
+    return null;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return INSTRUMENTATION_NAME;
+  }
+
+  @Override
+  protected String method(final RoutingContext routingContext) {
+    return routingContext.request().rawMethod();
+  }
+
+  @Override
+  protected URIDataAdapter url(final RoutingContext routingContext) {
+    return new VertxURIDataAdapter(routingContext);
+  }
+
+  @Override
+  public AgentSpan onRequest(
+      final AgentSpan span,
+      final RoutingContext connection,
+      final RoutingContext routingContext,
+      AgentSpan.Context.Extracted context) {
+    return span;
+  }
+
+  @Override
+  protected String peerHostIP(final RoutingContext routingContext) {
+    return routingContext.request().connection().remoteAddress().host();
+  }
+
+  @Override
+  protected int peerPort(final RoutingContext routingContext) {
+    return routingContext.request().connection().remoteAddress().port();
+  }
+
+  @Override
+  protected int status(final HttpServerResponse httpServerResponse) {
+    return httpServerResponse.getStatusCode();
+  }
+
+  protected static final class VertxURIDataAdapter extends URIDataAdapterBase {
+    private final RoutingContext routingContext;
+
+    public VertxURIDataAdapter(final RoutingContext routingContext) {
+      this.routingContext = routingContext;
+    }
+
+    @Override
+    public String scheme() {
+      return routingContext.request().scheme();
+    }
+
+    @Override
+    public String host() {
+      return routingContext.request().host();
+    }
+
+    @Override
+    public int port() {
+      return routingContext.request().localAddress().port();
+    }
+
+    @Override
+    public String path() {
+      return routingContext.request().path();
+    }
+
+    @Override
+    public String fragment() {
+      return null;
+    }
+
+    @Override
+    public String query() {
+      return routingContext.request().query();
+    }
+
+    @Override
+    public boolean supportsRaw() {
+      return false;
+    }
+
+    @Override
+    public String rawPath() {
+      return null;
+    }
+
+    @Override
+    public String rawQuery() {
+      return null;
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/client/VertxHttpClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/client/VertxHttpClientForkedTest.groovy
@@ -41,7 +41,7 @@ class VertxHttpClientForkedTest extends HttpClientTest {
     httpClient.request(HttpMethod.valueOf(method), uri.port, uri.host, "$uri", { requestReadyToBeSend ->
       def request = requestReadyToBeSend.result()
       headers.each { request.putHeader(it.key, it.value) }
-      request.send({ response ->
+      request.send(body, { response ->
         try {
           callback?.call()
           future.complete(response.result())

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/client/VertxHttpClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/client/VertxHttpClientForkedTest.groovy
@@ -1,0 +1,76 @@
+package client
+
+import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
+import io.vertx.core.Vertx
+import io.vertx.core.VertxOptions
+import io.vertx.core.http.HttpClientOptions
+import io.vertx.core.http.HttpClientResponse
+import io.vertx.core.http.HttpMethod
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+
+class VertxHttpClientForkedTest extends HttpClientTest {
+
+  @Override
+  boolean useStrictTraceWrites() {
+    return false
+  }
+
+  @AutoCleanup
+  @Shared
+  def vertx = Vertx.vertx(new VertxOptions())
+
+  @Shared
+  def clientOptions = new HttpClientOptions().setConnectTimeout(CONNECT_TIMEOUT_MS).setIdleTimeout(READ_TIMEOUT_MS)
+
+  @AutoCleanup
+  @Shared
+  def httpClient = vertx.createHttpClient(clientOptions)
+
+  @Override
+  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+    CompletableFuture<HttpClientResponse> future = new CompletableFuture<>()
+    def request = httpClient.request(HttpMethod.valueOf(method), uri.port, uri.host, "$uri")
+    headers.each { request.putHeader(it.key, it.value) }
+    request.handler { response ->
+      try {
+        callback?.call()
+        future.complete(response)
+      } catch (Exception e) {
+        future.completeExceptionally(e)
+      }
+    }
+    request.end()
+
+    return future.get(10, TimeUnit.SECONDS).statusCode()
+  }
+
+  @Override
+  CharSequence component() {
+    return NettyHttpClientDecorator.DECORATE.component()
+  }
+
+  @Override
+  String expectedOperationName() {
+    return "netty.client.request"
+  }
+
+  @Override
+  boolean testRedirects() {
+    false
+  }
+
+  @Override
+  boolean testConnectionFailure() {
+    false
+  }
+
+  boolean testRemoteConnection() {
+    // FIXME: figure out how to configure timeouts.
+    false
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -37,10 +37,9 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
 
     @Override
     void start() {
-      server = Vertx.vertx(new VertxOptions()
-        // Useful for debugging:
-        // .setBlockedThreadCheckInterval(Integer.MAX_VALUE)
-        .setClusterPort(0))
+      server = Vertx.vertx()
+
+      port = 1242
       final CompletableFuture<Void> future = new CompletableFuture<>()
       server.deployVerticle(verticle().name,
         new DeploymentOptions()
@@ -52,7 +51,6 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
           future.complete(null)
         }
       future.get()
-      port = server.sharedHttpServers().values().first().actualPort()
     }
 
     @Override

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -40,10 +40,10 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
 
       final CompletableFuture<Void> future = new CompletableFuture<>()
       server.eventBus().localConsumer("PORT_DATA")
-        .handler({ message -> 
-          port = message.body();
-          message.reply(null);
-          future.complete(null);
+        .handler({ message ->
+          port = message.body()
+          message.reply(null)
+          future.complete(null)
         })
 
       server.deployVerticle(verticle().name,
@@ -53,7 +53,7 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
           if (!res.succeeded()) {
             throw new RuntimeException("Cannot deploy server Verticle", res.cause())
           }
-      }
+        }
       future.get()
     }
 

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -10,26 +10,19 @@ import datadog.trace.instrumentation.vertx_4_0.server.VertxDecorator
 import io.vertx.core.AbstractVerticle
 import io.vertx.core.DeploymentOptions
 import io.vertx.core.Vertx
-import io.vertx.core.VertxOptions
 import io.vertx.core.impl.VertxInternal
 import io.vertx.core.json.JsonObject
 
 import java.util.concurrent.CompletableFuture
 
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.LOGIN
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static server.VertxTestServer.CONFIG_HTTP_SERVER_PORT
 
 class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
 
   private class VertxServer implements HttpServer {
     private VertxInternal server
-    private int port = 0
     private String routerBasePath
+    private port = 12420
 
     VertxServer(String routerBasePath) {
       this.routerBasePath = routerBasePath
@@ -39,7 +32,6 @@ class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
     void start() {
       server = Vertx.vertx()
 
-      port = 1242
       final CompletableFuture<Void> future = new CompletableFuture<>()
       server.deployVerticle(verticle().name,
         new DeploymentOptions()

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -15,6 +15,12 @@ import io.vertx.core.json.JsonObject
 
 import java.util.concurrent.CompletableFuture
 
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.LOGIN
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static server.VertxTestServer.CONFIG_HTTP_SERVER_PORT
 
 class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -1,0 +1,180 @@
+package server
+
+import datadog.trace.agent.test.asserts.TraceAssert
+import datadog.trace.agent.test.base.HttpServer
+import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.api.DDSpanTypes
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.instrumentation.netty41.server.NettyHttpServerDecorator
+import datadog.trace.instrumentation.vertx_4_0.server.VertxDecorator
+import io.vertx.core.AbstractVerticle
+import io.vertx.core.DeploymentOptions
+import io.vertx.core.Vertx
+import io.vertx.core.VertxOptions
+import io.vertx.core.impl.VertxInternal
+import io.vertx.core.json.JsonObject
+
+import java.util.concurrent.CompletableFuture
+
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.LOGIN
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static server.VertxTestServer.CONFIG_HTTP_SERVER_PORT
+
+class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
+
+  private class VertxServer implements HttpServer {
+    private VertxInternal server
+    private int port = 0
+    private String routerBasePath
+
+    VertxServer(String routerBasePath) {
+      this.routerBasePath = routerBasePath
+    }
+
+    @Override
+    void start() {
+      server = Vertx.vertx(new VertxOptions()
+        // Useful for debugging:
+        // .setBlockedThreadCheckInterval(Integer.MAX_VALUE)
+        .setClusterPort(0))
+      final CompletableFuture<Void> future = new CompletableFuture<>()
+      server.deployVerticle(verticle().name,
+        new DeploymentOptions()
+        .setConfig(new JsonObject().put(CONFIG_HTTP_SERVER_PORT, port))
+        .setInstances(1)) { res ->
+          if (!res.succeeded()) {
+            throw new RuntimeException("Cannot deploy server Verticle", res.cause())
+          }
+          future.complete(null)
+        }
+      future.get()
+      port = server.sharedHttpServers().values().first().actualPort()
+    }
+
+    @Override
+    void stop() {
+      server.close()
+    }
+
+    @Override
+    URI address() {
+      return new URI("http://localhost:$port$routerBasePath")
+    }
+  }
+
+  @Override
+  HttpServer server() {
+    return new VertxServer(routerBasePath())
+  }
+
+  protected Class<AbstractVerticle> verticle() {
+    VertxTestServer
+  }
+
+  String routerBasePath() {
+    return "/"
+  }
+
+  @Override
+  String component() {
+    return NettyHttpServerDecorator.DECORATE.component()
+  }
+
+  @Override
+  String expectedOperationName() {
+    "netty.request"
+  }
+
+  @Override
+  String testPathParam() {
+    routerBasePath() + "path/:id/param"
+  }
+
+  @Override
+  boolean testExceptionBody() {
+    // Vertx wraps the exception
+    false
+  }
+
+  @Override
+  Map<String, ?> expectedIGPathParams() {
+    [id: '123']
+  }
+
+  @Override
+  boolean testBodyUrlencoded() {
+    true
+  }
+
+  @Override
+  boolean testBodyJson() {
+    true
+  }
+
+  @Override
+  Class<? extends Exception> expectedExceptionType() {
+    return RuntimeException
+  }
+
+  boolean testExceptionTag() {
+    true
+  }
+
+  @Override
+  boolean hasDecodedResource() {
+    return false
+  }
+
+  @Override
+  int spanCount(ServerEndpoint endpoint) {
+    if (endpoint == NOT_FOUND) {
+      return super.spanCount(endpoint) - 1
+    }
+    return super.spanCount(endpoint)
+  }
+
+  @Override
+  boolean hasHandlerSpan() {
+    true
+  }
+
+  @Override
+  Serializable expectedServerSpanRoute(ServerEndpoint endpoint) {
+    switch (endpoint) {
+      case LOGIN:
+      case NOT_FOUND:
+        return null
+      case PATH_PARAM:
+        return testPathParam()
+      default:
+        return routerBasePath() + endpoint.relativePath()
+    }
+  }
+
+  @Override
+  void handlerSpan(TraceAssert trace, ServerEndpoint endpoint = SUCCESS) {
+    if (endpoint == NOT_FOUND) {
+      return
+    }
+    trace.span {
+      serviceName expectedServiceName()
+      operationName "vertx.route-handler"
+      spanType DDSpanTypes.HTTP_SERVER
+      errored endpoint == ERROR || endpoint == EXCEPTION
+      childOfPrevious()
+      tags {
+        "$Tags.COMPONENT" VertxDecorator.DECORATE.component()
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        "$Tags.HTTP_STATUS" Integer
+        if (endpoint == EXCEPTION && this.testExceptionTag()) {
+          errorTags(RuntimeException, EXCEPTION.body)
+        }
+        defaultTags()
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/server/VertxMiddlewareHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/server/VertxMiddlewareHttpServerForkedTest.groovy
@@ -1,0 +1,44 @@
+package server
+
+import datadog.trace.agent.test.asserts.TraceAssert
+import datadog.trace.api.DDSpanTypes
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.instrumentation.vertx_4_0.server.VertxDecorator
+import io.vertx.core.AbstractVerticle
+
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+
+class VertxMiddlewareHttpServerForkedTest extends VertxHttpServerForkedTest {
+  @Override
+  protected Class<AbstractVerticle> verticle() {
+    VertxMiddlewareTestServer
+  }
+
+  @Override
+  int spanCount(ServerEndpoint endpoint) {
+    return 2 + (hasHandlerSpan() ? 1 : 0) + (hasResponseSpan(endpoint) ? 1 : 0)
+  }
+
+  @Override
+  void handlerSpan(TraceAssert trace, ServerEndpoint endpoint = SUCCESS) {
+    trace.span {
+      serviceName expectedServiceName()
+      operationName "vertx.route-handler"
+      spanType DDSpanTypes.HTTP_SERVER
+      errored endpoint == ERROR || endpoint == EXCEPTION
+      childOfPrevious()
+      tags {
+        "$Tags.COMPONENT" VertxDecorator.DECORATE.component()
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        "$Tags.HTTP_STATUS" Integer
+        "before" true
+        if (endpoint == EXCEPTION && this.testExceptionTag()) {
+          errorTags(RuntimeException, EXCEPTION.body)
+        }
+        defaultTags()
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/server/VertxSubrouterForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/server/VertxSubrouterForkedTest.groovy
@@ -1,0 +1,16 @@
+package server
+
+
+import io.vertx.core.AbstractVerticle
+
+class VertxSubrouterForkedTest extends VertxHttpServerForkedTest {
+  @Override
+  protected Class<AbstractVerticle> verticle() {
+    VertxSubrouterTestServer
+  }
+
+  @Override
+  String routerBasePath() {
+    return "/sub/"
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/java/server/VertxMiddlewareTestServer.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/java/server/VertxMiddlewareTestServer.java
@@ -1,0 +1,17 @@
+package server;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+public class VertxMiddlewareTestServer extends VertxTestServer {
+  @Override
+  protected void customizeBeforeRoutes(Router router) {
+    router.route().handler(VertxMiddlewareTestServer::firstHandler);
+  }
+
+  private static void firstHandler(final RoutingContext ctx) {
+    AgentTracer.activeSpan().setTag("before", true);
+    ctx.next();
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/java/server/VertxSubrouterTestServer.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/java/server/VertxSubrouterTestServer.java
@@ -1,0 +1,12 @@
+package server;
+
+import io.vertx.ext.web.Router;
+
+public class VertxSubrouterTestServer extends VertxTestServer {
+  @Override
+  protected Router customizeAfterRoutes(Router configured) {
+    Router router = Router.router(vertx);
+    router.mountSubRouter("/sub/", configured);
+    return router;
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/java/server/VertxTestServer.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/java/server/VertxTestServer.java
@@ -1,0 +1,218 @@
+package server;
+
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_JSON;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_URLENCODED;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.CREATED;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_BOTH;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_QUERY;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.UNKNOWN;
+import static datadog.trace.agent.test.utils.TraceUtils.runnableUnderTraceAsync;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+
+import datadog.trace.agent.test.base.HttpServerTest;
+import datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+import io.vertx.core.MultiMap;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
+
+public class VertxTestServer extends AbstractVerticle {
+  public static final String CONFIG_HTTP_SERVER_PORT = "http.server.port";
+
+  @Override
+  public void start(final Future<Void> startFuture) {
+    final int port = config().getInteger(CONFIG_HTTP_SERVER_PORT);
+    Router router = Router.router(vertx);
+
+    customizeBeforeRoutes(router);
+
+    router
+        .route(SUCCESS.getPath())
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    SUCCESS,
+                    () ->
+                        ctx.response().setStatusCode(SUCCESS.getStatus()).end(SUCCESS.getBody())));
+    router
+        .route(FORWARDED.getPath())
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    FORWARDED,
+                    () ->
+                        ctx.response()
+                            .setStatusCode(FORWARDED.getStatus())
+                            .end(ctx.request().getHeader("x-forwarded-for"))));
+    router
+        .route(CREATED.getPath())
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    CREATED,
+                    () ->
+                        ctx.request()
+                            .bodyHandler(
+                                body ->
+                                    ctx.response()
+                                        .setStatusCode(CREATED.getStatus())
+                                        .end(CREATED.getBody() + ": " + body.toString()))));
+    router.route(BODY_URLENCODED.getPath()).handler(BodyHandler.create());
+    router
+        .route(BODY_URLENCODED.getPath())
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    BODY_URLENCODED,
+                    () -> {
+                      String res = "[";
+                      MultiMap entries = ctx.request().formAttributes();
+                      for (String name : entries.names()) {
+                        if (name.equals("ignore")) {
+                          continue;
+                        }
+                        if (res.length() > 1) {
+                          res += ", ";
+                        }
+                        res += name;
+                        res += ":[";
+                        int i = 0;
+                        for (String s : entries.getAll(name)) {
+                          if (i++ > 0) {
+                            res += ", ";
+                          }
+                          res += s;
+                        }
+                        res += ']';
+                      }
+                      res += ']';
+                      ctx.response().setStatusCode(BODY_URLENCODED.getStatus()).end(res);
+                    }));
+    router.route(BODY_JSON.getPath()).handler(BodyHandler.create());
+    router
+        .route(BODY_JSON.getPath())
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    BODY_JSON,
+                    () -> {
+                      JsonObject json = ctx.getBodyAsJson();
+                      ctx.response().setStatusCode(BODY_JSON.getStatus()).end(json.toString());
+                    }));
+    router
+        .route(QUERY_ENCODED_BOTH.getRawPath())
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    QUERY_ENCODED_BOTH,
+                    () ->
+                        ctx.response()
+                            .setStatusCode(QUERY_ENCODED_BOTH.getStatus())
+                            .end(QUERY_ENCODED_BOTH.bodyForQuery(ctx.request().query()))));
+    router
+        .route(QUERY_ENCODED_QUERY.getPath())
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    QUERY_ENCODED_QUERY,
+                    () ->
+                        ctx.response()
+                            .setStatusCode(QUERY_ENCODED_QUERY.getStatus())
+                            .end(QUERY_ENCODED_QUERY.bodyForQuery(ctx.request().query()))));
+    router
+        .route(QUERY_PARAM.getPath())
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    QUERY_PARAM,
+                    () ->
+                        ctx.response()
+                            .setStatusCode(QUERY_PARAM.getStatus())
+                            .end(ctx.request().query())));
+    router
+        .route("/path/:id/param")
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    PATH_PARAM,
+                    () ->
+                        ctx.response()
+                            .setStatusCode(PATH_PARAM.getStatus())
+                            .end(ctx.request().getParam("id"))));
+    router
+        .route(REDIRECT.getPath())
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    REDIRECT,
+                    () ->
+                        ctx.response()
+                            .setStatusCode(REDIRECT.getStatus())
+                            .putHeader("location", REDIRECT.getBody())
+                            .end()));
+    router
+        .route(ERROR.getPath())
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    ERROR,
+                    () -> ctx.response().setStatusCode(ERROR.getStatus()).end(ERROR.getBody())));
+    router
+        .route(EXCEPTION.getPath())
+        .handler(ctx -> controller(ctx, EXCEPTION, VertxTestServer::exception));
+
+    router = customizeAfterRoutes(router);
+
+    vertx
+        .createHttpServer()
+        .requestHandler(router::accept)
+        .listen(port, event -> startFuture.complete());
+  }
+
+  protected void customizeBeforeRoutes(Router router) {}
+
+  protected Router customizeAfterRoutes(final Router router) {
+    return router;
+  }
+
+  private static void exception() {
+    throw new RuntimeException(EXCEPTION.getBody());
+  }
+
+  private static void controller(
+      RoutingContext ctx, final ServerEndpoint endpoint, final Runnable runnable) {
+    assert activeSpan() != null : "Controller should have a parent span.";
+    assert activeScope().isAsyncPropagating() : "Scope should be propagating async.";
+    ctx.response()
+        .putHeader(
+            HttpServerTest.getIG_RESPONSE_HEADER(), HttpServerTest.getIG_RESPONSE_HEADER_VALUE());
+    if (endpoint == NOT_FOUND || endpoint == UNKNOWN) {
+      runnable.run();
+      return;
+    }
+    runnableUnderTraceAsync("controller", runnable);
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/java/server/VertxTestServer.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/java/server/VertxTestServer.java
@@ -187,17 +187,27 @@ public class VertxTestServer extends AbstractVerticle {
 
     router = customizeAfterRoutes(router);
 
-    vertx.createHttpServer().requestHandler(router).listen(port, event -> {
-      // send this though event bus and succed deploy after successfull response
-      int actualPort = event.result().actualPort();
-      vertx.eventBus().request(PORT_DATA_ADDRESS, actualPort, ar -> {
-        if (ar.succeeded()) {
-          startPromise.complete();
-        } else {
-          startPromise.fail(ar.cause());
-        }
-      });
-    });
+    vertx
+        .createHttpServer()
+        .requestHandler(router)
+        .listen(
+            port,
+            event -> {
+              // send this though event bus and succed deploy after successfull response
+              int actualPort = event.result().actualPort();
+              vertx
+                  .eventBus()
+                  .request(
+                      PORT_DATA_ADDRESS,
+                      actualPort,
+                      ar -> {
+                        if (ar.succeeded()) {
+                          startPromise.complete();
+                        } else {
+                          startPromise.fail(ar.cause());
+                        }
+                      });
+            });
   }
 
   protected void customizeBeforeRoutes(Router router) {}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/java/server/VertxTestServer.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/java/server/VertxTestServer.java
@@ -21,8 +21,8 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 import datadog.trace.agent.test.base.HttpServerTest;
 import datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint;
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
+import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
@@ -32,7 +32,7 @@ public class VertxTestServer extends AbstractVerticle {
   public static final String CONFIG_HTTP_SERVER_PORT = "http.server.port";
 
   @Override
-  public void start(final Future<Void> startFuture) {
+  public void start(final Promise<Void> startPromise) {
     final int port = config().getInteger(CONFIG_HTTP_SERVER_PORT);
     Router router = Router.router(vertx);
 
@@ -186,10 +186,7 @@ public class VertxTestServer extends AbstractVerticle {
 
     router = customizeAfterRoutes(router);
 
-    vertx
-        .createHttpServer()
-        .requestHandler(router::accept)
-        .listen(port, event -> startFuture.complete());
+    vertx.createHttpServer().requestHandler(router).listen(port, event -> startPromise.complete());
   }
 
   protected void customizeBeforeRoutes(Router router) {}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/vertx-web-4.0.gradle
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/vertx-web-4.0.gradle
@@ -39,8 +39,8 @@ dependencies {
   testImplementation project(':dd-java-agent:instrumentation:netty-4.1')
   testImplementation project(':dd-java-agent:instrumentation:trace-annotation')
 
-  testImplementation group: 'io.vertx', name: 'vertx-web', version: '4.2.7'
-  testImplementation group: 'io.vertx', name: 'vertx-web-client', version: '4.2.7'
+  testImplementation group: 'io.vertx', name: 'vertx-web', version: '4.0.0'
+  testImplementation group: 'io.vertx', name: 'vertx-web-client', version: '4.0.0'
 
   latestDepTestImplementation group: 'io.vertx', name: 'vertx-web', version: '4.+'
   latestDepTestImplementation group: 'io.vertx', name: 'vertx-web-client', version: '4.+'

--- a/dd-java-agent/instrumentation/vertx-web-4.0/vertx-web-4.0.gradle
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/vertx-web-4.0.gradle
@@ -1,0 +1,47 @@
+// Set properties before any plugins get loaded
+ext {
+  minJavaVersionForTests = JavaVersion.VERSION_1_8
+  // TODO Java 17: This version of vertx-web doesn't support Java 17
+  maxJavaVersionForTests = JavaVersion.VERSION_15
+}
+
+apply from: "$rootDir/gradle/java.gradle"
+
+apply plugin: 'org.unbroken-dome.test-sets'
+
+muzzle {
+  pass {
+    group = 'io.vertx'
+    module = "vertx-web"
+    versions = "[4.0.0,5)"
+    assertInverse = true
+  }
+}
+
+testSets {
+  latestDepTest {
+    dirName = 'test'
+  }
+}
+
+configurations {
+  testArtifacts
+}
+
+// Create test artifacts so vertx-rx can reuse the server test instrumentation and base class
+artifacts {
+  testArtifacts testJar
+}
+
+dependencies {
+  main_java8CompileOnly group: 'io.vertx', name: 'vertx-web', version: '4.2.7'
+
+  testImplementation project(':dd-java-agent:instrumentation:netty-4.1')
+  testImplementation project(':dd-java-agent:instrumentation:trace-annotation')
+
+  testImplementation group: 'io.vertx', name: 'vertx-web', version: '4.2.7'
+  testImplementation group: 'io.vertx', name: 'vertx-web-client', version: '4.2.7'
+
+  latestDepTestImplementation group: 'io.vertx', name: 'vertx-web', version: '4.+'
+  latestDepTestImplementation group: 'io.vertx', name: 'vertx-web-client', version: '4.+'
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -287,6 +287,7 @@ include ':dd-java-agent:instrumentation:vertx-redis-client-3.9'
 include ':dd-java-agent:instrumentation:vertx-redis-client-3.9:stubs'
 include ':dd-java-agent:instrumentation:vertx-rx-3.5'
 include ':dd-java-agent:instrumentation:vertx-web-3.4'
+include ':dd-java-agent:instrumentation:vertx-web-4.0'
 include ':dd-java-agent:instrumentation:redisson-2.0.0'
 
 // benchmark


### PR DESCRIPTION
# What Does This Do
- providing support for Vert.x web 4
- Vert.x HttpServerResponseImpl class was replaced between versions 3 and 4. Reflect changes in instrumentation.
- Migrate other parts of code to Vert.x 4
- Migrate all Vert.x 3 tests to 4.

# Motivation
- provide instrumentation for Vert.x 4 (currently broken)

# Additional Notes / open questions
- main instrumentation related change is in `HttpServerResponseEndHandlerInstrumentation` class when the change in underlying Vert.x classes is reflected
- some test fails currently: 
```
./gradlew :dd-java-agent:instrumentation:vertx-web-4.0:test
136 tests completed, 90 failed, 23 skipped
```
- What is a minimal test suite to get this merged? I couldn't really see from run of Vert.x vertx-3.4 tests what is the number of successful tests there as the final output doesn't provide this (the immediate step before the success message is showing around 130). But some constructs seem suspicious for Vert.x 3 test suite (fe. setting Vert.x clustering port for local test server - but maybe I'm lacking some internal Vert.x knowledge, why this is there)

