### PR TITLE
Fix JMXFetchTest

### DIFF
--- a/dd-java-agent/src/test/java/jvmbootstraptest/JmxStartedChecker.java
+++ b/dd-java-agent/src/test/java/jvmbootstraptest/JmxStartedChecker.java
@@ -13,10 +13,16 @@ public class JmxStartedChecker {
     }
 
     if (!jmxStarted) {
-      throw new IllegalStateException("JMXFetch did not start");
+      System.out.println("ERROR: dd-jmx-collector did not start");
+      System.exit(1);
     }
 
-    // Give time for metrics to flush
-    Thread.sleep(500);
+    System.out.println("READY");
+    System.out.close();
+
+    // Give time for the test to finish if needed
+    if (args.length > 0) {
+      Thread.sleep(Long.parseLong(args[0]));
+    }
   }
 }


### PR DESCRIPTION
# What Does This Do

Avoid relying on an arbitrary sleep in JmxStartedChecker, which might be
not enough if the system is under heavy load.

Instead of sleeping within the process under test, we print `READY` from
the process when it's ready and continue the test right away. Under normal
circumstances, this is faster (JMXFetchTest goes from 15s to 11 on my machine)
and under heavy load, it shouldn't fail because of the arbitrary 500ms sleep
(unless it's delayed up to the 30s timeout for the test).

# Motivation

This test occasionally fails with a timeout, possibly because the process under
test exits before the JMX data has been sent.

# Additional Notes
