### PR TITLE
Add additional tags for pathway injection in RabbitMQ instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/ClientCallImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/ClientCallImplInstrumentation.java
@@ -18,6 +18,7 @@ import io.grpc.ClientCall;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -83,7 +84,7 @@ public final class ClientCallImplInstrumentation extends Instrumenter.Tracing
       span = InstrumentationContext.get(ClientCall.class, AgentSpan.class).get(call);
       if (null != span) {
         propagate().inject(span, headers, SETTER);
-        propagate().injectPathwayContext(span, headers, SETTER);
+        propagate().injectPathwayContext(span, headers, SETTER, Arrays.asList("type:internal"));
         // span has been retrieved from the context - resume
         span.finishThreadMigration();
         return activateSpan(span);

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -19,6 +19,7 @@ import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
+import java.util.Arrays;
 import net.bytebuddy.asm.Advice;
 import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.producer.Callback;
@@ -88,7 +89,7 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Tracing
           && !Config.get().isKafkaClientPropagationDisabledForTopic(record.topic())) {
         try {
           propagate().inject(span, record.headers(), SETTER);
-          propagate().injectBinaryPathwayContext(span, record.headers(), SETTER);
+          propagate().injectBinaryPathwayContext(span, record.headers(), SETTER, Arrays.asList("type:internal"));
         } catch (final IllegalStateException e) {
           // headers must be read-only from reused record. try again with new one.
           record =
@@ -101,7 +102,7 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Tracing
                   record.headers());
 
           propagate().inject(span, record.headers(), SETTER);
-          propagate().injectBinaryPathwayContext(span, record.headers(), SETTER);
+          propagate().injectBinaryPathwayContext(span, record.headers(), SETTER, Arrays.asList("type:internal"));
         }
         if (!KAFKA_LEGACY_TRACING) {
           SETTER.injectTimeInQueue(record.headers());

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -16,8 +16,6 @@ import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.PRODUC
 import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.RABBITMQ_LEGACY_TRACING;
 import static datadog.trace.instrumentation.rabbitmq.amqp.TagsCache.EXCHANGE_TAG_CACHE;
 import static datadog.trace.instrumentation.rabbitmq.amqp.TagsCache.EXCHANGE_TAG_PREFIX;
-import static datadog.trace.instrumentation.rabbitmq.amqp.TagsCache.ROUTING_KEY_TAG_CACHE;
-import static datadog.trace.instrumentation.rabbitmq.amqp.TagsCache.ROUTING_KEY_TAG_PREFIX;
 import static datadog.trace.instrumentation.rabbitmq.amqp.TextMapInjectAdapter.SETTER;
 import static net.bytebuddy.matcher.ElementMatchers.canThrow;
 import static net.bytebuddy.matcher.ElementMatchers.isGetter;
@@ -190,9 +188,9 @@ public class RabbitChannelInstrumentation extends Instrumenter.Tracing
         propagate().inject(span, headers, SETTER);
         propagate().injectPathwayContext(span, headers, SETTER,
             Arrays.asList(
-                "type:internal",
                 EXCHANGE_TAG_CACHE.computeIfAbsent(exchange, EXCHANGE_TAG_PREFIX),
-                ROUTING_KEY_TAG_CACHE.computeIfAbsent(routingKey, ROUTING_KEY_TAG_PREFIX)));
+                routingKey == null || routingKey.equals("") ? "has_routing_key:false" : "has_routing_key:true",
+                "type:internal"));
         props =
             new AMQP.BasicProperties(
                 props.getContentType(),

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -155,7 +155,6 @@ public class RabbitChannelInstrumentation extends Instrumenter.Tracing
         @Advice.Argument(1) final String routingKey,
         @Advice.Argument(value = 4, readOnly = false) AMQP.BasicProperties props,
         @Advice.Argument(5) final byte[] body) {
-      System.out.println("[TEST_LOGS] About to inject");
       final int callDepth = CallDepthThreadLocalMap.incrementCallDepth(Channel.class);
       if (callDepth > 0) {
         return null;
@@ -189,15 +188,11 @@ public class RabbitChannelInstrumentation extends Instrumenter.Tracing
           RabbitDecorator.injectTimeInQueueStart(headers);
         }
         propagate().inject(span, headers, SETTER);
-        try {
-          propagate().injectPathwayContext(span, headers, SETTER,
-              Arrays.asList(
-                  "type:internal",
-                  EXCHANGE_TAG_CACHE.computeIfAbsent(exchange, EXCHANGE_TAG_PREFIX),
-                  ROUTING_KEY_TAG_CACHE.computeIfAbsent(routingKey, ROUTING_KEY_TAG_PREFIX)));
-        } catch (Exception e) {
-          e.printStackTrace();
-        }
+        propagate().injectPathwayContext(span, headers, SETTER,
+            Arrays.asList(
+                "type:internal",
+                EXCHANGE_TAG_CACHE.computeIfAbsent(exchange, EXCHANGE_TAG_PREFIX),
+                ROUTING_KEY_TAG_CACHE.computeIfAbsent(routingKey, ROUTING_KEY_TAG_PREFIX)));
         props =
             new AMQP.BasicProperties(
                 props.getContentType(),

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/TagsCache.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/TagsCache.java
@@ -1,0 +1,25 @@
+package datadog.trace.instrumentation.rabbitmq.amqp;
+
+import datadog.trace.api.cache.DDCache;
+import datadog.trace.api.cache.DDCaches;
+import datadog.trace.api.function.Function;
+
+public class TagsCache {
+  public static final class StringPrefix implements Function<String, String> {
+    private final String prefix;
+
+    public StringPrefix(String prefix) {
+      this.prefix = prefix;
+    }
+
+    @Override
+    public String apply(String key) {
+      return prefix + key;
+    }
+  }
+
+    public static final DDCache<String, String> EXCHANGE_TAG_CACHE = DDCaches.newFixedSizeCache(32);
+    public static final Function<String, String> EXCHANGE_TAG_PREFIX = new StringPrefix("exchange:");
+    public static final DDCache<String, String> ROUTING_KEY_TAG_CACHE = DDCaches.newFixedSizeCache(32);
+    public static final Function<String, String> ROUTING_KEY_TAG_PREFIX = new StringPrefix("routing_key:");
+}

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/TagsCache.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/TagsCache.java
@@ -20,6 +20,4 @@ public class TagsCache {
 
     public static final DDCache<String, String> EXCHANGE_TAG_CACHE = DDCaches.newFixedSizeCache(32);
     public static final Function<String, String> EXCHANGE_TAG_PREFIX = new StringPrefix("exchange:");
-    public static final DDCache<String, String> ROUTING_KEY_TAG_CACHE = DDCaches.newFixedSizeCache(32);
-    public static final Function<String, String> ROUTING_KEY_TAG_PREFIX = new StringPrefix("routing_key:");
 }

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -153,8 +153,8 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags.containsAll(["type:internal"])
-        edgeTags.size() == 1
+        edgeTags.containsAll(["type:internal", "exchange:" + exchangeName, "routing_key:" + routingKey])
+        edgeTags.size() == 3
       }
 
       StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
@@ -207,8 +207,8 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags.containsAll(["type:internal"])
-        edgeTags.size() == 1
+        edgeTags.containsAll(["type:internal", "exchange:", "routing_key:<generated>"])
+        edgeTags.size() == 3
       }
 
       StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
@@ -304,8 +304,8 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
       List<StatsGroup> producerPoints = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == 0 }
       producerPoints.each { producerPoint ->
         verifyAll(producerPoint) {
-          edgeTags.containsAll(["type:internal"])
-          edgeTags.size() == 1
+          edgeTags.containsAll(["type:internal", "exchange:" + exchangeName, "routing_key:"])
+          edgeTags.size() == 3
         }
       }
 
@@ -396,8 +396,8 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags.containsAll(["type:internal"])
-        edgeTags.size() == 1
+        edgeTags.containsAll(["type:internal", "exchange:" + exchangeName, "routing_key:"])
+        edgeTags.size() == 3
       }
 
       StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
@@ -481,8 +481,8 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags.containsAll(["type:internal"])
-        edgeTags.size() == 1
+        edgeTags.containsAll(["type:internal", "exchange:", "routing_key:" + "some-routing-queue"])
+        edgeTags.size() == 3
       }
 
       StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
@@ -565,8 +565,8 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled() && !noParent) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags.containsAll(["type:internal"])
-        edgeTags.size() == 1
+        edgeTags.containsAll(["type:internal", "exchange:" + exchangeName, "routing_key:" + routingKey])
+        edgeTags.size() == 3
       }
 
       StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
@@ -658,8 +658,8 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled() && !noParent) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags.containsAll(["type:internal"])
-        edgeTags.size() == 1
+        edgeTags.containsAll(["type:internal", "exchange:" + exchangeName, "routing_key:" + routingKey])
+        edgeTags.size() == 3
       }
 
       StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -153,7 +153,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags.containsAll(["type:internal", "exchange:" + exchangeName, "routing_key:" + routingKey])
+        edgeTags.containsAll(["type:internal", "exchange:" + exchangeName, "has_routing_key:true"])
         edgeTags.size() == 3
       }
 
@@ -207,7 +207,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags.containsAll(["type:internal", "exchange:", "routing_key:<generated>"])
+        edgeTags.containsAll(["type:internal", "exchange:", "has_routing_key:true"])
         edgeTags.size() == 3
       }
 
@@ -304,7 +304,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
       List<StatsGroup> producerPoints = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == 0 }
       producerPoints.each { producerPoint ->
         verifyAll(producerPoint) {
-          edgeTags.containsAll(["type:internal", "exchange:" + exchangeName, "routing_key:"])
+          edgeTags.containsAll(["type:internal", "exchange:" + exchangeName, "has_routing_key:false"])
           edgeTags.size() == 3
         }
       }
@@ -396,7 +396,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags.containsAll(["type:internal", "exchange:" + exchangeName, "routing_key:"])
+        edgeTags.containsAll(["type:internal", "exchange:" + exchangeName, "has_routing_key:false"])
         edgeTags.size() == 3
       }
 
@@ -481,7 +481,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags.containsAll(["type:internal", "exchange:", "routing_key:" + "some-routing-queue"])
+        edgeTags.containsAll(["type:internal", "exchange:", "has_routing_key:true"])
         edgeTags.size() == 3
       }
 
@@ -565,7 +565,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled() && !noParent) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags.containsAll(["type:internal", "exchange:" + exchangeName, "routing_key:" + routingKey])
+        edgeTags.containsAll(["type:internal", "exchange:" + exchangeName, "has_routing_key:true"])
         edgeTags.size() == 3
       }
 
@@ -658,7 +658,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled() && !noParent) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags.containsAll(["type:internal", "exchange:" + exchangeName, "routing_key:" + routingKey])
+        edgeTags.containsAll(["type:internal", "exchange:" + exchangeName, "has_routing_key:true"])
         edgeTags.size() == 3
       }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -765,9 +765,9 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   @Override
-  public <C> void injectBinaryPathwayContext(AgentSpan span, C carrier, BinarySetter<C> setter) {
+  public <C> void injectBinaryPathwayContext(AgentSpan span, C carrier, BinarySetter<C> setter, List<String> edgeTags) {
     PathwayContext pathwayContext = span.context().getPathwayContext();
-    pathwayContext.setCheckpoint(Arrays.asList("type:internal"), dataStreamsCheckpointer);
+    pathwayContext.setCheckpoint(edgeTags, dataStreamsCheckpointer);
 
     try {
       byte[] encodedContext = span.context().getPathwayContext().encode();
@@ -782,9 +782,9 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   @Override
-  public <C> void injectPathwayContext(AgentSpan span, C carrier, Setter<C> setter) {
+  public <C> void injectPathwayContext(AgentSpan span, C carrier, Setter<C> setter, List<String> edgeTags) {
     PathwayContext pathwayContext = span.context().getPathwayContext();
-    pathwayContext.setCheckpoint(Arrays.asList("type:internal"), dataStreamsCheckpointer);
+    pathwayContext.setCheckpoint(edgeTags, dataStreamsCheckpointer);
     try {
       String encodedContext = pathwayContext.strEncode();
       if (encodedContext != null) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
@@ -234,9 +234,9 @@ public class DefaultPathwayContext implements PathwayContext {
         new PathwayContextExtractor(timeSource, wellKnownTags);
     getter.forEachKey(carrier, pathwayContextExtractor);
     if (pathwayContextExtractor.extractedContext == null) {
-      System.out.println("No context extracted");
+      log.debug("No context extracted");
     } else {
-      System.out.println("Extracted context: " + pathwayContextExtractor.extractedContext);
+      log.debug("Extracted context: {} ", pathwayContextExtractor.extractedContext);
     }
     return pathwayContextExtractor.extractedContext;
   }
@@ -250,9 +250,9 @@ public class DefaultPathwayContext implements PathwayContext {
         new BinaryPathwayContextExtractor(timeSource, wellKnownTags);
     getter.forEachKey(carrier, pathwayContextExtractor);
     if (pathwayContextExtractor.extractedContext == null) {
-      System.out.println("No context extracted");
+      log.debug("No context extracted");
     } else {
-      System.out.println("Extracted context: " + pathwayContextExtractor.extractedContext);
+      log.debug("Extracted context: {} ", pathwayContextExtractor.extractedContext);
     }
     return pathwayContextExtractor.extractedContext;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
@@ -234,9 +234,9 @@ public class DefaultPathwayContext implements PathwayContext {
         new PathwayContextExtractor(timeSource, wellKnownTags);
     getter.forEachKey(carrier, pathwayContextExtractor);
     if (pathwayContextExtractor.extractedContext == null) {
-      log.debug("No context extracted");
+      System.out.println("No context extracted");
     } else {
-      log.debug("Extracted context: {} ", pathwayContextExtractor.extractedContext);
+      System.out.println("Extracted context: " + pathwayContextExtractor.extractedContext);
     }
     return pathwayContextExtractor.extractedContext;
   }
@@ -250,9 +250,9 @@ public class DefaultPathwayContext implements PathwayContext {
         new BinaryPathwayContextExtractor(timeSource, wellKnownTags);
     getter.forEachKey(carrier, pathwayContextExtractor);
     if (pathwayContextExtractor.extractedContext == null) {
-      log.debug("No context extracted");
+      System.out.println("No context extracted");
     } else {
-      log.debug("Extracted context: {} ", pathwayContextExtractor.extractedContext);
+      System.out.println("Extracted context: " + pathwayContextExtractor.extractedContext);
     }
     return pathwayContextExtractor.extractedContext;
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
@@ -1,6 +1,7 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
 import datadog.trace.api.PropagationStyle;
+import java.util.List;
 
 public interface AgentPropagation {
 
@@ -12,9 +13,9 @@ public interface AgentPropagation {
 
   <C> void inject(AgentSpan span, C carrier, Setter<C> setter, PropagationStyle style);
 
-  <C> void injectBinaryPathwayContext(AgentSpan span, C carrier, BinarySetter<C> setter);
+  <C> void injectBinaryPathwayContext(AgentSpan span, C carrier, BinarySetter<C> setter, List<String> edgeTags);
 
-  <C> void injectPathwayContext(AgentSpan span, C carrier, Setter<C> setter);
+  <C> void injectPathwayContext(AgentSpan span, C carrier, Setter<C> setter, List<String> edgeTags);
 
   interface Setter<C> {
     void set(C carrier, String key, String value);

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -356,10 +356,11 @@ public class AgentTracer {
     public <C> void inject(AgentSpan span, C carrier, Setter<C> setter, PropagationStyle style) {}
 
     @Override
-    public <C> void injectBinaryPathwayContext(AgentSpan span, C carrier, BinarySetter<C> setter) {}
+    public <C> void injectBinaryPathwayContext(
+        AgentSpan span, C carrier, BinarySetter<C> setter, List<String> edgeTags) {}
 
     @Override
-    public <C> void injectPathwayContext(AgentSpan span, C carrier, Setter<C> setter) {}
+    public <C> void injectPathwayContext(AgentSpan span, C carrier, Setter<C> setter, List<String> edgeTags) {}
 
     @Override
     public <C> Context.Extracted extract(final C carrier, final ContextVisitor<C> getter) {
@@ -765,10 +766,11 @@ public class AgentTracer {
     public <C> void inject(AgentSpan span, C carrier, Setter<C> setter, PropagationStyle style) {}
 
     @Override
-    public <C> void injectBinaryPathwayContext(AgentSpan span, C carrier, BinarySetter<C> setter) {}
+    public <C> void injectBinaryPathwayContext(
+        AgentSpan span, C carrier, BinarySetter<C> setter, List<String> edgeTags) {}
 
     @Override
-    public <C> void injectPathwayContext(AgentSpan span, C carrier, Setter<C> setter) {}
+    public <C> void injectPathwayContext(AgentSpan span, C carrier, Setter<C> setter, List<String> edgeTags) {}
 
     @Override
     public <C> Context.Extracted extract(final C carrier, final ContextVisitor<C> getter) {


### PR DESCRIPTION
# What Does This Do
This PR add two new tags for pathway injection in RabbitMQ instrumentation: `exchange` and `has_routing_key`. The `exchange` tag stores the RabbitMQ exchange used to publish a message while the `has_routing_key` tag indicates whether a routing key was set.

Tested with a RabbitMQ application and confirmed that the tags show up for the relevant metrics.