### PR TITLE
Cleanup exclusion of shared content when creating shadow jars

### DIFF
--- a/dd-cws-tls/dd-cws-tls.gradle
+++ b/dd-cws-tls/dd-cws-tls.gradle
@@ -20,11 +20,7 @@ dependencies {
 }
 
 shadowJar {
-  dependencies deps.sharedInverse
-  dependencies {
-    exclude(project(':dd-trace-api'))
-    exclude(project(':internal-api'))
-  }
+  dependencies deps.excludeShared
 }
 
 ext {

--- a/dd-java-agent/agent-debugger/agent-debugger.gradle
+++ b/dd-java-agent/agent-debugger/agent-debugger.gradle
@@ -60,17 +60,9 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 shadowJar {
-  dependencies deps.sharedInverse
+  dependencies deps.excludeShared
   dependencies {
-    exclude(project(':dd-java-agent:agent-bootstrap'))
     exclude(project(':dd-java-agent:agent-debugger:debugger-bootstrap'))
-    exclude(project(':dd-java-agent:agent-logging'))
-    exclude(project(':dd-trace-api'))
-    exclude(project(':internal-api'))
-    exclude(project(':internal-api:internal-api-8'))
-    exclude(project(':utils:socket-utils'))
-    exclude(project(':utils:time-utils'))
-    exclude(dependency('org.slf4j::'))
   }
 }
 

--- a/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
+++ b/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
@@ -13,18 +13,7 @@ dependencies {
 }
 
 shadowJar {
-  dependencies deps.sharedInverse
-  dependencies {
-    exclude(project(':dd-java-agent:agent-bootstrap'))
-    exclude(project(':dd-java-agent:agent-logging'))
-    exclude(project(':dd-trace-api'))
-    exclude(project(':internal-api'))
-    exclude(project(':internal-api:internal-api-8'))
-    exclude(project(':utils:time-utils'))
-    exclude(project(':utils:socket-utils'))
-    exclude(project(':utils:version-utils'))
-    exclude(dependency('org.slf4j::'))
-  }
+  dependencies deps.excludeShared
 }
 
 tasks.register("submodulesUpdate", Exec) {

--- a/dd-java-agent/agent-profiling/agent-profiling.gradle
+++ b/dd-java-agent/agent-profiling/agent-profiling.gradle
@@ -37,18 +37,7 @@ configurations {
 }
 
 shadowJar {
-  dependencies deps.sharedInverse
-  dependencies {
-    exclude(project(':dd-java-agent:agent-bootstrap'))
-    exclude(project(':dd-java-agent:agent-logging'))
-    exclude(project(':dd-trace-api'))
-    exclude(project(':internal-api'))
-    exclude(project(':internal-api:internal-api-8'))
-    exclude(project(':utils:socket-utils'))
-    exclude(project(':utils:time-utils'))
-    exclude(project(':utils:version-utils'))
-    exclude(dependency('org.slf4j::'))
-  }
+  dependencies deps.excludeShared
   exclude {
     if (it.path.startsWith('org/jctools/')) {
       def ret = true

--- a/dd-java-agent/agent-tooling/agent-tooling.gradle
+++ b/dd-java-agent/agent-tooling/agent-tooling.gradle
@@ -14,6 +14,8 @@ configurations {
 }
 
 compileJava.dependsOn 'generateClassNameTries'
+packageSources.dependsOn 'generateClassNameTries'
+sourcesJar.dependsOn 'generateClassNameTries'
 
 dependencies {
   api(project(':dd-java-agent:agent-bootstrap')) {

--- a/dd-java-agent/appsec/appsec.gradle
+++ b/dd-java-agent/appsec/appsec.gradle
@@ -41,17 +41,7 @@ targetCompatibility = JavaVersion.VERSION_1_8
 
 shadowJar {
   exclude '**/*-dbgsym.zip'
-  dependencies deps.sharedInverse
-  dependencies {
-    exclude(project(':dd-java-agent:agent-bootstrap'))
-    exclude(project(':dd-java-agent:agent-logging'))
-    exclude(project(':dd-trace-api'))
-    exclude(project(':internal-api'))
-    exclude(project(':utils:time-utils'))
-    exclude(project(':utils:version-utils'))
-    exclude(project(':communication'))
-    exclude(dependency('org.slf4j::'))
-  }
+  dependencies deps.excludeShared
 }
 
 jar {
@@ -98,6 +88,9 @@ jsonSchema2Pojo {
 
   targetVersion = "1.8"
 }
+
+packageSources.dependsOn 'generateJsonSchema2Pojo'
+sourcesJar.dependsOn 'generateJsonSchema2Pojo'
 
 task runSampleApp(type: GradleBuild, dependsOn: ':dd-java-agent:shadowJar') {
   description = "Run AppSec sample app with instrumentation"

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -154,10 +154,13 @@ dependencies {
   shadowInclude project(path: ':dd-java-agent:agent-bootstrap')
 
   // Includes for the shared internal shadow jar
-  sharedShadowInclude project(':utils:socket-utils')
   sharedShadowInclude deps.shared
-  sharedShadowInclude deps.moshi
   sharedShadowInclude project(':communication'), {
+    transitive = false
+    // do not bring along slf4j and dependent subprojects
+    // (which are loaded on the bootstrap cl)
+  }
+  sharedShadowInclude project(':telemetry'), {
     transitive = false
     // do not bring along slf4j and dependent subprojects
     // (which are loaded on the bootstrap cl)
@@ -165,10 +168,12 @@ dependencies {
   sharedShadowInclude project(':utils:container-utils'), {
     transitive = false
   }
+  sharedShadowInclude project(':utils:socket-utils'), {
+    transitive = false
+  }
   sharedShadowInclude project(':utils:version-utils'), {
     transitive = false
   }
-  sharedShadowInclude project(':telemetry')
 }
 
 tasks.withType(Test).configureEach {

--- a/dd-java-agent/instrumentation/instrumentation.gradle
+++ b/dd-java-agent/instrumentation/instrumentation.gradle
@@ -103,17 +103,6 @@ dependencies {
 
 tasks.named('shadowJar').configure {
   duplicatesStrategy = DuplicatesStrategy.FAIL
-  dependencies deps.sharedInverse
-  dependencies {
-    exclude(project(':dd-java-agent:agent-bootstrap'))
-    exclude(project(':dd-java-agent:agent-logging'))
-    exclude(project(':dd-trace-api'))
-    exclude(project(':internal-api'))
-    exclude(project(':internal-api:internal-api-8'))
-    exclude(project(':utils:time-utils'))
-    exclude(project(':utils:socket-utils'))
-    exclude(project(':utils:version-utils'))
-    exclude(dependency('org.slf4j::'))
-  }
+  dependencies deps.excludeShared
 }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -97,28 +97,38 @@ final class CachedData {
       "com.squareup.okio:okio:${versions.okio}",
       "com.datadoghq:java-dogstatsd-client:${versions.dogstatsd}",
       "com.github.jnr:jnr-unixsocket:${versions.jnr_unixsocket}",
+      "com.squareup.moshi:moshi:${versions.moshi}",
     ],
 
     // Inverse of "shared".  These exclude directives are part of shadowJar's DSL
     // which is similar but not exactly the same as the regular gradle dependency{} block
     // Also, transitive dependencies have to be explicitly listed
-    sharedInverse        : (Closure) {
-      // dogstatsd and its transitives
-      exclude(dependency('com.datadoghq:java-dogstatsd-client'))
-      exclude(dependency('com.github.jnr::'))
-      exclude(dependency('org.ow2.asm::'))
+    excludeShared        : (Closure) {
+      // projects bundled with shared or on bootstrap
+      exclude(project(':dd-java-agent:agent-bootstrap'))
+      exclude(project(':dd-java-agent:agent-logging'))
+      exclude(project(':dd-trace-api'))
+      exclude(project(':internal-api'))
+      exclude(project(':internal-api:internal-api-8'))
+      exclude(project(':communication'))
+      exclude(project(':telemetry'))
+      exclude(project(':utils:container-utils'))
+      exclude(project(':utils:socket-utils'))
+      exclude(project(':utils:time-utils'))
+      exclude(project(':utils:version-utils'))
+      exclude(dependency('org.slf4j::'))
 
       // okhttp and its transitives
       exclude(dependency('com.squareup.okhttp3:okhttp'))
       exclude(dependency('com.squareup.okio:okio'))
 
-      exclude(dependency("com.squareup.moshi:moshi:${versions.moshi}"))
+      // dogstatsd and its transitives
+      exclude(dependency('com.datadoghq:java-dogstatsd-client'))
+      exclude(dependency('com.github.jnr::'))
+      exclude(dependency('org.ow2.asm::'))
 
-      // container-utils/communication and transitives
-      exclude(project(':communication'))
-
-      exclude(project(':utils:container-utils'))
-      exclude(dependency("org.slf4j:slf4j-api:${versions.slf4j}"))
+      // moshi and its transitives
+      exclude(dependency('com.squareup.moshi::'))
     }
   ]
 }

--- a/telemetry/telemetry.gradle
+++ b/telemetry/telemetry.gradle
@@ -22,7 +22,8 @@ ext {
     'datadog.telemetry.Uname.UtsNameLinux',
     'datadog.telemetry.Uname.EmptyUtsName',
     'datadog.telemetry.dependency.LocationsCollectingTransformer',
-    'datadog.telemetry.TelemetrySystem'
+    'datadog.telemetry.TelemetrySystem',
+    'datadog.telemetry.api.*'
   ]
   excludedClassesBranchCoverage = [
     'datadog.telemetry.PolymorphicAdapterFactory.1',
@@ -71,16 +72,13 @@ openApiGenerate {
 }
 
 def openApiSrcDir = "$buildDir/generated/src/main/java" as String
-sourceSets {
-  generatedApis {
-    java.srcDirs openApiSrcDir
-  }
-}
-compileGeneratedApisJava.dependsOn tasks.openApiGenerate
-compileGeneratedApisJava {
-  sourceCompatibility = JavaVersion.VERSION_1_7
-  targetCompatibility = JavaVersion.VERSION_1_7
-}
+sourceSets.main.java.srcDirs += [openApiSrcDir]
+compileJava.dependsOn 'openApiGenerate'
+
+forbiddenApisMain.exclude('datadog/telemetry/api/*.class')
+
+packageSources.dependsOn 'openApiGenerate'
+sourcesJar.dependsOn 'openApiGenerate'
 
 dependencies {
   implementation deps.slf4j
@@ -93,15 +91,11 @@ dependencies {
   compileOnly project(':utils:container-utils')
   testImplementation project(':utils:container-utils')
 
-  compileOnly sourceSets.generatedApis.compileClasspath
-  api sourceSets.generatedApis.output
-
   api deps.okhttp
+  api deps.moshi
 
   compileOnly deps.jnr_ffi
   testImplementation deps.jnr_ffi
-
-  generatedApisImplementation deps.moshi
 
   testImplementation project(':utils:test-utils')
   testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.2'
@@ -109,6 +103,3 @@ dependencies {
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-loader', version: '1.5.22.RELEASE'
 }
 
-forbiddenApisGeneratedApis {
-  signaturesFiles = files('/dev/null')
-}


### PR DESCRIPTION
# What Does This Do
* rename 'deps.sharedInverse' to 'deps.excludeShared'
* include shared projects in 'deps.excludeShared' to reduce repetition
* make some implicit generated-source task dependencies explicit
  * this lets gradle keep certain build optimizations enabled
# Motivation
Reduces repetition in the build and also cleans up some duplicated content in the current jar
