### PR TITLE
Remove redundant logging from FieldBackedContextProvider

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextProvider.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextProvider.java
@@ -116,14 +116,7 @@ public final class FieldBackedContextProvider implements InstrumentationContextP
             final String contextClassName = entry.getValue();
 
             if (!installedContextMatchers.add(entry)) {
-              if (log.isDebugEnabled()) {
-                log.debug(
-                    "Skipping duplicate builder for matcher {} - instrumentation.class={} instrumentation.target.context={}->{}",
-                    classLoaderMatcher,
-                    instrumenterName,
-                    keyClassName,
-                    contextClassName);
-              }
+              // skip duplicate builder as we've already got one for this context store
               continue;
             }
 


### PR DESCRIPTION
# Motivation
it doesn't tell us anything we need to act on (we expect there to be duplicates when several instrumentations share the same context store)
