### PR TITLE
Add some simple trace-annotation inheritance tests

### DIFF
--- a/dd-java-agent/instrumentation/trace-annotation/src/test/java/dd/test/trace/annotation/TracedInterface.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/java/dd/test/trace/annotation/TracedInterface.java
@@ -1,0 +1,18 @@
+package dd.test.trace.annotation;
+
+import datadog.trace.api.Trace;
+
+public interface TracedInterface {
+  @Trace
+  String testTracedInterfaceMethod();
+
+  @Trace
+  default String testTracedDefaultMethod() {
+    return "Hello from default method";
+  }
+
+  @Trace
+  default String testOverriddenTracedDefaultMethod() {
+    return "Expected to be overridden!";
+  }
+}

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/java/dd/test/trace/annotation/TracedSubClass.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/java/dd/test/trace/annotation/TracedSubClass.java
@@ -1,0 +1,23 @@
+package dd.test.trace.annotation;
+
+public class TracedSubClass extends TracedSuperClass implements TracedInterface {
+  @Override
+  public String testTracedInterfaceMethod() {
+    return "Hello from implemented interface method";
+  }
+
+  @Override
+  public String testOverriddenTracedDefaultMethod() {
+    return "Hello from overridden default method";
+  }
+
+  @Override
+  public String testTracedAbstractMethod() {
+    return "Hello from implemented abstract method";
+  }
+
+  @Override
+  public String testOverriddenTracedSuperMethod() {
+    return "Hello from overridden super method";
+  }
+}

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/java/dd/test/trace/annotation/TracedSuperClass.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/java/dd/test/trace/annotation/TracedSuperClass.java
@@ -1,0 +1,18 @@
+package dd.test.trace.annotation;
+
+import datadog.trace.api.Trace;
+
+public abstract class TracedSuperClass {
+  @Trace
+  public abstract String testTracedAbstractMethod();
+
+  @Trace
+  public String testTracedSuperMethod() {
+    return "Hello from super method";
+  }
+
+  @Trace
+  public String testOverriddenTracedSuperMethod() {
+    return "Expected to be overridden!";
+  }
+}

--- a/dd-java-agent/instrumentation/trace-annotation/trace-annotation.gradle
+++ b/dd-java-agent/instrumentation/trace-annotation/trace-annotation.gradle
@@ -1,3 +1,7 @@
+ext {
+  minJavaVersionForTests = JavaVersion.VERSION_1_8
+}
+
 muzzle {
   pass {
     group = "com.datadoghq"


### PR DESCRIPTION
# What Does This Do
This codifies what we currently expect when using `@Traced` with interface/class methods when they're overridden or implemented without explicitly copying over the `@Traced` annotation from the original interface/class method.

The current expected behaviour is that only methods that are directly annotated with `@Trace` produce spans. These methods can be declared in super-classes or as default interface methods, but if they are overridden in a sub-class then the overriding method also needs to be annotated with `@Trace` in order for that method to produce spans (note the original method will still produce its own spans if it is invoked from the overriding method with `super.method(...)`)

If a method is overridden (or implemented in the case of an interface or abstract method) and the overriding/implementing method is not annotated with `@Trace` then that method will not produce spans, even if the interface/abstract method is annotated with `@Trace`. In other words the `@Trace` annotation is _not_ implicitly inherited by overriding/implementing methods. It has to be explicitly copied over.

In the future we may decide to extend the trace-annotation instrumentation to support inheriting `@Trace` from interface/super-class methods, because that is a useful feature - at which point these tests will be updated to reflect that.

NOTE: this is the same behaviour as previous releases, except they had a bug where default interface methods annotated with `@Trace` did not produce spans.

# Motivation
Having tests capture the current behaviour makes it easier to a) verify that's what we want and b) evolve the behaviour to support new use-cases

# Additional Notes
Further tests would be useful to capture expected trace annotation behaviour for classes that use generics and generated private accessors, where the method invocation involves a bridge/synthetic method.
