### PR TITLE
Add timestamp to debugger probe diagnostics messages

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ProbeStatus.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ProbeStatus.java
@@ -11,6 +11,7 @@ import datadog.trace.bootstrap.debugger.CapturedStackFrame;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -25,14 +26,24 @@ public class ProbeStatus {
 
   private final String service;
   private final String message;
+  private final long timestamp;
 
   @Json(name = "debugger")
   private final Diagnostics diagnostics;
 
   public ProbeStatus(String service, String message, Diagnostics diagnostics) {
+    this(service, message, diagnostics, System.currentTimeMillis());
+  }
+
+  public ProbeStatus(String service, String message, Diagnostics diagnostics, long timestamp) {
     this.service = service;
     this.message = message;
     this.diagnostics = diagnostics;
+    this.timestamp = timestamp;
+  }
+
+  public ProbeStatus withNewTimestamp(Instant now) {
+    return new ProbeStatus(service, message, diagnostics, now.toEpochMilli());
   }
 
   public String getDdSource() {
@@ -47,6 +58,10 @@ public class ProbeStatus {
     return message;
   }
 
+  public long getTimestamp() {
+    return timestamp;
+  }
+
   public Diagnostics getDiagnostics() {
     return diagnostics;
   }
@@ -57,10 +72,10 @@ public class ProbeStatus {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     ProbeStatus that = (ProbeStatus) o;
-    return ddSource.equals(that.ddSource)
-        && service.equals(that.service)
-        && message.equals(that.message)
-        && diagnostics.equals(that.diagnostics);
+    return Objects.equals(ddSource, that.ddSource)
+        && Objects.equals(service, that.service)
+        && Objects.equals(message, that.message)
+        && Objects.equals(diagnostics, that.diagnostics);
   }
 
   @Generated

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
@@ -60,6 +60,7 @@ public class ConfigurationUpdaterTest {
   @BeforeEach
   void setUp() {
     lenient().when(tracerConfig.getFinalDebuggerSnapshotUrl()).thenReturn("http://localhost");
+    lenient().when(tracerConfig.getDebuggerUploadBatchSize()).thenReturn(100);
     debuggerSinkWithMockStatusSink = new DebuggerSink(tracerConfig, probeStatusSink);
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/ProbeStatusSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/ProbeStatusSinkTest.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.sink;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.datadog.debugger.agent.ProbeStatus;
@@ -28,6 +29,7 @@ class ProbeStatusSinkTest {
 
   private static final String SERVICE_NAME = "service-name";
   private static final String PROBE_ID = UUID.randomUUID().toString();
+  private static final String PROBE_ID2 = UUID.randomUUID().toString();
   private static final String MESSAGE = "Foo";
   private static final int DIAGNOSTICS_INTERVAL = 60 * 60; // in seconds = 1h
   private static final Instant AFTER_INTERVAL_HAS_PASSED =
@@ -44,7 +46,7 @@ class ProbeStatusSinkTest {
   void setUp() {
     when(config.getServiceName()).thenReturn(SERVICE_NAME);
     when(config.getDebuggerDiagnosticsInterval()).thenReturn(DIAGNOSTICS_INTERVAL);
-    when(config.getDebuggerUploadBatchSize()).thenReturn(1000);
+    when(config.getDebuggerUploadBatchSize()).thenReturn(100);
     builder = new Builder(config);
     probeStatusSink = new ProbeStatusSink(config);
   }
@@ -163,13 +165,17 @@ class ProbeStatusSinkTest {
   void reemitOnlyLatestMessage() {
     probeStatusSink.addReceived(PROBE_ID);
     probeStatusSink.addError(PROBE_ID, MESSAGE);
+    List<ProbeStatus> firstDiagnostics = probeStatusSink.getDiagnostics();
     assertEquals(
         Arrays.asList(builder.receivedMessage(PROBE_ID), builder.errorMessage(PROBE_ID, MESSAGE)),
-        probeStatusSink.getDiagnostics());
+        firstDiagnostics);
     Clock fixed = Clock.fixed(AFTER_INTERVAL_HAS_PASSED, ZoneId.systemDefault());
+    List<ProbeStatus> secondDiagnostics = probeStatusSink.getDiagnostics(fixed);
     assertEquals(
-        Collections.singletonList(builder.errorMessage(PROBE_ID, MESSAGE)),
-        probeStatusSink.getDiagnostics(fixed));
+        Collections.singletonList(builder.errorMessage(PROBE_ID, MESSAGE)), secondDiagnostics);
+
+    // expect timestamp to be updated
+    assertTrue(firstDiagnostics.get(1).getTimestamp() < secondDiagnostics.get(0).getTimestamp());
   }
 
   @Test
@@ -229,16 +235,46 @@ class ProbeStatusSinkTest {
   }
 
   @Test
-  void dropDiagnostics() {
+  void dropRepeatingDiagnostics() {
     probeStatusSink.addReceived(PROBE_ID);
-    for (int i = 1; i <= 999; i++) {
-      probeStatusSink.addError(PROBE_ID, "foo");
+
+    // enqueues only a single error message (checking if queue already have that message).
+    for (int i = 1; i <= 100; i++) {
+      probeStatusSink.addError(PROBE_ID, "bar");
     }
-    // This will trigger clearing and re-populating the queue with the latest status per probe
-    probeStatusSink.addError(PROBE_ID, "bar");
+    // this will enqueue a new error message
+    probeStatusSink.addError(PROBE_ID, "foo");
     assertEquals(
-        Collections.singletonList(builder.errorMessage(PROBE_ID, "bar")),
+        Arrays.asList(
+            builder.receivedMessage(PROBE_ID),
+            builder.errorMessage(PROBE_ID, "bar"),
+            builder.errorMessage(PROBE_ID, "foo")),
         probeStatusSink.getDiagnostics());
+  }
+
+  @Test
+  void dealingFullQueueDroppedDiagnostics() {
+    probeStatusSink.addReceived(PROBE_ID);
+    // enqueues all messages
+    for (int i = 1; i <= 199; i++) {
+      probeStatusSink.addError(PROBE_ID, "bar " + i);
+    }
+    // those two messages would be dropped because the queue is full.
+    // However, getDiagnostics will ensure we emit the last message for each probe once it is
+    // drained
+    probeStatusSink.addReceived(PROBE_ID2);
+    probeStatusSink.addInstalled(PROBE_ID2);
+
+    List<ProbeStatus> firstBatch = probeStatusSink.getDiagnostics();
+    List<ProbeStatus> secondBatch = probeStatusSink.getDiagnostics();
+    List<ProbeStatus> thirdBatch = probeStatusSink.getDiagnostics();
+    assertEquals(100, firstBatch.size());
+    assertEquals(100, secondBatch.size());
+    assertEquals(1, thirdBatch.size());
+
+    // when fetching all messages the queue will reset and only send last messages for ecah probe
+
+    assertEquals(Arrays.asList(builder.installedMessage(PROBE_ID2)), thirdBatch);
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/diagnosticsRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/diagnosticsRegex.txt
@@ -7,5 +7,6 @@
 \}
 \},
 "message":"Received probe \d.",
-"service":"service-name"
+"service":"service-name",
+"timestamp":\d+
 \}\]

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/multipleDiagnosticsRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/multipleDiagnosticsRegex.txt
@@ -8,7 +8,8 @@
 \}
 \},
 "message":"Received probe \d.",
-"service":"service-name"
+"service":"service-name",
+"timestamp":\d+
 \},
 \{
 "ddsource":"dd_debugger",
@@ -19,6 +20,7 @@
 \}
 \},
 "message":"Received probe \d.",
-"service":"service-name"
+"service":"service-name",
+"timestamp":\d+
 \}
 \]


### PR DESCRIPTION
# What Does This Do

Adds timestamp to probe diagnostics message so the status would appear when it was sent and not when it was received by the backend.

# Motivation

Two bugs:
1. Wrong probe status appear when multiple status messages are sent on the same batch
2. timestamp not updated when probe status been reemitted

# Additional Notes
