### PR TITLE
Fix ProcessSupervisorTest flakiness

### DIFF
--- a/internal-api/src/test/groovy/datadog/trace/util/ProcessSupervisorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/util/ProcessSupervisorTest.groovy
@@ -24,8 +24,8 @@ class ProcessSupervisorTest extends DDSpecification {
     then:
     conditions.eventually {
       def process = processSupervisor.currentProcess
-      process != null
-      process.isAlive()
+      assert process != null
+      assert process.isAlive()
     }
 
     when:
@@ -41,9 +41,9 @@ class ProcessSupervisorTest extends DDSpecification {
     then:
     oldProcess != null
     conditions.eventually {
-      !oldProcess.isAlive()
+      assert !oldProcess.isAlive()
       def process = processSupervisor.currentProcess
-      process == null || !process.isAlive()
+      assert process == null || !process.isAlive()
     }
   }
 
@@ -71,11 +71,11 @@ class ProcessSupervisorTest extends DDSpecification {
     then:
     firstProcess != null
     conditions.eventually {
-      !firstProcess.isAlive()
+      assert !firstProcess.isAlive()
       def process = processSupervisor.currentProcess
-      process != null
-      process != firstProcess
-      process.isAlive()
+      assert process != null
+      assert process != firstProcess
+      assert process.isAlive()
     }
 
     when:
@@ -87,9 +87,9 @@ class ProcessSupervisorTest extends DDSpecification {
     then:
     secondProcess != null
     conditions.eventually {
-      !secondProcess.isAlive()
+      assert !secondProcess.isAlive()
       def process = processSupervisor.currentProcess
-      process == null || !process.isAlive()
+      assert process == null || !process.isAlive()
     }
   }
 }


### PR DESCRIPTION
# What Does This Do

Adds missing `assert`s within closures.

# Motivation

Spock does not introduce implicit asserts in closures. This means that
everything in the `conditions.eventually` blocks in these tests is being
ignored unless it throws an exception.

In some cases, this makes the `Process respawns when killed` test case
fail on the `secondProcess != null` assertion.

# Additional Notes
