### PR TITLE
Exclude undertow 2.3 (alpha) from latestDepTest / muzzle

### DIFF
--- a/dd-java-agent/instrumentation/undertow-2.0/undertow-2.0.gradle
+++ b/dd-java-agent/instrumentation/undertow-2.0/undertow-2.0.gradle
@@ -7,7 +7,7 @@ muzzle {
   pass {
     group = "io.undertow"
     module = "undertow-servlet"
-    versions = "[2.0.0.Final ,)"
+    versions = "[2.0.0.Final,2.3)"
     assertInverse = false
   }
 }
@@ -30,5 +30,5 @@ dependencies {
   testImplementation project(':dd-java-agent:instrumentation:servlet')
   testImplementation project(':dd-java-agent:instrumentation:servlet:request-3')
 
-  latestDepTestImplementation group: 'io.undertow', name: 'undertow-servlet', version: '+'
+  latestDepTestImplementation group: 'io.undertow', name: 'undertow-servlet', version: '2.2.+'
 }


### PR DESCRIPTION
undertow 2.3 (alpha) builds against Java 11 and `jakarta.servlet` , so exclude 2.3 from the range of versions expected to work with our `undertow-2.0` module