### PR TITLE
Fix packaging duplicates

### DIFF
--- a/dd-java-agent/agent-crashtracking/agent-crashtracking.gradle
+++ b/dd-java-agent/agent-crashtracking/agent-crashtracking.gradle
@@ -1,7 +1,3 @@
-plugins {
-  id "com.github.johnrengelman.shadow"
-}
-
 // Set properties before any plugins get loaded
 ext {
   enableJunitPlatform = true
@@ -9,7 +5,6 @@ ext {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-apply from: "$rootDir/gradle/version.gradle"
 
 // FIXME: Improve test coverage.
 minimumBranchCoverage = 0.6
@@ -21,46 +16,15 @@ dependencies {
   implementation project(':internal-api')
   implementation project(':utils:container-utils')
   implementation project(':utils:process-utils')
-  implementation project(':utils:socket-utils')
   implementation project(':utils:version-utils')
 
   implementation deps.okhttp
   implementation group: 'com.squareup.moshi', name: 'moshi', version: versions.moshi
 
   testImplementation deps.junit5
-  testImplementation project(':dd-java-agent:agent-profiling:profiling-testing')
   testImplementation deps.mockito
   testImplementation group: 'com.squareup.okhttp3', name: 'mockwebserver', version: versions.okhttp
   testImplementation(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.10')
-}
-
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-configurations {
-  // exclude bootstrap dependencies from shadowJar
-  runtime.exclude module: deps.slf4j
-  runtime.exclude group: 'org.slf4j'
-}
-
-shadowJar {
-  dependencies deps.excludeShared
-  exclude {
-    if (it.path.startsWith('org/jctools/')) {
-      def ret = true
-      if (it.path.equals('org/jctools/util') || it.path.equals('org/jctools/maps')) {
-        ret = false
-      } else {
-        ret = !(it.path.contains('/util') || it.path.contains('AbstractEntry') || it.path.contains('ConcurrentAutoTable') || it.path.contains('NonBlockingHashMap'))
-      }
-      return ret
-    }
-    return false
-  }
-}
-
-jar {
-  classifier = 'unbundled'
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -19,7 +19,7 @@ configurations {
 /*
  * 6 shadow jars are created
  * - The main "dd-java-agent" jar that also has the bootstrap project
- * - 5 jars based on projects (instrumentation, jmxfetch, profiling, appsec, crashtracking)
+ * - 4 jars based on projects (instrumentation, jmxfetch, profiling, appsec)
  * - 1 based on the shared dependencies
  * This general config is shared by all of them
  */
@@ -84,7 +84,6 @@ def includeSubprojShadowJar(String projName, String jarname) {
 includeSubprojShadowJar ':dd-java-agent:instrumentation', 'inst'
 includeSubprojShadowJar ':dd-java-agent:agent-jmxfetch', 'metrics'
 includeSubprojShadowJar ':dd-java-agent:agent-profiling', 'profiling'
-includeSubprojShadowJar ':dd-java-agent:agent-crashtracking', 'crashtracking'
 includeSubprojShadowJar ':dd-java-agent:appsec', 'appsec'
 
 def sharedShadowJar = tasks.register('sharedShadowJar', ShadowJar) {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -113,6 +113,7 @@ final class CachedData {
       exclude(project(':communication'))
       exclude(project(':telemetry'))
       exclude(project(':utils:container-utils'))
+      exclude(project(':utils:process-utils'))
       exclude(project(':utils:socket-utils'))
       exclude(project(':utils:time-utils'))
       exclude(project(':utils:version-utils'))


### PR DESCRIPTION
# What Does This Do

* Add `process-utils` (new shared utils library) to `excludeShared`
* Remove `agent-crashtracking` duplicates in final agent jar, keep version included in `agent-tooling`
  * simplified project setup as it doesn't really need its own `shadowJar`
  * since `CrashUploader` is used directly by `AgentCLI` it currently needs to reside in the same class-loader
  * we can promote it to a `shadowJar` if it becomes large enough, but would then need indirection in `AgentCLI`

# Motivation

Removes duplicate content from final `dd-java-agent` jar.