### PR TITLE
Add feature flag for IAST

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -69,6 +69,7 @@ public class Agent {
     STARTUP_LOGS("dd.trace.startup.logs", true),
     PROFILING("dd.profiling.enabled", false),
     APPSEC("dd.appsec.enabled", false),
+    APPSEC_IAST("dd.appsec.iast.enabled", false),
     CWS("dd.cws.enabled", false),
     CIVISIBILITY("dd.civisibility.enabled", false),
     CIVISIBILITY_AGENTLESS("dd.civisibility.agentless.enabled", false);
@@ -111,6 +112,7 @@ public class Agent {
   private static boolean jmxFetchEnabled = true;
   private static boolean profilingEnabled = false;
   private static boolean appSecEnabled = false;
+  private static boolean appSecIastEnabled = false;
   private static boolean cwsEnabled = false;
   private static boolean ciVisibilityEnabled = false;
 
@@ -131,6 +133,7 @@ public class Agent {
       setSystemPropertyDefault(AgentFeature.JMXFETCH.getSystemProp(), "false");
       setSystemPropertyDefault(AgentFeature.PROFILING.getSystemProp(), "false");
       setSystemPropertyDefault(AgentFeature.APPSEC.getSystemProp(), "false");
+      setSystemPropertyDefault(AgentFeature.APPSEC_IAST.getSystemProp(), "false");
       setSystemPropertyDefault(AgentFeature.CWS.getSystemProp(), "false");
 
       /*if CI Visibility is enabled, the PrioritizationType should be {@code Prioritization.ENSURE_TRACE} */
@@ -145,6 +148,7 @@ public class Agent {
     jmxFetchEnabled = isFeatureEnabled(AgentFeature.JMXFETCH);
     profilingEnabled = isFeatureEnabled(AgentFeature.PROFILING);
     appSecEnabled = isFeatureEnabled(AgentFeature.APPSEC);
+    appSecIastEnabled = isFeatureEnabled(AgentFeature.APPSEC_IAST);
     cwsEnabled = isFeatureEnabled(AgentFeature.CWS);
 
     if (profilingEnabled) {

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -51,6 +51,7 @@ public class AgentInstaller {
     if (Config.get().isTraceEnabled()
         || Config.get().isProfilingEnabled()
         || Config.get().isAppSecEnabled()
+        || Config.get().isAppSecIastEnabled()
         || Config.get().isCiVisibilityEnabled()) {
       installBytebuddyAgent(inst, false, new AgentBuilder.Listener[0]);
       if (DEBUG) {
@@ -169,6 +170,9 @@ public class AgentInstaller {
     }
     if (cfg.isAppSecEnabled()) {
       enabledSystems.add(Instrumenter.TargetSystem.APPSEC);
+    }
+    if (cfg.isAppSecIastEnabled()) {
+      enabledSystems.add(Instrumenter.TargetSystem.APPSEC_IAST);
     }
     if (cfg.isCiVisibilityEnabled()) {
       enabledSystems.add(Instrumenter.TargetSystem.CIVISIBILITY);

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -48,6 +48,7 @@ public interface Instrumenter {
     TRACING,
     PROFILING,
     APPSEC,
+    APPSEC_IAST,
     CIVISIBILITY
   }
 
@@ -303,6 +304,18 @@ public interface Instrumenter {
     @Override
     public boolean isApplicable(Set<TargetSystem> enabledSystems) {
       return enabledSystems.contains(TargetSystem.APPSEC);
+    }
+  }
+
+  /** Parent class for all AppSec IAST related instrumentations */
+  abstract class AppSecIast extends Default {
+    public AppSecIast(String instrumentationName, String... additionalNames) {
+      super(instrumentationName, additionalNames);
+    }
+
+    @Override
+    public boolean isApplicable(Set<TargetSystem> enabledSystems) {
+      return enabledSystems.contains(TargetSystem.APPSEC_IAST);
     }
   }
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -75,6 +75,8 @@ public final class ConfigDefaults {
   static final int DEFAULT_APPSEC_TRACE_RATE_LIMIT = 100;
   static final boolean DEFAULT_APPSEC_WAF_METRICS = true;
 
+  static final boolean DEFAULT_APPSEC_IAST_ENABLED = false;
+
   static final boolean DEFAULT_CIVISIBILITY_ENABLED = false;
   static final boolean DEFAULT_CIVISIBILITY_AGENTLESS_ENABLED = false;
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/AppSecIastConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/AppSecIastConfig.java
@@ -1,0 +1,9 @@
+package datadog.trace.api.config;
+
+/** Constant with names of configuration options for AppSec IAST. */
+public final class AppSecIastConfig {
+
+  public static final String APPSEC_IAST_ENABLED = "appsec.iast.enabled";
+
+  private AppSecIastConfig() {}
+}

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -5,6 +5,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_TIMEOUT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_WRITER_TYPE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_ANALYTICS_SAMPLE_RATE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_IAST_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_REPORTING_INBAND;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_TRACE_RATE_LIMIT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_WAF_METRICS;
@@ -86,6 +87,7 @@ import static datadog.trace.api.config.AppSecConfig.APPSEC_REPORT_TIMEOUT_SEC;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_RULES_FILE;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_TRACE_RATE_LIMIT;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_WAF_METRICS;
+import static datadog.trace.api.config.AppSecIastConfig.APPSEC_IAST_ENABLED;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_AGENTLESS_ENABLED;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_AGENTLESS_URL;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_ENABLED;
@@ -484,6 +486,8 @@ public class Config {
   private final boolean appSecWafMetrics;
   private final String appSecObfuscationParameterKeyRegexp;
   private final String appSecObfuscationParameterValueRegexp;
+
+  private final boolean appSecIastEnabled;
 
   private final boolean ciVisibilityEnabled;
   private final boolean ciVisibilityAgentlessEnabled;
@@ -1013,6 +1017,8 @@ public class Config {
         configProvider.getString(APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP, null);
     appSecObfuscationParameterValueRegexp =
         configProvider.getString(APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP, null);
+
+    appSecIastEnabled = configProvider.getBoolean(APPSEC_IAST_ENABLED, DEFAULT_APPSEC_IAST_ENABLED);
 
     ciVisibilityEnabled =
         configProvider.getBoolean(CIVISIBILITY_ENABLED, DEFAULT_CIVISIBILITY_ENABLED);
@@ -1635,6 +1641,10 @@ public class Config {
 
   public String getAppSecObfuscationParameterValueRegexp() {
     return appSecObfuscationParameterValueRegexp;
+  }
+
+  public boolean isAppSecIastEnabled() {
+    return appSecIastEnabled;
   }
 
   public boolean isCiVisibilityEnabled() {


### PR DESCRIPTION
# What Does This Do

Add flat to enable IAST instrumentation.

# Motivation

* We'll need to keep IAST disabled by default.
* We should enable IAST independently of AppSec.
  * Especially, IAST instrumentation should be enabled explicitly.

# Additional Notes

Open questions:

* Naming convention (IAST, AppSec IAST, etc).
* How much will we couple internally with AppSec code?

Keeping the PR as draft for now.