### PR TITLE
[alpha] Add a publish step to tracer injection image for kubernetes

### DIFF
--- a/.github/workflows/test-lib-injection.yaml
+++ b/.github/workflows/test-lib-injection.yaml
@@ -1,6 +1,5 @@
 name: "Lib Injection Test"
-
-on: push
+on: [push, pull_request]
 
 jobs:
   lib-injection-test:
@@ -48,7 +47,7 @@ jobs:
       - name: Build injection image
         run: |
           export BUILDX_PLATFORMS=`docker buildx imagetools inspect --raw busybox:latest | jq -r 'reduce (.manifests[] | [ .platform.os, .platform.architecture, .platform.variant ] | join("/") | sub("\\/$"; "")) as $item (""; . + "," + $item)' | sed 's/,//'`
-          ./lib-injection/build.sh ghcr.io/datadog/dd-trace-java/dd-java-agent-k8s-init ${GITHUB_SHA}
+          ./lib-injection/build.sh ghcr.io/datadog/dd-trace-java/dd-java-agent-init ${GITHUB_SHA}
 
       - name: Deploy pre-modified pod
         run: |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -119,16 +119,25 @@ deploy_to_sonatype:
     - export GPG_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.signing.gpg_passphrase --with-decryption --query "Parameter.Value" --out text)
     - ./gradlew -PbuildInfo.build.number=$CI_JOB_ID publishToSonatype closeSonatypeStagingRepository --max-workers=1 --build-cache --stacktrace --no-daemon
 
-deploy_to_dockerhub:
-  <<: *docker
+deploy_to_docker_registries:
   stage: deploy
   rules:
+    - if: '$POPULATE_CACHE'
+      when: never
     - if: '$CI_COMMIT_BRANCH == "master"'
       when: on_success
     - if: '$CI_COMMIT_TAG =~ /^v.*/'
       when: on_success
-  script:
-    - docker images # TODO copy images from ghcr to appropriate mirrors with tagged version
+    - when: manual
+      allow_failure: true
+  trigger:
+    project: DataDog/public-images
+    branch: main
+    strategy: depend
+  variables:
+    IMG_SOURCES: ghcr.io/datadog/dd-trace-java/dd-java-agent-init:$CI_COMMIT_SHA
+    IMG_DESTINATIONS: dd-java-agent-init:$CI_COMMIT_TAG
+    IMG_SIGNING: "false"
 
 create_key:
   stage: generate-signing-key

--- a/lib-injection/run-local.sh
+++ b/lib-injection/run-local.sh
@@ -29,7 +29,7 @@ fi
 docker buildx use dd-trace-java
 export BUILDX_PLATFORMS=`docker buildx imagetools inspect --raw busybox:latest | jq -r 'reduce (.manifests[] | [ .platform.os, .platform.architecture, .platform.variant ] | join("/") | sub("\\/$"; "")) as $item (""; . + "," + $item)' | sed 's/,//'`
 
-./build.sh docker.io/${1}/dd-java-agent-k8s-init local
+./build.sh docker.io/${1}/dd-java-agent-init local
 
 kubectl apply -f app-config.yaml
 kubectl wait pod/my-app --for condition=ready --timeout=5m


### PR DESCRIPTION
# What Does This Do

Adds a publish step for tracer tags that is part of the tracer injection image for kubernetes

# Additional Notes

The jar used in the image is not the exact same file as the one that gets published to maven central. This isn't ideal in my mind so I think this is something we could address