### PR TITLE
Simplify shared suppliers…

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakCache.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakCache.java
@@ -1,7 +1,6 @@
 package datadog.trace.bootstrap;
 
 import datadog.trace.api.function.Function;
-import java.util.concurrent.atomic.AtomicReference;
 
 public interface WeakCache<K, V> {
   V getIfPresent(final K key);
@@ -11,16 +10,18 @@ public interface WeakCache<K, V> {
   void put(final K key, final V value);
 
   abstract class Supplier {
-    private static final AtomicReference<Supplier> SUPPLIER = new AtomicReference<>();
+    private static volatile Supplier SUPPLIER;
 
     protected abstract <K, V> WeakCache<K, V> get(long maxSize);
 
     public static <K, V> WeakCache<K, V> newWeakCache(long maxSize) {
-      return SUPPLIER.get().get(maxSize);
+      return SUPPLIER.get(maxSize);
     }
 
-    public static void registerIfAbsent(Supplier supplier) {
-      SUPPLIER.compareAndSet(null, supplier);
+    public static synchronized void registerIfAbsent(Supplier supplier) {
+      if (null == SUPPLIER) {
+        SUPPLIER = supplier;
+      }
     }
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMap.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMap.java
@@ -1,7 +1,6 @@
 package datadog.trace.bootstrap;
 
 import datadog.trace.api.function.Function;
-import java.util.concurrent.atomic.AtomicReference;
 
 public interface WeakMap<K, V> {
   int size();
@@ -19,16 +18,18 @@ public interface WeakMap<K, V> {
   V remove(K key);
 
   abstract class Supplier {
-    private static final AtomicReference<Supplier> SUPPLIER = new AtomicReference<>();
+    private static volatile Supplier SUPPLIER;
 
     protected abstract <K, V> WeakMap<K, V> get();
 
     public static <K, V> WeakMap<K, V> newWeakMap() {
-      return SUPPLIER.get().get();
+      return SUPPLIER.get();
     }
 
-    public static void registerIfAbsent(Supplier supplier) {
-      SUPPLIER.compareAndSet(null, supplier);
+    public static synchronized void registerIfAbsent(Supplier supplier) {
+      if (null == SUPPLIER) {
+        SUPPLIER = supplier;
+      }
     }
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/SharedTypePools.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/SharedTypePools.java
@@ -1,23 +1,24 @@
 package datadog.trace.agent.tooling.bytebuddy;
 
-import java.util.concurrent.atomic.AtomicReference;
 import net.bytebuddy.dynamic.ClassFileLocator;
 import net.bytebuddy.pool.TypePool;
 
 /** Pluggable {@link TypePool}s for use with instrumentation matching and muzzle checks. */
 public final class SharedTypePools {
-  private static final AtomicReference<Supplier> SUPPLIER = new AtomicReference<>();
+  private static volatile Supplier SUPPLIER;
 
   public static TypePool typePool(ClassLoader classLoader) {
-    return SUPPLIER.get().typePool(ClassFileLocators.classFileLocator(classLoader), classLoader);
+    return SUPPLIER.typePool(ClassFileLocators.classFileLocator(classLoader), classLoader);
   }
 
   public static TypePool typePool(ClassFileLocator classFileLocator, ClassLoader classLoader) {
-    return SUPPLIER.get().typePool(classFileLocator, classLoader);
+    return SUPPLIER.typePool(classFileLocator, classLoader);
   }
 
-  public static void registerIfAbsent(Supplier supplier) {
-    SUPPLIER.compareAndSet(null, supplier);
+  public static synchronized void registerIfAbsent(Supplier supplier) {
+    if (null == SUPPLIER) {
+      SUPPLIER = supplier;
+    }
   }
 
   public interface Supplier {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/HierarchyMatchers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/HierarchyMatchers.java
@@ -3,7 +3,6 @@ package datadog.trace.agent.tooling.bytebuddy.matcher;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 
 import de.thetaphi.forbiddenapis.SuppressForbidden;
-import java.util.concurrent.atomic.AtomicReference;
 import net.bytebuddy.description.DeclaredByType;
 import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.annotation.AnnotationSource;
@@ -15,31 +14,31 @@ import net.bytebuddy.matcher.ElementMatchers;
 
 /** Pluggable hierarchy matchers for use with instrumentation matching and muzzle checks. */
 public final class HierarchyMatchers {
-  private static final AtomicReference<Supplier> SUPPLIER = new AtomicReference<>();
+  private static volatile Supplier SUPPLIER;
 
   public static ElementMatcher.Junction<TypeDescription> declaresAnnotation(
       ElementMatcher.Junction<? super NamedElement> matcher) {
-    return SUPPLIER.get().declaresAnnotation(matcher);
+    return SUPPLIER.declaresAnnotation(matcher);
   }
 
   public static ElementMatcher.Junction<TypeDescription> declaresField(
       ElementMatcher.Junction<? super FieldDescription> matcher) {
-    return SUPPLIER.get().declaresField(matcher);
+    return SUPPLIER.declaresField(matcher);
   }
 
   public static ElementMatcher.Junction<TypeDescription> declaresMethod(
       ElementMatcher.Junction<? super MethodDescription> matcher) {
-    return SUPPLIER.get().declaresMethod(matcher);
+    return SUPPLIER.declaresMethod(matcher);
   }
 
   public static ElementMatcher.Junction<TypeDescription> extendsClass(
       ElementMatcher.Junction<? super TypeDescription> matcher) {
-    return SUPPLIER.get().extendsClass(matcher);
+    return SUPPLIER.extendsClass(matcher);
   }
 
   public static ElementMatcher.Junction<TypeDescription> implementsInterface(
       ElementMatcher.Junction<? super TypeDescription> matcher) {
-    return SUPPLIER.get().implementsInterface(matcher);
+    return SUPPLIER.implementsInterface(matcher);
   }
 
   /**
@@ -49,25 +48,25 @@ public final class HierarchyMatchers {
    */
   public static ElementMatcher.Junction<TypeDescription> hasInterface(
       ElementMatcher.Junction<? super TypeDescription> matcher) {
-    return SUPPLIER.get().hasInterface(matcher);
+    return SUPPLIER.hasInterface(matcher);
   }
 
   /** Considers both interfaces and super-classes when matching the target type's hierarchy. */
   public static ElementMatcher.Junction<TypeDescription> hasSuperType(
       ElementMatcher.Junction<? super TypeDescription> matcher) {
-    return SUPPLIER.get().hasSuperType(matcher);
+    return SUPPLIER.hasSuperType(matcher);
   }
 
   /** Targets methods whose declaring class has a super-type that declares a matching method. */
   public static ElementMatcher.Junction<MethodDescription> hasSuperMethod(
       ElementMatcher.Junction<? super MethodDescription> matcher) {
-    return SUPPLIER.get().hasSuperMethod(matcher);
+    return SUPPLIER.hasSuperMethod(matcher);
   }
 
   /** Matches classes that should have a field injected for the specified context-store. */
   public static ElementMatcher.Junction<TypeDescription> declaresContextField(
       String keyClassName, String contextClassName) {
-    return SUPPLIER.get().declaresContextField(keyClassName, contextClassName);
+    return SUPPLIER.declaresContextField(keyClassName, contextClassName);
   }
 
   @SuppressForbidden
@@ -77,8 +76,10 @@ public final class HierarchyMatchers {
     return ElementMatchers.isAnnotatedWith(matcher);
   }
 
-  public static void registerIfAbsent(Supplier supplier) {
-    SUPPLIER.compareAndSet(null, supplier);
+  public static synchronized void registerIfAbsent(Supplier supplier) {
+    if (null == SUPPLIER) {
+      SUPPLIER = supplier;
+    }
   }
 
   public interface Supplier {


### PR DESCRIPTION
… use `synchronized` `registerIfAbsent` method + `static` `volatile` field

# Motivation

atomic wrapper doesn't really provide much value here, also `AgentTracer` already uses a similar static volatile approach so this makes these other suppliers consistent with that.