### PR TITLE
Per-span context tracking fixes

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/LEB128Support.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/LEB128Support.java
@@ -16,11 +16,13 @@ final class LEB128Support {
     }
     int pos = 63;
     long mask = 0xFE00000000000000L;
+    long highBitMask = 0x8000000000000000L;
     while ((value & mask) == 0) {
       pos -= 7;
       mask = mask >>> 7;
+      highBitMask = highBitMask >>> 7;
     }
-    return ((pos - 1) / 7) + 1;
+    return Math.min((pos / 7) + (pos % 7 == 0 ? 0 : 1) + (((value & highBitMask) != 0 ? 1 : 0)), 9);
   }
 
   int longSize(long value) {

--- a/dd-java-agent/agent-profiling/profiling-context/src/test/java/com/datadog/profiling/context/IntervalEncoderTest.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/test/java/com/datadog/profiling/context/IntervalEncoderTest.java
@@ -10,12 +10,14 @@ import org.junit.jupiter.api.Test;
 
 class IntervalEncoderTest {
   private Instant now;
+  private long nowNanos;
   private IntervalEncoder instance;
 
   @BeforeEach
   void setup() {
     now = Instant.now();
-    instance = new IntervalEncoder(now.toEpochMilli(), 1000, 2, 32);
+    nowNanos = now.toEpochMilli() * 1_000_000L + now.getNano();
+    instance = new IntervalEncoder(nowNanos, 1000, 2, 32);
   }
 
   @Test
@@ -47,7 +49,7 @@ class IntervalEncoderTest {
     instance.startThread(1);
     assertThrows(IllegalStateException.class, () -> instance.startThread(2));
 
-    IntervalEncoder instance1 = new IntervalEncoder(System.currentTimeMillis(), 1000, 1, 100);
+    IntervalEncoder instance1 = new IntervalEncoder(nowNanos, 1000, 1, 100);
     instance1.startThread(1);
     assertThrows(IllegalStateException.class, () -> instance1.startThread(2));
   }
@@ -63,7 +65,7 @@ class IntervalEncoderTest {
 
     List<IntervalParser.Interval> intervals = new IntervalParser().parseIntervals(data.array());
     IntervalParser.Interval i1 = intervals.get(0);
-    assertEquals(now.toEpochMilli() * 1_000_000L + 200, i1.from);
+    assertEquals(nowNanos + 200, i1.from);
   }
 
   @Test
@@ -77,7 +79,7 @@ class IntervalEncoderTest {
 
     List<IntervalParser.Interval> intervals = new IntervalParser().parseIntervals(data.array());
     IntervalParser.Interval i1 = intervals.get(0);
-    assertEquals(now.toEpochMilli() * 1_000_000L + 200, i1.from);
+    assertEquals(nowNanos + 200, i1.from);
   }
 
   @Test

--- a/dd-java-agent/agent-profiling/profiling-context/src/test/java/com/datadog/profiling/context/LEB128SupportTest.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/test/java/com/datadog/profiling/context/LEB128SupportTest.java
@@ -42,20 +42,26 @@ class LEB128SupportTest {
       size = instance.varintSize(value);
       buffer.rewind();
       instance.putVarint(buffer, value);
-      assertEquals(i, size);
       assertEquals(buffer.position(), size);
+      assertEquals(i, size);
 
       if (i == 9) {
         value = value << 1;
         size = instance.varintSize(value);
         buffer.rewind();
         instance.putVarint(buffer, value);
-        assertEquals(i, size);
         assertEquals(buffer.position(), size);
+        assertEquals(i, size);
       } else {
         value = value << 7;
       }
     }
+
+    value = 8738041250962L;
+    size = instance.varintSize(value);
+    buffer.rewind();
+    instance.putVarint(buffer, value);
+    assertEquals(buffer.position(), size);
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do
- fixes the bug when the size of a varint is calculated incorrectly
- switches to `Instant.now()` 'epoch nanos' to peg the context intervals data instead of `System.currentTimeMillis()` - the clock source used by `Instant.now()` is used by JFR too and it will avoid big drifts between the JFR recordings and the context interval data caused by coarse granularity of `System.currentTimeMillis()`

# Motivation
The time drift between the JFR recordings and the context intervals data can lead to very surprising stacktraces shown in code hotspots.
While working on that change I also identified a bug in the varint size calculation leading to some context intervals not being properly written.

# Additional Notes
