### PR TITLE
Move jctools-core to shared dependency

### DIFF
--- a/dd-java-agent/agent-profiling/agent-profiling.gradle
+++ b/dd-java-agent/agent-profiling/agent-profiling.gradle
@@ -36,18 +36,6 @@ configurations {
 
 shadowJar {
   dependencies deps.excludeShared
-  exclude {
-    if (it.path.startsWith('org/jctools/')) {
-      def ret = true
-      if (it.path.equals('org/jctools/util') || it.path.equals('org/jctools/maps')) {
-        ret = false
-      } else {
-        ret = !(it.path.contains('/util') || it.path.contains('AbstractEntry') || it.path.contains('ConcurrentAutoTable') || it.path.contains('NonBlockingHashMap'))
-      }
-      return ret
-    }
-    return false
-  }
 }
 
 jar {

--- a/dd-java-agent/agent-profiling/profiling-context/profiling-context.gradle
+++ b/dd-java-agent/agent-profiling/profiling-context/profiling-context.gradle
@@ -27,7 +27,7 @@ dependencies {
   implementation deps.slf4j
   main_java11CompileOnly deps.slf4j
   implementation sourceSets.main_java11.output
-  implementation group: 'org.jctools', name: 'jctools-core', version: '3.3.0'
+  implementation deps.jctools
 
   testImplementation deps.junit5
   testImplementation deps.mockito

--- a/dd-trace-core/dd-trace-core.gradle
+++ b/dd-trace-core/dd-trace-core.gradle
@@ -49,8 +49,8 @@ dependencies {
 
   implementation deps.slf4j
   implementation deps.moshi
+  implementation deps.jctools
 
-  implementation group: 'org.jctools', name: 'jctools-core', version: '3.3.0'
   implementation group: 'com.datadoghq', name: 'sketches-java', version: '0.8.2'
 
   implementation group: 'com.google.re2j', name: 're2j', version: '1.7'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -27,6 +27,7 @@ final class CachedData {
     commons       : "3.2",
     mockito       : '4.4.0',
     moshi         : '1.9.2',
+    jctools       : '3.3.0',
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
@@ -39,6 +40,7 @@ final class CachedData {
     slf4j                : "org.slf4j:slf4j-api:${versions.slf4j}",
     guava                : "com.google.guava:guava:$versions.guava",
     moshi                : "com.squareup.moshi:moshi:${versions.moshi}",
+    jctools              : "org.jctools:jctools-core:${versions.jctools}",
     okhttp               : "com.squareup.okhttp3:okhttp:${versions.okhttp}",
     okio                 : "com.squareup.okio:okio:${versions.okio}",
     bytebuddy            : "net.bytebuddy:byte-buddy:${versions.bytebuddy}",
@@ -98,6 +100,7 @@ final class CachedData {
       "com.datadoghq:java-dogstatsd-client:${versions.dogstatsd}",
       "com.github.jnr:jnr-unixsocket:${versions.jnr_unixsocket}",
       "com.squareup.moshi:moshi:${versions.moshi}",
+      "org.jctools:jctools-core:${versions.jctools}",
     ],
 
     // Inverse of "shared".  These exclude directives are part of shadowJar's DSL
@@ -130,6 +133,9 @@ final class CachedData {
 
       // moshi and its transitives
       exclude(dependency('com.squareup.moshi::'))
+
+      // jctools and its transitives
+      exclude(dependency('org.jctools::'))
     }
   ]
 }


### PR DESCRIPTION
This library is currently used by both the tracer and profiling which results in some duplication that this PR removes