### PR TITLE
Avoid wrapping null JMS MessageListeners

### DIFF
--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
@@ -186,7 +186,7 @@ public final class JMSMessageConsumerInstrumentation extends Instrumenter.Tracin
     public static void setMessageListener(
         @Advice.This MessageConsumer messageConsumer,
         @Advice.Argument(value = 0, readOnly = false) MessageListener listener) {
-      if (!(listener instanceof DatadogMessageListener)) {
+      if (null != listener && !(listener instanceof DatadogMessageListener)) {
         MessageConsumerState consumerState =
             InstrumentationContext.get(MessageConsumer.class, MessageConsumerState.class)
                 .get(messageConsumer);

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
@@ -345,6 +345,32 @@ class JMS1Test extends AgentTestRunner {
     session.createTemporaryTopic()   | "Temporary Topic"
   }
 
+  def "sending to a null MessageListener on #jmsResourceName generates only producer spans"() {
+    setup:
+    def producer = session.createProducer(destination)
+    def consumer = session.createConsumer(destination)
+    consumer.setMessageListener(null)
+
+    producer.send(message1)
+
+    expect:
+    assertTraces(1) {
+      producerTrace(it, jmsResourceName)
+    }
+
+    cleanup:
+    producer.close()
+    consumer.receiveNoWait()
+    consumer.close()
+
+    where:
+    destination                      | jmsResourceName
+    session.createQueue("someQueue") | "Queue someQueue"
+    session.createTopic("someTopic") | "Topic someTopic"
+    session.createTemporaryQueue()   | "Temporary Queue"
+    session.createTemporaryTopic()   | "Temporary Topic"
+  }
+
   def "failing to receive message with receiveNoWait on #jmsResourceName works"() {
     setup:
     def consumer = session.createConsumer(destination)


### PR DESCRIPTION
# Motivation

A null MessageListener is passed in when the user wants to remove the current listener, so we should just leave the null alone and pass it onto the consumer without wrapping it.
