### PR TITLE
Exclude jcommander

### DIFF
--- a/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
+++ b/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
@@ -4,7 +4,7 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 
 dependencies {
-  api('com.datadoghq:jmxfetch:0.47.0-SNAPSHOT') {
+  api('com.datadoghq:jmxfetch:0.47.0') {
     exclude group: 'org.slf4j', module: 'slf4j-api'
     exclude group: 'org.slf4j', module: 'slf4j-jdk14'
     exclude group: 'org.yaml', module: 'snakeyaml'

--- a/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
+++ b/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
@@ -4,10 +4,11 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 
 dependencies {
-  api('com.datadoghq:jmxfetch:0.45.3') {
+  api('com.datadoghq:jmxfetch:0.47.0-SNAPSHOT') {
     exclude group: 'org.slf4j', module: 'slf4j-api'
     exclude group: 'org.slf4j', module: 'slf4j-jdk14'
     exclude group: 'org.yaml', module: 'snakeyaml'
+    exclude group: 'com.beust', module: 'jcommander'
   }
   api deps.slf4j
   api project(':internal-api')


### PR DESCRIPTION
# What Does This Do

Excludes jcommander from our JMXFetch transitives, depends on https://github.com/DataDog/jmxfetch/pull/397

# Motivation

The version of jcommander has a CVE, this also makes our jar smaller

# Additional Notes
