### PR TITLE
Epoch nano calculation can not use epoch millis

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/PerSpanTracingContextTracker.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/PerSpanTracingContextTracker.java
@@ -200,7 +200,7 @@ public final class PerSpanTracingContextTracker implements TracingContextTracker
 
   private static long currentTimeNanos() {
     Instant now = Instant.now();
-    return now.toEpochMilli() * 1_000_000L + now.getNano();
+    return now.getEpochSecond() * 1_000_000_000L + now.getNano();
   }
 
   @Override

--- a/dd-java-agent/agent-profiling/profiling-context/src/test/java/com/datadog/profiling/context/IntervalEncoderTest.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/test/java/com/datadog/profiling/context/IntervalEncoderTest.java
@@ -16,7 +16,7 @@ class IntervalEncoderTest {
   @BeforeEach
   void setup() {
     now = Instant.now();
-    nowNanos = now.toEpochMilli() * 1_000_000L + now.getNano();
+    nowNanos = now.getEpochSecond() * 1_000_000_000L + now.getNano();
     instance = new IntervalEncoder(nowNanos, 1000, 2, 32);
   }
 


### PR DESCRIPTION
# What Does This Do
Fixes the epoch nanos calculation

# Motivation
Apparently, using epoch millis to extract epoch nanos from an `Instant` does not work. The `getNano()` call returns the number of nanos after the epoch second - and that already includes also the milliseconds so by using the epoch millis the calculation gets completely messed up.

# Additional Notes
