### PR TITLE
A simple unused code artifacts cleanup

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -119,8 +119,7 @@ public final class ProfilingConfig {
   public static final String PROFILING_CHECKPOINTS_SAMPLER_WINDOW_MS =
       "profiling.checkpoints.sampler.sliding-window.ms";
   public static final int PROFILING_CHECKPOINTS_SAMPLER_WINDOW_MS_DEFAULT = 5000;
-  public static final String PROFILING_CHECKPOINTS_SAMPLER_LIMIT =
-      "profiling.checkpoints.sampler.limit";
+  public static final String PROFILING_CHECKPOINTS_SAMPLER_LIMIT = "profiling.checkpoints.limit";
   public static final int PROFILING_CHECKPOINTS_SAMPLER_LIMIT_DEFAULT = 500_000;
   public static final String PROFILING_ENDPOINT_COLLECTION_ENABLED =
       "profiling.endpoint.collection.enabled";


### PR DESCRIPTION
# What Does This Do
Removes an unused argument, fixes logging formats and renames the config param for checkpoints hard limit

# Motivation
These changes should have been a part of the original PR (#3232) - unfortunately, they slipped through so they should be fixed now (thanks goes to @mar-kolya for pointing this out!)

# Additional Notes
