### PR TITLE
Minor performance fix for span context tracking

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-context/profiling-context.gradle
+++ b/dd-java-agent/agent-profiling/profiling-context/profiling-context.gradle
@@ -11,6 +11,7 @@ ext {
     // jacoco does not allow per-method excludes so, here we go
     "com.datadog.profiling.context.ProfilerTracingContextTrackerFactory*",
     "com.datadog.profiling.context.ProfilerTracingContextTracker.TimeTicksProvider*",
+    "com.datadog.profiling.context.StatsDAccessor"
   ]
 }
 

--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/ProfilerTracingContextTrackerFactory.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/ProfilerTracingContextTrackerFactory.java
@@ -65,15 +65,14 @@ public final class ProfilerTracingContextTrackerFactory
           Collection<TracingContextTracker.DelayedTracker> timeouts = new ArrayList<>(capacity);
           int drainedAll = 0;
           int drained = 0;
-          do {
-            drained = target.drainTo(timeouts, capacity);
-            if (drained > 0) {
+          while ((drained = target.drainTo(timeouts, capacity)) > 0) {
+            if (log.isDebugEnabled()) {
               log.debug("Drained {} inactive trackers", drained);
             }
             timeouts.forEach(TracingContextTracker.DelayedTracker::cleanup);
             timeouts.clear();
             drainedAll += drained;
-          } while (drained > 0);
+          }
           if (drainedAll > 0) {
             statsd.count("tracing.context.spans.drained_inactive", drainedAll);
           }

--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/StatsDAccessor.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/StatsDAccessor.java
@@ -1,0 +1,37 @@
+package com.datadog.profiling.context;
+
+import datadog.trace.api.GlobalTracer;
+import datadog.trace.api.StatsDClient;
+import datadog.trace.api.Tracer;
+import java.lang.reflect.Field;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class StatsDAccessor {
+  private static final Logger log = LoggerFactory.getLogger(StatsDAccessor.class);
+
+  private static StatsDClient statsd = null;
+
+  public static StatsDClient getStatsdClient() {
+    if (statsd == null) {
+      // a possibility of harmless data race when the reflective field access will be used several
+      // times
+      try {
+        Tracer tracer = GlobalTracer.get();
+        Field fld = tracer.getClass().getDeclaredField("statsDClient");
+        fld.setAccessible(true);
+        StatsDClient statsdClient = (StatsDClient) fld.get(tracer);
+        log.debug("Set up custom StatsD Client instance {}", statsdClient);
+        statsd = statsdClient;
+      } catch (Throwable t) {
+        if (log.isDebugEnabled()) {
+          log.warn("Unable to obtain a StatsD client instance", t);
+        } else {
+          log.warn("Unable to obtain a StatsD client instance");
+        }
+        statsd = StatsDClient.NO_OP;
+      }
+    }
+    return statsd;
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/allocator/direct/DirectAllocator.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/allocator/direct/DirectAllocator.java
@@ -1,12 +1,10 @@
 package com.datadog.profiling.context.allocator.direct;
 
 import com.datadog.profiling.context.Allocator;
+import com.datadog.profiling.context.StatsDAccessor;
 import com.datadog.profiling.context.allocator.AllocatedBuffer;
-import datadog.trace.api.GlobalTracer;
 import datadog.trace.api.StatsDClient;
-import datadog.trace.api.Tracer;
 import datadog.trace.relocate.api.RatelimitedLogger;
-import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -94,17 +92,8 @@ public final class DirectAllocator implements Allocator {
     }
     this.capacity = alignedCapacity;
     this.bitmapSize = (int) Math.ceil(lockSectionSize / 8d);
-    StatsDClient statsd = StatsDClient.NO_OP;
-    try {
-      Tracer tracer = GlobalTracer.get();
-      Field fld = tracer.getClass().getDeclaredField("statsDClient");
-      fld.setAccessible(true);
-      statsd = (StatsDClient) fld.get(tracer);
-      log.debug("Set up custom StatsD Client instance {}", statsd);
-    } catch (Throwable t) {
-      t.printStackTrace();
-    }
-    statsDClient = statsd;
+    statsDClient = StatsDAccessor.getStatsdClient();
+    ;
   }
 
   @Override

--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/allocator/direct/DirectAllocator.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/allocator/direct/DirectAllocator.java
@@ -93,7 +93,6 @@ public final class DirectAllocator implements Allocator {
     this.capacity = alignedCapacity;
     this.bitmapSize = (int) Math.ceil(lockSectionSize / 8d);
     statsDClient = StatsDAccessor.getStatsdClient();
-    ;
   }
 
   @Override

--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/allocator/heap/HeapAllocator.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/allocator/heap/HeapAllocator.java
@@ -1,12 +1,10 @@
 package com.datadog.profiling.context.allocator.heap;
 
 import com.datadog.profiling.context.Allocator;
+import com.datadog.profiling.context.StatsDAccessor;
 import com.datadog.profiling.context.allocator.AllocatedBuffer;
-import datadog.trace.api.GlobalTracer;
 import datadog.trace.api.StatsDClient;
-import datadog.trace.api.Tracer;
 import datadog.trace.relocate.api.RatelimitedLogger;
-import java.lang.reflect.Field;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
@@ -32,28 +30,10 @@ public final class HeapAllocator implements Allocator {
     this.topMemory = numChunks * (long) chunkSize;
     this.remaining = new AtomicLong(topMemory);
 
-    StatsDClient statsd = getStatsdClient();
+    StatsDClient statsd = StatsDAccessor.getStatsdClient();
     statsDClient = statsd;
 
     log.info("HeapAllocator created with the limit of {} bytes", topMemory);
-  }
-
-  private static StatsDClient getStatsdClient() {
-    try {
-      Tracer tracer = GlobalTracer.get();
-      Field fld = tracer.getClass().getDeclaredField("statsDClient");
-      fld.setAccessible(true);
-      StatsDClient statsd = (StatsDClient) fld.get(tracer);
-      log.debug("Set up custom StatsD Client instance {}", statsd);
-      return statsd;
-    } catch (Throwable t) {
-      if (log.isDebugEnabled()) {
-        log.warn("Unable to obtain a StatsD client instance", t);
-      } else {
-        log.warn("Unable to obtain a StatsD client instance");
-      }
-      return StatsDClient.NO_OP;
-    }
   }
 
   @Override

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -103,7 +103,7 @@ public final class ProfilingConfig {
       20_000; // 20k bytes is the default
 
   public static final String PROFILING_TRACING_CONTEXT_SPAN_INACTIVITY_CHECK =
-      "profiling.tracing_context.trackerk.inactive_check.ms";
+      "profiling.tracing_context.span_inactivity_check.ms";
 
   public static final int PROFILING_TRACING_CONTEXT_SPAN_INACTIVITY_CHECK_DEFAULT =
       5_000; // 5 secs default

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -102,6 +102,12 @@ public final class ProfilingConfig {
   public static final int PROFILING_TRACING_CONTEXT_MAX_SIZE_DEFAULT =
       20_000; // 20k bytes is the default
 
+  public static final String PROFILING_TRACING_CONTEXT_SPAN_INACTIVITY_CHECK =
+      "profiling.tracing_context.trackerk.inactive_check.ms";
+
+  public static final int PROFILING_TRACING_CONTEXT_SPAN_INACTIVITY_CHECK_DEFAULT =
+      5_000; // 5 secs default
+
   public static final String PROFILING_LEGACY_TRACING_INTEGRATION =
       "profiling.legacy.tracing.integration";
   public static final boolean PROFILING_LEGACY_TRACING_INTEGRATION_DEFAULT = true;


### PR DESCRIPTION
# What Does This Do

Avoids unnecessary array copies in the the routine handling the queue of inactive spans.
Adds a config knob to configure the amount of time after which a span is considered inactive.

# Motivation

Apparently, there are services out there creating a large numbers of mostly inactive spans which need to be tracked and then properly cleaned up in the per span context tracker. With this large number of inactive spans the performance issues related to arraylist resizing in the queue draining procedure became obvious.

First, there is a bug when the `drainTo()` method is not called with the maximum number of elements - leading to several rounds of resizing the target array list (even though the array list is pre-sized, the incorrect invocation defeats the pre-sizing).
And then there is the issue with `iterator.remove()` for array lists - it turns out that will do a lot of array-copying as well and the overall better way to remove all elements from an array list is just to call `clear()` method.

# Additional Notes
