### PR TITLE
[CI-APP] Report test as `skipped` when `org.junit.AssumptionViolatedException` is thrown in JUnit5

### DIFF
--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
@@ -3,6 +3,7 @@ import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.bootstrap.instrumentation.decorator.TestDecorator
 import datadog.trace.instrumentation.junit5.JUnit5Decorator
 import org.example.TestAssumption
+import org.example.TestAssumptionLegacy
 import org.example.TestError
 import org.example.TestFactory
 import org.example.TestFailed
@@ -229,6 +230,24 @@ class JUnit5Test extends TestFrameworkTest {
 
     where:
     testTags = ["$Tags.TEST_SKIP_REASON": "Assumption failed: assumption is not true"]
+  }
+
+  def "test with failing legacy assumptions generated spans"() {
+    setup:
+    def launcherReq = LauncherDiscoveryRequestBuilder.request()
+      .selectors(selectClass(TestAssumptionLegacy)).build()
+    def launcher = LauncherFactory.create()
+    launcher.execute(launcherReq)
+
+    expect:
+    assertTraces(1) {
+      trace(1) {
+        testSpan(it, 0, "org.example.TestAssumptionLegacy", "test_fail_assumption_legacy", TestDecorator.TEST_SKIP, testTags)
+      }
+    }
+
+    where:
+    testTags = ["$Tags.TEST_SKIP_REASON": "assumption is not fulfilled"]
   }
 
   @Override

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestAssumptionLegacy.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestAssumptionLegacy.java
@@ -1,0 +1,12 @@
+package org.example;
+
+import org.junit.AssumptionViolatedException;
+import org.junit.jupiter.api.Test;
+
+public class TestAssumptionLegacy {
+
+  @Test
+  public void test_fail_assumption_legacy() {
+    throw new AssumptionViolatedException("assumption is not fulfilled");
+  }
+}


### PR DESCRIPTION
# What Does This Do

This PR includes the logic to report a particular test as `skipped` when the `org.junit.AssumptionViolatedException` is thrown during a test execution run in a JUnit5 runner.

# Motivation

The `org.junit.AssumptionViolatedException` exception belongs to the JUnit4 world, but as you can execute JUnit4 tests using JUnit5 engines, the tests that throw this type of exception in JUnit5 must be reported as `skipped`.

# Additional Notes
