### PR TITLE
Fall back to -javaagent if CodeSource#codeLocation is null

### DIFF
--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
@@ -78,12 +78,14 @@ public final class AgentBootstrap {
 
     if (codeSource != null) {
       ddJavaAgentJarURL = codeSource.getLocation();
-      final File bootstrapFile = new File(ddJavaAgentJarURL.toURI());
+      if (ddJavaAgentJarURL != null) {
+        final File bootstrapFile = new File(ddJavaAgentJarURL.toURI());
 
-      if (!bootstrapFile.isDirectory()) {
-        checkJarManifestMainClassIsThis(ddJavaAgentJarURL);
-        inst.appendToBootstrapClassLoaderSearch(new JarFile(bootstrapFile));
-        return ddJavaAgentJarURL;
+        if (!bootstrapFile.isDirectory()) {
+          checkJarManifestMainClassIsThis(ddJavaAgentJarURL);
+          inst.appendToBootstrapClassLoaderSearch(new JarFile(bootstrapFile));
+          return ddJavaAgentJarURL;
+        }
       }
     }
 


### PR DESCRIPTION
# What Does This Do
If the `CodeSource.getLocation` returns null, attempt to fall back to parsing the `-javaagent` argument

# Motivation
Fix NPE on bootstrap:

```
ERROR datadog.trace.bootstrap.AgentBootstrap
java.lang.NullPointerException
        at datadog.trace.bootstrap.AgentBootstrap.installBootstrapJar(AgentBootstrap.java:81)
        at datadog.trace.bootstrap.AgentBootstrap.agentmain(AgentBootstrap.java:52)
        at datadog.trace.bootstrap.AgentBootstrap.premain(AgentBootstrap.java:47)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:513)
        at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:525)
```

# Additional Notes
I did not see a straight forward way to add automated tests to this. `AgentLoadedIntoBootstrapTest` was the closest I found but not really set up to build the custom classloader set up that would be needed to test it. Let me know if there is a good way to add a test