### PR TITLE
HotSpotStackWalker utility implementation

### DIFF
--- a/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
@@ -78,6 +78,13 @@ class AgentTestRunnerTest extends AgentTestRunner {
             }
             // rethrow the exception otherwise
             throw e
+          } catch (NoClassDefFoundError e) {
+            // A dirty hack to allow passing this test on Java 7
+            if (info.getName() == "sun.misc.SharedSecrets") {
+              //datadog.trace.util.stacktrace.HotSpotStackWalker uses sun.misc.SharedSecrets to improve performance in jdk8 with hotspot
+              break
+            }
+            // rethrow the exception otherwise
           }
         }
       }

--- a/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
@@ -62,6 +62,11 @@ class AgentTestRunnerTest extends AgentTestRunner {
               // Simply ignore the error as the class will not be even attempted to get loaded on Java 7
               break
             }
+            if (info.getName().startsWith("datadog.trace.util.stacktrace.")) {
+              //It is known that support for Java 7 is going to be discontinued
+              //so we have decided to implement everything related to IAST in java8
+              break
+            }
             // rethrow the exception otherwise
             throw e
           } catch (IllegalAccessError e) {

--- a/internal-api/internal-api-8/internal-api-8.gradle
+++ b/internal-api/internal-api-8/internal-api-8.gradle
@@ -13,8 +13,12 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 minimumBranchCoverage = 0.8
+minimumInstructionCoverage = 0.8
 
-excludedClassesCoverage += ["datadog.trace.api.sampling.ConstantSampler",]
+excludedClassesCoverage += [
+  "datadog.trace.api.sampling.ConstantSampler",
+  "datadog.trace.util.stacktrace.StackWalkerFactory"
+]
 
 dependencies {
   api project(':internal-api')

--- a/internal-api/internal-api-8/src/jmh/java/datadog/trace/util/stacktrace/HotSpotStackWalkerBenchmark.java
+++ b/internal-api/internal-api-8/src/jmh/java/datadog/trace/util/stacktrace/HotSpotStackWalkerBenchmark.java
@@ -1,0 +1,51 @@
+package datadog.trace.util.stacktrace;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import java.util.stream.Collectors;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Simple Benchmark to test that HotSpotStackWalker has better performance that
+ * DefaultSpotStackWalker for JDK8 with hotspot
+ */
+@Warmup(iterations = 5, time = 1000, timeUnit = MILLISECONDS)
+@Measurement(iterations = 5, time = 1000, timeUnit = MILLISECONDS)
+@OutputTimeUnit(MILLISECONDS)
+@BenchmarkMode(Mode.Throughput)
+@State(Scope.Benchmark)
+public class HotSpotStackWalkerBenchmark {
+
+  private HotSpotStackWalker hotSpotStackWalker;
+
+  private DefaultStackWalker defaultStackWalker;
+
+  @Param({"1", "3", "10"})
+  int limit;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    hotSpotStackWalker = new HotSpotStackWalker();
+    defaultStackWalker = new DefaultStackWalker();
+  }
+
+  @Benchmark
+  public void hotSpotStackWalkerWalk() {
+    hotSpotStackWalker.walk().limit(limit).collect(Collectors.toList());
+  }
+
+  @Benchmark
+  public void defaultStackWalkerWalk() {
+    defaultStackWalker.walk().limit(limit).collect(Collectors.toList());
+  }
+}

--- a/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/AbstractStackWalker.java
+++ b/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/AbstractStackWalker.java
@@ -1,0 +1,23 @@
+package datadog.trace.util.stacktrace;
+
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+public abstract class AbstractStackWalker implements StackWalker {
+
+  private static final Predicate<StackTraceElement> NOT_DD_TRACE_CLASS =
+      (stackTraceElement) ->
+          !stackTraceElement.getClassName().startsWith("datadog.trace.")
+              && !stackTraceElement.getClassName().startsWith("com.datadog.appsec.");
+
+  @Override
+  public Stream<StackTraceElement> walk() {
+    return doFilterStack(doGetStack());
+  }
+
+  Stream<StackTraceElement> doFilterStack(Stream<StackTraceElement> stream) {
+    return stream.filter(NOT_DD_TRACE_CLASS);
+  }
+
+  abstract Stream<StackTraceElement> doGetStack();
+}

--- a/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/DefaultStackWalker.java
+++ b/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/DefaultStackWalker.java
@@ -1,0 +1,19 @@
+package datadog.trace.util.stacktrace;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+public class DefaultStackWalker extends AbstractStackWalker {
+
+  DefaultStackWalker() {}
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+
+  @Override
+  Stream<StackTraceElement> doGetStack() {
+    return Arrays.stream(new Throwable().getStackTrace());
+  }
+}

--- a/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/HotSpotStackTraceIterator.java
+++ b/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/HotSpotStackTraceIterator.java
@@ -1,0 +1,40 @@
+package datadog.trace.util.stacktrace;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+public class HotSpotStackTraceIterator implements Iterator<StackTraceElement> {
+
+  private int index = 0;
+
+  private final int size;
+
+  private final Throwable throwable;
+
+  private final sun.misc.JavaLangAccess access;
+
+  public HotSpotStackTraceIterator(
+      final Throwable throwable, final sun.misc.JavaLangAccess access) {
+    this.throwable = throwable;
+    this.access = access;
+    size = this.access.getStackTraceDepth(throwable);
+  }
+
+  @Override
+  public boolean hasNext() {
+    return index < size;
+  }
+
+  @Override
+  public StackTraceElement next() {
+    if (index >= size) {
+      throw new NoSuchElementException();
+    }
+    return access.getStackTraceElement(throwable, index++);
+  }
+
+  @Override
+  public void remove() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/HotSpotStackWalker.java
+++ b/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/HotSpotStackWalker.java
@@ -1,0 +1,63 @@
+package datadog.trace.util.stacktrace;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class HotSpotStackWalker extends AbstractStackWalker {
+
+  private final sun.misc.JavaLangAccess access = sun.misc.SharedSecrets.getJavaLangAccess();
+
+  @Override
+  public boolean isEnabled() {
+    try {
+      String str = System.getProperty("java.version");
+      if (str.length() > 3
+          && str.startsWith("1.")
+          && Integer.parseInt(Character.toString(str.charAt(2))) >= 7) {
+        if (access != null) {
+          access.getStackTraceElement(new Throwable(), 0);
+          return true;
+        }
+      }
+    } catch (Throwable localThrowable) {
+    }
+    return false;
+  }
+
+  @Override
+  Stream<StackTraceElement> doGetStack() {
+
+    Throwable throwable = new Throwable();
+
+    Iterable<StackTraceElement> iterable =
+        () ->
+            new Iterator<StackTraceElement>() {
+
+              int index = 0;
+
+              final int size = access.getStackTraceDepth(throwable);
+
+              @Override
+              public boolean hasNext() {
+                return index < size;
+              }
+
+              @Override
+              public StackTraceElement next() {
+                if (index >= size) {
+                  throw new NoSuchElementException();
+                }
+                return access.getStackTraceElement(throwable, index++);
+              }
+
+              @Override
+              public void remove() {
+                throw new UnsupportedOperationException();
+              }
+            };
+
+    return StreamSupport.stream(iterable.spliterator(), false);
+  }
+}

--- a/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/HotSpotStackWalker.java
+++ b/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/HotSpotStackWalker.java
@@ -1,5 +1,6 @@
 package datadog.trace.util.stacktrace;
 
+import datadog.trace.api.Platform;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.stream.Stream;
@@ -17,21 +18,15 @@ public class HotSpotStackWalker extends AbstractStackWalker {
     try {
       access = get();
     } catch (Throwable e) {
-      // Not hotspot available
     }
   }
 
   @Override
   public boolean isEnabled() {
     try {
-      String str = System.getProperty("java.version");
-      if (str.length() > 3
-          && str.startsWith("1.")
-          && Integer.parseInt(Character.toString(str.charAt(2))) >= 7) {
-        if (access != null) {
-          access.getStackTraceElement(new Throwable(), 0);
-          return true;
-        }
+      if (Platform.isJavaVersion(8) && access != null) {
+        access.getStackTraceElement(new Throwable(), 0);
+        return true;
       }
     } catch (Throwable localThrowable) {
     }

--- a/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/HotSpotStackWalker.java
+++ b/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/HotSpotStackWalker.java
@@ -7,7 +7,19 @@ import java.util.stream.StreamSupport;
 
 public class HotSpotStackWalker extends AbstractStackWalker {
 
-  private final sun.misc.JavaLangAccess access = sun.misc.SharedSecrets.getJavaLangAccess();
+  private static sun.misc.JavaLangAccess access;
+
+  private static sun.misc.JavaLangAccess get() {
+    return sun.misc.SharedSecrets.getJavaLangAccess();
+  }
+
+  static {
+    try {
+      access = get();
+    } catch (Throwable e) {
+      // Not hotspot available
+    }
+  }
 
   @Override
   public boolean isEnabled() {

--- a/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/HotSpotStackWalker.java
+++ b/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/HotSpotStackWalker.java
@@ -1,22 +1,16 @@
 package datadog.trace.util.stacktrace;
 
 import datadog.trace.api.Platform;
-import java.util.Iterator;
-import java.util.NoSuchElementException;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 public class HotSpotStackWalker extends AbstractStackWalker {
 
-  private static sun.misc.JavaLangAccess access;
+  sun.misc.JavaLangAccess access;
 
-  private static sun.misc.JavaLangAccess get() {
-    return sun.misc.SharedSecrets.getJavaLangAccess();
-  }
-
-  static {
+  HotSpotStackWalker() {
     try {
-      access = get();
+      access = sun.misc.SharedSecrets.getJavaLangAccess();
     } catch (Throwable e) {
     }
   }
@@ -36,34 +30,8 @@ public class HotSpotStackWalker extends AbstractStackWalker {
   @Override
   Stream<StackTraceElement> doGetStack() {
 
-    Throwable throwable = new Throwable();
-
     Iterable<StackTraceElement> iterable =
-        () ->
-            new Iterator<StackTraceElement>() {
-
-              int index = 0;
-
-              final int size = access.getStackTraceDepth(throwable);
-
-              @Override
-              public boolean hasNext() {
-                return index < size;
-              }
-
-              @Override
-              public StackTraceElement next() {
-                if (index >= size) {
-                  throw new NoSuchElementException();
-                }
-                return access.getStackTraceElement(throwable, index++);
-              }
-
-              @Override
-              public void remove() {
-                throw new UnsupportedOperationException();
-              }
-            };
+        () -> new HotSpotStackTraceIterator(new Throwable(), access);
 
     return StreamSupport.stream(iterable.spliterator(), false);
   }

--- a/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/StackWalker.java
+++ b/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/StackWalker.java
@@ -1,0 +1,11 @@
+package datadog.trace.util.stacktrace;
+
+import java.util.stream.Stream;
+
+public interface StackWalker {
+
+  boolean isEnabled();
+
+  /** StackTrace should be returned without any element from the dd-trace-java-agent itself. */
+  Stream<StackTraceElement> walk();
+}

--- a/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/StackWalkerFactory.java
+++ b/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/StackWalkerFactory.java
@@ -1,11 +1,18 @@
 package datadog.trace.util.stacktrace;
 
+import java.util.stream.Stream;
+
 public class StackWalkerFactory {
 
   public static StackWalker INSTANCE = getInstance();
 
   private static StackWalker getInstance() {
-    // New StackWalker implementations must be added in the future
-    return new DefaultStackWalker();
+
+    // New StackTraceGenerator must be added to the list
+    Stream<StackWalker> implementations = Stream.of(new HotSpotStackWalker());
+    return implementations
+        .filter(StackWalker::isEnabled)
+        .findFirst()
+        .orElse(new DefaultStackWalker());
   }
 }

--- a/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/StackWalkerFactory.java
+++ b/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/StackWalkerFactory.java
@@ -1,0 +1,11 @@
+package datadog.trace.util.stacktrace;
+
+public class StackWalkerFactory {
+
+  public static StackWalker INSTANCE = getInstance();
+
+  private static StackWalker getInstance() {
+    // New StackWalker implementations must be added in the future
+    return new DefaultStackWalker();
+  }
+}

--- a/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/DefaultStackWalkerTest.java
+++ b/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/DefaultStackWalkerTest.java
@@ -1,0 +1,65 @@
+package datadog.trace.util.stacktrace;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+public class DefaultStackWalkerTest {
+
+  private final DefaultStackWalker defaultStackWalker = new DefaultStackWalker();
+
+  @Test
+  public void defaultStackWalker_must_be_enabled() {
+    assertTrue(defaultStackWalker.isEnabled());
+  }
+
+  @Test
+  public void walk_retrieves_stackTraceElements() {
+    // When
+    Stream<StackTraceElement> stream = defaultStackWalker.walk();
+    // Then
+    assertNotEquals(stream.count(), 0);
+  }
+
+  @Test
+  public void get_stack_trace() {
+    // When
+    Stream<StackTraceElement> stream = defaultStackWalker.doGetStack();
+    // Then
+    assertNotEquals(stream.count(), 0);
+  }
+
+  @Test
+  public void stack_element_not_in_DD_trace_project_is_not_filtered() {
+    // when
+    Stream<StackTraceElement> stream = Stream.of(element("com.foo.Foo"));
+    Stream<StackTraceElement> filtered = defaultStackWalker.doFilterStack(stream);
+    // Then
+    assertEquals(filtered.count(), 1);
+  }
+
+  @Test
+  public void filter_DataDog_Trace_classes_from_StackTraceElements() {
+    // when
+    Stream<StackTraceElement> stream = Stream.of(element("datadog.trace.Foo"));
+    Stream<StackTraceElement> filtered = defaultStackWalker.doFilterStack(stream);
+    // Then
+    assertEquals(filtered.count(), 0);
+  }
+
+  @Test
+  public void filter_DataDog_AppSec_classes_from_StackTraceElements() {
+    // when
+    Stream<StackTraceElement> stream = Stream.of(element("com.datadog.appsec.Foo"));
+    Stream<StackTraceElement> filtered = defaultStackWalker.doFilterStack(stream);
+    // Then
+    assertEquals(filtered.count(), 0);
+  }
+
+  private StackTraceElement element(final String className) {
+    return new StackTraceElement(className, "method", "fileName", 1);
+  }
+}

--- a/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/HotSpotStackTraceIteratorTest.java
+++ b/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/HotSpotStackTraceIteratorTest.java
@@ -1,0 +1,48 @@
+package datadog.trace.util.stacktrace;
+
+import static datadog.trace.util.stacktrace.StackWalkerTestUtil.isRunningJDK8WithHotSpot;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class HotSpotStackTraceIteratorTest {
+
+  @BeforeAll
+  public static void setUp() {
+    assumeTrue(isRunningJDK8WithHotSpot());
+  }
+
+  @Test
+  public void hasNext() {
+    assertTrue(getTestIterator().hasNext());
+  }
+
+  @Test
+  public void next() {
+    assertNotNull(getTestIterator().next());
+  }
+
+  @Test
+  public void next_throws_NoSuchElementException_when_there_are_no_more_elements() {
+    HotSpotStackTraceIterator iterator = getTestIterator();
+    while (iterator.hasNext()) {
+      iterator.next();
+    }
+    Assertions.assertThrows(NoSuchElementException.class, iterator::next);
+  }
+
+  @Test
+  public void remove_throws_UnsupportedOperationException() {
+    Assertions.assertThrows(UnsupportedOperationException.class, getTestIterator()::remove);
+  }
+
+  private HotSpotStackTraceIterator getTestIterator() {
+    return new HotSpotStackTraceIterator(
+        new Throwable(), sun.misc.SharedSecrets.getJavaLangAccess());
+  }
+}

--- a/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/HotSpotStackWalkerTest.java
+++ b/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/HotSpotStackWalkerTest.java
@@ -1,0 +1,25 @@
+package datadog.trace.util.stacktrace;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+public class HotSpotStackWalkerTest {
+
+  private final HotSpotStackWalker hotSpotStackWalker = new HotSpotStackWalker();
+
+  @Test
+  public void hotSpotStackWalker_must_be_enabled_for_JDK8_with_hotspot() {
+    assertTrue(hotSpotStackWalker.isEnabled());
+  }
+
+  @Test
+  public void get_stack_trace() {
+    // When
+    Stream<StackTraceElement> stream = hotSpotStackWalker.doGetStack();
+    // Then
+    assertNotEquals(stream.count(), 0);
+  }
+}

--- a/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/HotSpotStackWalkerTest.java
+++ b/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/HotSpotStackWalkerTest.java
@@ -1,25 +1,41 @@
 package datadog.trace.util.stacktrace;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import datadog.trace.api.Platform;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import sun.misc.JavaLangAccess;
+import sun.misc.SharedSecrets;
 
 public class HotSpotStackWalkerTest {
+
+  private final boolean isJDK8WithHotSpot = isRunningJDK8WithHotSpot();
 
   private final HotSpotStackWalker hotSpotStackWalker = new HotSpotStackWalker();
 
   @Test
   public void hotSpotStackWalker_must_be_enabled_for_JDK8_with_hotspot() {
-    assertTrue(hotSpotStackWalker.isEnabled());
+    assertEquals(isJDK8WithHotSpot, hotSpotStackWalker.isEnabled());
   }
 
   @Test
   public void get_stack_trace() {
+    assumeTrue(isJDK8WithHotSpot);
     // When
     Stream<StackTraceElement> stream = hotSpotStackWalker.doGetStack();
     // Then
     assertNotEquals(stream.count(), 0);
+  }
+
+  private boolean isRunningJDK8WithHotSpot() {
+    try {
+      JavaLangAccess access = SharedSecrets.getJavaLangAccess();
+      return Platform.isJavaVersion(8) && access != null;
+    } catch (Throwable throwable) {
+      return false;
+    }
   }
 }

--- a/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/StackWalkerFactoryTest.java
+++ b/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/StackWalkerFactoryTest.java
@@ -1,0 +1,16 @@
+package datadog.trace.util.stacktrace;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class StackWalkerFactoryTest {
+
+  @Test
+  public void stackWalker_instance_must_be_enabled() {
+    // When
+    StackWalker stackWalker = StackWalkerFactory.INSTANCE;
+    // Then
+    assertTrue(stackWalker.isEnabled());
+  }
+}

--- a/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/StackWalkerTestUtil.java
+++ b/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/StackWalkerTestUtil.java
@@ -1,0 +1,19 @@
+package datadog.trace.util.stacktrace;
+
+import datadog.trace.api.Platform;
+import sun.misc.JavaLangAccess;
+import sun.misc.SharedSecrets;
+
+public class StackWalkerTestUtil {
+
+  private StackWalkerTestUtil() {}
+
+  public static boolean isRunningJDK8WithHotSpot() {
+    try {
+      JavaLangAccess access = SharedSecrets.getJavaLangAccess();
+      return Platform.isJavaVersion(8) && access != null;
+    } catch (Throwable throwable) {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
# What Does This Do

HotSpotStackWalker utility implementation  that improves DefaultStackWalker implementation for JDK8 with hotspot.

# Motivation

Improve performance obtaining stacktrace

# Additional Notes

This PR continues [Util to get stacktrace for reported vulnerabilities](https://github.com/DataDog/dd-trace-java/pull/3647)