### PR TITLE
Add test to demonstrate difference between kafka streams 2.7 and 3.2

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -76,6 +76,7 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Tracing
         span.setTag(InstrumentationTags.TOMBSTONE, true);
       }
 
+      System.out.println("[TEST_LOG] KafkaProducerInstrumentation.onMethodEnter");
       // Do not inject headers for batch versions below 2
       // This is how similar check is being done in Kafka client itself:
       // https://github.com/apache/kafka/blob/05fcfde8f69b0349216553f711fdfc3f0259c601/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java#L411-L412

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
@@ -65,6 +65,7 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
       AgentSpan span, queueSpan = null;
       if (val != null) {
         if (!Config.get().isKafkaClientPropagationDisabledForTopic(val.topic())) {
+          System.out.println("[TEST_LOG] TracingIterator.startNewRecordSpan");
           final Context spanContext = propagate().extract(val.headers(), GETTER);
           long timeInQueueStart = GETTER.extractTimeInQueueStart(val.headers());
           if (timeInQueueStart == 0 || KAFKA_LEGACY_TRACING) {

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/kafka-streams-0.11.gradle
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/kafka-streams-0.11.gradle
@@ -13,6 +13,7 @@ apply plugin: 'org.unbroken-dome.test-sets'
 
 testSets {
   latestDepTest
+  kafka32Test
 }
 
 dependencies {
@@ -38,4 +39,12 @@ dependencies {
   latestDepTestImplementation group: 'org.springframework.kafka', name: 'spring-kafka', version: '2.7+'
   latestDepTestImplementation group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '2.7+'
   latestDepTestImplementation group: 'org.assertj', name: 'assertj-core', version: '3.+'
+
+  kafka32TestImplementation group: 'org.apache.kafka', name: 'kafka_2.13', version: '3.2.0'
+  kafka32TestImplementation group: 'org.apache.kafka', name: 'kafka-clients', version: '3.2.0'
+  kafka32TestImplementation group: 'org.apache.kafka', name: 'kafka-streams', version: '3.2.0'
+  // spring-kafka 2.8.x pulls in kafka-clients/streams 3.x which behaves differently
+  kafka32TestImplementation group: 'org.springframework.kafka', name: 'spring-kafka', version: '2.8+'
+  kafka32TestImplementation group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '2.8+'
+  kafka32TestImplementation group: 'org.assertj', name: 'assertj-core', version: '3.+'
 }

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/kafka32Test/groovy/KafkaStreams32Test.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/kafka32Test/groovy/KafkaStreams32Test.groovy
@@ -1,0 +1,209 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.checkpoints.CheckpointValidationMode
+import datadog.trace.agent.test.checkpoints.CheckpointValidator
+import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.serialization.Serdes
+import org.apache.kafka.streams.KafkaStreams
+import org.apache.kafka.streams.StreamsBuilder
+import org.apache.kafka.streams.StreamsConfig
+import org.apache.kafka.streams.kstream.KStream
+import org.apache.kafka.streams.kstream.Produced
+import org.apache.kafka.streams.kstream.ValueMapper
+import org.junit.ClassRule
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaProducerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.listener.ContainerProperties
+import org.springframework.kafka.listener.KafkaMessageListenerContainer
+import org.springframework.kafka.listener.MessageListener
+import org.springframework.kafka.test.EmbeddedKafkaBroker
+import org.springframework.kafka.test.rule.EmbeddedKafkaRule
+import org.springframework.kafka.test.utils.ContainerTestUtils
+import org.springframework.kafka.test.utils.KafkaTestUtils
+import spock.lang.Shared
+
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+class KafkaStreams32Test extends AgentTestRunner {
+  static final STREAM_PENDING = "test.pending"
+  static final STREAM_PROCESSED = "test.processed"
+
+  @Shared
+  @ClassRule
+  EmbeddedKafkaRule kafkaRule = new EmbeddedKafkaRule(1, true, STREAM_PENDING, STREAM_PROCESSED)
+  @Shared
+  EmbeddedKafkaBroker embeddedKafka = kafkaRule.embeddedKafka
+
+  @Override
+  protected boolean isDataStreamsEnabled() {
+    return true;
+  }
+
+  def "test kafka produce and consume with streams in-between"() {
+    setup:
+    CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(CheckpointValidationMode.INTERVALS)
+    def config = new Properties()
+    def producerProps = KafkaTestUtils.producerProps(embeddedKafka.getBrokersAsString())
+    config.putAll(producerProps)
+    config.put(StreamsConfig.APPLICATION_ID_CONFIG, "test-application")
+    config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName())
+    config.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName())
+
+    // CONFIGURE CONSUMER
+    def consumerFactory = new DefaultKafkaConsumerFactory<String, String>(KafkaTestUtils.consumerProps("sender", "false", embeddedKafka))
+
+    def consumerContainer = new KafkaMessageListenerContainer<>(consumerFactory, new ContainerProperties(STREAM_PROCESSED))
+
+    // create a thread safe queue to store the processed message
+    def records = new LinkedBlockingQueue<ConsumerRecord<String, String>>()
+
+    // setup a Kafka message listener
+    consumerContainer.setupMessageListener(new MessageListener<String, String>() {
+      @Override
+      void onMessage(ConsumerRecord<String, String> record) {
+        // ensure consistent ordering of traces
+        // this is the last processing step so we should see 2 traces here
+        TEST_WRITER.waitForTraces(2)
+        TEST_TRACER.activeSpan().setTag("testing", 123)
+        records.add(record)
+      }
+    })
+
+    // start the container and underlying message listener
+    consumerContainer.start()
+
+    // wait until the container has the required number of assigned partitions
+    ContainerTestUtils.waitForAssignment(consumerContainer, embeddedKafka.getPartitionsPerTopic())
+
+    // CONFIGURE PROCESSOR
+    StreamsBuilder builder = new StreamsBuilder()
+    KStream<String, String> textLines = builder.stream(STREAM_PENDING)
+    def values = textLines
+      .mapValues(new ValueMapper<String, String>() {
+        @Override
+        String apply(String textLine) {
+          TEST_WRITER.waitForTraces(1) // ensure consistent ordering of traces
+          TEST_TRACER.activeSpan().setTag("asdf", "testing")
+          return textLine.toLowerCase()
+        }
+      })
+
+    def producer = Produced.with(Serdes.String(), Serdes.String())
+    values.to(STREAM_PROCESSED, producer)
+    KafkaStreams streams = new KafkaStreams(builder.build(), config)
+    streams.start()
+
+    // CONFIGURE PRODUCER
+    def producerFactory = new DefaultKafkaProducerFactory<String, String>(producerProps)
+    def kafkaTemplate = new KafkaTemplate<String, String>(producerFactory)
+
+    when:
+    String greeting = "TESTING TESTING 123!"
+    kafkaTemplate.send(STREAM_PENDING, greeting)
+
+    then:
+    // check that the message was received
+    def received = records.poll(10, TimeUnit.SECONDS)
+    received.value() == greeting.toLowerCase()
+    received.key() == null
+
+    assertTraces(3) {
+      trace(1) {
+        // PRODUCER span 0
+        span {
+          serviceName "kafka"
+          operationName "kafka.produce"
+          resourceName "Produce Topic $STREAM_PENDING"
+          spanType "queue"
+          errored false
+          measured true
+          parent()
+          tags {
+            "$Tags.COMPONENT" "java-kafka"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
+            defaultTags()
+          }
+        }
+      }
+      def producerSpan = null
+      trace(2) {
+        sortSpansByStart()
+
+        // STREAMING span 0
+        span {
+          serviceName "kafka"
+          operationName "kafka.consume"
+          resourceName "Consume Topic $STREAM_PENDING"
+          spanType "queue"
+          errored false
+          measured true
+          childOf trace(0)[0]
+
+          tags {
+            "$Tags.COMPONENT" "java-kafka-streams"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+            "$InstrumentationTags.PARTITION" { it >= 0 }
+            "$InstrumentationTags.OFFSET" 0
+            "$InstrumentationTags.PROCESSOR_NAME" "KSTREAM-SOURCE-0000000000"
+            "asdf" "testing"
+            defaultTags(true)
+          }
+        }
+
+        // STREAMING span 1
+        span {
+          producerSpan = it.span
+          serviceName "kafka"
+          operationName "kafka.produce"
+          resourceName "Produce Topic $STREAM_PROCESSED"
+          spanType "queue"
+          errored false
+          measured true
+          childOf span(0)
+
+          tags {
+            "$Tags.COMPONENT" "java-kafka"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
+            defaultTags()
+          }
+        }
+      }
+      trace(1) {
+        // CONSUMER span 0
+        span {
+          serviceName "kafka"
+          operationName "kafka.consume"
+          resourceName "Consume Topic $STREAM_PROCESSED"
+          spanType "queue"
+          errored false
+          measured true
+          childOf producerSpan
+          tags {
+            "$Tags.COMPONENT" "java-kafka"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+            "$InstrumentationTags.PARTITION" { it >= 0 }
+            "$InstrumentationTags.OFFSET" 0
+            "$InstrumentationTags.CONSUMER_GROUP" "sender"
+            "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
+            "testing" 123
+            defaultTags(true)
+          }
+        }
+      }
+    }
+
+    def headers = received.headers()
+    headers.iterator().hasNext()
+    new String(headers.headers("x-datadog-trace-id").iterator().next().value()) == "${TEST_WRITER[1][0].traceId}"
+    new String(headers.headers("x-datadog-parent-id").iterator().next().value()) == "${TEST_WRITER[1][0].spanId}"
+
+
+    cleanup:
+    producerFactory?.destroy()
+    streams?.close()
+    consumerContainer?.stop()
+  }
+}

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/kafka32Test/groovy/KafkaStreams32Test.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/kafka32Test/groovy/KafkaStreams32Test.groovy
@@ -37,11 +37,6 @@ class KafkaStreams32Test extends AgentTestRunner {
   @Shared
   EmbeddedKafkaBroker embeddedKafka = kafkaRule.embeddedKafka
 
-  @Override
-  protected boolean isDataStreamsEnabled() {
-    return true;
-  }
-
   def "test kafka produce and consume with streams in-between"() {
     setup:
     CheckpointValidator.excludeValidations_DONOTUSE_I_REPEAT_DO_NOT_USE(CheckpointValidationMode.INTERVALS)

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
@@ -105,6 +105,7 @@ public class KafkaStreamTaskInstrumentation extends Instrumenter.Tracing
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void onEnter(
         @Advice.Argument(value = 1, readOnly = false) Iterable<ConsumerRecord<?, ?>> records) {
+      System.out.println("[TEST_LOG] UnwrapIterableAdvice.onMethodEnter");
       // This method adds the records to a queue, so we want to bypass the kafka instrumentation
       // since the resulting spans are very short and uninteresting.
       // KafkaStreamsProcessorInstrumentation will create a new span instead.
@@ -124,6 +125,7 @@ public class KafkaStreamTaskInstrumentation extends Instrumenter.Tracing
         @Advice.Argument(0) final StampedRecord record,
         @Advice.Argument(1) final ProcessorNode node,
         @Advice.This StreamTask task) {
+      System.out.println("[TEST_LOG] StartSpanAdvice.onMethodEnter");
       if (record == null || record.partition() == -1 || record.offset() == -1) {
         // partition|offset == -1 -> punctuation call.
         return;
@@ -169,6 +171,7 @@ public class KafkaStreamTaskInstrumentation extends Instrumenter.Tracing
         @Advice.Argument(0) final ProcessorNode node,
         @Advice.Argument(2) final ProcessorRecordContext record,
         @Advice.This StreamTask task) {
+      System.out.println("[TEST_LOG] StartSpanAdvice27.onMethodEnter");
       if (record == null || record.partition() == -1 || record.offset() == -1) {
         // partition|offset == -1 -> punctuation call.
         return;


### PR DESCRIPTION
# What Does This Do
This draft PR demonstrates differences in behavior between kafka streams 2.7 and 3.2 instrumentation. It adds 4 log messages in both `kafka_clients` instrumentation and `kafka_streams` instrumentation. It creates a new test under `kafka32Test` directory which is a copy of `latestDepTest`, but uses version `3.2.0` for Kafka (along with upgrading to `spring-kafka 2.8` which uses the `3.X.0 kafka-clients` versions).

The `latestDepTest` passes but `kafka32Test` fails. The ordering of the added logs messages are as follows:

Kafka32Test:
<img width="1323" alt="Screen Shot 2022-08-01 at 2 57 06 PM" src="https://user-images.githubusercontent.com/49738731/182223267-7f6cf680-9339-42e6-ab9b-e282a787c7a3.png">

latestDepTest:
<img width="1296" alt="Screen Shot 2022-08-01 at 2 57 15 PM" src="https://user-images.githubusercontent.com/49738731/182223322-c4a6429f-e88b-4605-8f72-3075ed19f7ad.png">

As we can see, `Kafka32Test` has an additional call to `TracingIterator.startNewRecordSpan` before `UnwrapIterableAdvice.onMethodEnter` and `StartSpanAdvice27.onMethodEnter`. This means that when using Kafka streams `3.2` to consume a message, both `kafka-clients` instrumentation and `kafka-streams` instrumentation are running. Whereas when using Kafka streams `2.7`, only `kafka-stream` instrumentation runs.

The new test currently fails, because there are 4 traces found instead of 3, presumably with the additional trace coming from the `kafka-clients` instrumentation.
<img width="1253" alt="Screen Shot 2022-08-01 at 3 04 26 PM" src="https://user-images.githubusercontent.com/49738731/182225651-b3bf7a26-4ae9-44bf-a01f-dd7e64cd7ab7.png">

# Motivation

# Additional Notes
