### PR TITLE
Separate out annotation matching on classes (declaresAnnotation) from annotation matching on methods (isAnnotatedWith)

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentTransformerBuilder.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentTransformerBuilder.java
@@ -2,7 +2,7 @@ package datadog.trace.agent.tooling;
 
 import static datadog.trace.agent.tooling.bytebuddy.DDTransformers.defaultTransformers;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.ANY_CLASS_LOADER;
-import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.isAnnotatedWith;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.declaresAnnotation;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isSynthetic;
@@ -20,7 +20,6 @@ import java.security.ProtectionDomain;
 import java.util.Map;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.agent.builder.ResettableClassFileTransformer;
-import net.bytebuddy.description.annotation.AnnotationSource;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.DynamicType;
@@ -32,8 +31,8 @@ public class AgentTransformerBuilder
 
   // Added here instead of byte-buddy's ignores because it's relatively
   // expensive. https://github.com/DataDog/dd-trace-java/pull/1045
-  public static final ElementMatcher.Junction<AnnotationSource> NOT_DECORATOR_MATCHER =
-      not(isAnnotatedWith(named("javax.decorator.Decorator")));
+  public static final ElementMatcher.Junction<TypeDescription> NOT_DECORATOR_MATCHER =
+      not(declaresAnnotation(named("javax.decorator.Decorator")));
 
   private AgentBuilder agentBuilder;
   private ElementMatcher<? super MethodDescription> ignoreMatcher;

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/DDElementMatchers.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/DDElementMatchers.java
@@ -1,7 +1,7 @@
 package datadog.trace.agent.tooling.bytebuddy.matcher;
 
 import de.thetaphi.forbiddenapis.SuppressForbidden;
-import net.bytebuddy.description.annotation.AnnotationSource;
+import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.field.FieldDescription;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDefinition;
@@ -18,53 +18,53 @@ public class DDElementMatchers implements HierarchyMatchers.Supplier {
   }
 
   @Override
-  public <T extends TypeDescription> ElementMatcher.Junction<T> extendsClass(
-      ElementMatcher<? super TypeDescription> matcher) {
-    return new SafeHasSuperTypeMatcher<>(matcher, false, true, false);
-  }
-
-  @Override
-  public <T extends TypeDescription> ElementMatcher.Junction<T> implementsInterface(
-      ElementMatcher<? super TypeDescription> matcher) {
-    return new SafeHasSuperTypeMatcher<>(matcher, true, true, true);
-  }
-
-  @Override
   @SuppressForbidden
-  public <T extends AnnotationSource> ElementMatcher.Junction<T> isAnnotatedWith(
-      ElementMatcher<? super TypeDescription> matcher) {
+  public ElementMatcher.Junction<TypeDescription> declaresAnnotation(
+      ElementMatcher.Junction<? super NamedElement> matcher) {
     return ElementMatchers.isAnnotatedWith(matcher);
   }
 
   @Override
   @SuppressForbidden
-  public <T extends TypeDescription> ElementMatcher.Junction<T> declaresField(
-      ElementMatcher<? super FieldDescription> matcher) {
+  public ElementMatcher.Junction<TypeDescription> declaresField(
+      ElementMatcher.Junction<? super FieldDescription> matcher) {
     return ElementMatchers.declaresField(matcher);
   }
 
   @Override
   @SuppressForbidden
-  public <T extends TypeDescription> ElementMatcher.Junction<T> declaresMethod(
-      ElementMatcher<? super MethodDescription> matcher) {
+  public ElementMatcher.Junction<TypeDescription> declaresMethod(
+      ElementMatcher.Junction<? super MethodDescription> matcher) {
     return ElementMatchers.declaresMethod(matcher);
   }
 
   @Override
-  public <T extends TypeDescription> ElementMatcher.Junction<T> hasInterface(
-      ElementMatcher<? super TypeDescription> matcher) {
+  public ElementMatcher.Junction<TypeDescription> extendsClass(
+      ElementMatcher.Junction<? super TypeDescription> matcher) {
+    return new SafeHasSuperTypeMatcher<>(matcher, false, true, false);
+  }
+
+  @Override
+  public ElementMatcher.Junction<TypeDescription> implementsInterface(
+      ElementMatcher.Junction<? super TypeDescription> matcher) {
+    return new SafeHasSuperTypeMatcher<>(matcher, true, true, true);
+  }
+
+  @Override
+  public ElementMatcher.Junction<TypeDescription> hasInterface(
+      ElementMatcher.Junction<? super TypeDescription> matcher) {
     return new SafeHasSuperTypeMatcher<>(matcher, true, false, true);
   }
 
   @Override
-  public <T extends TypeDescription> ElementMatcher.Junction<T> hasSuperType(
-      ElementMatcher<? super TypeDescription> matcher) {
+  public ElementMatcher.Junction<TypeDescription> hasSuperType(
+      ElementMatcher.Junction<? super TypeDescription> matcher) {
     return new SafeHasSuperTypeMatcher<>(matcher, false, true, true);
   }
 
   @Override
-  public <T extends MethodDescription> ElementMatcher.Junction<T> hasSuperMethod(
-      ElementMatcher<? super MethodDescription> matcher) {
+  public ElementMatcher.Junction<MethodDescription> hasSuperMethod(
+      ElementMatcher.Junction<? super MethodDescription> matcher) {
     return new HasSuperMethodMatcher<>(matcher);
   }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ClassLoaderMatchers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ClassLoaderMatchers.java
@@ -87,8 +87,7 @@ public final class ClassLoaderMatchers {
    * @param classNames list of names to match. returns true if empty.
    * @return true if class is available as a resource and not the bootstrap classloader.
    */
-  public static ElementMatcher.Junction.AbstractBase<ClassLoader> hasClassesNamed(
-      final String... classNames) {
+  public static ElementMatcher.Junction<ClassLoader> hasClassesNamed(final String... classNames) {
     return new ClassLoaderHasClassesNamedMatcher(classNames);
   }
 
@@ -99,8 +98,7 @@ public final class ClassLoaderMatchers {
    * @param className the className to match.
    * @return true if class is available as a resource and not the bootstrap classloader.
    */
-  public static ElementMatcher.Junction.AbstractBase<ClassLoader> hasClassesNamed(
-      final String className) {
+  public static ElementMatcher.Junction<ClassLoader> hasClassesNamed(final String className) {
     return new ClassLoaderHasClassNamedMatcher(className);
   }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/HierarchyMatchers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/HierarchyMatchers.java
@@ -2,6 +2,8 @@ package datadog.trace.agent.tooling.bytebuddy.matcher;
 
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.util.concurrent.atomic.AtomicReference;
+import net.bytebuddy.description.DeclaredByType;
+import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.annotation.AnnotationSource;
 import net.bytebuddy.description.field.FieldDescription;
 import net.bytebuddy.description.method.MethodDescription;
@@ -13,29 +15,29 @@ import net.bytebuddy.matcher.ElementMatchers;
 public final class HierarchyMatchers {
   private static final AtomicReference<Supplier> SUPPLIER = new AtomicReference<>();
 
-  public static <T extends TypeDescription> ElementMatcher.Junction<T> extendsClass(
-      ElementMatcher<? super TypeDescription> matcher) {
-    return SUPPLIER.get().extendsClass(matcher);
+  public static ElementMatcher.Junction<TypeDescription> declaresAnnotation(
+      ElementMatcher.Junction<? super NamedElement> matcher) {
+    return SUPPLIER.get().declaresAnnotation(matcher);
   }
 
-  public static <T extends TypeDescription> ElementMatcher.Junction<T> implementsInterface(
-      ElementMatcher<? super TypeDescription> matcher) {
-    return SUPPLIER.get().implementsInterface(matcher);
-  }
-
-  public static <T extends AnnotationSource> ElementMatcher.Junction<T> isAnnotatedWith(
-      ElementMatcher<? super TypeDescription> matcher) {
-    return SUPPLIER.get().isAnnotatedWith(matcher);
-  }
-
-  public static <T extends TypeDescription> ElementMatcher.Junction<T> declaresField(
-      ElementMatcher<? super FieldDescription> matcher) {
+  public static ElementMatcher.Junction<TypeDescription> declaresField(
+      ElementMatcher.Junction<? super FieldDescription> matcher) {
     return SUPPLIER.get().declaresField(matcher);
   }
 
-  public static <T extends TypeDescription> ElementMatcher.Junction<T> declaresMethod(
-      ElementMatcher<? super MethodDescription> matcher) {
+  public static ElementMatcher.Junction<TypeDescription> declaresMethod(
+      ElementMatcher.Junction<? super MethodDescription> matcher) {
     return SUPPLIER.get().declaresMethod(matcher);
+  }
+
+  public static ElementMatcher.Junction<TypeDescription> extendsClass(
+      ElementMatcher.Junction<? super TypeDescription> matcher) {
+    return SUPPLIER.get().extendsClass(matcher);
+  }
+
+  public static ElementMatcher.Junction<TypeDescription> implementsInterface(
+      ElementMatcher.Junction<? super TypeDescription> matcher) {
+    return SUPPLIER.get().implementsInterface(matcher);
   }
 
   /**
@@ -43,21 +45,28 @@ public final class HierarchyMatchers {
    *
    * <p>Use this when matching return or parameter types that could be classes or interfaces.
    */
-  public static <T extends TypeDescription> ElementMatcher.Junction<T> hasInterface(
-      ElementMatcher<? super TypeDescription> matcher) {
+  public static ElementMatcher.Junction<TypeDescription> hasInterface(
+      ElementMatcher.Junction<? super TypeDescription> matcher) {
     return SUPPLIER.get().hasInterface(matcher);
   }
 
   /** Considers both interfaces and super-classes when matching the target type's hierarchy. */
-  public static <T extends TypeDescription> ElementMatcher.Junction<T> hasSuperType(
-      ElementMatcher<? super TypeDescription> matcher) {
+  public static ElementMatcher.Junction<TypeDescription> hasSuperType(
+      ElementMatcher.Junction<? super TypeDescription> matcher) {
     return SUPPLIER.get().hasSuperType(matcher);
   }
 
   /** Targets methods whose declaring class has a super-type that declares a matching method. */
-  public static <T extends MethodDescription> ElementMatcher.Junction<T> hasSuperMethod(
-      ElementMatcher<? super MethodDescription> matcher) {
+  public static ElementMatcher.Junction<MethodDescription> hasSuperMethod(
+      ElementMatcher.Junction<? super MethodDescription> matcher) {
     return SUPPLIER.get().hasSuperMethod(matcher);
+  }
+
+  @SuppressForbidden
+  public static <T extends AnnotationSource & DeclaredByType.WithMandatoryDeclaration>
+      ElementMatcher.Junction<T> isAnnotatedWith(
+          ElementMatcher.Junction<? super NamedElement> matcher) {
+    return ElementMatchers.isAnnotatedWith(matcher);
   }
 
   public static void registerIfAbsent(Supplier supplier) {
@@ -65,29 +74,29 @@ public final class HierarchyMatchers {
   }
 
   public interface Supplier {
-    <T extends TypeDescription> ElementMatcher.Junction<T> extendsClass(
-        ElementMatcher<? super TypeDescription> matcher);
+    ElementMatcher.Junction<TypeDescription> declaresAnnotation(
+        ElementMatcher.Junction<? super NamedElement> matcher);
 
-    <T extends TypeDescription> ElementMatcher.Junction<T> implementsInterface(
-        ElementMatcher<? super TypeDescription> matcher);
+    ElementMatcher.Junction<TypeDescription> declaresField(
+        ElementMatcher.Junction<? super FieldDescription> matcher);
 
-    <T extends AnnotationSource> ElementMatcher.Junction<T> isAnnotatedWith(
-        ElementMatcher<? super TypeDescription> matcher);
+    ElementMatcher.Junction<TypeDescription> declaresMethod(
+        ElementMatcher.Junction<? super MethodDescription> matcher);
 
-    <T extends TypeDescription> ElementMatcher.Junction<T> declaresField(
-        ElementMatcher<? super FieldDescription> matcher);
+    ElementMatcher.Junction<TypeDescription> extendsClass(
+        ElementMatcher.Junction<? super TypeDescription> matcher);
 
-    <T extends TypeDescription> ElementMatcher.Junction<T> declaresMethod(
-        ElementMatcher<? super MethodDescription> matcher);
+    ElementMatcher.Junction<TypeDescription> implementsInterface(
+        ElementMatcher.Junction<? super TypeDescription> matcher);
 
-    <T extends TypeDescription> ElementMatcher.Junction<T> hasInterface(
-        ElementMatcher<? super TypeDescription> matcher);
+    ElementMatcher.Junction<TypeDescription> hasInterface(
+        ElementMatcher.Junction<? super TypeDescription> matcher);
 
-    <T extends TypeDescription> ElementMatcher.Junction<T> hasSuperType(
-        ElementMatcher<? super TypeDescription> matcher);
+    ElementMatcher.Junction<TypeDescription> hasSuperType(
+        ElementMatcher.Junction<? super TypeDescription> matcher);
 
-    <T extends MethodDescription> ElementMatcher.Junction<T> hasSuperMethod(
-        ElementMatcher<? super MethodDescription> matcher);
+    ElementMatcher.Junction<MethodDescription> hasSuperMethod(
+        ElementMatcher.Junction<? super MethodDescription> matcher);
   }
 
   /** Simple hierarchy checks for use during the build when testing or validating muzzle ranges. */
@@ -95,57 +104,57 @@ public final class HierarchyMatchers {
     return new HierarchyMatchers.Supplier() {
       @Override
       @SuppressForbidden
-      public <T extends TypeDescription> ElementMatcher.Junction<T> extendsClass(
-          ElementMatcher<? super TypeDescription> matcher) {
-        return ElementMatchers.hasSuperClass(matcher);
-      }
-
-      @Override
-      @SuppressForbidden
-      public <T extends TypeDescription> ElementMatcher.Junction<T> implementsInterface(
-          ElementMatcher<? super TypeDescription> matcher) {
-        return ElementMatchers.hasSuperType(matcher);
-      }
-
-      @Override
-      @SuppressForbidden
-      public <T extends AnnotationSource> ElementMatcher.Junction<T> isAnnotatedWith(
-          ElementMatcher<? super TypeDescription> matcher) {
+      public ElementMatcher.Junction<TypeDescription> declaresAnnotation(
+          ElementMatcher.Junction<? super NamedElement> matcher) {
         return ElementMatchers.isAnnotatedWith(matcher);
       }
 
       @Override
       @SuppressForbidden
-      public <T extends TypeDescription> ElementMatcher.Junction<T> declaresField(
-          ElementMatcher<? super FieldDescription> matcher) {
+      public ElementMatcher.Junction<TypeDescription> declaresField(
+          ElementMatcher.Junction<? super FieldDescription> matcher) {
         return ElementMatchers.declaresField(matcher);
       }
 
       @Override
       @SuppressForbidden
-      public <T extends TypeDescription> ElementMatcher.Junction<T> declaresMethod(
-          ElementMatcher<? super MethodDescription> matcher) {
+      public ElementMatcher.Junction<TypeDescription> declaresMethod(
+          ElementMatcher.Junction<? super MethodDescription> matcher) {
         return ElementMatchers.declaresMethod(matcher);
       }
 
       @Override
       @SuppressForbidden
-      public <T extends TypeDescription> ElementMatcher.Junction<T> hasInterface(
-          ElementMatcher<? super TypeDescription> matcher) {
+      public ElementMatcher.Junction<TypeDescription> extendsClass(
+          ElementMatcher.Junction<? super TypeDescription> matcher) {
+        return ElementMatchers.hasSuperClass(matcher);
+      }
+
+      @Override
+      @SuppressForbidden
+      public ElementMatcher.Junction<TypeDescription> implementsInterface(
+          ElementMatcher.Junction<? super TypeDescription> matcher) {
         return ElementMatchers.hasSuperType(matcher);
       }
 
       @Override
       @SuppressForbidden
-      public <T extends TypeDescription> ElementMatcher.Junction<T> hasSuperType(
-          ElementMatcher<? super TypeDescription> matcher) {
+      public ElementMatcher.Junction<TypeDescription> hasInterface(
+          ElementMatcher.Junction<? super TypeDescription> matcher) {
         return ElementMatchers.hasSuperType(matcher);
       }
 
       @Override
       @SuppressForbidden
-      public <T extends MethodDescription> ElementMatcher.Junction<T> hasSuperMethod(
-          ElementMatcher<? super MethodDescription> matcher) {
+      public ElementMatcher.Junction<TypeDescription> hasSuperType(
+          ElementMatcher.Junction<? super TypeDescription> matcher) {
+        return ElementMatchers.hasSuperType(matcher);
+      }
+
+      @Override
+      @SuppressForbidden
+      public ElementMatcher.Junction<MethodDescription> hasSuperMethod(
+          ElementMatcher.Junction<? super MethodDescription> matcher) {
         return ElementMatchers.isDeclaredBy(
             ElementMatchers.hasSuperType(ElementMatchers.declaresMethod(matcher)));
       }

--- a/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/JakartaRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/JakartaRsAnnotationsInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.jakarta3;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.declaresAnnotation;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.declaresMethod;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.hasSuperMethod;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.hasSuperType;
@@ -50,8 +51,8 @@ public final class JakartaRsAnnotationsInstrumentation extends Instrumenter.Trac
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
     return hasSuperType(
-        isAnnotatedWith(named("jakarta.ws.rs.Path"))
-            .<TypeDescription>or(declaresMethod(isAnnotatedWith(named("jakarta.ws.rs.Path")))));
+        declaresAnnotation(named("jakarta.ws.rs.Path"))
+            .or(declaresMethod(isAnnotatedWith(named("jakarta.ws.rs.Path")))));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsInstrumentation.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.jaxrs1;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.hasClassesNamed;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.declaresAnnotation;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.declaresMethod;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.hasSuperMethod;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.hasSuperType;
@@ -44,8 +45,8 @@ public final class JaxRsAnnotationsInstrumentation extends Instrumenter.Tracing
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
     return hasSuperType(
-        isAnnotatedWith(named("javax.ws.rs.Path"))
-            .<TypeDescription>or(declaresMethod(isAnnotatedWith(named("javax.ws.rs.Path")))));
+        declaresAnnotation(named("javax.ws.rs.Path"))
+            .or(declaresMethod(isAnnotatedWith(named("javax.ws.rs.Path")))));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.jaxrs2;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.declaresAnnotation;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.declaresMethod;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.hasSuperMethod;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.hasSuperType;
@@ -50,8 +51,8 @@ public final class JaxRsAnnotationsInstrumentation extends Instrumenter.Tracing
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
     return hasSuperType(
-        isAnnotatedWith(named("javax.ws.rs.Path"))
-            .<TypeDescription>or(declaresMethod(isAnnotatedWith(named("javax.ws.rs.Path")))));
+        declaresAnnotation(named("javax.ws.rs.Path"))
+            .or(declaresMethod(isAnnotatedWith(named("javax.ws.rs.Path")))));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jax-ws-annotations-1/src/main/java/datadog/trace/instrumentation/jaxws1/WebServiceInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-ws-annotations-1/src/main/java/datadog/trace/instrumentation/jaxws1/WebServiceInstrumentation.java
@@ -1,8 +1,8 @@
 package datadog.trace.instrumentation.jaxws1;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.declaresAnnotation;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.hasSuperMethod;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.hasSuperType;
-import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.isAnnotatedWith;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
@@ -40,7 +40,7 @@ public final class WebServiceInstrumentation extends Instrumenter.Tracing
 
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
-    return hasSuperType(isAnnotatedWith(named(WEB_SERVICE_ANNOTATION_NAME)));
+    return hasSuperType(declaresAnnotation(named(WEB_SERVICE_ANNOTATION_NAME)));
   }
 
   @Override
@@ -56,7 +56,9 @@ public final class WebServiceInstrumentation extends Instrumenter.Tracing
         isMethod()
             .and(isPublic())
             .and(not(isStatic()))
-            .and(hasSuperMethod(isDeclaredBy(isAnnotatedWith(named(WEB_SERVICE_ANNOTATION_NAME))))),
+            .and(
+                hasSuperMethod(
+                    isDeclaredBy(declaresAnnotation(named(WEB_SERVICE_ANNOTATION_NAME))))),
         getClass().getName() + "$InvokeAdvice");
   }
 

--- a/dd-java-agent/instrumentation/jax-ws-annotations-2/src/main/java/datadog/trace/instrumentation/jaxws2/WebServiceProviderInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-ws-annotations-2/src/main/java/datadog/trace/instrumentation/jaxws2/WebServiceProviderInstrumentation.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.jaxws2;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.declaresAnnotation;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
-import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.isAnnotatedWith;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
@@ -39,7 +39,7 @@ public final class WebServiceProviderInstrumentation extends Instrumenter.Tracin
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
     return implementsInterface(named(WEB_SERVICE_PROVIDER_INTERFACE_NAME))
-        .and(isAnnotatedWith(named(WEB_SERVICE_PROVIDER_ANNOTATION_NAME)));
+        .and(declaresAnnotation(named(WEB_SERVICE_PROVIDER_ANNOTATION_NAME)));
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

Small refactoring to use `declaresAnnotation` to match annotations on types (aligns with existing `declaresMethod` and `declaresField` matchers) while continuing to use `isAnnotatedWith` to match annotations on methods/fields. Generic type constraints are used to ensure the right matcher is used with the right element.

# Motivation

This lets us cleanly memoize annotation matching on types (where we search the type hierarchy) without having to filter out method/field matching requests at runtime.