### PR TITLE
Fix race condition in embedded mongo tests

### DIFF
--- a/dd-java-agent/instrumentation/mongo/mongo.gradle
+++ b/dd-java-agent/instrumentation/mongo/mongo.gradle
@@ -3,22 +3,3 @@ apply from: "$rootDir/gradle/java.gradle"
 dependencies {
   testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '1.50.5'
 }
-
-// Forcing strict test execution order (no parallel execution) to ensure proper mongo executable initialization.
-List<Test> testTasks = []
-tasks.withType(Test).configureEach { Test testTask ->
-  testTasks.each {
-    testTask.shouldRunAfter(it)
-  }
-  testTasks.add(testTask)
-}
-subprojects {
-  afterEvaluate {
-    tasks.withType(Test).configureEach { Test testTask ->
-      testTasks.each {
-        testTask.shouldRunAfter(it)
-      }
-      testTasks.add(testTask)
-    }
-  }
-}


### PR DESCRIPTION
# What Does This Do

The embedded mongo installed had a race condition when multiple modules
tried to install it concurrently. There was a workaround at gradle
level, which did not work reliably.

Removed the gradle-level solution, and synchronize install across
multiple modules with a file lock and a timeout.

# Motivation

# Additional Notes
