### PR TITLE
Limit TestNG muzzle range because TestNG 7.6+ is compiled with Java 11

### DIFF
--- a/dd-java-agent/instrumentation/testng-6.4/testng-6.4.gradle
+++ b/dd-java-agent/instrumentation/testng-6.4/testng-6.4.gradle
@@ -1,10 +1,14 @@
 apply from: "$rootDir/gradle/java.gradle"
 
 muzzle {
+  /**
+   * TestNG 7.6+ passes if muzzle is run with Java 11 but fails otherwise because it
+   * is compiled with Java 11, so we can't validate with muzzle which uses Java 8.
+   */
   pass {
     group = 'org.testng'
     module = 'testng'
-    versions = '[6.4,)'
+    versions = '[6.4,7.6)'
   }
 }
 


### PR DESCRIPTION
... so we can't validate with muzzle which uses Java 8.

This follows the example set in https://github.com/DataDog/dd-trace-java/commit/8a8771cb044#diff-86fe7e2d35e228e4efdb21811bca4dce7fe6d8e2e430ef619117e32ce7ba5c5eR3 - long term we should look at how to run Muzzle to allow matching against a wider range of JDK versions.