### PR TITLE
Bump async-profiler 2.8.3-DD-20220720

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -30,7 +30,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    asyncprofiler : "2.8-DD-20220530",
+    asyncprofiler : "2.8.3-DD-20220720",
     asm           : "9.2"
   ]
 


### PR DESCRIPTION
# What Does This Do
Bumps the async-profiler library to the latest release

# Motivation
Async-profiler 2.8.3 contains a fix preventing a lot of crashes when collecting CPU stacktraces. 
Merging the upstream to our fork and updating the lib in dd-trace-java will make the async-profiler usage much safer.

# Additional Notes
