### PR TITLE
Include context field matching in hierarchy matchers

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/DDElementMatchers.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/DDElementMatchers.java
@@ -1,5 +1,6 @@
 package datadog.trace.agent.tooling.bytebuddy.matcher;
 
+import datadog.trace.agent.tooling.context.ShouldInjectFieldsMatcher;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.field.FieldDescription;
@@ -66,6 +67,12 @@ public class DDElementMatchers implements HierarchyMatchers.Supplier {
   public ElementMatcher.Junction<MethodDescription> hasSuperMethod(
       ElementMatcher.Junction<? super MethodDescription> matcher) {
     return new HasSuperMethodMatcher<>(matcher);
+  }
+
+  @Override
+  public ElementMatcher.Junction<TypeDescription> declaresContextField(
+      String keyClassName, String contextClassName) {
+    return new ShouldInjectFieldsMatcher(keyClassName, contextClassName);
   }
 
   @SuppressForbidden

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextProvider.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextProvider.java
@@ -1,12 +1,16 @@
 package datadog.trace.agent.tooling.context;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.declaresContextField;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.hasSuperType;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 
 import datadog.trace.agent.tooling.AgentTransformerBuilder;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.Config;
+import datadog.trace.bootstrap.FieldBackedContextAccessor;
 import datadog.trace.bootstrap.InstrumentationContext;
+import java.security.ProtectionDomain;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -171,10 +175,59 @@ public final class FieldBackedContextProvider implements InstrumentationContextP
     }
   }
 
-  static class ShouldInjectFieldsRawMatcher extends ShouldInjectFieldsMatcher
-      implements AgentBuilder.RawMatcher {
+  static final class ShouldInjectFieldsRawMatcher implements AgentBuilder.RawMatcher {
+    private final String keyType;
+    private final String valueType;
+
+    private final ElementMatcher.Junction<TypeDescription> shouldInjectContextField;
+
     ShouldInjectFieldsRawMatcher(String keyType, String valueType) {
-      super(keyType, valueType);
+      this.keyType = keyType;
+      this.valueType = valueType;
+
+      shouldInjectContextField = declaresContextField(keyType, valueType);
+    }
+
+    @Override
+    public boolean matches(
+        TypeDescription typeDescription,
+        ClassLoader classLoader,
+        JavaModule module,
+        Class<?> classBeingRedefined,
+        ProtectionDomain protectionDomain) {
+
+      /*
+       * The idea here is that we can add fields if class is just being loaded
+       * (classBeingRedefined == null) and we have to add same fields again if
+       * the class we added fields before is being transformed again.
+       *
+       * Note: here we assume that Class#getInterfaces() returns list of interfaces
+       * defined immediately on a given class, not inherited from its parents. It
+       * looks like current JVM implementation does exactly this but javadoc is not
+       * explicit about that.
+       */
+      boolean canInjectContextField =
+          classBeingRedefined == null
+              || Arrays.asList(classBeingRedefined.getInterfaces())
+                  .contains(FieldBackedContextAccessor.class);
+
+      if (canInjectContextField && shouldInjectContextField.matches(typeDescription)) {
+        return true;
+      }
+
+      if (log.isDebugEnabled()) {
+        if (!canInjectContextField && shouldInjectContextField.matches(typeDescription)) {
+          // must be a redefine of a class that we weren't able to field-inject on startup
+          // - make sure we'd have field-injected (if we'd had the chance) before tracking
+          log.debug(
+              "Failed to add context-store field - instrumentation.target.class={} instrumentation.target.context={}->{}",
+              typeDescription.getName(),
+              keyType,
+              valueType);
+        }
+      }
+
+      return false;
     }
   }
 }

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextProvider.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextProvider.java
@@ -211,14 +211,14 @@ public final class FieldBackedContextProvider implements InstrumentationContextP
               || Arrays.asList(classBeingRedefined.getInterfaces())
                   .contains(FieldBackedContextAccessor.class);
 
-      if (canInjectContextField && shouldInjectContextField.matches(typeDescription)) {
-        return true;
+      if (canInjectContextField) {
+        return shouldInjectContextField.matches(typeDescription);
       }
 
       if (log.isDebugEnabled()) {
-        if (!canInjectContextField && shouldInjectContextField.matches(typeDescription)) {
-          // must be a redefine of a class that we weren't able to field-inject on startup
-          // - make sure we'd have field-injected (if we'd had the chance) before tracking
+        // must be a redefine of a class that we weren't able to field-inject on startup
+        // - make sure we'd have field-injected (if we'd had the chance) before tracking
+        if (shouldInjectContextField.matches(typeDescription)) {
           log.debug(
               "Failed to add context-store field - instrumentation.target.class={} instrumentation.target.context={}->{}",
               typeDescription.getName(),

--- a/dd-java-agent/agent-builder/src/test/groovy/datadog/trace/agent/tooling/context/ShouldInjectFieldsMatcherTest.groovy
+++ b/dd-java-agent/agent-builder/src/test/groovy/datadog/trace/agent/tooling/context/ShouldInjectFieldsMatcherTest.groovy
@@ -1,9 +1,6 @@
 package datadog.trace.agent.tooling.context
 
 import datadog.trace.agent.tooling.bytebuddy.matcher.AbstractHierarchyMatcherTest
-import net.bytebuddy.utility.JavaModule
-
-import java.security.ProtectionDomain
 
 class ShouldInjectFieldsMatcherTest extends AbstractHierarchyMatcherTest {
 
@@ -12,15 +9,7 @@ class ShouldInjectFieldsMatcherTest extends AbstractHierarchyMatcherTest {
     def matcher = new ShouldInjectFieldsMatcher(keyType, "java.lang.String")
 
     when:
-    boolean matches = matcher.matches(
-      typePool.describe(klass).resolve(),
-      getClass().getClassLoader(),
-      Mock(JavaModule),
-      // need to transform the class to add a marker interface
-      // to be able to test the non-null case
-      null,
-      Mock(ProtectionDomain)
-      )
+    boolean matches = matcher.matches(typePool.describe(klass).resolve())
 
     then:
     ((klass == keyType) && matches) || ((klass != keyType) && !matches)
@@ -37,15 +26,7 @@ class ShouldInjectFieldsMatcherTest extends AbstractHierarchyMatcherTest {
     def matcher = new ShouldInjectFieldsMatcher(keyType, "java.lang.String")
 
     when:
-    boolean matches = matcher.matches(
-      typePool.describe(klass).resolve(),
-      getClass().getClassLoader(),
-      Mock(JavaModule),
-      // need to transform the class to add a marker interface
-      // to be able to test the non-null case
-      null,
-      Mock(ProtectionDomain)
-      )
+    boolean matches = matcher.matches(typePool.describe(klass).resolve())
 
     then:
     ((klass == expected) && matches) || ((klass != expected) && !matches)

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/HierarchyMatchers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/HierarchyMatchers.java
@@ -1,5 +1,7 @@
 package datadog.trace.agent.tooling.bytebuddy.matcher;
 
+import static net.bytebuddy.matcher.ElementMatchers.none;
+
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.util.concurrent.atomic.AtomicReference;
 import net.bytebuddy.description.DeclaredByType;
@@ -62,6 +64,12 @@ public final class HierarchyMatchers {
     return SUPPLIER.get().hasSuperMethod(matcher);
   }
 
+  /** Matches classes that should have a field injected for the specified context-store. */
+  public static ElementMatcher.Junction<TypeDescription> declaresContextField(
+      String keyClassName, String contextClassName) {
+    return SUPPLIER.get().declaresContextField(keyClassName, contextClassName);
+  }
+
   @SuppressForbidden
   public static <T extends AnnotationSource & DeclaredByType.WithMandatoryDeclaration>
       ElementMatcher.Junction<T> isAnnotatedWith(
@@ -97,6 +105,9 @@ public final class HierarchyMatchers {
 
     ElementMatcher.Junction<MethodDescription> hasSuperMethod(
         ElementMatcher.Junction<? super MethodDescription> matcher);
+
+    ElementMatcher.Junction<TypeDescription> declaresContextField(
+        String keyClassName, String contextClassName);
   }
 
   /** Simple hierarchy checks for use during the build when testing or validating muzzle ranges. */
@@ -157,6 +168,12 @@ public final class HierarchyMatchers {
           ElementMatcher.Junction<? super MethodDescription> matcher) {
         return ElementMatchers.isDeclaredBy(
             ElementMatchers.hasSuperType(ElementMatchers.declaresMethod(matcher)));
+      }
+
+      @Override
+      public ElementMatcher.Junction<TypeDescription> declaresContextField(
+          String keyClassName, String contextClassName) {
+        return none(); // unused during build
       }
     };
   }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextInjector.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextInjector.java
@@ -1,6 +1,6 @@
 package datadog.trace.agent.tooling.context;
 
-import static datadog.trace.agent.tooling.context.ShouldInjectFieldsMatcher.hasInjectedField;
+import static datadog.trace.agent.tooling.context.ShouldInjectFieldsState.hasInjectedField;
 import static datadog.trace.bootstrap.FieldBackedContextStores.getContextStoreId;
 import static datadog.trace.util.Strings.getInternalName;
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ShouldInjectFieldsMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ShouldInjectFieldsMatcher.java
@@ -3,34 +3,28 @@ package datadog.trace.agent.tooling.context;
 import static datadog.trace.agent.tooling.context.ShouldInjectFieldsState.excludeInjectedField;
 import static datadog.trace.agent.tooling.context.ShouldInjectFieldsState.findInjectionTarget;
 
-import datadog.trace.bootstrap.FieldBackedContextAccessor;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
-import java.security.ProtectionDomain;
-import java.util.Arrays;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.utility.JavaModule;
+import net.bytebuddy.matcher.ElementMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class ShouldInjectFieldsMatcher {
+public final class ShouldInjectFieldsMatcher
+    extends ElementMatcher.Junction.ForNonNullValues<TypeDescription> {
   private static final Logger log = LoggerFactory.getLogger(ShouldInjectFieldsMatcher.class);
 
   private final String keyType;
   private final String valueType;
   private final ExcludeFilter.ExcludeType skipType;
 
-  ShouldInjectFieldsMatcher(String keyType, String valueType) {
+  public ShouldInjectFieldsMatcher(String keyType, String valueType) {
     this.keyType = keyType;
     this.valueType = valueType;
     this.skipType = ExcludeFilter.ExcludeType.fromFieldType(keyType);
   }
 
-  public final boolean matches(
-      final TypeDescription typeDescription,
-      final ClassLoader classLoader,
-      final JavaModule module,
-      final Class<?> classBeingRedefined,
-      final ProtectionDomain protectionDomain) {
+  @Override
+  protected boolean doMatch(TypeDescription typeDescription) {
     String matchedType = typeDescription.getName();
 
     // First check if we should skip injecting the field based on the key type
@@ -38,75 +32,42 @@ class ShouldInjectFieldsMatcher {
       excludeInjectedField(matchedType, keyType, valueType);
       if (log.isDebugEnabled()) {
         log.debug(
-            "Skipping context-store field - instrumentation.target.class={} instrumentation.target.classloader={} instrumentation.target.context={}->{}",
+            "Skipping context-store field - instrumentation.target.class={} instrumentation.target.context={}->{}",
             matchedType,
-            classLoader,
             keyType,
             valueType);
       }
       return false;
     }
-    /*
-     * The idea here is that we can add fields if class is just being loaded
-     * (classBeingRedefined == null) and we have to add same fields again if class we added
-     * fields before is being transformed again. Note: here we assume that Class#getInterfaces()
-     * returns list of interfaces defined immediately on a given class, not inherited from its
-     * parents. It looks like current JVM implementation does exactly this but javadoc is not
-     * explicit about that.
-     */
-    boolean shouldInject =
-        classBeingRedefined == null
-            || Arrays.asList(classBeingRedefined.getInterfaces())
-                .contains(FieldBackedContextAccessor.class);
     String injectionTarget = null;
-    if (shouldInject) {
-      // will always inject the key type if it's a class,
-      // if this isn't the key class, we need to find the
-      // last super class that implements the key type,
-      // if it is an interface. This could be streamlined
-      // slightly if we knew whether the key type were an
-      // interface or a class, but can be figured out as
-      // we go along
-      if (!keyType.equals(matchedType)) {
-        injectionTarget = findInjectionTarget(typeDescription, keyType);
-        shouldInject &= matchedType.equals(injectionTarget);
-      }
+    // will always inject the key type if it's a class,
+    // if this isn't the key class, we need to find the
+    // last super class that implements the key type,
+    // if it is an interface. This could be streamlined
+    // slightly if we knew whether the key type were an
+    // interface or a class, but can be figured out as
+    // we go along
+    boolean shouldInject;
+    if (keyType.equals(matchedType)) {
+      shouldInject = true;
+    } else {
+      injectionTarget = findInjectionTarget(typeDescription, keyType);
+      shouldInject = matchedType.equals(injectionTarget);
     }
     if (log.isDebugEnabled()) {
       if (shouldInject) {
-        // Only log success the first time we add it to the class
-        if (classBeingRedefined == null) {
-          log.debug(
-              "Added context-store field - instrumentation.target.class={} instrumentation.target.classloader={} instrumentation.target.context={}->{}",
-              matchedType,
-              classLoader,
-              keyType,
-              valueType);
-        }
-      } else if (null != injectionTarget) {
         log.debug(
-            "Will not add context-store field, alternate target found {} - instrumentation.target.class={} instrumentation.target.classloader={} instrumentation.target.context={}->{}",
-            injectionTarget,
+            "Added context-store field - instrumentation.target.class={} instrumentation.target.context={}->{}",
             matchedType,
-            classLoader,
             keyType,
             valueType);
-      } else {
-        // must be a redefine of a class that we weren't able to field-inject on startup
-        // - make sure we'd have field-injected (if we'd had the chance) before tracking
-        if (keyType.equals(matchedType)
-            || matchedType.equals(findInjectionTarget(typeDescription, keyType))) {
-
-          excludeInjectedField(matchedType, keyType, valueType);
-
-          // Only log failed redefines where we would have injected this class
-          log.debug(
-              "Failed to add context-store field - instrumentation.target.class={} instrumentation.target.classloader={} instrumentation.target.context={}->{}",
-              matchedType,
-              classLoader,
-              keyType,
-              valueType);
-        }
+      } else if (null != injectionTarget) {
+        log.debug(
+            "Will not add context-store field, alternate target found {} - instrumentation.target.class={} instrumentation.target.context={}->{}",
+            injectionTarget,
+            matchedType,
+            keyType,
+            valueType);
       }
     }
     return shouldInject;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ShouldInjectFieldsState.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ShouldInjectFieldsState.java
@@ -1,0 +1,161 @@
+package datadog.trace.agent.tooling.context;
+
+import static datadog.trace.bootstrap.FieldBackedContextStores.getContextStoreId;
+
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import net.bytebuddy.description.type.TypeDefinition;
+import net.bytebuddy.description.type.TypeDescription;
+
+/** Manages the persistent state associated with {@link ShouldInjectFieldsMatcher}. */
+class ShouldInjectFieldsState {
+
+  // this map will contain as many entries as there are unique
+  // context store keys, so can't get very big
+  private static final ConcurrentHashMap<String, Boolean> KEY_TYPE_IS_CLASS =
+      new ConcurrentHashMap<>();
+
+  // this map will contain entries for any root type that we wanted to field-inject
+  // but were not able to - either because it was explicitly excluded, or because we
+  // failed to field-inject as the type was already loaded
+  private static final ConcurrentHashMap<String, BitSet> EXCLUDED_STORE_IDS_BY_TYPE =
+      new ConcurrentHashMap<String, BitSet>();
+
+  private ShouldInjectFieldsState() {}
+
+  /**
+   * Searches for the earliest class in the hierarchy to have fields injected under the given key.
+   */
+  public static String findInjectionTarget(TypeDescription typeDescription, String keyType) {
+    // precondition: typeDescription must be a sub type of the key class
+    // verifying this isn't free so the caller (in the same package) is trusted
+
+    // The flag takes 3 values:
+    // true: the key type is a class, so should be the injection target
+    // false: the key type is an interface, so we need to find the class
+    // closest to java.lang.Object which implements the key type
+    // null: we don't know yet because we haven't seen the key type before
+    Boolean keyTypeIsClass = KEY_TYPE_IS_CLASS.get(keyType);
+    if (null != keyTypeIsClass && keyTypeIsClass) {
+      // if we already know the key type is a class,
+      // we must inject into that class.
+      return keyType;
+    }
+    // then we don't know it's a class so need to
+    // follow the type's ancestry to find out
+    TypeDefinition superClass = typeDescription.getSuperClass();
+    String implementingClass = typeDescription.getName();
+    Map<String, Boolean> visitedInterfaces = new HashMap<>();
+    while (null != superClass) {
+      String superClassName = superClass.asErasure().getTypeName();
+      if (null == keyTypeIsClass && keyType.equals(superClassName)) {
+        // short circuit the search with this key type next time
+        KEY_TYPE_IS_CLASS.put(keyType, true);
+        return keyType;
+      }
+      if (hasKeyInterface(superClass, keyType, visitedInterfaces)) {
+        // then the key type must be an interface
+        if (null == keyTypeIsClass) {
+          KEY_TYPE_IS_CLASS.put(keyType, false);
+          keyTypeIsClass = false;
+        }
+        implementingClass = superClassName;
+      }
+      superClass = superClass.getSuperClass();
+    }
+    return implementingClass;
+  }
+
+  private static boolean hasKeyInterface(
+      TypeDefinition typeDefinition, String keyType, Map<String, Boolean> visitedInterfaces) {
+    for (TypeDefinition iface : typeDefinition.getInterfaces()) {
+      String interfaceName = iface.asErasure().getTypeName();
+      if (keyType.equals(interfaceName)) {
+        return true;
+      }
+      Boolean foundKeyInterface = visitedInterfaces.get(interfaceName);
+      if (Boolean.TRUE.equals(foundKeyInterface)) {
+        return true; // already know this will lead to the key
+      }
+      if (null == foundKeyInterface) {
+        // avoid cycle issues by assuming we won't find the key
+        visitedInterfaces.put(interfaceName, false);
+        if (hasKeyInterface(iface, keyType, visitedInterfaces)) {
+          visitedInterfaces.put(interfaceName, true); // update assumption
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Keep track of which stores (per-type) were explicitly excluded or we failed to field-inject.
+   * This is used to decide when we can't apply certain store optimizations ahead of loading.
+   */
+  public static void excludeInjectedField(
+      String instrumentedType, String keyType, String valueType) {
+    int storeId = getContextStoreId(keyType, valueType);
+    BitSet excludedStoreIdsForType = EXCLUDED_STORE_IDS_BY_TYPE.get(instrumentedType);
+    if (null == excludedStoreIdsForType) {
+      BitSet tempStoreIds = new BitSet();
+      tempStoreIds.set(storeId);
+      excludedStoreIdsForType =
+          EXCLUDED_STORE_IDS_BY_TYPE.putIfAbsent(instrumentedType, tempStoreIds);
+    }
+    // if we didn't get there first then add this store to the existing set
+    if (null != excludedStoreIdsForType) {
+      synchronized (excludedStoreIdsForType) {
+        excludedStoreIdsForType.set(storeId);
+      }
+    }
+  }
+
+  /**
+   * Scans the class hierarchy to see if it matches any known context-key types which implies it has
+   * an injected field somewhere. This avoids having to record successful field-injections which can
+   * add up to a lot of entries. Unfortunately we can't check for the marker interface because the
+   * type won't have that at this point.
+   *
+   * <p>At the same time we collect which context stores failed to be field-injected in the class
+   * hierarchy. This tells us when to redirect store requests to the weak-map vs delegating to the
+   * superclass.
+   *
+   * <p>Assumes the type has already been processed by ShouldInjectFieldsMatcher.
+   */
+  public static boolean hasInjectedField(TypeDefinition typeDefinition, BitSet excludedStoreIds) {
+    Set<String> visitedInterfaces = new HashSet<>();
+    while (null != typeDefinition) {
+      String className = typeDefinition.asErasure().getTypeName();
+      BitSet excludedStoreIdsForType = EXCLUDED_STORE_IDS_BY_TYPE.get(className);
+      if (null != excludedStoreIdsForType) {
+        synchronized (excludedStoreIdsForType) {
+          excludedStoreIds.or(excludedStoreIdsForType);
+        }
+      } else if (KEY_TYPE_IS_CLASS.containsKey(className)
+          || impliesInjectedField(typeDefinition, visitedInterfaces)) {
+        return true;
+      }
+      typeDefinition = typeDefinition.getSuperClass();
+    }
+    return false;
+  }
+
+  /** Scans transitive interfaces to see if any match known context-key types. */
+  private static boolean impliesInjectedField(
+      final TypeDefinition typeDefinition, final Set<String> visitedInterfaces) {
+    for (TypeDefinition iface : typeDefinition.getInterfaces()) {
+      String interfaceName = iface.asErasure().getTypeName();
+      if (KEY_TYPE_IS_CLASS.containsKey(interfaceName)
+          || (visitedInterfaces.add(interfaceName)
+              && impliesInjectedField(iface, visitedInterfaces))) {
+        return true;
+      }
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
# What Does This Do

- splits management of the persistent `ShouldInjectFields` state out from the matcher
- refactors `ShouldInjectFieldsMatcher` so it can be moved under `HierarchyMatchers`
- some logic that requires knowing if we're redefining a class without the accessor API is moved to the raw matcher which then calls to the element matcher provided by `HierarchyMatchers`
- some logging is simplified to remove details of the classloader, which we don't know inside element matchers
- a stray call to `excludeStoreForType` that was only called when debug logging was on is removed
  - this call was an attempt at an optimization, but it was never actually called in production (when debug is off)

# Motivation

This lets us memoize all non-trivial matchers that work on the type hierarchy, both instrumentation and field injection