### PR TITLE
StatusLogger should report the 'dd_version' configured for the app/service

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
@@ -7,7 +7,6 @@ import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.JsonWriter;
 import com.squareup.moshi.Moshi;
 import datadog.trace.api.Config;
-import datadog.trace.api.DDTraceApiInfo;
 import datadog.trace.logging.LoggingSettingsDescription;
 import datadog.trace.util.AgentTaskScheduler;
 import java.io.IOException;
@@ -107,7 +106,7 @@ public final class StatusLogger extends JsonAdapter<Config>
     writer.name("appsec_rules_file_path");
     writer.value(config.getAppSecRulesFile());
     writer.name("dd_version");
-    writer.value(DDTraceApiInfo.VERSION);
+    writer.value(config.getVersion());
     writer.name("health_checks_enabled");
     writer.value(config.isHealthMetricsEnabled());
     writer.name("configuration_file");


### PR DESCRIPTION
# Motivation

The `dd_version` reported by `StatusLogger` should be the configured app/service version, not the tracer version.

For example: https://github.com/DataDog/dd-trace-go/blob/v1.40.1/ddtrace/tracer/log.go#L48