### PR TITLE
Dependencies resolution distributed in time.

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
@@ -19,11 +19,13 @@ public class TelemetrySystem {
   private static final Logger log = LoggerFactory.getLogger(TelemetrySystem.class);
 
   private static Thread TELEMETRY_THREAD;
+  private static DependencyService DEPENDENCY_SERVICE;
 
   static DependencyService createDependencyService(Instrumentation instrumentation) {
     if (instrumentation != null) {
       DependencyServiceImpl dependencyService = new DependencyServiceImpl();
       dependencyService.installOn(instrumentation);
+      dependencyService.schedulePeriodicResolution();
       return dependencyService;
     }
     return null;
@@ -33,6 +35,7 @@ public class TelemetrySystem {
       TelemetryService telemetryService,
       OkHttpClient okHttpClient,
       DependencyService dependencyService) {
+    DEPENDENCY_SERVICE = dependencyService;
     TelemetryRunnable telemetryRunnable =
         new TelemetryRunnable(
             okHttpClient,
@@ -55,6 +58,9 @@ public class TelemetrySystem {
   }
 
   public static void stop() {
+    if (DEPENDENCY_SERVICE != null) {
+      DEPENDENCY_SERVICE.stop();
+    }
     if (TELEMETRY_THREAD != null) {
       TELEMETRY_THREAD.interrupt();
       try {

--- a/telemetry/src/main/java/datadog/telemetry/dependency/Dependency.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/Dependency.java
@@ -132,7 +132,7 @@ public final class Dependency {
     String artifactId;
     String groupId = null;
     String version;
-    String hash = null;
+    String hash;
 
     // Guess from manifest
     String bundleSymbolicName = null;
@@ -194,19 +194,6 @@ public final class Dependency {
     } else if (equalsNonNull(bundleVersion, fileNameVersion)) {
       version = fileNameVersion;
     } else {
-      // No reliable version calculate hash and use any version
-      MessageDigest md;
-      try {
-        md = MessageDigest.getInstance("SHA-1");
-      } catch (NoSuchAlgorithmException e) {
-        // should not happen
-        throw new UndeclaredThrowableException(e);
-      }
-      is = new DigestInputStream(is, md);
-      while (is.read(buf, 0, buf.length) > 0) {}
-
-      hash = String.format("%040X", new BigInteger(1, md.digest()));
-
       artifactId = source;
 
       if (implementationVersion != null) {
@@ -227,6 +214,19 @@ public final class Dependency {
       // no group resolved. use only artifactId
       name = artifactId;
     }
+
+    // Compute hash for all dependencies that has no pom
+    // No reliable version calculate hash and use any version
+    MessageDigest md;
+    try {
+      md = MessageDigest.getInstance("SHA-1");
+    } catch (NoSuchAlgorithmException e) {
+      // should not happen
+      throw new UndeclaredThrowableException(e);
+    }
+    is = new DigestInputStream(is, md);
+    while (is.read(buf, 0, buf.length) > 0) {}
+    hash = String.format("%040X", new BigInteger(1, md.digest()));
 
     return new Dependency(name, version, source, hash);
   }

--- a/telemetry/src/main/java/datadog/telemetry/dependency/DependencyPeriodicAction.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/DependencyPeriodicAction.java
@@ -14,7 +14,7 @@ public class DependencyPeriodicAction implements TelemetryRunnable.TelemetryPeri
 
   @Override
   public void doIteration(TelemetryService telService) {
-    Collection<Dependency> dependencies = dependencyService.determineNewDependencies();
+    Collection<Dependency> dependencies = dependencyService.drainDeterminedDependencies();
     for (Dependency dep : dependencies) {
       datadog.telemetry.api.Dependency telDep = new datadog.telemetry.api.Dependency();
       telDep.setHash(dep.getHash());

--- a/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolver.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolver.java
@@ -1,0 +1,137 @@
+package datadog.telemetry.dependency;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.JarURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DependencyResolver {
+
+  private static final Logger log = LoggerFactory.getLogger(DependencyResolver.class);
+  private static final String JAR_SUFFIX = ".jar";
+
+  public static Dependency resolve(URI uri) {
+    return identifyLibrary(uri);
+  }
+
+  /**
+   * Identify library from a URI
+   *
+   * @param uri URI to a dependency
+   * @return dependency, or null if unable to qualify jar
+   */
+  // package private for testing
+  static Dependency identifyLibrary(URI uri) {
+    String scheme = uri.getScheme();
+    Dependency dependency = null;
+    try {
+      if ("file".equals(scheme)) {
+        dependency = identifyLibrary(new File(uri));
+      } else if ("jar".equals(scheme)) {
+        dependency = getNestedDependency(uri);
+      }
+    } catch (RuntimeException rte) {
+      log.warn("Failed to determine dependency for uri {}", uri, rte);
+    }
+    // TODO : moving jboss vfs here is probably a idea
+    // it might however require to do somme checks to make sure it's only applied to jboss
+    // and not any application server that also uses vfs:// locations
+
+    return dependency;
+  }
+
+  /**
+   * Identify a library from a .jar file
+   *
+   * @param jar jar dependency
+   * @return detected dependency, {@code null} if unable to get dependency from jar
+   */
+  static Dependency identifyLibrary(File jar) {
+    if (!jar.exists()) {
+      log.warn("unable to find dependency {}", jar);
+      return null;
+    } else if (!jar.getName().endsWith(JAR_SUFFIX)) {
+      log.debug("unsupported file dependency type : {}", jar);
+      return null;
+    }
+
+    Dependency dependency = null;
+    try (JarFile file = new JarFile(jar, false /* no verify */);
+        InputStream is = Files.newInputStream(jar.toPath())) {
+
+      // Try to get from maven properties
+      dependency = Dependency.fromMavenPom(file);
+
+      // Try to guess from manifest or file name
+      if (dependency == null) {
+        Manifest manifest = file.getManifest();
+        dependency = Dependency.guessFallbackNoPom(manifest, jar.getName(), is);
+      }
+    } catch (IOException e) {
+      log.debug("unable to read jar file {}", jar, e);
+    }
+
+    return dependency;
+  }
+
+  /* for jar urls as handled by spring boot */
+  static Dependency getNestedDependency(URI uri) {
+    String lastPart = null;
+    String fileName = null;
+    try {
+      URL url = uri.toURL();
+      JarURLConnection jarConnection = (JarURLConnection) url.openConnection();
+      Manifest manifest = jarConnection.getManifest();
+
+      JarFile jarFile = jarConnection.getJarFile();
+
+      // the !/ separator is hardcoded into JarURLConnection class
+      String jarFileName = jarFile.getName();
+      int posSep = jarFileName.indexOf("!/");
+      if (posSep == -1) {
+        log.warn("Unable to guess nested dependency for uri '{}': '!/' not found", uri);
+        return null;
+      }
+      lastPart = jarFileName.substring(posSep + 1);
+      fileName = lastPart.substring(lastPart.lastIndexOf("/") + 1);
+
+      return Dependency.guessFallbackNoPom(manifest, fileName, jarConnection.getInputStream());
+    } catch (IOException e) {
+      log.debug("unable to open nested jar manifest for {}", uri, e);
+    }
+    log.info(
+        "Unable to guess nested dependency for uri '{}', lastPart: '{}', fileName: '{}'",
+        uri,
+        lastPart,
+        fileName);
+    return null;
+  }
+
+  public static Attributes getManifestAttributes(File jarFile) {
+    Manifest manifest = getJarManifest(jarFile);
+    return manifest == null ? null : manifest.getMainAttributes();
+  }
+
+  /**
+   * Get manifest from jar file
+   *
+   * @param jarFile jar file
+   * @return manifest or null if none is available or unable to read it
+   */
+  public static Manifest getJarManifest(File jarFile) {
+    try (JarFile file = new JarFile(jarFile)) {
+      return file.getManifest();
+    } catch (IOException e) {
+      // silently ignored
+    }
+    return null;
+  }
+}

--- a/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolverQueue.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolverQueue.java
@@ -1,0 +1,71 @@
+package datadog.telemetry.dependency;
+
+import java.net.URI;
+import java.util.HashSet;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DependencyResolverQueue {
+
+  private static final Logger log = LoggerFactory.getLogger(DependencyResolverQueue.class);
+
+  private final Queue<URI> newUrlsQueue;
+  private final Set<URI> processedUrlsSet; // guarded by this
+
+  public DependencyResolverQueue() {
+    this.newUrlsQueue = new ConcurrentLinkedQueue<>();
+    this.processedUrlsSet = new HashSet<>();
+  }
+
+  public void queueURI(URI uri) {
+    if (uri == null) {
+      return;
+    }
+
+    // we ignore .class files directly within webapp folder (they aren't part of dependencies)
+    String path = uri.getPath();
+    if (path != null && path.endsWith(".class")) {
+      return;
+    }
+
+    // ignore already processed url
+    synchronized (this) {
+      if (processedUrlsSet.contains(uri)) {
+        return;
+      }
+    }
+
+    newUrlsQueue.add(uri);
+  }
+
+  public Dependency pollDependency() {
+    URI uri = newUrlsQueue.poll();
+
+    // no new deps
+    if (uri == null) {
+      return null;
+    }
+
+    Dependency dep = DependencyResolver.resolve(uri);
+    if (dep == null) {
+      if ("jrt".equals(uri.getScheme()) || "x-internal-jar".equals(uri.getScheme())) {
+        log.debug("unable to detect dependency for URI {}", uri);
+      } else {
+        log.warn("unable to detect dependency for URI {}", uri);
+      }
+      return null;
+    }
+    if (log.isDebugEnabled()) {
+      log.debug("dependency detected {} for {}", dep, uri);
+    }
+
+    synchronized (this) {
+      processedUrlsSet.add(uri);
+    }
+
+    return dep;
+  }
+}

--- a/telemetry/src/main/java/datadog/telemetry/dependency/DependencyService.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/DependencyService.java
@@ -4,7 +4,9 @@ import java.net.URL;
 import java.util.Collection;
 
 public interface DependencyService {
-  Collection<Dependency> determineNewDependencies();
+  Collection<Dependency> drainDeterminedDependencies();
 
   void addURL(URL uri);
+
+  void stop();
 }

--- a/telemetry/src/main/java/datadog/telemetry/dependency/DependencyServiceImpl.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/DependencyServiceImpl.java
@@ -1,43 +1,40 @@
 package datadog.telemetry.dependency;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import datadog.trace.util.AgentTaskScheduler;
 import java.lang.instrument.Instrumentation;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.lang.reflect.UndeclaredThrowableException;
-import java.net.JarURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.jar.Attributes;
-import java.util.jar.JarFile;
-import java.util.jar.Manifest;
+import java.util.*;
+import java.util.concurrent.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Service that detects app dependencies from classloading by using a no-op class-file transformer
  */
-public class DependencyServiceImpl implements DependencyService {
+public class DependencyServiceImpl implements DependencyService, Runnable {
 
   private static final Logger log = LoggerFactory.getLogger(DependencyServiceImpl.class);
 
-  private static final String JAR_SUFFIX = ".jar";
+  private final DependencyResolverQueue resolverQueue = new DependencyResolverQueue();
 
-  private Set<URI> currentSet; // guarded by this
-  private volatile JbossVirtualFileHelper jbossVirtualFileHelper;
+  private final BlockingQueue<Dependency> newDependencies = new LinkedBlockingQueue<>();
 
-  public DependencyServiceImpl() {
-    this.currentSet = new HashSet<>();
+  private AgentTaskScheduler.Scheduled<Runnable> scheduledTask;
+
+  public void schedulePeriodicResolution() {
+    scheduledTask =
+        AgentTaskScheduler.INSTANCE.scheduleAtFixedRate(
+            AgentTaskScheduler.RunnableTask.INSTANCE, this, 0, 1000L, TimeUnit.MILLISECONDS);
+  }
+
+  public void resolveOneDependency() {
+    Dependency dep = resolverQueue.pollDependency();
+    if (dep != null) {
+      log.info("Resolved dependency {}", dep.getName());
+      newDependencies.add(dep);
+    }
   }
 
   /**
@@ -50,53 +47,18 @@ public class DependencyServiceImpl implements DependencyService {
   }
 
   @Override
-  public Collection<Dependency> determineNewDependencies() {
-    Set<URI> currentSet;
-    synchronized (this) {
-      currentSet = this.currentSet;
-      this.currentSet = new HashSet<>();
+  public Collection<Dependency> drainDeterminedDependencies() {
+    List<Dependency> list = new LinkedList<>();
+    int drained = newDependencies.drainTo(list);
+    if (drained > 0) {
+      return list;
     }
-
-    List<Dependency> deps = new ArrayList<>(currentSet.size());
-    for (URI uri : currentSet) {
-      if (Thread.interrupted()) {
-        log.warn("Interrupted while processing dependencies");
-        break;
-      }
-
-      if (uri == null) {
-        continue;
-      }
-
-      Dependency dep = identifyLibrary(uri);
-      if (dep == null) {
-        if ("jrt".equals(uri.getScheme()) || "x-internal-jar".equals(uri.getScheme())) {
-          log.debug("unable to detect dependency for URI {}", uri);
-        } else {
-          log.warn("unable to detect dependency for URI {}", uri);
-        }
-        continue;
-      }
-      if (log.isDebugEnabled()) {
-        log.debug("dependency detected {} for {}", dep, uri);
-      }
-      deps.add(dep);
-    }
-
-    return deps;
+    return Collections.emptyList();
   }
 
   @Override
   public void addURL(URL url) {
-    // we ignore .class files directly within webapp folder (they aren't part of dependencies)
-    String path = url.getPath();
-    if (path != null && path.endsWith(".class")) {
-      return;
-    }
-
-    synchronized (this) {
-      currentSet.add(convertToURI(url));
-    }
+    resolverQueue.queueURI(convertToURI(url));
   }
 
   private URI convertToURI(URL location) {
@@ -105,7 +67,7 @@ public class DependencyServiceImpl implements DependencyService {
     if (location.getProtocol().equals("vfs")) {
       // resolve jboss virtual file system
       try {
-        uri = getJbossVfsPath(location);
+        uri = JbossVirtualFileHelper.getJbossVfsPath(location);
       } catch (RuntimeException rte) {
         log.debug("Error in call to getJbossVfsPath", rte);
         return null;
@@ -124,201 +86,16 @@ public class DependencyServiceImpl implements DependencyService {
     return uri;
   }
 
-  /**
-   * Identify library from a URI
-   *
-   * @param uri URI to a dependency
-   * @return dependency, or null if unable to qualify jar
-   */
-  // package private for testing
-  Dependency identifyLibrary(URI uri) {
-    String scheme = uri.getScheme();
-    Dependency dependency = null;
-    try {
-      if ("file".equals(scheme)) {
-        dependency = identifyLibrary(new File(uri));
-      } else if ("jar".equals(scheme)) {
-        dependency = getNestedDependency(uri);
-      }
-    } catch (RuntimeException rte) {
-      log.warn("Failed to determine dependency for uri {}", uri, rte);
-    }
-    // TODO : moving jboss vfs here is probably a idea
-    // it might however require to do somme checks to make sure it's only applied to jboss
-    // and not any application server that also uses vfs:// locations
-
-    return dependency;
+  @Override
+  public void run() {
+    resolveOneDependency();
   }
 
-  /**
-   * Identify a library from a .jar file
-   *
-   * @param jar jar dependency
-   * @return detected dependency, {@code null} if unable to get dependency from jar
-   */
-  private Dependency identifyLibrary(File jar) {
-    if (!jar.exists()) {
-      log.warn("unable to find dependency {}", jar);
-      return null;
-    } else if (!jar.getName().endsWith(JAR_SUFFIX)) {
-      log.debug("unsupported file dependency type : {}", jar);
-      return null;
+  @Override
+  public void stop() {
+    if (scheduledTask != null) {
+      scheduledTask.cancel();
+      scheduledTask = null;
     }
-
-    Dependency dependency = null;
-    try (JarFile file = new JarFile(jar, false /* no verify */);
-        InputStream is = new FileInputStream(jar)) {
-
-      // Try to get from maven properties
-      dependency = Dependency.fromMavenPom(file);
-
-      // Try to guess from manifest or file name
-      if (dependency == null) {
-        Manifest manifest = file.getManifest();
-        dependency = Dependency.guessFallbackNoPom(manifest, jar.getName(), is);
-      }
-    } catch (IOException e) {
-      log.debug("unable to read jar file {}", jar, e);
-    }
-
-    return dependency;
-  }
-
-  /* for jar urls as handled by spring boot */
-  Dependency getNestedDependency(URI uri) {
-    String lastPart = null;
-    String fileName = null;
-    try {
-      URL url = uri.toURL();
-      JarURLConnection jarConnection = (JarURLConnection) url.openConnection();
-      Manifest manifest = jarConnection.getManifest();
-
-      JarFile jarFile = jarConnection.getJarFile();
-
-      // the !/ separator is hardcoded into JarURLConnection class
-      String jarFileName = jarFile.getName();
-      int posSep = jarFileName.indexOf("!/");
-      if (posSep == -1) {
-        log.warn("Unable to guess nested dependency for uri '{}': '!/' not found", uri);
-        return null;
-      }
-      lastPart = jarFileName.substring(posSep + 1);
-      fileName = lastPart.substring(lastPart.lastIndexOf("/") + 1);
-
-      return Dependency.guessFallbackNoPom(manifest, fileName, jarConnection.getInputStream());
-    } catch (IOException e) {
-      log.debug("unable to open nested jar manifest for {}", uri, e);
-    }
-    log.info(
-        "Unable to guess nested dependency for uri '{}', lastPart: '{}', fileName: '{}'",
-        uri,
-        lastPart,
-        fileName);
-    return null;
-  }
-
-  public static Attributes getManifestAttributes(File jarFile) {
-    Manifest manifest = getJarManifest(jarFile);
-    return manifest == null ? null : manifest.getMainAttributes();
-  }
-
-  /**
-   * Get manifest from jar file
-   *
-   * @param jarFile jar file
-   * @return manifest or null if none is available or unable to read it
-   */
-  public static Manifest getJarManifest(File jarFile) {
-    try (JarFile file = new JarFile(jarFile)) {
-      return file.getManifest();
-    } catch (IOException e) {
-      // silently ignored
-    }
-    return null;
-  }
-
-  static class JbossVirtualFileHelper {
-    private final MethodHandle getPhysicalFile;
-    private final MethodHandle getName;
-
-    public static final JbossVirtualFileHelper FAILED_HELPER = new JbossVirtualFileHelper();
-
-    public JbossVirtualFileHelper(ClassLoader loader) throws Exception {
-      MethodHandles.Lookup lookup = MethodHandles.lookup();
-      Class<?> virtualFileCls = loader.loadClass("org.jboss.vfs.VirtualFile");
-      getPhysicalFile =
-          lookup.findVirtual(virtualFileCls, "getPhysicalFile", MethodType.methodType(File.class));
-      getName = lookup.findVirtual(virtualFileCls, "getName", MethodType.methodType(String.class));
-    }
-
-    private JbossVirtualFileHelper() {
-      getPhysicalFile = null;
-      getName = null;
-    }
-
-    public File getPhysicalFile(Object virtualFile) {
-      try {
-        return (File) getPhysicalFile.invoke(virtualFile);
-      } catch (Throwable e) {
-        throw new UndeclaredThrowableException(e);
-      }
-    }
-
-    public String getName(Object virtualFile) {
-      try {
-        return (String) getName.invoke(virtualFile);
-      } catch (Throwable e) {
-        throw new UndeclaredThrowableException(e);
-      }
-    }
-  }
-
-  private URI getJbossVfsPath(URL location) {
-    JbossVirtualFileHelper jbossVirtualFileHelper = this.jbossVirtualFileHelper;
-    if (jbossVirtualFileHelper == JbossVirtualFileHelper.FAILED_HELPER) {
-      return null;
-    }
-
-    Object virtualFile;
-    try {
-      virtualFile = location.openConnection().getContent();
-    } catch (IOException e) {
-      // silently ignored
-      return null;
-    }
-    if (virtualFile == null) {
-      return null;
-    }
-
-    if (jbossVirtualFileHelper == null) {
-      try {
-        jbossVirtualFileHelper =
-            this.jbossVirtualFileHelper =
-                new JbossVirtualFileHelper(virtualFile.getClass().getClassLoader());
-      } catch (Exception e) {
-        log.warn("Error preparing for inspection of jboss virtual files", e);
-        return null;
-      }
-    }
-
-    // call VirtualFile.getPhysicalFile
-    File physicalFile = jbossVirtualFileHelper.getPhysicalFile(virtualFile);
-    if (physicalFile.isFile() && physicalFile.getName().endsWith(".jar")) {
-      return physicalFile.toURI();
-    } else {
-      log.warn("Physical file {} is not a jar", physicalFile);
-    }
-
-    // not sure what this is about, but it's what the old code used to do
-    // this is not correct as a general matter, since getName returns the virtual name,
-    // which may not match the physical name
-    // The original comment reads:
-    // "physical file returns 'content' folder, we manually resolve to the actual jar location"
-    String fileName = jbossVirtualFileHelper.getName(virtualFile);
-    physicalFile = new File(physicalFile.getParentFile(), fileName);
-    if (physicalFile.isFile()) {
-      return physicalFile.toURI();
-    }
-    return null;
   }
 }

--- a/telemetry/src/main/java/datadog/telemetry/dependency/JbossVirtualFileHelper.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/JbossVirtualFileHelper.java
@@ -1,0 +1,101 @@
+package datadog.telemetry.dependency;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.net.URI;
+import java.net.URL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JbossVirtualFileHelper {
+
+  private final MethodHandle getPhysicalFile;
+  private final MethodHandle getName;
+
+  private static JbossVirtualFileHelper jbossVirtualFileHelper;
+  public static final JbossVirtualFileHelper FAILED_HELPER = new JbossVirtualFileHelper();
+
+  private static final Logger log = LoggerFactory.getLogger(JbossVirtualFileHelper.class);
+
+  public JbossVirtualFileHelper(ClassLoader loader) throws Exception {
+    MethodHandles.Lookup lookup = MethodHandles.lookup();
+    Class<?> virtualFileCls = loader.loadClass("org.jboss.vfs.VirtualFile");
+    getPhysicalFile =
+        lookup.findVirtual(virtualFileCls, "getPhysicalFile", MethodType.methodType(File.class));
+    getName = lookup.findVirtual(virtualFileCls, "getName", MethodType.methodType(String.class));
+  }
+
+  private JbossVirtualFileHelper() {
+    getPhysicalFile = null;
+    getName = null;
+  }
+
+  public File getPhysicalFile(Object virtualFile) {
+    try {
+      return (File) getPhysicalFile.invoke(virtualFile);
+    } catch (Throwable e) {
+      throw new UndeclaredThrowableException(e);
+    }
+  }
+
+  public String getName(Object virtualFile) {
+    try {
+      return (String) getName.invoke(virtualFile);
+    } catch (Throwable e) {
+      throw new UndeclaredThrowableException(e);
+    }
+  }
+
+  public static URI getJbossVfsPath(URL location) {
+    JbossVirtualFileHelper jbossVirtualFileHelper = JbossVirtualFileHelper.jbossVirtualFileHelper;
+    if (jbossVirtualFileHelper == JbossVirtualFileHelper.FAILED_HELPER) {
+      return null;
+    }
+
+    Object virtualFile;
+    try {
+      virtualFile = location.openConnection().getContent();
+    } catch (IOException e) {
+      // silently ignored
+      return null;
+    }
+    if (virtualFile == null) {
+      return null;
+    }
+
+    if (jbossVirtualFileHelper == null) {
+      try {
+        jbossVirtualFileHelper =
+            JbossVirtualFileHelper.jbossVirtualFileHelper =
+                new JbossVirtualFileHelper(virtualFile.getClass().getClassLoader());
+      } catch (Exception e) {
+        log.warn("Error preparing for inspection of jboss virtual files", e);
+        return null;
+      }
+    }
+
+    // call VirtualFile.getPhysicalFile
+    File physicalFile = jbossVirtualFileHelper.getPhysicalFile(virtualFile);
+    if (physicalFile.isFile() && physicalFile.getName().endsWith(".jar")) {
+      return physicalFile.toURI();
+    } else {
+      log.warn("Physical file {} is not a jar", physicalFile);
+    }
+
+    // not sure what this is about, but it's what the old code used to do
+    // this is not correct as a general matter, since getName returns the virtual name,
+    // which may not match the physical name
+    // The original comment reads:
+    // "physical file returns 'content' folder, we manually resolve to the actual jar location"
+    String fileName = jbossVirtualFileHelper.getName(virtualFile);
+    physicalFile = new File(physicalFile.getParentFile(), fileName);
+    if (physicalFile.isFile()) {
+      return physicalFile.toURI();
+    }
+    return null;
+  }
+}

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetrySystemSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetrySystemSpecification.groovy
@@ -19,10 +19,13 @@ class TelemetrySystemSpecification extends DDSpecification {
     injectSysConfig('dd.instrumentation.telemetry.enabled', 'true')
 
     when:
-    TelemetrySystem.createDependencyService(inst)
+    def depService = TelemetrySystem.createDependencyService(inst)
 
     then:
     1 * inst.addTransformer(_ as LocationsCollectingTransformer)
+
+    cleanup:
+    depService.stop()
   }
 
   void 'create telemetry thread'() {

--- a/telemetry/src/test/groovy/datadog/telemetry/dependency/DepSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/dependency/DepSpecification.groovy
@@ -1,0 +1,13 @@
+package datadog.telemetry.dependency
+
+import datadog.trace.test.util.DDSpecification
+
+abstract class DepSpecification extends DDSpecification {
+
+  protected static File getJar(String jarName) {
+    String path = ClassLoader.systemClassLoader.getResource("datadog/telemetry/dependencies/$jarName").path
+    File jarFile = new File(path)
+    assert jarFile.isFile()
+    jarFile
+  }
+}

--- a/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyPeriodActionSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyPeriodActionSpecification.groovy
@@ -14,7 +14,7 @@ class DependencyPeriodActionSpecification extends DDSpecification {
     periodicAction.doIteration(telemetryService)
 
     then:
-    1 * depService.determineNewDependencies() >> [new Dependency('name', '1.2.3', 'name-1.2.3.jar', 'DEADBEEF')]
+    1 * depService.drainDeterminedDependencies() >> [new Dependency('name', '1.2.3', 'name-1.2.3.jar', 'DEADBEEF')]
     1 * telemetryService.addDependency({ datadog.telemetry.api.Dependency dep ->
       dep.name == 'name' &&
         dep.version == '1.2.3' &&

--- a/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyResolverQueueSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyResolverQueueSpecification.groovy
@@ -1,0 +1,49 @@
+package datadog.telemetry.dependency
+
+class DependencyResolverQueueSpecification extends DepSpecification {
+
+  DependencyResolverQueue resolverQueue = new DependencyResolverQueue()
+
+  void 'resolve set of dependencies'() {
+    when:
+    resolverQueue.queueURI(getJar('junit-4.12.jar').toURI())
+    resolverQueue.queueURI(getJar('asm-util-9.2.jar').toURI())
+    resolverQueue.queueURI(getJar('bson-4.2.0.jar').toURI())
+
+    and:
+    def dep = resolverQueue.pollDependency()
+
+    then:
+    assert dep != null
+    assert dep.name == 'junit'
+    assert dep.version == '4.12'
+    assert dep.source == 'junit-4.12.jar'
+    assert dep.hash == '4376590587C49AC6DA6935564233F36B092412AE'
+
+    when:
+    dep = resolverQueue.pollDependency()
+
+    then:
+    assert dep != null
+    assert dep.name == 'asm-util'
+    assert dep.version == '9.2'
+    assert dep.source == 'asm-util-9.2.jar'
+    assert dep.hash == '9A5AEC2CB852B8BD20DAF5D2CE9174891267FE27'
+
+    when:
+    dep = resolverQueue.pollDependency()
+
+    then:
+    assert dep != null
+    assert dep.name == 'org.mongodb:bson'
+    assert dep.version == '4.2.0'
+    assert dep.source == 'bson-4.2.0.jar'
+    assert dep.hash == 'F87C3A90DA4BB1DA6D3A73CA18004545AD2EF06A'
+
+    when:
+    dep = resolverQueue.pollDependency()
+
+    then:
+    assert dep == null
+  }
+}

--- a/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyResolverSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyResolverSpecification.groovy
@@ -1,0 +1,187 @@
+package datadog.telemetry.dependency
+
+import org.apache.tools.ant.taskdefs.Classloader
+
+import java.util.jar.Attributes
+import java.util.jar.JarFile
+import java.util.jar.Manifest
+
+class DependencyResolverSpecification extends DepSpecification {
+
+  void 'guess groupId/artifactId from bundleSymbolicName - #jar'() {
+    expect:
+    knownJarCheck(
+      jarName: jar,
+      name: name,
+      hash: hash,
+      version: version)
+
+    where:
+    jar                       |  name                        | hash                                       | version
+    'bson4jackson-2.11.0.jar' | 'de.undercouch:bson4jackson' | '428A23E33D19DACD6E04CA7DD746206849861A95' | '2.11.0'
+    'bson-4.2.0.jar'          | 'org.mongodb:bson'           | 'F87C3A90DA4BB1DA6D3A73CA18004545AD2EF06A' | '4.2.0'
+  }
+
+  void 'groupId cannot be resolved #jar'() {
+    expect:
+    knownJarCheck(
+      jarName: jar,
+      name: name,
+      hash: hash,
+      version: version)
+
+    where:
+    jar                  |  name        | hash    | version
+    'asm-util-9.2.jar'   | 'asm-util'   | '9A5AEC2CB852B8BD20DAF5D2CE9174891267FE27' | '9.2'
+    'agrona-1.7.2.jar'   | 'agrona'     | '0646535BE30190223DA51F5AACB080DC1F25FFF9' | '1.7.2'
+    'caffeine-2.8.5.jar' | 'caffeine'   | 'E4CD34260D3AF66A928E6DB1D2BB6807C6136859' | '2.8.5'
+  }
+
+  void 'no version in file name'() {
+    expect:
+    knownJarCheck(
+      jarName: 'spring-webmvc.jar',
+      name: 'spring-webmvc',
+      hash: '5B3B4AAC5C802E31BCC8517EFA9C9818EF625A0A',
+      version: '3.0.0.RELEASE'
+      )
+  }
+
+  void 'known jar with maven pom'() {
+    expect:
+    knownJarCheck(
+      jarName: 'commons-logging-1.2.jar',
+      name: 'commons-logging:commons-logging',
+      version: '1.2')
+  }
+
+  void 'known jar with manifest implementation'() {
+    expect:
+    knownJarCheck(
+      jarName: 'junit-4.12.jar',
+      name: 'junit',
+      hash: '4376590587C49AC6DA6935564233F36B092412AE',
+      version: '4.12')
+  }
+
+  void 'known jar with manifest bundle'() {
+    expect:
+    knownJarCheck(
+      jarName: 'groovy-manifest.jar',
+      name: 'groovy',
+      hash: '04DF0875A66F111880217FE1C5C59CA877403239',
+      version: '2.4.12')
+  }
+
+  void 'known jar from filename'() {
+    // this jar has a manifest but should be resolved with its file name
+    expect:
+    knownJarCheck(
+      jarName: 'multiverse-core-0.7.0.jar',
+      name: 'org.multiverse:multiverse-core',
+      version: '0.7.0')
+  }
+
+  void 'no manifest info bad filename'() {
+    // If no manifest info and no suitable file name - calculate sha1 hash
+    knownJarCheck(
+      jarName: 'groovy-no-manifest-info.jar',
+      name: 'groovy-no-manifest-info.jar',
+      expectedVersion: '',
+      expectedInfo: '1C1C8E5547A54F593B97584D45F3636F479B9498')
+  }
+
+  void 'guess artifact name from jar'() {
+    when:
+    File jar = getJar("freemarker-2.3.27-incubating.jar")
+
+    JarFile file = new JarFile(jar)
+    Manifest manifest = file.manifest
+    String source = jar.name
+    Dependency dep = Dependency.guessFallbackNoPom(manifest, source, new FileInputStream(jar))
+
+    then:
+    dep != null
+    dep.name == 'freemarker-2.3.27-incubating.jar'
+    dep.version == '2.3.27'
+    dep.hash == '3F476E5A287F5CE4951E2F61F3287C122C558067'
+    dep.source == 'freemarker-2.3.27-incubating.jar'
+  }
+
+  void 'guess artifact name from jar variant'() throws IOException {
+    when:
+    File jar = getJar('hsqldb-2.3.5-jdk6debug.jar')
+    JarFile file = new JarFile(jar)
+    Manifest manifest = file.manifest
+    String source = jar.name
+    Dependency dep = Dependency.guessFallbackNoPom(manifest, source, new FileInputStream(jar))
+
+    then:
+    dep != null
+    dep.name == 'hsqldb'
+    dep.version == '2.3.5'
+    dep.hash == 'CA0722D57F25455BA0CFCBDCA2C347941BD22601'
+    dep.source == 'hsqldb-2.3.5-jdk6debug.jar'
+  }
+
+  void 'try to determine lib name'() throws IOException {
+    setup:
+    File temp = File.createTempFile('temp', '.zip')
+
+    expect:
+    DependencyResolver.identifyLibrary(temp) == null
+
+    cleanup:
+    temp.delete()
+  }
+
+  void 'spring boot dependency'() throws IOException {
+    setup:
+    org.springframework.boot.loader.jar.JarFile.registerUrlProtocolHandler()
+
+    when:
+    String zipPath = Classloader.classLoader.getResource('datadog/telemetry/dependencies/spring-boot-app.jar').path
+    URI uri = new URI("jar:file:$zipPath!/BOOT-INF/lib/opentracing-util-0.33.0.jar!/")
+
+    Dependency dep = DependencyResolver.resolve(uri)
+
+    then:
+    dep != null
+    dep.name == 'opentracing-util-0.33.0.jar'
+    dep.version == '0.33.0'
+    dep.hash == '132630F17E198A1748F23CE33597EFDF4A807FB9'
+    dep.source == 'opentracing-util-0.33.0.jar'
+  }
+
+  void 'retrieve manifest attributes'() {
+    when:
+    Attributes attributes = manifestAttributesFromJar('junit-4.12.jar')
+
+    then:
+    attributes != null
+
+    attributes.getValue('implementation-title') == 'JUnit'
+    attributes.getValue('implementation-version') ==  '4.12'
+    attributes.getValue('implementation-vendor') == 'JUnit'
+    attributes.getValue('built-by') == 'jenkins'
+  }
+
+  private static void knownJarCheck(Map opts) {
+    File jarFile = getJar(opts['jarName'])
+    Dependency dep = DependencyResolver.identifyLibrary(jarFile)
+
+    assert dep != null
+    assert dep.source == opts['jarName']
+    assert dep.name == opts['name']
+    assert dep.version == opts['version']
+    assert dep.hash == opts['hash']
+  }
+
+  private static Attributes manifestAttributesFromJar(String jarName){
+    File jarFile = getJar(jarName)
+
+    Attributes attributes = DependencyResolver.getManifestAttributes(jarFile)
+    assert attributes != null
+    attributes
+  }
+}

--- a/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyServiceImplSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyServiceImplSpecification.groovy
@@ -1,29 +1,24 @@
 package datadog.telemetry.dependency
 
-import datadog.trace.test.util.DDSpecification
-import org.apache.tools.ant.taskdefs.Classloader
-
 import java.lang.instrument.ClassFileTransformer
 import java.lang.instrument.IllegalClassFormatException
 import java.lang.instrument.Instrumentation
 import java.security.CodeSigner
 import java.security.CodeSource
 import java.security.ProtectionDomain
-import java.util.jar.Attributes
-import java.util.jar.JarFile
-import java.util.jar.Manifest
 
 import static org.hamcrest.Matchers.is
 import static org.junit.Assert.assertThat
 
-class DependencyServiceImplSpecification extends DDSpecification {
+class DependencyServiceImplSpecification extends DepSpecification {
   DependencyServiceImpl depService = new DependencyServiceImpl()
 
   void 'no uris pushed should result in empty list'() {
     when:
-    def dependencies = depService.determineNewDependencies()
+    depService.resolveOneDependency()
 
     then:
+    def dependencies = depService.drainDeterminedDependencies()
     dependencies.isEmpty()
   }
 
@@ -38,9 +33,10 @@ class DependencyServiceImplSpecification extends DDSpecification {
   void 'class files are ignored as dependencies'() {
     when:
     depService.addURL(new URL('file:///tmp/toto.class'))
+    depService.resolveOneDependency()
 
     then:
-    depService.determineNewDependencies().isEmpty()
+    depService.drainDeterminedDependencies().isEmpty()
   }
 
   void 'add missing jar url dependency'() throws URISyntaxException {
@@ -48,127 +44,19 @@ class DependencyServiceImplSpecification extends DDSpecification {
     // this URI comes from a spring-boot application
     URL url = new URL('jar:file:/tmp//spring-petclinic-2.1.0.BUILD-SNAPSHOT.jar!/BOOT-INF/lib/spring-boot-2.1.0.BUILD-SNAPSHOT.jar!//')
     depService.addURL(url)
+    depService.resolveOneDependency()
 
     then:
-    depService.determineNewDependencies().isEmpty()
+    depService.drainDeterminedDependencies().isEmpty()
   }
 
   void 'invalid jar names are ignored'() {
     when:
     depService.addURL(new File(".zip").toURL())
+    depService.resolveOneDependency()
 
     then:
-    depService.determineNewDependencies().isEmpty()
-  }
-
-  void 'try to determine lib name'() throws IOException {
-    setup:
-    File temp = File.createTempFile('temp', '.zip')
-
-    expect:
-    depService.identifyLibrary(temp) == null
-
-    cleanup:
-    temp.delete()
-  }
-
-  void 'get manifest attributes'() {
-    when:
-    Attributes attributes = manifestAttributesFromJar('junit-4.12.jar')
-
-    then:
-    attributes != null
-
-    attributes.getValue('implementation-title') == 'JUnit'
-    attributes.getValue('implementation-version') ==  '4.12'
-    attributes.getValue('implementation-vendor') == 'JUnit'
-    attributes.getValue('built-by') == 'jenkins'
-  }
-
-  private static Attributes manifestAttributesFromJar(String jarName){
-    File jarFile = getJar(jarName)
-
-    Attributes attributes = DependencyServiceImpl.getManifestAttributes(jarFile)
-    assert attributes != null
-    attributes
-  }
-
-  void 'get groupId/artifactId from bundleSymbolicName - #jar'() {
-    expect:
-    knownJarCheck(
-      jarName: jar,
-      name: name,
-      version: version)
-
-    where:
-    jar                       |  name                        | version
-    'bson4jackson-2.11.0.jar' | 'de.undercouch:bson4jackson' | '2.11.0'
-    'bson-4.2.0.jar'          | 'org.mongodb:bson'           | '4.2.0'
-  }
-
-  void 'groupId cannot be resolved #jar'() {
-    expect:
-    knownJarCheck(
-      jarName: jar,
-      name: name,
-      version: version)
-
-    where:
-    jar                  |  name        | version
-    'asm-util-9.2.jar'   | 'asm-util'   | '9.2'
-    'agrona-1.7.2.jar'   | 'agrona'     | '1.7.2'
-    'caffeine-2.8.5.jar' | 'caffeine'   | '2.8.5'
-  }
-
-  void 'no version in file name'() {
-    expect:
-    knownJarCheck(
-      jarName: 'spring-webmvc.jar',
-      name: 'spring-webmvc',
-      version: '3.0.0.RELEASE'
-      )
-  }
-
-  void 'known jar with maven pom'() {
-    expect:
-    knownJarCheck(
-      jarName: 'commons-logging-1.2.jar',
-      name: 'commons-logging:commons-logging',
-      version: '1.2')
-  }
-
-  void 'known jar with manifest implementation'() {
-    expect:
-    knownJarCheck(
-      jarName: 'junit-4.12.jar',
-      name: 'junit',
-      version: '4.12')
-  }
-
-  void 'known jar with manifest bundle'() {
-    expect:
-    knownJarCheck(
-      jarName: 'groovy-manifest.jar',
-      name: 'groovy',
-      version: '2.4.12')
-  }
-
-  void 'known jar from filename'() {
-    // this jar has a manifest but should be resolved with its file name
-    expect:
-    knownJarCheck(
-      jarName: 'multiverse-core-0.7.0.jar',
-      name: 'org.multiverse:multiverse-core',
-      version: '0.7.0')
-  }
-
-  void 'no manifest info bad filename'() {
-    // If no manifest info and no suitable file name - calculate sha1 hash
-    knownJarCheck(
-      jarName: 'groovy-no-manifest-info.jar',
-      name: 'groovy-no-manifest-info.jar',
-      expectedVersion: '',
-      expectedInfo: '1C1C8E5547A54F593B97584D45F3636F479B9498')
+    depService.drainDeterminedDependencies().isEmpty()
   }
 
   void 'build dependency set from known jar'() {
@@ -176,64 +64,14 @@ class DependencyServiceImplSpecification extends DDSpecification {
     File junitJar = getJar('junit-4.12.jar')
 
     depService.addURL(new File(junitJar.getAbsolutePath()).toURL())
-    def set = depService.determineNewDependencies() as Set
+    depService.resolveOneDependency()
 
     then:
+    def set = depService.drainDeterminedDependencies() as Set
     assertThat(set.size(), is(1))
 
     assertThat(set.first().name, is('junit'))
     assertThat(set.first().version, is('4.12'))
-  }
-
-  void 'guess artifact name from jar'() {
-    when:
-    File jar = getJar("freemarker-2.3.27-incubating.jar")
-
-    JarFile file = new JarFile(jar)
-    Manifest manifest = file.manifest
-    String source = jar.name
-    Dependency dep = Dependency.guessFallbackNoPom(manifest, source, new FileInputStream(jar))
-
-    then:
-    dep != null
-    dep.name == 'freemarker-2.3.27-incubating.jar'
-    dep.version == '2.3.27'
-    dep.hash == '3F476E5A287F5CE4951E2F61F3287C122C558067'
-    dep.source == 'freemarker-2.3.27-incubating.jar'
-  }
-
-  void 'guess artifact name from jar variant'() throws IOException {
-    when:
-    File jar = getJar('hsqldb-2.3.5-jdk6debug.jar')
-    JarFile file = new JarFile(jar)
-    Manifest manifest = file.manifest
-    String source = jar.name
-    Dependency dep = Dependency.guessFallbackNoPom(manifest, source, new FileInputStream(jar))
-
-    then:
-    dep != null
-    dep.name == 'hsqldb'
-    dep.version == '2.3.5'
-    dep.hash == null
-    dep.source == 'hsqldb-2.3.5-jdk6debug.jar'
-  }
-
-  void 'spring boot dependency'() throws IOException {
-    setup:
-    org.springframework.boot.loader.jar.JarFile.registerUrlProtocolHandler()
-
-    when:
-    String zipPath = Classloader.classLoader.getResource('datadog/telemetry/dependencies/spring-boot-app.jar').path
-    URI uri = new URI("jar:file:$zipPath!/BOOT-INF/lib/opentracing-util-0.33.0.jar!/")
-
-    Dependency dep = depService.identifyLibrary(uri)
-
-    then:
-    dep != null
-    dep.name == 'opentracing-util-0.33.0.jar'
-    dep.version == '0.33.0'
-    dep.hash == '132630F17E198A1748F23CE33597EFDF4A807FB9'
-    dep.source == 'opentracing-util-0.33.0.jar'
   }
 
   void 'transformer invalid code source'() throws IllegalClassFormatException, MalformedURLException {
@@ -251,27 +89,30 @@ class DependencyServiceImplSpecification extends DDSpecification {
     when:
     // null protection domain
     t.transform(null, null, null, null, null)
+    depService.resolveOneDependency()
 
     then:
-    depService.determineNewDependencies().isEmpty()
+    depService.drainDeterminedDependencies().isEmpty()
 
     when:
     // null code source
     ProtectionDomain protectionDomain1 = new ProtectionDomain(null, null, null, null)
     t.transform(null, null, null, protectionDomain1, null)
+    depService.resolveOneDependency()
 
     then:
-    depService.determineNewDependencies().isEmpty()
+    depService.drainDeterminedDependencies().isEmpty()
 
     when:
     // null code source location
     CodeSource codeSource2 = new CodeSource(null, (CodeSigner[]) null)
     ProtectionDomain protectionDomain2 = new ProtectionDomain(codeSource2, null, null, null)
     t.transform(null, null, null, protectionDomain2, null)
+    depService.resolveOneDependency()
 
     then:
     codeSource2.location == null
-    depService.determineNewDependencies().isEmpty()
+    depService.drainDeterminedDependencies().isEmpty()
 
     when:
     // null or invalid URI syntax
@@ -279,26 +120,9 @@ class DependencyServiceImplSpecification extends DDSpecification {
     CodeSource codeSource3 = new CodeSource(url3, (CodeSigner[]) null)
     ProtectionDomain protectionDomain3 = new ProtectionDomain(codeSource3, null, null, null)
     t.transform(null, null, null, protectionDomain3, null)
+    depService.resolveOneDependency()
 
     then:
-    depService.determineNewDependencies().isEmpty()
-  }
-
-  private void knownJarCheck(Map opts) {
-    File jarFile = getJar(opts['jarName'])
-    Dependency dep = depService.identifyLibrary(jarFile)
-
-    assert dep != null
-    assert dep.source == opts['jarName']
-    assert dep.name == opts['name']
-    assert dep.version == opts['version']
-    assert dep.hash == opts['hash']
-  }
-
-  private static File getJar(String jarName) {
-    String path = ClassLoader.systemClassLoader.getResource("datadog/telemetry/dependencies/$jarName").path
-    File jarFile = new File(path)
-    assert jarFile.isFile()
-    jarFile
+    depService.drainDeterminedDependencies().isEmpty()
   }
 }

--- a/telemetry/src/test/java/datadog/telemetry/dependency/DependencyServiceImplTests.java
+++ b/telemetry/src/test/java/datadog/telemetry/dependency/DependencyServiceImplTests.java
@@ -78,7 +78,8 @@ public class DependencyServiceImplTests {
     CodeSource codeSource = new CodeSource(groovyJarURL, (Certificate[]) null);
     ProtectionDomain domain = new ProtectionDomain(codeSource, null);
     t.transform(getClass().getClassLoader(), "class.name", Object.class, domain, new byte[0]);
-    Collection<Dependency> deps = depService.determineNewDependencies();
+    depService.run(); // for test enforce instant dependency resolution
+    Collection<Dependency> deps = depService.drainDeterminedDependencies();
 
     if (deps.isEmpty()) {
       return null;

--- a/telemetry/telemetry.gradle
+++ b/telemetry/telemetry.gradle
@@ -22,6 +22,7 @@ ext {
     'datadog.telemetry.Uname.UtsNameLinux',
     'datadog.telemetry.Uname.EmptyUtsName',
     'datadog.telemetry.dependency.LocationsCollectingTransformer',
+    'datadog.telemetry.dependency.JbossVirtualFileHelper',
     'datadog.telemetry.TelemetrySystem',
     'datadog.telemetry.api.*'
   ]


### PR DESCRIPTION
# What Does This Do
Reworked dependency resolution. Now - distributed in time.
Always computing hash if there is no reliable (built-in) maven info inside the dependency jar-file.

# Motivation
Dependency resolution and hash computation can take a lot of resource depends on jar-file size. In practice this will looks like CPU usage spike at application startup.

# Additional Notes
In current implementation we are resolving one new dependency every second. We assume that 1 second is enough to traverse entries of one jar and compute hash. E.g. in one minute we will recognise 60 dependencies without huge impact to a customer's application.