### PR TITLE
Send additional StatsPoint for each pathway checkpoint to compute availability metric.

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTest.groovy
@@ -105,7 +105,7 @@ class KafkaClientTest extends AgentTestRunner {
       }
       blockUntilChildSpansFinished(2)
     }
-    TEST_DATA_STREAMS_WRITER.waitForGroups(2)
+    TEST_DATA_STREAMS_WRITER.waitForGroups(4)
 
     then:
     // check that the message was received
@@ -161,17 +161,21 @@ class KafkaClientTest extends AgentTestRunner {
     new String(headers.headers("x-datadog-trace-id").iterator().next().value()) == "${TEST_WRITER[0][2].traceId}"
     new String(headers.headers("x-datadog-parent-id").iterator().next().value()) == "${TEST_WRITER[0][2].spanId}"
 
-    if (Platform.isJavaVersionAtLeast(8)) {
-      StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
-      verifyAll(first) {
-        edgeTags.containsAll(["type:internal"])
-        edgeTags.size() == 1
+    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+      List<StatsGroup> producerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == 0 }
+      producerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:internal"])
+          edgeTags.size() == 1
+        }
       }
 
-      StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
-      verifyAll(second) {
-        edgeTags.containsAll(["type:kafka", "group:sender", "topic:$SHARED_TOPIC".toString()])
-        edgeTags.size() == 3
+      List<StatsGroup> consumerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == producerGroups.get(0).hash }
+      consumerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:kafka", "group:sender", "topic:$SHARED_TOPIC".toString()])
+          edgeTags.size() == 3
+        }
       }
     }
 
@@ -226,7 +230,7 @@ class KafkaClientTest extends AgentTestRunner {
       })
       blockUntilChildSpansFinished(2)
     }
-    TEST_DATA_STREAMS_WRITER.waitForGroups(2)
+    TEST_DATA_STREAMS_WRITER.waitForGroups(4)
 
     then:
     // check that the message was received
@@ -282,17 +286,21 @@ class KafkaClientTest extends AgentTestRunner {
     new String(headers.headers("x-datadog-trace-id").iterator().next().value()) == "${TEST_WRITER[0][2].traceId}"
     new String(headers.headers("x-datadog-parent-id").iterator().next().value()) == "${TEST_WRITER[0][2].spanId}"
 
-    if (Platform.isJavaVersionAtLeast(8)) {
-      StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
-      verifyAll(first) {
-        edgeTags.containsAll(["type:internal"])
-        edgeTags.size() == 1
+    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+      List<StatsGroup> producerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == 0 }
+      producerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:internal"])
+          edgeTags.size() == 1
+        }
       }
 
-      StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
-      verifyAll(second) {
-        edgeTags.containsAll(["type:kafka", "group:sender", "topic:$SHARED_TOPIC".toString()])
-        edgeTags.size() == 3
+      List<StatsGroup> consumerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == producerGroups.get(0).hash }
+      consumerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:kafka", "group:sender", "topic:$SHARED_TOPIC".toString()])
+          edgeTags.size() == 3
+        }
       }
     }
 
@@ -737,7 +745,7 @@ class KafkaClientTest extends AgentTestRunner {
       }
       blockUntilChildSpansFinished(2 * greetings.size())
     }
-    TEST_DATA_STREAMS_WRITER.waitForGroups(2)
+    TEST_DATA_STREAMS_WRITER.waitForGroups(4)
 
     then:
     def receivedSet = greetings.toSet()
@@ -860,17 +868,21 @@ class KafkaClientTest extends AgentTestRunner {
       }
     }
 
-    if (Platform.isJavaVersionAtLeast(8)) {
-      StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
-      verifyAll(first) {
-        edgeTags.containsAll(["type:internal"])
-        edgeTags.size() == 1
+    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+      List<StatsGroup> producerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == 0 }
+      producerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:internal"])
+          edgeTags.size() == 1
+        }
       }
 
-      StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
-      verifyAll(second) {
-        edgeTags.containsAll(["type:kafka", "group:sender", "topic:$SHARED_TOPIC".toString()])
-        edgeTags.size() == 3
+      List<StatsGroup> consumerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == producerGroups.get(0).hash }
+      consumerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:kafka", "group:sender", "topic:$SHARED_TOPIC".toString()])
+          edgeTags.size() == 3
+        }
       }
     }
 

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
@@ -108,7 +108,7 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
       blockUntilChildSpansFinished(2)
     }
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
-      TEST_DATA_STREAMS_WRITER.waitForGroups(2)
+      TEST_DATA_STREAMS_WRITER.waitForGroups(4)
     }
 
     then:
@@ -141,16 +141,20 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
     new String(headers.headers("x-datadog-parent-id").iterator().next().value()) == "${TEST_WRITER[0][2].spanId}"
 
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
-      StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
-      verifyAll(first) {
-        edgeTags.containsAll(["type:internal"])
-        edgeTags.size() == 1
+      List<StatsGroup> producerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == 0 }
+      producerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:internal"])
+          edgeTags.size() == 1
+        }
       }
 
-      StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
-      verifyAll(second) {
-        edgeTags.containsAll(["type:kafka", "group:sender", "topic:$SHARED_TOPIC".toString()])
-        edgeTags.size() == 3
+      List<StatsGroup> consumerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == producerGroups.get(0).hash }
+      consumerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:kafka", "group:sender", "topic:$SHARED_TOPIC".toString()])
+          edgeTags.size() == 3
+        }
       }
     }
 
@@ -206,7 +210,7 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
       blockUntilChildSpansFinished(2)
     }
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
-      TEST_DATA_STREAMS_WRITER.waitForGroups(2)
+      TEST_DATA_STREAMS_WRITER.waitForGroups(4)
     }
 
     then:
@@ -239,16 +243,20 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
     new String(headers.headers("x-datadog-parent-id").iterator().next().value()) == "${TEST_WRITER[0][2].spanId}"
 
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
-      StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
-      verifyAll(first) {
-        edgeTags.containsAll(["type:internal"])
-        edgeTags.size() == 1
+      List<StatsGroup> producerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == 0 }
+      producerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:internal"])
+          edgeTags.size() == 1
+        }
       }
 
-      StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
-      verifyAll(second) {
-        edgeTags.containsAll(["type:kafka", "group:sender", "topic:$SHARED_TOPIC".toString()])
-        edgeTags.size() == 3
+      List<StatsGroup> consumerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == producerGroups.get(0).hash }
+      consumerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:kafka", "group:sender", "topic:$SHARED_TOPIC".toString()])
+          edgeTags.size() == 3
+        }
       }
     }
 
@@ -638,7 +646,7 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
       blockUntilChildSpansFinished(2 * greetings.size())
     }
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
-      TEST_DATA_STREAMS_WRITER.waitForGroups(2)
+      TEST_DATA_STREAMS_WRITER.waitForGroups(4)
     }
 
     then:
@@ -692,16 +700,20 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
     }
 
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
-      StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
-      verifyAll(first) {
-        edgeTags.containsAll(["type:internal"])
-        edgeTags.size() == 1
+      List<StatsGroup> producerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == 0 }
+      producerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:internal"])
+          edgeTags.size() == 1
+        }
       }
 
-      StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
-      verifyAll(second) {
-        edgeTags.containsAll(["type:kafka", "group:sender", "topic:$SHARED_TOPIC".toString()])
-        edgeTags.size() == 3
+      List<StatsGroup> consumerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == producerGroups.get(0).hash }
+      consumerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:kafka", "group:sender", "topic:$SHARED_TOPIC".toString()])
+          edgeTags.size() == 3
+        }
       }
     }
 

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -119,7 +119,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
       return channel.basicGet(queueName, true)
     }
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
-      TEST_DATA_STREAMS_WRITER.waitForGroups(2)
+      TEST_DATA_STREAMS_WRITER.waitForGroups(4)
     }
 
     expect:
@@ -151,16 +151,20 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
 
     and:
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
-      StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
-      verifyAll(first) {
-        edgeTags.containsAll(["type:internal"])
-        edgeTags.size() == 1
+      List<StatsGroup> producerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == 0 }
+      producerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:internal"])
+          edgeTags.size() == 1
+        }
       }
 
-      StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
-      verifyAll(second) {
-        edgeTags.containsAll(["type:rabbitmq", "topic:" + queueName])
-        edgeTags.size() == 2
+      List<StatsGroup> consumerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == producerGroups.get(0).hash }
+      consumerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:rabbitmq", "topic:" + queueName])
+          edgeTags.size() == 2
+        }
       }
     }
 
@@ -175,7 +179,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     channel.basicPublish("", queueName, null, "Hello, world!".getBytes())
     GetResponse response = channel.basicGet(queueName, true)
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
-      TEST_DATA_STREAMS_WRITER.waitForGroups(2)
+      TEST_DATA_STREAMS_WRITER.waitForGroups(4)
     }
 
     expect:
@@ -205,16 +209,20 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
 
     and:
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
-      StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
-      verifyAll(first) {
-        edgeTags.containsAll(["type:internal"])
-        edgeTags.size() == 1
+      List<StatsGroup> producerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == 0 }
+      producerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:internal"])
+          edgeTags.size() == 1
+        }
       }
 
-      StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
-      verifyAll(second) {
-        edgeTags.containsAll(["type:rabbitmq", "topic:" + queueName])
-        edgeTags.size() == 2
+      List<StatsGroup> consumerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == producerGroups.get(0).hash }
+      consumerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:rabbitmq", "topic:" + queueName])
+          edgeTags.size() == 2
+        }
       }
     }
   }
@@ -253,7 +261,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
       }
       TEST_WRITER.waitForTraces(5 + ((it - 1) * 2))
       if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
-        TEST_DATA_STREAMS_WRITER.waitForGroups(it * 2)
+        TEST_DATA_STREAMS_WRITER.waitForGroups(it * 4)
       }
       phaser.arriveAndAwaitAdvance()
     }
@@ -355,7 +363,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     TEST_WRITER.waitForTraces(3)
     phaser.arriveAndAwaitAdvance()
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
-      TEST_DATA_STREAMS_WRITER.waitForGroups(2)
+      TEST_DATA_STREAMS_WRITER.waitForGroups(4)
     }
 
     expect:
@@ -394,16 +402,20 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
 
     and:
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
-      StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
-      verifyAll(first) {
-        edgeTags.containsAll(["type:internal"])
-        edgeTags.size() == 1
+      List<StatsGroup> producerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == 0 }
+      producerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:internal"])
+          edgeTags.size() == 1
+        }
       }
 
-      StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
-      verifyAll(second) {
-        edgeTags.containsAll(["type:rabbitmq", "topic:" + queueName])
-        edgeTags.size() == 2
+      List<StatsGroup> consumerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == producerGroups.get(0).hash }
+      consumerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:rabbitmq", "topic:" + queueName])
+          edgeTags.size() == 2
+        }
       }
     }
 
@@ -479,16 +491,20 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
 
     and:
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
-      StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
-      verifyAll(first) {
-        edgeTags.containsAll(["type:internal"])
-        edgeTags.size() == 1
+      List<StatsGroup> producerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == 0 }
+      producerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:internal"])
+          edgeTags.size() == 1
+        }
       }
 
-      StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
-      verifyAll(second) {
-        edgeTags.containsAll(["type:rabbitmq", "topic:some-routing-queue"])
-        edgeTags.size() == 2
+      List<StatsGroup> consumerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == producerGroups.get(0).hash }
+      consumerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:rabbitmq", "topic:some-routing-queue"])
+          edgeTags.size() == 2
+        }
       }
     }
   }
@@ -562,17 +578,21 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled() && !noParent) {
-      StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
-      verifyAll(first) {
-        edgeTags.containsAll(["type:internal"])
-        edgeTags.size() == 1
+    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+      List<StatsGroup> producerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == 0 }
+      producerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:internal"])
+          edgeTags.size() == 1
+        }
       }
 
-      StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
-      verifyAll(second) {
-        edgeTags.containsAll(["type:rabbitmq", "topic:" + queueName])
-        edgeTags.size() == 2
+      List<StatsGroup> consumerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == producerGroups.get(0).hash }
+      consumerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:rabbitmq", "topic:" + queueName])
+          edgeTags.size() == 2
+        }
       }
     }
 
@@ -655,17 +675,21 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled() && !noParent) {
-      StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
-      verifyAll(first) {
-        edgeTags.containsAll(["type:internal"])
-        edgeTags.size() == 1
+    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+      List<StatsGroup> producerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == 0 }
+      producerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:internal"])
+          edgeTags.size() == 1
+        }
       }
 
-      StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
-      verifyAll(second) {
-        edgeTags.containsAll(["type:rabbitmq", "topic:" + queueName])
-        edgeTags.size() == 2
+      List<StatsGroup> consumerGroups = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == producerGroups.get(0).hash }
+      consumerGroups.each {
+        verifyAll(it) {
+          edgeTags.containsAll(["type:rabbitmq", "topic:" + queueName])
+          edgeTags.size() == 2
+        }
       }
     }
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/datastreams/RecordingDatastreamsPayloadWriter.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/datastreams/RecordingDatastreamsPayloadWriter.groovy
@@ -9,17 +9,24 @@ import java.util.concurrent.TimeUnit
 
 class RecordingDatastreamsPayloadWriter implements DatastreamsPayloadWriter {
   List<Collection<StatsBucket>> payloads = []
+  List<StatsBucket.BucketType> payloadBucketTypes = []
   List<StatsGroup> groups = []
+  List<StatsBucket.BucketType> groupBucketTypes = []
 
   @Override
-  void writePayload(Collection<StatsBucket> data) {
+  void writePayload(Collection<StatsBucket> data, StatsBucket.BucketType bucketType) {
     payloads.add(data)
-    data.each { groups.addAll(it.groups) }
+    payloadBucketTypes.add(bucketType)
+    data.each {
+      groups.addAll(it.groups)
+      groupBucketTypes.add([bucketType] * it.groups.size())
+    }
   }
 
   void clear() {
     payloads.clear()
     groups.clear()
+    bucketTypes.clear()
   }
 
   void waitForPayloads(int count, long timeout = TimeUnit.SECONDS.toMillis(1)) {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/datastreams/RecordingDatastreamsPayloadWriter.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/datastreams/RecordingDatastreamsPayloadWriter.groovy
@@ -26,7 +26,8 @@ class RecordingDatastreamsPayloadWriter implements DatastreamsPayloadWriter {
   void clear() {
     payloads.clear()
     groups.clear()
-    bucketTypes.clear()
+    payloadBucketTypes.clear()
+    groupBucketTypes.clear()
   }
 
   void waitForPayloads(int count, long timeout = TimeUnit.SECONDS.toMillis(1)) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DatastreamsPayloadWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DatastreamsPayloadWriter.java
@@ -3,5 +3,5 @@ package datadog.trace.core.datastreams;
 import java.util.Collection;
 
 public interface DatastreamsPayloadWriter {
-  void writePayload(Collection<StatsBucket> data);
+  void writePayload(Collection<StatsBucket> data, StatsBucket.BucketType bucketType);
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsCheckpointer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsCheckpointer.java
@@ -42,7 +42,8 @@ public class DefaultDataStreamsCheckpointer
   private static final StatsPoint POISON_PILL =
       new StatsPoint(Collections.<String>emptyList(), 0, 0, 0, 0, 0);
 
-  private final Map<Long, StatsBucket> timeToBucket = new HashMap<>();
+  private final Map<Long, StatsBucket> tsCurrentBuckets = new HashMap<>();
+  private final Map<Long, StatsBucket> tsOriginBuckets = new HashMap<>();
   private final BlockingQueue<StatsPoint> inbox = new MpscBlockingConsumerArrayQueue<>(1024);
   private final DatastreamsPayloadWriter payloadWriter;
   private final DDAgentFeaturesDiscovery features;
@@ -177,18 +178,25 @@ public class DefaultDataStreamsCheckpointer
             }
             break;
           } else if (supportsDataStreams) {
-            Long bucket = currentBucket(statsPoint.getTimestampNanos());
+            Long tsOriginBucket = currentBucket(statsPoint.getTimestampNanos() - statsPoint.getPathwayLatencyNano());
+            Long tsCurrentBucket = currentBucket(statsPoint.getTimestampNanos());
 
             // FIXME computeIfAbsent() is not available because Java 7
             // No easy way to have Java 8 in core even though datastreams monitoring is 8+ from
             // DDSketch
-            StatsBucket statsBucket = timeToBucket.get(bucket);
-            if (statsBucket == null) {
-              statsBucket = new StatsBucket(bucket, bucketDurationNanos);
-              timeToBucket.put(bucket, statsBucket);
+            StatsBucket tsCurrentStatsBucket = tsCurrentBuckets.get(tsCurrentBucket);
+            if (tsCurrentStatsBucket == null) {
+              tsCurrentStatsBucket = new StatsBucket(tsCurrentBucket, bucketDurationNanos);
+              tsCurrentBuckets.put(tsCurrentBucket, tsCurrentStatsBucket);
             }
+            tsCurrentStatsBucket.addPoint(statsPoint);
 
-            statsBucket.addPoint(statsPoint);
+            StatsBucket tsOriginStatsBucket = tsOriginBuckets.get(tsOriginBucket);
+            if (tsOriginStatsBucket == null) {
+              tsOriginStatsBucket = new StatsBucket(tsOriginBucket, bucketDurationNanos);
+              tsOriginBuckets.put(tsOriginBucket, tsOriginStatsBucket);
+            }
+            tsOriginStatsBucket.addPoint(statsPoint);
           }
         } catch (InterruptedException e) {
           currentThread.interrupt();
@@ -203,11 +211,10 @@ public class DefaultDataStreamsCheckpointer
     return timestampNanos - (timestampNanos % bucketDurationNanos);
   }
 
-  private void flush(long timestampNanos) {
+  private void flush(long timestampNanos, Iterator<Map.Entry<Long, StatsBucket>> mapIterator, StatsBucket.BucketType bucketType) {
     long currentBucket = currentBucket(timestampNanos);
 
     List<StatsBucket> includedBuckets = new ArrayList<>();
-    Iterator<Map.Entry<Long, StatsBucket>> mapIterator = timeToBucket.entrySet().iterator();
 
     while (mapIterator.hasNext()) {
       Map.Entry<Long, StatsBucket> entry = mapIterator.next();
@@ -220,8 +227,16 @@ public class DefaultDataStreamsCheckpointer
 
     if (!includedBuckets.isEmpty()) {
       log.debug("Flushing {} buckets", includedBuckets.size());
-      payloadWriter.writePayload(includedBuckets);
+      payloadWriter.writePayload(includedBuckets, bucketType);
     }
+  }
+
+  private void flush(long timestampNanos) {
+    Iterator<Map.Entry<Long, StatsBucket>> tsCurrentIterator = tsCurrentBuckets.entrySet().iterator();
+    flush(timestampNanos, tsCurrentIterator, StatsBucket.BucketType.TIMESTAMP_CURRENT);
+
+    Iterator<Map.Entry<Long, StatsBucket>> tsOriginIterator = tsOriginBuckets.entrySet().iterator();
+    flush(timestampNanos, tsOriginIterator, StatsBucket.BucketType.TIMESTAMP_ORIGIN);
   }
 
   void report() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsCheckpointer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsCheckpointer.java
@@ -178,7 +178,8 @@ public class DefaultDataStreamsCheckpointer
             }
             break;
           } else if (supportsDataStreams) {
-            Long tsOriginBucket = currentBucket(statsPoint.getTimestampNanos() - statsPoint.getPathwayLatencyNano());
+            Long tsOriginBucket =
+                currentBucket(statsPoint.getTimestampNanos() - statsPoint.getPathwayLatencyNano());
             Long tsCurrentBucket = currentBucket(statsPoint.getTimestampNanos());
 
             // FIXME computeIfAbsent() is not available because Java 7
@@ -211,7 +212,10 @@ public class DefaultDataStreamsCheckpointer
     return timestampNanos - (timestampNanos % bucketDurationNanos);
   }
 
-  private void flush(long timestampNanos, Iterator<Map.Entry<Long, StatsBucket>> mapIterator, StatsBucket.BucketType bucketType) {
+  private void flush(
+      long timestampNanos,
+      Iterator<Map.Entry<Long, StatsBucket>> mapIterator,
+      StatsBucket.BucketType bucketType) {
     long currentBucket = currentBucket(timestampNanos);
 
     List<StatsBucket> includedBuckets = new ArrayList<>();
@@ -232,7 +236,8 @@ public class DefaultDataStreamsCheckpointer
   }
 
   private void flush(long timestampNanos) {
-    Iterator<Map.Entry<Long, StatsBucket>> tsCurrentIterator = tsCurrentBuckets.entrySet().iterator();
+    Iterator<Map.Entry<Long, StatsBucket>> tsCurrentIterator =
+        tsCurrentBuckets.entrySet().iterator();
     flush(timestampNanos, tsCurrentIterator, StatsBucket.BucketType.TIMESTAMP_CURRENT);
 
     Iterator<Map.Entry<Long, StatsBucket>> tsOriginIterator = tsOriginBuckets.entrySet().iterator();

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/MsgPackDatastreamsPayloadWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/MsgPackDatastreamsPayloadWriter.java
@@ -102,7 +102,7 @@ public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter
     for (StatsGroup group : groups) {
       boolean firstNode = group.getEdgeTags().isEmpty();
 
-      packer.startMap(firstNode ? 4 : 5);
+      packer.startMap(firstNode ? 5 : 6);
 
       /* 1 */
       packer.writeUTF8(PATHWAY_LATENCY);

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/MsgPackDatastreamsPayloadWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/MsgPackDatastreamsPayloadWriter.java
@@ -24,6 +24,7 @@ public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter
   private static final byte[] EDGE_TAGS = "EdgeTags".getBytes(ISO_8859_1);
   private static final byte[] HASH = "Hash".getBytes(ISO_8859_1);
   private static final byte[] PARENT_HASH = "ParentHash".getBytes(ISO_8859_1);
+  private static final byte[] TIMESTAMP_TYPE = "TimestampType".getBytes(ISO_8859_1);
 
   private static final int INITIAL_CAPACITY = 512 * 1024;
 
@@ -49,7 +50,7 @@ public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter
   }
 
   @Override
-  public void writePayload(Collection<StatsBucket> data) {
+  public void writePayload(Collection<StatsBucket> data, StatsBucket.BucketType bucketType) {
     writer.startMap(6);
     /* 1 */
     writer.writeUTF8(ENV);
@@ -87,7 +88,7 @@ public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter
 
       /* 3 */
       writer.writeUTF8(STATS);
-      writeBucket(bucket, writer);
+      writeBucket(bucket, writer, bucketType);
     }
 
     buffer.mark();
@@ -95,7 +96,7 @@ public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter
     buffer.reset();
   }
 
-  private void writeBucket(StatsBucket bucket, Writable packer) {
+  private void writeBucket(StatsBucket bucket, Writable packer, StatsBucket.BucketType bucketType) {
     Collection<StatsGroup> groups = bucket.getGroups();
     packer.startArray(groups.size());
     for (StatsGroup group : groups) {
@@ -127,6 +128,10 @@ public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter
           packer.writeString(tag, null);
         }
       }
+
+      /* 6 */
+      packer.writeUTF8(TIMESTAMP_TYPE);
+      packer.writeString(bucketType.getValue(), null);
     }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/StatsBucket.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/StatsBucket.java
@@ -16,7 +16,9 @@ public class StatsBucket {
       this.value = value;
     }
 
-    public String getValue() { return value; }
+    public String getValue() {
+      return value;
+    }
   }
 
   private final long startTimeNanos;

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/StatsBucket.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/StatsBucket.java
@@ -6,6 +6,19 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class StatsBucket {
+  public enum BucketType {
+    TIMESTAMP_CURRENT("current"),
+    TIMESTAMP_ORIGIN("origin");
+
+    private final String value;
+
+    BucketType(String value) {
+      this.value = value;
+    }
+
+    public String getValue() { return value; }
+  }
+
   private final long startTimeNanos;
   private final long bucketDurationNanos;
   private final Map<Long, StatsGroup> hashToGroup = new HashMap<>();

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DataStreamsWritingTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DataStreamsWritingTest.groovy
@@ -90,7 +90,7 @@ class DataStreamsWritingTest extends DDCoreSpecification {
 
     then:
     conditions.eventually {
-      assert requestBodies.size() == 1
+      assert requestBodies.size() == 2
     }
     validateMessage(requestBodies[0])
 
@@ -127,11 +127,11 @@ class DataStreamsWritingTest extends DDCoreSpecification {
     assert unpacker.unpackString() == "Stats"
     assert unpacker.unpackArrayHeader() == 2 // 2 groups in first bucket
 
-    Set availableSizes = [4, 5] // we don't know the order the groups will be reported
+    Set availableSizes = [5, 6] // we don't know the order the groups will be reported
     2.times {
       int mapHeaderSize = unpacker.unpackMapHeader()
       assert availableSizes.remove(mapHeaderSize)
-      if (mapHeaderSize == 4) {  // empty topic group
+      if (mapHeaderSize == 5) {  // empty topic group
         assert unpacker.unpackString() == "PathwayLatency"
         unpacker.skipValue()
         assert unpacker.unpackString() == "EdgeLatency"
@@ -140,6 +140,9 @@ class DataStreamsWritingTest extends DDCoreSpecification {
         assert unpacker.unpackLong() == 9
         assert unpacker.unpackString() == "ParentHash"
         assert unpacker.unpackLong() == 0
+        assert unpacker.unpackString() == "TimestampType"
+        String timestampType = unpacker.unpackString()
+        assert timestampType == "current" || timestampType == "origin"
       } else { //other group
         assert unpacker.unpackString() == "PathwayLatency"
         unpacker.skipValue()
@@ -154,6 +157,9 @@ class DataStreamsWritingTest extends DDCoreSpecification {
         assert unpacker.unpackString() == "type:testType"
         assert unpacker.unpackString() == "group:testGroup"
         assert unpacker.unpackString() == "topic:testTopic"
+        assert unpacker.unpackString() == "TimestampType"
+        String timestampType = unpacker.unpackString()
+        assert timestampType == "current" || timestampType == "origin"
       }
     }
 
@@ -168,7 +174,7 @@ class DataStreamsWritingTest extends DDCoreSpecification {
 
     Set<Long> availableHashes = [1L, 3L] // we don't know the order the groups will be reported
     2.times {
-      assert unpacker.unpackMapHeader() == 5
+      assert unpacker.unpackMapHeader() == 6
       assert unpacker.unpackString() == "PathwayLatency"
       unpacker.skipValue()
       assert unpacker.unpackString() == "EdgeLatency"
@@ -183,6 +189,9 @@ class DataStreamsWritingTest extends DDCoreSpecification {
       assert unpacker.unpackString() == "type:testType"
       assert unpacker.unpackString() == "group:testGroup"
       assert unpacker.unpackString() == (hash == 1 ? "topic:testTopic" : "topic:testTopic2")
+      assert unpacker.unpackString() == "TimestampType"
+      String timestampType = unpacker.unpackString()
+      assert timestampType == "current" || timestampType == "origin"
     }
 
     return true

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DefaultDataStreamsCheckpointerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DefaultDataStreamsCheckpointerTest.groovy
@@ -56,13 +56,14 @@ class DefaultDataStreamsCheckpointerTest extends DDCoreSpecification {
       supportsDataStreams() >> true
     }
     def timeSource = new ControllableTimeSource()
+    timeSource.advance(SECONDS.toNanos(30))
     def sink = Mock(Sink)
     def payloadWriter = new CapturingPayloadWriter()
 
     when:
     def checkpointer = new DefaultDataStreamsCheckpointer(sink, features, timeSource, wellKnownTags, payloadWriter, DEFAULT_BUCKET_DURATION_NANOS)
     checkpointer.start()
-    checkpointer.accept(new StatsPoint(["type:testType", "group:testGroup", "topic:testTopic"], 1, 2, timeSource.currentTimeNanos, 0, 0))
+    checkpointer.accept(new StatsPoint(["type:testType", "group:testGroup", "topic:testTopic"], 1, 2, timeSource.currentTimeNanos, SECONDS.toNanos(20), 20))
     timeSource.advance(DEFAULT_BUCKET_DURATION_NANOS)
     checkpointer.report()
 
@@ -70,13 +71,16 @@ class DefaultDataStreamsCheckpointerTest extends DDCoreSpecification {
     conditions.eventually {
       assert checkpointer.inbox.isEmpty()
       assert checkpointer.thread.state != Thread.State.RUNNABLE
-      assert payloadWriter.buckets.size() == 1
+      assert payloadWriter.buckets.size() == 2
+      assert payloadWriter.bucketTypes.size() == 2
+      assert payloadWriter.bucketTypes.containsAll([StatsBucket.BucketType.TIMESTAMP_CURRENT, StatsBucket.BucketType.TIMESTAMP_ORIGIN])
+      assert payloadWriter.buckets.get(0).getStartTimeNanos() != payloadWriter.buckets.get(1).getStartTimeNanos()
     }
 
-    with(payloadWriter.buckets.get(0)) {
-      groups.size() == 1
+    payloadWriter.buckets.each {
+      it.groups.size() == 1
 
-      with(groups.iterator().next()) {
+      with(it.groups.iterator().next()) {
         edgeTags.containsAll(["type:testType", "group:testGroup", "topic:testTopic"])
         edgeTags.size() == 3
         hash == 1
@@ -97,6 +101,7 @@ class DefaultDataStreamsCheckpointerTest extends DDCoreSpecification {
       supportsDataStreams() >> true
     }
     def timeSource = new ControllableTimeSource()
+    timeSource.advance(SECONDS.toNanos(30))
     def sink = Mock(Sink)
     def payloadWriter = new CapturingPayloadWriter()
     def bucketDuration = TimeUnit.MILLISECONDS.toNanos(200)
@@ -104,20 +109,23 @@ class DefaultDataStreamsCheckpointerTest extends DDCoreSpecification {
     when:
     def checkpointer = new DefaultDataStreamsCheckpointer(sink, features, timeSource, wellKnownTags, payloadWriter, bucketDuration)
     checkpointer.start()
-    checkpointer.accept(new StatsPoint(["type:testType", "group:testGroup", "topic:testTopic"], 1, 2, timeSource.currentTimeNanos, 0, 0))
+    checkpointer.accept(new StatsPoint(["type:testType", "group:testGroup", "topic:testTopic"], 1, 2, timeSource.currentTimeNanos, SECONDS.toNanos(20), 20))
     timeSource.advance(bucketDuration)
 
     then:
     conditions.eventually {
       assert checkpointer.inbox.isEmpty()
       assert checkpointer.thread.state != Thread.State.RUNNABLE
-      assert payloadWriter.buckets.size() == 1
+      assert payloadWriter.buckets.size() == 2
+      assert payloadWriter.bucketTypes.size() == 2
+      assert payloadWriter.bucketTypes.containsAll([StatsBucket.BucketType.TIMESTAMP_CURRENT, StatsBucket.BucketType.TIMESTAMP_ORIGIN])
+      assert payloadWriter.buckets.get(0).getStartTimeNanos() != payloadWriter.buckets.get(1).getStartTimeNanos()
     }
 
-    with(payloadWriter.buckets.get(0)) {
-      groups.size() == 1
+    payloadWriter.buckets.each {
+      it.groups.size() == 1
 
-      with(groups.iterator().next()) {
+      with(it.groups.iterator().next()) {
         edgeTags.containsAll(["type:testType", "group:testGroup", "topic:testTopic"])
         edgeTags.size() == 3
         hash == 1
@@ -137,15 +145,16 @@ class DefaultDataStreamsCheckpointerTest extends DDCoreSpecification {
       supportsDataStreams() >> true
     }
     def timeSource = new ControllableTimeSource()
+    timeSource.advance(SECONDS.toNanos(30))
     def sink = Mock(Sink)
     def payloadWriter = new CapturingPayloadWriter()
 
     when:
     def checkpointer = new DefaultDataStreamsCheckpointer(sink, features, timeSource, wellKnownTags, payloadWriter, DEFAULT_BUCKET_DURATION_NANOS)
     checkpointer.start()
-    checkpointer.accept(new StatsPoint(["type:testType", "group:testGroup", "topic:testTopic"], 1, 2, timeSource.currentTimeNanos, 0, 0))
+    checkpointer.accept(new StatsPoint(["type:testType", "group:testGroup", "topic:testTopic"], 1, 2, timeSource.currentTimeNanos, SECONDS.toNanos(20), 20))
     timeSource.advance(DEFAULT_BUCKET_DURATION_NANOS)
-    checkpointer.accept(new StatsPoint(["type:testType", "group:testGroup", "topic:testTopic"], 3, 4, timeSource.currentTimeNanos, 0, 0))
+    checkpointer.accept(new StatsPoint(["type:testType", "group:testGroup", "topic:testTopic"], 3, 4, timeSource.currentTimeNanos, SECONDS.toNanos(20), 20))
     timeSource.advance(DEFAULT_BUCKET_DURATION_NANOS - 100l)
     checkpointer.report()
 
@@ -153,17 +162,30 @@ class DefaultDataStreamsCheckpointerTest extends DDCoreSpecification {
     conditions.eventually {
       assert checkpointer.inbox.isEmpty()
       assert checkpointer.thread.state != Thread.State.RUNNABLE
-      assert payloadWriter.buckets.size() == 1
+      assert payloadWriter.buckets.size() == 3
+      assert payloadWriter.bucketTypes.size() == 3
+      assert payloadWriter.bucketTypes.count { it == StatsBucket.BucketType.TIMESTAMP_CURRENT } == 1
+      assert payloadWriter.bucketTypes.count { it == StatsBucket.BucketType.TIMESTAMP_ORIGIN } == 2
     }
 
-    with(payloadWriter.buckets.get(0)) {
-      groups.size() == 1
+    payloadWriter.buckets.eachWithIndex { it, index ->
+      it.groups.size() == 1
+      long startTimeNano = it.getStartTimeNanos()
 
-      with(groups.iterator().next()) {
+      with(it.groups.iterator().next()) {
         edgeTags.containsAll(["type:testType", "group:testGroup", "topic:testTopic"])
         edgeTags.size() == 3
-        hash == 1
-        parentHash == 2
+        if (payloadWriter.bucketTypes.get(index) == StatsBucket.BucketType.TIMESTAMP_CURRENT) {
+          hash == 1
+          parentHash == 2
+        } else if (startTimeNano == SECONDS.toNanos(30) - SECONDS.toNanos(20)) {
+          // Origin-based bucket for first point
+          hash == 1
+          parentHash == 2
+        } else {
+          hash == 3
+          parentHash == 4
+        }
       }
     }
 
@@ -179,15 +201,16 @@ class DefaultDataStreamsCheckpointerTest extends DDCoreSpecification {
       supportsDataStreams() >> true
     }
     def timeSource = new ControllableTimeSource()
+    timeSource.advance(SECONDS.toNanos(30))
     def sink = Mock(Sink)
     def payloadWriter = new CapturingPayloadWriter()
 
     when:
     def checkpointer = new DefaultDataStreamsCheckpointer(sink, features, timeSource, wellKnownTags, payloadWriter, DEFAULT_BUCKET_DURATION_NANOS)
     checkpointer.start()
-    checkpointer.accept(new StatsPoint(["type:testType", "group:testGroup", "topic:testTopic"], 1, 2, timeSource.currentTimeNanos, 0, 0))
+    checkpointer.accept(new StatsPoint(["type:testType", "group:testGroup", "topic:testTopic"], 1, 2, timeSource.currentTimeNanos, SECONDS.toNanos(20), 20))
     timeSource.advance(DEFAULT_BUCKET_DURATION_NANOS)
-    checkpointer.accept(new StatsPoint(["type:testType", "group:testGroup", "topic:testTopic2"], 3, 4, timeSource.currentTimeNanos, 0, 0))
+    checkpointer.accept(new StatsPoint(["type:testType", "group:testGroup", "topic:testTopic2"], 3, 4, timeSource.currentTimeNanos, SECONDS.toNanos(20), 20))
     timeSource.advance(DEFAULT_BUCKET_DURATION_NANOS - 100l)
     checkpointer.close()
 
@@ -195,28 +218,27 @@ class DefaultDataStreamsCheckpointerTest extends DDCoreSpecification {
     conditions.eventually {
       assert checkpointer.inbox.isEmpty()
       assert checkpointer.thread.state != Thread.State.RUNNABLE
-      assert payloadWriter.buckets.size() == 2
+      assert payloadWriter.buckets.size() == 4
+      assert payloadWriter.bucketTypes.count { it == StatsBucket.BucketType.TIMESTAMP_CURRENT } == 2
+      assert payloadWriter.bucketTypes.count { it == StatsBucket.BucketType.TIMESTAMP_ORIGIN } == 2
     }
 
-    with(payloadWriter.buckets.get(0)) {
-      groups.size() == 1
+    payloadWriter.buckets.eachWithIndex { it, index ->
+      it.groups.size() == 1
+      long startTimeNano = it.getStartTimeNanos()
 
-      with(groups.iterator().next()) {
-        edgeTags.containsAll(["type:testType", "group:testGroup", "topic:testTopic"])
+      with(it.groups.iterator().next()) {
         edgeTags.size() == 3
-        hash == 1
-        parentHash == 2
-      }
-    }
-
-    with(payloadWriter.buckets.get(1)) {
-      groups.size() == 1
-
-      with(groups.iterator().next()) {
-        edgeTags.containsAll(["type:testType", "group:testGroup", "topic:testTopic2"])
-        edgeTags.size() == 3
-        hash == 3
-        parentHash == 4
+        if (startTimeNano == SECONDS.toNanos(30) - SECONDS.toNanos(20) ||
+          startTimeNano == SECONDS.toNanos(30)) {
+          edgeTags.containsAll(["type:testType", "group:testGroup", "topic:testTopic"])
+          hash == 1
+          parentHash == 2
+        } else {
+          edgeTags.containsAll(["type:testType", "group:testGroup", "topic:testTopic2"])
+          hash == 3
+          parentHash == 4
+        }
       }
     }
 
@@ -231,15 +253,16 @@ class DefaultDataStreamsCheckpointerTest extends DDCoreSpecification {
       supportsDataStreams() >> true
     }
     def timeSource = new ControllableTimeSource()
+    timeSource.advance(SECONDS.toNanos(30))
     def sink = Mock(Sink)
     def payloadWriter = new CapturingPayloadWriter()
 
     when:
     def checkpointer = new DefaultDataStreamsCheckpointer(sink, features, timeSource, wellKnownTags, payloadWriter, DEFAULT_BUCKET_DURATION_NANOS)
     checkpointer.start()
-    checkpointer.accept(new StatsPoint(["type:testType", "group:testGroup", "topic:testTopic"], 1, 2, timeSource.currentTimeNanos, 0, 0))
+    checkpointer.accept(new StatsPoint(["type:testType", "group:testGroup", "topic:testTopic"], 1, 2, timeSource.currentTimeNanos, SECONDS.toNanos(20), 20))
     timeSource.advance(DEFAULT_BUCKET_DURATION_NANOS)
-    checkpointer.accept(new StatsPoint(["type:testType", "group:testGroup", "topic:testTopic2"], 3, 4, timeSource.currentTimeNanos, 0, 0))
+    checkpointer.accept(new StatsPoint(["type:testType", "group:testGroup", "topic:testTopic2"], 3, 4, timeSource.currentTimeNanos, SECONDS.toNanos(20), 20))
     timeSource.advance(DEFAULT_BUCKET_DURATION_NANOS)
     checkpointer.report()
 
@@ -247,28 +270,27 @@ class DefaultDataStreamsCheckpointerTest extends DDCoreSpecification {
     conditions.eventually {
       assert checkpointer.inbox.isEmpty()
       assert checkpointer.thread.state != Thread.State.RUNNABLE
-      assert payloadWriter.buckets.size() == 2
+      assert payloadWriter.buckets.size() == 4
+      assert payloadWriter.bucketTypes.count { it == StatsBucket.BucketType.TIMESTAMP_CURRENT } == 2
+      assert payloadWriter.bucketTypes.count { it == StatsBucket.BucketType.TIMESTAMP_ORIGIN } == 2
     }
 
-    with(payloadWriter.buckets.get(0)) {
-      groups.size() == 1
+    payloadWriter.buckets.eachWithIndex { it, index ->
+      it.groups.size() == 1
+      long startTimeNano = it.getStartTimeNanos()
 
-      with(groups.iterator().next()) {
-        edgeTags.containsAll(["type:testType", "group:testGroup", "topic:testTopic"])
+      with(it.groups.iterator().next()) {
         edgeTags.size() == 3
-        hash == 1
-        parentHash == 2
-      }
-    }
-
-    with(payloadWriter.buckets.get(1)) {
-      groups.size() == 1
-
-      with(groups.iterator().next()) {
-        edgeTags.containsAll(["type:testType", "group:testGroup", "topic:testTopic2"])
-        edgeTags.size() == 3
-        hash == 3
-        parentHash == 4
+        if (startTimeNano == SECONDS.toNanos(30) - SECONDS.toNanos(20) ||
+          startTimeNano == SECONDS.toNanos(30)) {
+          edgeTags.containsAll(["type:testType", "group:testGroup", "topic:testTopic"])
+          hash == 1
+          parentHash == 2
+        } else {
+          edgeTags.containsAll(["type:testType", "group:testGroup", "topic:testTopic2"])
+          hash == 3
+          parentHash == 4
+        }
       }
     }
 
@@ -284,12 +306,20 @@ class DefaultDataStreamsCheckpointerTest extends DDCoreSpecification {
       supportsDataStreams() >> true
     }
     def timeSource = new ControllableTimeSource()
+    timeSource.advance(SECONDS.toNanos(30))
     def sink = Mock(Sink)
     def payloadWriter = new CapturingPayloadWriter()
 
     when:
     def checkpointer = new DefaultDataStreamsCheckpointer(sink, features, timeSource, wellKnownTags, payloadWriter, DEFAULT_BUCKET_DURATION_NANOS)
     checkpointer.start()
+    /*
+     * origin        current        topic
+     * 30s           30s            testTopic
+     * 29s9...900ns  39s9...900ns   testTopic
+     * 44s9...900ns  49s9...900ns   testTopic
+     * 47s9...900ns  49s9...900ns   testTopic2
+     */
     checkpointer.accept(new StatsPoint(["type:testType", "group:testGroup", "topic:testTopic"], 1, 2, timeSource.currentTimeNanos, 0, 0))
     timeSource.advance(DEFAULT_BUCKET_DURATION_NANOS - 100l)
     checkpointer.accept(new StatsPoint(["type:testType", "group:testGroup", "topic:testTopic"], 1, 2, timeSource.currentTimeNanos, SECONDS.toNanos(10), SECONDS.toNanos(10)))
@@ -303,44 +333,64 @@ class DefaultDataStreamsCheckpointerTest extends DDCoreSpecification {
     conditions.eventually {
       assert checkpointer.inbox.isEmpty()
       assert checkpointer.thread.state != Thread.State.RUNNABLE
-      assert payloadWriter.buckets.size() == 2
+      assert payloadWriter.buckets.size() == 5
+      assert payloadWriter.bucketTypes.count { it == StatsBucket.BucketType.TIMESTAMP_CURRENT } == 2
+      assert payloadWriter.bucketTypes.count { it == StatsBucket.BucketType.TIMESTAMP_ORIGIN } == 3
     }
 
-    with(payloadWriter.buckets.get(0)) {
-      groups.size() == 1
+    payloadWriter.buckets.eachWithIndex { it, index ->
+      it.groups.size() == 1
+      long startTimeNano = it.getStartTimeNanos()
 
-      with(groups.iterator().next()) {
-        edgeTags.containsAll(["type:testType", "group:testGroup", "topic:testTopic"])
-        edgeTags.size() == 3
-        hash == 1
-        parentHash == 2
-        pathwayLatency.max() >= 10
-        pathwayLatency.max() < 10.1
-      }
-    }
+      if (startTimeNano == SECONDS.toNanos(20)) {
+        with(it.groups.iterator().next()) {
+          edgeTags.size() == 3
+          edgeTags.containsAll(["type:testType", "group:testGroup", "topic:testTopic"])
+          hash == 1
+          parentHash == 2
+          payloadWriter.bucketTypes.get(index) == StatsBucket.BucketType.TIMESTAMP_ORIGIN
+        }
+      } else if (startTimeNano == SECONDS.toNanos(30) && payloadWriter.bucketTypes.get(index) == StatsBucket.BucketType.TIMESTAMP_ORIGIN) {
+        with(it.groups.iterator().next()) {
+          edgeTags.size() == 3
+          edgeTags.containsAll(["type:testType", "group:testGroup", "topic:testTopic"])
+          hash == 1
+          parentHash == 2
+        }
+      } else if (startTimeNano == SECONDS.toNanos(30) && payloadWriter.bucketTypes.get(index) == StatsBucket.BucketType.TIMESTAMP_CURRENT) {
+        with(it.groups.iterator().next()) {
+          edgeTags.size() == 3
+          edgeTags.containsAll(["type:testType", "group:testGroup", "topic:testTopic"])
+          hash == 1
+          parentHash == 2
+          pathwayLatency.max() >= 10
+          pathwayLatency.max() < 10.1
+        }
+      } else if (startTimeNano == SECONDS.toNanos(40)) {
+        it.groups.size() == 2
 
-    with(payloadWriter.buckets.get(1)) {
-      groups.size() == 2
+        List<StatsGroup> sortedGroups = new ArrayList<>(it.groups)
+        sortedGroups.sort({ it.hash })
 
-      List<StatsGroup> sortedGroups = new ArrayList<>(groups)
-      sortedGroups.sort({ it.hash })
+        with(sortedGroups[0]) {
+          hash == 1
+          parentHash == 2
+          edgeTags.containsAll(["type:testType", "group:testGroup", "topic:testTopic"])
+          edgeTags.size() == 3
+          pathwayLatency.max() >= 5
+          pathwayLatency.max() < 5.1
+        }
 
-      with(sortedGroups[0]) {
-        hash == 1
-        parentHash == 2
-        edgeTags.containsAll(["type:testType", "group:testGroup", "topic:testTopic"])
-        edgeTags.size() == 3
-        pathwayLatency.max() >= 5
-        pathwayLatency.max() < 5.1
-      }
-
-      with(sortedGroups[1]) {
-        hash == 3
-        parentHash == 4
-        edgeTags.containsAll(["type:testType", "group:testGroup", "topic:testTopic2"])
-        edgeTags.size() == 3
-        pathwayLatency.max() >= 2
-        pathwayLatency.max() < 2.1
+        with(sortedGroups[1]) {
+          hash == 3
+          parentHash == 4
+          edgeTags.containsAll(["type:testType", "group:testGroup", "topic:testTopic2"])
+          edgeTags.size() == 3
+          pathwayLatency.max() >= 2
+          pathwayLatency.max() < 2.1
+        }
+      } else {
+        assert false : "Unexpected bucket: " + it.toString()
       }
     }
 
@@ -400,13 +450,13 @@ class DefaultDataStreamsCheckpointerTest extends DDCoreSpecification {
     then: "points are now reported"
     conditions.eventually {
       assert checkpointer.inbox.isEmpty()
-      assert payloadWriter.buckets.size() == 1
+      assert payloadWriter.buckets.size() == 2
     }
 
-    with(payloadWriter.buckets.get(0)) {
-      groups.size() == 1
+    payloadWriter.buckets.each {
+      it.groups.size() == 1
 
-      with(groups.iterator().next()) {
+      with(it.groups.iterator().next()) {
         edgeTags.containsAll(["type:testType", "group:testGroup", "topic:testTopic"])
         edgeTags.size() == 3
         hash == 1
@@ -459,13 +509,13 @@ class DefaultDataStreamsCheckpointerTest extends DDCoreSpecification {
     then: "points are now reported"
     conditions.eventually {
       assert checkpointer.inbox.isEmpty()
-      assert payloadWriter.buckets.size() == 1
+      assert payloadWriter.buckets.size() == 2
     }
 
-    with(payloadWriter.buckets.get(0)) {
-      groups.size() == 1
+    payloadWriter.buckets.each {
+      it.groups.size() == 1
 
-      with(groups.iterator().next()) {
+      with(it.groups.iterator().next()) {
         edgeTags.containsAll(["type:testType", "group:testGroup", "topic:testTopic"])
         edgeTags.size() == 3
         hash == 1
@@ -482,10 +532,12 @@ class DefaultDataStreamsCheckpointerTest extends DDCoreSpecification {
 class CapturingPayloadWriter implements DatastreamsPayloadWriter {
   boolean accepting = true
   List<StatsBucket> buckets = new ArrayList<>()
+  List<StatsBucket.BucketType> bucketTypes = new ArrayList<>()
 
-  void writePayload(Collection<StatsBucket> payload) {
+  void writePayload(Collection<StatsBucket> payload, StatsBucket.BucketType bucketType) {
     if (accepting) {
       buckets.addAll(payload)
+      bucketTypes.addAll([bucketType] * payload.size())
     }
   }
 


### PR DESCRIPTION
# What Does This Do
This change, modeled after Golang PR https://github.com/DataDog/data-streams-go/pull/12/files, introduces the concept of an origin-based StatsPoint, where the timestamp of the StatsPoint is based on the time at origin instead of the current time. When sending the StatsPoint to Datadog, both the current timestamp StatsPoint (today's default StatsPoint) and the origin-based StatsPoint are sent.

# Motivation
Having a new origin-based StatsPoint will allow us to compute a `received points / sent points` ratio, aligned at the same timestamp for a particular pathway, regardless of when the message was produced or consumed.

# Additional Notes
