### PR TITLE
Add Agent.shutdown API

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -258,6 +258,12 @@ public class Agent {
     }
   }
 
+  public static void shutdown(final boolean sync) {
+    if (profilingEnabled) {
+      shutdownProfilingAgent(sync);
+    }
+  }
+
   public static synchronized Class<?> installAgentCLI(final URL bootstrapURL) throws Exception {
     createSharedClassloader(bootstrapURL);
     if (null == AGENT_CLASSLOADER) {
@@ -670,6 +676,34 @@ public class Agent {
       log.debug("Profiling requires OpenJDK 8 or above - skipping");
     } catch (final Throwable ex) {
       log.error("Throwable thrown while starting profiling agent", ex);
+    } finally {
+      Thread.currentThread().setContextClassLoader(contextLoader);
+    }
+  }
+
+  private static void shutdownProfilingAgent(final boolean sync) {
+    if (PROFILING_CLASSLOADER == null) {
+      // It wasn't started, so no need to shut it down
+      return;
+    }
+
+    final ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      final ClassLoader classLoader = PROFILING_CLASSLOADER;
+      Thread.currentThread().setContextClassLoader(classLoader);
+      final Class<?> profilingAgentClass =
+          classLoader.loadClass("com.datadog.profiling.agent.ProfilingAgent");
+      final Method profilingInstallerMethod =
+          profilingAgentClass.getMethod("shutdown", Boolean.TYPE);
+      profilingInstallerMethod.invoke(null, sync);
+    } catch (final ClassFormatError e) {
+      /*
+      Profiling is compiled for Java8. Loading it on Java7 results in ClassFormatError
+      (more specifically UnsupportedClassVersionError). Just ignore and continue when this happens.
+      */
+      log.debug("Profiling requires OpenJDK 8 or above - skipping");
+    } catch (final Throwable ex) {
+      log.error("Throwable thrown while shutting down profiling agent", ex);
     } finally {
       Thread.currentThread().setContextClassLoader(contextLoader);
     }

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/RecordingDataListener.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/RecordingDataListener.java
@@ -24,6 +24,7 @@ public interface RecordingDataListener {
    *
    * @param type type of the recording
    * @param data the new data available
+   * @param handleSynchronously whether to handle the data synchronously
    */
-  void onNewData(RecordingType type, RecordingData data);
+  void onNewData(RecordingType type, RecordingData data, boolean handleSynchronously);
 }

--- a/dd-java-agent/agent-profiling/profiling-uploader/profiling-uploader.gradle
+++ b/dd-java-agent/agent-profiling/profiling-uploader/profiling-uploader.gradle
@@ -4,7 +4,7 @@ ext {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-minimumBranchCoverage = 0.78
+minimumBranchCoverage = 0.80
 
 excludedClassesCoverage += [
   // This is just a static declaration that is hard to test

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
@@ -268,9 +268,7 @@ public final class ProfileUploader {
    *     failing)
    */
   public void upload(
-      final RecordingType type,
-      final RecordingData data,
-      @Nonnull final Runnable onCompletion) {
+      final RecordingType type, final RecordingData data, @Nonnull final Runnable onCompletion) {
     upload(type, data, false, onCompletion);
   }
 

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
@@ -243,6 +243,17 @@ public final class ProfileUploader {
    * @param type {@link RecordingType recording type}
    * @param data {@link RecordingData recording data}
    */
+  public void upload(final RecordingType type, final RecordingData data) {
+    upload(type, data, false);
+  }
+
+  /**
+   * Enqueue an upload request. Do not receive any notification when the upload has been completed.
+   *
+   * @param type {@link RecordingType recording type}
+   * @param data {@link RecordingData recording data}
+   * @param sync {@link boolean uploading synchronously}
+   */
   public void upload(final RecordingType type, final RecordingData data, final boolean sync) {
     upload(type, data, sync, () -> {});
   }
@@ -253,6 +264,23 @@ public final class ProfileUploader {
    *
    * @param type {@link RecordingType recording type}
    * @param data {@link RecordingData recording data}
+   * @param onCompletion call-back to execute once the request is completed (successfully or
+   *     failing)
+   */
+  public void upload(
+      final RecordingType type,
+      final RecordingData data,
+      @Nonnull final Runnable onCompletion) {
+    upload(type, data, false, onCompletion);
+  }
+
+  /**
+   * Enqueue an upload request and run the provided hook when that request is completed
+   * (successfully or failing).
+   *
+   * @param type {@link RecordingType recording type}
+   * @param data {@link RecordingData recording data}
+   * @param sync {@link boolean uploading synchronously}
    * @param onCompletion call-back to execute once the request is completed (successfully or
    *     failing)
    */

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -526,6 +526,8 @@ public class ProfileUploaderTest {
 
   @Test
   public void test413Response() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(413));
+
     final RecordingData recording = mockRecordingData();
     uploadAndWait(RECORDING_TYPE, recording);
 
@@ -533,7 +535,7 @@ public class ProfileUploaderTest {
 
     verify(recording).release();
     verify(ioLogger).error(eq("Failed to upload profile, it's too big. Dumping information about the profile"));
-    verify(ioLogger, times(10)).error(startsWith("Event: "));
+    verify(ioLogger, times(10)).error(matches("Event: .*, size = [0-9]+, count = [0-9]+"));
   }
 
   @Test

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -149,6 +150,7 @@ public class ProfileUploaderTest {
     when(config.getApiKey()).thenReturn(null);
     when(config.getMergedProfilingTags()).thenReturn(TAGS);
     when(config.getProfilingUploadTimeout()).thenReturn((int) REQUEST_TIMEOUT.getSeconds());
+    when(config.isProfilingUploadSummaryOn413Enabled()).thenReturn(true);
 
     uploader =
         new ProfileUploader(
@@ -520,6 +522,18 @@ public class ProfileUploaderTest {
     assertNotNull(server.takeRequest(5, TimeUnit.SECONDS));
 
     verify(recording).release();
+  }
+
+  @Test
+  public void test413Response() throws Exception {
+    final RecordingData recording = mockRecordingData();
+    uploadAndWait(RECORDING_TYPE, recording);
+
+    assertNotNull(server.takeRequest(5, TimeUnit.SECONDS));
+
+    verify(recording).release();
+    verify(ioLogger).error(eq("Failed to upload profile, it's too big. Dumping information about the profile"));
+    verify(ioLogger, times(10)).error(startsWith("Event: "));
   }
 
   @Test

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
@@ -534,9 +534,15 @@ public class ProfileUploaderTest {
     assertNotNull(server.takeRequest(5, TimeUnit.SECONDS));
 
     verify(recording).release();
-    verify(ioLogger)
-        .error(eq("Failed to upload profile, it's too big. Dumping information about the profile"));
-    verify(ioLogger, times(10)).error(matches("Event: .*, size = [0-9]+, count = [0-9]+"));
+
+    if (Files.exists(Paths.get(System.getProperty("java.home"), "bin", "jfr"))) {
+      verify(ioLogger)
+          .error(
+              eq("Failed to upload profile, it's too big. Dumping information about the profile"));
+      verify(ioLogger, times(10)).error(matches("Event: .*, size = [0-9]+, count = [0-9]+"));
+    } else {
+      verify(ioLogger).error(eq("Failed to gather information on recording, can't find `jfr`"));
+    }
   }
 
   @Test

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
@@ -51,6 +51,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.ConnectException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
@@ -534,7 +534,8 @@ public class ProfileUploaderTest {
     assertNotNull(server.takeRequest(5, TimeUnit.SECONDS));
 
     verify(recording).release();
-    verify(ioLogger).error(eq("Failed to upload profile, it's too big. Dumping information about the profile"));
+    verify(ioLogger)
+        .error(eq("Failed to upload profile, it's too big. Dumping information about the profile"));
     verify(ioLogger, times(10)).error(matches("Event: .*, size = [0-9]+, count = [0-9]+"));
   }
 


### PR DESCRIPTION
# What Does This Do

It triggers shutdown of ProfilingAgent to support profile upload on shutdown.

# Motivation

This is to be used by other integrations that want to guarantee that data will be flushed and uploaded before the shutdown of the process. It will be used by CI app for example to guarantee we have all profiling data.

# Additional Notes
