### PR TITLE
[IAST] Vulnerability hashing and deduplication V0

### DIFF
--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/IastSystem.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/IastSystem.java
@@ -28,7 +28,7 @@ public class IastSystem {
     }
     log.debug("IAST is starting");
 
-    final Reporter reporter = new Reporter();
+    final Reporter reporter = new Reporter(config);
     final OverheadController overheadController =
         new OverheadController(config, AgentTaskScheduler.INSTANCE);
     final IastModule iastModule = new IastModuleImpl(config, reporter, overheadController);

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/Reporter.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/Reporter.java
@@ -2,16 +2,32 @@ package com.datadog.iast;
 
 import com.datadog.iast.model.Vulnerability;
 import com.datadog.iast.model.VulnerabilityBatch;
+import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.TraceSegment;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
 
 /** Reports IAST vulnerabilities. */
 public class Reporter {
 
-  public Reporter() {}
+  private final Predicate<Vulnerability> duplicated;
+
+  Reporter() {
+    this(Config.get());
+  }
+
+  public Reporter(final Config config) {
+    this(config.isIastDeduplicationEnabled() ? new HashBasedDeduplication() : v -> false);
+  }
+
+  Reporter(final Predicate<Vulnerability> duplicate) {
+    this.duplicated = duplicate;
+  }
 
   public void report(final AgentSpan span, final Vulnerability vulnerability) {
     if (span == null) {
@@ -25,6 +41,9 @@ public class Reporter {
     if (ctx == null) {
       return;
     }
+    if (duplicated.test(vulnerability)) {
+      return;
+    }
     final VulnerabilityBatch batch = ctx.getVulnerabilityBatch();
     batch.add(vulnerability);
     if (!ctx.getAndSetSpanDataIsSet()) {
@@ -34,6 +53,38 @@ public class Reporter {
       // TODO: We need to check if we can have an API with more fine-grained semantics on why traces
       // are kept.
       segment.setTagTop(DDTags.MANUAL_KEEP, true);
+    }
+  }
+
+  /**
+   * This class maintains a set of vulnerability hashes that have already been reported, we don't
+   * care about thread safety too much as an occasional duplicated report is not a big deal.
+   */
+  protected static class HashBasedDeduplication implements Predicate<Vulnerability> {
+
+    private static final int DEFAULT_MAX_SIZE = 1000;
+
+    private final int maxSize;
+
+    private final Set<Long> hashes;
+
+    public HashBasedDeduplication() {
+      this(DEFAULT_MAX_SIZE);
+    }
+
+    HashBasedDeduplication(final int size) {
+      maxSize = size;
+      hashes = ConcurrentHashMap.newKeySet(size);
+    }
+
+    @Override
+    public boolean test(final Vulnerability vulnerability) {
+      final boolean newVulnerability = hashes.add(vulnerability.getHash());
+      if (newVulnerability && hashes.size() > maxSize) {
+        hashes.clear();
+        hashes.add(vulnerability.getHash());
+      }
+      return !newVulnerability;
     }
   }
 }

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/model/Vulnerability.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/model/Vulnerability.java
@@ -11,11 +11,14 @@ public final class Vulnerability {
 
   private final @Nullable Evidence evidence;
 
+  private final long hash;
+
   public Vulnerability(
       final VulnerabilityType type, final Location location, final Evidence evidence) {
     this.type = type;
     this.location = location;
     this.evidence = evidence;
+    this.hash = type.calculateHash(this);
   }
 
   public VulnerabilityType getType() {
@@ -28,5 +31,26 @@ public final class Vulnerability {
 
   public Evidence getEvidence() {
     return evidence;
+  }
+
+  public long getHash() {
+    return hash;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Vulnerability that = (Vulnerability) o;
+    return hash == that.hash;
+  }
+
+  @Override
+  public int hashCode() {
+    return ((Long) hash).hashCode();
   }
 }

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
@@ -1,6 +1,20 @@
 package com.datadog.iast.model;
 
+import java.util.zip.CRC32;
+import javax.annotation.Nonnull;
+
 public enum VulnerabilityType {
   WEAK_CIPHER,
   WEAK_HASH;
+
+  public long calculateHash(@Nonnull final Vulnerability vulnerability) {
+    CRC32 crc = new CRC32();
+    crc.update(name().getBytes());
+    final Location location = vulnerability.getLocation();
+    if (location != null) {
+      crc.update(location.getLine());
+      crc.update(location.getPath().getBytes());
+    }
+    return crc.getValue();
+  }
 }

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
@@ -11,6 +11,12 @@ import datadog.trace.api.gateway.RequestContextSlot
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.test.util.DDSpecification
 
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+import static datadog.trace.api.config.IastConfig.IAST_DEDUPLICATION_ENABLED
+
 class ReporterTest extends DDSpecification {
 
   void 'basic vulnerability reporting'() {
@@ -37,7 +43,7 @@ class ReporterTest extends DDSpecification {
 
     then:
     1 * traceSegment.setDataTop('iast', _) >> { batch = it[1] as VulnerabilityBatch }
-    batch.toString() == '{"vulnerabilities":[{"evidence":{"value":"MD5"},"location":{"line":1,"path":"foo"},"type":"WEAK_HASH"}]}'
+    batch.toString() == '{"vulnerabilities":[{"evidence":{"value":"MD5"},"hash":1042880134,"location":{"line":1,"path":"foo"},"type":"WEAK_HASH"}]}'
     1 * traceSegment.setTagTop('manual.keep', true)
     0 * _
   }
@@ -62,7 +68,7 @@ class ReporterTest extends DDSpecification {
       )
     final v2 = new Vulnerability(
       VulnerabilityType.WEAK_HASH,
-      Location.forStack(new StackTraceElement("foo", "foo", "foo", 1)),
+      Location.forStack(new StackTraceElement("foo", "foo", "foo", 2)),
       new Evidence("MD4")
       )
 
@@ -72,7 +78,7 @@ class ReporterTest extends DDSpecification {
 
     then:
     1 * traceSegment.setDataTop('iast', _) >> { batch = it[1] as VulnerabilityBatch }
-    batch.toString() == '{"vulnerabilities":[{"evidence":{"value":"MD5"},"location":{"line":1,"path":"foo"},"type":"WEAK_HASH"},{"evidence":{"value":"MD4"},"location":{"line":1,"path":"foo"},"type":"WEAK_HASH"}]}'
+    batch.toString() == '{"vulnerabilities":[{"evidence":{"value":"MD5"},"hash":1042880134,"location":{"line":1,"path":"foo"},"type":"WEAK_HASH"},{"evidence":{"value":"MD4"},"hash":748468584,"location":{"line":2,"path":"foo"},"type":"WEAK_HASH"}]}'
     1 * traceSegment.setTagTop('manual.keep', true)
     0 * _
   }
@@ -136,5 +142,170 @@ class ReporterTest extends DDSpecification {
     1 * span.getRequestContext() >> reqCtx
     1 * reqCtx.getData(RequestContextSlot.IAST)
     0 * _
+  }
+
+  void 'Vulnerabilities with same type and location are equals'() {
+    given:
+    final vulnerability1 = new Vulnerability(
+      VulnerabilityType.WEAK_HASH,
+      Location.forStack(new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("GOOD")
+      )
+    final vulnerability2 = new Vulnerability(
+      VulnerabilityType.WEAK_HASH,
+      Location.forStack(new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("BAD")
+      )
+
+    expect:
+    vulnerability1 == vulnerability2
+  }
+
+  void 'Vulnerabilities with same type and different location are not equals'() {
+    given:
+    final vulnerability1 = new Vulnerability(
+      VulnerabilityType.WEAK_HASH,
+      Location.forStack(new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("GOOD")
+      )
+    final vulnerability2 = new Vulnerability(
+      VulnerabilityType.WEAK_HASH,
+      Location.forStack(new StackTraceElement("foo", "foo", "foo", 2)),
+      new Evidence("BAD")
+      )
+
+    expect:
+    vulnerability1 != vulnerability2
+  }
+
+  void 'Reporter when IAST_DEDUPLICATION_ENABLED is enabled prevents duplicates'() {
+    given:
+    injectSysConfig(IAST_DEDUPLICATION_ENABLED, "true")
+    final Reporter reporter = new Reporter()
+    final batch = new VulnerabilityBatch()
+    final span = spanWithBatch(batch)
+    final vulnerability = new Vulnerability(
+      VulnerabilityType.WEAK_HASH,
+      Location.forStack(new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("GOOD")
+      )
+
+    when: 'first time a vulnerability is reported'
+    reporter.report(span, vulnerability)
+
+    then:
+    batch.vulnerabilities.size() == 1
+
+    when: 'second time the a vulnerability is reported'
+    reporter.report(span, vulnerability)
+
+    then:
+    batch.vulnerabilities.size() == 1
+  }
+
+  void 'Reporter when IAST_DEDUPLICATION_ENABLED is disabled does not prevent duplicates'() {
+    given:
+    injectSysConfig(IAST_DEDUPLICATION_ENABLED, "false")
+    final Reporter reporter = new Reporter()
+    final batch = new VulnerabilityBatch()
+    final span = spanWithBatch(batch)
+    final vulnerability = new Vulnerability(
+      VulnerabilityType.WEAK_HASH,
+      Location.forStack(new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("GOOD")
+      )
+
+    when: 'first time a vulnerability is reported'
+    reporter.report(span, vulnerability)
+
+    then:
+    batch.vulnerabilities.size() == 1
+
+    when: 'second time the a vulnerability is reported'
+    reporter.report(span, vulnerability)
+
+    then:
+    batch.vulnerabilities.size() == 2
+  }
+
+  void 'Reporter when IAST_DEDUPLICATION_ENABLED is enabled clears the cache after 1000 different vulnerabilities'() {
+    given:
+    injectSysConfig(IAST_DEDUPLICATION_ENABLED, "true")
+    final vulnerabilityBuilder = { int index ->
+      new Vulnerability(
+        VulnerabilityType.WEAK_HASH,
+        Location.forStack(new StackTraceElement(index.toString(), index.toString(), index.toString(), index)),
+        new Evidence("GOOD")
+        )
+    }
+    final deduplicationRange = (0..Reporter.HashBasedDeduplication.DEFAULT_MAX_SIZE - 1)
+    final Reporter reporter = new Reporter()
+    final batch = new VulnerabilityBatch()
+    final span = spanWithBatch(batch)
+
+    when: 'the deduplication cache is filled for the first time'
+    deduplicationRange.each { i -> reporter.report(span, vulnerabilityBuilder.call(i)) }
+
+    then: 'all vulnerabilities are reported'
+    batch.vulnerabilities.size() == Reporter.HashBasedDeduplication.DEFAULT_MAX_SIZE
+
+    when: 'duplicated vulnerabilities are checked'
+    deduplicationRange.each { i -> reporter.report(span, vulnerabilityBuilder.call(i)) }
+
+    then: 'no vulnerabilities are reported'
+    batch.vulnerabilities.size() == Reporter.HashBasedDeduplication.DEFAULT_MAX_SIZE
+
+    when: 'a new vulnerability pops up'
+    reporter.report(span, vulnerabilityBuilder.call(Reporter.HashBasedDeduplication.DEFAULT_MAX_SIZE))
+    deduplicationRange.each { i -> reporter.report(span, vulnerabilityBuilder.call(i)) }
+
+    then: 'the new vulnerability is reported and the cache cleared'
+    batch.vulnerabilities.size() == 2 * Reporter.HashBasedDeduplication.DEFAULT_MAX_SIZE + 1
+  }
+
+  void 'test hash based deduplication under concurrency'() {
+    given:
+    final executors = Executors.newCachedThreadPool()
+    final vulnerabilityBuilder = { int index ->
+      new Vulnerability(
+        VulnerabilityType.WEAK_HASH,
+        Location.forStack(new StackTraceElement(index.toString(), index.toString(), index.toString(), index)),
+        new Evidence("GOOD")
+        )
+    }
+    final int size = 32
+    final latch = new CountDownLatch(size)
+    final predicate = new Reporter.HashBasedDeduplication(size >> 3) // maximum of 4 hashes
+    final Reporter reporter = new Reporter({ final Vulnerability vul ->
+      latch.countDown()
+      predicate.test(vul)
+    })
+    final batch = new VulnerabilityBatch()
+    final span = spanWithBatch(batch)
+
+    when: 'a few duplicates are reported in a concurrent scenario'
+    (0..size).each { index ->
+      executors.execute({ reporter.report(span, vulnerabilityBuilder.call(index % 16)) }) // 8 different vuls
+    }
+
+    then: 'there are vulnerabilities reported'
+    executors.shutdown()
+    executors.awaitTermination(5, TimeUnit.SECONDS)
+    executors.isTerminated()
+    batch.vulnerabilities.size() >= 8
+  }
+
+  private AgentSpan spanWithBatch(final VulnerabilityBatch batch) {
+    final traceSegment = Mock(TraceSegment)
+    final ctx = Mock(IastRequestContext) {
+      it.getVulnerabilityBatch() >> batch
+    }
+    final reqCtx = Stub(RequestContext) {
+      it.getData(RequestContextSlot.IAST) >> ctx
+      it.getTraceSegment() >> traceSegment
+    }
+    final span = Mock(AgentSpan)
+    span.getRequestContext() >> reqCtx
+    return span
   }
 }

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/model/VulnerabilityTypeTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/model/VulnerabilityTypeTest.groovy
@@ -1,0 +1,21 @@
+package com.datadog.iast.model
+
+import datadog.trace.test.util.DDSpecification
+
+import static com.datadog.iast.model.VulnerabilityType.WEAK_CIPHER
+
+class VulnerabilityTypeTest extends DDSpecification {
+
+  def 'test compute hash'(final VulnerabilityType type, final Location location, final Evidence evidence, final long expected) {
+    when:
+    final vulnerability = new Vulnerability(type, location, evidence)
+    then:
+    vulnerability.hash == expected
+
+    where:
+    type        | location                                                         | evidence            | expected
+    WEAK_CIPHER | Location.forStack(new StackTraceElement("foo", "foo", "foo", 1)) | new Evidence("MD5") | 1045110372
+    WEAK_CIPHER | null                                                             | new Evidence("MD5") | 1272119222
+    WEAK_CIPHER | null                                                             | null                | 1272119222
+  }
+}

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/model/json/VulnerabilityEncodingTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/model/json/VulnerabilityEncodingTest.groovy
@@ -1,14 +1,13 @@
 package com.datadog.iast.model.json
 
-
-import com.datadog.iast.model.Source
-import com.datadog.iast.model.SourceType
-import com.datadog.iast.model.VulnerabilityBatch
 import com.datadog.iast.model.Evidence
 import com.datadog.iast.model.Location
-import com.datadog.iast.model.VulnerabilityType
-import com.datadog.iast.model.Vulnerability
 import com.datadog.iast.model.Range
+import com.datadog.iast.model.Source
+import com.datadog.iast.model.SourceType
+import com.datadog.iast.model.Vulnerability
+import com.datadog.iast.model.VulnerabilityBatch
+import com.datadog.iast.model.VulnerabilityType
 import datadog.trace.test.util.DDSpecification
 import groovy.json.JsonSlurper
 
@@ -35,6 +34,7 @@ class VulnerabilityEncodingTest extends DDSpecification {
           "evidence": {
             "value": "MD5"
           },
+          "hash":1042880134,
           "location": {
             "line": 1,
             "path": "foo"
@@ -72,6 +72,7 @@ class VulnerabilityEncodingTest extends DDSpecification {
               }
             ]
           },
+          "hash":1042880134,
           "location": {
             "line": 1,
             "path": "foo"
@@ -124,6 +125,7 @@ class VulnerabilityEncodingTest extends DDSpecification {
               }
             ]
           },
+          "hash":1042880134,
           "location": {
             "line": 1,
             "path": "foo"
@@ -172,6 +174,7 @@ class VulnerabilityEncodingTest extends DDSpecification {
               }
             ]
           },
+          "hash":1042880134,
           "location": {
             "line": 1,
             "path": "foo"
@@ -209,6 +212,7 @@ class VulnerabilityEncodingTest extends DDSpecification {
               }
             ]
           },
+          "hash":1042880134,
           "location": {
             "line": 1,
             "path": "foo"
@@ -257,6 +261,7 @@ class VulnerabilityEncodingTest extends DDSpecification {
             ],
             "value": "BAD1"
           },
+          "hash": 1042880134,
           "location": {
             "line": 1,
             "path": "foo"
@@ -274,6 +279,7 @@ class VulnerabilityEncodingTest extends DDSpecification {
             ],
             "value": "BAD2"
           },
+          "hash": 1042880134,
           "location": {
             "line": 1,
             "path": "foo"
@@ -323,6 +329,7 @@ class VulnerabilityEncodingTest extends DDSpecification {
             ],
             "value": "BAD"
           },
+          "hash": 1042880134,
           "location": {
             "line": 1,
             "path": "foo"
@@ -340,6 +347,7 @@ class VulnerabilityEncodingTest extends DDSpecification {
             ],
             "value": "BAD"
           },
+          "hash": 1042880134,
           "location": {
             "line": 1,
             "path": "foo"

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -87,6 +87,8 @@ public final class ConfigDefaults {
   static final String DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS =
       "^(?:PBEWITH(?:HMACSHA(?:2(?:24ANDAES_(?:128|256)|56ANDAES_(?:128|256))|384ANDAES_(?:128|256)|512ANDAES_(?:128|256)|1ANDAES_(?:128|256))|SHA1AND(?:RC(?:2_(?:128|40)|4_(?:128|40))|DESEDE)|MD5AND(?:TRIPLEDES|DES))|DES(?:EDE(?:WRAP)?)?|BLOWFISH|ARCFOUR|RC2).*$";
 
+  static final boolean DEFAULT_IAST_DEDUPLICATION_ENABLED = true;
+
   static final boolean DEFAULT_CIVISIBILITY_ENABLED = false;
   static final boolean DEFAULT_CIVISIBILITY_AGENTLESS_ENABLED = false;
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/IastConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/IastConfig.java
@@ -9,6 +9,7 @@ public final class IastConfig {
   public static final String IAST_MAX_CONCURRENT_REQUESTS = "iast.max-concurrent-request";
   public static final String IAST_VULNERABILITIES_PER_REQUEST = "iast.vulnerabilities-per-request";
   public static final String IAST_REQUEST_SAMPLING = "iast.request-sampling";
+  public static final String IAST_DEDUPLICATION_ENABLED = "iast.deduplication.enabled";
 
   private IastConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -37,6 +37,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_CLIENT_TAG_QUERY_STR
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_ERROR_STATUSES;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_ROUTE_BASED_NAMING;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_TAG_QUERY_STRING;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_DEDUPLICATION_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_MAX_CONCURRENT_REQUESTS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_REQUEST_SAMPLING;
@@ -151,6 +152,7 @@ import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_IGNORED_RESO
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_AGGREGATES;
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_PENDING;
 import static datadog.trace.api.config.GeneralConfig.VERSION;
+import static datadog.trace.api.config.IastConfig.IAST_DEDUPLICATION_ENABLED;
 import static datadog.trace.api.config.IastConfig.IAST_ENABLED;
 import static datadog.trace.api.config.IastConfig.IAST_MAX_CONCURRENT_REQUESTS;
 import static datadog.trace.api.config.IastConfig.IAST_REQUEST_SAMPLING;
@@ -621,6 +623,8 @@ public class Config {
   private final Set<String> iastWeakHashAlgorithms;
 
   private final Pattern iastWeakCipherAlgorithms;
+
+  private final boolean iastDeduplicationEnabled;
 
   private final boolean telemetryEnabled;
 
@@ -1110,6 +1114,8 @@ public class Config {
         getPattern(
             DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS,
             configProvider.getString(IAST_WEAK_CIPHER_ALGORITHMS));
+    iastDeduplicationEnabled =
+        configProvider.getBoolean(IAST_DEDUPLICATION_ENABLED, DEFAULT_IAST_DEDUPLICATION_ENABLED);
 
     ciVisibilityEnabled =
         configProvider.getBoolean(CIVISIBILITY_ENABLED, DEFAULT_CIVISIBILITY_ENABLED);
@@ -1392,6 +1398,10 @@ public class Config {
 
   public Pattern getIastWeakCipherAlgorithms() {
     return iastWeakCipherAlgorithms;
+  }
+
+  public boolean isIastDeduplicationEnabled() {
+    return iastDeduplicationEnabled;
   }
 
   public Map<String, String> getServiceMapping() {


### PR DESCRIPTION
# What Does This Do

- Add the `hash` property to vulnerability model,  this will be used to determine if two vulnerabilities are equals
- Add logic to `Reporter` that manages duplicated vulnerabilities reporting

# Motivation

Because we discover vulnerabilities by analyzing the requests, and different requests can lead to vulnerabilities with same type in the same file and line, we need mechanisms to not be reporting vulnerabilities persistently referencing same code issue.

# Additional Notes
PR fixing system tests: https://github.com/DataDog/system-tests/pull/508

For this first version:

- We are going to define that whenever a vulnerability has same type and occurs in the same file and line, they will be considered equals regardless of the rest of the parameters. This is the reason to add a hash field composed with type, file and line to the vulnerability model. 

- There will have two working modes:
     - `iast.deduplication.enabled=true` (Default): Vulnerabilities with same hash can be reported one time per run time. It is necessary to maintain a cache with already reported vulnerabilities hashes that can cause performance issues if not limited, for this reasons once 1000 vulnerabilities have been reported the cache will be reset.
    - `iast.deduplication.enabled=false` this working mode is demo oriented and skips deduplication


