### PR TITLE
Respect explicit setting of 'dd.profiling.async.enabled=false'…

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ControllerFactory.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ControllerFactory.java
@@ -78,9 +78,8 @@ public final class ControllerFactory {
           System.getProperty("java.vendor").equals("IBM Corporation")
               && System.getProperty("java.vm.name").contains("J9");
       if (configProvider.getBoolean(
-              ProfilingConfig.PROFILING_ASYNC_ENABLED,
-              ProfilingConfig.PROFILING_ASYNC_ENABLED_DEFAULT)
-          || isOpenJ9) {
+          ProfilingConfig.PROFILING_ASYNC_ENABLED,
+          ProfilingConfig.PROFILING_ASYNC_ENABLED_DEFAULT || isOpenJ9)) {
         try {
           Class<?> asyncProfilerClass = Class.forName("com.datadog.profiling.async.AsyncProfiler");
           if ((boolean)

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -88,6 +88,7 @@ abstract class AbstractSmokeTest extends ProcessManager {
     "-Ddd.profiling.start-delay=${PROFILING_START_DELAY_SECONDS}",
     "-Ddd.profiling.upload.period=${PROFILING_RECORDING_UPLOAD_PERIOD_SECONDS}",
     "-Ddd.profiling.url=${getProfilingUrl()}",
+    "-Ddd.profiling.async.enabled=false",
     "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug",
     "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"
   ]


### PR DESCRIPTION
…even when attaching to an IBM J9 JVM and use that to workaround the current async-profiler crash on CircleCI

# Motivation

IBM smoke tests on CircleCI are regularly failing with the following abort stack:
```
3XMTHREADINFO      "Async-profiler Sampler" J9VMThread:0x00000000006DA000, omrthread_t:0x00007F8131CF0118, java/lang/Thread:0x00000000E0BAB120, state:R, prio=5
3XMJAVALTHREAD            (java/lang/Thread getId:0x20, isDaemon:true)
3XMJAVALTHRCCL            sun/misc/Launcher$AppClassLoader(0x00000000E009E8B8)
3XMTHREADINFO1            (native thread ID:0x2E9B, native priority:0x5, native policy:UNKNOWN, vmstate:R, vm thread flags:0x000000a1)
3XMTHREADINFO2            (native stack address range from:0x00007F811ED8F000, to:0x00007F811F58F000, size:0x800000)
3XMCPUTIME               CPU usage total: 0.255376233 secs, current category="Application"
3XMHEAPALLOC             Heap bytes allocated since last GC cycle=0 (0x0)
3XMTHREADINFO3           No Java callstack associated with this thread
3XMTHREADINFO3           Native callstack:
4XENATIVESTACK               protectedBacktrace+0x12 (0x00007F81368AD592 [libj9prt29.so+0x5a592])
4XENATIVESTACK               omrsig_protect+0x1e3 (0x00007F813687A433 [libj9prt29.so+0x27433])
4XENATIVESTACK               omrintrospect_backtrace_thread_raw+0xbb (0x00007F81368ADA8B [libj9prt29.so+0x5aa8b])
4XENATIVESTACK               omrsig_protect+0x1e3 (0x00007F813687A433 [libj9prt29.so+0x27433])
4XENATIVESTACK               omrintrospect_backtrace_thread+0x70 (0x00007F81368AD450 [libj9prt29.so+0x5a450])
4XENATIVESTACK               setup_native_thread+0x1d2 (0x00007F81368A9AA2 [libj9prt29.so+0x56aa2])
4XENATIVESTACK               omrintrospect_threads_startDo_with_signal+0x474 (0x00007F81368AA874 [libj9prt29.so+0x57874])
4XENATIVESTACK               omrsig_protect+0x1e3 (0x00007F813687A433 [libj9prt29.so+0x27433])
4XENATIVESTACK               _ZN18JavaCoreDumpWriter28writeThreadsWithNativeStacksEv+0xa46 (0x00007F8136253326 [libj9dmp29.so+0x1b326])
4XENATIVESTACK               protectedWriteThreadsWithNativeStacks+0xd (0x00007F81362534BD [libj9dmp29.so+0x1b4bd])
4XENATIVESTACK               omrsig_protect+0x1e3 (0x00007F813687A433 [libj9prt29.so+0x27433])
4XENATIVESTACK               _ZN18JavaCoreDumpWriter18writeThreadSectionEv+0x14d (0x00007F813624FC0D [libj9dmp29.so+0x17c0d])
4XENATIVESTACK               protectedWriteSection+0x1d (0x00007F813624ADFD [libj9dmp29.so+0x12dfd])
4XENATIVESTACK               omrsig_protect+0x1e3 (0x00007F813687A433 [libj9prt29.so+0x27433])
4XENATIVESTACK               _ZN18JavaCoreDumpWriterC2EPKcP16J9RASdumpContextP14J9RASdumpAgent+0x41f (0x00007F813624C1DF [libj9dmp29.so+0x141df])
4XENATIVESTACK               runJavadump+0x1c (0x00007F8136255C0C [libj9dmp29.so+0x1dc0c])
4XENATIVESTACK               doJavaDump+0x3d (0x00007F813623D1FD [libj9dmp29.so+0x51fd])
4XENATIVESTACK               protectedDumpFunction+0x15 (0x00007F813623C8E5 [libj9dmp29.so+0x48e5])
4XENATIVESTACK               omrsig_protect+0x1e3 (0x00007F813687A433 [libj9prt29.so+0x27433])
4XENATIVESTACK               runDumpFunction+0x6b (0x00007F813623FF3B [libj9dmp29.so+0x7f3b])
4XENATIVESTACK               runDumpAgent+0x15f (0x00007F81362400CF [libj9dmp29.so+0x80cf])
4XENATIVESTACK               triggerDumpAgents+0x34e (0x00007F81362579DE [libj9dmp29.so+0x1f9de])
4XENATIVESTACK               abortHandler+0x10e (0x00007F81362423EE [libj9dmp29.so+0xa3ee])
4XENATIVESTACK                (0x00007F8138881420 [libpthread.so.0+0x14420])
4XENATIVESTACK               gsignal+0xcb (0x00007F813849600B [libc.so.6+0x4300b])
4XENATIVESTACK               abort+0x12b (0x00007F8138475859 [libc.so.6+0x22859])
4XENATIVESTACK               mainSynchSignalHandler+0xab (0x00007F813687977B [libj9prt29.so+0x2677b])
4XENATIVESTACK                (0x00007F8138881420 [libpthread.so.0+0x14420])
4XENATIVESTACK               _ZN8Profiler20recordExternalSampleEyP5EventiiP15ASGCT_CallFrameb.constprop.0+0x42e (0x00007F811C6F9CDE [libasyncProfiler5138009216728900701.so+0x3acde])
4XENATIVESTACK               _ZN11J9WallClock11threadEntryEPv+0x22a (0x00007F811C6FA14A [libasyncProfiler5138009216728900701.so+0x3b14a])
4XENATIVESTACK               start_thread+0xd9 (0x00007F8138875609 [libpthread.so.0+0x8609])
4XENATIVESTACK               clone+0x43 (0x00007F8138572133 [libc.so.6+0x11f133])
```

Note the IBM smoke tests don't explicitly enable the async-profiler, but because CircleCI is testing an IBM J9 JVM (Java 8 version) that doesn't include JFR it currently falls back to use that as a profiling `Controller` on Linux as a last resort after trying the OpenJDK and Oracle controllers.

When it falls back in this way there's no way to override this decision. This PR fixes that so that if a user has an explicit setting for `dd.profiling.async.enabled` then we respect that - and if there is no such setting then we default it to off on all platforms except where we're attaching to an IBM J9 JVM without JFR.

In other words this should behave exactly the same as before, except allowing users to override the default. We then use this to explicitly turn off async profiling for the CircleCI smoke tests.