### PR TITLE
Separate out configured type matching from static constant matching

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -56,6 +56,11 @@ public interface Instrumenter {
     String instrumentedType();
   }
 
+  /** Instrumentation that matches a type configured at runtime. */
+  interface ForConfiguredType {
+    String configuredMatchingType();
+  }
+
   /** Instrumentation that can match a series of named types. */
   interface ForKnownTypes {
     String[] knownMatchingTypes();

--- a/dd-java-agent/instrumentation/aws-lambda-handler/src/main/java/datadog/trace/instrumentation/aws/v1/lambda/LambdaHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/src/main/java/datadog/trace/instrumentation/aws/v1/lambda/LambdaHandlerInstrumentation.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
 
 @AutoService(Instrumenter.class)
 public class LambdaHandlerInstrumentation extends Instrumenter.Tracing
-    implements Instrumenter.ForSingleType {
+    implements Instrumenter.ForConfiguredType {
 
   // these must remain as String literals so they can be easily be shared (copied) with the nested
   // advice classes
@@ -57,7 +57,7 @@ public class LambdaHandlerInstrumentation extends Instrumenter.Tracing
   }
 
   @Override
-  public String instrumentedType() {
+  public String configuredMatchingType() {
     return this.instrumentedType;
   }
 

--- a/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/LambdaHandlerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/LambdaHandlerInstrumentationTest.groovy
@@ -9,7 +9,7 @@ class LambdaHandlerInstrumentationTest extends AgentTestRunner {
     def objTest = new LambdaHandlerInstrumentation()
 
     then:
-    objTest.instrumentedType() == instrumentedType
+    objTest.configuredMatchingType() == instrumentedType
     objTest.getMethodName() == methodName
     environmentVariables.clear("_HANDLER")
 

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
@@ -6,7 +6,7 @@ import datadog.trace.api.Config;
 
 @AutoService(Instrumenter.class)
 public class ConnectionInstrumentation extends AbstractConnectionInstrumentation
-    implements Instrumenter.ForKnownTypes {
+    implements Instrumenter.ForKnownTypes, Instrumenter.ForConfiguredType {
 
   private static final String[] CONCRETE_TYPES = {
     // redshift
@@ -70,10 +70,14 @@ public class ConnectionInstrumentation extends AbstractConnectionInstrumentation
     // aws-mysql-jdbc
     "software.aws.rds.jdbc.mysql.shading.com.mysql.cj.jdbc.ConnectionImpl",
     // for testing purposes
-    "test.TestConnection",
-    // this won't match any class unless the property is set
-    Config.get().getJdbcConnectionClassName()
+    "test.TestConnection"
   };
+
+  @Override
+  public String configuredMatchingType() {
+    // this won't match any class unless the property is set
+    return Config.get().getJdbcConnectionClassName();
+  }
 
   public ConnectionInstrumentation() {
     super("jdbc");

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -6,7 +6,7 @@ import datadog.trace.api.Config;
 
 @AutoService(Instrumenter.class)
 public final class PreparedStatementInstrumentation extends AbstractPreparedStatementInstrumentation
-    implements Instrumenter.ForKnownTypes {
+    implements Instrumenter.ForKnownTypes, Instrumenter.ForConfiguredType {
 
   private static final String[] CONCRETE_TYPES = {
     // redshift
@@ -111,10 +111,14 @@ public final class PreparedStatementInstrumentation extends AbstractPreparedStat
     "software.aws.rds.jdbc.mysql.shading.com.mysql.cj.jdbc.ServerPreparedStatement",
     "software.aws.rds.jdbc.mysql.shading.com.mysql.cj.JdbcCallableStatement",
     // for testing purposes
-    "test.TestPreparedStatement",
-    // this won't match any classes unless set
-    Config.get().getJdbcPreparedStatementClassName()
+    "test.TestPreparedStatement"
   };
+
+  @Override
+  public String configuredMatchingType() {
+    // this won't match any class unless the property is set
+    return Config.get().getJdbcPreparedStatementClassName();
+  }
 
   public PreparedStatementInstrumentation() {
     super("jdbc");


### PR DESCRIPTION
# Motivation

This helps us separate out statically named instrumented types which we can index at build time from instrumented types where the name is only known at runtime.