### PR TITLE
Provide a stable sequence of Instrumenter ids

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentCLI.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentCLI.java
@@ -3,7 +3,6 @@ package datadog.trace.agent.tooling;
 import datadog.trace.bootstrap.Agent;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -13,8 +12,7 @@ public final class AgentCLI {
   /** Prints all known integrations in alphabetical order. */
   public static void printIntegrationNames() {
     Set<String> names = new TreeSet<>();
-    for (Instrumenter instrumenter :
-        ServiceLoader.load(Instrumenter.class, Instrumenter.class.getClassLoader())) {
+    for (Instrumenter instrumenter : Instrumenters.load(Instrumenter.class.getClassLoader())) {
       if (instrumenter instanceof Instrumenter.Default) {
         names.add(((Instrumenter.Default) instrumenter).name());
       }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenters.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenters.java
@@ -1,0 +1,114 @@
+package datadog.trace.agent.tooling;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provides a stable sequence of {@link Instrumenters} registered as META-INF services. The id of
+ * the {@link Instrumenter} currently being installed is available during iteration by calling
+ * {@link #currentInstrumentationId()}.
+ *
+ * <p>Note: it is expected that only one thread will iterate over instrumenters at a time.
+ */
+public final class Instrumenters implements Iterable<Instrumenter> {
+  static final Logger log = LoggerFactory.getLogger(Instrumenters.class);
+
+  final ClassLoader loader;
+  final String[] names;
+
+  final Instrumenter[] instrumenters;
+  static int currentInstrumentationId;
+
+  public static Instrumenters load(ClassLoader loader) {
+    return new Instrumenters(loader, loadInstrumenterNames(loader));
+  }
+
+  Instrumenters(ClassLoader loader, String[] names) {
+    this.loader = loader;
+    this.names = names;
+
+    this.instrumenters = new Instrumenter[names.length];
+  }
+
+  /** Returns the id of the {@link Instrumenter} currently being installed. */
+  public static int currentInstrumentationId() {
+    return currentInstrumentationId;
+  }
+
+  @Override
+  public Iterator<Instrumenter> iterator() {
+    return new Iterator<Instrumenter>() {
+      private int index = 0;
+
+      @Override
+      public boolean hasNext() {
+        while (index < instrumenters.length) {
+          if (null != instrumenters[index]) {
+            currentInstrumentationId = index;
+            return true;
+          }
+          String nextName = names[index];
+          if (null != nextName) {
+            try {
+              currentInstrumentationId = index; // set before loading instrumenter
+              @SuppressWarnings({"rawtypes", "unchecked"})
+              Class<Instrumenter> nextType = (Class) loader.loadClass(nextName);
+              instrumenters[index] = nextType.getConstructor().newInstance();
+              return true;
+            } catch (Throwable e) {
+              log.error("Failed to load - instrumentation.class={}", nextName, e);
+              names[index] = null; // only attempt to load instrumenter once
+            }
+          }
+          index++;
+        }
+        return false;
+      }
+
+      @Override
+      public Instrumenter next() {
+        if (hasNext()) {
+          return instrumenters[index++];
+        } else {
+          throw new NoSuchElementException();
+        }
+      }
+
+      @Override
+      public void remove() {
+        throw new UnsupportedOperationException();
+      }
+    };
+  }
+
+  private static String[] loadInstrumenterNames(ClassLoader loader) {
+    Set<String> lines = new LinkedHashSet<>();
+    try {
+      Enumeration<URL> urls =
+          loader.getResources("META-INF/services/datadog.trace.agent.tooling.Instrumenter");
+      while (urls.hasMoreElements()) {
+        try (BufferedReader reader =
+            new BufferedReader(
+                new InputStreamReader(urls.nextElement().openStream(), StandardCharsets.UTF_8))) {
+          String line = reader.readLine();
+          while (line != null) {
+            lines.add(line);
+            line = reader.readLine();
+          }
+        }
+      }
+    } catch (Throwable e) {
+      log.error("Failed to load - instrumentation.class list", e);
+    }
+    return lines.toArray(new String[0]);
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
@@ -2,6 +2,7 @@ package datadog.trace.agent.tooling.muzzle;
 
 import datadog.trace.agent.tooling.HelperInjector;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.Instrumenters;
 import datadog.trace.agent.tooling.bytebuddy.SharedTypePools;
 import datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers;
 import java.io.IOException;
@@ -11,7 +12,6 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.ServiceLoader;
 import java.util.Set;
 import net.bytebuddy.dynamic.ClassFileLocator;
 
@@ -34,9 +34,9 @@ public class MuzzleVersionScanPlugin {
       final ClassLoader userClassLoader,
       final boolean assertPass)
       throws Exception {
+    Iterable<Instrumenter> instrumenters = Instrumenters.load(instrumentationLoader);
     // muzzle validate all instrumenters
-    for (Instrumenter instrumenter :
-        ServiceLoader.load(Instrumenter.class, instrumentationLoader)) {
+    for (Instrumenter instrumenter : instrumenters) {
       if (instrumenter.getClass().getName().endsWith("TraceConfigInstrumentation")) {
         // TraceConfigInstrumentation doesn't do muzzle checks
         // check on TracerClassInstrumentation instead
@@ -90,8 +90,7 @@ public class MuzzleVersionScanPlugin {
     }
     // run helper injector on all instrumenters
     if (assertPass) {
-      for (Instrumenter instrumenter :
-          ServiceLoader.load(Instrumenter.class, instrumentationLoader)) {
+      for (Instrumenter instrumenter : instrumenters) {
         if (instrumenter.getClass().getName().endsWith("TraceConfigInstrumentation")) {
           // TraceConfigInstrumentation doesn't do muzzle checks
           // check on TracerClassInstrumentation instead
@@ -157,8 +156,7 @@ public class MuzzleVersionScanPlugin {
   }
 
   public static void printMuzzleReferences(final ClassLoader instrumentationLoader) {
-    for (final Instrumenter instrumenter :
-        ServiceLoader.load(Instrumenter.class, instrumentationLoader)) {
+    for (final Instrumenter instrumenter : Instrumenters.load(instrumentationLoader)) {
       if (instrumenter instanceof Instrumenter.Default) {
         try {
           final Method getMuzzleMethod =


### PR DESCRIPTION
# What Does This Do

Provides a stable sequence of `Instrumenter`s registered as `META-INF` services as well as access to the id of the `Instrumenter` currently being installed (available via static context to avoid need to pass it around as parameter.)

# Motivation

The stable instrumentation id will be used in various memoization techniques as well as allowing use of a trie to match against instrumentations that target statically named types. (This means we can perform a single trie check across all statically named types rather than multiple `named` checks.)