### PR TITLE
[IAST] Add overhead controller to add caps on analyzed requests and reported vulnerabilities

### DIFF
--- a/dd-java-agent/iast/iast.gradle
+++ b/dd-java-agent/iast/iast.gradle
@@ -1,5 +1,6 @@
 plugins {
   id "com.github.johnrengelman.shadow"
+  id 'me.champeau.jmh'
 }
 
 apply from: "$rootDir/gradle/java.gradle"
@@ -52,4 +53,9 @@ spotless {
   java {
     target 'src/**/*.java'
   }
+}
+
+jmh {
+  jmhVersion = '1.28'
+  duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/dd-java-agent/iast/src/jmh/java/com/datadog/iast/overhead/OverheadControllerBenchmark.java
+++ b/dd-java-agent/iast/src/jmh/java/com/datadog/iast/overhead/OverheadControllerBenchmark.java
@@ -1,0 +1,46 @@
+package com.datadog.iast.overhead;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import datadog.trace.api.Config;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Warmup(iterations = 1, time = 1000, timeUnit = MILLISECONDS)
+@Measurement(iterations = 5, time = 1000, timeUnit = MILLISECONDS)
+@OutputTimeUnit(MILLISECONDS)
+@BenchmarkMode(Mode.Throughput)
+@State(Scope.Benchmark)
+public class OverheadControllerBenchmark {
+
+  private OverheadController overheadController;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    System.setProperty("dd.iast.request-sampling", "100");
+    System.setProperty("dd.iast.max-context-operations", "100000");
+    overheadController = new OverheadController(Config.get(), null);
+  }
+
+  @Benchmark
+  public void acquireReleaseRequestNoSampling() {
+    if (overheadController.acquireRequest()) {
+      overheadController.releaseRequest();
+    } else {
+      throw new IllegalStateException();
+    }
+  }
+
+  @Benchmark
+  public void consumeQuota() {
+    overheadController.consumeQuota(Operations.REPORT_VULNERABILITY, null);
+  }
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/IastRequestContext.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/IastRequestContext.java
@@ -1,6 +1,7 @@
 package com.datadog.iast;
 
 import com.datadog.iast.model.VulnerabilityBatch;
+import com.datadog.iast.overhead.OverheadContext;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class IastRequestContext {
@@ -9,9 +10,12 @@ public class IastRequestContext {
 
   private final AtomicBoolean spanDataIsSet;
 
+  private final OverheadContext overheadContext;
+
   public IastRequestContext() {
     this.vulnerabilityBatch = new VulnerabilityBatch();
     this.spanDataIsSet = new AtomicBoolean(false);
+    this.overheadContext = new OverheadContext();
   }
 
   public VulnerabilityBatch getVulnerabilityBatch() {
@@ -20,5 +24,9 @@ public class IastRequestContext {
 
   public boolean getAndSetSpanDataIsSet() {
     return spanDataIsSet.getAndSet(true);
+  }
+
+  public OverheadContext getOverheadContext() {
+    return overheadContext;
   }
 }

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/IastSystem.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/IastSystem.java
@@ -1,7 +1,8 @@
 package com.datadog.iast;
 
+import com.datadog.iast.overhead.OverheadController;
 import datadog.trace.api.Config;
-import datadog.trace.api.TraceSegment;
+import datadog.trace.api.function.BiFunction;
 import datadog.trace.api.function.Supplier;
 import datadog.trace.api.gateway.EventType;
 import datadog.trace.api.gateway.Events;
@@ -11,6 +12,7 @@ import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.SubscriptionService;
 import datadog.trace.api.iast.IastModule;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.util.AgentTaskScheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,27 +29,24 @@ public class IastSystem {
     log.debug("IAST is starting");
 
     final Reporter reporter = new Reporter();
-    final IastModule iastModule = new IastModuleImpl(config, reporter);
+    final OverheadController overheadController =
+        new OverheadController(config, AgentTaskScheduler.INSTANCE);
+    final IastModule iastModule = new IastModuleImpl(config, reporter, overheadController);
     InstrumentationBridge.registerIastModule(iastModule);
-    registerRequestStartedCallback(ss);
-    registerRequestEndedCallback(ss);
+    registerRequestStartedCallback(ss, overheadController);
+    registerRequestEndedCallback(ss, overheadController);
   }
 
-  private static void registerRequestStartedCallback(final SubscriptionService ss) {
+  private static void registerRequestStartedCallback(
+      final SubscriptionService ss, final OverheadController overheadController) {
     final EventType<Supplier<Flow<Object>>> event = Events.get().requestStarted();
-    ss.registerCallback(event, () -> new Flow.ResultFlow<>(new IastRequestContext()));
+    ss.registerCallback(event, new RequestStartedHandler(overheadController));
   }
 
-  private static void registerRequestEndedCallback(final SubscriptionService ss) {
-    ss.registerCallback(
-        Events.get().requestEnded(),
-        (RequestContext ctx_, IGSpanInfo spanInfo) -> {
-          TraceSegment traceSeg = ctx_.getTraceSegment();
-
-          if (traceSeg != null) {
-            traceSeg.setTagTop("_dd.iast.enabled", 1);
-          }
-          return Flow.ResultFlow.empty();
-        });
+  private static void registerRequestEndedCallback(
+      final SubscriptionService ss, final OverheadController overheadController) {
+    final EventType<BiFunction<RequestContext, IGSpanInfo, Flow<Void>>> event =
+        Events.get().requestEnded();
+    ss.registerCallback(event, new RequestEndedHandler(overheadController));
   }
 }

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/RequestEndedHandler.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/RequestEndedHandler.java
@@ -1,0 +1,30 @@
+package com.datadog.iast;
+
+import com.datadog.iast.overhead.OverheadController;
+import datadog.trace.api.TraceSegment;
+import datadog.trace.api.function.BiFunction;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.IGSpanInfo;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+
+public class RequestEndedHandler implements BiFunction<RequestContext, IGSpanInfo, Flow<Void>> {
+
+  private final OverheadController overheadController;
+
+  public RequestEndedHandler(final OverheadController overheadController) {
+    this.overheadController = overheadController;
+  }
+
+  @Override
+  public Flow<Void> apply(final RequestContext requestContext, final IGSpanInfo igSpanInfo) {
+    if (requestContext != null && requestContext.getData(RequestContextSlot.IAST) != null) {
+      final TraceSegment traceSeg = requestContext.getTraceSegment();
+      if (traceSeg != null) {
+        traceSeg.setTagTop("_dd.iast.enabled", 1);
+      }
+      overheadController.releaseRequest();
+    }
+    return Flow.ResultFlow.empty();
+  }
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/RequestStartedHandler.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/RequestStartedHandler.java
@@ -1,0 +1,22 @@
+package com.datadog.iast;
+
+import com.datadog.iast.overhead.OverheadController;
+import datadog.trace.api.function.Supplier;
+import datadog.trace.api.gateway.Flow;
+
+public class RequestStartedHandler implements Supplier<Flow<Object>> {
+
+  private final OverheadController overheadController;
+
+  public RequestStartedHandler(final OverheadController overheadController) {
+    this.overheadController = overheadController;
+  }
+
+  @Override
+  public Flow<Object> get() {
+    if (!overheadController.acquireRequest()) {
+      return Flow.ResultFlow.empty();
+    }
+    return new Flow.ResultFlow<>(new IastRequestContext());
+  }
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/overhead/Operation.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/overhead/Operation.java
@@ -1,0 +1,7 @@
+package com.datadog.iast.overhead;
+
+public interface Operation {
+  boolean hasQuota(final OverheadContext context);
+
+  boolean consumeQuota(final OverheadContext context);
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/overhead/Operations.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/overhead/Operations.java
@@ -1,0 +1,25 @@
+package com.datadog.iast.overhead;
+
+public class Operations {
+
+  private Operations() {}
+
+  public static final Operation REPORT_VULNERABILITY =
+      new Operation() {
+        @Override
+        public boolean hasQuota(OverheadContext context) {
+          if (context == null) {
+            return false;
+          }
+          return context.getAvailableQuota() > 0;
+        }
+
+        @Override
+        public boolean consumeQuota(OverheadContext context) {
+          if (context == null) {
+            return false;
+          }
+          return context.consumeQuota(1);
+        }
+      };
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/overhead/Operations.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/overhead/Operations.java
@@ -7,7 +7,7 @@ public class Operations {
   public static final Operation REPORT_VULNERABILITY =
       new Operation() {
         @Override
-        public boolean hasQuota(OverheadContext context) {
+        public boolean hasQuota(final OverheadContext context) {
           if (context == null) {
             return false;
           }
@@ -15,7 +15,7 @@ public class Operations {
         }
 
         @Override
-        public boolean consumeQuota(OverheadContext context) {
+        public boolean consumeQuota(final OverheadContext context) {
           if (context == null) {
             return false;
           }

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/overhead/OverheadContext.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/overhead/OverheadContext.java
@@ -1,0 +1,28 @@
+package com.datadog.iast.overhead;
+
+import datadog.trace.api.Config;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class OverheadContext {
+
+  private static final int MAX_OPERATIONS = Config.get().getIastMaxContextOperations();
+
+  private final AtomicInteger availableOperations = new AtomicInteger(MAX_OPERATIONS);
+
+  public int getAvailableQuota() {
+    return availableOperations.get();
+  }
+
+  public boolean consumeQuota(final int delta) {
+    final int availableAfter = availableOperations.addAndGet(-delta);
+    if (availableAfter < 0) {
+      availableOperations.addAndGet(delta);
+      return false;
+    }
+    return true;
+  }
+
+  public void reset() {
+    availableOperations.set(MAX_OPERATIONS);
+  }
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/overhead/OverheadContext.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/overhead/OverheadContext.java
@@ -14,12 +14,9 @@ public class OverheadContext {
   }
 
   public boolean consumeQuota(final int delta) {
-    final int availableAfter = availableOperations.addAndGet(-delta);
-    if (availableAfter < 0) {
-      availableOperations.addAndGet(delta);
-      return false;
-    }
-    return true;
+    final int beforeUpdate =
+        availableOperations.getAndAccumulate(delta, (v, d) -> (v < d) ? v : v - d);
+    return beforeUpdate >= delta;
   }
 
   public void reset() {

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/overhead/OverheadContext.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/overhead/OverheadContext.java
@@ -5,21 +5,23 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class OverheadContext {
 
-  private static final int MAX_OPERATIONS = Config.get().getIastMaxContextOperations();
+  private static final int VULNERABILITIES_PER_REQUEST =
+      Config.get().getIastVulnerabilitiesPerRequest();
 
-  private final AtomicInteger availableOperations = new AtomicInteger(MAX_OPERATIONS);
+  private final AtomicInteger availableVulnerabilities =
+      new AtomicInteger(VULNERABILITIES_PER_REQUEST);
 
   public int getAvailableQuota() {
-    return availableOperations.get();
+    return availableVulnerabilities.get();
   }
 
   public boolean consumeQuota(final int delta) {
     final int beforeUpdate =
-        availableOperations.getAndAccumulate(delta, (v, d) -> (v < d) ? v : v - d);
+        availableVulnerabilities.getAndAccumulate(delta, (v, d) -> (v < d) ? v : v - d);
     return beforeUpdate >= delta;
   }
 
   public void reset() {
-    availableOperations.set(MAX_OPERATIONS);
+    availableVulnerabilities.set(VULNERABILITIES_PER_REQUEST);
   }
 }

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/overhead/OverheadController.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/overhead/OverheadController.java
@@ -1,0 +1,96 @@
+package com.datadog.iast.overhead;
+
+import com.datadog.iast.IastRequestContext;
+import datadog.trace.api.Config;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.util.AgentTaskScheduler;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class OverheadController {
+
+  private final int maxConcurrentRequests;
+  private final int sampling;
+
+  final AtomicInteger availableRequests;
+
+  final AtomicInteger executedRequests = new AtomicInteger(0);
+
+  final OverheadContext globalContext = new OverheadContext();
+
+  public OverheadController(final Config config, final AgentTaskScheduler taskScheduler) {
+    maxConcurrentRequests = config.getIastMaxConcurrentRequests();
+    sampling = computeSamplingParameter(config.getIastRequestSampling());
+    availableRequests = new AtomicInteger(maxConcurrentRequests);
+    if (taskScheduler != null) {
+      taskScheduler.scheduleAtFixedRate(this::reset, 60, 60, TimeUnit.SECONDS);
+    }
+  }
+
+  public boolean acquireRequest() {
+    if (executedRequests.incrementAndGet() % sampling != 0) {
+      // Skipped by sampling
+      return false;
+    }
+    if (availableRequests.get() <= 0) {
+      return false;
+    }
+    final int availableAfterAcquire = availableRequests.decrementAndGet();
+    if (availableAfterAcquire < 0) {
+      availableRequests.incrementAndGet();
+      return false;
+    }
+    return true;
+  }
+
+  public void releaseRequest() {
+    final int availableAfterRelease = availableRequests.incrementAndGet();
+    if (availableAfterRelease > maxConcurrentRequests) {
+      // This means that:
+      // - An acquire was buggy, or
+      // - we received the same release event twice, or
+      // - more likely, that the periodic counter reset (see ResetTask) has kicked in.
+      availableRequests.decrementAndGet();
+    }
+  }
+
+  public boolean hasQuota(final Operation operation, final AgentSpan span) {
+    return operation.hasQuota(getContext(span));
+  }
+
+  public boolean consumeQuota(final Operation operation, final AgentSpan span) {
+    return operation.consumeQuota(getContext(span));
+  }
+
+  public OverheadContext getContext(AgentSpan span) {
+    final RequestContext requestContext = span != null ? span.getRequestContext() : null;
+    if (requestContext != null) {
+      IastRequestContext iastRequestContext = requestContext.getData(RequestContextSlot.IAST);
+      return iastRequestContext != null ? iastRequestContext.getOverheadContext() : null;
+    }
+    return globalContext;
+  }
+
+  static int computeSamplingParameter(final float pct) {
+    if (pct >= 100) {
+      return 1;
+    }
+    if (pct <= 0) {
+      // We don't support disabling IAST by setting it, so we set it to 100%.
+      // TODO: We probably want a warning here.
+      return 1;
+    }
+    return Math.round(100 / pct);
+  }
+
+  public void reset() {
+    globalContext.reset();
+    // Periodic reset of maximum concurrent requests. This guards us against exhausting concurrent
+    // requests if some bug led us to lose a request end event. This will lead to periodically
+    // going above the max concurrent requests. But overall, it should be self-stabilizing. So for
+    // practical purposes, the max concurrent requests is a hint.
+    availableRequests.set(maxConcurrentRequests);
+  }
+}

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/IastModuleImplCipherTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/IastModuleImplCipherTest.groovy
@@ -17,6 +17,7 @@ class IastModuleImplCipherTest extends IastModuleImplTestBase {
 
     then:
     1 * tracer.activeSpan()
+    1 * overheadController.consumeQuota(_, _) >> true
     1 * reporter.report(_, _) >> { args ->
       Vulnerability vuln = args[1] as Vulnerability
       assert vuln != null

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/IastModuleImplHashTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/IastModuleImplHashTest.groovy
@@ -17,6 +17,7 @@ class IastModuleImplHashTest extends IastModuleImplTestBase {
 
     then:
     1 * tracer.activeSpan()
+    1 * overheadController.consumeQuota(_, _) >> true
     1 * reporter.report(_, _) >> { args ->
       Vulnerability vuln = args[1] as Vulnerability
       assert vuln != null

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/IastModuleImplTestBase.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/IastModuleImplTestBase.groovy
@@ -1,6 +1,9 @@
 package com.datadog.iast
 
+import com.datadog.iast.overhead.Operation
+import com.datadog.iast.overhead.OverheadController
 import datadog.trace.api.Config
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.test.util.DDSpecification
 import spock.lang.Shared
@@ -12,12 +15,16 @@ class IastModuleImplTestBase extends DDSpecification {
 
   protected Reporter reporter = Mock(Reporter)
 
-  protected IastModuleImpl module = new IastModuleImpl(Config.get(), reporter)
+  protected OverheadController overheadController = Mock(OverheadController)
+
+  protected IastModuleImpl module = new IastModuleImpl(Config.get(), reporter, overheadController)
 
   protected AgentTracer.TracerAPI tracer = Mock(AgentTracer.TracerAPI)
 
   def setup() {
     AgentTracer.forceRegister(tracer)
+    overheadController.acquireRequest() >> true
+    overheadController.consumeQuota(_ as Operation, _ as AgentSpan) >> true
   }
 
   def cleanup() {

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/RequestEndedHandlerTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/RequestEndedHandlerTest.groovy
@@ -1,0 +1,57 @@
+package com.datadog.iast
+
+
+import com.datadog.iast.overhead.OverheadController
+import datadog.trace.api.TraceSegment
+import datadog.trace.api.gateway.Flow
+import datadog.trace.api.gateway.IGSpanInfo
+import datadog.trace.api.gateway.RequestContext
+import datadog.trace.api.gateway.RequestContextSlot
+import datadog.trace.test.util.DDSpecification
+
+class RequestEndedHandlerTest extends DDSpecification {
+
+  void 'request ends with IAST context'() {
+    given:
+    final OverheadController overheadController = Mock(OverheadController)
+    final handler = new RequestEndedHandler(overheadController)
+    final iastCtx = Mock(IastRequestContext)
+    final TraceSegment traceSegment = Mock(TraceSegment)
+    final reqCtx = Mock(RequestContext)
+    reqCtx.getTraceSegment() >> traceSegment
+    reqCtx.getData(RequestContextSlot.IAST) >> iastCtx
+    final spanInfo = Mock(IGSpanInfo)
+
+    when:
+    def flow = handler.apply(reqCtx, spanInfo)
+
+    then:
+    flow.getAction() == Flow.Action.Noop.INSTANCE
+    flow.getResult() == null
+    1 * reqCtx.getData(RequestContextSlot.IAST) >> iastCtx
+    1 * reqCtx.getTraceSegment() >> traceSegment
+    1 * traceSegment.setTagTop("_dd.iast.enabled", 1)
+    1 * overheadController.releaseRequest()
+    0 * _
+  }
+
+  void 'request ends without IAST context'() {
+    given:
+    final OverheadController overheadController = Mock(OverheadController)
+    final handler = new RequestEndedHandler(overheadController)
+    final TraceSegment traceSegment = Mock(TraceSegment)
+    final reqCtx = Mock(RequestContext)
+    reqCtx.getTraceSegment() >> traceSegment
+    final spanInfo = Mock(IGSpanInfo)
+
+    when:
+    def flow = handler.apply(reqCtx, spanInfo)
+
+    then:
+    flow.getAction() == Flow.Action.Noop.INSTANCE
+    flow.getResult() == null
+    1 * reqCtx.getData(RequestContextSlot.IAST) >> null
+    0 * overheadController.releaseRequest()
+    0 * _
+  }
+}

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/RequestStartedHandlerTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/RequestStartedHandlerTest.groovy
@@ -1,0 +1,40 @@
+package com.datadog.iast
+
+import com.datadog.iast.overhead.OverheadController
+import datadog.trace.api.gateway.Flow
+import datadog.trace.test.util.DDSpecification
+
+class RequestStartedHandlerTest extends DDSpecification {
+
+  void 'request starts successfully'() {
+    given:
+    final OverheadController overheadController = Mock(OverheadController)
+    overheadController.acquireRequest() >> true
+    def handler = new RequestStartedHandler(overheadController)
+
+    when:
+    def flow = handler.get()
+
+    then:
+    flow.getAction() == Flow.Action.Noop.INSTANCE
+    flow.getResult() instanceof IastRequestContext
+    1 * overheadController.acquireRequest() >> true
+    0 * _
+  }
+
+  void 'request start cannot acquire'() {
+    given:
+    final OverheadController overheadController = Mock(OverheadController)
+    overheadController.acquireRequest() >> false
+    def handler = new RequestStartedHandler(overheadController)
+
+    when:
+    def flow = handler.get()
+
+    then:
+    flow.getAction() == Flow.Action.Noop.INSTANCE
+    flow.getResult() == null
+    1 * overheadController.acquireRequest() >> false
+    0 * _
+  }
+}

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/overhead/OverheadContextTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/overhead/OverheadContextTest.groovy
@@ -1,0 +1,46 @@
+package com.datadog.iast.overhead
+
+import datadog.trace.api.Config
+import datadog.trace.test.util.DDSpecification
+import datadog.trace.util.AgentTaskScheduler
+
+class OverheadContextTest extends DDSpecification {
+
+  void 'Can reset global overhead context'() {
+    given:
+    def taskSchedler = Stub(AgentTaskScheduler)
+    def overheadController = new OverheadController(Config.get(), taskSchedler)
+
+    when:
+    overheadController.globalContext.consumeQuota(1)
+
+    then:
+    overheadController.globalContext.getAvailableQuota() == 1
+
+    when:
+    overheadController.globalContext.reset()
+
+    then:
+    overheadController.globalContext.getAvailableQuota() == 2
+  }
+
+  void 'Quota is not consumed once it has been exhausted'() {
+    given:
+    def overheadContext = new OverheadContext()
+    boolean consumed = false
+
+    when: 'reduce quota by two'
+    consumed = overheadContext.consumeQuota(2)
+
+    then: 'available quota is zero'
+    consumed
+    overheadContext.getAvailableQuota() == 0
+
+    when: 'reduce quota again'
+    consumed = overheadContext.consumeQuota(1)
+
+    then: 'available quota still zero'
+    !consumed
+    overheadContext.getAvailableQuota() == 0
+  }
+}

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/overhead/OverheadControllerTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/overhead/OverheadControllerTest.groovy
@@ -1,0 +1,287 @@
+package com.datadog.iast.overhead
+
+import com.datadog.iast.IastRequestContext
+import datadog.trace.api.Config
+import datadog.trace.api.gateway.RequestContext
+import datadog.trace.api.gateway.RequestContextSlot
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import datadog.trace.test.util.DDSpecification
+import datadog.trace.util.AgentTaskScheduler
+import spock.lang.Shared
+
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.Semaphore
+
+class OverheadControllerTest extends DDSpecification {
+
+  @Shared
+  static final float DEFAULT_REQUEST_SAMPLING = Config.get().getIastRequestSampling()
+
+  def 'Request sampling'() {
+    given: 'Set the request sampling percentage'
+    def config = Spy(Config.get())
+    config.getIastRequestSampling() >> samplingPct
+    def taskSchedler = Stub(AgentTaskScheduler)
+    def overheadController = new OverheadController(config, taskSchedler)
+
+    when:
+    int sampledRequests = 0
+    for (int i = 0; i < requests; i++) {
+      if (overheadController.acquireRequest()) {
+        sampledRequests += 1
+        overheadController.releaseRequest()
+      }
+    }
+
+    then:
+    sampledRequests == expectedSampledRequests
+
+    where:
+    samplingPct              | requests | expectedSampledRequests
+    DEFAULT_REQUEST_SAMPLING | 100      | 33
+    30                       | 100      | 33
+    30                       | 10       | 3
+    30                       | 9        | 3
+    50                       | 100      | 50
+    50                       | 10       | 5
+    100                      | 1        | 1
+    100                      | 100      | 100
+    200                      | 100      | 100
+    1000                     | 100      | 100
+    0                        | 100      | 100
+  }
+
+  void 'No more than two request can be acquired concurrently'() {
+    given: 'Set sampling to 100%'
+    def config = Spy(Config.get())
+    config.getIastRequestSampling() >> 100
+    def taskSchedler = Stub(AgentTaskScheduler)
+    def overheadController = new OverheadController(config, taskSchedler)
+
+    when: 'Acquire max concurrent requests'
+    def maxRequests = overheadController.maxConcurrentRequests
+    assert maxRequests > 0
+    def acquired = (1..maxRequests).collect({ overheadController.acquireRequest() })
+
+    then: 'All of them are acquired'
+    acquired.every { it }
+
+    when: 'Requests arrive over concurrency limit'
+    def extraAcquired = (1..maxRequests).collect({ overheadController.acquireRequest() })
+
+    then: 'None of them is acquired'
+    extraAcquired.every { !it }
+  }
+
+  void 'getContext defaults to global context if span is null'() {
+    given:
+    def taskSchedler = Stub(AgentTaskScheduler)
+    def overheadController = new OverheadController(Config.get(), taskSchedler)
+
+    when:
+    def context = overheadController.getContext(null)
+
+    then:
+    context == overheadController.globalContext
+  }
+
+  void 'getContext defaults to request context if span is null'() {
+    given:
+    def taskSchedler = Stub(AgentTaskScheduler)
+    def overheadController = new OverheadController(Config.get(), taskSchedler)
+    def span = Stub(AgentSpan)
+    span.getRequestContext() >> null
+
+    when:
+    def context = overheadController.getContext(span)
+
+    then:
+    context == overheadController.globalContext
+  }
+
+  void 'getContext returns null if there is no IAST request context'() {
+    given:
+    def taskSchedler = Stub(AgentTaskScheduler)
+    def overheadController = new OverheadController(Config.get(), taskSchedler)
+    def span = getAgentSpanWithNoIASTRequest()
+
+    when:
+    def context = overheadController.getContext(span)
+
+    then:
+    context == null
+  }
+
+  void 'getContext returns specific OverheadContext for IAST request context'() {
+    given:
+    def taskSchedler = Stub(AgentTaskScheduler)
+    def overheadController = new OverheadController(Config.get(), taskSchedler)
+    def overheadContext = Mock(OverheadContext)
+    def iastRequestContext = Stub(IastRequestContext)
+    iastRequestContext.getOverheadContext() >> overheadContext
+    def requestContext = Stub(RequestContext)
+    requestContext.getData(RequestContextSlot.IAST) >> iastRequestContext
+    def span = Stub(AgentSpan)
+    span.getRequestContext() >> requestContext
+
+    when:
+    def context = overheadController.getContext(span)
+
+    then:
+    context == overheadContext
+  }
+
+  void 'If no context available operations has not quota'() {
+    given:
+    def taskSchedler = Stub(AgentTaskScheduler)
+    def overheadController = new OverheadController(Config.get(), taskSchedler)
+    def span = getAgentSpanWithNoIASTRequest()
+
+    when:
+    def hasQuota = overheadController.hasQuota(Operations.REPORT_VULNERABILITY, span)
+
+    then:
+    !hasQuota
+  }
+
+  void 'Only two REPORT_VULNERABILITY operations can be consumed in a OverheadContext instance'() {
+    given:
+    def taskSchedler = Stub(AgentTaskScheduler)
+    def overheadController = new OverheadController(Config.get(), taskSchedler)
+    def span = getAgentSpanWithOverheadContext()
+
+    when:
+    def hasQuota1 = overheadController.hasQuota(Operations.REPORT_VULNERABILITY, span)
+
+    then:
+    hasQuota1
+
+    when:
+    def consumedQuota1 = overheadController.consumeQuota(Operations.REPORT_VULNERABILITY, span)
+    def consumedQuota2 = overheadController.consumeQuota(Operations.REPORT_VULNERABILITY, span)
+    def consumedQuota3 = overheadController.consumeQuota(Operations.REPORT_VULNERABILITY, span)
+
+    then:
+    consumedQuota1
+    consumedQuota2
+    !consumedQuota3
+
+    when:
+    def hasQuota2 = overheadController.hasQuota(Operations.REPORT_VULNERABILITY, span)
+
+    then:
+    !hasQuota2
+  }
+
+  def 'Available requests always ends up at max'() {
+    setup:
+    def taskSchedler = Stub(AgentTaskScheduler)
+    def overheadController = new OverheadController(Config.get(), taskSchedler)
+
+    def nThreads = 32
+    def nIters = 50000
+    def executorService = Executors.newFixedThreadPool(nThreads)
+    def startLatch = new CountDownLatch(nThreads)
+    def sem = new Semaphore(Config.get().getIastMaxConcurrentRequests())
+
+    when:
+    List<Future<Boolean[]>> futures = (0..nThreads).collect { thread ->
+      executorService.submit({
+        ->
+        startLatch.countDown()
+        startLatch.await()
+        final results = new Boolean[nIters]
+        for (int j = 0; j < nIters; j++) {
+          if (overheadController.acquireRequest()) {
+            results[j] = true
+            if (!sem.tryAcquire()) {
+              throw new RuntimeException("Could not acquire semaphore")
+            }
+            sem.release()
+            overheadController.releaseRequest()
+          } else {
+            results[j] = false
+          }
+        }
+        return results
+      } as Callable<Boolean[]>)
+    }
+    def results = futures.collect({
+      it.get()
+    })
+
+    then:
+    // At least one request ran.
+    results.flatten().any { it }
+    // At least one request did not run.
+    results.flatten().any { !it }
+    // In the final state, there is no consumed available request.
+    overheadController.availableRequests.get() == Config.get().getIastMaxConcurrentRequests()
+
+    cleanup:
+    executorService?.shutdown()
+  }
+
+  def 'acquireRequest works for max concurrent request per reset'() {
+    setup:
+    def taskSchedler = Stub(AgentTaskScheduler)
+    injectSysConfig("dd.iast.request-sampling", "100")
+    rebuildConfig()
+    def overheadController = new OverheadController(Config.get(), taskSchedler)
+
+    when:
+    def acquired1 = overheadController.acquireRequest()
+    def acquired2 = overheadController.acquireRequest()
+    def acquired3 = overheadController.acquireRequest()
+
+    then:
+    acquired1
+    acquired2
+    !acquired3
+
+    when:
+    overheadController.reset()
+    acquired1 = overheadController.acquireRequest()
+    acquired2 = overheadController.acquireRequest()
+    acquired3 = overheadController.acquireRequest()
+
+    then:
+    acquired1
+    acquired2
+    !acquired3
+
+    when:
+    overheadController.releaseRequest()
+    overheadController.releaseRequest()
+    acquired1 = overheadController.acquireRequest()
+    acquired2 = overheadController.acquireRequest()
+    acquired3 = overheadController.acquireRequest()
+
+    then:
+    acquired1
+    acquired2
+    !acquired3
+  }
+
+  private AgentSpan getAgentSpanWithOverheadContext() {
+    def iastRequestContext = Stub(IastRequestContext)
+    iastRequestContext.getOverheadContext() >> new OverheadContext()
+    def requestContext = Stub(RequestContext)
+    requestContext.getData(RequestContextSlot.IAST) >> iastRequestContext
+    def span = Stub(AgentSpan)
+    span.getRequestContext() >> requestContext
+
+    return span
+  }
+
+  private AgentSpan getAgentSpanWithNoIASTRequest() {
+    def requestContext = Stub(RequestContext)
+    requestContext.getData(RequestContextSlot.IAST) >> null
+    def span = Stub(AgentSpan)
+    span.getRequestContext() >> requestContext
+    return span
+  }
+}

--- a/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
@@ -16,7 +16,7 @@ class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
     List<String> command = new ArrayList<>()
     command.add(javaPath())
     command.addAll(defaultJavaProperties)
-    command.addAll(["-Ddd.appsec.enabled=true", "-Ddd.iast.enabled=true"])
+    command.addAll(["-Ddd.appsec.enabled=true", "-Ddd.iast.enabled=true", "-Ddd.iast-request-sampling=100"])
     command.addAll((String[]) ["-jar", springBootShadowJar, "--server.port=${httpPort}"])
     ProcessBuilder processBuilder = new ProcessBuilder(command)
     processBuilder.directory(new File(buildDirectory))

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -80,7 +80,7 @@ public final class ConfigDefaults {
 
   static final boolean DEFAULT_IAST_ENABLED = false;
   public static final int DEFAULT_IAST_MAX_CONCURRENT_REQUESTS = 2;
-  public static final int DEFAULT_IAST_MAX_CONTEXT_OPERATIONS = 2;
+  public static final int DEFAULT_IAST_VULNERABILITIES_PER_REQUEST = 2;
   public static final int DEFAULT_IAST_REQUEST_SAMPLING = 30;
   static final Set<String> DEFAULT_IAST_WEAK_HASH_ALGORITHMS =
       new HashSet<>(Arrays.asList("MD2", "MD5", "RIPEMD128", "MD4"));

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -79,6 +79,9 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_APPSEC_WAF_METRICS = true;
 
   static final boolean DEFAULT_IAST_ENABLED = false;
+  public static final int DEFAULT_IAST_MAX_CONCURRENT_REQUESTS = 2;
+  public static final int DEFAULT_IAST_MAX_CONTEXT_OPERATIONS = 2;
+  public static final int DEFAULT_IAST_REQUEST_SAMPLING = 30;
   static final Set<String> DEFAULT_IAST_WEAK_HASH_ALGORITHMS =
       new HashSet<>(Arrays.asList("MD2", "MD5", "RIPEMD128", "MD4"));
   static final Set<String> DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS =

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/IastConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/IastConfig.java
@@ -6,6 +6,9 @@ public final class IastConfig {
   public static final String IAST_ENABLED = "iast.enabled";
   public static final String IAST_WEAK_HASH_ALGORITHMS = "iast.weak-hash.algorithms";
   public static final String IAST_WEAK_CIPHER_ALGORITHMS = "iast.weak-cipher.algorithms";
+  public static final String IAST_MAX_CONCURRENT_REQUESTS = "iast.max-concurrent-request";
+  public static final String IAST_MAX_CONTEXT_OPERATIONS = "iast.max-context-operations";
+  public static final String IAST_REQUEST_SAMPLING = "iast.request-sampling";
 
   private IastConfig() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/IastConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/IastConfig.java
@@ -7,7 +7,7 @@ public final class IastConfig {
   public static final String IAST_WEAK_HASH_ALGORITHMS = "iast.weak-hash.algorithms";
   public static final String IAST_WEAK_CIPHER_ALGORITHMS = "iast.weak-cipher.algorithms";
   public static final String IAST_MAX_CONCURRENT_REQUESTS = "iast.max-concurrent-request";
-  public static final String IAST_MAX_CONTEXT_OPERATIONS = "iast.max-context-operations";
+  public static final String IAST_VULNERABILITIES_PER_REQUEST = "iast.vulnerabilities-per-request";
   public static final String IAST_REQUEST_SAMPLING = "iast.request-sampling";
 
   private IastConfig() {}

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -39,8 +39,8 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_ROUTE_BASED_N
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_TAG_QUERY_STRING;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_MAX_CONCURRENT_REQUESTS;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_MAX_CONTEXT_OPERATIONS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_REQUEST_SAMPLING;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_VULNERABILITIES_PER_REQUEST;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_WEAK_HASH_ALGORITHMS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_INTEGRATIONS_ENABLED;
@@ -153,8 +153,8 @@ import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_PENDING;
 import static datadog.trace.api.config.GeneralConfig.VERSION;
 import static datadog.trace.api.config.IastConfig.IAST_ENABLED;
 import static datadog.trace.api.config.IastConfig.IAST_MAX_CONCURRENT_REQUESTS;
-import static datadog.trace.api.config.IastConfig.IAST_MAX_CONTEXT_OPERATIONS;
 import static datadog.trace.api.config.IastConfig.IAST_REQUEST_SAMPLING;
+import static datadog.trace.api.config.IastConfig.IAST_VULNERABILITIES_PER_REQUEST;
 import static datadog.trace.api.config.IastConfig.IAST_WEAK_CIPHER_ALGORITHMS;
 import static datadog.trace.api.config.IastConfig.IAST_WEAK_HASH_ALGORITHMS;
 import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_CHECK_PERIOD;
@@ -526,7 +526,7 @@ public class Config {
 
   private final boolean iastEnabled;
   private final int iastMaxConcurrentRequests;
-  private final int iastMaxContextOperations;
+  private final int iastVulnerabilitiesPerRequest;
   private final float iastRequestSampling;
 
   private final boolean ciVisibilityEnabled;
@@ -1096,8 +1096,9 @@ public class Config {
     iastMaxConcurrentRequests =
         configProvider.getInteger(
             IAST_MAX_CONCURRENT_REQUESTS, DEFAULT_IAST_MAX_CONCURRENT_REQUESTS);
-    iastMaxContextOperations =
-        configProvider.getInteger(IAST_MAX_CONTEXT_OPERATIONS, DEFAULT_IAST_MAX_CONTEXT_OPERATIONS);
+    iastVulnerabilitiesPerRequest =
+        configProvider.getInteger(
+            IAST_VULNERABILITIES_PER_REQUEST, DEFAULT_IAST_VULNERABILITIES_PER_REQUEST);
     iastRequestSampling =
         configProvider.getFloat(IAST_REQUEST_SAMPLING, DEFAULT_IAST_REQUEST_SAMPLING);
     iastWeakHashAlgorithms =
@@ -1787,8 +1788,8 @@ public class Config {
     return iastMaxConcurrentRequests;
   }
 
-  public int getIastMaxContextOperations() {
-    return iastMaxContextOperations;
+  public int getIastVulnerabilitiesPerRequest() {
+    return iastVulnerabilitiesPerRequest;
   }
 
   public float getIastRequestSampling() {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -38,6 +38,9 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_ERROR_STATUSE
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_ROUTE_BASED_NAMING;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_TAG_QUERY_STRING;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_MAX_CONCURRENT_REQUESTS;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_MAX_CONTEXT_OPERATIONS;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_REQUEST_SAMPLING;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_WEAK_HASH_ALGORITHMS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_INTEGRATIONS_ENABLED;
@@ -149,6 +152,9 @@ import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_AGGREGAT
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_PENDING;
 import static datadog.trace.api.config.GeneralConfig.VERSION;
 import static datadog.trace.api.config.IastConfig.IAST_ENABLED;
+import static datadog.trace.api.config.IastConfig.IAST_MAX_CONCURRENT_REQUESTS;
+import static datadog.trace.api.config.IastConfig.IAST_MAX_CONTEXT_OPERATIONS;
+import static datadog.trace.api.config.IastConfig.IAST_REQUEST_SAMPLING;
 import static datadog.trace.api.config.IastConfig.IAST_WEAK_CIPHER_ALGORITHMS;
 import static datadog.trace.api.config.IastConfig.IAST_WEAK_HASH_ALGORITHMS;
 import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_CHECK_PERIOD;
@@ -519,6 +525,9 @@ public class Config {
   private final String appSecObfuscationParameterValueRegexp;
 
   private final boolean iastEnabled;
+  private final int iastMaxConcurrentRequests;
+  private final int iastMaxContextOperations;
+  private final float iastRequestSampling;
 
   private final boolean ciVisibilityEnabled;
   private final boolean ciVisibilityAgentlessEnabled;
@@ -1084,6 +1093,13 @@ public class Config {
         configProvider.getString(APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP, null);
 
     iastEnabled = configProvider.getBoolean(IAST_ENABLED, DEFAULT_IAST_ENABLED);
+    iastMaxConcurrentRequests =
+        configProvider.getInteger(
+            IAST_MAX_CONCURRENT_REQUESTS, DEFAULT_IAST_MAX_CONCURRENT_REQUESTS);
+    iastMaxContextOperations =
+        configProvider.getInteger(IAST_MAX_CONTEXT_OPERATIONS, DEFAULT_IAST_MAX_CONTEXT_OPERATIONS);
+    iastRequestSampling =
+        configProvider.getFloat(IAST_REQUEST_SAMPLING, DEFAULT_IAST_REQUEST_SAMPLING);
     iastWeakHashAlgorithms =
         tryMakeImmutableSet(
             configProvider.getSet(IAST_WEAK_HASH_ALGORITHMS, DEFAULT_IAST_WEAK_HASH_ALGORITHMS));
@@ -1765,6 +1781,18 @@ public class Config {
 
   public boolean isIastEnabled() {
     return iastEnabled;
+  }
+
+  public int getIastMaxConcurrentRequests() {
+    return iastMaxConcurrentRequests;
+  }
+
+  public int getIastMaxContextOperations() {
+    return iastMaxContextOperations;
+  }
+
+  public float getIastRequestSampling() {
+    return iastRequestSampling;
   }
 
   public boolean isCiVisibilityEnabled() {


### PR DESCRIPTION
# What Does This Do

Implement Overhead Control Engine (OCE) for IAST operations. It creates a module that by design ensures the maximum overhead for IAST operations. The OCE will be responsible for assuring performance and short circuiting the logic if it reaches the maximum.

# Motivation

Low overhead is a mandatory requirement for a software that is running in production. The main constraint is that having to introduce many hooks for taint tracking keeping a low overhead is a challenging task.

The OCE is an element that by design ensures that the overhead does not go over a maximum limit. It will measure operations being executed in a request and it will deactivate detection (and therefore reduce the overhead to nearly 0) if a certain threshold is reached.

# Additional Notes

First approach set threshold (configurable) to: 

- Only about 30% of the requests will be analysed
- 2 concurrent request
- 2 vulnerabilities per request
- ~2 vulnerabilities out of request~ (reporting out of request is not supported yet)
 
Future versions will implement a more fine-tuned policy for different operation types. The current PR implements one of the simplest policies.

Depends on https://github.com/DataDog/system-tests/pull/483
