### PR TITLE
Util to get stacktrace for reported vulnerabilities

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,27 +22,27 @@ jobs:
         language: [ 'java' ]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
+      - name: Checkout repository
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@1a927e9307bc11970b2c679922ebc4d03a5bd980 # 1.0.31
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@1a927e9307bc11970b2c679922ebc4d03a5bd980 # 1.0.31
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    - name: Build dd-trace-java for creating the CodeQL database
-      run: JAVA_HOME=$JAVA_HOME_8_X64 JAVA_11_HOME=$JAVA_HOME_11_X64 ./gradlew clean :dd-java-agent:shadowJar --build-cache --parallel --stacktrace --no-daemon --max-workers=8
+      - name: Build dd-trace-java for creating the CodeQL database
+        run: JAVA_HOME=$JAVA_HOME_8_X64 JAVA_8_HOME=$JAVA_HOME_8_X64 JAVA_11_HOME=$JAVA_HOME_11_X64 ./gradlew clean :dd-java-agent:shadowJar --build-cache --parallel --stacktrace --no-daemon --max-workers=8
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@1a927e9307bc11970b2c679922ebc4d03a5bd980 # 1.0.31
-      
-    - name: upload_artifact
-      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # 2.3.1
-      with:
-         name: CodeQL Analysis Sarif
-         path: /home/runner/work/dd-trace-java/results/java.sarif    
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@1a927e9307bc11970b2c679922ebc4d03a5bd980 # 1.0.31
+
+      - name: upload_artifact
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # 2.3.1
+        with:
+          name: CodeQL Analysis Sarif
+          path: /home/runner/work/dd-trace-java/results/java.sarif

--- a/.github/workflows/test-lib-injection.yaml
+++ b/.github/workflows/test-lib-injection.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Build app image
         run: |
-          JAVA_HOME=$JAVA_HOME_8_X64 JAVA_11_HOME=$JAVA_HOME_11_X64 \
+          JAVA_HOME=$JAVA_HOME_8_X64 JAVA_8_HOME=$JAVA_HOME_8_X64 JAVA_11_HOME=$JAVA_HOME_11_X64 \
           ./lib-injection/run.sh build-test-app-image push-test-app-image
 
   lib-injection-image-build:
@@ -51,7 +51,7 @@ jobs:
               max-parallelism = 1
 
       - name: Build dd-java-agent.jar
-        run: JAVA_HOME=$JAVA_HOME_8_X64 JAVA_11_HOME=$JAVA_HOME_11_X64 ./gradlew clean shadowJar --build-cache --parallel --no-daemon --max-workers=8
+        run: JAVA_HOME=$JAVA_HOME_8_X64 JAVA_8_HOME=$JAVA_HOME_8_X64 JAVA_11_HOME=$JAVA_HOME_11_X64 ./gradlew clean shadowJar --build-cache --parallel --no-daemon --max-workers=8
 
       - name: Build injection image
         run: |
@@ -64,8 +64,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        use-admission-controller: ["", "use-admission-controller"]
-        use-uds: ["", "use-uds"]
+        use-admission-controller: [ "", "use-admission-controller" ]
+        use-uds: [ "", "use-uds" ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -96,7 +96,7 @@ jobs:
       - name: Test
         run: |
           ./lib-injection/run.sh test-for-traces
-      
+
       - name: Get app output for debugging
         if: ${{ failure() }}
         run: kubectl logs pod/my-app

--- a/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
@@ -62,6 +62,11 @@ class AgentTestRunnerTest extends AgentTestRunner {
               // Simply ignore the error as the class will not be even attempted to get loaded on Java 7
               break
             }
+            if (info.getName().startsWith("datadog.trace.util.stacktrace.")) {
+              //It is known that support for Java 7 is going to be discontinued
+              //so we have decided to implement everything related to IAST in java8
+              break
+            }
             // rethrow the exception otherwise
             throw e
           } catch (IllegalAccessError e) {
@@ -73,6 +78,13 @@ class AgentTestRunnerTest extends AgentTestRunner {
             }
             // rethrow the exception otherwise
             throw e
+          } catch (NoClassDefFoundError e) {
+            // A dirty hack to allow passing this test on Java 7
+            if (info.getName() == "sun.misc.SharedSecrets") {
+              //datadog.trace.util.stacktrace.HotSpotStackWalker uses sun.misc.SharedSecrets to improve performance in jdk8 with hotspot
+              break
+            }
+            // rethrow the exception otherwise
           }
         }
       }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,5 @@
 org.gradle.parallel=true
 org.gradle.caching=true
-
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=1g
 org.gradle.java.installations.auto-detect=false
 org.gradle.java.installations.auto-download=false

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -113,6 +113,7 @@ final class CachedData {
       exclude(project(':dd-trace-api'))
       exclude(project(':internal-api'))
       exclude(project(':internal-api:internal-api-8'))
+      exclude(project(':internal-api:internal-api-9'))
       exclude(project(':communication'))
       exclude(project(':telemetry'))
       exclude(project(':utils:container-utils'))

--- a/internal-api/internal-api-8/internal-api-8.gradle
+++ b/internal-api/internal-api-8/internal-api-8.gradle
@@ -3,6 +3,8 @@ plugins {
 }
 
 ext {
+  // need access to sun.misc.SharedSecrets
+  skipSettingCompilerRelease = true
   enableJunitPlatform = true
   minJavaVersionForTests = JavaVersion.VERSION_1_8
 }
@@ -12,9 +14,20 @@ apply from: "$rootDir/gradle/java.gradle"
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
-minimumBranchCoverage = 0.8
+[JavaCompile, GroovyCompile].each {
+  tasks.withType(it).configureEach {
+    setJavaVersion(it, 8)
+  }
+}
 
-excludedClassesCoverage += ["datadog.trace.api.sampling.ConstantSampler",]
+minimumBranchCoverage = 0.8
+minimumInstructionCoverage = 0.8
+
+excludedClassesCoverage += ["datadog.trace.api.sampling.ConstantSampler"]
+
+excludedClassesBranchCoverage = ['datadog.trace.util.stacktrace.HotSpotStackWalker']
+
+excludedClassesInstructionCoverage = ['datadog.trace.util.stacktrace.StackWalkerFactory']
 
 dependencies {
   api project(':internal-api')

--- a/internal-api/internal-api-8/src/jmh/java/datadog/trace/util/stacktrace/HotSpotStackWalkerBenchmark.java
+++ b/internal-api/internal-api-8/src/jmh/java/datadog/trace/util/stacktrace/HotSpotStackWalkerBenchmark.java
@@ -1,0 +1,74 @@
+package datadog.trace.util.stacktrace;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import external.util.stacktrace.RecursiveRunner;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Simple Benchmark to test that HotSpotStackWalker has better performance that
+ * DefaultSpotStackWalker for JDK8 with hotspot
+ */
+@Warmup(iterations = 5, time = 1000, timeUnit = MILLISECONDS)
+@Measurement(iterations = 5, time = 1000, timeUnit = MILLISECONDS)
+@OutputTimeUnit(MILLISECONDS)
+@BenchmarkMode(Mode.Throughput)
+@State(Scope.Benchmark)
+public class HotSpotStackWalkerBenchmark {
+
+  private HotSpotStackWalker hotSpotStackWalker;
+
+  private DefaultStackWalker defaultStackWalker;
+
+  @Param({"1", "3", "10"})
+  int limit;
+
+  @Param({"10", "50", "100"})
+  int deep;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    hotSpotStackWalker = new HotSpotStackWalker();
+    defaultStackWalker = new DefaultStackWalker();
+  }
+
+  @Benchmark
+  public void hotSpotStackWalkerWalk() {
+    generateStack(hotSpotStackWalker);
+  }
+
+  @Benchmark
+  public void defaultStackWalkerWalk() {
+    generateStack(defaultStackWalker);
+  }
+
+  private void generateStack(final StackWalker stackWalker) {
+
+    Runnable runnable =
+        new Runnable() {
+          @Override
+          public void run() {
+            stackWalker.walk(this::toLimitedList).forEach(System.out::println);
+          }
+
+          private List<StackTraceElement> toLimitedList(final Stream<StackTraceElement> stack) {
+            return stack.limit(limit).collect(Collectors.toList());
+          }
+        };
+
+    RecursiveRunner runner = new RecursiveRunner(deep, runnable);
+  }
+}

--- a/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/AbstractStackWalker.java
+++ b/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/AbstractStackWalker.java
@@ -1,0 +1,24 @@
+package datadog.trace.util.stacktrace;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+public abstract class AbstractStackWalker implements StackWalker {
+
+  private static final Predicate<StackTraceElement> NOT_DD_TRACE_STACK_ELEMENT =
+      (stackTraceElement) ->
+          !stackTraceElement.getClassName().startsWith("datadog.trace.")
+              && !stackTraceElement.getClassName().startsWith("com.datadog.appsec.");
+
+  @Override
+  public <T> T walk(Function<Stream<StackTraceElement>, T> consumer) {
+    return doGetStack(input -> consumer.apply(doFilterStack(input)));
+  }
+
+  final Stream<StackTraceElement> doFilterStack(Stream<StackTraceElement> stream) {
+    return stream.filter(NOT_DD_TRACE_STACK_ELEMENT);
+  }
+
+  abstract <T> T doGetStack(Function<Stream<StackTraceElement>, T> consumer);
+}

--- a/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/DefaultStackWalker.java
+++ b/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/DefaultStackWalker.java
@@ -1,0 +1,20 @@
+package datadog.trace.util.stacktrace;
+
+import java.util.Arrays;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class DefaultStackWalker extends AbstractStackWalker {
+
+  DefaultStackWalker() {}
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+
+  @Override
+  <T> T doGetStack(final Function<Stream<StackTraceElement>, T> consumer) {
+    return consumer.apply(Arrays.stream(Thread.currentThread().getStackTrace()));
+  }
+}

--- a/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/HotSpotStackTraceIterator.java
+++ b/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/HotSpotStackTraceIterator.java
@@ -1,0 +1,40 @@
+package datadog.trace.util.stacktrace;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+public class HotSpotStackTraceIterator implements Iterator<StackTraceElement> {
+
+  private int index = 0;
+
+  private final int size;
+
+  private final Throwable throwable;
+
+  private final sun.misc.JavaLangAccess access;
+
+  public HotSpotStackTraceIterator(
+      final Throwable throwable, final sun.misc.JavaLangAccess access) {
+    this.throwable = throwable;
+    this.access = access;
+    size = this.access.getStackTraceDepth(throwable);
+  }
+
+  @Override
+  public boolean hasNext() {
+    return index < size;
+  }
+
+  @Override
+  public StackTraceElement next() {
+    if (index >= size) {
+      throw new NoSuchElementException();
+    }
+    return access.getStackTraceElement(throwable, index++);
+  }
+
+  @Override
+  public void remove() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/HotSpotStackWalker.java
+++ b/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/HotSpotStackWalker.java
@@ -1,0 +1,38 @@
+package datadog.trace.util.stacktrace;
+
+import datadog.trace.api.Platform;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class HotSpotStackWalker extends AbstractStackWalker {
+
+  sun.misc.JavaLangAccess access;
+
+  HotSpotStackWalker() {
+    try {
+      access = sun.misc.SharedSecrets.getJavaLangAccess();
+    } catch (Throwable e) {
+    }
+  }
+
+  @Override
+  public boolean isEnabled() {
+    try {
+      if (Platform.isJavaVersion(8) && access != null) {
+        access.getStackTraceElement(new Throwable(), 0);
+        return true;
+      }
+    } catch (Throwable localThrowable) {
+    }
+    return false;
+  }
+
+  @Override
+  <T> T doGetStack(Function<Stream<StackTraceElement>, T> consumer) {
+
+    Throwable throwable = new Throwable();
+    Iterable<StackTraceElement> iterable = () -> new HotSpotStackTraceIterator(throwable, access);
+    return consumer.apply(StreamSupport.stream(iterable.spliterator(), false));
+  }
+}

--- a/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/StackWalker.java
+++ b/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/StackWalker.java
@@ -1,0 +1,12 @@
+package datadog.trace.util.stacktrace;
+
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public interface StackWalker {
+
+  boolean isEnabled();
+
+  /** StackTrace should be returned without any element from the dd-trace-java-agent itself. */
+  <T> T walk(Function<Stream<StackTraceElement>, T> consumer);
+}

--- a/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/StackWalkerFactory.java
+++ b/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/StackWalkerFactory.java
@@ -1,0 +1,48 @@
+package datadog.trace.util.stacktrace;
+
+import de.thetaphi.forbiddenapis.SuppressForbidden;
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressForbidden
+public class StackWalkerFactory {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(StackWalkerFactory.class);
+
+  public static final StackWalker INSTANCE;
+
+  static {
+    Stream<StackWalker> stream = Stream.of(hotspot(), jdk9()).map(Supplier::get);
+    INSTANCE =
+        stream
+            .filter(Objects::nonNull)
+            .filter(StackWalker::isEnabled)
+            .findFirst()
+            .orElseGet(defaultStackWalker());
+  }
+
+  private static Supplier<StackWalker> defaultStackWalker() {
+    return DefaultStackWalker::new;
+  }
+
+  private static Supplier<StackWalker> hotspot() {
+    return HotSpotStackWalker::new;
+  }
+
+  private static Supplier<StackWalker> jdk9() {
+    return () -> {
+      try {
+        return (StackWalker)
+            Class.forName("datadog.trace.util.stacktrace.JDK9StackWalker")
+                .getDeclaredConstructor()
+                .newInstance();
+      } catch (Throwable e) {
+        LOGGER.warn("JDK9StackWalker not available", e);
+        return null;
+      }
+    };
+  }
+}

--- a/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/DefaultStackWalkerTest.java
+++ b/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/DefaultStackWalkerTest.java
@@ -1,0 +1,66 @@
+package datadog.trace.util.stacktrace;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+public class DefaultStackWalkerTest {
+
+  private final DefaultStackWalker defaultStackWalker = new DefaultStackWalker();
+
+  @Test
+  public void defaultStackWalker_must_be_enabled() {
+    assertTrue(defaultStackWalker.isEnabled());
+  }
+
+  @Test
+  public void walk_retrieves_stackTraceElements() {
+    // When
+    List<StackTraceElement> list = defaultStackWalker.walk(StackWalkerTestUtil::toList);
+    // Then
+    assertFalse(list.isEmpty());
+  }
+
+  @Test
+  public void get_stack_trace() {
+    // When
+    List<StackTraceElement> list = defaultStackWalker.doGetStack(StackWalkerTestUtil::toList);
+    // Then
+    assertFalse(list.isEmpty());
+  }
+
+  @Test
+  public void stack_element_not_in_DD_trace_project_is_not_filtered() {
+    // when
+    Stream<StackTraceElement> stream = Stream.of(element("com.foo.Foo"));
+    Stream<StackTraceElement> filtered = defaultStackWalker.doFilterStack(stream);
+    // Then
+    assertEquals(filtered.count(), 1);
+  }
+
+  @Test
+  public void filter_DataDog_Trace_classes_from_StackTraceElements() {
+    // when
+    Stream<StackTraceElement> stream = Stream.of(element("datadog.trace.Foo"));
+    Stream<StackTraceElement> filtered = defaultStackWalker.doFilterStack(stream);
+    // Then
+    assertEquals(filtered.count(), 0);
+  }
+
+  @Test
+  public void filter_DataDog_AppSec_classes_from_StackTraceElements() {
+    // when
+    Stream<StackTraceElement> stream = Stream.of(element("com.datadog.appsec.Foo"));
+    Stream<StackTraceElement> filtered = defaultStackWalker.doFilterStack(stream);
+    // Then
+    assertEquals(filtered.count(), 0);
+  }
+
+  private StackTraceElement element(final String className) {
+    return new StackTraceElement(className, "method", "fileName", 1);
+  }
+}

--- a/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/HotSpotStackTraceIteratorTest.java
+++ b/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/HotSpotStackTraceIteratorTest.java
@@ -1,0 +1,48 @@
+package datadog.trace.util.stacktrace;
+
+import static datadog.trace.util.stacktrace.StackWalkerTestUtil.isRunningJDK8WithHotSpot;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class HotSpotStackTraceIteratorTest {
+
+  @BeforeAll
+  public static void setUp() {
+    assumeTrue(isRunningJDK8WithHotSpot());
+  }
+
+  @Test
+  public void hasNext() {
+    assertTrue(getTestIterator().hasNext());
+  }
+
+  @Test
+  public void next() {
+    assertNotNull(getTestIterator().next());
+  }
+
+  @Test
+  public void next_throws_NoSuchElementException_when_there_are_no_more_elements() {
+    HotSpotStackTraceIterator iterator = getTestIterator();
+    while (iterator.hasNext()) {
+      iterator.next();
+    }
+    Assertions.assertThrows(NoSuchElementException.class, iterator::next);
+  }
+
+  @Test
+  public void remove_throws_UnsupportedOperationException() {
+    Assertions.assertThrows(UnsupportedOperationException.class, getTestIterator()::remove);
+  }
+
+  private HotSpotStackTraceIterator getTestIterator() {
+    return new HotSpotStackTraceIterator(
+        new Throwable(), sun.misc.SharedSecrets.getJavaLangAccess());
+  }
+}

--- a/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/HotSpotStackWalkerTest.java
+++ b/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/HotSpotStackWalkerTest.java
@@ -1,0 +1,70 @@
+package datadog.trace.util.stacktrace;
+
+import static datadog.trace.util.stacktrace.StackWalkerTestUtil.isRunningJDK8WithHotSpot;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class HotSpotStackWalkerTest {
+
+  @BeforeAll
+  public static void setUp() {
+    assumeTrue(isRunningJDK8WithHotSpot());
+  }
+
+  @Test
+  public void hotSpotStackWalker_must_be_enabled_for_JDK8_with_hotspot() {
+    assertTrue(new HotSpotStackWalker().isEnabled());
+  }
+
+  @Test
+  public void get_stack_trace() {
+    // When
+    List<StackTraceElement> list = new HotSpotStackWalker().doGetStack(StackWalkerTestUtil::toList);
+    // Then
+    assertFalse(list.isEmpty());
+  }
+
+  @Test
+  public void is_not_enabled_when_access_throws_exception() {
+    // When
+    sun.misc.JavaLangAccess mockedAccess = mock(sun.misc.JavaLangAccess.class);
+    when(mockedAccess.getStackTraceElement(any(Throwable.class), eq(0)))
+        .thenThrow(new RuntimeException());
+    HotSpotStackWalker hotSpotStackWalker = new HotSpotStackWalker();
+    hotSpotStackWalker.access = mockedAccess;
+    // Then
+    assertFalse(hotSpotStackWalker.isEnabled());
+  }
+
+  @Test
+  public void is_not_enabled_when_access_is_null() {
+    // When
+    HotSpotStackWalker hotSpotStackWalker = new HotSpotStackWalker();
+    hotSpotStackWalker.access = null;
+    // Then
+    assertFalse(hotSpotStackWalker.isEnabled());
+  }
+
+  @Test
+  public void iterable_from_HotSpotStackWalker_doGetStack_is_not_in_the_filtered_stack() {
+    // When
+    List<StackTraceElement> list = new HotSpotStackWalker().doGetStack(StackWalkerTestUtil::toList);
+    // Then
+    assertFalse(
+        list.stream()
+            .anyMatch(
+                stackTraceElement ->
+                    stackTraceElement
+                        .toString()
+                        .equals("java.lang.Iterable.spliterator(Iterable.java:101)")));
+  }
+}

--- a/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/StackWalkerFactoryTest.java
+++ b/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/StackWalkerFactoryTest.java
@@ -1,0 +1,16 @@
+package datadog.trace.util.stacktrace;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class StackWalkerFactoryTest {
+
+  @Test
+  public void stackWalker_instance_must_be_enabled() {
+    // When
+    StackWalker stackWalker = StackWalkerFactory.INSTANCE;
+    // Then
+    assertTrue(stackWalker.isEnabled());
+  }
+}

--- a/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/StackWalkerTestUtil.java
+++ b/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/StackWalkerTestUtil.java
@@ -1,0 +1,26 @@
+package datadog.trace.util.stacktrace;
+
+import datadog.trace.api.Platform;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import sun.misc.JavaLangAccess;
+import sun.misc.SharedSecrets;
+
+public class StackWalkerTestUtil {
+
+  private StackWalkerTestUtil() {}
+
+  public static boolean isRunningJDK8WithHotSpot() {
+    try {
+      JavaLangAccess access = SharedSecrets.getJavaLangAccess();
+      return Platform.isJavaVersion(8) && access != null;
+    } catch (Throwable throwable) {
+      return false;
+    }
+  }
+
+  public static List<StackTraceElement> toList(final Stream<StackTraceElement> stack) {
+    return stack.collect(Collectors.toList());
+  }
+}

--- a/internal-api/internal-api-9/internal-api-9.gradle
+++ b/internal-api/internal-api-9/internal-api-9.gradle
@@ -1,0 +1,44 @@
+plugins {
+  id 'me.champeau.jmh'
+}
+
+ext {
+  minJavaVersionForTests = JavaVersion.VERSION_11
+}
+
+apply from: "$rootDir/gradle/java.gradle"
+apply plugin: "idea"
+
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
+
+[JavaCompile, GroovyCompile].each {
+  tasks.withType(it).configureEach {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+    setJavaVersion(it, 11)
+  }
+}
+
+minimumBranchCoverage = 0.8
+minimumInstructionCoverage = 0.8
+
+dependencies {
+  api project(':internal-api:internal-api-8')
+
+  testImplementation project(':dd-java-agent:testing')
+  testImplementation deps.slf4j
+}
+
+idea {
+  module {
+    jdkName = '11'
+  }
+}
+
+jmh {
+  jmhVersion = '1.28'
+  duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
+  jvm = System.getenv('JAVA_11_HOME') + '/bin/java'
+}
+

--- a/internal-api/internal-api-9/src/jmh/java/datadog/trace/util/stacktrace/JDK9StackWalkerBenchmark.java
+++ b/internal-api/internal-api-9/src/jmh/java/datadog/trace/util/stacktrace/JDK9StackWalkerBenchmark.java
@@ -1,0 +1,79 @@
+package datadog.trace.util.stacktrace;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import external.util.stacktrace.RecursiveRunner;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Simple Benchmark to test that JDK9StackWalker has better performance that DefaultSpotStackWalker
+ * for jdk9+
+ */
+@Warmup(iterations = 5, time = 1000, timeUnit = MILLISECONDS)
+@Measurement(iterations = 5, time = 1000, timeUnit = MILLISECONDS)
+@OutputTimeUnit(MILLISECONDS)
+@BenchmarkMode(Mode.Throughput)
+@State(Scope.Benchmark)
+public class JDK9StackWalkerBenchmark {
+
+  private JDK9StackWalker jdk9StackWalker;
+
+  private DefaultStackWalker defaultStackWalker;
+
+  @Param({"1", "3", "10"})
+  int limit;
+
+  @Param({"10", "50", "100"})
+  int deep;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    jdk9StackWalker = new JDK9StackWalker();
+    defaultStackWalker = new DefaultStackWalker();
+  }
+
+  @Benchmark
+  public void JDK9StackWalkerWalk() {
+    generateStack(jdk9StackWalker);
+  }
+
+  @Benchmark
+  public void defaultStackWalkerWalk() {
+    generateStack(defaultStackWalker);
+  }
+
+  private List<StackTraceElement> toLimitedList(final Stream<StackTraceElement> stack) {
+    return stack.limit(limit).collect(Collectors.toList());
+  }
+
+  private void generateStack(final StackWalker stackWalker) {
+
+    Runnable runnable =
+        new Runnable() {
+          @Override
+          public void run() {
+            stackWalker.walk(this::toLimitedList);
+          }
+
+          private List<StackTraceElement> toLimitedList(final Stream<StackTraceElement> stack) {
+            return stack.limit(limit).collect(Collectors.toList());
+          }
+        };
+
+    RecursiveRunner runner = new RecursiveRunner(deep, runnable);
+    runner.run();
+  }
+}

--- a/internal-api/internal-api-9/src/main/java/datadog/trace/util/stacktrace/JDK9StackWalker.java
+++ b/internal-api/internal-api-9/src/main/java/datadog/trace/util/stacktrace/JDK9StackWalker.java
@@ -1,0 +1,31 @@
+package datadog.trace.util.stacktrace;
+
+import de.thetaphi.forbiddenapis.SuppressForbidden;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+@SuppressForbidden
+public class JDK9StackWalker extends AbstractStackWalker {
+
+  static java.lang.StackWalker walker;
+
+  static {
+    try {
+      walker = java.lang.StackWalker.getInstance();
+
+    } catch (Throwable e) {
+      // Nothing to do
+    }
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return walker != null;
+  }
+
+  @Override
+  <T> T doGetStack(final Function<Stream<StackTraceElement>, T> consumer) {
+    return walker.walk(
+        stack -> consumer.apply(stack.map(java.lang.StackWalker.StackFrame::toStackTraceElement)));
+  }
+}

--- a/internal-api/internal-api-9/src/test/groovy/datadog/trace/util/stacktrace/JDK9StackWalkerTest.groovy
+++ b/internal-api/internal-api-9/src/test/groovy/datadog/trace/util/stacktrace/JDK9StackWalkerTest.groovy
@@ -1,0 +1,42 @@
+package datadog.trace.util.stacktrace
+
+import datadog.trace.test.util.DDSpecification
+
+import java.util.stream.Collectors
+
+class JDK9StackWalkerTest extends DDSpecification {
+
+  def 'stack walker enabled'() {
+    given:
+    final walker = new JDK9StackWalker()
+
+    when:
+    final enabled = walker.isEnabled()
+
+    then:
+    enabled
+  }
+
+  def 'walk retrieves stackTraceElements'() {
+    given:
+    final walker = new JDK9StackWalker()
+
+    when:
+    final stream = walker.walk { it.collect() }
+
+    then:
+    !stream.empty
+  }
+
+
+  def 'walk retrieves no datadog stack elements'() {
+    given:
+    final walker = new JDK9StackWalker()
+
+    when:
+    final stream = walker.walk { it.collect(Collectors.toList()) }
+
+    then:
+    stream.findAll { it.className.startsWith('datadog') } == []
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -34,6 +34,7 @@ include ':dd-trace-ot'
 // agent projects
 include ':internal-api'
 include ':internal-api:internal-api-8'
+include ':internal-api:internal-api-9'
 include ':dd-trace-core'
 include ':dd-trace-core:jfr-openjdk'
 include ':dd-java-agent'

--- a/utils/test-utils/src/main/java/external/util/stacktrace/RecursiveRunner.java
+++ b/utils/test-utils/src/main/java/external/util/stacktrace/RecursiveRunner.java
@@ -1,0 +1,26 @@
+package external.util.stacktrace;
+
+/** This class is used to generate stacks not filtered by StackWalker in jmh benchmarks */
+public class RecursiveRunner {
+
+  private final int deep;
+
+  private final Runnable runnable;
+
+  public RecursiveRunner(int deep, final Runnable runnable) {
+    this.deep = deep;
+    this.runnable = runnable;
+  }
+
+  public void run() {
+    recursiveRun(0);
+  }
+
+  private void recursiveRun(int reps) {
+    if (reps > deep) {
+      runnable.run();
+    } else {
+      recursiveRun(++reps);
+    }
+  }
+}


### PR DESCRIPTION
# What Does This Do
Util to do partial walks of stacktraces. Excludes elements that belong to the dd-trace-java project.

# Motivation
In IAST, when we detect a vulnerability, we need to get the class and line where it happened. The relevant class and the line will not be the last in the stack. The relevant class and line will be calculated ignoring internal dd-trace-java classes, usually applying a filter of classes on top of that (e.g standard library).
So the filtering of dd-trace-java elements is built-in, and the API uses streams for further filtering operations.
In most cases, only a few elements need to be walked through (e.g. 2-4), and only in some rare cases the whole stack needs to be examined.

# Additional Notes
This functionality will be used whenever a vulnerability is found, so its performance is critical to vulnerability reporting. To optimize performance, three implementations are included:
- Default implementation: uses Thread.currentThread().getStackTrace() and gets an array with the full stacktrace. This is the most expensive when doing a partial walk, since it needs to create StackTraceElement objects for the whole stacktrace.
- Improve performance for JDK8 with HotSpot ([(JavaLangAccess)](https://github.com/openjdk/jdk/blob/jdk8-b120/jdk/src/share/classes/sun/misc/JavaLangAccess.java)). Relies on JavaLangAccess to create StackTraceElements on-demand.
- Improve performance for JDK9+ ([StackWalker](https://docs.oracle.com/javase/9/docs/api/java/lang/StackWalker.html)). Uses the newer StackWalker API.
 
The implementation is currently in the internal-api-* packages. This was picked arbitrarily to some extent, so other suggestions about locations are welcome. Initially, this API will only be used from the upcoming dd-java-agent/iast module.


# Performance
Here are sample results for the implementations. “Deep” is the number of total elements in the stack. “Limit” is the number of elements retrieved.

**JDK8 with HotSpot implementation performance**

<table>
  <tr>
    <th>Limit</th>
    <th>Deep</th>
    <th>Performance improvement %</th>
  </tr>
  <tr>
    <td>1</td>
    <td>10</td>
    <td>80.46%</td>
  </tr>
<tr>
    <td>3</td>
    <td>10</td>
    <td>75.31%</td>
  </tr>
<tr>
    <td>10</td>
    <td>10</td>
    <td>58.67%</td>
  </tr>
<tr>
    <td>1</td>
    <td>50</td>
    <td>85.42%</td>
  </tr>
<tr>
    <td>3</td>
    <td>50</td>
    <td>82.72%</td>
  </tr>
<tr>
    <td>10</td>
    <td>50</td>
    <td>74.13%</td>
  </tr>
<tr>
    <td>1</td>
    <td>100</td>
    <td>87.05%</td>
  </tr>
<tr>
    <td>3</td>
    <td>100</td>
    <td>85.51%</td>
  </tr>
<tr>
    <td>10</td>
    <td>100</td>
    <td>80.24%</td>
  </tr>
</table>

**JDK9 implementation performance**

<table>
  <tr>
    <th>Limit</th>
    <th>Deep</th>
    <th>Performance improvement %</th>
  </tr>
  <tr>
    <td>1</td>
    <td>10</td>
    <td>71.97%</td>
  </tr>
<tr>
    <td>3</td>
    <td>10</td>
    <td>63.46%</td>
  </tr>
<tr>
    <td>10</td>
    <td>10</td>
    <td>20.49%</td>
  </tr>
<tr>
    <td>1</td>
    <td>50</td>
    <td>82.92%</td>
  </tr>
<tr>
    <td>3</td>
    <td>50</td>
    <td>78.33%</td>
  </tr>
<tr>
    <td>10</td>
    <td>50</td>
    <td>54.04%</td>
  </tr>
<tr>
    <td>1</td>
    <td>100</td>
    <td>88.22%</td>
  </tr>
<tr>
    <td>3</td>
    <td>100</td>
    <td>85.42%</td>
  </tr>
<tr>
    <td>10</td>
    <td>100</td>
    <td>69.66%</td>
  </tr>
</table>

# Future Work
Future versions of this utility may include further performance optimizations:
- Filtering by class name before creating StackTraceElement objects (possible in all implementations except the default).
- Skipping a fixed number of initial frames without inspecting them at all. We will always have a number of elements that are part of dd-trace java, and we can skip them by default. This would save some superfluous allocations of StackTraceElements.

