### PR TITLE
Revert "Revert "Upgrade gradle to 7.5 (#3655)""

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
   implementation("org.ow2.asm", "asm-tree", "9.0")
 
   testImplementation("org.spockframework", "spock-core", "2.0-groovy-3.0")
-  testImplementation("org.codehaus.groovy", "groovy-all", "3.0.9")
+  testImplementation("org.codehaus.groovy", "groovy-all", "3.0.10")
 }
 
 tasks.test {

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -212,6 +212,10 @@ project.afterEvaluate {
           enabled = false
         }
       }
+      if (metadata.languageVersion.asInt() >= 16) {
+        // temporary workaround when using Java16+: some tests require reflective access to java.lang/java.util
+        jvmArgs += ['--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/java.util=ALL-UNNAMED']
+      }
     } else {
       def name = it.name
       onlyIf { isJavaVersionAllowed(JavaVersion.current(), name) }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=e6d864e3b5bc05cc62041842b306383fc1fefcec359e70cebb1d470a6094ca82
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionSha256Sum=97a52d145762adc241bad7fd18289bf7f6801e08ece6badf80402fe2b9f250b1
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This reverts commit 5d3677cb28adb32029c32555f5c653c07f4fabab.

# What Does This Do

Reverts back https://github.com/DataDog/dd-trace-java/pull/3680

# Motivation

It didn't help to fix the release issue, still getting ` Failed to parse secret key`

# Additional Notes
