### PR TITLE
Copy a Kafka test: the new test fails

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
@@ -926,3 +926,27 @@ class KafkaClientLegacyTracingForkedTest extends KafkaClientTestBase {
     return false
   }
 }
+
+class KafkaClientForkedDataStreamsDisabledTest extends KafkaClientTestBase {
+  @Override
+  void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("dd.service", "KafkaClientTest")
+    injectSysConfig("dd.kafka.legacy.tracing.enabled", "false")
+  }
+
+  @Override
+  String expectedServiceName()  {
+    return "KafkaClientTest"
+  }
+
+  @Override
+  boolean hasQueueSpan() {
+    return true
+  }
+
+  @Override
+  boolean splitByDestination() {
+    return false
+  }
+}


### PR DESCRIPTION
# What Does This Do

Added a new test `KafkaClientForkedDataStreamsDisabledTest` which is an exact copy of `KafkaClientForkedTest` except for the name. This test will fail due to serviceName not matching. It is unclear what exactly is causing this test to fail for now.

# Motivation

# Additional Notes
