### PR TITLE
Properly detect non-OpenJ9 J9 distributions

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-async/src/test/java/com/datadog/profiling/controller/ControllerFactoryTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-async/src/test/java/com/datadog/profiling/controller/ControllerFactoryTest.java
@@ -24,9 +24,9 @@ public class ControllerFactoryTest {
       throws UnsupportedEnvironmentException, ConfigurationException {
     // Enable test on OpenJ9 only
     final String javaVendor = System.getProperty("java.vendor");
-    final String javaRuntimeName = System.getProperty("java.runtime.name");
+    final String javaVmName = System.getProperty("java.vm.name");
     assumeTrue(
-        javaVendor.equals("IBM Corporation") && javaRuntimeName.startsWith("IBM Semeru Runtime"));
+        javaVendor.equals("IBM Corporation") && javaVmName.contains("J9"));
 
     Properties props = new Properties();
     props.put(PROFILING_ASYNC_ENABLED, Boolean.toString(true));

--- a/dd-java-agent/agent-profiling/profiling-controller-async/src/test/java/com/datadog/profiling/controller/ControllerFactoryTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-async/src/test/java/com/datadog/profiling/controller/ControllerFactoryTest.java
@@ -25,8 +25,7 @@ public class ControllerFactoryTest {
     // Enable test on OpenJ9 only
     final String javaVendor = System.getProperty("java.vendor");
     final String javaVmName = System.getProperty("java.vm.name");
-    assumeTrue(
-        javaVendor.equals("IBM Corporation") && javaVmName.contains("J9"));
+    assumeTrue(javaVendor.equals("IBM Corporation") && javaVmName.contains("J9"));
 
     Properties props = new Properties();
     props.put(PROFILING_ASYNC_ENABLED, Boolean.toString(true));

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ControllerFactory.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ControllerFactory.java
@@ -76,7 +76,7 @@ public final class ControllerFactory {
     if (impl == Implementation.NONE) {
       boolean isOpenJ9 =
           System.getProperty("java.vendor").equals("IBM Corporation")
-              && System.getProperty("java.runtime.name").startsWith("IBM Semeru Runtime");
+              && System.getProperty("java.vm.name").contains("J9");
       if (configProvider.getBoolean(
               ProfilingConfig.PROFILING_ASYNC_ENABLED,
               ProfilingConfig.PROFILING_ASYNC_ENABLED_DEFAULT)


### PR DESCRIPTION
# What Does This Do

Some distributions of J9 wouldn't be detected as they wouldn't come from the open source Ecplise OpenJ9 distribution.

# Motivation

Fix a customer's case.

# Additional Notes
