### PR TITLE
Fix NPE when listing integrations with 'java -jar dd-java-agent.jar -li'

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentCLI.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentCLI.java
@@ -1,5 +1,7 @@
 package datadog.trace.agent.tooling;
 
+import datadog.trace.agent.tooling.bytebuddy.SharedTypePools;
+import datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers;
 import datadog.trace.bootstrap.Agent;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -9,6 +11,10 @@ import java.util.TreeSet;
 
 /** CLI methods, used when running the agent as a sample application with -jar. */
 public final class AgentCLI {
+  static {
+    SharedTypePools.registerIfAbsent(SharedTypePools.simpleCache());
+    HierarchyMatchers.registerIfAbsent(HierarchyMatchers.simpleChecks());
+  }
 
   /** Prints all known integrations in alphabetical order. */
   public static void printIntegrationNames() {

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/ListIntegrationsTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/ListIntegrationsTest.groovy
@@ -1,0 +1,22 @@
+package datadog.trace.agent
+
+import datadog.trace.agent.test.IntegrationTestUtils
+import datadog.trace.bootstrap.AgentJar
+import spock.lang.Specification
+import spock.lang.Timeout
+
+@Timeout(30)
+class ListIntegrationsTest extends Specification {
+
+  def "dd.trace.debug false"() {
+    setup:
+    def testOutput = new ByteArrayOutputStream()
+    expect:
+    IntegrationTestUtils.runOnSeparateJvm(AgentJar.name
+      , [] as String[]
+      , ["-li"] as String[]
+      , [:]
+      , new PrintStream(testOutput)) == 0
+    !new String(testOutput.toByteArray()).contains("ERROR")
+  }
+}


### PR DESCRIPTION
Register simple matchers/type-pool to avoid NPE when querying the various `Instrumenter`s in the CLI