### PR TITLE
Miscellaneous ClassNameTrie improvements

### DIFF
--- a/internal-api/src/main/java/datadog/trace/util/ClassNameTrie.java
+++ b/internal-api/src/main/java/datadog/trace/util/ClassNameTrie.java
@@ -336,7 +336,9 @@ public final class ClassNameTrie {
         char value = trieData[valueIndex];
 
         if ((value & (LEAF_MARKER | BUD_MARKER)) != 0 && keyIndex == keyLength) {
-          return; // ignore duplicate key
+          // duplicate key: overwrite existing value in the tree with the new value
+          trieData[valueIndex] = (char) ((value & ~MAX_NODE_VALUE) | valueToInsert);
+          return;
         }
 
         int branch = branchIndex - dataIndex;
@@ -419,6 +421,10 @@ public final class ClassNameTrie {
               trieData[valueIndex]--;
               jumpOffset = appendLeaf(dataIndex, key, keyIndex, valueToInsert);
               break;
+            } else {
+              // duplicate key: overwrite existing value in the tree with the new value
+              trieData[dataIndex] = (char) ((value & ~MAX_NODE_VALUE) | valueToInsert);
+              return;
             }
           } else /* segment is followed by a node */ {
             if (keyIndex == keyLength) {

--- a/internal-api/src/main/java/datadog/trace/util/ClassNameTrie.java
+++ b/internal-api/src/main/java/datadog/trace/util/ClassNameTrie.java
@@ -205,6 +205,11 @@ public final class ClassNameTrie {
       return trieLength == 0;
     }
 
+    /** Allow querying while the class-name trie is being built. */
+    public int apply(String key) {
+      return ClassNameTrie.apply(trieData, longJumps, key);
+    }
+
     public ClassNameTrie buildTrie() {
       return new ClassNameTrie(
           Arrays.copyOfRange(trieData, 0, trieLength),

--- a/internal-api/src/main/java/datadog/trace/util/ClassNameTrie.java
+++ b/internal-api/src/main/java/datadog/trace/util/ClassNameTrie.java
@@ -228,6 +228,9 @@ public final class ClassNameTrie {
 
     /** Merges a new class-name mapping into the current builder */
     public void put(String className, int number) {
+      if (null == className || className.isEmpty()) {
+        throw new IllegalArgumentException("Null or empty class name");
+      }
       if (number < 0) {
         throw new IllegalArgumentException("Number for " + className + " is negative: " + number);
       }

--- a/internal-api/src/test/groovy/datadog/trace/util/ClassNameTrieTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/util/ClassNameTrieTest.groovy
@@ -156,4 +156,26 @@ class ClassNameTrieTest extends DDSpecification {
     ['aaaabbbb', 'aaacccbb']             | '\001\141\002\141\141\002\141\143\004\004\005\142\142\142\142\u8001\143\143\142\142\u8001'
     // spotless:on
   }
+
+  def 'trie builder allows overwriting'() {
+    setup:
+    def mapping = (0..128).collectEntries({
+      [UUID.randomUUID().toString().replace('-', '.'), it]
+    }) as TreeMap<String, Integer>
+    when:
+    def builder = new ClassNameTrie.Builder()
+    // initial values
+    mapping.each { className, number ->
+      builder.put(className, number)
+    }
+    // update values
+    mapping.each { className, number ->
+      builder.put(className, (0x1000 | number))
+    }
+    def trie = builder.buildTrie()
+    then:
+    mapping.each({
+      assert trie.apply(it.key) == (0x1000 | it.value)
+    })
+  }
 }


### PR DESCRIPTION
# What Does This Do
* Allow querying while the trie is being built
*  Allow overwriting of existing mapped values when building trie
* Reject null or empty class names when building trie