### PR TITLE
Bridge between instrumentation and IAST

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/iast/IastModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/IastModule.java
@@ -1,0 +1,10 @@
+package datadog.trace.api.iast;
+
+import javax.annotation.Nonnull;
+
+public interface IastModule {
+
+  void onCipherAlgorithm(@Nonnull String algorithm);
+
+  void onHashingAlgorithm(@Nonnull String algorithm);
+}

--- a/internal-api/src/main/java/datadog/trace/api/iast/InstrumentationBridge.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/InstrumentationBridge.java
@@ -1,0 +1,58 @@
+package datadog.trace.api.iast;
+
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Bridge between instrumentations and {@link IastModule} that contains the business logic relative
+ * to vulnerability detection. The class contains a list of {@code public static} methods that will
+ * be injected into the bytecode via {@code invokestatic} instructions. It's important that all
+ * methods are protected from exception leakage.
+ */
+public abstract class InstrumentationBridge {
+
+  private static final Logger LOG = LoggerFactory.getLogger(InstrumentationBridge.class);
+
+  private static IastModule MODULE;
+
+  private InstrumentationBridge() {}
+
+  public static void registerIastModule(final IastModule module) {
+    MODULE = module;
+  }
+
+  /**
+   * Executed when access to a cryptographic cipher is detected
+   *
+   * <p>{@link javax.crypto.Cipher#getInstance(String)}
+   */
+  public static void onCipherGetInstance(@Nonnull final String algorithm) {
+    try {
+      if (MODULE != null) {
+        MODULE.onCipherAlgorithm(algorithm);
+      }
+    } catch (final Throwable t) {
+      onUnexpectedException("Callback for onCipher threw.", t);
+    }
+  }
+
+  /**
+   * Executed when access to a message digest algorithm is detected
+   *
+   * <p>{@link java.security.MessageDigest#getInstance(String)}
+   */
+  public static void onMessageDigestGetInstance(@Nonnull final String algorithm) {
+    try {
+      if (MODULE != null) {
+        MODULE.onHashingAlgorithm(algorithm);
+      }
+    } catch (final Throwable t) {
+      onUnexpectedException("Callback for onHash threw.", t);
+    }
+  }
+
+  private static void onUnexpectedException(final String message, final Throwable error) {
+    LOG.warn(message, error);
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/iast/InstrumentationBridgeTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/iast/InstrumentationBridgeTest.groovy
@@ -1,0 +1,79 @@
+package datadog.trace.api.iast
+
+
+import datadog.trace.test.util.DDSpecification
+
+class InstrumentationBridgeTest extends DDSpecification {
+
+  def "bridge calls module when a new hash is detected"() {
+    setup:
+    final module = Mock(IastModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    InstrumentationBridge.onMessageDigestGetInstance('SHA-1')
+
+    then:
+    1 * module.onHashingAlgorithm('SHA-1')
+  }
+
+  def "bridge calls don't fail with null module when a new hash is detected"() {
+    setup:
+    InstrumentationBridge.registerIastModule(null)
+
+    when:
+    InstrumentationBridge.onMessageDigestGetInstance('SHA-1')
+
+    then:
+    noExceptionThrown()
+  }
+
+  def "bridge calls don't leak exceptions when a new hash is detected"() {
+    setup:
+    final module = Mock(IastModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    InstrumentationBridge.onMessageDigestGetInstance('SHA-1')
+
+    then:
+    1 * module.onHashingAlgorithm(_) >> { throw new Error('Boom!!!') }
+    noExceptionThrown()
+  }
+
+  def "bridge calls module when a new cipher is detected"() {
+    setup:
+    final module = Mock(IastModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    InstrumentationBridge.onCipherGetInstance('AES')
+
+    then:
+    1 * module.onCipherAlgorithm('AES')
+  }
+
+  def "bridge calls don't fail with null module when a new cipher is detected"() {
+    setup:
+    InstrumentationBridge.registerIastModule(null)
+
+    when:
+    InstrumentationBridge.onCipherGetInstance('AES')
+
+    then:
+    noExceptionThrown()
+  }
+
+  def "bridge calls don't leak exceptions when a new cipher is detected"() {
+    setup:
+    final module = Mock(IastModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    InstrumentationBridge.onCipherGetInstance('AES')
+
+    then:
+    1 * module.onCipherAlgorithm(_) >> { throw new Error('Boom!!!') }
+    noExceptionThrown()
+  }
+}


### PR DESCRIPTION
# What Does This Do
Introduces a bridge class between instrumentations and an IAST module. All hooks in IAST instrumentation will call static methods of this bridge.

# Motivation
Due to the potentially large amount of callbacks the IAST module will receive and performance requirements for certain operations, we have decided to introduce a custom bridge for direct communication between instrumentations and IAST.
This bridge will have static methods for each of the callbacks that the IAST will be installing. Static methods are selected mostly because they need simpler instrumentation, with less stack operations and better performance.
The callbacks will be added to client code by instrumentation modules. The callback implementations will be in the dd-java-agent/iast module.

# Additional Notes
`IASTModule` will be implemented in future pull requests.
