### PR TITLE
[alpha][lib-injection] Change admission annotation

### DIFF
--- a/lib-injection/src/test/shell/functions.sh
+++ b/lib-injection/src/test/shell/functions.sh
@@ -170,7 +170,7 @@ metadata:
     tags.datadoghq.com/version: local
     admission.datadoghq.com/enabled: "true"
   annotations:
-    admission.datadoghq.com/java-tracer.custom-image: ${INIT_DOCKER_IMAGE_REPO}:${DOCKER_IMAGE_TAG}
+    admission.datadoghq.com/java-lib.custom-image: ${INIT_DOCKER_IMAGE_REPO}:${DOCKER_IMAGE_TAG}
   name: my-app
 spec:
 EOF


### PR DESCRIPTION
# What Does This Do

Change the admission controller annotation, `admission.datadoghq.com/java-lib.custom-image` instead of `admission.datadoghq.com/java-tracer.custom-image`

# Motivation

Use more inclusive terminology

# Additional Notes

Related to https://github.com/DataDog/datadog-agent/pull/13094