### PR TITLE
Simplify trace-annotation matcher

### DIFF
--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java
@@ -1,7 +1,6 @@
 package datadog.trace.instrumentation.trace_annotation;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.declaresMethod;
-import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.hasSuperType;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.isAnnotatedWith;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 
@@ -61,7 +60,7 @@ public final class TraceAnnotationsInstrumentation extends Instrumenter.Tracing
 
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
-    return hasSuperType(declaresMethod(isAnnotatedWith(methodTraceMatcher)));
+    return declaresMethod(isAnnotatedWith(methodTraceMatcher));
   }
 
   @Override


### PR DESCRIPTION
# Motivation

We only apply custom trace advice to declared methods that are directly annotated with the trace annotation:

https://github.com/DataDog/dd-trace-java/blob/v0.102.0/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java#L76

so there's no point in also matching sub-classes because:
* either they don't override the method, in which case there's nothing to instrument as the super-class implementation has already been instrumented
* or they override the method but don't annotate it, in which case the declared method will not have the annotation (overridden methods do not inherit annotations declared on the super-method) and the current advice matcher won't apply to the un-annotated method
* or they override the method and annotate it, in which case the simplified matcher will still match the class

# Notes

If we decide in the future to widen the current advice matcher to include un-annotated method overrides then we can easily change the class matcher back to keep it consistent with the wider advice matcher.