### PR TITLE
Byte Buddy 1.12.12

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
   implementation(gradleApi())
   implementation(localGroovy())
 
-  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.12.9")
+  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.12.12")
 
   implementation("org.eclipse.aether", "aether-connector-basic", "1.1.0")
   implementation("org.eclipse.aether", "aether-transport-http", "1.1.0")

--- a/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
+++ b/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
@@ -20,7 +20,7 @@ class InstrumentPluginTest extends Specification {
     }
 
     dependencies {
-      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.12.9' // just to build TestPlugin
+      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.12.12' // just to build TestPlugin
     }
 
     apply plugin: 'instrument'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -13,7 +13,7 @@ final class CachedData {
     groovy        : groovyVer,
     junit5        : "5.6.2",
     logback       : "1.2.3",
-    bytebuddy     : "1.12.9",
+    bytebuddy     : "1.12.12",
     scala         : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)
     scala210      : "2.10.7",
     scala211      : "2.11.12",


### PR DESCRIPTION
Changes since we last updated...

[Byte Buddy 1.12.12](https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.12.12)
* Use correct annotation in Byte Buddy Gradle plugin.
* Correctly resolve generified anonymous/local types that are declared within a method.

[Byte Buddy 1.12.11](https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.12.11)
* Remove use of thread-local to guarantee Loom compatibility.
* Allow usage of byte-buddy-parent as BOM for imports.
* Add convenience for Maven to disable type validation on entry point.
* Allow Gradle plugin to consume pluginName property and discoverySet to only load plugins in the plugin class loader.

[Byte Buddy 1.12.10](https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.12.10)
* Correctly resolve temporary folder, if custom folder is set, on Linux during emulated attach.
* Attempt guessing if Graal automatic configuration agent for native image is run.
* Avoid hard-coded dependencies to classes of java.management module.
* Do not include OSGi info in Byte Buddy source module.