### PR TITLE
Change synapse server operation name to match other servers

### DIFF
--- a/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerDecorator.java
+++ b/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerDecorator.java
@@ -20,7 +20,7 @@ public final class SynapseServerDecorator
     extends HttpServerDecorator<HttpRequest, NHttpConnection, HttpResponse, HttpRequest> {
   public static final SynapseServerDecorator DECORATE = new SynapseServerDecorator();
 
-  public static final CharSequence SYNAPSE_REQUEST = UTF8BytesString.create("http.request");
+  public static final CharSequence SYNAPSE_REQUEST = UTF8BytesString.create("synapse.request");
   public static final CharSequence SYNAPSE_SERVER = UTF8BytesString.create("synapse-server");
 
   public static final String SYNAPSE_SPAN_KEY = "dd.trace.synapse.span";

--- a/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerDecorator.java
+++ b/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerDecorator.java
@@ -5,6 +5,7 @@ import static datadog.trace.api.cache.RadixTreeCache.UNSET_STATUS;
 import static datadog.trace.instrumentation.synapse3.ExtractAdapter.Request;
 import static datadog.trace.instrumentation.synapse3.ExtractAdapter.Response;
 
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.URIDefaultDataAdapter;
@@ -21,6 +22,7 @@ public final class SynapseServerDecorator
   public static final SynapseServerDecorator DECORATE = new SynapseServerDecorator();
 
   public static final CharSequence SYNAPSE_REQUEST = UTF8BytesString.create("synapse.request");
+  public static final CharSequence LEGACY_SYNAPSE_REQUEST = UTF8BytesString.create("http.request");
   public static final CharSequence SYNAPSE_SERVER = UTF8BytesString.create("synapse-server");
 
   public static final String SYNAPSE_SPAN_KEY = "dd.trace.synapse.span";
@@ -48,6 +50,9 @@ public final class SynapseServerDecorator
 
   @Override
   public CharSequence spanName() {
+    if (Config.get().isIntegrationSynapseLegacyOperationName()) {
+      return LEGACY_SYNAPSE_REQUEST;
+    }
     return SYNAPSE_REQUEST;
   }
 

--- a/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerInstrumentation.java
@@ -5,7 +5,6 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOn
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.synapse3.SynapseServerDecorator.DECORATE;
-import static datadog.trace.instrumentation.synapse3.SynapseServerDecorator.SYNAPSE_REQUEST;
 import static datadog.trace.instrumentation.synapse3.SynapseServerDecorator.SYNAPSE_SPAN_KEY;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -73,7 +72,7 @@ public final class SynapseServerInstrumentation extends Instrumenter.Tracing
       if (null != extractedContext) {
         span = DECORATE.startSpan(request, extractedContext);
       } else {
-        span = startSpan(SYNAPSE_REQUEST);
+        span = startSpan(DECORATE.spanName());
         span.setMeasured(true);
       }
       DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/synapse-3/src/test/groovy/datadog/trace/instrumentation/synapse3/SynapseTest.groovy
+++ b/dd-java-agent/instrumentation/synapse-3/src/test/groovy/datadog/trace/instrumentation/synapse3/SynapseTest.groovy
@@ -122,6 +122,26 @@ class SynapseTest extends AgentTestRunner {
     statusCode == 200
   }
 
+  def "test plain request is traced with legacy operation name"() {
+    setup:
+    injectSysConfig("integration.synapse.legacy-operation-name", "true")
+    def request = new Request.Builder()
+      .url("http://127.0.0.1:${port}/services/SimpleStockQuoteService?wsdl")
+      .get()
+      .build()
+
+    when:
+    int statusCode = client.newCall(request).execute().code()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        serverSpan(it, 0, 'GET', statusCode, null, false, true)
+      }
+    }
+    statusCode == 200
+  }
+
   def "test passthru request is traced"() {
     setup:
     def request = new Request.Builder()
@@ -203,10 +223,10 @@ class SynapseTest extends AgentTestRunner {
     statusCode == 200
   }
 
-  def serverSpan(TraceAssert trace, int index, String method, int statusCode, Object parentSpan = null, boolean distributedRootSpan = false) {
+  def serverSpan(TraceAssert trace, int index, String method, int statusCode, Object parentSpan = null, boolean distributedRootSpan = false, boolean legacyOperationName = false) {
     trace.span {
       serviceName expectedServiceName()
-      operationName "synapse.request"
+      operationName legacyOperationName ? "http.request" : "synapse.request"
       resourceName "${method} /services/SimpleStockQuoteService"
       spanType DDSpanTypes.HTTP_SERVER
       errored statusCode >= 500

--- a/dd-java-agent/instrumentation/synapse-3/src/test/groovy/datadog/trace/instrumentation/synapse3/SynapseTest.groovy
+++ b/dd-java-agent/instrumentation/synapse-3/src/test/groovy/datadog/trace/instrumentation/synapse3/SynapseTest.groovy
@@ -206,7 +206,7 @@ class SynapseTest extends AgentTestRunner {
   def serverSpan(TraceAssert trace, int index, String method, int statusCode, Object parentSpan = null, boolean distributedRootSpan = false) {
     trace.span {
       serviceName expectedServiceName()
-      operationName "http.request"
+      operationName "synapse.request"
       resourceName "${method} /services/SimpleStockQuoteService"
       spanType DDSpanTypes.HTTP_SERVER
       errored statusCode >= 500
@@ -232,7 +232,7 @@ class SynapseTest extends AgentTestRunner {
   def proxySpan(TraceAssert trace, int index, String method, int statusCode, Object parentSpan = null) {
     trace.span {
       serviceName expectedServiceName()
-      operationName "http.request"
+      operationName "synapse.request"
       resourceName "${method} /services/StockQuoteProxy"
       spanType DDSpanTypes.HTTP_SERVER
       errored statusCode >= 500

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -12,6 +12,8 @@ public final class TraceInstrumentationConfig {
   public static final String TRACE_ENABLED = "trace.enabled";
   public static final String INTEGRATIONS_ENABLED = "integrations.enabled";
 
+  public static final String INTEGRATION_SYNAPSE_LEGACY_OPERATION_NAME =
+      "integration.synapse.legacy-operation-name";
   public static final String TRACE_ANNOTATIONS = "trace.annotations";
   public static final String TRACE_EXECUTORS_ALL = "trace.executors.all";
   public static final String TRACE_EXECUTORS = "trace.executors";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -202,6 +202,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.HYSTRIX_MEASUR
 import static datadog.trace.api.config.TraceInstrumentationConfig.HYSTRIX_TAGS_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.IGNITE_CACHE_INCLUDE_KEYS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.INTEGRATIONS_ENABLED;
+import static datadog.trace.api.config.TraceInstrumentationConfig.INTEGRATION_SYNAPSE_LEGACY_OPERATION_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_CONNECTION_CLASS_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_PREPARED_STATEMENT_CLASS_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JMS_PROPAGATION_DISABLED_QUEUES;
@@ -353,6 +354,7 @@ public class Config {
   private final String rootContextServiceName;
   private final boolean traceEnabled;
   private final boolean integrationsEnabled;
+  private final boolean integrationSynapseLegacyOperationName;
   private final String writerType;
   private final boolean agentConfiguredUsingDefault;
   private final String agentUrl;
@@ -619,6 +621,8 @@ public class Config {
     traceEnabled = configProvider.getBoolean(TRACE_ENABLED, DEFAULT_TRACE_ENABLED);
     integrationsEnabled =
         configProvider.getBoolean(INTEGRATIONS_ENABLED, DEFAULT_INTEGRATIONS_ENABLED);
+    integrationSynapseLegacyOperationName =
+        configProvider.getBoolean(INTEGRATION_SYNAPSE_LEGACY_OPERATION_NAME, false);
     writerType = configProvider.getString(WRITER_TYPE, DEFAULT_AGENT_WRITER_TYPE);
 
     idGenerationStrategy =
@@ -1198,6 +1202,10 @@ public class Config {
 
   public boolean isIntegrationsEnabled() {
     return integrationsEnabled;
+  }
+
+  public boolean isIntegrationSynapseLegacyOperationName() {
+    return integrationSynapseLegacyOperationName;
   }
 
   public String getWriterType() {
@@ -2441,6 +2449,8 @@ public class Config {
         + traceEnabled
         + ", integrationsEnabled="
         + integrationsEnabled
+        + ", integrationSynapseLegacyOperationName="
+        + integrationSynapseLegacyOperationName
         + ", writerType='"
         + writerType
         + '\''


### PR DESCRIPTION
# What Does This Do

Changes the synapse server operation name to match the patterns for other servers. Adds a config to revert to the previous behavior.
