### PR TITLE
[TestNG] APMJAVA-790: Avoid npe testng framework (TestNGDecorator)

### DIFF
--- a/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TestNGDecorator.java
+++ b/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TestNGDecorator.java
@@ -72,7 +72,7 @@ public class TestNGDecorator extends TestDecorator {
       sb.append("\"")
           .append(i)
           .append("\":\"")
-          .append(Strings.escapeToJson(result.getParameters()[i].toString()))
+          .append(Strings.escapeToJson(result.getParameters()[i] != null? result.getParameters()[i].toString(): null))
           .append("\"");
       if (i != result.getParameters().length - 1) {
         sb.append(",");

--- a/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TestNGDecorator.java
+++ b/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TestNGDecorator.java
@@ -72,7 +72,7 @@ public class TestNGDecorator extends TestDecorator {
       sb.append("\"")
           .append(i)
           .append("\":\"")
-          .append(Strings.escapeToJson(result.getParameters()[i] != null? result.getParameters()[i].toString(): null))
+          .append(Strings.escapeToJson(String.valueOf(result.getParameters()[i])))
           .append("\"");
       if (i != result.getParameters().length - 1) {
         sb.append(",");


### PR DESCRIPTION
NullPointerException when I instrument with trace library the test developed with testng framework.

The case can be reproduced when DataProviders returns null values.

fix #APMJAVA-790

# What Does This Do

# Motivation

# Additional Notes
https://datadoghq.atlassian.net/browse/APMJAVA-790