### PR TITLE
IAST vulnerability reporting API

### DIFF
--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -17,9 +17,9 @@ configurations {
 }
 
 /*
- * 6 shadow jars are created
+ * 7 shadow jars are created
  * - The main "dd-java-agent" jar that also has the bootstrap project
- * - 4 jars based on projects (instrumentation, jmxfetch, profiling, appsec)
+ * - 5 jars based on projects (instrumentation, jmxfetch, profiling, appsec, iast)
  * - 1 based on the shared dependencies
  * This general config is shared by all of them
  */
@@ -85,6 +85,7 @@ includeSubprojShadowJar ':dd-java-agent:instrumentation', 'inst'
 includeSubprojShadowJar ':dd-java-agent:agent-jmxfetch', 'metrics'
 includeSubprojShadowJar ':dd-java-agent:agent-profiling', 'profiling'
 includeSubprojShadowJar ':dd-java-agent:appsec', 'appsec'
+includeSubprojShadowJar ':dd-java-agent:iast', 'iast'
 includeSubprojShadowJar ':dd-java-agent:agent-debugger', 'debugger'
 
 def sharedShadowJar = tasks.register('sharedShadowJar', ShadowJar) {

--- a/dd-java-agent/iast/iast.gradle
+++ b/dd-java-agent/iast/iast.gradle
@@ -1,0 +1,55 @@
+plugins {
+  id "com.github.johnrengelman.shadow"
+}
+
+apply from: "$rootDir/gradle/java.gradle"
+apply from: "$rootDir/gradle/version.gradle"
+
+dependencies {
+  api deps.slf4j
+  implementation project(':internal-api')
+  implementation project(':internal-api:internal-api-8')
+  implementation project(':internal-api:internal-api-9')
+  implementation group: 'com.squareup.moshi', name: 'moshi', version: versions.moshi
+
+  testImplementation deps.bytebuddy
+  testImplementation project(':utils:test-utils')
+}
+
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
+
+shadowJar {
+  dependencies deps.excludeShared
+}
+
+jar {
+  archiveClassifier = 'unbundled'
+}
+
+ext {
+  minimumBranchCoverage = 0.6
+  minimumInstructionCoverage = 0.8
+  excludedClassesCoverage = [
+    // Avoid coverage measurement of model getters atm
+    'com.datadog.iast.model.Evidence',
+    'com.datadog.iast.model.Range',
+    'com.datadog.iast.model.Source',
+    'com.datadog.iast.model.Vulnerability',
+    // Small JsonAdapters with unimplemented fromJson
+    'com.datadog.iast.model.json.SourceTypeAdapter',
+  ]
+  excludedClassesBranchCoverage = []
+  excludedClassesInstructionCoverage = []
+  minJavaVersionForTests = JavaVersion.VERSION_1_8
+}
+
+tasks.withType(Test).configureEach {
+  jvmArgs += ['-Ddd.iast.enabled=true']
+}
+def rootDir = project.rootDir
+spotless {
+  java {
+    target 'src/**/*.java'
+  }
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/IastRequestContext.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/IastRequestContext.java
@@ -1,0 +1,24 @@
+package com.datadog.iast;
+
+import com.datadog.iast.model.VulnerabilityBatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class IastRequestContext {
+
+  private final VulnerabilityBatch vulnerabilityBatch;
+
+  private final AtomicBoolean spanDataIsSet;
+
+  public IastRequestContext() {
+    this.vulnerabilityBatch = new VulnerabilityBatch();
+    this.spanDataIsSet = new AtomicBoolean(false);
+  }
+
+  public VulnerabilityBatch getVulnerabilityBatch() {
+    return vulnerabilityBatch;
+  }
+
+  public boolean getAndSetSpanDataIsSet() {
+    return spanDataIsSet.getAndSet(true);
+  }
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/IastSystem.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/IastSystem.java
@@ -1,0 +1,31 @@
+package com.datadog.iast;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.function.Supplier;
+import datadog.trace.api.gateway.EventType;
+import datadog.trace.api.gateway.Events;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.SubscriptionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class IastSystem {
+
+  private static final Logger log = LoggerFactory.getLogger(IastSystem.class);
+
+  public static void start(final SubscriptionService ss) {
+    final Config config = Config.get();
+    if (!config.isIastEnabled()) {
+      log.debug("IAST is disabled");
+      return;
+    }
+    log.debug("IAST is starting");
+
+    registerRequestStartedCallback(ss);
+  }
+
+  private static void registerRequestStartedCallback(final SubscriptionService ss) {
+    final EventType<Supplier<Flow<Object>>> event = Events.get().requestStarted();
+    ss.registerCallback(event, () -> new Flow.ResultFlow<>(new IastRequestContext()));
+  }
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/Reporter.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/Reporter.java
@@ -1,0 +1,32 @@
+package com.datadog.iast;
+
+import com.datadog.iast.model.Vulnerability;
+import com.datadog.iast.model.VulnerabilityBatch;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+
+/** Reports IAST vulnerabilities. */
+public final class Reporter {
+
+  private Reporter() {}
+
+  public static void report(final AgentSpan span, final Vulnerability vulnerability) {
+    if (span == null) {
+      return;
+    }
+    final RequestContext reqCtx = span.getRequestContext();
+    if (reqCtx == null) {
+      return;
+    }
+    final IastRequestContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+    if (ctx == null) {
+      return;
+    }
+    final VulnerabilityBatch batch = ctx.getVulnerabilityBatch();
+    batch.add(vulnerability);
+    if (!ctx.getAndSetSpanDataIsSet()) {
+      reqCtx.getTraceSegment().setDataTop("iast", batch);
+    }
+  }
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/model/Evidence.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/model/Evidence.java
@@ -1,0 +1,28 @@
+package com.datadog.iast.model;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public final class Evidence {
+
+  private final @Nonnull String value;
+
+  private final @Nullable Range[] ranges;
+
+  public Evidence(final String value) {
+    this(value, null);
+  }
+
+  public Evidence(final String value, final Range[] ranges) {
+    this.value = value;
+    this.ranges = ranges;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public Range[] getRanges() {
+    return ranges;
+  }
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/model/Location.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/model/Location.java
@@ -1,0 +1,25 @@
+package com.datadog.iast.model;
+
+public final class Location {
+
+  private final String path;
+
+  private final int line;
+
+  private Location(final String path, final int line) {
+    this.path = path;
+    this.line = line;
+  }
+
+  public static Location forStack(final StackTraceElement stack) {
+    return new Location(stack.getClassName(), stack.getLineNumber());
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public int getLine() {
+    return line;
+  }
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/model/Range.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/model/Range.java
@@ -1,0 +1,29 @@
+package com.datadog.iast.model;
+
+import com.datadog.iast.model.json.SourceIndex;
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+
+public final class Range {
+  private final @Nonnegative int start;
+  private final @Nonnegative int length;
+  private final @Nonnull @SourceIndex Source source;
+
+  public Range(final int start, final int length, final Source source) {
+    this.start = start;
+    this.length = length;
+    this.source = source;
+  }
+
+  public int getStart() {
+    return start;
+  }
+
+  public int getLength() {
+    return length;
+  }
+
+  public Source getSource() {
+    return source;
+  }
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/model/Source.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/model/Source.java
@@ -1,0 +1,27 @@
+package com.datadog.iast.model;
+
+import com.datadog.iast.model.json.SourceTypeString;
+
+public final class Source {
+  private final @SourceTypeString byte origin;
+  private final String name;
+  private final String value;
+
+  public Source(final byte origin, final String name, final String value) {
+    this.origin = origin;
+    this.name = name;
+    this.value = value;
+  }
+
+  public byte getOrigin() {
+    return origin;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getValue() {
+    return value;
+  }
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/model/SourceType.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/model/SourceType.java
@@ -1,0 +1,24 @@
+package com.datadog.iast.model;
+
+public final class SourceType {
+
+  private SourceType() {}
+
+  public static final byte NONE = 0;
+
+  public static final byte REQUEST_QUERY_PARAMETER = 1;
+  private static final String REQUEST_QUERY_PARAMETER_STRING = "http.url_details.queryString";
+  public static final byte REQUEST_PATH = 2;
+  private static final String REQUEST_PATH_STRING = "http.url_details.path";
+
+  public static String toString(final byte sourceType) {
+    switch (sourceType) {
+      case REQUEST_QUERY_PARAMETER:
+        return REQUEST_QUERY_PARAMETER_STRING;
+      case REQUEST_PATH:
+        return REQUEST_PATH_STRING;
+      default:
+        return null;
+    }
+  }
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/model/Vulnerability.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/model/Vulnerability.java
@@ -1,0 +1,32 @@
+package com.datadog.iast.model;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public final class Vulnerability {
+
+  private final @Nonnull VulnerabilityType type;
+
+  private final @Nonnull Location location;
+
+  private final @Nullable Evidence evidence;
+
+  public Vulnerability(
+      final VulnerabilityType type, final Location location, final Evidence evidence) {
+    this.type = type;
+    this.location = location;
+    this.evidence = evidence;
+  }
+
+  public VulnerabilityType getType() {
+    return type;
+  }
+
+  public Location getLocation() {
+    return location;
+  }
+
+  public Evidence getEvidence() {
+    return evidence;
+  }
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/model/VulnerabilityBatch.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/model/VulnerabilityBatch.java
@@ -1,0 +1,41 @@
+package com.datadog.iast.model;
+
+import com.datadog.iast.model.json.VulnerabilityEncoding;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Collects vulnerabilities and serializes to JSON lazily on {@link #toString()}. */
+public final class VulnerabilityBatch {
+
+  private List<Vulnerability> vulnerabilities;
+  private volatile String json;
+
+  public void add(final Vulnerability v) {
+    synchronized (this) {
+      json = null;
+      if (vulnerabilities == null) {
+        this.vulnerabilities = new ArrayList<>();
+      }
+      vulnerabilities.add(v);
+    }
+  }
+
+  /** Internal list of vulnerabilities. Not thread-safe. */
+  public List<Vulnerability> getVulnerabilities() {
+    return vulnerabilities;
+  }
+
+  @Override
+  public String toString() {
+    String currentJson = json;
+    if (currentJson != null) {
+      return currentJson;
+    }
+    synchronized (this) {
+      if (json == null) {
+        json = VulnerabilityEncoding.toJson(this);
+      }
+      return json;
+    }
+  }
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
@@ -1,0 +1,6 @@
+package com.datadog.iast.model;
+
+public enum VulnerabilityType {
+  WEAK_CIPHER,
+  WEAK_HASH;
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/model/json/AdapterFactory.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/model/json/AdapterFactory.java
@@ -1,0 +1,129 @@
+package com.datadog.iast.model.json;
+
+import com.datadog.iast.model.Source;
+import com.datadog.iast.model.Vulnerability;
+import com.datadog.iast.model.VulnerabilityBatch;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import com.squareup.moshi.Moshi;
+import com.squareup.moshi.Types;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * Stateful adapter for {@link VulnerabilityBatch}. It will fill encode vulnerabilities, collecting
+ * all references to {@link Source}, and replacing them with indexes. Then it will encode a sources
+ * list at the end, in the same order that they were found within the vulnerabilities.
+ */
+class AdapterFactory implements JsonAdapter.Factory {
+
+  private static final ThreadLocal<Context> CONTEXT_THREAD_LOCAL =
+      ThreadLocal.withInitial(Context::new);
+
+  private static class Context {
+    private final List<Source> sources;
+    private final Map<Source, Integer> sourceIndexMap;
+
+    public Context() {
+      sources = new ArrayList<>();
+      sourceIndexMap = new HashMap<>();
+    }
+  }
+
+  @Override
+  @Nullable
+  public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations, Moshi moshi) {
+    final Class<?> rawType = Types.getRawType(type);
+    if (Source.class.equals(rawType)) {
+      for (final Annotation annotation : annotations) {
+        if (SourceIndex.class.equals(annotation.annotationType())) {
+          return new SourceIndexAdapter();
+        }
+      }
+      return null;
+    } else if (VulnerabilityBatch.class.equals(Types.getRawType(type))) {
+      return new VulnerabilityBatchAdapter(moshi);
+    }
+    return null;
+  }
+
+  public static class SourceIndexAdapter extends JsonAdapter<Source> {
+
+    @Override
+    public void toJson(JsonWriter writer, @Nullable @SourceIndex Source value) throws IOException {
+      if (value == null) {
+        writer.nullValue();
+        return;
+      }
+      final Context ctx = CONTEXT_THREAD_LOCAL.get();
+      Integer index = ctx.sourceIndexMap.get(value);
+      if (index == null) {
+        index = ctx.sources.size();
+        ctx.sources.add(value);
+        ctx.sourceIndexMap.put(value, index);
+      }
+      writer.value(index);
+    }
+
+    @Nullable
+    @Override
+    public @SourceIndex Source fromJson(JsonReader reader) throws IOException {
+      throw new UnsupportedOperationException("Source deserialization is not supported");
+    }
+  }
+
+  public static class VulnerabilityBatchAdapter extends JsonAdapter<VulnerabilityBatch> {
+
+    private final JsonAdapter<List<Source>> sourcesAdapter;
+
+    private final JsonAdapter<List<Vulnerability>> vulnerabilitiesAdapter;
+
+    public VulnerabilityBatchAdapter(final Moshi moshi) {
+      sourcesAdapter = moshi.adapter(Types.newParameterizedType(List.class, Source.class));
+      vulnerabilitiesAdapter =
+          moshi.adapter(Types.newParameterizedType(List.class, Vulnerability.class));
+    }
+
+    @Override
+    public void toJson(JsonWriter writer, @Nullable VulnerabilityBatch value) throws IOException {
+      if (value == null) {
+        writer.nullValue();
+        return;
+      }
+
+      final Context ctx = CONTEXT_THREAD_LOCAL.get();
+      try {
+        final List<Vulnerability> vulnerabilities = value.getVulnerabilities();
+        writer.beginObject();
+        if (vulnerabilities != null && !vulnerabilities.isEmpty()) {
+          writer.name("vulnerabilities");
+          vulnerabilitiesAdapter.toJson(writer, vulnerabilities);
+
+          if (!ctx.sources.isEmpty()) {
+            writer.name("sources");
+            sourcesAdapter.toJson(writer, ctx.sources);
+          }
+        }
+
+        writer.endObject();
+      } finally {
+        CONTEXT_THREAD_LOCAL.remove();
+      }
+    }
+
+    @Nullable
+    @Override
+    public VulnerabilityBatch fromJson(JsonReader reader) throws IOException {
+      throw new UnsupportedOperationException(
+          "VulnerabilityBatch deserialization is not supported");
+    }
+  }
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/model/json/SourceIndex.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/model/json/SourceIndex.java
@@ -1,0 +1,9 @@
+package com.datadog.iast.model.json;
+
+import com.squareup.moshi.JsonQualifier;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@JsonQualifier
+public @interface SourceIndex {}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/model/json/SourceTypeAdapter.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/model/json/SourceTypeAdapter.java
@@ -1,0 +1,27 @@
+package com.datadog.iast.model.json;
+
+import com.datadog.iast.model.SourceType;
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import com.squareup.moshi.ToJson;
+import java.io.IOException;
+
+class SourceTypeAdapter {
+
+  @ToJson
+  void toJson(JsonWriter writer, @SourceTypeString byte value) throws IOException {
+    final String stringValue = SourceType.toString(value);
+    if (stringValue == null) {
+      writer.nullValue();
+      return;
+    }
+    writer.value(stringValue);
+  }
+
+  @FromJson
+  @SourceTypeString
+  byte fromJson(JsonReader reader) {
+    throw new UnsupportedOperationException("SourceType deserialization not supported");
+  }
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/model/json/SourceTypeString.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/model/json/SourceTypeString.java
@@ -1,0 +1,9 @@
+package com.datadog.iast.model.json;
+
+import com.squareup.moshi.JsonQualifier;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@JsonQualifier
+public @interface SourceTypeString {}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/model/json/VulnerabilityEncoding.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/model/json/VulnerabilityEncoding.java
@@ -1,0 +1,19 @@
+package com.datadog.iast.model.json;
+
+import com.datadog.iast.model.VulnerabilityBatch;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+
+public class VulnerabilityEncoding {
+
+  private static final JsonAdapter<VulnerabilityBatch> adapter =
+      new Moshi.Builder()
+          .add(new SourceTypeAdapter())
+          .add(new AdapterFactory())
+          .build()
+          .adapter(VulnerabilityBatch.class);
+
+  public static String toJson(final VulnerabilityBatch value) {
+    return adapter.toJson(value);
+  }
+}

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/IastSystemTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/IastSystemTest.groovy
@@ -1,0 +1,52 @@
+package com.datadog.iast
+
+
+import datadog.trace.api.gateway.Events
+import datadog.trace.api.gateway.InstrumentationGateway
+import datadog.trace.api.gateway.RequestContextSlot
+import datadog.trace.api.gateway.SubscriptionService
+import datadog.trace.test.util.DDSpecification
+
+class IastSystemTest extends DDSpecification {
+
+  void 'start'() {
+    given:
+    final ig = new InstrumentationGateway()
+    final ss = Spy(ig.getSubscriptionService(RequestContextSlot.IAST))
+    final cbp = ig.getCallbackProvider(RequestContextSlot.IAST)
+
+    when:
+    IastSystem.start(ss)
+
+    then:
+    1 * ss.registerCallback(Events.get().requestStarted(), _)
+    0 * _
+
+    when:
+    final startCallback = cbp.getCallback(Events.get().requestStarted())
+    final endCallback = cbp.getCallback(Events.get().requestEnded())
+
+    then:
+    startCallback != null
+    endCallback == null
+
+    when:
+    startCallback.get()
+
+    then:
+    noExceptionThrown()
+  }
+
+  void 'start disabled'() {
+    setup:
+    injectSysConfig('dd.iast.enabled', "false")
+    rebuildConfig()
+    final ss = Mock(SubscriptionService)
+
+    when:
+    IastSystem.start(ss)
+
+    then:
+    0 * _
+  }
+}

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
@@ -1,0 +1,110 @@
+package com.datadog.iast
+
+import com.datadog.iast.model.Evidence
+import com.datadog.iast.model.Location
+import com.datadog.iast.model.Vulnerability
+import com.datadog.iast.model.VulnerabilityBatch
+import com.datadog.iast.model.VulnerabilityType
+import datadog.trace.api.TraceSegment
+import datadog.trace.api.gateway.RequestContext
+import datadog.trace.api.gateway.RequestContextSlot
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import datadog.trace.test.util.DDSpecification
+
+class ReporterTest extends DDSpecification {
+
+  void 'basic vulnerability reporting'() {
+    given:
+    final traceSegment = Mock(TraceSegment)
+    final ctx = new IastRequestContext()
+    final reqCtx = Stub(RequestContext)
+    reqCtx.getData(RequestContextSlot.IAST) >> ctx
+    reqCtx.getTraceSegment() >> traceSegment
+    VulnerabilityBatch batch = null
+
+    final span = Stub(AgentSpan)
+    span.getRequestContext() >> reqCtx
+
+    final v = new Vulnerability(
+      VulnerabilityType.WEAK_HASH,
+      Location.forStack(new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("MD5")
+      )
+
+    when:
+    Reporter.report(span, v)
+
+    then:
+    1 * traceSegment.setDataTop('iast', _) >> { batch = it[1] as VulnerabilityBatch }
+    batch.toString() == '{"vulnerabilities":[{"evidence":{"value":"MD5"},"location":{"line":1,"path":"foo"},"type":"WEAK_HASH"}]}'
+    0 * _
+  }
+
+  void 'two vulnerabilities'() {
+    given:
+    final traceSegment = Mock(TraceSegment)
+    final ctx = new IastRequestContext()
+    final reqCtx = Stub(RequestContext)
+    reqCtx.getData(RequestContextSlot.IAST) >> ctx
+    reqCtx.getTraceSegment() >> traceSegment
+    VulnerabilityBatch batch = null
+
+    final span = Stub(AgentSpan)
+    span.getRequestContext() >> reqCtx
+
+    final v1 = new Vulnerability(
+      VulnerabilityType.WEAK_HASH,
+      Location.forStack(new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("MD5")
+      )
+    final v2 = new Vulnerability(
+      VulnerabilityType.WEAK_HASH,
+      Location.forStack(new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("MD4")
+      )
+
+    when:
+    Reporter.report(span, v1)
+    Reporter.report(span, v2)
+
+    then:
+    1 * traceSegment.setDataTop('iast', _) >> { batch = it[1] as VulnerabilityBatch }
+    batch.toString() == '{"vulnerabilities":[{"evidence":{"value":"MD5"},"location":{"line":1,"path":"foo"},"type":"WEAK_HASH"},{"evidence":{"value":"MD4"},"location":{"line":1,"path":"foo"},"type":"WEAK_HASH"}]}'
+    0 * _
+  }
+
+  void 'null span does not throw'() {
+    given:
+    final span = null
+    final v = new Vulnerability(
+      VulnerabilityType.WEAK_HASH,
+      Location.forStack(new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("MD5")
+      )
+
+    when:
+    Reporter.report(span, v)
+
+    then:
+    noExceptionThrown()
+    0 * _
+  }
+
+  void 'null RequestContext does not throw'() {
+    given:
+    final span = Stub(AgentSpan)
+    span.getRequestContext() >> null
+    final v = new Vulnerability(
+      VulnerabilityType.WEAK_HASH,
+      Location.forStack(new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("MD5")
+      )
+
+    when:
+    Reporter.report(span, v)
+
+    then:
+    noExceptionThrown()
+    0 * _
+  }
+}

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/model/LocationTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/model/LocationTest.groovy
@@ -1,0 +1,18 @@
+package com.datadog.iast.model
+
+import datadog.trace.test.util.DDSpecification
+
+class LocationTest extends DDSpecification {
+
+  void 'forStack'() {
+    given:
+    final stack = new StackTraceElement("declaringClass", "methodName", "fileName", 42)
+
+    when:
+    final location = Location.forStack(stack)
+
+    then:
+    location.getPath() == "declaringClass"
+    location.getLine() == 42
+  }
+}

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/model/json/VulnerabilityEncodingTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/model/json/VulnerabilityEncodingTest.groovy
@@ -1,0 +1,364 @@
+package com.datadog.iast.model.json
+
+
+import com.datadog.iast.model.Source
+import com.datadog.iast.model.SourceType
+import com.datadog.iast.model.VulnerabilityBatch
+import com.datadog.iast.model.Evidence
+import com.datadog.iast.model.Location
+import com.datadog.iast.model.VulnerabilityType
+import com.datadog.iast.model.Vulnerability
+import com.datadog.iast.model.Range
+import datadog.trace.test.util.DDSpecification
+import groovy.json.JsonSlurper
+
+class VulnerabilityEncodingTest extends DDSpecification {
+
+  void 'one vulnerability'() {
+    given:
+    final slurper = new JsonSlurper()
+    final value = new VulnerabilityBatch()
+    value.add(new Vulnerability(
+      VulnerabilityType.WEAK_HASH,
+      Location.forStack(new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("MD5")
+      ))
+
+    when:
+    final result = VulnerabilityEncoding.toJson(value)
+
+    then:
+    slurper.parseText(result) == slurper.parseText('''{
+      "vulnerabilities": [
+        {
+          "type": "WEAK_HASH",
+          "evidence": {
+            "value": "MD5"
+          },
+          "location": {
+            "line": 1,
+            "path": "foo"
+          }
+        }
+      ]
+    }''')
+  }
+
+  void 'one vulnerability with one source'() {
+    given:
+    final slurper = new JsonSlurper()
+    final value = new VulnerabilityBatch()
+    value.add(new Vulnerability(
+      VulnerabilityType.WEAK_HASH,
+      Location.forStack(new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("BAD", [new Range(0, 1, new Source(SourceType.REQUEST_PATH, "key", "value"))] as Range[])
+      ))
+
+    when:
+    final result = VulnerabilityEncoding.toJson(value)
+
+    then:
+    slurper.parseText(result) == slurper.parseText('''{
+      "vulnerabilities": [
+        {
+          "type": "WEAK_HASH",
+          "evidence": {
+            "value": "BAD",
+            "ranges": [
+              {
+                "length": 1,
+                "start": 0,
+                "source": 0
+              }
+            ]
+          },
+          "location": {
+            "line": 1,
+            "path": "foo"
+          }
+        }
+      ],
+      "sources": [
+        {
+          "origin": "http.url_details.path",
+          "name": "key",
+          "value": "value",
+        }
+      ]
+    }''')
+  }
+
+  void 'one vulnerability with two sources'() {
+    given:
+    final slurper = new JsonSlurper()
+    final value = new VulnerabilityBatch()
+    value.add(new Vulnerability(
+      VulnerabilityType.WEAK_HASH,
+      Location.forStack(new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("BAD", [
+        new Range(0, 1, new Source(SourceType.REQUEST_PATH, "key", "value")),
+        new Range(1, 1, new Source(SourceType.REQUEST_QUERY_PARAMETER, "key2", "value2"))
+      ] as Range[])
+      ))
+
+    when:
+    final result = VulnerabilityEncoding.toJson(value)
+
+    then:
+    slurper.parseText(result) == slurper.parseText('''{
+      "vulnerabilities": [
+        {
+          "type": "WEAK_HASH",
+          "evidence": {
+            "value": "BAD",
+            "ranges": [
+              {
+                "length": 1,
+                "start": 0,
+                "source": 0,
+              },
+              {
+                "length": 1,
+                "start": 1,
+                "source": 1
+              }
+            ]
+          },
+          "location": {
+            "line": 1,
+            "path": "foo"
+          }
+        }
+      ],
+      "sources": [
+        {
+          "origin": "http.url_details.path",
+          "name": "key",
+          "value": "value"
+        },
+        {
+          "origin": "http.url_details.queryString",
+          "name": "key2",
+          "value": "value2"
+        }
+      ]
+    }''')
+  }
+
+  void 'one vulnerability with null source'() {
+    given:
+    final slurper = new JsonSlurper()
+    final value = new VulnerabilityBatch()
+    value.add(new Vulnerability(
+      VulnerabilityType.WEAK_HASH,
+      Location.forStack(new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("BAD", [new Range(0, 1, null)] as Range[])
+      ))
+
+    when:
+    final result = VulnerabilityEncoding.toJson(value)
+
+    then:
+    slurper.parseText(result) == slurper.parseText('''{
+      "vulnerabilities": [
+        {
+          "type": "WEAK_HASH",
+          "evidence": {
+            "value": "BAD",
+            "ranges": [
+              {
+                "length": 1,
+                "start": 0
+              }
+            ]
+          },
+          "location": {
+            "line": 1,
+            "path": "foo"
+          }
+        }
+      ]
+    }''')
+  }
+
+  void 'one vulnerability with no source type'() {
+    given:
+    final slurper = new JsonSlurper()
+    final value = new VulnerabilityBatch()
+    value.add(new Vulnerability(
+      VulnerabilityType.WEAK_HASH,
+      Location.forStack(new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("BAD", [new Range(0, 1, new Source(SourceType.NONE, "key", "value"))] as Range[])
+      ))
+
+    when:
+    final result = VulnerabilityEncoding.toJson(value)
+
+    then:
+    slurper.parseText(result) == slurper.parseText('''{
+      "vulnerabilities": [
+        {
+          "type": "WEAK_HASH",
+          "evidence": {
+            "value": "BAD",
+            "ranges": [
+              {
+                "length": 1,
+                "start": 0,
+                "source": 0
+              }
+            ]
+          },
+          "location": {
+            "line": 1,
+            "path": "foo"
+          }
+        }
+      ],
+      "sources": [
+        {
+          "name": "key",
+          "value": "value",
+        }
+      ]
+    }''')
+  }
+
+  void 'two vulnerabilities with one shared source'() {
+    given:
+    final slurper = new JsonSlurper()
+    final value = new VulnerabilityBatch()
+    final source = new Source(SourceType.REQUEST_PATH, "key", "value")
+    value.add(new Vulnerability(
+      VulnerabilityType.WEAK_HASH,
+      Location.forStack(new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("BAD1", [new Range(0, 1, source)] as Range[])
+      ))
+    value.add(new Vulnerability(
+      VulnerabilityType.WEAK_HASH,
+      Location.forStack(new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("BAD2", [new Range(0, 1, source)] as Range[])
+      ))
+
+    when:
+    final result = VulnerabilityEncoding.toJson(value)
+
+    then:
+    slurper.parseText(result) == slurper.parseText('''{
+      "vulnerabilities": [
+        {
+          "evidence": {
+            "ranges": [
+              {
+                "length": 1,
+                "source": 0,
+                "start": 0
+              }
+            ],
+            "value": "BAD1"
+          },
+          "location": {
+            "line": 1,
+            "path": "foo"
+          },
+          "type": "WEAK_HASH"
+        },
+        {
+          "evidence": {
+            "ranges": [
+              {
+                "length": 1,
+                "source": 0,
+                "start": 0
+              }
+            ],
+            "value": "BAD2"
+          },
+          "location": {
+            "line": 1,
+            "path": "foo"
+          },
+          "type": "WEAK_HASH"
+        }
+      ],
+      "sources": [
+        {
+          "name": "key",
+          "origin": "http.url_details.path",
+          "value": "value"
+        }
+      ]
+    }''')
+  }
+
+  void 'two vulnerability with no shared sources'() {
+    given:
+    final slurper = new JsonSlurper()
+    final value = new VulnerabilityBatch()
+    value.add(new Vulnerability(
+      VulnerabilityType.WEAK_HASH,
+      Location.forStack(new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("BAD", [new Range(0, 1, new Source(SourceType.REQUEST_PATH, "key1", "value"))] as Range[])
+      ))
+    value.add(new Vulnerability(
+      VulnerabilityType.WEAK_HASH,
+      Location.forStack(new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("BAD", [new Range(0, 1, new Source(SourceType.REQUEST_PATH, "key2", "value"))] as Range[])
+      ))
+
+    when:
+    final result = VulnerabilityEncoding.toJson(value)
+
+    then:
+    slurper.parseText(result) == slurper.parseText('''{
+      "vulnerabilities": [
+        {
+          "evidence": {
+            "ranges": [
+              {
+                "length": 1,
+                "source": 0,
+                "start": 0
+              }
+            ],
+            "value": "BAD"
+          },
+          "location": {
+            "line": 1,
+            "path": "foo"
+          },
+          "type": "WEAK_HASH"
+        },
+        {
+          "evidence": {
+            "ranges": [
+              {
+                "length": 1,
+                "source": 1,
+                "start": 0
+              }
+            ],
+            "value": "BAD"
+          },
+          "location": {
+            "line": 1,
+            "path": "foo"
+          },
+          "type": "WEAK_HASH"
+        }
+      ],
+      "sources": [
+        {
+          "name": "key1",
+          "origin": "http.url_details.path",
+          "value": "value"
+        },
+        {
+          "name": "key2",
+          "origin": "http.url_details.path",
+          "value": "value"
+        }
+      ]
+    }''')
+  }
+}

--- a/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
@@ -1,0 +1,69 @@
+package datadog.smoketest
+
+import datadog.trace.api.Platform
+import okhttp3.Request
+import spock.lang.IgnoreIf
+
+@IgnoreIf({
+  !Platform.isJavaVersionAtLeast(8)
+})
+class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
+
+  @Override
+  ProcessBuilder createProcessBuilder() {
+    String springBootShadowJar = System.getProperty("datadog.smoketest.springboot.shadowJar.path")
+
+    List<String> command = new ArrayList<>()
+    command.add(javaPath())
+    command.addAll(defaultJavaProperties)
+    command.addAll(["-Ddd.appsec.enabled=true", "-Ddd.iast.enabled=true"])
+    command.addAll((String[]) ["-jar", springBootShadowJar, "--server.port=${httpPort}"])
+    ProcessBuilder processBuilder = new ProcessBuilder(command)
+    processBuilder.directory(new File(buildDirectory))
+    // Spring will print all environment variables to the log, which may pollute it and affect log assertions.
+    processBuilder.environment().clear()
+    processBuilder
+  }
+
+  def "IAST subsystem starts"() {
+    given: 'an initial request has succeeded'
+    String url = "http://localhost:${httpPort}/greeting"
+    def request = new Request.Builder().url(url).get().build()
+    client.newCall(request).execute()
+
+    when: 'logs are read'
+    String startMsg = null
+    String errorMsg = null
+    checkLog {
+      if (it.contains("Not starting IAST subsystem")) {
+        errorMsg = it
+      }
+      if (it.contains("IAST is starting")) {
+        startMsg = it
+      }
+    }
+
+    then: 'there are no errors in the log and IAST has started'
+    errorMsg == null
+    startMsg != null
+    !logHasErrors
+  }
+
+  def "default home page without errors"() {
+    setup:
+    String url = "http://localhost:${httpPort}/greeting"
+    def request = new Request.Builder().url(url).get().build()
+
+    when:
+    def response = client.newCall(request).execute()
+
+    then:
+    def responseBodyStr = response.body().string()
+    responseBodyStr != null
+    responseBodyStr.contains("Sup Dawg")
+    response.body().contentType().toString().contains("text/plain")
+    response.code() == 200
+    checkLog()
+    !logHasErrors
+  }
+}

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -90,7 +90,7 @@ final class CachedData {
       "org.openjdk.jmc:flightrecorder:${versions.jmc}"
     ],
 
-    // Shared between appsec, agent tooling, instrumentation, JMXFetch, and profiling
+    // Shared between appsec, agent tooling, iast, instrumentation, JMXFetch, and profiling
     shared               : [
       "com.squareup.okhttp3:okhttp:${versions.okhttp}",
       // Force specific version of okio required by com.squareup.moshi:moshi

--- a/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/AbstractStackWalker.java
+++ b/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/AbstractStackWalker.java
@@ -9,7 +9,7 @@ public abstract class AbstractStackWalker implements StackWalker {
   private static final Predicate<StackTraceElement> NOT_DD_TRACE_STACK_ELEMENT =
       (stackTraceElement) ->
           !stackTraceElement.getClassName().startsWith("datadog.trace.")
-              && !stackTraceElement.getClassName().startsWith("com.datadog.appsec.");
+              && !stackTraceElement.getClassName().startsWith("com.datadog.iast.");
 
   @Override
   public <T> T walk(Function<Stream<StackTraceElement>, T> consumer) {

--- a/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/DefaultStackWalkerTest.java
+++ b/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/DefaultStackWalkerTest.java
@@ -52,9 +52,9 @@ public class DefaultStackWalkerTest {
   }
 
   @Test
-  public void filter_DataDog_AppSec_classes_from_StackTraceElements() {
+  public void filter_DataDog_Iast_classes_from_StackTraceElements() {
     // when
-    Stream<StackTraceElement> stream = Stream.of(element("com.datadog.appsec.Foo"));
+    Stream<StackTraceElement> stream = Stream.of(element("com.datadog.iast.Foo"));
     Stream<StackTraceElement> filtered = defaultStackWalker.doFilterStack(stream);
     // Then
     assertEquals(filtered.count(), 0);

--- a/settings.gradle
+++ b/settings.gradle
@@ -74,6 +74,8 @@ include ':remote-config'
 include ':dd-java-agent:appsec'
 include ':dd-java-agent:appsec:weblog:weblog-common'
 
+include ':dd-java-agent:iast'
+
 // misc
 include ':dd-java-agent:testing'
 include ':utils:container-utils'

--- a/utils/test-utils/src/main/groovy/datadog/trace/test/util/DDSpecification.groovy
+++ b/utils/test-utils/src/main/groovy/datadog/trace/test/util/DDSpecification.groovy
@@ -112,7 +112,7 @@ abstract class DDSpecification extends Specification {
   void setupSpec() {
     assert !configModificationFailed: "Config class modification failed.  Ensure all test classes extend DDSpecification"
     assert System.getenv().findAll { it.key.startsWith("DD_") }.isEmpty()
-    assert nonAppSecSystemProperties().findAll { it.key.toString().startsWith("dd.") }.isEmpty()
+    assert systemPropertiesExceptAllowed().findAll { it.key.toString().startsWith("dd.") }.isEmpty()
 
     if (getDDThreads().isEmpty()) {
       ignoreThreadCleanup = false
@@ -128,7 +128,7 @@ abstract class DDSpecification extends Specification {
     restoreProperties()
 
     assert System.getenv().findAll { it.key.startsWith("DD_") }.isEmpty()
-    assert nonAppSecSystemProperties().findAll { it.key.toString().startsWith("dd.") }.isEmpty()
+    assert systemPropertiesExceptAllowed().findAll { it.key.toString().startsWith("dd.") }.isEmpty()
 
     if (isConfigInstanceModifiable) {
       rebuildConfig()
@@ -137,16 +137,17 @@ abstract class DDSpecification extends Specification {
     checkThreads()
   }
 
-  private Map<Object, Object> nonAppSecSystemProperties() {
+  private static Map<Object, Object> systemPropertiesExceptAllowed() {
+    def allowlist = ['dd.appsec.enabled', 'dd.iast.enabled']
     System.getProperties()
-      .findAll { key, value -> key as String != 'dd.appsec.enabled' }
+      .findAll { key, value -> !allowlist.contains(key as String) }
   }
 
   void setup() {
     restoreProperties()
 
     assert System.getenv().findAll { it.key.startsWith("DD_") }.isEmpty()
-    assert nonAppSecSystemProperties().findAll { it.key.toString().startsWith("dd.") }.isEmpty()
+    assert systemPropertiesExceptAllowed().findAll { it.key.toString().startsWith("dd.") }.isEmpty()
 
     if (isConfigInstanceModifiable) {
       rebuildConfig()
@@ -157,7 +158,7 @@ abstract class DDSpecification extends Specification {
     restoreProperties()
 
     assert System.getenv().findAll { it.key.startsWith("DD_") }.isEmpty()
-    assert nonAppSecSystemProperties().findAll { it.key.toString().startsWith("dd.") }.isEmpty()
+    assert systemPropertiesExceptAllowed().findAll { it.key.toString().startsWith("dd.") }.isEmpty()
 
     if (isConfigInstanceModifiable) {
       rebuildConfig()


### PR DESCRIPTION
# What Does This Do

Add initial vulnerability reporting API for IAST. This PR includes:
* `iast` module and initial skeleton and initialization of the IAST subsystem.
* IAST callbacks when requests start, and end.
* Request context for IAST data.
* Vulnerability model.
* Reporter to add vulnerabilities to a request, and serialize them at the end of the request.

When IAST is enabled, we’ll add vulnerabilities for each request in a JSON-encoded object, stored in an internal tag (_dd.iast.json). The vulnerability objects are accumulated during the request, and encoded to JSON at the end of the request.


# Motivation

This API will be used whenever a vulnerability is found. It will attach a vulnerability to the current request, and it will encode them in an internal tag in JSON once the request ends.

# Additional Notes

Out of scope of this PR but coming up:
* Deduplicate vulnerabilities before reporting to the backend.
* Limit the number of vulnerabilities per request.
