### PR TITLE
Run test containers on docker in docker on CircleCI

### DIFF
--- a/.circleci/autoforward.py
+++ b/.circleci/autoforward.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import dataclasses
+import threading
+import sys
+import signal
+import subprocess
+import json
+import re
+import time
+import logging
+
+
+@dataclasses.dataclass(frozen=True)
+class Forward:
+  port: int
+
+  def __ne__(self, other):
+    return not self.__eq__(other)
+
+  @staticmethod
+  def parse_list(ports):
+    r = []
+    for port in ports.split(","):
+      port_splits = port.split("->")
+      if len(port_splits) < 2:
+        continue
+      host, ports = Forward.parse_host(port_splits[0], "localhost")
+      for port in ports:
+        r.append(Forward(port))
+    return r
+
+  @staticmethod
+  def parse_host(s, default_host):
+    s = re.sub("/.*$", "", s)
+    hp = s.split(":")
+    if len(hp) == 1:
+      return default_host, Forward.parse_ports(hp[0])
+    if len(hp) == 2:
+      return hp[0], Forward.parse_ports(hp[1])
+    return None, []
+
+  @staticmethod
+  def parse_ports(ports):
+    port_range = ports.split("-")
+    start = int(port_range[0])
+    end = int(port_range[0]) + 1
+    if len(port_range) > 2 or len(port_range) < 1:
+      raise RuntimeError(f"don't know what to do with ports {ports}")
+    if len(port_range) == 2:
+      end = int(port_range[1]) + 1
+    return list(range(start, end))
+
+
+class PortForwarder:
+  def __init__(self, forward, local_bind_address="127.0.0.1"):
+    self.process = subprocess.Popen(
+      [
+        "ssh",
+        "-N",
+        f"-L{local_bind_address}:{forward.port}:localhost:{forward.port}",
+        "remote-docker",
+      ]
+    )
+
+  def stop(self):
+    self.process.kill()
+
+
+class DockerForwarder:
+  def __init__(self):
+    self.running = threading.Event()
+    self.running.set()
+
+  def start(self):
+    forwards = {}
+    try:
+      while self.running.is_set():
+        new_forwards = self.container_config()
+        existing_forwards = list(forwards.keys())
+        for forward in new_forwards:
+          if forward in existing_forwards:
+            existing_forwards.remove(forward)
+          else:
+            logging.info(f"adding forward {forward}")
+            forwards[forward] = PortForwarder(forward)
+
+        for to_clean in existing_forwards:
+          logging.info(f"stopping forward {to_clean}")
+          forwards[to_clean].stop()
+          del forwards[to_clean]
+        time.sleep(0.8)
+    finally:
+      for forward in forwards.values():
+        forward.stop()
+
+  @staticmethod
+  def container_config():
+    def cmd(cmd_array):
+      out = subprocess.Popen(
+        cmd_array,
+        universal_newlines=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+      )
+      out.wait()
+      return out.communicate()[0]
+
+    try:
+      stdout = cmd(["docker", "ps", "--format", "'{{json .}}'"])
+      stdout = stdout.replace("'", "")
+      configs = map(lambda l: json.loads(l), stdout.splitlines())
+      forwards = []
+      for c in configs:
+        if c is None or c["Ports"] is None:
+          continue
+        ports = c["Ports"].strip()
+        if ports == "":
+          continue
+        forwards += Forward.parse_list(ports)
+      return forwards
+    except RuntimeError:
+      logging.error("Unexpected error:", sys.exc_info()[0])
+      return []
+
+  def stop(self):
+    logging.info("stopping")
+    self.running.clear()
+
+
+def main():
+  logging.basicConfig(
+    format='%(asctime)s %(levelname)-8s %(message)s',
+    level=logging.INFO,
+    datefmt='%Y-%m-%d %H:%M:%S')
+  forwarder = DockerForwarder()
+
+  def handler(*_):
+    forwarder.stop()
+
+  signal.signal(signal.SIGINT, handler)
+
+  forwarder.start()
+
+
+if __name__ == "__main__":
+  main()

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,52 @@ commands:
       - attach_workspace:
           at: .
 
+  setup_testcontainers:
+    description: >-
+      Sets up remote docker and automatic port forwarding needed for docker on docker
+      version of Testcontainers.
+    steps:
+      - setup_remote_docker:
+          version: 20.10.14
+          docker_layer_caching: true
+
+      - run:
+          name: Show local ports
+          command: |
+            sudo sysctl net.ipv4.ip_local_port_range
+
+      - run:
+          name: Show remote Docker ports
+          command: |
+            ssh remote-docker 'sudo sysctl net.ipv4.ip_local_port_range'
+
+      - run:
+          name: Offset remote Docker ports to avoid tunnel collisions
+          command: |
+            ssh remote-docker 'sudo sysctl -w net.ipv4.ip_local_port_range="59095 60906"'
+
+      - run:
+          name: Restart remote Docker
+          command: |
+            ssh remote-docker 'sudo sh -c "systemctl daemon-reload; systemctl restart docker"'
+
+      - run:
+          name: Show remote Docker ports
+          command: |
+            ssh remote-docker 'sudo sysctl net.ipv4.ip_local_port_range'
+
+      - run:
+          name: Testcontainers environment variables
+          command: |
+            echo "export TESTCONTAINERS_HOST_OVERRIDE=localhost" >> $BASH_ENV
+            echo "export TESTCONTAINERS_RYUK_DISABLED=true" >> $BASH_ENV
+
+      - run:
+          name: Testcontainers tunnels
+          background: true
+          command: |
+            .circleci/autoforward.py
+
   early_return_for_forked_pull_requests:
     description: >-
       If this build is from a fork, stop executing the current job and return success.
@@ -225,33 +271,20 @@ jobs:
 
     docker:
       - image: *default_container
-        # This is used by spymemcached instrumentation tests
-      - image: memcached
-        # This is used by rabbitmq instrumentation tests
-      - image: rabbitmq
-        # This is used by aerospike instrumentation tests
-      - image: aerospike:5.5.0.9
-        # This is used by mongodb instrumentation tests
-      - image: mongo
-        # This is used by jdbc and vert.x tests
-      - image: mysql
-        environment:
-          MYSQL_ROOT_PASSWORD: password
-          MYSQL_USER: sa
-          MYSQL_PASSWORD: sa
-          MYSQL_DATABASE: jdbcUnitTest
-        # This is used by jdbc tests
-      - image: postgres
-        environment:
-          POSTGRES_USER: sa
-          POSTGRES_PASSWORD: sa
-          POSTGRES_DB: jdbcUnitTest
 
     steps:
       - setup_code
 
       - restore_cache:
           <<: *cache_keys
+
+      - setup_testcontainers
+
+      - run:
+          name: Start RabbitMQ (since the forked AmqpTests are having issues with Testcontainers)
+          background: true
+          command: |
+            docker run -p 5672:5672 rabbitmq:3.9.20-alpine
 
       - run:
           name: Run tests
@@ -295,16 +328,14 @@ jobs:
 
     docker:
       - image: *default_container
-        # This is used by rabbitmq smoke tests
-      - image: rabbitmq
-        # This is used by mongodb smoke tests
-      - image: mongo
 
     steps:
       - setup_code
 
       - restore_cache:
           <<: *cache_keys
+
+      - setup_testcontainers
 
       - run:
           name: Run Tests

--- a/dd-java-agent/instrumentation/aerospike-4/aerospike-4.gradle
+++ b/dd-java-agent/instrumentation/aerospike-4/aerospike-4.gradle
@@ -25,3 +25,7 @@ dependencies {
 
   latestDepTestImplementation group: 'com.aerospike', name: 'aerospike-client', version: '+'
 }
+
+tasks.withType(Test).configureEach {
+  usesService(testcontainersLimit)
+}

--- a/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeAsyncClientTest.groovy
@@ -8,10 +8,13 @@ import com.aerospike.client.async.EventLoops
 import com.aerospike.client.async.NioEventLoops
 import com.aerospike.client.listener.WriteListener
 import com.aerospike.client.policy.ClientPolicy
+import spock.lang.Requires
 import spock.lang.Shared
 
 import static org.junit.Assert.fail
 
+// Do not run tests on Java7 since testcontainers are not compatible with Java7
+@Requires({ jvm.java8Compatible })
 class AerospikeAsyncClientTest extends AerospikeBaseTest {
 
   @Shared

--- a/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeBaseTest.groovy
+++ b/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeBaseTest.groovy
@@ -13,9 +13,8 @@ import static datadog.trace.agent.test.utils.PortUtils.waitForPortToOpen
 import static java.util.concurrent.TimeUnit.SECONDS
 import static org.testcontainers.containers.wait.strategy.Wait.forLogMessage
 
-// Do not run tests locally on Java7 since testcontainers are not compatible with Java7
-// It is fine to run on CI because CI provides aerospike externally, not through testcontainers
-@Requires({ "true" == System.getenv("CI") || jvm.java8Compatible })
+// Do not run tests on Java7 since testcontainers are not compatible with Java7
+@Requires({ jvm.java8Compatible })
 abstract class AerospikeBaseTest extends AgentTestRunner {
 
   @Shared
@@ -28,20 +27,13 @@ abstract class AerospikeBaseTest extends AgentTestRunner {
   int aerospikePort = 3000
 
   def setup() throws Exception {
-    /*
-     CI will provide us with an aerospike container running alongside our build.
-     When building locally, however, we need to take matters into our own hands
-     and we use 'testcontainers' for this.
-     */
-    if ("true" != System.getenv("CI")) {
-      aerospike = new GenericContainer('aerospike:5.5.0.9')
-        .withExposedPorts(3000)
-        .waitingFor(forLogMessage(".*heartbeat-received.*\\n", 1))
+    aerospike = new GenericContainer('aerospike:5.5.0.9')
+      .withExposedPorts(3000)
+      .waitingFor(forLogMessage(".*heartbeat-received.*\\n", 1))
 
-      aerospike.start()
+    aerospike.start()
 
-      aerospikePort = aerospike.getMappedPort(3000)
-    }
+    aerospikePort = aerospike.getMappedPort(3000)
 
     waitForPortToOpen(aerospikePort, 10, SECONDS)
   }

--- a/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeClientTest.groovy
+++ b/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeClientTest.groovy
@@ -3,8 +3,11 @@ package datadog.trace.instrumentation.aerospike4
 import com.aerospike.client.AerospikeClient
 import com.aerospike.client.Bin
 import com.aerospike.client.Key
+import spock.lang.Requires
 import spock.lang.Shared
 
+// Do not run tests on Java7 since testcontainers are not compatible with Java7
+@Requires({ jvm.java8Compatible })
 class AerospikeClientTest extends AerospikeBaseTest {
 
   @Shared

--- a/dd-java-agent/instrumentation/jdbc/jdbc.gradle
+++ b/dd-java-agent/instrumentation/jdbc/jdbc.gradle
@@ -80,3 +80,7 @@ tasks.named("test").configure {
 tasks.named("latestDepJava11Test").configure {
   javaLauncher = getJavaLauncherFor(11)
 }
+
+tasks.withType(Test).configureEach {
+  usesService(testcontainersLimit)
+}

--- a/dd-java-agent/instrumentation/mongo/src/test/groovy/MongoBaseTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/src/test/groovy/MongoBaseTest.groovy
@@ -31,25 +31,16 @@ class MongoBaseTest extends AgentTestRunner {
   MongodProcess mongod
 
   def setupSpec() throws Exception {
-    /*
-     CI will provide us with a mongo container running alongside our build.
-     When building locally we need to take matters into our own hands and
-     start our own mongo server.
-     */
-    if ("true" != System.getenv("CI")) {
-      port = PortUtils.randomOpenPort()
+    port = PortUtils.randomOpenPort()
 
-      final IMongodConfig mongodConfig =
-        new MongodConfigBuilder()
-        .version(Version.Main.PRODUCTION)
-        .net(new Net("localhost", port, Network.localhostIsIPv6()))
-        .build()
+    final IMongodConfig mongodConfig =
+      new MongodConfigBuilder()
+      .version(Version.Main.PRODUCTION)
+      .net(new Net("localhost", port, Network.localhostIsIPv6()))
+      .build()
 
-      mongodExe = STARTER.prepare(mongodConfig)
-      mongod = mongodExe.start()
-    } else {
-      port = 27017 // default mongo port when running on CI
-    }
+    mongodExe = STARTER.prepare(mongodConfig)
+    mongod = mongodExe.start()
   }
 
   def cleanupSpec() throws Exception {

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/rabbitmq-amqp-2.7.gradle
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/rabbitmq-amqp-2.7.gradle
@@ -34,3 +34,7 @@ configurations.testRuntimeClasspath {
     force group: 'com.rabbitmq', name: 'amqp-client', version: '2.7.0'
   }
 }
+
+tasks.withType(Test).configureEach {
+  usesService(testcontainersLimit)
+}

--- a/dd-java-agent/instrumentation/spring-rabbit/spring-rabbit.gradle
+++ b/dd-java-agent/instrumentation/spring-rabbit/spring-rabbit.gradle
@@ -33,3 +33,7 @@ dependencies {
 
   latestDepTestImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-amqp', version: '+'
 }
+
+tasks.withType(Test).configureEach {
+  usesService(testcontainersLimit)
+}

--- a/dd-java-agent/instrumentation/spring-rabbit/src/test/groovy/SpringAmqpTest.groovy
+++ b/dd-java-agent/instrumentation/spring-rabbit/src/test/groovy/SpringAmqpTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.utils.PortUtils
 import org.testcontainers.containers.RabbitMQContainer
 import rabbit.MessagingRabbitMQApplication
 import rabbit.Receiver
@@ -16,14 +17,13 @@ class SpringAmqpTest extends AgentTestRunner {
 
   @Override
   def setupSpec() {
-    if (System.getenv("CI") != "true") {
-      rabbit = new RabbitMQContainer("rabbitmq:latest")
-      rabbit.start()
-      MessagingRabbitMQApplication.hostName = rabbit.getHost()
-      MessagingRabbitMQApplication.port = rabbit.getMappedPort(MessagingRabbitMQApplication.port)
-    } else {
-      rabbit = null
-    }
+    rabbit = new RabbitMQContainer("rabbitmq:3.9.20-alpine")
+    rabbit.start()
+    def hostName = rabbit.getHost()
+    def port = rabbit.getMappedPort(MessagingRabbitMQApplication.port)
+    MessagingRabbitMQApplication.hostName = hostName
+    MessagingRabbitMQApplication.port = port
+    PortUtils.waitForPortToOpen(hostName, port, 5, TimeUnit.SECONDS)
   }
 
   @Override

--- a/dd-java-agent/instrumentation/spymemcached-2.12/spymemcached-2.12.gradle
+++ b/dd-java-agent/instrumentation/spymemcached-2.12/spymemcached-2.12.gradle
@@ -25,3 +25,7 @@ dependencies {
 
   latestDepTestImplementation group: 'net.spy', name: 'spymemcached', version: '+'
 }
+
+tasks.withType(Test).configureEach {
+  usesService(testcontainersLimit)
+}

--- a/dd-java-agent/instrumentation/vertx-mysql-client-3.9/vertx-mysql-client-3.9.gradle
+++ b/dd-java-agent/instrumentation/vertx-mysql-client-3.9/vertx-mysql-client-3.9.gradle
@@ -49,3 +49,7 @@ dependencies {
 
   latestDepTestImplementation group: 'io.vertx', name: 'vertx-mysql-client', version: '3.+'
 }
+
+tasks.withType(Test).configureEach {
+  usesService(testcontainersLimit)
+}

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -149,6 +149,7 @@ abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.L
 
     rootLogger.setLevel(Level.WARN)
     ((Logger) LoggerFactory.getLogger("datadog")).setLevel(Level.DEBUG)
+    ((Logger) LoggerFactory.getLogger("org.testcontainers")).setLevel(Level.DEBUG)
   }
 
   @SuppressForbidden

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/PortUtils.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/PortUtils.java
@@ -38,7 +38,11 @@ public class PortUtils {
   }
 
   private static boolean isPortOpen(final int port) {
-    try (final Socket socket = new Socket((String) null, port)) {
+    return isPortOpen(null, port);
+  }
+
+  private static boolean isPortOpen(String host, int port) {
+    try (final Socket socket = new Socket(host, port)) {
       return true;
     } catch (final IOException e) {
       return false;
@@ -72,31 +76,46 @@ public class PortUtils {
     throw new RuntimeException("Timed out waiting for port " + port + " to be opened");
   }
 
+  public static void waitForPortToOpen(String host, int port, long timeout, TimeUnit unit) {
+    waitForPort(host, port, timeout, unit, true);
+  }
+
   public static void waitForPortToOpen(int port, long timeout, TimeUnit unit) {
-    waitForPort(port, timeout, unit, true);
+    waitForPortToOpen(null, port, timeout, unit);
   }
 
   public static void waitForPortToClose(int port, long timeout, TimeUnit unit) {
-    waitForPort(port, timeout, unit, false);
+    waitForPort(null, port, timeout, unit, false);
   }
 
-  private static void waitForPort(int port, long timeout, TimeUnit unit, boolean open) {
+  private static void waitForPort(
+      String host, int port, long timeout, TimeUnit unit, boolean open) {
     long waitNanos = unit.toNanos(timeout);
     long start = System.nanoTime();
     String state = open ? "open" : "closed";
 
     while (System.nanoTime() - start < waitNanos) {
-      if (isPortOpen(port) == open) {
+      if (isPortOpen(host, port) == open) {
         return;
       }
 
       try {
         Thread.sleep(100);
       } catch (final InterruptedException e) {
-        throw new RuntimeException("Interrupted while waiting for " + port + " to be " + state);
+        throw new RuntimeException(
+            "Interrupted while waiting for "
+                + (host != null ? host + ":" : "")
+                + port
+                + " to be "
+                + state);
       }
     }
 
-    throw new RuntimeException("Timed out waiting for port " + port + " to be " + state);
+    throw new RuntimeException(
+        "Timed out waiting for port "
+            + (host != null ? host + ":" : "")
+            + port
+            + " to be "
+            + state);
   }
 }

--- a/dd-smoke-tests/spring-boot-rabbit/README.md
+++ b/dd-smoke-tests/spring-boot-rabbit/README.md
@@ -22,7 +22,7 @@ The HTTP server accepts requests on `http://{host}:{port}/roundtrip/{message}`
 Here is an example with two participating nodes that use the queues `queue` and `otherqueue` to communicate.
 
 ```
-terminal1> docker run -d --hostname my-rabbit --name some-rabbit -p 5672:5672 rabbitmq:latest
+terminal1> docker run -d --hostname my-rabbit --name some-rabbit -p 5672:5672 rabbitmq:3.9.20-alpine
 
 terminal1> java -Ddd.service.name=spring-rabbit-1 -jar build/libs/build/libs/spring-boot-rabbit-X.Y.Z-all.jar --rabbit.sender.queue=otherqueue
 

--- a/dd-smoke-tests/spring-boot-rabbit/spring-boot-rabbit.gradle
+++ b/dd-smoke-tests/spring-boot-rabbit/spring-boot-rabbit.gradle
@@ -34,4 +34,6 @@ tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
 
   jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archivePath}"
+
+  usesService(testcontainersLimit)
 }

--- a/dd-smoke-tests/spring-boot-rabbit/src/test/groovy/datadog/smoketest/SpringBootRabbitIntegrationTest.groovy
+++ b/dd-smoke-tests/spring-boot-rabbit/src/test/groovy/datadog/smoketest/SpringBootRabbitIntegrationTest.groovy
@@ -1,8 +1,11 @@
 package datadog.smoketest
 
+import datadog.trace.agent.test.utils.PortUtils
 import okhttp3.Request
 import org.testcontainers.containers.RabbitMQContainer
 import spock.lang.Shared
+
+import java.util.concurrent.TimeUnit
 
 class SpringBootRabbitIntegrationTest extends AbstractServerSmokeTest {
 
@@ -27,14 +30,11 @@ class SpringBootRabbitIntegrationTest extends AbstractServerSmokeTest {
 
   @Override
   void beforeProcessBuilders() {
-    if ("true" == System.getenv("CI")) {
-      // CircleCI provides a rabbit image
-    } else {
-      rabbitMQContainer = new RabbitMQContainer("rabbitmq:latest")
-      rabbitMQContainer.start()
-      rabbitHost = rabbitMQContainer.getHost()
-      rabbitPort = rabbitMQContainer.getMappedPort(5672)
-    }
+    rabbitMQContainer = new RabbitMQContainer("rabbitmq:3.9.20-alpine")
+    rabbitMQContainer.start()
+    rabbitHost = rabbitMQContainer.getHost()
+    rabbitPort = rabbitMQContainer.getMappedPort(5672)
+    PortUtils.waitForPortToOpen(rabbitHost, rabbitPort, 5, TimeUnit.SECONDS)
   }
 
   @Override

--- a/dd-smoke-tests/springboot-mongo/springboot-mongo.gradle
+++ b/dd-smoke-tests/springboot-mongo/springboot-mongo.gradle
@@ -33,4 +33,6 @@ tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
 
   jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archivePath}"
+
+  usesService(testcontainersLimit)
 }

--- a/dd-smoke-tests/springboot-mongo/src/test/groovy/datadog/smoketest/SpringBootMongoIntegrationTest.groovy
+++ b/dd-smoke-tests/springboot-mongo/src/test/groovy/datadog/smoketest/SpringBootMongoIntegrationTest.groovy
@@ -23,13 +23,9 @@ class SpringBootMongoIntegrationTest extends AbstractServerSmokeTest {
 
   @Override
   void beforeProcessBuilders() {
-    if ("true" == System.getenv("CI")) {
-      // CircleCI provides a mongo image
-    } else {
-      mongoDbContainer = new MongoDBContainer(DockerImageName.parse("mongo:4.0.10"))
-      mongoDbContainer.start()
-      mongoDbUri = mongoDbContainer.replicaSetUrl
-    }
+    mongoDbContainer = new MongoDBContainer(DockerImageName.parse("mongo:4.0.10"))
+    mongoDbContainer.start()
+    mongoDbUri = mongoDbContainer.replicaSetUrl
   }
 
   @Override

--- a/dd-trace-core/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
@@ -91,7 +91,7 @@ class DDApiIntegrationTest extends DDSpecification {
       //        print output.utf8String
       //      }
       agentContainer.start()
-      agentContainerHost = agentContainer.containerIpAddress
+      agentContainerHost = agentContainer.getHost()
       agentContainerPort = agentContainer.getMappedPort(datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_PORT)
     }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -26,7 +26,7 @@ final class CachedData {
     commons       : "3.2",
     mockito       : '4.4.0',
     moshi         : '1.9.2',
-    testcontainers: '1.17.2',
+    testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
     asyncprofiler : "2.8-DD-20220530"

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -8,6 +8,11 @@ apply from: "$rootDir/gradle/spotless.gradle"
 apply from: "$rootDir/gradle/spotbugs.gradle"
 apply from: "$rootDir/gradle/repositories.gradle"
 
+// Only run one testcontainers test at a time
+ext.testcontainersLimit = gradle.sharedServices.registerIfAbsent("testcontainersLimit", BuildService) {
+  maxParallelUsages = 1
+}
+
 // Task for tests that want to run forked in their own separate JVM
 tasks.register('forkedTest', Test) {
 }


### PR DESCRIPTION
# What Does This Do

This sets up CI to run Testcontainers on Docker in Docker.

# Motivation

Make it easier to add Testcontainers to integrations that need to test against standalone services, without having a Docker containter for each service run during the whole CI execution.

# Additional Notes

* Uses a Python script to forward ports from the `remote-docker` instance that is only reachable via `ssh`, to the host running the tests.
* The `rabbit-amqp-2.7` forked tests are having issues with Testcontainers, even locally, so they get a rabbit instance running on the standar rabbit port during the whole integration test run.