### PR TITLE
Simplify name matcher implementation

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
@@ -31,7 +31,7 @@ public class GlobalIgnoresMatcher implements AgentBuilder.RawMatcher {
     if (ClassLoaderMatchers.skipClassLoader(classLoader)) {
       return true;
     }
-    String name = typeDescription.getActualName();
+    String name = typeDescription.getName();
     return GlobalIgnores.isIgnored(name, skipAdditionalLibraryMatcher)
         || CustomExcludes.isExcluded(name)
         || CodeSourceExcludes.isExcluded(protectionDomain)

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/HierarchyMatchers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/HierarchyMatchers.java
@@ -17,7 +17,12 @@ public final class HierarchyMatchers {
   private static volatile Supplier SUPPLIER;
 
   public static ElementMatcher.Junction<TypeDescription> declaresAnnotation(
-      ElementMatcher.Junction<? super NamedElement> matcher) {
+      NameMatchers.Named<? super NamedElement> matcher) {
+    return SUPPLIER.declaresAnnotation(matcher);
+  }
+
+  public static ElementMatcher.Junction<TypeDescription> declaresAnnotation(
+      NameMatchers.OneOf<? super NamedElement> matcher) {
     return SUPPLIER.declaresAnnotation(matcher);
   }
 
@@ -71,8 +76,13 @@ public final class HierarchyMatchers {
 
   @SuppressForbidden
   public static <T extends AnnotationSource & DeclaredByType.WithMandatoryDeclaration>
-      ElementMatcher.Junction<T> isAnnotatedWith(
-          ElementMatcher.Junction<? super NamedElement> matcher) {
+      ElementMatcher.Junction<T> isAnnotatedWith(NameMatchers.Named<? super NamedElement> matcher) {
+    return ElementMatchers.isAnnotatedWith(matcher);
+  }
+
+  @SuppressForbidden
+  public static <T extends AnnotationSource & DeclaredByType.WithMandatoryDeclaration>
+      ElementMatcher.Junction<T> isAnnotatedWith(NameMatchers.OneOf<? super NamedElement> matcher) {
     return ElementMatchers.isAnnotatedWith(matcher);
   }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextInjector.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextInjector.java
@@ -501,7 +501,7 @@ final class FieldBackedContextInjector implements AsmVisitorWrapper {
               null,
               computeSVUID());
         } catch (final Exception e) {
-          log.debug("Failed to add serialVersionUID to {}", instrumentedType.getActualName(), e);
+          log.debug("Failed to add serialVersionUID to {}", instrumentedType.getName(), e);
         }
       }
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ShouldInjectFieldsState.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/ShouldInjectFieldsState.java
@@ -51,7 +51,7 @@ class ShouldInjectFieldsState {
     String implementingClass = typeDescription.getName();
     Map<String, Boolean> visitedInterfaces = new HashMap<>();
     while (null != superClass) {
-      String superClassName = superClass.asErasure().getTypeName();
+      String superClassName = superClass.asErasure().getName();
       if (null == keyTypeIsClass && keyType.equals(superClassName)) {
         // short circuit the search with this key type next time
         KEY_TYPE_IS_CLASS.put(keyType, true);
@@ -73,7 +73,7 @@ class ShouldInjectFieldsState {
   private static boolean hasKeyInterface(
       TypeDefinition typeDefinition, String keyType, Map<String, Boolean> visitedInterfaces) {
     for (TypeDefinition iface : typeDefinition.getInterfaces()) {
-      String interfaceName = iface.asErasure().getTypeName();
+      String interfaceName = iface.asErasure().getName();
       if (keyType.equals(interfaceName)) {
         return true;
       }
@@ -130,7 +130,7 @@ class ShouldInjectFieldsState {
   public static boolean hasInjectedField(TypeDefinition typeDefinition, BitSet excludedStoreIds) {
     Set<String> visitedInterfaces = new HashSet<>();
     while (null != typeDefinition) {
-      String className = typeDefinition.asErasure().getTypeName();
+      String className = typeDefinition.asErasure().getName();
       BitSet excludedStoreIdsForType = EXCLUDED_STORE_IDS_BY_TYPE.get(className);
       if (null != excludedStoreIdsForType) {
         synchronized (excludedStoreIdsForType) {
@@ -149,7 +149,7 @@ class ShouldInjectFieldsState {
   private static boolean impliesInjectedField(
       final TypeDefinition typeDefinition, final Set<String> visitedInterfaces) {
     for (TypeDefinition iface : typeDefinition.getInterfaces()) {
-      String interfaceName = iface.asErasure().getTypeName();
+      String interfaceName = iface.asErasure().getName();
       if (KEY_TYPE_IS_CLASS.containsKey(interfaceName)
           || (visitedInterfaces.add(interfaceName)
               && impliesInjectedField(iface, visitedInterfaces))) {

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java
@@ -6,6 +6,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOn
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers;
 import datadog.trace.api.Config;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.util.Arrays;
@@ -22,7 +23,7 @@ public final class TraceAnnotationsInstrumentation extends Instrumenter.Tracing
 
   static final String CONFIG_FORMAT = "(?:\\s*[\\w.$]+\\s*;)*\\s*[\\w.$]+\\s*;?\\s*";
 
-  private final ElementMatcher.Junction<NamedElement> methodTraceMatcher;
+  private final NameMatchers.OneOf<NamedElement> methodTraceMatcher;
 
   @SuppressForbidden
   public TraceAnnotationsInstrumentation() {


### PR DESCRIPTION
# What Does This Do
 * split implementation back into separate specialized classes so we can tell them apart at runtime
 * only apply deduplication to single-name matchers (the other name matchers rarely have duplicates)
 * enforce that annotation matching only uses named/oneOf matchers to allow type parsing optimization
 * prefer `TypeDescription.getName()` (when available) over other type-name methods for consistency

# Motivation
By limiting annotation matchers to `named` and `namedOneOf` we can optimize parsing of annotation elements to specific annotations only and pre-cache their descriptions. This will then avoid having to lookup (and parse) the actual annotation class at runtime.

# Additional Information
Currently there are 839 individual requests for `named` matchers, of which only 464 are unique.

The cache was sized at 256 because that currently provides the best combination of de-duplication and occupancy:

| cache size | `named` instances |
|------------|--------------------|
|    32            |  558                         |
|    64            |  540                         |
|   128           |  520                         |
|   256           |  483                         |
|   512           |  471                          |
|  1024          |  466                         |
