### PR TITLE
Remove obsolete 'metrics' label in toString

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -594,8 +594,7 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext<Object>,
             .append("/")
             .append(getOperationName())
             .append("/")
-            .append(getResourceName())
-            .append(" metrics=");
+            .append(getResourceName());
     if (errorFlag) {
       s.append(" *errored*");
     }


### PR DESCRIPTION
# What Does This Do

Previously metrics were included in the toString of DDSpanContext.

They're no longer includd in the string representation, but the
label for them is still there, so this commit removes the obsolete
metrics label.
