### PR TITLE
Limit amazon-sqs-java-messaging-lib to 1.x when testing aws-java-sqs-1.0 integration

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/aws-java-sqs-1.0.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/aws-java-sqs-1.0.gradle
@@ -36,5 +36,5 @@ dependencies {
   testImplementation group: 'com.amazonaws', name: 'amazon-sqs-java-messaging-lib', version: '1.0.8'
 
   latestDepTestImplementation group: 'com.amazonaws', name: 'aws-java-sdk-sqs', version: '+'
-  latestDepTestImplementation group: 'com.amazonaws', name: 'amazon-sqs-java-messaging-lib', version: '+'
+  latestDepTestImplementation group: 'com.amazonaws', name: 'amazon-sqs-java-messaging-lib', version: '1.+'
 }


### PR DESCRIPTION
# Motivation

`amazon-sqs-java-messaging-lib` v2 was just released and that requires v2 of the AWS SDK - since our `aws-java-sqs-1.0` integration uses v1 of the AWS SDK we should limit the version of this library to match.

(a separate integration will be added to support `aws-java-sqs-2.0`)