### PR TITLE
Attempt to prevent buffer overflow due to data race

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/LongSequence.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/LongSequence.java
@@ -238,12 +238,11 @@ final class LongSequence {
   }
 
   /**
-   * Get the last 'captured' size; if the size has not been captured yet capture and return it now
+   * Get the last 'captured' size
+   *
+   * @return the captured size or {@literal -1} if the size has not been captured yet
    */
   public int getCapturedSize() {
-    if (capturedSize == -1) {
-      capturedSize = size();
-    }
     return capturedSize;
   }
 

--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/LongSequence.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/LongSequence.java
@@ -76,6 +76,7 @@ final class LongSequence {
 
   private AtomicInteger state = new AtomicInteger(0);
   private final int limit;
+  private int capturedSize = -1;
 
   public LongSequence(Allocator allocator) {
     this(allocator, Integer.MAX_VALUE);
@@ -222,6 +223,28 @@ final class LongSequence {
 
   public int size() {
     return size;
+  }
+
+  /**
+   * Store and return the current sequence size - creating a kind of snapshot in time that could be
+   * used to make sure the subsequent iteration (eg. during persisting the data) will not overflow
+   * the limit deduced at the time of snapshotting.
+   *
+   * @return the sequence size
+   */
+  public int captureSize() {
+    capturedSize = size();
+    return capturedSize;
+  }
+
+  /**
+   * Get the last 'captured' size; if the size has not been captured yet capture and return it now
+   */
+  public int getCapturedSize() {
+    if (capturedSize == -1) {
+      capturedSize = size();
+    }
+    return capturedSize;
   }
 
   public int sizeInBytes() {


### PR DESCRIPTION
# What Does This Do

Adds the concept of 'captured' long sequence size to allow concurrent updates to the sequence without causing buffer overflow when persisting that sequence.

# Motivation

Currently, the profiler span context is serialized to a byte buffer which is pre-sized to the sum of sizes of all relevant interval sequences. However, the serialization is done in a subsequent step and this means that there might be few extra intervals added to each sequence in the meantime and writing them out would cause buffer overflow.

# Additional Notes
