### PR TITLE
Adds datastreams monitoring support to RabbitMQ

### DIFF
--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -181,6 +181,7 @@ public class RabbitChannelInstrumentation extends Instrumenter.Tracing
           RabbitDecorator.injectTimeInQueueStart(headers);
         }
         propagate().inject(span, headers, SETTER);
+        propagate().injectPathwayContext(span, headers, SETTER);
         props =
             new AMQP.BasicProperties(
                 props.getContentType(),

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
@@ -187,9 +187,11 @@ public class RabbitDecorator extends MessagingClientDecorator {
     }
     final AgentSpan span = startSpan(AMQP_COMMAND, parentContext, spanStartMicros);
 
-    PathwayContext pathwayContext = propagate().extractPathwayContext(headers, ContextVisitors.objectValuesMap());
-    span.mergePathwayContext(pathwayContext);
-    AgentTracer.get().setDataStreamCheckpoint(span, Arrays.asList("type:rabbitmq", "topic:" + queue));
+    if (null != headers) {
+      PathwayContext pathwayContext = propagate().extractPathwayContext(headers, ContextVisitors.objectValuesMap());
+      span.mergePathwayContext(pathwayContext);
+      AgentTracer.get().setDataStreamCheckpoint(span, Arrays.asList("type:rabbitmq", "topic:" + queue));
+    }
 
     if (null != body) {
       span.setTag("message.size", body.length);

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
@@ -15,11 +15,14 @@ import com.rabbitmq.client.Envelope;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.ContextVisitors;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
+import datadog.trace.bootstrap.instrumentation.api.PathwayContext;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.MessagingClientDecorator;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -183,6 +186,11 @@ public class RabbitDecorator extends MessagingClientDecorator {
       // spans are written out together by the TraceStructureWriter when running in strict mode
     }
     final AgentSpan span = startSpan(AMQP_COMMAND, parentContext, spanStartMicros);
+
+    PathwayContext pathwayContext = propagate().extractPathwayContext(headers, ContextVisitors.objectValuesMap());
+    span.mergePathwayContext(pathwayContext);
+    AgentTracer.get().setDataStreamCheckpoint(span, Arrays.asList("type:rabbitmq", "topic:" + queue));
+
     if (null != body) {
       span.setTag("message.size", body.length);
     }

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
@@ -188,9 +188,11 @@ public class RabbitDecorator extends MessagingClientDecorator {
     final AgentSpan span = startSpan(AMQP_COMMAND, parentContext, spanStartMicros);
 
     if (null != headers) {
-      PathwayContext pathwayContext = propagate().extractPathwayContext(headers, ContextVisitors.objectValuesMap());
+      PathwayContext pathwayContext =
+          propagate().extractPathwayContext(headers, ContextVisitors.objectValuesMap());
       span.mergePathwayContext(pathwayContext);
-      AgentTracer.get().setDataStreamCheckpoint(span, Arrays.asList("type:rabbitmq", "topic:" + queue));
+      AgentTracer.get()
+          .setDataStreamCheckpoint(span, Arrays.asList("type:rabbitmq", "topic:" + queue));
     }
 
     if (null != body) {

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -110,7 +110,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
 
   def "test rabbit publish/get"() {
     setup:
-    String queueName;
+    String queueName
     GetResponse response = runUnderTrace("parent") {
       channel.exchangeDeclare(exchangeName, "direct", false)
       queueName = channel.queueDeclare().getQueue()
@@ -487,7 +487,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
 
       StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
       verifyAll(second) {
-        edgeTags.containsAll(["type:rabbitmq", "topic:" + "some-routing-queue"])
+        edgeTags.containsAll(["type:rabbitmq", "topic:some-routing-queue"])
         edgeTags.size() == 2
       }
     }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/datastreams/RecordingDatastreamsPayloadWriter.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/datastreams/RecordingDatastreamsPayloadWriter.groovy
@@ -19,6 +19,7 @@ class RecordingDatastreamsPayloadWriter implements DatastreamsPayloadWriter {
 
   void clear() {
     payloads.clear()
+    groups.clear()
   }
 
   void waitForPayloads(int count, long timeout = TimeUnit.SECONDS.toMillis(1)) {


### PR DESCRIPTION
# What Does This Do
This PR adds datastreams monitoring support to RabbitMQ, by extracting any existing pathway context in the `RabbitDecorator` and injecting pathway context in `RabbitChannelInstrumentation`. This follows similar pattern we already have today for datastreams monitoring instrumentation in Kafka Client and gRPC.

# Motivation
To allow end-to-end monitoring of datastreams on RabbitMQ.

# Additional Notes
This was tested manually using example apps built with `com.rabbitmq:amqp-client:5.15.0`. This was also tested with example apps built with RabbitMQ via springboot.