### PR TITLE
Support span activation intervals size limit

### DIFF
--- a/dd-java-agent/agent-profiling/agent-profiling.gradle
+++ b/dd-java-agent/agent-profiling/agent-profiling.gradle
@@ -46,6 +46,18 @@ shadowJar {
     exclude(project(':utils:time-utils'))
     exclude(dependency('org.slf4j::'))
   }
+  exclude {
+    if (it.path.startsWith('org/jctools/')) {
+      def ret = true
+      if (it.path.equals('org/jctools/util') || it.path.equals('org/jctools/maps')) {
+        ret = false
+      } else {
+        ret = !(it.path.contains('/util') || it.path.contains('AbstractEntry') || it.path.contains('ConcurrentAutoTable') || it.path.contains('NonBlockingHashMap'))
+      }
+      return ret
+    }
+    return false
+  }
 }
 
 jar {

--- a/dd-java-agent/agent-profiling/profiling-context/profiling-context.gradle
+++ b/dd-java-agent/agent-profiling/profiling-context/profiling-context.gradle
@@ -26,6 +26,7 @@ dependencies {
   implementation deps.slf4j
   main_java11CompileOnly deps.slf4j
   implementation sourceSets.main_java11.output
+  implementation group: 'org.jctools', name: 'jctools-core', version: '3.3.0'
 
   testImplementation deps.junit5
   testImplementation deps.mockito

--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/LongSequence.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/LongSequence.java
@@ -1,6 +1,7 @@
 package com.datadog.profiling.context;
 
 import com.datadog.profiling.context.allocator.AllocatedBuffer;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,7 +61,7 @@ final class LongSequence {
   private int[] bufferBoundaryMap = new int[10];
 
   private int bufferInitSlot = 0;
-  private int bufferWriteSlot = 0;
+  private int bufferWriteSlot = -1;
   private int capacity = 0;
   private int capacityInChunks = 0;
   private int size = 0;
@@ -74,18 +75,34 @@ final class LongSequence {
   }
 
   private AtomicInteger state = new AtomicInteger(0);
+  private final int limit;
 
   public LongSequence(Allocator allocator) {
+    this(allocator, Integer.MAX_VALUE);
+  }
+
+  public LongSequence(Allocator allocator, int limit) {
     this.allocator = allocator;
+    this.limit = limit;
     this.bufferWriteSlot = -1;
+    Arrays.fill(bufferBoundaryMap, Integer.MAX_VALUE);
   }
 
   public int add(long value) {
+    return add(value, true);
+  }
+
+  public int add(long value, boolean obeyLimit) {
     // check'n'update the state - if it is non-negative, increment the counter and proceed,
     // otherwise bail out
     if (state.updateAndGet(prev -> prev >= 0 ? prev + 1 : prev) < 0) {
       // bail out if this instance was already released
       return -1;
+    }
+
+    if (obeyLimit && sizeInBytes > limit) {
+      // hit the sequence bytes limit; bail out
+      return -2;
     }
 
     try {
@@ -105,23 +122,29 @@ final class LongSequence {
           threshold = -1;
         }
       } else {
+        if (bufferWriteSlot == buffers.length || buffers[bufferWriteSlot] == null) {
+          return 0;
+        }
         if (threshold > -1 && sizeInBytes == threshold) {
-          // we hit the threshold - let's prepare the next-in-line buffer
-          int newCapacity = 2 * capacityInChunks; // capacity stays aligned
-          AllocatedBuffer cBuffer = allocator.allocateChunks(newCapacity);
-          if (cBuffer != null) {
-            bufferInitSlot = bufferWriteSlot + 1;
-            buffers[bufferInitSlot] = cBuffer;
-            capacityInChunks += newCapacity;
-            capacity += cBuffer.capacity(); // update the sequence capacity
-            threshold = align((int) (capacity * 0.75f)); // update the threshold
-            bufferBoundaryMap[bufferInitSlot] = capacity - 1;
-          } else {
-            threshold = -1;
+          // we hit the threshold - let's prepare the next-in-line buffer if it can be done without
+          // breaking the limit
+          if (bufferWriteSlot < buffers.length - 1) {
+            int newCapacity = 2 * capacityInChunks; // capacity stays aligned
+            AllocatedBuffer cBuffer = allocator.allocateChunks(newCapacity);
+            if (cBuffer != null) {
+              bufferInitSlot = bufferWriteSlot + 1;
+              buffers[bufferInitSlot] = cBuffer;
+              capacityInChunks += newCapacity;
+              capacity += cBuffer.capacity(); // update the sequence capacity
+              threshold = align((int) (capacity * 0.75f)); // update the threshold
+              bufferBoundaryMap[bufferInitSlot] = capacity - 1;
+            } else {
+              threshold = -1;
+            }
           }
         }
       }
-      if (bufferWriteSlot == buffers.length || buffers[bufferWriteSlot] == null) {
+      if (buffers[bufferWriteSlot] == null) {
         return 0;
       }
       while (!buffers[bufferWriteSlot].putLong(value)) {
@@ -154,7 +177,11 @@ final class LongSequence {
       PositionDecoder.Coordinates decoded =
           positionDecoder.decode(index * 8, bufferBoundaryMap, bufferInitSlot + 1);
       if (decoded != null) {
-        return buffers[decoded.slot].putLong(decoded.index, value);
+        if (decoded.slot >= buffers.length) {
+          return false;
+        }
+        AllocatedBuffer buffer = buffers[decoded.slot];
+        return buffer != null && buffer.putLong(decoded.index, value);
       }
       return false;
     } finally {
@@ -177,7 +204,11 @@ final class LongSequence {
       PositionDecoder.Coordinates decoded =
           positionDecoder.decode(index * 8, bufferBoundaryMap, bufferInitSlot + 1);
       if (decoded != null) {
-        return buffers[decoded.slot].getLong(decoded.index);
+        if (decoded.slot >= buffers.length) {
+          return Long.MIN_VALUE;
+        }
+        AllocatedBuffer buffer = buffers[decoded.slot];
+        return buffer != null ? buffer.getLong(decoded.index) : Long.MIN_VALUE;
       }
       return Long.MIN_VALUE;
     } finally {
@@ -198,6 +229,24 @@ final class LongSequence {
     }
     try {
       return size;
+    } finally {
+      // check'n'update the state - if it is negative before update, perform release, otherwise just
+      // decrement the counter
+      if (state.getAndUpdate(prev -> prev > 0 ? prev - 1 : prev) < 0) {
+        doRelease();
+      }
+    }
+  }
+
+  public int sizeInBytes() {
+    // check'n'update the state - if it is non-negative, increment the counter and proceed,
+    // otherwise bail out
+    if (state.updateAndGet(prev -> prev >= 0 ? prev + 1 : prev) < 0) {
+      // bail out if this instance was already released
+      return 0;
+    }
+    try {
+      return sizeInBytes;
     } finally {
       // check'n'update the state - if it is negative before update, perform release, otherwise just
       // decrement the counter

--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/LongSequence.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/LongSequence.java
@@ -281,4 +281,8 @@ final class LongSequence {
   public LongIterator iterator() {
     return new LongIteratorImpl();
   }
+
+  public int getCapacity() {
+    return capacity;
+  }
 }

--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/LongSequence.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/LongSequence.java
@@ -221,39 +221,11 @@ final class LongSequence {
   }
 
   public int size() {
-    // check'n'update the state - if it is non-negative, increment the counter and proceed,
-    // otherwise bail out
-    if (state.updateAndGet(prev -> prev >= 0 ? prev + 1 : prev) < 0) {
-      // bail out if this instance was already released
-      return 0;
-    }
-    try {
-      return size;
-    } finally {
-      // check'n'update the state - if it is negative before update, perform release, otherwise just
-      // decrement the counter
-      if (state.getAndUpdate(prev -> prev > 0 ? prev - 1 : prev) < 0) {
-        doRelease();
-      }
-    }
+    return size;
   }
 
   public int sizeInBytes() {
-    // check'n'update the state - if it is non-negative, increment the counter and proceed,
-    // otherwise bail out
-    if (state.updateAndGet(prev -> prev >= 0 ? prev + 1 : prev) < 0) {
-      // bail out if this instance was already released
-      return 0;
-    }
-    try {
-      return sizeInBytes;
-    } finally {
-      // check'n'update the state - if it is negative before update, perform release, otherwise just
-      // decrement the counter
-      if (state.getAndUpdate(prev -> prev > 0 ? prev - 1 : prev) < 0) {
-        doRelease();
-      }
-    }
+    return sizeInBytes;
   }
 
   public void release() {
@@ -274,7 +246,6 @@ final class LongSequence {
     buffers = null;
     bufferBoundaryMap = null;
     bufferInitSlot = -1;
-    size = 0;
     state.set(-1);
   }
 

--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/PositionDecoder.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/PositionDecoder.java
@@ -32,6 +32,11 @@ public final class PositionDecoder {
     public int hashCode() {
       return Objects.hash(slot, index);
     }
+
+    @Override
+    public String toString() {
+      return "Coordinates{" + "slot=" + slot + ", index=" + index + '}';
+    }
   }
 
   private static final class Singleton {
@@ -60,7 +65,7 @@ public final class PositionDecoder {
    *
    * @param position the position
    * @param bufferBoundaryMap an array of buffer boundaries - a boundary is defined as 'size - 1'
-   *     for each buffer element
+   *     for each buffer element; unused slots must have boundary of {@linkplain Integer#MAX_VALUE}
    * @param bufferBoundaryMapLimit limit the buffer boundaries to be used only to the first
    *     {@literal bufferBoundaryMapLimit} ones
    * @return decoded {@linkplain Coordinates} or {@literal null}

--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/ProfilerTracingContextTracker.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/ProfilerTracingContextTracker.java
@@ -247,6 +247,7 @@ public final class ProfilerTracingContextTracker implements TracingContextTracke
     storeDelayedActivation();
     long tsDiff = timestamp - startTimestampTicks;
     long masked = maskDeactivation(tsDiff, maybe);
+    // store the transition even if it would cross the limit - for the sake of interval completeness
     store(threadId, masked, false);
   }
 
@@ -404,7 +405,6 @@ public final class ProfilerTracingContextTracker implements TracingContextTracke
       to that span still being executed in some other thread is pretty low. Therefore, most of the time the lock
       will be uncontented.
        */
-      //
       synchronized (rawIntervals) {
         LongIterator iterator = pruneIntervals(rawIntervals);
         int sequenceIndex = 0;

--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/ProfilerTracingContextTracker.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/ProfilerTracingContextTracker.java
@@ -1,7 +1,9 @@
 package com.datadog.profiling.context;
 
+import datadog.trace.api.config.ProfilingConfig;
 import datadog.trace.api.function.ToIntFunction;
 import datadog.trace.api.profiling.TracingContextTracker;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.relocate.api.RatelimitedLogger;
 import java.nio.ByteBuffer;
@@ -110,7 +112,7 @@ public final class ProfilerTracingContextTracker implements TracingContextTracke
   static final long TRANSITION_MASK = TRANSITION_FINISHED_MASK | TRANSITION_MAYBE_FINISHED_MASK;
   static final long TIMESTAMP_MASK = ~TRANSITION_MASK;
 
-  private static final int SPAN_ACTIVATION_DATA_LIMIT = 20000; // at most 20000 bytes
+  private static final int SPAN_ACTIVATION_DATA_LIMIT;
 
   private final long inactivityDelay;
 
@@ -143,6 +145,14 @@ public final class ProfilerTracingContextTracker implements TracingContextTracke
   private long lastTransitionTimestamp = -1;
 
   private volatile DelayedTrackerImpl delayedTrackerRef = null;
+
+  static {
+    SPAN_ACTIVATION_DATA_LIMIT =
+        ConfigProvider.getInstance()
+            .getInteger(
+                ProfilingConfig.PROFILING_TRACING_CONTEXT_MAX_SIZE,
+                ProfilingConfig.PROFILING_TRACING_CONTEXT_MAX_SIZE_DEFAULT);
+  }
 
   ProfilerTracingContextTracker(
       Allocator allocator,

--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/allocator/heap/HeapAllocator.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/allocator/heap/HeapAllocator.java
@@ -34,6 +34,8 @@ public final class HeapAllocator implements Allocator {
 
     StatsDClient statsd = getStatsdClient();
     statsDClient = statsd;
+
+    log.info("HeapAllocator created with the limit of {} bytes", topMemory);
   }
 
   private static StatsDClient getStatsdClient() {
@@ -71,7 +73,7 @@ public final class HeapAllocator implements Allocator {
         long restored = remaining.addAndGet(size); // restore the remaining size
         size = (int) (newRemaining + size);
         if (size <= chunkSize) {
-          warnlog.warn("Capacity exhausted - buffer could not be allocated");
+          warnlog.warn("Capacity exhausted ({} bytes)- buffer could not be allocated", topMemory);
           return null;
         }
         // align at chunkSize

--- a/dd-java-agent/agent-profiling/profiling-context/src/test/java/com/datadog/profiling/context/IntervalEncoderTest.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/test/java/com/datadog/profiling/context/IntervalEncoderTest.java
@@ -67,6 +67,20 @@ class IntervalEncoderTest {
   }
 
   @Test
+  void testEncodeSequenceTruncated() {
+    IntervalEncoder.ThreadEncoder encoder = instance.startThread(1);
+    encoder.recordInterval(200, 300);
+    encoder.recordInterval(500, 600);
+    ByteBuffer data = encoder.finish().finish();
+    assertNotNull(data);
+    assertTrue(data.limit() > 0);
+
+    List<IntervalParser.Interval> intervals = new IntervalParser().parseIntervals(data.array());
+    IntervalParser.Interval i1 = intervals.get(0);
+    assertEquals(now.toEpochMilli() * 1_000_000L + 200, i1.from);
+  }
+
+  @Test
   void testIntervalAfterFinish() {
     IntervalEncoder.ThreadEncoder encoder = instance.startThread(1);
     encoder.recordInterval(200, 300);

--- a/dd-java-agent/agent-profiling/profiling-context/src/test/java/com/datadog/profiling/context/IntervalParser.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/test/java/com/datadog/profiling/context/IntervalParser.java
@@ -83,6 +83,7 @@ public final class IntervalParser {
 
   public void parseIntervals(byte[] intervalData, IntervalConsumer consumer) {
     ByteBuffer buffer = ByteBuffer.wrap(intervalData);
+    boolean truncated = buffer.get() != 0;
     int chunkDataOffset = buffer.getInt();
     long timestampMillis = getVarint(buffer);
     long frequencyMultiplier = getVarint(buffer);

--- a/dd-java-agent/agent-profiling/profiling-context/src/test/java/com/datadog/profiling/context/PositionDecoderTest.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/test/java/com/datadog/profiling/context/PositionDecoderTest.java
@@ -66,4 +66,27 @@ class PositionDecoderTest {
 
     assertNull(instance.decode(map[map.length - 1] + 1, map));
   }
+
+  @Test
+  void testDecodeWithPartialBoundaryMap() {
+    int[] boundaryMap =
+        new int[] {
+          31,
+          95,
+          287,
+          863,
+          2591,
+          7775,
+          Integer.MAX_VALUE,
+          Integer.MAX_VALUE,
+          Integer.MAX_VALUE,
+          Integer.MAX_VALUE
+        };
+    int limit = 5;
+    int pos = 324 * 8;
+    PositionDecoder.Coordinates expectedCoordinates = new PositionDecoder.Coordinates(5, 0);
+
+    PositionDecoder.Coordinates decoded = instance.decode(pos, boundaryMap, limit + 1);
+    assertEquals(expectedCoordinates, decoded);
+  }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -95,6 +95,11 @@ public final class ProfilingConfig {
       "profiling.tracing_context.memory.type";
   public static final String PROFILING_TRACING_CONTEXT_RESERVED_MEMORY_TYPE_DEFAULT = "heap";
 
+  public static final String PROFILING_TRACING_CONTEXT_MAX_SIZE =
+      "profiling.tracing_context.max_size.bytes";
+  public static final int PROFILING_TRACING_CONTEXT_MAX_SIZE_DEFAULT =
+      20_000; // 20k bytes is the default
+
   public static final String PROFILING_LEGACY_TRACING_INTEGRATION =
       "profiling.legacy.tracing.integration";
   public static final boolean PROFILING_LEGACY_TRACING_INTEGRATION_DEFAULT = true;


### PR DESCRIPTION
# What Does This Do
This adds hard limits on the size of the data representing the span activation intervals.

# Motivation
The span metadata size (this includes the span tags) is limited to 25000 bytes - therefore it does not make sense to generate and keep more data if that is going to be discarded anyway. It is better to have the limit applied directly in the agent where we have control over when to cut off the data collection (saving CPU cycles) and the data export (where we can assure valid data).

# Additional Notes
For the sakes of minimizing the costs of `Long.valueOf()` this change is also adding a few classes from JCTools which are necessary to support `NonBlockingHashMapLong` class that is used instead of `ConcurrentHashMap`.
The JCTools classes are stripped to the bare minimum required for the code to run and they are not adding a significant weight to the agent jar.