### PR TITLE
[Serverless] fix lambda event serialization

### DIFF
--- a/dd-trace-core/dd-trace-core.gradle
+++ b/dd-trace-core/dd-trace-core.gradle
@@ -58,11 +58,14 @@ dependencies {
   testAnnotationProcessor deps.autoserviceProcessor
   testCompileOnly deps.autoserviceAnnotation
 
+
+
   testImplementation project(":dd-java-agent:testing")
   testImplementation group: 'org.msgpack', name: 'msgpack-core', version: '0.8.20'
   testImplementation group: 'org.msgpack', name: 'jackson-dataformat-msgpack', version: '0.8.20'
   testImplementation group: 'org.openjdk.jol', name: 'jol-core', version: '0.16'
   testImplementation group: 'commons-codec', name: 'commons-codec', version: '1.3'
+  testImplementation group: 'com.amazonaws', name: 'aws-lambda-java-events', version:'3.11.0'
 
   traceAgentTestImplementation deps.testcontainers
 }

--- a/dd-trace-core/dd-trace-core.gradle
+++ b/dd-trace-core/dd-trace-core.gradle
@@ -57,9 +57,7 @@ dependencies {
   // We have autoservices defined in test subtree, looks like we need this to be able to properly rebuild this
   testAnnotationProcessor deps.autoserviceProcessor
   testCompileOnly deps.autoserviceAnnotation
-
-
-
+  
   testImplementation project(":dd-java-agent:testing")
   testImplementation group: 'org.msgpack', name: 'msgpack-core', version: '0.8.20'
   testImplementation group: 'org.msgpack', name: 'jackson-dataformat-msgpack', version: '0.8.20'

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaHandler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaHandler.java
@@ -51,7 +51,12 @@ public class LambdaHandler {
 
   private static final MediaType jsonMediaType = MediaType.parse("application/json");
   private static final JsonAdapter<Object> adapter =
-      new Moshi.Builder().build().adapter(Object.class);
+      new Moshi.Builder()
+          // we need to bypass those classes as moshi fails to marshal this into JSON
+          .add(NoOpAdapter.newFactory("org.joda.time.Chronology"))
+          .add(NoOpAdapter.newFactory("java.nio.ByteBuffer"))
+          .build()
+          .adapter(Object.class);
 
   private static String EXTENSION_BASE_URL = "http://127.0.0.1:8124";
 

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/NoOpAdapter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/NoOpAdapter.java
@@ -1,0 +1,40 @@
+package datadog.trace.lambda;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import com.squareup.moshi.Moshi;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Set;
+
+public final class NoOpAdapter<T> extends JsonAdapter<T> {
+  private final JsonAdapter<T> delegate;
+
+  private NoOpAdapter(JsonAdapter<T> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public T fromJson(JsonReader reader) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void toJson(JsonWriter writer, T value) throws IOException {
+    delegate.toJson(writer, value);
+  }
+
+  public static <T> Factory newFactory(final String type) {
+    return new Factory() {
+      @Override
+      public JsonAdapter<?> create(
+          Type requestedType, Set<? extends Annotation> annotations, Moshi moshi) {
+        if (!type.equals(requestedType.getTypeName())) return null;
+        JsonAdapter<T> delegate = moshi.nextAdapter(this, Object.class, annotations);
+        return new NoOpAdapter<>(delegate);
+      }
+    };
+  }
+}


### PR DESCRIPTION
# What Does This Do

This PR fixes AWS Lambda event serialization when communication with the serverless extension
By default, moshi does not know how to serialize some nested types used in some AWS Events (SNS, SQS or S3)
We don't need those fields to be serialized to this PR just ignores them.

# Motivation

Consistent JSON serialization across AWS events
