### PR TITLE
Upgrade jnr-unixsocket to avoid 'use after free' vulnerability

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -22,7 +22,7 @@ final class CachedData {
     kotlin        : "1.3.72",
     coroutines    : "1.3.0",
     dogstatsd     : "4.0.0",
-    jnr_unixsocket: "0.28",
+    jnr_unixsocket: "0.38.17",
     commons       : "3.2",
     mockito       : '4.4.0',
     moshi         : '1.9.2',


### PR DESCRIPTION
# What Does This Do

Upgrades the `com.github.jnr:jnr-unixsocket` dependency to the latest version. 

# Motivation

`com.github.jnr:jnr-unixsocket:0.28` depends on `com.github.jnr:jnr-posix:3.0.61` which contains a ["high" security vulnerability](https://security.snyk.io/vuln/SNYK-JAVA-COMGITHUBJNR-1570422). 

The latest `jnr-unixsocket`, version `0.38.17`, [uses com.github.jnr:jnr-posix:3.1.15](https://github.com/jnr/jnr-unixsocket/blob/jnr-unixsocket-0.38.17/pom.xml#L77-L82), which has resolved the vulnerability. 