### PR TITLE
IG support for IAST 

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -16,7 +16,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.StatsDClientManager;
 import datadog.trace.api.Tracer;
 import datadog.trace.api.WithGlobalTracer;
-import datadog.trace.api.gateway.InstrumentationGateway;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.gateway.SubscriptionService;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.WriterConstants;
@@ -601,17 +601,17 @@ public class Agent {
       return;
     }
 
-    InstrumentationGateway gw = AgentTracer.get().instrumentationGateway();
-    startAppSec(gw, scoClass, o);
+    SubscriptionService ss = AgentTracer.get().getSubscriptionService(RequestContextSlot.APPSEC);
+    startAppSec(ss, scoClass, o);
   }
 
-  private static void startAppSec(InstrumentationGateway gw, Class<?> scoClass, Object sco) {
+  private static void startAppSec(SubscriptionService ss, Class<?> scoClass, Object sco) {
     try {
       final Class<?> appSecSysClass =
           APPSEC_CLASSLOADER.loadClass("com.datadog.appsec.AppSecSystem");
       final Method appSecInstallerMethod =
           appSecSysClass.getMethod("start", SubscriptionService.class, scoClass);
-      appSecInstallerMethod.invoke(null, gw, sco);
+      appSecInstallerMethod.invoke(null, ss, sco);
     } catch (final Throwable ex) {
       log.warn("Not starting AppSec subsystem: {}", ex.getMessage());
     }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -13,6 +13,7 @@ import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.IGSpanInfo;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -240,30 +241,39 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
   //  }
 
   private AgentSpan.Context.Extracted callIGCallbackStart(AgentSpan.Context.Extracted context) {
-    CallbackProvider cbp = tracer().instrumentationGateway();
-    if (null != cbp) {
-      Supplier<Flow<Object>> startedCB = cbp.getCallback(EVENTS.requestStarted());
-      if (null != startedCB) {
-        Object requestContextData = startedCB.get().getResult();
-        if (null != requestContextData) {
-          TagContext tagContext = null;
-          if (context == null) {
-            tagContext = new TagContext();
-          } else if (context instanceof TagContext) {
-            tagContext = (TagContext) context;
-          }
-          if (null != tagContext) {
-            context = tagContext.withRequestContextData(requestContextData);
-          }
-        }
-      }
+    AgentTracer.TracerAPI tracer = tracer();
+    Supplier<Flow<Object>> startedCbAppSec =
+        tracer.getCallbackProvider(RequestContextSlot.APPSEC).getCallback(EVENTS.requestStarted());
+    Supplier<Flow<Object>> startedCbIast =
+        tracer.getCallbackProvider(RequestContextSlot.IAST).getCallback(EVENTS.requestStarted());
+
+    if (startedCbAppSec == null && startedCbIast == null) {
+      return context;
     }
+
+    TagContext tagContext = null;
+    if (context == null) {
+      tagContext = new TagContext();
+    } else if (context instanceof TagContext) {
+      tagContext = (TagContext) context;
+    }
+
+    if (tagContext != null) {
+      if (startedCbAppSec != null) {
+        tagContext.withRequestContextDataAppSec(startedCbAppSec.get().getResult());
+      }
+      if (startedCbIast != null) {
+        tagContext.withRequestContextDataAppSec(startedCbIast.get().getResult());
+      }
+      return tagContext;
+    }
+
     return context;
   }
 
   private void callIGCallbackRequestHeaders(AgentSpan span, REQUEST_CARRIER carrier) {
-    CallbackProvider cbp = tracer().instrumentationGateway();
-    RequestContext<Object> requestContext = span.getRequestContext();
+    CallbackProvider cbp = tracer().getCallbackProvider(RequestContextSlot.APPSEC);
+    RequestContext requestContext = span.getRequestContext();
     AgentPropagation.ContextVisitor<REQUEST_CARRIER> getter = getter();
     if (requestContext == null || cbp == null || getter == null) {
       return;
@@ -280,12 +290,12 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
   }
 
   private void callIGCallbackResponseAndHeaders(AgentSpan span, RESPONSE carrier, int status) {
-    CallbackProvider cbp = tracer().instrumentationGateway();
-    RequestContext<Object> requestContext = span.getRequestContext();
+    CallbackProvider cbp = tracer().getCallbackProvider(RequestContextSlot.APPSEC);
+    RequestContext requestContext = span.getRequestContext();
     if (cbp == null || requestContext == null) {
       return;
     }
-    BiFunction<RequestContext<Object>, Integer, Flow<Void>> addrCallback =
+    BiFunction<RequestContext, Integer, Flow<Void>> addrCallback =
         cbp.getCallback(EVENTS.responseStarted());
     if (null != addrCallback) {
       addrCallback.apply(requestContext, status);
@@ -308,13 +318,13 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
   private void callIGCallbackURI(
       @Nonnull final AgentSpan span, @Nonnull final URIDataAdapter url, final String method) {
     // TODO:appsec there must be some better way to do this?
-    CallbackProvider cbp = tracer().instrumentationGateway();
-    RequestContext<Object> requestContext = span.getRequestContext();
+    CallbackProvider cbp = tracer().getCallbackProvider(RequestContextSlot.APPSEC);
+    RequestContext requestContext = span.getRequestContext();
     if (requestContext == null || cbp == null) {
       return;
     }
 
-    TriFunction<RequestContext<Object>, String, URIDataAdapter, Flow<Void>> callback =
+    TriFunction<RequestContext, String, URIDataAdapter, Flow<Void>> callback =
         cbp.getCallback(EVENTS.requestMethodUriRaw());
     if (callback != null) {
       callback.apply(requestContext, method, url);
@@ -331,10 +341,10 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
     if (span.getLocalRootSpan() != span) {
       return;
     }
-    CallbackProvider cbp = tracer().instrumentationGateway();
-    RequestContext<Object> requestContext = span.getRequestContext();
+    CallbackProvider cbp = tracer().getUniversalCallbackProvider();
+    RequestContext requestContext = span.getRequestContext();
     if (cbp != null && requestContext != null) {
-      BiFunction<RequestContext<Object>, IGSpanInfo, Flow<Void>> callback =
+      BiFunction<RequestContext, IGSpanInfo, Flow<Void>> callback =
           cbp.getCallback(EVENTS.requestEnded());
       if (callback != null) {
         callback.apply(requestContext, span);
@@ -344,13 +354,13 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
 
   private Flow<Void> callIGCallbackSocketAddress(
       @Nonnull final AgentSpan span, @Nonnull final String ip, final int port) {
-    CallbackProvider cbp = tracer().instrumentationGateway();
+    CallbackProvider cbp = tracer().getCallbackProvider(RequestContextSlot.APPSEC);
     if (cbp == null || (ip == null && port == UNSET_PORT)) {
       return Flow.ResultFlow.empty();
     }
-    RequestContext<Object> ctx = span.getRequestContext();
+    RequestContext ctx = span.getRequestContext();
     if (ctx != null) {
-      TriFunction<RequestContext<Object>, String, Integer, Flow<Void>> addrCallback =
+      TriFunction<RequestContext, String, Integer, Flow<Void>> addrCallback =
           cbp.getCallback(EVENTS.requestClientSocketAddress());
       if (null != addrCallback) {
         return addrCallback.apply(ctx, ip != null ? ip : "0.0.0.0", port);
@@ -363,23 +373,23 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
   private static final class IGKeyClassifier implements AgentPropagation.KeyClassifier {
 
     private static IGKeyClassifier create(
-        RequestContext<Object> requestContext,
-        TriConsumer<RequestContext<Object>, String, String> headerCallback,
-        Function<RequestContext<Object>, Flow<Void>> doneCallback) {
+        RequestContext requestContext,
+        TriConsumer<RequestContext, String, String> headerCallback,
+        Function<RequestContext, Flow<Void>> doneCallback) {
       if (null == requestContext || null == headerCallback) {
         return null;
       }
       return new IGKeyClassifier(requestContext, headerCallback, doneCallback);
     }
 
-    private final RequestContext<Object> requestContext;
-    private final TriConsumer<RequestContext<Object>, String, String> headerCallback;
-    private final Function<RequestContext<Object>, Flow<Void>> doneCallback;
+    private final RequestContext requestContext;
+    private final TriConsumer<RequestContext, String, String> headerCallback;
+    private final Function<RequestContext, Flow<Void>> doneCallback;
 
     private IGKeyClassifier(
-        RequestContext<Object> requestContext,
-        TriConsumer<RequestContext<Object>, String, String> headerCallback,
-        Function<RequestContext<Object>, Flow<Void>> doneCallback) {
+        RequestContext requestContext,
+        TriConsumer<RequestContext, String, String> headerCallback,
+        Function<RequestContext, Flow<Void>> doneCallback) {
       this.requestContext = requestContext;
       this.headerCallback = headerCallback;
       this.doneCallback = doneCallback;

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/AppSecSystemSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/AppSecSystemSpecification.groovy
@@ -13,6 +13,7 @@ import datadog.trace.api.function.BiFunction
 import datadog.trace.api.gateway.Flow
 import datadog.trace.api.gateway.IGSpanInfo
 import datadog.trace.api.gateway.RequestContext
+import datadog.trace.api.gateway.RequestContextSlot
 import datadog.trace.api.gateway.SubscriptionService
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.test.util.DDSpecification
@@ -68,7 +69,7 @@ class AppSecSystemSpecification extends DDSpecification {
     then:
     1 * span.getTags() >> ['http.client_ip':'1.1.1.1']
     1 * subService.registerCallback(EVENTS.requestEnded(), _) >> { requestEndedCB = it[1]; null }
-    1 * requestContext.data >> appSecReqCtx
+    1 * requestContext.getData(RequestContextSlot.APPSEC) >> appSecReqCtx
     1 * requestContext.traceSegment >> traceSegment
     1 * appSecReqCtx.transferCollectedEvents() >> [Mock(AppSecEvent100)]
     1 * appSecReqCtx.getRequestHeaders() >> ['foo-bar': ['1.1.1.1']]
@@ -96,7 +97,7 @@ class AppSecSystemSpecification extends DDSpecification {
     span.getTags() >> ['http.client_ip':'1.1.1.1']
     1 * sco.monitoring.newCounter('_dd.java.appsec.rate_limit.dropped_traces') >> throttledCounter
     1 * subService.registerCallback(EVENTS.requestEnded(), _) >> { requestEndedCB = it[1]; null }
-    7 * requestContext.data >> appSecReqCtx
+    7 * requestContext.getData(RequestContextSlot.APPSEC) >> appSecReqCtx
     7 * requestContext.traceSegment >> traceSegment
     7 * appSecReqCtx.transferCollectedEvents() >> [Mock(AppSecEvent100)]
     // allow for one extra in case we move to another second and round down the prev count

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/ParsedBodyParametersInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/ParsedBodyParametersInstrumentation.java
@@ -12,6 +12,7 @@ import datadog.trace.api.function.BiFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -94,10 +95,10 @@ public class ParsedBodyParametersInstrumentation extends Instrumenter.AppSec
           return;
         }
 
-        CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-        BiFunction<RequestContext<Object>, Object, Flow<Void>> callback =
+        CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+        BiFunction<RequestContext, Object, Flow<Void>> callback =
             cbp.getCallback(EVENTS.requestBodyProcessed());
-        RequestContext<Object> requestContext = agentSpan.getRequestContext();
+        RequestContext requestContext = agentSpan.getRequestContext();
         if (requestContext == null || callback == null) {
           return;
         }

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyCharBodyInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyCharBodyInstrumentationTest.groovy
@@ -2,6 +2,7 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.function.BiFunction
 import datadog.trace.api.gateway.Flow
 import datadog.trace.api.gateway.RequestContext
+import datadog.trace.api.gateway.RequestContextSlot
 import datadog.trace.api.http.StoredBodySupplier
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.bootstrap.instrumentation.api.TagContext
@@ -24,7 +25,7 @@ class GrizzlyCharBodyInstrumentationTest extends AgentTestRunner {
   InputBuffer mockInputBuffer = Mock()
   AttributeHolder attributeHolder = Mock()
   def scope
-  def ig = AgentTracer.get().instrumentationGateway()
+  def ss = AgentTracer.get().getSubscriptionService(RequestContextSlot.APPSEC)
   def supplier
   boolean bodyDone
 
@@ -32,15 +33,15 @@ class GrizzlyCharBodyInstrumentationTest extends AgentTestRunner {
     _ * mockHttpHeader.attributes >> attributeHolder
     1 * attributeHolder.setAttribute('datadog.intercepted_request_body', Boolean.TRUE)
 
-    TagContext ctx = new TagContext().withRequestContextData(new Object())
+    TagContext ctx = new TagContext().withRequestContextDataAppSec(new Object())
     def agentSpan = AgentTracer.startSpan('test-span', ctx, true)
     this.scope = AgentTracer.activateSpan(agentSpan)
 
-    ig.registerCallback(EVENTS.requestBodyStart(), { RequestContext<Object> reqContext, StoredBodySupplier sup ->
+    ss.registerCallback(EVENTS.requestBodyStart(), { RequestContext reqContext, StoredBodySupplier sup ->
       supplier = sup
       null
     } as BiFunction)
-    ig.registerCallback(EVENTS.requestBodyDone(), { RequestContext<Object> reqContext, StoredBodySupplier sup ->
+    ss.registerCallback(EVENTS.requestBodyDone(), { RequestContext reqContext, StoredBodySupplier sup ->
       bodyDone = true
       Flow.ResultFlow.empty()
     } as BiFunction)
@@ -53,7 +54,7 @@ class GrizzlyCharBodyInstrumentationTest extends AgentTestRunner {
   }
 
   void cleanup() {
-    ig.reset()
+    ss.reset()
     nioReader.recycle()
     this.scope.close()
   }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
@@ -19,6 +19,7 @@ import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.IGSpanInfo;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context;
@@ -61,19 +62,17 @@ public class TracingServerInterceptor implements ServerInterceptor {
     }
 
     Context spanContext = propagate().extract(headers, GETTER);
+    AgentTracer.TracerAPI tracer = tracer();
+    spanContext = callIGCallbackRequestStarted(tracer, spanContext);
 
-    CallbackProvider cbp = tracer().instrumentationGateway();
-    if (cbp != null) {
-      spanContext = callIGCallbackRequestStarted(cbp, spanContext);
-    }
-
+    CallbackProvider cbp = tracer.getCallbackProvider(RequestContextSlot.APPSEC);
     final AgentSpan span = startSpan(GRPC_SERVER, spanContext).setMeasured(true);
 
     PathwayContext pathwayContext = propagate().extractPathwayContext(headers, GETTER);
     span.mergePathwayContext(pathwayContext);
     AgentTracer.get().setDataStreamCheckpoint(span, Arrays.asList("type:grpc"));
 
-    RequestContext<Object> reqContext = span.getRequestContext();
+    RequestContext reqContext = span.getRequestContext();
     if (reqContext != null) {
       callIGCallbackClientAddress(cbp, reqContext, call);
       callIGCallbackHeaders(cbp, reqContext, headers);
@@ -242,31 +241,41 @@ public class TracingServerInterceptor implements ServerInterceptor {
 
   // IG helpers follow
 
-  private static Context callIGCallbackRequestStarted(CallbackProvider cbp, Context context) {
-    Supplier<Flow<Object>> startedCB = cbp.getCallback(EVENTS.requestStarted());
-    if (startedCB == null) {
+  private static Context callIGCallbackRequestStarted(AgentTracer.TracerAPI cbp, Context context) {
+    Supplier<Flow<Object>> startedCbAppSec =
+        cbp.getCallbackProvider(RequestContextSlot.APPSEC).getCallback(EVENTS.requestStarted());
+    Supplier<Flow<Object>> startedCbIast =
+        cbp.getCallbackProvider(RequestContextSlot.IAST).getCallback(EVENTS.requestStarted());
+
+    if (startedCbAppSec == null && startedCbIast == null) {
       return context;
     }
-    Object requestContextData = startedCB.get().getResult();
-    if (requestContextData != null) {
-      TagContext tagContext = null;
-      if (context == null) {
-        tagContext = new TagContext();
-      } else if (context instanceof TagContext) {
-        tagContext = (TagContext) context;
+
+    TagContext tagContext = null;
+    if (context == null) {
+      tagContext = new TagContext();
+    } else if (context instanceof TagContext) {
+      tagContext = (TagContext) context;
+    }
+    if (tagContext != null) {
+      if (startedCbAppSec != null) {
+        Flow<Object> flowAppSec = startedCbAppSec.get();
+        tagContext.withRequestContextDataAppSec(flowAppSec.getResult());
       }
-      if (tagContext != null) {
-        tagContext.withRequestContextData(requestContextData);
+      if (startedCbIast != null) {
+        Flow<Object> flowIast = startedCbIast.get();
+        tagContext.withRequestContextDataAppSec(flowIast.getResult());
       }
       return tagContext;
     }
+
     return context;
   }
 
   private static <ReqT, RespT> void callIGCallbackClientAddress(
-      CallbackProvider cbp, RequestContext<Object> ctx, ServerCall<ReqT, RespT> call) {
+      CallbackProvider cbp, RequestContext ctx, ServerCall<ReqT, RespT> call) {
     SocketAddress socketAddress = call.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
-    TriFunction<RequestContext<Object>, String, Integer, Flow<Void>> cb =
+    TriFunction<RequestContext, String, Integer, Flow<Void>> cb =
         cbp.getCallback(EVENTS.requestClientSocketAddress());
     if (socketAddress == null || !(socketAddress instanceof InetSocketAddress) || cb == null) {
       return;
@@ -277,11 +286,9 @@ public class TracingServerInterceptor implements ServerInterceptor {
   }
 
   private static void callIGCallbackHeaders(
-      CallbackProvider cbp, RequestContext<Object> reqCtx, Metadata metadata) {
-    TriConsumer<RequestContext<Object>, String, String> headerCb =
-        cbp.getCallback(EVENTS.requestHeader());
-    Function<RequestContext<Object>, Flow<Void>> headerEndCb =
-        cbp.getCallback(EVENTS.requestHeaderDone());
+      CallbackProvider cbp, RequestContext reqCtx, Metadata metadata) {
+    TriConsumer<RequestContext, String, String> headerCb = cbp.getCallback(EVENTS.requestHeader());
+    Function<RequestContext, Flow<Void>> headerEndCb = cbp.getCallback(EVENTS.requestHeaderDone());
     if (headerCb == null || headerEndCb == null) {
       return;
     }
@@ -298,13 +305,13 @@ public class TracingServerInterceptor implements ServerInterceptor {
   }
 
   private static void callIGCallbackRequestEnded(@Nonnull final AgentSpan span) {
-    CallbackProvider cbp = tracer().instrumentationGateway();
+    CallbackProvider cbp = tracer().getUniversalCallbackProvider();
     if (cbp == null) {
       return;
     }
-    RequestContext<Object> requestContext = span.getRequestContext();
+    RequestContext requestContext = span.getRequestContext();
     if (requestContext != null) {
-      BiFunction<RequestContext<Object>, IGSpanInfo, Flow<Void>> callback =
+      BiFunction<RequestContext, IGSpanInfo, Flow<Void>> callback =
           cbp.getCallback(EVENTS.requestEnded());
       if (callback != null) {
         callback.apply(requestContext, span);
@@ -317,16 +324,16 @@ public class TracingServerInterceptor implements ServerInterceptor {
       return;
     }
 
-    CallbackProvider cbp = tracer().instrumentationGateway();
+    CallbackProvider cbp = tracer().getCallbackProvider(RequestContextSlot.APPSEC);
     if (cbp == null) {
       return;
     }
-    BiFunction<RequestContext<Object>, Object, Flow<Void>> callback =
+    BiFunction<RequestContext, Object, Flow<Void>> callback =
         cbp.getCallback(EVENTS.grpcServerRequestMessage());
     if (callback == null) {
       return;
     }
-    RequestContext<Object> requestContext = span.getRequestContext();
+    RequestContext requestContext = span.getRequestContext();
     if (requestContext == null) {
       return;
     }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -9,6 +9,7 @@ import datadog.trace.api.function.Supplier
 import datadog.trace.api.function.TriConsumer
 import datadog.trace.api.gateway.Flow
 import datadog.trace.api.gateway.RequestContext
+import datadog.trace.api.gateway.RequestContextSlot
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -57,7 +58,7 @@ abstract class GrpcTest extends AgentTestRunner {
   }
 
   def setupSpec() {
-    ig = AgentTracer.get().instrumentationGateway()
+    ig = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC)
   }
 
   def setup() {

--- a/dd-java-agent/instrumentation/jersey-2-appsec/src/main/java/datadog/trace/instrumentation/jersey2/MessageBodyReaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey-2-appsec/src/main/java/datadog/trace/instrumentation/jersey2/MessageBodyReaderInstrumentation.java
@@ -11,6 +11,7 @@ import datadog.trace.api.function.BiFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import javax.ws.rs.core.Form;
@@ -57,10 +58,10 @@ public class MessageBodyReaderInstrumentation extends Instrumenter.AppSec
         objToPass = ret;
       }
 
-      CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-      BiFunction<RequestContext<Object>, Object, Flow<Void>> callback =
+      CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+      BiFunction<RequestContext, Object, Flow<Void>> callback =
           cbp.getCallback(EVENTS.requestBodyProcessed());
-      RequestContext<Object> requestContext = agentSpan.getRequestContext();
+      RequestContext requestContext = agentSpan.getRequestContext();
       if (requestContext == null || callback == null) {
         return;
       }

--- a/dd-java-agent/instrumentation/jersey-3-appsec/src/main/java/datadog/trace/instrumentation/jersey3/MessageBodyReaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey-3-appsec/src/main/java/datadog/trace/instrumentation/jersey3/MessageBodyReaderInstrumentation.java
@@ -11,6 +11,7 @@ import datadog.trace.api.function.BiFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import jakarta.ws.rs.core.Form;
@@ -56,10 +57,10 @@ public class MessageBodyReaderInstrumentation extends Instrumenter.AppSec
         objToPass = ret;
       }
 
-      CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-      BiFunction<RequestContext<Object>, Object, Flow<Void>> callback =
+      CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+      BiFunction<RequestContext, Object, Flow<Void>> callback =
           cbp.getCallback(EVENTS.requestBodyProcessed());
-      RequestContext<Object> requestContext = agentSpan.getRequestContext();
+      RequestContext requestContext = agentSpan.getRequestContext();
       if (requestContext == null || callback == null) {
         return;
       }

--- a/dd-java-agent/instrumentation/jetty-appsec-7/src/main/java/datadog/trace/instrumentation/jetty70/UrlEncodedInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-appsec-7/src/main/java/datadog/trace/instrumentation/jetty70/UrlEncodedInstrumentation.java
@@ -14,6 +14,7 @@ import datadog.trace.api.function.BiFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -86,10 +87,10 @@ public class UrlEncodedInstrumentation extends Instrumenter.AppSec
           return;
         }
 
-        CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-        BiFunction<RequestContext<Object>, Object, Flow<Void>> callback =
+        CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+        BiFunction<RequestContext, Object, Flow<Void>> callback =
             cbp.getCallback(EVENTS.requestBodyProcessed());
-        RequestContext<Object> requestContext = agentSpan.getRequestContext();
+        RequestContext requestContext = agentSpan.getRequestContext();
         if (requestContext == null || callback == null) {
           return;
         }

--- a/dd-java-agent/instrumentation/jetty-appsec-9.2/src/main/java/datadog/trace/instrumentation/jetty92/RequestExtractContentParametersInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-appsec-9.2/src/main/java/datadog/trace/instrumentation/jetty92/RequestExtractContentParametersInstrumentation.java
@@ -12,6 +12,7 @@ import datadog.trace.api.function.BiFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import net.bytebuddy.asm.Advice;
@@ -61,10 +62,10 @@ public class RequestExtractContentParametersInstrumentation extends Instrumenter
         return;
       }
 
-      CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-      BiFunction<RequestContext<Object>, Object, Flow<Void>> callback =
+      CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+      BiFunction<RequestContext, Object, Flow<Void>> callback =
           cbp.getCallback(EVENTS.requestBodyProcessed());
-      RequestContext<Object> requestContext = agentSpan.getRequestContext();
+      RequestContext requestContext = agentSpan.getRequestContext();
       if (requestContext == null || callback == null) {
         return;
       }

--- a/dd-java-agent/instrumentation/jetty-appsec-9.3/src/main/java/datadog/trace/instrumentation/jetty93/RequestExtractContentParametersInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-appsec-9.3/src/main/java/datadog/trace/instrumentation/jetty93/RequestExtractContentParametersInstrumentation.java
@@ -12,6 +12,7 @@ import datadog.trace.api.function.BiFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import net.bytebuddy.asm.Advice;
@@ -61,10 +62,10 @@ public class RequestExtractContentParametersInstrumentation extends Instrumenter
         return;
       }
 
-      CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-      BiFunction<RequestContext<Object>, Object, Flow<Void>> callback =
+      CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+      BiFunction<RequestContext, Object, Flow<Void>> callback =
           cbp.getCallback(EVENTS.requestBodyProcessed());
-      RequestContext<Object> requestContext = agentSpan.getRequestContext();
+      RequestContext requestContext = agentSpan.getRequestContext();
       if (requestContext == null || callback == null) {
         return;
       }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/HttpPostRequestDecoderInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/HttpPostRequestDecoderInstrumentation.java
@@ -14,6 +14,7 @@ import datadog.trace.api.function.BiFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import io.netty.handler.codec.http.multipart.Attribute;
@@ -82,10 +83,10 @@ public class HttpPostRequestDecoderInstrumentation extends Instrumenter.AppSec
 
       AgentSpan agentSpan = activeSpan();
       if (agentSpan != null) {
-        CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-        BiFunction<RequestContext<Object>, Object, Flow<Void>> callback =
+        CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+        BiFunction<RequestContext, Object, Flow<Void>> callback =
             cbp.getCallback(EVENTS.requestBodyProcessed());
-        RequestContext<Object> requestContext = agentSpan.getRequestContext();
+        RequestContext requestContext = agentSpan.getRequestContext();
 
         if (requestContext != null && callback != null) {
           doOnlyRelease = false;

--- a/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/TypeConverterTest.groovy
@@ -77,6 +77,7 @@ class TypeConverterTest extends AgentTestRunner {
       0,
       trace,
       null,
+      null,
       NoopPathwayContext.INSTANCE,
       false) {
         @Override void setServiceName(final String serviceName) {

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/TypeConverterTest.groovy
@@ -85,6 +85,7 @@ class TypeConverterTest extends AgentTestRunner {
       0,
       trace,
       null,
+      null,
       NoopPathwayContext.INSTANCE,
       false) {
         @Override void setServiceName(final String serviceName) {

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/TypeConverterTest.groovy
@@ -85,6 +85,7 @@ class TypeConverterTest extends AgentTestRunner {
       0,
       trace,
       null,
+      null,
       NoopPathwayContext.INSTANCE,
       false) {
         @Override void setServiceName(final String serviceName) {

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/ContextParseAdvice.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/ContextParseAdvice.java
@@ -7,6 +7,7 @@ import datadog.trace.api.function.BiFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import net.bytebuddy.asm.Advice;
@@ -31,10 +32,10 @@ public class ContextParseAdvice {
       return;
     }
 
-    CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-    BiFunction<RequestContext<Object>, Object, Flow<Void>> callback =
+    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+    BiFunction<RequestContext, Object, Flow<Void>> callback =
         cbp.getCallback(EVENTS.requestBodyProcessed());
-    RequestContext<Object> requestContext = agentSpan.getRequestContext();
+    RequestContext requestContext = agentSpan.getRequestContext();
     if (requestContext == null || callback == null) {
       return;
     }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/PathBindingPublishingHandler.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java8/datadog/trace/instrumentation/ratpack/PathBindingPublishingHandler.java
@@ -7,6 +7,7 @@ import datadog.trace.api.function.BiFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.Map;
@@ -38,10 +39,10 @@ public class PathBindingPublishingHandler implements Handler {
       return;
     }
 
-    CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-    BiFunction<RequestContext<Object>, Map<String, ?>, Flow<Void>> callback =
+    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+    BiFunction<RequestContext, Map<String, ?>, Flow<Void>> callback =
         cbp.getCallback(EVENTS.requestPathParams());
-    RequestContext<Object> requestContext = agentSpan.getRequestContext();
+    RequestContext requestContext = agentSpan.getRequestContext();
     if (requestContext == null || callback == null) {
       return;
     }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/DecodedFormParametersInstrumentation.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/DecodedFormParametersInstrumentation.java
@@ -13,6 +13,7 @@ import datadog.trace.api.function.BiFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.ArrayList;
@@ -102,10 +103,10 @@ public class DecodedFormParametersInstrumentation extends Instrumenter.AppSec
         return;
       }
 
-      CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-      BiFunction<RequestContext<Object>, Object, Flow<Void>> callback =
+      CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+      BiFunction<RequestContext, Object, Flow<Void>> callback =
           cbp.getCallback(EVENTS.requestBodyProcessed());
-      RequestContext<Object> requestContext = agentSpan.getRequestContext();
+      RequestContext requestContext = agentSpan.getRequestContext();
       if (requestContext == null || callback == null) {
         return;
       }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/MessageBodyReaderInvocationInstrumentation.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/MessageBodyReaderInvocationInstrumentation.java
@@ -13,6 +13,7 @@ import datadog.trace.api.function.BiFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import net.bytebuddy.asm.Advice;
@@ -51,10 +52,10 @@ public class MessageBodyReaderInvocationInstrumentation extends Instrumenter.App
         return;
       }
 
-      CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-      BiFunction<RequestContext<Object>, Object, Flow<Void>> callback =
+      CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+      BiFunction<RequestContext, Object, Flow<Void>> callback =
           cbp.getCallback(EVENTS.requestBodyProcessed());
-      RequestContext<Object> requestContext = agentSpan.getRequestContext();
+      RequestContext requestContext = agentSpan.getRequestContext();
       if (requestContext == null || callback == null) {
         return;
       }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/testFixtures/groovy/datadog/trace/instrumentation/resteasy/AbstractResteasyAppsecTest.groovy
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/testFixtures/groovy/datadog/trace/instrumentation/resteasy/AbstractResteasyAppsecTest.groovy
@@ -8,6 +8,7 @@ import datadog.trace.api.function.Supplier
 import datadog.trace.api.gateway.Events
 import datadog.trace.api.gateway.Flow
 import datadog.trace.api.gateway.RequestContext
+import datadog.trace.api.gateway.RequestContextSlot
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
@@ -46,12 +47,12 @@ abstract class AbstractResteasyAppsecTest extends AgentTestRunner {
 
   def setupSpec() {
     Events<Object> events = Events.get()
-    ig = AgentTracer.get().instrumentationGateway()
+    ig = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC)
     ig.registerCallback(events.requestStarted(), { -> new Flow.ResultFlow<Object>(new Object()) } as Supplier<Flow<Object>>)
-    ig.registerCallback(events.requestBodyProcessed(), { RequestContext<Object> ctx, Object obj ->
+    ig.registerCallback(events.requestBodyProcessed(), { RequestContext ctx, Object obj ->
       ctx.traceSegment.setTagTop('request.body.converted', obj as String)
       Flow.ResultFlow.empty()
-    } as BiFunction<RequestContext<Object>, Object, Flow<Void>>)
+    } as BiFunction<RequestContext, Object, Flow<Void>>)
 
     startServer()
   }

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/ServletRequestBodyInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/ServletRequestBodyInstrumentation.java
@@ -17,6 +17,7 @@ import datadog.trace.api.function.BiFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.http.StoredBodySupplier;
 import datadog.trace.api.http.StoredByteBody;
 import datadog.trace.api.http.StoredCharBody;
@@ -189,15 +190,15 @@ public class ServletRequestBodyInstrumentation extends Instrumenter.AppSec
       if (alreadyWrapped != null || is instanceof ServletInputStreamWrapper) {
         return;
       }
-      RequestContext<Object> requestContext = agentSpan.getRequestContext();
+      RequestContext requestContext = agentSpan.getRequestContext();
       if (requestContext == null) {
         return;
       }
 
-      CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-      BiFunction<RequestContext<Object>, StoredBodySupplier, Void> requestStartCb =
+      CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+      BiFunction<RequestContext, StoredBodySupplier, Void> requestStartCb =
           cbp.getCallback(EVENTS.requestBodyStart());
-      BiFunction<RequestContext<Object>, StoredBodySupplier, Flow<Void>> requestEndedCb =
+      BiFunction<RequestContext, StoredBodySupplier, Flow<Void>> requestEndedCb =
           cbp.getCallback(EVENTS.requestBodyDone());
       if (requestStartCb == null || requestEndedCb == null) {
         return;
@@ -253,14 +254,14 @@ public class ServletRequestBodyInstrumentation extends Instrumenter.AppSec
       if (alreadyWrapped != null || reader instanceof BufferedReaderWrapper) {
         return;
       }
-      RequestContext<Object> requestContext = agentSpan.getRequestContext();
+      RequestContext requestContext = agentSpan.getRequestContext();
       if (requestContext == null) {
         return;
       }
-      CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-      BiFunction<RequestContext<Object>, StoredBodySupplier, Void> requestStartCb =
+      CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+      BiFunction<RequestContext, StoredBodySupplier, Void> requestStartCb =
           cbp.getCallback(EVENTS.requestBodyStart());
-      BiFunction<RequestContext<Object>, StoredBodySupplier, Flow<Void>> requestEndedCb =
+      BiFunction<RequestContext, StoredBodySupplier, Flow<Void>> requestEndedCb =
           cbp.getCallback(EVENTS.requestBodyDone());
       if (requestStartCb == null || requestEndedCb == null) {
         return;

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/WrapperForkedTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/WrapperForkedTest.groovy
@@ -1,6 +1,7 @@
 import datadog.trace.api.function.BiFunction
 import datadog.trace.api.gateway.Flow
 import datadog.trace.api.gateway.RequestContext
+import datadog.trace.api.gateway.RequestContextSlot
 import datadog.trace.api.http.StoredBodySupplier
 import datadog.trace.api.http.StoredByteBody
 import datadog.trace.api.http.StoredCharBody
@@ -16,8 +17,8 @@ import java.nio.charset.Charset
  * classloader and then failing other tests that run under SpockRunner
  * (see datadog.trace.agent.test.SpockRunner#setupBootstrapClasspath()). */
 class WrapperForkedTest extends Specification {
-  RequestContext<Object> requestContext = Mock(RequestContext) {
-    getData() >> it
+  RequestContext requestContext = Mock(RequestContext) {
+    getData(RequestContextSlot.APPSEC) >> it
   }
   BiFunction<RequestContext, StoredBodySupplier, Void> startCb = Mock()
   BiFunction<RequestContext, StoredBodySupplier, Flow<Void>> endCb = Mock()

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HttpMessageConverterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HttpMessageConverterInstrumentation.java
@@ -16,6 +16,7 @@ import datadog.trace.api.function.BiFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.lang.reflect.Type;
@@ -78,10 +79,10 @@ public class HttpMessageConverterInstrumentation extends Instrumenter.AppSec
         return;
       }
 
-      CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-      BiFunction<RequestContext<Object>, Object, Flow<Void>> callback =
+      CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+      BiFunction<RequestContext, Object, Flow<Void>> callback =
           cbp.getCallback(EVENTS.requestBodyProcessed());
-      RequestContext<Object> requestContext = agentSpan.getRequestContext();
+      RequestContext requestContext = agentSpan.getRequestContext();
       if (requestContext == null || callback == null) {
         return;
       }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateAndMatrixVariablesInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateAndMatrixVariablesInstrumentation.java
@@ -15,6 +15,7 @@ import datadog.trace.api.function.BiFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.HashMap;
@@ -103,10 +104,10 @@ public class TemplateAndMatrixVariablesInstrumentation extends Instrumenter.AppS
       }
 
       if (map != null && !map.isEmpty()) {
-        CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-        BiFunction<RequestContext<Object>, Map<String, ?>, Flow<Void>> callback =
+        CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+        BiFunction<RequestContext, Map<String, ?>, Flow<Void>> callback =
             cbp.getCallback(EVENTS.requestPathParams());
-        RequestContext<Object> requestContext = agentSpan.getRequestContext();
+        RequestContext requestContext = agentSpan.getRequestContext();
         if (requestContext == null || callback == null) {
           return;
         }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateVariablesUrlHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateVariablesUrlHandlerInstrumentation.java
@@ -15,6 +15,7 @@ import datadog.trace.api.function.BiFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.Map;
@@ -77,10 +78,10 @@ public class TemplateVariablesUrlHandlerInstrumentation extends Instrumenter.App
         return;
       }
 
-      CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-      BiFunction<RequestContext<Object>, Map<String, ?>, Flow<Void>> callback =
+      CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+      BiFunction<RequestContext, Map<String, ?>, Flow<Void>> callback =
           cbp.getCallback(EVENTS.requestPathParams());
-      RequestContext<Object> requestContext = agentSpan.getRequestContext();
+      RequestContext requestContext = agentSpan.getRequestContext();
       if (requestContext == null || callback == null) {
         return;
       }

--- a/dd-java-agent/instrumentation/tomcat-appsec-5.5/src/main/java/datadog/trace/instrumentation/tomcat55/ParsedBodyParametersInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-appsec-5.5/src/main/java/datadog/trace/instrumentation/tomcat55/ParsedBodyParametersInstrumentation.java
@@ -14,6 +14,7 @@ import datadog.trace.api.function.BiFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -123,10 +124,10 @@ public class ParsedBodyParametersInstrumentation extends Instrumenter.AppSec
           return;
         }
 
-        CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-        BiFunction<RequestContext<Object>, Object, Flow<Void>> callback =
+        CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+        BiFunction<RequestContext, Object, Flow<Void>> callback =
             cbp.getCallback(EVENTS.requestBodyProcessed());
-        RequestContext<Object> requestContext = agentSpan.getRequestContext();
+        RequestContext requestContext = agentSpan.getRequestContext();
         if (requestContext == null || callback == null) {
           return;
         }

--- a/dd-java-agent/instrumentation/tomcat-appsec-6/src/main/java/datadog/trace/instrumentation/tomcat6/ParsedBodyParametersInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-appsec-6/src/main/java/datadog/trace/instrumentation/tomcat6/ParsedBodyParametersInstrumentation.java
@@ -13,6 +13,7 @@ import datadog.trace.api.function.BiFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -116,10 +117,10 @@ public class ParsedBodyParametersInstrumentation extends Instrumenter.AppSec
           return;
         }
 
-        CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-        BiFunction<RequestContext<Object>, Object, Flow<Void>> callback =
+        CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+        BiFunction<RequestContext, Object, Flow<Void>> callback =
             cbp.getCallback(EVENTS.requestBodyProcessed());
-        RequestContext<Object> requestContext = agentSpan.getRequestContext();
+        RequestContext requestContext = agentSpan.getRequestContext();
         if (requestContext == null || callback == null) {
           return;
         }

--- a/dd-java-agent/instrumentation/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/FormDataParserInstrumentation.java
+++ b/dd-java-agent/instrumentation/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/FormDataParserInstrumentation.java
@@ -15,6 +15,7 @@ import datadog.trace.api.function.BiFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import io.undertow.server.HttpServerExchange;
@@ -67,10 +68,10 @@ public class FormDataParserInstrumentation extends Instrumenter.AppSec
         return;
       }
 
-      CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-      BiFunction<RequestContext<Object>, Object, Flow<Void>> callback =
+      CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+      BiFunction<RequestContext, Object, Flow<Void>> callback =
           cbp.getCallback(EVENTS.requestBodyProcessed());
-      RequestContext<Object> requestContext = agentSpan.getRequestContext();
+      RequestContext requestContext = agentSpan.getRequestContext();
       if (requestContext == null || callback == null) {
         return;
       }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java8/datadog/trace/instrumentation/vertx_3_4/server/PathParameterPublishingHelper.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java8/datadog/trace/instrumentation/vertx_3_4/server/PathParameterPublishingHelper.java
@@ -7,6 +7,7 @@ import datadog.trace.api.function.BiFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.Map;
@@ -18,10 +19,10 @@ public class PathParameterPublishingHelper {
       return;
     }
 
-    CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-    BiFunction<RequestContext<Object>, Map<String, ?>, Flow<Void>> callback =
+    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+    BiFunction<RequestContext, Map<String, ?>, Flow<Void>> callback =
         cbp.getCallback(EVENTS.requestPathParams());
-    RequestContext<Object> requestContext = agentSpan.getRequestContext();
+    RequestContext requestContext = agentSpan.getRequestContext();
     if (requestContext == null || callback == null) {
       return;
     }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java8/datadog/trace/instrumentation/vertx_3_4/server/RoutingContextJsonAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java8/datadog/trace/instrumentation/vertx_3_4/server/RoutingContextJsonAdvice.java
@@ -7,6 +7,7 @@ import datadog.trace.api.function.BiFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import io.vertx.core.json.JsonObject;
@@ -27,10 +28,10 @@ class RoutingContextJsonAdvice {
     if (agentSpan == null) {
       return;
     }
-    CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-    BiFunction<RequestContext<Object>, Object, Flow<Void>> callback =
+    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+    BiFunction<RequestContext, Object, Flow<Void>> callback =
         cbp.getCallback(EVENTS.requestBodyProcessed());
-    RequestContext<Object> requestContext = agentSpan.getRequestContext();
+    RequestContext requestContext = agentSpan.getRequestContext();
     if (requestContext == null || callback == null) {
       return;
     }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/PathParameterPublishingHelper.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/PathParameterPublishingHelper.java
@@ -7,6 +7,7 @@ import datadog.trace.api.function.BiFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.Map;
@@ -18,10 +19,10 @@ public class PathParameterPublishingHelper {
       return;
     }
 
-    CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-    BiFunction<RequestContext<Object>, Map<String, ?>, Flow<Void>> callback =
+    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+    BiFunction<RequestContext, Map<String, ?>, Flow<Void>> callback =
         cbp.getCallback(EVENTS.requestPathParams());
-    RequestContext<Object> requestContext = agentSpan.getRequestContext();
+    RequestContext requestContext = agentSpan.getRequestContext();
     if (requestContext == null || callback == null) {
       return;
     }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextJsonAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextJsonAdvice.java
@@ -7,6 +7,7 @@ import datadog.trace.api.function.BiFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import io.vertx.core.json.JsonObject;
@@ -27,10 +28,10 @@ class RoutingContextJsonAdvice {
     if (agentSpan == null) {
       return;
     }
-    CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-    BiFunction<RequestContext<Object>, Object, Flow<Void>> callback =
+    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+    BiFunction<RequestContext, Object, Flow<Void>> callback =
         cbp.getCallback(EVENTS.requestBodyProcessed());
-    RequestContext<Object> requestContext = agentSpan.getRequestContext();
+    RequestContext requestContext = agentSpan.getRequestContext();
     if (requestContext == null || callback == null) {
       return;
     }

--- a/dd-trace-core/src/jmh/java/datadog/trace/core/PendingTraceWrite.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/PendingTraceWrite.java
@@ -58,6 +58,7 @@ public class PendingTraceWrite {
                 0,
                 trace,
                 null,
+                null,
                 NoopPathwayContext.INSTANCE,
                 false));
     span =
@@ -79,6 +80,7 @@ public class PendingTraceWrite {
                 "type",
                 0,
                 trace,
+                null,
                 null,
                 NoopPathwayContext.INSTANCE,
                 false));

--- a/dd-trace-core/src/jmh/java/datadog/trace/core/TracerMapperMap.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/TracerMapperMap.java
@@ -116,6 +116,7 @@ public class TracerMapperMap {
             0,
             trace,
             null,
+            null,
             NoopPathwayContext.INSTANCE,
             false));
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -23,8 +23,11 @@ import datadog.trace.api.PropagationStyle;
 import datadog.trace.api.SamplingCheckpointer;
 import datadog.trace.api.StatsDClient;
 import datadog.trace.api.config.GeneralConfig;
+import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.InstrumentationGateway;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.gateway.SubscriptionService;
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.api.interceptor.TraceInterceptor;
 import datadog.trace.api.profiling.TracingContextTrackerFactory;
@@ -61,7 +64,6 @@ import datadog.trace.lambda.LambdaHandler;
 import datadog.trace.relocate.api.RatelimitedLogger;
 import datadog.trace.util.AgentTaskScheduler;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
-import java.io.Closeable;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.InvocationTargetException;
@@ -173,6 +175,9 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   private final HttpCodec.Extractor extractor;
 
   private final InstrumentationGateway instrumentationGateway;
+  private final CallbackProvider callbackProviderAppSec;
+  private final CallbackProvider callbackProviderIast;
+  private final CallbackProvider universalCallbackProvider;
 
   @Override
   public AgentScope.Continuation capture() {
@@ -545,6 +550,10 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     }
 
     this.instrumentationGateway = instrumentationGateway;
+    this.callbackProviderAppSec =
+        instrumentationGateway.getCallbackProvider(RequestContextSlot.APPSEC);
+    this.callbackProviderIast = instrumentationGateway.getCallbackProvider(RequestContextSlot.IAST);
+    this.universalCallbackProvider = instrumentationGateway.getUniversalCallbackProvider();
 
     shutdownCallback = new ShutdownHook(this);
     try {
@@ -892,10 +901,10 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
         // request context is propagated to contexts in child spans
         // Assume here that if present it will be so starting in the top span
-        RequestContext<Object> requestContext = rootSpan.getRequestContext();
-        if (requestContext != null && requestContext.getData() instanceof Closeable) {
+        RequestContext requestContext = rootSpan.getRequestContext();
+        if (requestContext != null) {
           try {
-            ((Closeable) requestContext.getData()).close();
+            requestContext.close();
           } catch (IOException e) {
             log.warn("Error closing request context data", e);
           }
@@ -954,8 +963,24 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   @Override
-  public InstrumentationGateway instrumentationGateway() {
-    return instrumentationGateway;
+  public SubscriptionService getSubscriptionService(RequestContextSlot slot) {
+    return (SubscriptionService) this.instrumentationGateway.getCallbackProvider(slot);
+  }
+
+  @Override
+  public CallbackProvider getCallbackProvider(RequestContextSlot slot) {
+    if (slot == RequestContextSlot.APPSEC) {
+      return callbackProviderAppSec;
+    } else if (slot == RequestContextSlot.IAST) {
+      return callbackProviderIast;
+    } else {
+      return CallbackProvider.CallbackProviderNoop.INSTANCE;
+    }
+  }
+
+  @Override
+  public CallbackProvider getUniversalCallbackProvider() {
+    return universalCallbackProvider;
   }
 
   @Override
@@ -1192,7 +1217,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       final Map<String, ?> rootSpanTags;
 
       final DDSpanContext context;
-      final Object requestContextData;
+      Object requestContextDataAppSec;
+      Object requestContextDataIast;
       final PathwayContext pathwayContext;
 
       // FIXME [API] parentContext should be an interface implemented by ExtractedContext,
@@ -1226,8 +1252,14 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         if (serviceName == null) {
           serviceName = parentServiceName;
         }
-        RequestContext<Object> requestContext = ddsc.getRequestContext();
-        requestContextData = null == requestContext ? null : requestContext.getData();
+        RequestContext requestContext = ((DDSpanContext) parentContext).getRequestContext();
+        if (requestContext != null) {
+          requestContextDataAppSec = requestContext.getData(RequestContextSlot.APPSEC);
+          requestContextDataIast = requestContext.getData(RequestContextSlot.IAST);
+        } else {
+          requestContextDataAppSec = null;
+          requestContextDataIast = null;
+        }
         pathwayContext =
             ddsc.getPathwayContext().isStarted()
                 ? ddsc.getPathwayContext()
@@ -1259,11 +1291,13 @@ public class CoreTracer implements AgentTracer.TracerAPI {
           TagContext tc = (TagContext) parentContext;
           coreTags = tc.getTags();
           origin = tc.getOrigin();
-          requestContextData = tc.getRequestContextData();
+          requestContextDataAppSec = tc.getRequestContextDataAppSec();
+          requestContextDataIast = tc.getRequestContextDataIast();
         } else {
           coreTags = null;
           origin = null;
-          requestContextData = null;
+          requestContextDataAppSec = null;
+          requestContextDataIast = null;
         }
 
         rootSpanTags = localRootSpanTags;
@@ -1307,7 +1341,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
               spanType,
               tagsSize,
               parentTrace,
-              requestContextData,
+              requestContextDataAppSec,
+              requestContextDataIast,
               pathwayContext,
               disableSamplingMechanismValidation);
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -594,7 +594,7 @@ public class DDSpan
   }
 
   @Override
-  public RequestContext<Object> getRequestContext() {
+  public RequestContext getRequestContext() {
     return context.getRequestContext();
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -11,6 +11,7 @@ import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
 import datadog.trace.api.config.TracerConfig;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.api.sampling.SamplingMechanism;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -21,6 +22,8 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.core.taginterceptor.TagInterceptor;
 import datadog.trace.core.tagprocessor.QueryObfuscator;
 import datadog.trace.core.tagprocessor.TagsPostProcessor;
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -39,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * across Span boundaries and (2) any Datadog fields that are needed to identify or contextualize
  * the associated Span instance
  */
-public class DDSpanContext implements AgentSpan.Context, RequestContext<Object>, TraceSegment {
+public class DDSpanContext implements AgentSpan.Context, RequestContext, TraceSegment {
   private static final Logger log = LoggerFactory.getLogger(DDSpanContext.class);
 
   public static final String PRIORITY_SAMPLING_KEY = "_sampling_priority_v1";
@@ -108,7 +111,9 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext<Object>,
   private volatile CharSequence origin;
 
   /** RequestContext data for the InstrumentationGateway */
-  private final Object requestContextData;
+  private final Object requestContextDataAppSec;
+
+  private final Object requestContextDataIast;
 
   private final boolean disableSamplingMechanismValidation;
 
@@ -151,7 +156,8 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext<Object>,
       final CharSequence spanType,
       final int tagsSize,
       final PendingTrace trace,
-      final Object requestContextData,
+      final Object requestContextDataAppSec,
+      final Object requestContextDataIast,
       final PathwayContext pathwayContext,
       final boolean disableSamplingMechanismValidation) {
 
@@ -172,7 +178,8 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext<Object>,
       this.baggageItems = new ConcurrentHashMap<>(baggageItems);
     }
 
-    this.requestContextData = requestContextData;
+    this.requestContextDataAppSec = requestContextDataAppSec;
+    this.requestContextDataIast = requestContextDataIast;
 
     assert pathwayContext != null;
     this.pathwayContext = pathwayContext;
@@ -438,8 +445,8 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext<Object>,
     return trace;
   }
 
-  public RequestContext<Object> getRequestContext() {
-    return null == requestContextData ? null : this;
+  public RequestContext getRequestContext() {
+    return this;
   }
 
   @Override
@@ -616,8 +623,39 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext<Object>,
 
   /** RequestContext Implementation */
   @Override
-  public Object getData() {
-    return requestContextData;
+  public Object getData(RequestContextSlot slot) {
+    if (slot == RequestContextSlot.APPSEC) {
+      return this.requestContextDataAppSec;
+    } else if (slot == RequestContextSlot.IAST) {
+      return this.requestContextDataIast;
+    }
+    return null;
+  }
+
+  @Override
+  public void close() throws IOException {
+    Exception exc = null;
+    if (this.requestContextDataAppSec instanceof Closeable) {
+      try {
+        ((Closeable) this.requestContextDataAppSec).close();
+      } catch (IOException | RuntimeException e) {
+        exc = e;
+      }
+    }
+    if (this.requestContextDataIast instanceof Closeable) {
+      try {
+        ((Closeable) this.requestContextDataIast).close();
+      } catch (IOException | RuntimeException e) {
+        exc = e;
+      }
+    }
+    if (exc != null) {
+      if (exc instanceof RuntimeException) {
+        throw (RuntimeException) exc;
+      } else {
+        throw (IOException) exc;
+      }
+    }
   }
 
   @Override

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
@@ -440,6 +440,7 @@ class DDAgentApiTest extends DDCoreSpecification {
       0,
       tracer.pendingTraceFactory.create(DDId.from(1)),
       null,
+      null,
       NoopPathwayContext.INSTANCE,
       false)
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
@@ -281,6 +281,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
       0,
       trace,
       null,
+      null,
       NoopPathwayContext.INSTANCE,
       false)
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
@@ -184,6 +184,7 @@ class DDAgentWriterTest extends DDCoreSpecification {
       0,
       trace,
       null,
+      null,
       NoopPathwayContext.INSTANCE,
       false)
     return new DDSpan(0, context)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
@@ -748,6 +748,7 @@ class DDIntakeWriterCombinedTest extends DDCoreSpecification {
       0,
       trace,
       null,
+      null,
       AgentTracer.NoopPathwayContext.INSTANCE,
       false)
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterTest.groovy
@@ -173,6 +173,7 @@ class DDIntakeWriterTest extends DDCoreSpecification{
       0,
       trace,
       null,
+      null,
       AgentTracer.NoopPathwayContext.INSTANCE,
       false)
     return new DDSpan(0, context)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
@@ -170,6 +170,7 @@ class PayloadDispatcherTest extends DDSpecification {
       0,
       trace,
       null,
+      null,
       NoopPathwayContext.INSTANCE,
       false)
     return new DDSpan(0, context)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDIntakeApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDIntakeApiTest.groovy
@@ -224,6 +224,7 @@ class DDIntakeApiTest extends DDCoreSpecification {
       0,
       tracer.pendingTraceFactory.create(DDId.from(1)),
       null,
+      null,
       AgentTracer.NoopPathwayContext.INSTANCE,
       false)
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
@@ -220,7 +220,8 @@ class DDSpanContextTest extends DDCoreSpecification {
 
   def "set TraceSegment tags and data on correct span"() {
     setup:
-    def extracted = new ExtractedContext(DDId.from(123), DDId.from(456), SAMPLER_KEEP, DEFAULT, "789", 0, [:], [:]).withRequestContextData("dummy")
+    def extracted = new ExtractedContext(DDId.from(123), DDId.from(456), SAMPLER_KEEP, DEFAULT, "789", 0, [:], [:])
+    .withRequestContextDataAppSec("dummy")
     def top = tracer.buildSpan("top").asChildOf((AgentSpan.Context) extracted).start()
     def topC = (DDSpanContext) top.context()
     def topTS = top.getRequestContext().getTraceSegment()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
@@ -149,6 +149,7 @@ class DDSpanSerializationTest extends DDCoreSpecification {
       tags.size(),
       tracer.pendingTraceFactory.create(DDId.ONE),
       null,
+      null,
       NoopPathwayContext.INSTANCE,
       false)
     context.setAllTags(tags)
@@ -218,6 +219,7 @@ class DDSpanSerializationTest extends DDCoreSpecification {
       null,
       tags.size(),
       tracer.pendingTraceFactory.create(DDId.ONE),
+      null,
       null,
       NoopPathwayContext.INSTANCE,
       false)
@@ -298,6 +300,7 @@ class DDSpanSerializationTest extends DDCoreSpecification {
       spanType,
       1,
       tracer.pendingTraceFactory.create(DDId.ONE),
+      null,
       null,
       NoopPathwayContext.INSTANCE,
       false)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -8,6 +8,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopPathwayContext
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString
 import datadog.trace.common.sampling.RateByServiceSampler
+import datadog.trace.api.gateway.RequestContextSlot
 import datadog.trace.api.sampling.SamplingMechanism
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.propagation.ExtractedContext
@@ -317,13 +318,13 @@ class DDSpanTest extends DDCoreSpecification {
   def 'publishing of root span closes the request context data'() {
     setup:
     def reqContextData = Mock(Closeable)
-    def context = new TagContext().withRequestContextData(reqContextData)
+    def context = new TagContext().withRequestContextDataAppSec(reqContextData)
     def root = tracer.buildSpan("root").asChildOf(context).start()
     def child = tracer.buildSpan("child").asChildOf(root).start()
 
     expect:
-    root.requestContext.data.is(reqContextData)
-    child.requestContext.data.is(reqContextData)
+    root.requestContext.getData(RequestContextSlot.APPSEC).is(reqContextData)
+    child.requestContext.getData(RequestContextSlot.APPSEC).is(reqContextData)
 
     when:
     child.finish()
@@ -357,6 +358,7 @@ class DDSpanTest extends DDCoreSpecification {
       "fakeType",
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
+      null,
       null,
       NoopPathwayContext.INSTANCE,
       false)
@@ -394,6 +396,7 @@ class DDSpanTest extends DDCoreSpecification {
       "fakeType",
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
+      null,
       null,
       NoopPathwayContext.INSTANCE,
       false)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
@@ -416,6 +416,7 @@ class PendingTraceBufferTest extends DDSpecification {
       0,
       trace,
       null,
+      null,
       NoopPathwayContext.INSTANCE,
       false)
     return DDSpan.create(0, context)
@@ -439,6 +440,7 @@ class PendingTraceBufferTest extends DDSpecification {
       "fakeType",
       0,
       trace,
+      null,
       null,
       NoopPathwayContext.INSTANCE,
       false)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpInjectorTest.groovy
@@ -43,6 +43,7 @@ class B3HttpInjectorTest extends DDCoreSpecification {
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
       null,
+      null,
       NoopPathwayContext.INSTANCE,
       false)
 
@@ -103,6 +104,7 @@ class B3HttpInjectorTest extends DDCoreSpecification {
       "fakeType",
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
+      null,
       null,
       NoopPathwayContext.INSTANCE,
       false)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpInjectorTest.groovy
@@ -38,6 +38,7 @@ class DatadogHttpInjectorTest extends DDCoreSpecification {
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
       null,
+      null,
       NoopPathwayContext.INSTANCE,
       false)
 
@@ -91,6 +92,7 @@ class DatadogHttpInjectorTest extends DDCoreSpecification {
       "fakeType",
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
+      null,
       null,
       NoopPathwayContext.INSTANCE,
       false)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpInjectorTest.groovy
@@ -37,6 +37,7 @@ class HaystackHttpInjectorTest extends DDCoreSpecification {
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
       null,
+      null,
       NoopPathwayContext.INSTANCE,
       false)
 
@@ -88,6 +89,7 @@ class HaystackHttpInjectorTest extends DDCoreSpecification {
       "fakeType",
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
+      null,
       null,
       NoopPathwayContext.INSTANCE,
       false)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
@@ -45,6 +45,7 @@ class HttpInjectorTest extends DDCoreSpecification {
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
       null,
+      null,
       NoopPathwayContext.INSTANCE,
       false)
 
@@ -118,6 +119,7 @@ class HttpInjectorTest extends DDCoreSpecification {
       "fakeType",
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
+      null,
       null,
       NoopPathwayContext.INSTANCE,
       false)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/XRayHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/XRayHttpInjectorTest.groovy
@@ -39,6 +39,7 @@ class XRayHttpInjectorTest extends DDCoreSpecification {
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
       null,
+      null,
       NoopPathwayContext.INSTANCE,
       false)
 
@@ -92,6 +93,7 @@ class XRayHttpInjectorTest extends DDCoreSpecification {
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
       null,
+      null,
       NoopPathwayContext.INSTANCE,
       false)
     final Map<String, String> carrier = Mock()
@@ -137,6 +139,7 @@ class XRayHttpInjectorTest extends DDCoreSpecification {
       "fakeType",
       0,
       tracer.pendingTraceFactory.create(DDId.ONE),
+      null,
       null,
       NoopPathwayContext.INSTANCE,
       false)

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/TypeConverterTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/TypeConverterTest.groovy
@@ -91,6 +91,7 @@ class TypeConverterTest extends DDSpecification {
       0,
       trace,
       null,
+      null,
       NoopPathwayContext.INSTANCE,
       false)
   }

--- a/internal-api/src/main/java/datadog/trace/api/gateway/CallbackProvider.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/CallbackProvider.java
@@ -3,4 +3,15 @@ package datadog.trace.api.gateway;
 /** The API used by the producers to retrieve callbacks. */
 public interface CallbackProvider {
   <C> C getCallback(EventType<C> eventType);
+
+  class CallbackProviderNoop implements CallbackProvider {
+    public static final CallbackProvider INSTANCE = new CallbackProviderNoop();
+
+    private CallbackProviderNoop() {}
+
+    @Override
+    public <C> C getCallback(EventType<C> eventType) {
+      return null;
+    }
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
@@ -33,8 +33,8 @@ public final class Events<D> {
   private static final EventType REQUEST_ENDED = new ET<>("request.ended", REQUEST_ENDED_ID);
   /** A request ended */
   @SuppressWarnings("unchecked")
-  public EventType<BiFunction<RequestContext<D>, IGSpanInfo, Flow<Void>>> requestEnded() {
-    return (EventType<BiFunction<RequestContext<D>, IGSpanInfo, Flow<Void>>>) REQUEST_ENDED;
+  public EventType<BiFunction<RequestContext, IGSpanInfo, Flow<Void>>> requestEnded() {
+    return (EventType<BiFunction<RequestContext, IGSpanInfo, Flow<Void>>>) REQUEST_ENDED;
   }
 
   static final int REQUEST_HEADER_ID = 2;
@@ -44,8 +44,8 @@ public final class Events<D> {
       new ET<>("server.request.header", REQUEST_HEADER_ID);
   /** A request header as a key and values separated by , */
   @SuppressWarnings("unchecked")
-  public EventType<TriConsumer<RequestContext<D>, String, String>> requestHeader() {
-    return (EventType<TriConsumer<RequestContext<D>, String, String>>) REQUEST_HEADER;
+  public EventType<TriConsumer<RequestContext, String, String>> requestHeader() {
+    return (EventType<TriConsumer<RequestContext, String, String>>) REQUEST_HEADER;
   }
 
   static final int REQUEST_HEADER_DONE_ID = 3;
@@ -55,8 +55,8 @@ public final class Events<D> {
       new ET<>("server.request.header.done", REQUEST_HEADER_DONE_ID);
   /** All request headers have been provided */
   @SuppressWarnings("unchecked")
-  public EventType<Function<RequestContext<D>, Flow<Void>>> requestHeaderDone() {
-    return (EventType<Function<RequestContext<D>, Flow<Void>>>) REQUEST_HEADER_DONE;
+  public EventType<Function<RequestContext, Flow<Void>>> requestHeaderDone() {
+    return (EventType<Function<RequestContext, Flow<Void>>>) REQUEST_HEADER_DONE;
   }
 
   static final int REQUEST_METHOD_URI_RAW_ID = 4;
@@ -66,9 +66,9 @@ public final class Events<D> {
       new ET<>("server.request.method.uri.raw", REQUEST_METHOD_URI_RAW_ID);
   /** The method (uppercase) and URIDataAdapter for the request. */
   @SuppressWarnings("unchecked")
-  public EventType<TriFunction<RequestContext<D>, String /* method */, URIDataAdapter, Flow<Void>>>
+  public EventType<TriFunction<RequestContext, String /* method */, URIDataAdapter, Flow<Void>>>
       requestMethodUriRaw() {
-    return (EventType<TriFunction<RequestContext<D>, String, URIDataAdapter, Flow<Void>>>)
+    return (EventType<TriFunction<RequestContext, String, URIDataAdapter, Flow<Void>>>)
         REQUEST_METHOD_URI_RAW;
   }
 
@@ -79,9 +79,8 @@ public final class Events<D> {
       new ET<>("server.request.method.uri.raw", REQUEST_PATH_PARAMS_ID);
   /** The parameters the framework got from the request uri (but not the query string) */
   @SuppressWarnings("unchecked")
-  public EventType<BiFunction<RequestContext<D>, Map<String, ?>, Flow<Void>>> requestPathParams() {
-    return (EventType<BiFunction<RequestContext<D>, Map<String, ?>, Flow<Void>>>)
-        REQUEST_PATH_PARAMS;
+  public EventType<BiFunction<RequestContext, Map<String, ?>, Flow<Void>>> requestPathParams() {
+    return (EventType<BiFunction<RequestContext, Map<String, ?>, Flow<Void>>>) REQUEST_PATH_PARAMS;
   }
 
   static final int REQUEST_CLIENT_SOCKET_ADDRESS_ID = 6;
@@ -91,9 +90,9 @@ public final class Events<D> {
       new ET<>("http.server.client_socket_address", REQUEST_CLIENT_SOCKET_ADDRESS_ID);
   /** The method (uppercase) and URIDataAdapter for the request. */
   @SuppressWarnings("unchecked")
-  public EventType<TriFunction<RequestContext<D>, String, Integer, Flow<Void>>>
+  public EventType<TriFunction<RequestContext, String, Integer, Flow<Void>>>
       requestClientSocketAddress() {
-    return (EventType<TriFunction<RequestContext<D>, String, Integer, Flow<Void>>>)
+    return (EventType<TriFunction<RequestContext, String, Integer, Flow<Void>>>)
         REQUEST_CLIENT_SOCKET_ADDRESS;
   }
 
@@ -104,8 +103,8 @@ public final class Events<D> {
       new ET<>("request.body.started", REQUEST_BODY_START_ID);
   /** The request body has started being read */
   @SuppressWarnings("unchecked")
-  public EventType<BiFunction<RequestContext<D>, StoredBodySupplier, Void>> requestBodyStart() {
-    return (EventType<BiFunction<RequestContext<D>, StoredBodySupplier, Void>>) REQUEST_BODY_START;
+  public EventType<BiFunction<RequestContext, StoredBodySupplier, Void>> requestBodyStart() {
+    return (EventType<BiFunction<RequestContext, StoredBodySupplier, Void>>) REQUEST_BODY_START;
   }
 
   static final int REQUEST_BODY_DONE_ID = 8;
@@ -115,9 +114,8 @@ public final class Events<D> {
       new ET<>("request.body.done", REQUEST_BODY_DONE_ID);
   /** The request body is done being read */
   @SuppressWarnings("unchecked")
-  public EventType<BiFunction<RequestContext<D>, StoredBodySupplier, Flow<Void>>>
-      requestBodyDone() {
-    return (EventType<BiFunction<RequestContext<D>, StoredBodySupplier, Flow<Void>>>)
+  public EventType<BiFunction<RequestContext, StoredBodySupplier, Flow<Void>>> requestBodyDone() {
+    return (EventType<BiFunction<RequestContext, StoredBodySupplier, Flow<Void>>>)
         REQUEST_BODY_DONE;
   }
 
@@ -128,8 +126,8 @@ public final class Events<D> {
       new ET<>("request.body.done", REQUEST_BODY_CONVERTED_ID);
   /** The request body has been converted by the framework */
   @SuppressWarnings("unchecked")
-  public EventType<BiFunction<RequestContext<D>, Object, Flow<Void>>> requestBodyProcessed() {
-    return (EventType<BiFunction<RequestContext<D>, Object, Flow<Void>>>) REQUEST_BODY_CONVERTED;
+  public EventType<BiFunction<RequestContext, Object, Flow<Void>>> requestBodyProcessed() {
+    return (EventType<BiFunction<RequestContext, Object, Flow<Void>>>) REQUEST_BODY_CONVERTED;
   }
 
   static final int RESPONSE_STARTED_ID = 10;
@@ -139,8 +137,8 @@ public final class Events<D> {
       new ET<>("response.started", RESPONSE_STARTED_ID);
   /** A response started */
   @SuppressWarnings("unchecked")
-  public EventType<BiFunction<RequestContext<D>, Integer, Flow<Void>>> responseStarted() {
-    return (EventType<BiFunction<RequestContext<D>, Integer, Flow<Void>>>) RESPONSE_STARTED;
+  public EventType<BiFunction<RequestContext, Integer, Flow<Void>>> responseStarted() {
+    return (EventType<BiFunction<RequestContext, Integer, Flow<Void>>>) RESPONSE_STARTED;
   }
 
   static final int RESPONSE_HEADER_ID = 11;
@@ -150,8 +148,8 @@ public final class Events<D> {
       new ET<>("server.response.header", RESPONSE_HEADER_ID);
   /** A response header as a key and values separated by , */
   @SuppressWarnings("unchecked")
-  public EventType<TriConsumer<RequestContext<D>, String, String>> responseHeader() {
-    return (EventType<TriConsumer<RequestContext<D>, String, String>>) RESPONSE_HEADER;
+  public EventType<TriConsumer<RequestContext, String, String>> responseHeader() {
+    return (EventType<TriConsumer<RequestContext, String, String>>) RESPONSE_HEADER;
   }
 
   static final int RESPONSE_HEADER_DONE_ID = 12;
@@ -161,8 +159,8 @@ public final class Events<D> {
       new ET<>("server.response.header.done", RESPONSE_HEADER_DONE_ID);
   /** All response headers have been provided */
   @SuppressWarnings("unchecked")
-  public EventType<Function<RequestContext<D>, Flow<Void>>> responseHeaderDone() {
-    return (EventType<Function<RequestContext<D>, Flow<Void>>>) RESPONSE_HEADER_DONE;
+  public EventType<Function<RequestContext, Flow<Void>>> responseHeaderDone() {
+    return (EventType<Function<RequestContext, Flow<Void>>>) RESPONSE_HEADER_DONE;
   }
 
   static final int GRPC_SERVER_REQUEST_MESSAGE_ID = 13;
@@ -172,9 +170,8 @@ public final class Events<D> {
       new ET<>("grpc.server.request.message", GRPC_SERVER_REQUEST_MESSAGE_ID);
   /** All response headers have been provided */
   @SuppressWarnings("unchecked")
-  public EventType<BiFunction<RequestContext<D>, Object, Flow<Void>>> grpcServerRequestMessage() {
-    return (EventType<BiFunction<RequestContext<D>, Object, Flow<Void>>>)
-        GRPC_SERVER_REQUEST_MESSAGE;
+  public EventType<BiFunction<RequestContext, Object, Flow<Void>>> grpcServerRequestMessage() {
+    return (EventType<BiFunction<RequestContext, Object, Flow<Void>>>) GRPC_SERVER_REQUEST_MESSAGE;
   }
 
   static final int MAX_EVENTS = nextId.get();

--- a/internal-api/src/main/java/datadog/trace/api/gateway/RequestContext.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/RequestContext.java
@@ -1,13 +1,14 @@
 package datadog.trace.api.gateway;
 
 import datadog.trace.api.TraceSegment;
+import java.io.Closeable;
 
 /**
  * This is the context that will travel along with the request and be presented to the
  * Instrumentation Gateway subscribers.
  */
-public interface RequestContext<D> {
-  D getData();
+public interface RequestContext extends Closeable {
+  <T> T getData(RequestContextSlot slot);
 
   TraceSegment getTraceSegment();
 }

--- a/internal-api/src/main/java/datadog/trace/api/gateway/RequestContextSlot.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/RequestContextSlot.java
@@ -1,0 +1,6 @@
+package datadog.trace.api.gateway;
+
+public enum RequestContextSlot {
+  APPSEC,
+  IAST;
+}

--- a/internal-api/src/main/java/datadog/trace/api/gateway/Subscription.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/Subscription.java
@@ -3,4 +3,13 @@ package datadog.trace.api.gateway;
 /** A handle to the started subscription of an event. */
 public interface Subscription {
   void cancel();
+
+  class SubscriptionNoop implements Subscription {
+    public static final Subscription INSTANCE = new SubscriptionNoop();
+
+    private SubscriptionNoop() {}
+
+    @Override
+    public void cancel() {}
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/api/gateway/SubscriptionService.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/SubscriptionService.java
@@ -3,4 +3,15 @@ package datadog.trace.api.gateway;
 /** The API used by the consumers to register callbacks. */
 public interface SubscriptionService {
   <C> Subscription registerCallback(EventType<C> eventType, C callback);
+
+  class SubscriptionServiceNoop implements SubscriptionService {
+    public static final SubscriptionService INSTANCE = new SubscriptionServiceNoop();
+
+    private SubscriptionServiceNoop() {}
+
+    @Override
+    public <C> Subscription registerCallback(EventType<C> eventType, C callback) {
+      return Subscription.SubscriptionNoop.INSTANCE;
+    }
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/api/http/StoredBodyFactories.java
+++ b/internal-api/src/main/java/datadog/trace/api/http/StoredBodyFactories.java
@@ -7,6 +7,7 @@ import datadog.trace.api.function.Supplier;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.nio.charset.Charset;
@@ -25,15 +26,15 @@ public class StoredBodyFactories {
   @SuppressWarnings("Duplicates")
   public static StoredByteBody maybeCreateForByte(
       Charset charset, AgentSpan agentSpan, Object contentLengthHeader) {
-    RequestContext<Object> requestContext = agentSpan.getRequestContext();
+    RequestContext requestContext = agentSpan.getRequestContext();
     if (requestContext == null) {
       return null;
     }
 
-    CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-    BiFunction<RequestContext<Object>, StoredBodySupplier, Void> requestStartCb =
+    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+    BiFunction<RequestContext, StoredBodySupplier, Void> requestStartCb =
         cbp.getCallback(EVENTS.requestBodyStart());
-    BiFunction<RequestContext<Object>, StoredBodySupplier, Flow<Void>> requestEndedCb =
+    BiFunction<RequestContext, StoredBodySupplier, Flow<Void>> requestEndedCb =
         cbp.getCallback(EVENTS.requestBodyDone());
     if (requestStartCb == null || requestEndedCb == null) {
       return null;
@@ -51,15 +52,15 @@ public class StoredBodyFactories {
       return Flow.ResultFlow.empty();
     }
 
-    RequestContext<Object> requestContext = agentSpan.getRequestContext();
+    RequestContext requestContext = agentSpan.getRequestContext();
     if (requestContext == null) {
       return Flow.ResultFlow.empty();
     }
 
-    CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-    BiFunction<RequestContext<Object>, StoredBodySupplier, Void> requestStartCb =
+    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+    BiFunction<RequestContext, StoredBodySupplier, Void> requestStartCb =
         cbp.getCallback(EVENTS.requestBodyStart());
-    BiFunction<RequestContext<Object>, StoredBodySupplier, Flow<Void>> requestEndedCb =
+    BiFunction<RequestContext, StoredBodySupplier, Flow<Void>> requestEndedCb =
         cbp.getCallback(EVENTS.requestBodyDone());
     if (requestStartCb == null || requestEndedCb == null) {
       return Flow.ResultFlow.empty();
@@ -103,15 +104,15 @@ public class StoredBodyFactories {
 
   @SuppressWarnings("Duplicates")
   public static StoredCharBody maybeCreateForChar(AgentSpan agentSpan, Object contentLengthHeader) {
-    RequestContext<Object> requestContext = agentSpan.getRequestContext();
+    RequestContext requestContext = agentSpan.getRequestContext();
     if (requestContext == null) {
       return null;
     }
 
-    CallbackProvider cbp = AgentTracer.get().instrumentationGateway();
-    BiFunction<RequestContext<Object>, StoredBodySupplier, Void> requestStartCb =
+    CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+    BiFunction<RequestContext, StoredBodySupplier, Void> requestStartCb =
         cbp.getCallback(EVENTS.requestBodyStart());
-    BiFunction<RequestContext<Object>, StoredBodySupplier, Flow<Void>> requestEndedCb =
+    BiFunction<RequestContext, StoredBodySupplier, Flow<Void>> requestEndedCb =
         cbp.getCallback(EVENTS.requestBodyDone());
     if (requestStartCb == null || requestEndedCb == null) {
       return null;

--- a/internal-api/src/main/java/datadog/trace/api/http/StoredByteBody.java
+++ b/internal-api/src/main/java/datadog/trace/api/http/StoredByteBody.java
@@ -29,9 +29,9 @@ public class StoredByteBody implements StoredBodySupplier {
   private StoredCharBody storedCharBody;
 
   public StoredByteBody(
-      RequestContext<Object> requestContext,
-      BiFunction<RequestContext<Object>, StoredBodySupplier, Void> startCb,
-      BiFunction<RequestContext<Object>, StoredBodySupplier, Flow<Void>> endCb,
+      RequestContext requestContext,
+      BiFunction<RequestContext, StoredBodySupplier, Void> startCb,
+      BiFunction<RequestContext, StoredBodySupplier, Flow<Void>> endCb,
       @Nullable Charset charset,
       int lengthHint) {
     if (charset != null) {

--- a/internal-api/src/main/java/datadog/trace/api/http/StoredCharBody.java
+++ b/internal-api/src/main/java/datadog/trace/api/http/StoredCharBody.java
@@ -13,9 +13,9 @@ public class StoredCharBody implements StoredBodySupplier {
   private static final int GROW_FACTOR = 4;
   private static final CharBuffer EMPTY_CHAR_BUFFER = CharBuffer.allocate(0);
 
-  private final RequestContext<Object> httpContext;
-  private final BiFunction<RequestContext<Object>, StoredBodySupplier, Void> startCb;
-  private final BiFunction<RequestContext<Object>, StoredBodySupplier, Flow<Void>> endCb;
+  private final RequestContext httpContext;
+  private final BiFunction<RequestContext, StoredBodySupplier, Void> startCb;
+  private final BiFunction<RequestContext, StoredBodySupplier, Flow<Void>> endCb;
   private final StoredBodySupplier supplierInNotifications;
 
   private boolean listenerNotified;
@@ -25,17 +25,17 @@ public class StoredCharBody implements StoredBodySupplier {
   private boolean bodyReadStarted = false;
 
   public StoredCharBody(
-      RequestContext<Object> httpContext,
-      BiFunction<RequestContext<Object>, StoredBodySupplier, Void> startCb,
-      BiFunction<RequestContext<Object>, StoredBodySupplier, Flow<Void>> endCb,
+      RequestContext httpContext,
+      BiFunction<RequestContext, StoredBodySupplier, Void> startCb,
+      BiFunction<RequestContext, StoredBodySupplier, Flow<Void>> endCb,
       int lengthHint) {
     this(httpContext, startCb, endCb, lengthHint, null);
   }
 
   StoredCharBody(
-      RequestContext<Object> httpContext,
-      BiFunction<RequestContext<Object>, StoredBodySupplier, Void> startCb,
-      BiFunction<RequestContext<Object>, StoredBodySupplier, Flow<Void>> endCb,
+      RequestContext httpContext,
+      BiFunction<RequestContext, StoredBodySupplier, Void> startCb,
+      BiFunction<RequestContext, StoredBodySupplier, Flow<Void>> endCb,
       int lengthHint,
       StoredBodySupplier supplierInNotifications) {
     this.httpContext = httpContext;

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -149,7 +149,7 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo {
   void finishWork();
 
   /** RequestContext for the Instrumentation Gateway */
-  RequestContext<Object> getRequestContext();
+  RequestContext getRequestContext();
 
   void mergePathwayContext(PathwayContext pathwayContext);
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -7,8 +7,10 @@ import datadog.trace.api.DDId;
 import datadog.trace.api.PropagationStyle;
 import datadog.trace.api.SpanCheckpointer;
 import datadog.trace.api.function.Consumer;
-import datadog.trace.api.gateway.InstrumentationGateway;
+import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.gateway.SubscriptionService;
 import datadog.trace.api.interceptor.TraceInterceptor;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context;
@@ -177,7 +179,11 @@ public class AgentTracer {
      */
     void registerCheckpointer(Checkpointer checkpointer);
 
-    InstrumentationGateway instrumentationGateway();
+    SubscriptionService getSubscriptionService(RequestContextSlot slot);
+
+    CallbackProvider getCallbackProvider(RequestContextSlot slot);
+
+    CallbackProvider getUniversalCallbackProvider();
 
     void setDataStreamCheckpoint(AgentSpan span, List<String> tags);
 
@@ -321,6 +327,21 @@ public class AgentTracer {
     public void registerCheckpointer(Checkpointer checkpointer) {}
 
     @Override
+    public SubscriptionService getSubscriptionService(RequestContextSlot slot) {
+      return SubscriptionService.SubscriptionServiceNoop.INSTANCE;
+    }
+
+    @Override
+    public CallbackProvider getCallbackProvider(RequestContextSlot slot) {
+      return CallbackProvider.CallbackProviderNoop.INSTANCE;
+    }
+
+    @Override
+    public CallbackProvider getUniversalCallbackProvider() {
+      return CallbackProvider.CallbackProviderNoop.INSTANCE;
+    }
+
+    @Override
     public AgentScope.Continuation capture() {
       return null;
     }
@@ -382,11 +403,6 @@ public class AgentTracer {
 
     @Override
     public void onRootSpanStarted(AgentSpan root) {}
-
-    @Override
-    public InstrumentationGateway instrumentationGateway() {
-      return null;
-    }
 
     @Override
     public void setDataStreamCheckpoint(AgentSpan span, List<String> tags) {}
@@ -530,7 +546,7 @@ public class AgentTracer {
     public void finishWork() {}
 
     @Override
-    public RequestContext<Object> getRequestContext() {
+    public RequestContext getRequestContext() {
       return null;
     }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
@@ -12,7 +12,8 @@ public class TagContext implements AgentSpan.Context.Extracted {
 
   private final String origin;
   private final Map<String, String> tags;
-  private Object requestContextData;
+  private Object requestContextDataAppSec;
+  private Object requestContextDataIast;
   private final HttpHeaders httpHeaders;
 
   public TagContext() {
@@ -162,12 +163,21 @@ public class TagContext implements AgentSpan.Context.Extracted {
     return AgentTracer.NoopAgentTrace.INSTANCE;
   }
 
-  public final Object getRequestContextData() {
-    return requestContextData;
+  public final Object getRequestContextDataAppSec() {
+    return requestContextDataAppSec;
   }
 
-  public final TagContext withRequestContextData(Object requestContextData) {
-    this.requestContextData = requestContextData;
+  public final TagContext withRequestContextDataAppSec(Object requestContextData) {
+    this.requestContextDataAppSec = requestContextData;
+    return this;
+  }
+
+  public final Object getRequestContextDataIast() {
+    return requestContextDataIast;
+  }
+
+  public final TagContext withRequestContextDataIast(Object requestContextData) {
+    this.requestContextDataIast = requestContextData;
     return this;
   }
 

--- a/internal-api/src/test/groovy/datadog/trace/api/gateway/CallbackProviderNoopTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/gateway/CallbackProviderNoopTest.groovy
@@ -1,0 +1,16 @@
+package datadog.trace.api.gateway
+
+import spock.lang.Specification
+
+class CallbackProviderNoopTest extends Specification {
+  void 'get callback on noop implementation'() {
+    setup:
+    def cbp = CallbackProvider.CallbackProviderNoop.INSTANCE
+
+    when:
+    def cb = cbp.getCallback(Events.get().requestHeaderDone())
+
+    then:
+    cb == null
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/gateway/SubscriptionServiceNoopTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/gateway/SubscriptionServiceNoopTest.groovy
@@ -1,0 +1,19 @@
+package datadog.trace.api.gateway
+
+import datadog.trace.api.function.Function
+import spock.lang.Specification
+
+class SubscriptionServiceNoopTest extends Specification {
+  void 'registration on noop implementation'() {
+    setup:
+    def ss = SubscriptionService.SubscriptionServiceNoop.INSTANCE
+    Function<RequestContext, Flow<Void>> cb = Mock()
+
+    when:
+    def sub = ss.registerCallback(Events.get().requestHeaderDone(), cb)
+    sub.cancel()
+
+    then:
+    0 * cb._(*_)
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/http/StoredCharBodyTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/http/StoredCharBodyTest.groovy
@@ -6,8 +6,8 @@ import datadog.trace.api.gateway.RequestContext
 import spock.lang.Specification
 
 class StoredCharBodyTest extends Specification {
-  RequestContext<Object> requestContext = Mock(RequestContext) {
-    getData() >> it
+  RequestContext requestContext = Mock(RequestContext) {
+    _ * getData(_) >> it
   }
   BiFunction<RequestContext, StoredBodySupplier, Void> startCb = Mock()
   BiFunction<RequestContext, StoredBodySupplier, Flow<Void> > endCb = Mock()


### PR DESCRIPTION
Stores different "request context data" in DDSpanContext for AppSec and IAST and makes the InstrumentationGateway have two separate sets of callbacks.