### PR TITLE
Lightweight streaming JFR chunk parser

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/profiling-controller-jfr.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/profiling-controller-jfr.gradle
@@ -1,14 +1,27 @@
-plugins {
-  id "de.undercouch.download" version "4.1.1"
+// Set properties before any plugins get loaded
+ext {
+  // the tests need Java 11 because the JFR writer got compiled with a version
+  // of ByteBuffer.position(int) which is binary incompatible with Java 8 ¯\_(ツ)_/¯
+  minJavaVersionForTests = JavaVersion.VERSION_11
+
+  // need access to jdk.jfr package
+  skipSettingCompilerRelease = true
 }
 
 apply from: "$rootDir/gradle/java.gradle"
+apply plugin: 'idea'
 
 dependencies {
   api project(':dd-java-agent:agent-profiling:profiling-controller')
 
+  implementation group: 'org.jctools', name: 'jctools-core', version: '3.3.0'
   implementation deps.slf4j
 
+  annotationProcessor deps.autoserviceProcessor
+  compileOnly deps.autoserviceAnnotation
+
+  testImplementation group: 'org.openjdk.jmc', name: 'flightrecorder.writer', version: '8.1.0-SNAPSHOT'
+  testImplementation deps.mockito
   testImplementation deps.junit5
 }
 
@@ -19,3 +32,24 @@ excludedClassesCoverage += ['com.datadog.profiling.controller.jfr.JdkTypeIDs']
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
+
+tasks.named("compileTestJava").configure {
+  setJavaVersion(it, 11)
+  // tests should be compiled in Java 8 compatible way
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+  // Disable '-processing' because some annotations are not claimed.
+  // Disable '-options' because we are compiling for java8 without specifying bootstrap - intentionally.
+  // Disable '-path' because we do not have some of the paths seem to be missing.
+  options.compilerArgs.addAll(['-Xlint:all,-processing,-options,-path'/*, '-Werror'*/])
+}
+
+forbiddenApisMain {
+  failOnMissingClasses = false
+}
+
+idea {
+  module {
+    jdkName = '11'
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/profiling-controller-jfr.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/profiling-controller-jfr.gradle
@@ -14,7 +14,7 @@ apply plugin: 'idea'
 dependencies {
   api project(':dd-java-agent:agent-profiling:profiling-controller')
 
-  implementation group: 'org.jctools', name: 'jctools-core', version: '3.3.0'
+  implementation deps.jctools
   implementation deps.slf4j
 
   annotationProcessor deps.autoserviceProcessor

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/parser/ChunkHeader.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/parser/ChunkHeader.java
@@ -1,0 +1,80 @@
+package com.datadog.profiling.controller.jfr.parser;
+
+import java.io.IOException;
+
+/** A chunk header data object */
+public final class ChunkHeader {
+  static final byte[] MAGIC = new byte[] {'F', 'L', 'R', '\0'};
+  public final short major;
+  public final short minor;
+  public final long size;
+  public final long cpOffset;
+  public final long metaOffset;
+  public final long startNanos;
+  public final long duration;
+  public final long startTicks;
+  public final long frequency;
+  public final boolean compressed;
+
+  ChunkHeader(RecordingStream recording) throws IOException {
+    byte[] buffer = new byte[MAGIC.length];
+    recording.read(buffer, 0, MAGIC.length);
+    for (int i = 0; i < MAGIC.length; i++) {
+      if (buffer[i] != MAGIC[i]) {
+        throw new IOException(
+            "Invalid JFR Magic Number: " + bytesToString(buffer, 0, MAGIC.length));
+      }
+    }
+    major = recording.readShort();
+    minor = recording.readShort();
+    size = recording.readLong();
+    cpOffset = recording.readLong();
+    metaOffset = recording.readLong();
+    startNanos = recording.readLong();
+    duration = recording.readLong();
+    startTicks = recording.readLong();
+    frequency = recording.readLong();
+    compressed = recording.readInt() != 0;
+  }
+
+  @Override
+  public String toString() {
+    return "ChunkHeader{"
+        + "major="
+        + major
+        + ", minor="
+        + minor
+        + ", size="
+        + size
+        + ", cpOffset="
+        + cpOffset
+        + ", metaOffset="
+        + metaOffset
+        + ", startNanos="
+        + startNanos
+        + ", duration="
+        + duration
+        + ", startTicks="
+        + startTicks
+        + ", frequency="
+        + frequency
+        + ", compressed="
+        + compressed
+        + '}';
+  }
+
+  private static String bytesToString(byte[] array, int offset, int len) {
+    StringBuilder sb = new StringBuilder("[");
+    boolean comma = false;
+    for (int i = 0; i < len; i++) {
+      if (comma) {
+        sb.append(", ");
+      } else {
+        comma = true;
+      }
+      sb.append(array[i + offset]);
+    }
+    sb.append(']');
+    return sb.toString();
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/parser/ChunkParserListener.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/parser/ChunkParserListener.java
@@ -1,0 +1,58 @@
+package com.datadog.profiling.controller.jfr.parser;
+
+import java.nio.file.Path;
+
+/**
+ * A callback to be provided to {@linkplain StreamingChunkParser#parse(Path, ChunkParserListener)}
+ */
+public interface ChunkParserListener {
+  /** Called when the recording starts to be processed */
+  default void onRecordingStart() {}
+
+  /**
+   * Called for each discovered chunk
+   *
+   * @param chunkIndex the chunk index (1-based)
+   * @param header the parsed chunk header
+   * @return {@literal false} if the chunk should be skipped
+   */
+  default boolean onChunkStart(int chunkIndex, ChunkHeader header) {
+    return true;
+  }
+
+  /**
+   * Called for the chunk metadata event
+   *
+   * @param metadata the chunk metadata event
+   * @return {@literal false} if the remainder of the chunk should be skipped
+   */
+  default boolean onMetadata(MetadataEvent metadata) {
+    return true;
+  }
+
+  /**
+   * Called for each parsed event
+   *
+   * @param typeId event type id
+   * @param stream {@linkplain RecordingStream} positioned at the event payload start
+   * @param payloadSize the size of the payload in bytes
+   * @return {@literal false} if the remainder of the chunk should be skipped
+   */
+  default boolean onEvent(long typeId, RecordingStream stream, long payloadSize) {
+    return true;
+  }
+
+  /**
+   * Called when a chunk is fully processed or skipped
+   *
+   * @param chunkIndex the chunk index (1-based)
+   * @param skipped {@literal true} if the chunk was skipped
+   * @return {@literal false} if the remaining chunks in the recording should be skipped
+   */
+  default boolean onChunkEnd(int chunkIndex, boolean skipped) {
+    return true;
+  }
+
+  /** Called when the recording was fully processed */
+  default void onRecordingEnd() {}
+}

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/parser/LongMapping.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/parser/LongMapping.java
@@ -1,0 +1,6 @@
+package com.datadog.profiling.controller.jfr.parser;
+
+/** Data structure mapping a long value to the type instance */
+public interface LongMapping<T> {
+  T getType(long value);
+}

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/parser/MetadataEvent.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/parser/MetadataEvent.java
@@ -1,0 +1,126 @@
+package com.datadog.profiling.controller.jfr.parser;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.jctools.maps.NonBlockingHashMapLong;
+
+/**
+ * JFR Chunk metadata
+ *
+ * <p>It contains the chunk specific type specifications
+ */
+public final class MetadataEvent {
+  private static final byte[] COMMON_BUFFER = new byte[4096]; // reusable byte buffer
+
+  public final int size;
+  public final long startTime;
+  public final long duration;
+  public final long metadataId;
+
+  private final NonBlockingHashMapLong<String> eventTypeNameMapBacking =
+      new NonBlockingHashMapLong<>(256);
+  private final LongMapping<String> eventTypeMap;
+
+  MetadataEvent(RecordingStream stream) throws IOException {
+    size = (int) stream.readVarint();
+    long typeId = stream.readVarint();
+    if (typeId != 0) {
+      throw new IOException("Unexpected event type: " + typeId + " (should be 0)");
+    }
+    startTime = stream.readVarint();
+    duration = stream.readVarint();
+    metadataId = stream.readVarint();
+    readElements(stream, readStringTable(stream));
+    eventTypeMap = eventTypeNameMapBacking::get;
+  }
+
+  /**
+   * Lazily compute and return the mappings of event type ids to event type names
+   *
+   * @return mappings of event type ids to event type names
+   */
+  public LongMapping<String> getEventTypeNameMap() {
+    return eventTypeMap;
+  }
+
+  private String[] readStringTable(RecordingStream stream) throws IOException {
+    int stringCnt = (int) stream.readVarint();
+    String[] stringConstants = new String[stringCnt];
+    for (int stringIdx = 0; stringIdx < stringCnt; stringIdx++) {
+      stringConstants[stringIdx] = readUTF8(stream);
+    }
+    return stringConstants;
+  }
+
+  private void readElements(RecordingStream stream, String[] stringConstants) throws IOException {
+    // get the element name
+    int stringPtr = (int) stream.readVarint();
+    boolean isClassElement = "class".equals(stringConstants[stringPtr]);
+
+    // process the attributes
+    int attrCount = (int) stream.readVarint();
+    String superType = null;
+    String name = null;
+    String id = null;
+    for (int i = 0; i < attrCount; i++) {
+      int keyPtr = (int) stream.readVarint();
+      int valPtr = (int) stream.readVarint();
+      // ignore anything but 'class' elements
+      if (isClassElement) {
+        if ("superType".equals(stringConstants[keyPtr])) {
+          superType = stringConstants[valPtr];
+        } else if ("name".equals(stringConstants[keyPtr])) {
+          name = stringConstants[valPtr];
+        } else if ("id".equals(stringConstants[keyPtr])) {
+          id = stringConstants[valPtr];
+        }
+      }
+    }
+    // only event types are currently collected
+    if (name != null && id != null && "jdk.jfr.Event".equals(superType)) {
+      eventTypeNameMapBacking.put(Long.parseLong(id), name);
+    }
+    // now inspect all the enclosed elements
+    int elemCount = (int) stream.readVarint();
+    for (int i = 0; i < elemCount; i++) {
+      readElements(stream, stringConstants);
+    }
+  }
+
+  private String readUTF8(RecordingStream stream) throws IOException {
+    byte id = stream.read();
+    if (id == 0) {
+      return null;
+    } else if (id == 1) {
+      return "";
+    } else if (id == 3) {
+      int size = (int) stream.readVarint();
+      byte[] content = size <= COMMON_BUFFER.length ? COMMON_BUFFER : new byte[size];
+      stream.read(content, 0, size);
+      return new String(content, 0, size, StandardCharsets.UTF_8);
+    } else if (id == 4) {
+      int size = (int) stream.readVarint();
+      char[] chars = new char[size];
+      for (int i = 0; i < size; i++) {
+        chars[i] = (char) stream.readVarint();
+      }
+      return new String(chars);
+    } else {
+      throw new IOException("Unexpected string constant id: " + id);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "Metadata{"
+        + "size="
+        + size
+        + ", startTime="
+        + startTime
+        + ", duration="
+        + duration
+        + ", metadataId="
+        + metadataId
+        + '}';
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/parser/RecordingStream.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/parser/RecordingStream.java
@@ -1,0 +1,98 @@
+package com.datadog.profiling.controller.jfr.parser;
+
+import java.io.BufferedInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+final class RecordingStream implements AutoCloseable {
+  private final DataInputStream delegate;
+  private long position = 0;
+
+  RecordingStream(InputStream is) {
+    BufferedInputStream bis =
+        (is instanceof BufferedInputStream)
+            ? (BufferedInputStream) is
+            : new BufferedInputStream(is);
+    delegate = new DataInputStream(bis);
+  }
+
+  long position() {
+    return position;
+  }
+
+  void read(byte[] buffer, int offset, int length) throws IOException {
+    while (length > 0) {
+      int read = delegate.read(buffer, offset, length);
+      if (read == -1) {
+        throw new IOException("Unexpected EOF");
+      }
+      offset += read;
+      length -= read;
+      position += read;
+    }
+  }
+
+  byte read() throws IOException {
+    position += 1;
+    return delegate.readByte();
+  }
+
+  short readShort() throws IOException {
+    position += 2;
+    return delegate.readShort();
+  }
+
+  int readInt() throws IOException {
+    position += 4;
+    return delegate.readInt();
+  }
+
+  long readLong() throws IOException {
+    position += 8;
+    return delegate.readLong();
+  }
+
+  long readVarint() throws IOException {
+    long value = 0;
+    int readValue = 0;
+    int i = 0;
+    do {
+      readValue = delegate.read();
+      value |= (long) (readValue & 0x7F) << (7 * i);
+      i++;
+    } while ((readValue & 0x80) != 0
+        // In fact a fully LEB128 encoded 64bit number could take up to 10 bytes
+        // (in order to store 64 bit original value using 7bit slots we need at most 10 of them).
+        // However, eg. JMC parser will stop at 9 bytes, assuming that the compressed number is
+        // a Java unsigned long (therefore having only 63 bits and they all fit in 9 bytes).
+        && i < 9);
+    position += i;
+    return value;
+  }
+
+  int available() throws IOException {
+    return delegate.available();
+  }
+
+  void skip(long bytes) throws IOException {
+    long toSkip = bytes;
+    while (toSkip > 0) {
+      toSkip -= delegate.skip(toSkip);
+    }
+    position += bytes;
+  }
+
+  public void mark(int readlimit) {
+    delegate.mark(readlimit);
+  }
+
+  public void reset() throws IOException {
+    delegate.reset();
+  }
+
+  @Override
+  public void close() throws IOException {
+    delegate.close();
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/parser/StreamingChunkParser.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/parser/StreamingChunkParser.java
@@ -11,7 +11,6 @@ import org.slf4j.LoggerFactory;
  * notifies its listeners as the data becomes available. Because of this it is possible for the
  * metadata events to come 'out-of-band' (although not very probable) and it is up to the caller to
  * deal with that eventuality. <br>
- * This class is not thread-safe and is intended to be used from a single thread only.
  */
 public final class StreamingChunkParser {
   private static final Logger log = LoggerFactory.getLogger(StreamingChunkParser.class);

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/parser/StreamingChunkParser.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/parser/StreamingChunkParser.java
@@ -1,0 +1,105 @@
+package com.datadog.profiling.controller.jfr.parser;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Streaming, almost zero-allocation, JFR chunk parser implementation. <br>
+ * This is an MVP of a chunk parser allowing to stream the JFR events efficiently. The parser
+ * notifies its listeners as the data becomes available. Because of this it is possible for the
+ * metadata events to come 'out-of-band' (although not very probable) and it is up to the caller to
+ * deal with that eventuality. <br>
+ * This class is not thread-safe and is intended to be used from a single thread only.
+ */
+public final class StreamingChunkParser {
+  private static final Logger log = LoggerFactory.getLogger(StreamingChunkParser.class);
+
+  /**
+   * Parse the given JFR recording stream.<br>
+   * The parser will process the recording stream and call the provided listener in this order:
+   *
+   * <ol>
+   *   <li>listener.onRecordingStart()
+   *   <li>listener.onChunkStart()
+   *   <li>listener.onEvent() | listener.onMetadata()
+   *   <li>listener.onChunkEnd()
+   *   <li>listener.onRecordingEnd()
+   * </ol>
+   *
+   * @param inputStream the JFR recording stream it will be closed when the parsing is over
+   * @param listener the parser listener
+   * @throws IOException
+   */
+  public void parse(InputStream inputStream, ChunkParserListener listener) throws IOException {
+    try (RecordingStream stream = new RecordingStream(inputStream)) {
+      parse(stream, listener);
+    }
+  }
+
+  private void parse(RecordingStream stream, ChunkParserListener listener) throws IOException {
+    if (stream.available() == 0) {
+      return;
+    }
+    try {
+      listener.onRecordingStart();
+      int chunkCounter = 1;
+      while (stream.available() > 0) {
+        long chunkStartPos = stream.position();
+        ChunkHeader header = new ChunkHeader(stream);
+        if (!listener.onChunkStart(chunkCounter, header)) {
+          log.debug(
+              "'onChunkStart' returned false. Skipping metadata and events for chunk {}",
+              chunkCounter);
+          stream.skip(header.size - (stream.position() - chunkStartPos));
+          listener.onChunkEnd(chunkCounter, true);
+          continue;
+        }
+        long chunkEndPos = chunkStartPos + (int) header.size;
+        while (stream.position() < chunkEndPos) {
+          long eventStartPos = stream.position();
+          stream.mark(20); // max 2 varints ahead
+          int eventSize = (int) stream.readVarint();
+          if (eventSize > 0) {
+            long eventType = stream.readVarint();
+            if (eventType == 0) {
+              // metadata
+              stream.reset(); // roll-back the stream to the event start
+              MetadataEvent m = new MetadataEvent(stream);
+              if (!listener.onMetadata(m)) {
+                log.debug(
+                    "'onMetadata' returned false. Skipping events for chunk {}", chunkCounter);
+                stream.skip(header.size - (stream.position() - chunkStartPos));
+                listener.onChunkEnd(chunkCounter, true);
+              }
+            } else if (eventType == 1) {
+              // checkpoint event; skip for now
+              stream.skip(eventSize - (stream.position() - eventStartPos));
+            } else {
+              long currentPos = stream.position();
+              if (!listener.onEvent(eventType, stream, eventSize - (currentPos - eventStartPos))) {
+                log.debug(
+                    "'onEvent({}, stream)' returned false. Skipping the rest of the chunk {}",
+                    eventType,
+                    chunkCounter);
+                // skip the rest of the chunk
+                stream.skip(header.size - (stream.position() - chunkStartPos));
+                listener.onChunkEnd(chunkCounter, true);
+                continue;
+              }
+              // always skip any unconsumed event data to get the stream into consistent state
+              stream.skip(eventSize - (stream.position() - eventStartPos));
+            }
+          }
+        }
+        if (!listener.onChunkEnd(chunkCounter, false)) {
+          return;
+        }
+        chunkCounter++;
+      }
+    } finally {
+      listener.onRecordingEnd();
+    }
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/src/test/java/com/datadog/profiling/controller/jfr/TestJfrRecorder.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/src/test/java/com/datadog/profiling/controller/jfr/TestJfrRecorder.java
@@ -1,0 +1,489 @@
+package com.datadog.profiling.controller.jfr;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import jdk.jfr.Event;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+import org.openjdk.jmc.flightrecorder.writer.RecordingImpl;
+import org.openjdk.jmc.flightrecorder.writer.api.Annotation;
+import org.openjdk.jmc.flightrecorder.writer.api.Recording;
+import org.openjdk.jmc.flightrecorder.writer.api.Type;
+import org.openjdk.jmc.flightrecorder.writer.api.TypeStructureBuilder;
+import org.openjdk.jmc.flightrecorder.writer.api.TypedFieldBuilder;
+import org.openjdk.jmc.flightrecorder.writer.api.TypedValue;
+import org.openjdk.jmc.flightrecorder.writer.api.TypedValueBuilder;
+import org.openjdk.jmc.flightrecorder.writer.api.Types;
+
+/** An 'extended' JFR recorder adding the ability to use the Java JFR API to define event types. */
+public class TestJfrRecorder {
+  static final class AnnotationValueObject {
+    final Type annotationType;
+    final String annotationValue;
+
+    public AnnotationValueObject(Type annotationType, String value) {
+      this.annotationType = annotationType;
+      this.annotationValue = value;
+    }
+  }
+
+  private final Map<StackTraceElement, TypedValue> frameCache = new HashMap<>(16000);
+  private final Map<String, TypedValue> classLoaderCache = new HashMap<>(128);
+  private final Map<String, TypedValue> moduleCache = new HashMap<>(4096);
+  private final Recording recording;
+
+  public TestJfrRecorder(Recording recording) {
+    this.recording = recording;
+  }
+
+  public final Type registerEventType(Class<? extends Event> eventType) {
+    Types types = recording.getTypes();
+    /*
+     * JMC implementation is slightly mishandling some event types - not using the special call
+     * and rather registering all implicit fields by hand.
+     */
+    return recording.registerType(
+        getEventName(eventType),
+        "jdk.jfr.Event",
+        b -> {
+          Field[] fields = eventType.getDeclaredFields();
+          for (Field f : fields) {
+            if (Modifier.isTransient(f.getModifiers()) || Modifier.isStatic(f.getModifiers())) {
+              // skip static and transient fields
+              continue;
+            }
+            // Add field definition
+            Type fieldType = types.getType(f.getType().getName());
+            if (fieldType != null) {
+              java.lang.annotation.Annotation[] as = f.getAnnotations();
+              String fieldName = getFieldName(f);
+              if (fieldName.equals("startTime")
+                  || fieldName.equals("eventThread")
+                  || fieldName.equals("stackTrace")) {
+                // built-in fields; skip
+                continue;
+              }
+              TypedFieldBuilder fieldTypeBuilder = types.fieldBuilder(fieldName, fieldType);
+
+              for (java.lang.annotation.Annotation a : as) {
+                AnnotationValueObject val = processAnnotation(types, a);
+                if (val != null) {
+                  fieldTypeBuilder =
+                      val.annotationValue != null
+                          ? fieldTypeBuilder.addAnnotation(val.annotationType, val.annotationValue)
+                          : fieldTypeBuilder.addAnnotation(val.annotationType);
+                }
+              }
+              b.addField(fieldTypeBuilder.build());
+            }
+          }
+          // force 'startTime' field
+          b.addField(
+              "startTime",
+              Types.Builtin.LONG,
+              field ->
+                  field.addAnnotation(Types.JDK.ANNOTATION_TIMESTAMP, "NANOSECONDS_SINCE_EPOCH"));
+          // force 'eventThread' field
+          b.addField("eventThread", Types.JDK.THREAD);
+
+          // force 'stackTrace' field if the event is collecting stacktraces
+          if (hasStackTrace(eventType)) {
+            b.addField("stackTrace", Types.JDK.STACK_TRACE);
+          }
+          for (java.lang.annotation.Annotation a : eventType.getAnnotations()) {
+            AnnotationValueObject val = processAnnotation(types, a);
+            if (val != null) {
+              b =
+                  val.annotationValue != null
+                      ? b.addAnnotation(val.annotationType, val.annotationValue)
+                      : b.addAnnotation(val.annotationType);
+            }
+          }
+        });
+  }
+
+  private AnnotationValueObject processAnnotation(
+      Types types, java.lang.annotation.Annotation annotation) {
+    // skip non-JFR related annotations
+    if (!isJfrAnnotation(annotation)) {
+      return null;
+    }
+    if (annotation instanceof Name) {
+      // skip @Name annotation
+      return null;
+    }
+
+    String value = null;
+    try {
+      Method m = annotation.getClass().getMethod("value");
+      if (!String.class.isAssignableFrom(m.getReturnType())) {
+        // wrong value type
+        return null;
+      }
+      value = (String) m.invoke(annotation);
+    } catch (NoSuchMethodException ignored) {
+      // no-value annotations are also permitted
+    } catch (SecurityException
+        | IllegalAccessException
+        | IllegalArgumentException
+        | InvocationTargetException e) {
+      // error retrieving value attribute
+      return null;
+    }
+    String annotationValue = value;
+    String annotationTypeName = annotation.annotationType().getTypeName();
+    Type annotationType =
+        types.getOrAdd(
+            annotationTypeName,
+            Annotation.ANNOTATION_SUPER_TYPE_NAME,
+            builder -> {
+              if (annotationValue != null) {
+                builder.addField("value", Types.Builtin.STRING);
+              }
+            });
+    return new AnnotationValueObject(annotationType, annotationValue);
+  }
+
+  public final TestJfrRecorder writeEvent(Event event) {
+    registerEventType(event.getClass());
+    recording.writeEvent(createEventValue(event));
+    return this;
+  }
+
+  public RecordingImpl writeEvent(TypedValue event) {
+    return recording.writeEvent(event);
+  }
+
+  public Type registerEventType(String name) {
+    return recording.registerEventType(name);
+  }
+
+  public Type registerEventType(String name, Consumer<TypeStructureBuilder> builderCallback) {
+    return recording.registerEventType(name, builderCallback);
+  }
+
+  public Type registerAnnotationType(String name) {
+    return recording.registerAnnotationType(name);
+  }
+
+  public Type registerAnnotationType(String name, Consumer<TypeStructureBuilder> builderCallback) {
+    return recording.registerAnnotationType(name, builderCallback);
+  }
+
+  public Type registerType(String name, Consumer<TypeStructureBuilder> builderCallback) {
+    return recording.registerType(name, builderCallback);
+  }
+
+  public Type registerType(
+      String name, String supertype, Consumer<TypeStructureBuilder> builderCallback) {
+    return recording.registerType(name, supertype, builderCallback);
+  }
+
+  public Type getType(Types.JDK type) {
+    return recording.getType(type);
+  }
+
+  public Type getType(String typeName) {
+    return recording.getType(typeName);
+  }
+
+  public Types getTypes() {
+    return recording.getTypes();
+  }
+
+  private TypedValue createEventValue(Event event) {
+    Type eventType = recording.getType(getEventName(event.getClass()));
+    Field[] fields = event.getClass().getDeclaredFields();
+
+    TypedValue typedValue =
+        eventType.asValue(
+            access -> {
+              boolean startTimeWritten = false;
+              boolean eventThreadWritten = false;
+              boolean stackTraceWritten = false;
+              for (Field f : fields) {
+                f.setAccessible(true);
+
+                /*
+                 * From jdk.jfr.Event.java: Supported field types are the Java primitives: {@code
+                 * boolean}, {@code char}, {@code byte}, {@code short}, {@code int}, {@code long},
+                 * {@code float}, and {@code double}. Supported reference types are: {@code String},
+                 * {@code Thread} and {@code Class}. Arrays, enums, and other reference types are
+                 * silently ignored and not included. Fields that are of the supported types can be
+                 * excluded by using the transient modifier. Static fields, even of the supported
+                 * types, are not included.
+                 */
+                // Transient and static fields are excluded
+                if (Modifier.isTransient(f.getModifiers()) || Modifier.isStatic(f.getModifiers())) {
+                  continue;
+                }
+
+                String fldName = getFieldName(f);
+                if (fldName.equals("startTime")) {
+                  startTimeWritten = true;
+                } else if (fldName.equals("eventThread")) {
+                  eventThreadWritten = true;
+                } else if (fldName.equals("stackTrace")) {
+                  stackTraceWritten = true;
+                }
+                try {
+                  switch (f.getType().getName()) {
+                    case "byte":
+                      {
+                        byte byteValue = f.getByte(event);
+                        access.putField(fldName, byteValue);
+                        break;
+                      }
+                    case "char":
+                      {
+                        char charValue = f.getChar(event);
+                        access.putField(fldName, charValue);
+                        break;
+                      }
+                    case "short":
+                      {
+                        short shortValue = f.getShort(event);
+                        access.putField(fldName, shortValue);
+                        break;
+                      }
+                    case "int":
+                      {
+                        int intValue = f.getInt(event);
+                        access.putField(fldName, intValue);
+                        break;
+                      }
+                    case "long":
+                      {
+                        long longValue = f.getLong(event);
+                        access.putField(fldName, longValue);
+                        break;
+                      }
+                    case "float":
+                      {
+                        float floatValue = f.getFloat(event);
+                        access.putField(fldName, floatValue);
+                        break;
+                      }
+                    case "double":
+                      {
+                        double doubleValue = f.getDouble(event);
+                        access.putField(fldName, doubleValue);
+                        break;
+                      }
+                    case "boolean":
+                      {
+                        boolean booleanValue = f.getBoolean(event);
+                        access.putField(fldName, booleanValue);
+                        break;
+                      }
+                    case "java.lang.String":
+                      {
+                        String stringValue = (String) f.get(event);
+                        access.putField(fldName, stringValue);
+                        break;
+                      }
+                    case "java.lang.Class":
+                      {
+                        Class<?> clz = (Class<?>) f.get(event);
+                        access.putField(
+                            fldName,
+                            fldAccess -> {
+                              fldAccess
+                                  .putField(
+                                      "name",
+                                      nameAccess -> {
+                                        nameAccess.putField("string", clz.getSimpleName());
+                                      })
+                                  .putField("package", clz.getPackage().getName())
+                                  .putField("modifiers", clz.getModifiers());
+                            });
+                        break;
+                      }
+                    case "java.lang.Thread":
+                      {
+                        Thread thrd = (Thread) f.get(event);
+                        putThreadField(access, fldName, thrd);
+                        break;
+                      }
+                    case "java.lang.StackTraceElement[]":
+                      {
+                        StackTraceElement[] stackTrace = (StackTraceElement[]) f.get(event);
+                        putStackTraceField(access, fldName, stackTrace);
+                        break;
+                      }
+                    default:
+                      {
+                        // System.err.println("Cannot write type:" + f.getType().getName());
+                      }
+                  }
+                } catch (IllegalAccessException e) {
+                  throw new RuntimeException();
+                }
+              }
+              if (!startTimeWritten) {
+                // default to 0
+                access.putField("startTime", 0L);
+              }
+              if (!eventThreadWritten) {
+                // default to current thread
+                putThreadField(access, "eventThread", Thread.currentThread());
+              }
+              if (!stackTraceWritten && hasStackTrace(event.getClass())) {
+                putStackTraceField(access, "stackTrace", Thread.currentThread().getStackTrace());
+              }
+            });
+
+    return typedValue;
+  }
+
+  private String getEventName(Class<? extends Event> eventType) {
+    Name nameAnnotation = eventType.getAnnotation(Name.class);
+    if (nameAnnotation != null) {
+      return nameAnnotation.value();
+    }
+    return eventType.getSimpleName();
+  }
+
+  private String getFieldName(Field fld) {
+    Name nameAnnotation = fld.getAnnotation(Name.class);
+    if (nameAnnotation != null) {
+      return nameAnnotation.value();
+    }
+    return fld.getName();
+  }
+
+  private boolean isJfrAnnotation(java.lang.annotation.Annotation target) {
+    String typeName = target.annotationType().getName();
+    if (typeName.startsWith("jdk.jfr.")) {
+      return true;
+    }
+    for (java.lang.annotation.Annotation annotation : target.annotationType().getAnnotations()) {
+      if (isJfrAnnotation(annotation)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void putThreadField(TypedValueBuilder access, String fldName, Thread thread) {
+    access.putField(
+        fldName,
+        fldAccess -> {
+          fldAccess
+              .putField("javaThreadId", thread.getId())
+              .putField("osThreadId", thread.getId())
+              .putField("javaName", thread.getName());
+        });
+  }
+
+  private void putStackTraceField(
+      TypedValueBuilder access, String fldName, StackTraceElement[] stackTrace) {
+    Types types = access.getType().getTypes();
+    TypedValue[] frames = new TypedValue[stackTrace.length];
+    boolean[] truncated = new boolean[] {false};
+    for (int i = 0; i < stackTrace.length; i++) {
+      frames[i] = asStackFrame(types, stackTrace[i]);
+      if (i >= 8192) {
+        truncated[0] = true;
+        break;
+      }
+    }
+    access.putField(
+        fldName,
+        p -> {
+          p.putField("frames", frames).putField("truncated", truncated[0]);
+        });
+  }
+
+  private TypedValue asStackFrame(Types types, StackTraceElement element) {
+    return frameCache.computeIfAbsent(
+        element,
+        k ->
+            types
+                .getType(Types.JDK.STACK_FRAME)
+                .asValue(
+                    p -> {
+                      p.putField("method", methodValue(types, k))
+                          .putField("lineNumber", k.getLineNumber())
+                          .putField("bytecodeIndex", -1)
+                          .putField("type", k.isNativeMethod() ? "native" : "java");
+                    }));
+  }
+
+  private TypedValue methodValue(Types types, StackTraceElement element) {
+    return types
+        .getType(Types.JDK.METHOD)
+        .asValue(
+            p -> {
+              p.putField("type", classValue(types, element))
+                  .putField("name", element.getMethodName());
+            });
+  }
+
+  private TypedValue classValue(Types types, StackTraceElement element) {
+    return types
+        .getType(Types.JDK.CLASS)
+        .asValue(
+            p -> {
+              p.putField("name", getSimpleName(element.getClassName()));
+            });
+  }
+
+  private TypedValue classLoaderValue(Types types, String classLoaderName) {
+    return classLoaderCache.computeIfAbsent(
+        classLoaderName,
+        k ->
+            types
+                .getType(Types.JDK.CLASS_LOADER)
+                .asValue(
+                    p -> {
+                      p.putField("name", k);
+                    }));
+  }
+
+  private TypedValue packageValue(Types types, String packageName, String module) {
+    return types
+        .getType(Types.JDK.PACKAGE)
+        .asValue(
+            p -> {
+              p.putField("name", packageName).putField("module", moduleValue(types, module));
+            });
+  }
+
+  private TypedValue moduleValue(Types types, String module) {
+    return moduleCache.computeIfAbsent(
+        module,
+        k ->
+            types
+                .getType(Types.JDK.MODULE)
+                .asValue(
+                    p -> {
+                      p.putField("name", k);
+                    }));
+  }
+
+  private String getSimpleName(String className) {
+    return className.substring(className.lastIndexOf('.') + 1);
+  }
+
+  private String getPackageName(String className) {
+    int idx = className.lastIndexOf('.');
+    if (idx > -1) {
+      return className.substring(0, idx);
+    }
+    return "";
+  }
+
+  private boolean hasStackTrace(Class<? extends Event> eventType) {
+    StackTrace stAnnotation = eventType.getAnnotation(StackTrace.class);
+    if (stAnnotation != null) {
+      return stAnnotation.value();
+    }
+    return false;
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/src/test/java/com/datadog/profiling/controller/jfr/parser/ParserEvent.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/src/test/java/com/datadog/profiling/controller/jfr/parser/ParserEvent.java
@@ -1,0 +1,18 @@
+package com.datadog.profiling.controller.jfr.parser;
+
+import jdk.jfr.Category;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+
+@Label("Parser Event")
+@Name("datadog.ParserEvent")
+@Category({"datadog", "test"})
+public class ParserEvent extends Event {
+  @Label("value")
+  private final int value;
+
+  public ParserEvent(int value) {
+    this.value = value;
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/src/test/java/com/datadog/profiling/controller/jfr/parser/StreamingChunkParserTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/src/test/java/com/datadog/profiling/controller/jfr/parser/StreamingChunkParserTest.java
@@ -1,0 +1,204 @@
+package com.datadog.profiling.controller.jfr.parser;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datadog.profiling.controller.jfr.TestJfrRecorder;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.internal.verification.VerificationModeFactory;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openjdk.jmc.flightrecorder.writer.api.Recording;
+import org.openjdk.jmc.flightrecorder.writer.api.Recordings;
+
+@ExtendWith(MockitoExtension.class)
+class StreamingChunkParserTest {
+  private StreamingChunkParser instance;
+  @Mock private ChunkParserListener listener;
+
+  @BeforeEach
+  void setup() throws Exception {
+    instance = new StreamingChunkParser();
+  }
+
+  @Test
+  void testNoChunk() throws Exception {
+    byte[] data = new byte[0];
+    InputStream is = new ByteArrayInputStream(data);
+
+    instance.parse(is, listener);
+
+    ChunkParserListener noInteractions = Mockito.verify(listener, VerificationModeFactory.times(0));
+    noInteractions.onRecordingStart();
+    noInteractions.onChunkStart(Mockito.anyInt(), Mockito.any(ChunkHeader.class));
+    noInteractions.onMetadata(Mockito.any(MetadataEvent.class));
+    noInteractions.onEvent(Mockito.anyLong(), Mockito.any(RecordingStream.class), Mockito.anyInt());
+    noInteractions.onChunkEnd(Mockito.anyInt(), Mockito.anyBoolean());
+    noInteractions.onRecordingEnd();
+  }
+
+  @Test
+  void testNoMagic() throws Exception {
+    byte[] data = new byte[100];
+    for (int i = 0; i < 100; i++) {
+      data[i] = (byte) i;
+    }
+
+    InputStream is = new ByteArrayInputStream(data);
+
+    Assertions.assertThrows(IOException.class, () -> instance.parse(is, listener));
+
+    Mockito.verify(listener, VerificationModeFactory.times(1)).onRecordingStart();
+    Mockito.verify(listener, VerificationModeFactory.times(1)).onRecordingEnd();
+    Mockito.verify(listener, VerificationModeFactory.times(0))
+        .onChunkStart(Mockito.anyInt(), Mockito.any(ChunkHeader.class));
+    Mockito.verify(listener, VerificationModeFactory.times(0))
+        .onChunkEnd(Mockito.anyInt(), Mockito.anyBoolean());
+    Mockito.verify(listener, VerificationModeFactory.times(0))
+        .onMetadata(Mockito.any(MetadataEvent.class));
+    Mockito.verify(listener, VerificationModeFactory.times(0))
+        .onEvent(Mockito.anyLong(), Mockito.any(RecordingStream.class), Mockito.anyLong());
+  }
+
+  @Test
+  void testOnlyMagic() throws Exception {
+    InputStream is = new ByteArrayInputStream(ChunkHeader.MAGIC);
+
+    Assertions.assertThrows(IOException.class, () -> instance.parse(is, listener));
+
+    Mockito.verify(listener, VerificationModeFactory.times(1)).onRecordingStart();
+    Mockito.verify(listener, VerificationModeFactory.times(1)).onRecordingEnd();
+    Mockito.verify(listener, VerificationModeFactory.times(0))
+        .onChunkStart(Mockito.anyInt(), Mockito.any(ChunkHeader.class));
+    Mockito.verify(listener, VerificationModeFactory.times(0))
+        .onChunkEnd(Mockito.anyInt(), Mockito.anyBoolean());
+    Mockito.verify(listener, VerificationModeFactory.times(0))
+        .onMetadata(Mockito.any(MetadataEvent.class));
+    Mockito.verify(listener, VerificationModeFactory.times(0))
+        .onEvent(Mockito.anyLong(), Mockito.any(RecordingStream.class), Mockito.anyLong());
+  }
+
+  @Test
+  void testSingleChunkRecording() throws Exception {
+    ByteArrayOutputStream recordingStream = new ByteArrayOutputStream();
+    long eventTypeId = -1;
+    try (Recording recording = Recordings.newRecording(recordingStream)) {
+      TestJfrRecorder rec = new TestJfrRecorder(recording);
+      eventTypeId = rec.registerEventType(ParserEvent.class).getId();
+      rec.writeEvent(new ParserEvent(10));
+    }
+
+    assertNotEquals(-1, eventTypeId);
+
+    Mockito.when(listener.onChunkStart(Mockito.anyInt(), Mockito.any(ChunkHeader.class)))
+        .thenReturn(true);
+    Mockito.when(listener.onMetadata(Mockito.any(MetadataEvent.class))).thenReturn(true);
+    Mockito.when(
+            listener.onEvent(
+                Mockito.anyLong(), Mockito.any(RecordingStream.class), Mockito.anyLong()))
+        .thenReturn(true);
+    Mockito.when(listener.onChunkEnd(Mockito.anyInt(), Mockito.anyBoolean())).thenReturn(true);
+
+    InputStream is = new ByteArrayInputStream(recordingStream.toByteArray());
+    instance.parse(is, listener);
+
+    Mockito.verify(listener, VerificationModeFactory.times(1)).onRecordingStart();
+    Mockito.verify(listener, VerificationModeFactory.times(1)).onRecordingEnd();
+    Mockito.verify(listener, VerificationModeFactory.times(1))
+        .onChunkStart(Mockito.eq(1), Mockito.notNull());
+    Mockito.verify(listener, VerificationModeFactory.times(1))
+        .onChunkEnd(Mockito.eq(1), Mockito.eq(false));
+    Mockito.verify(listener, VerificationModeFactory.times(1)).onMetadata(Mockito.notNull());
+    ArgumentCaptor<Long> capturedSize = ArgumentCaptor.forClass(Long.class);
+
+    Mockito.verify(listener, VerificationModeFactory.times(1))
+        .onEvent(Mockito.eq(eventTypeId), Mockito.notNull(), capturedSize.capture());
+
+    assertNotNull(capturedSize.getValue());
+    assertTrue(capturedSize.getValue() > 0);
+  }
+
+  @ParameterizedTest
+  @MethodSource("cancelledParserVerification")
+  void testCancellation(
+      String cancelAt,
+      int numRecStart,
+      int numChunkStart,
+      int numEvent,
+      int numMetadata,
+      int numChunkEnd,
+      int numRecEnd)
+      throws Exception {
+    long eventTypeId1 = -1;
+    long eventTypeId2 = -1;
+    ByteArrayOutputStream recordingStream = new ByteArrayOutputStream();
+    try (Recording recording = Recordings.newRecording(recordingStream)) {
+      TestJfrRecorder rec = new TestJfrRecorder(recording);
+      eventTypeId1 = rec.registerEventType(ParserEvent.class).getId();
+      rec.writeEvent(new ParserEvent(10));
+      rec.writeEvent(new ParserEvent(20));
+    }
+    try (Recording recording = Recordings.newRecording(recordingStream)) {
+      TestJfrRecorder rec = new TestJfrRecorder(recording);
+      eventTypeId2 = rec.registerEventType(ParserEvent.class).getId();
+      rec.writeEvent(new ParserEvent(30));
+      rec.writeEvent(new ParserEvent(40));
+    }
+
+    assertNotEquals(-1, eventTypeId1);
+    assertNotEquals(-1, eventTypeId2);
+
+    Mockito.lenient()
+        .when(listener.onChunkStart(Mockito.anyInt(), Mockito.any(ChunkHeader.class)))
+        .thenReturn(!"chunkStart".equals(cancelAt));
+    Mockito.lenient()
+        .when(listener.onMetadata(Mockito.any(MetadataEvent.class)))
+        .thenReturn(!"metadata".equals(cancelAt));
+    Mockito.lenient()
+        .when(
+            listener.onEvent(
+                Mockito.anyLong(), Mockito.any(RecordingStream.class), Mockito.anyLong()))
+        .thenReturn(!"event".equals(cancelAt));
+    Mockito.lenient()
+        .when(listener.onChunkEnd(Mockito.anyInt(), Mockito.anyBoolean()))
+        .thenReturn(!"chunkEnd".equals(cancelAt));
+
+    InputStream is = new ByteArrayInputStream(recordingStream.toByteArray());
+    instance.parse(is, listener);
+
+    boolean interruptedChunk = !"chunkEnd".equals(cancelAt);
+    Mockito.verify(listener, VerificationModeFactory.times(numRecStart)).onRecordingStart();
+    Mockito.verify(listener, VerificationModeFactory.times(numRecEnd)).onRecordingEnd();
+    Mockito.verify(listener, VerificationModeFactory.times(numChunkStart))
+        .onChunkStart(Mockito.anyInt(), Mockito.notNull());
+    Mockito.verify(listener, VerificationModeFactory.times(numChunkEnd))
+        .onChunkEnd(Mockito.anyInt(), Mockito.eq(interruptedChunk));
+    Mockito.verify(listener, VerificationModeFactory.times(numMetadata))
+        .onMetadata(Mockito.notNull());
+    Mockito.verify(listener, VerificationModeFactory.times(numEvent))
+        .onEvent(Mockito.eq(eventTypeId1), Mockito.notNull(), Mockito.anyLong());
+  }
+
+  private static Stream<Arguments> cancelledParserVerification() {
+    return Stream.of(
+        //                   cancelAt     rec     chunk   events  meta  endchunk  endrec
+        Arguments.arguments("chunkStart", 1, 2, 0, 0, 2, 1),
+        Arguments.arguments("metadata", 1, 2, 4, 2, 2, 1),
+        Arguments.arguments("event", 1, 2, 2, 0, 2, 1),
+        Arguments.arguments("chunkEnd", 1, 1, 2, 1, 1, 1));
+  }
+}


### PR DESCRIPTION
# What Does This Do
Brings in a light-weight streaming JFR parser.

# Motivation
This is necessary for running some heuristics for tweaking profiling settings between recordings based on the numbers of various collected JFR events.

# Additional Notes
The parser is in no way a replacement for the JMC parser nor the JDK built-in parser. In its current form it can not read the actual event values. This is by design as we really don't need the event values and are with basically event type histo.
However, it should be possible to add support for event body processing without sacrificing the performance when/if it is needed.
