### PR TITLE
[WIP] use build-time generated index to select instrumenter(s) for known types

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/KnownTypesIndex.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/KnownTypesIndex.java
@@ -1,0 +1,153 @@
+package datadog.trace.agent.tooling;
+
+import datadog.trace.agent.tooling.bytebuddy.SharedTypePools;
+import datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers;
+import datadog.trace.util.ClassNameTrie;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Maintains an index from known instrumented class names to stable {@link Instrumenter} ids. */
+public final class KnownTypesIndex {
+  private static final Logger log = LoggerFactory.getLogger(KnownTypesIndex.class);
+
+  private static final String KNOWN_TYPES_INDEX_NAME = "known-types.index";
+
+  // marks results that match multiple instrumentations
+  private static final int MULTIPLE_ID_MARKER = 0x1000;
+
+  // lookup table of multiple-id results
+  private final int[][] multipleIdTable;
+
+  private final ClassNameTrie knownTypesTrie;
+
+  private KnownTypesIndex(int[][] multipleIdTable, ClassNameTrie knownTypesTrie) {
+    this.multipleIdTable = multipleIdTable;
+    this.knownTypesTrie = knownTypesTrie;
+  }
+
+  public void apply(String name, BitSet instrumentationIds) {
+    int instrumentationId = knownTypesTrie.apply(name);
+    if (instrumentationId >= 0) {
+      if ((instrumentationId & MULTIPLE_ID_MARKER) != 0) {
+        for (int id : multipleIdTable[instrumentationId & ~MULTIPLE_ID_MARKER]) {
+          instrumentationIds.set(id);
+        }
+      } else {
+        instrumentationIds.set(instrumentationId);
+      }
+    }
+  }
+
+  public static KnownTypesIndex readIndex() {
+    ClassLoader instrumenterClassLoader = Instrumenter.class.getClassLoader();
+    try {
+      try (DataInputStream in =
+          new DataInputStream(
+              new BufferedInputStream(
+                  instrumenterClassLoader.getResourceAsStream(KNOWN_TYPES_INDEX_NAME)))) {
+        int multipleIdCount = in.readInt();
+        int[][] multipleIdTable = new int[multipleIdCount][];
+        for (int i = 0; i < multipleIdCount; i++) {
+          int idCount = in.readInt();
+          int[] ids = new int[idCount];
+          for (int j = 0; j < idCount; j++) {
+            ids[j] = in.readInt();
+          }
+          multipleIdTable[i] = ids;
+        }
+        return new KnownTypesIndex(multipleIdTable, ClassNameTrie.readFrom(in));
+      }
+    } catch (Throwable e) {
+      log.error("Unable to read " + KNOWN_TYPES_INDEX_NAME, e);
+      return null;
+    }
+  }
+
+  /** Generates an index from known instrumented types referenced by {@link Instrumenter}s. */
+  static class IndexGenerator {
+    private final ClassNameTrie.Builder knownTypesTrie = new ClassNameTrie.Builder();
+
+    private final List<BitSet> multipleIdTable = new ArrayList<>();
+
+    public void buildIndex() {
+      for (Instrumenter instrumenter : Instrumenters.load(Instrumenter.class.getClassLoader())) {
+        int instrumentationId = Instrumenters.currentInstrumentationId();
+        if (instrumenter instanceof Instrumenter.ForSingleType) {
+          String type = ((Instrumenter.ForSingleType) instrumenter).instrumentedType();
+          indexKnownType(instrumenter, type, instrumentationId);
+        } else if (instrumenter instanceof Instrumenter.ForKnownTypes) {
+          for (String type : ((Instrumenter.ForKnownTypes) instrumenter).knownMatchingTypes()) {
+            indexKnownType(instrumenter, type, instrumentationId);
+          }
+        }
+      }
+    }
+
+    /** Indexes a single match from known-type to instrumentation-id. */
+    private void indexKnownType(
+        Instrumenter instrumenter, String knownType, int instrumentationId) {
+      if (null == knownType || knownType.isEmpty()) {
+        throw new IllegalArgumentException(
+            instrumenter.getClass() + " declares a null or empty known-type");
+      }
+      int existingId = knownTypesTrie.apply(knownType);
+      if (existingId < 0) {
+        knownTypesTrie.put(knownType, instrumentationId);
+      } else {
+        BitSet instrumentationIds;
+        if ((existingId & MULTIPLE_ID_MARKER) != 0) {
+          // add new instrumentation-id to existing table entry, no need to update trie
+          instrumentationIds = multipleIdTable.get(existingId & ~MULTIPLE_ID_MARKER);
+        } else {
+          // create new table entry to hold multiple ids and update trie with its offset
+          knownTypesTrie.put(knownType, multipleIdTable.size() | MULTIPLE_ID_MARKER);
+          instrumentationIds = new BitSet();
+          multipleIdTable.add(instrumentationIds);
+          instrumentationIds.set(existingId);
+        }
+        instrumentationIds.set(instrumentationId);
+      }
+    }
+
+    public void writeIndex(Path indexFile) throws IOException {
+      try (DataOutputStream out =
+          new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(indexFile)))) {
+        out.writeInt(multipleIdTable.size());
+        for (BitSet ids : multipleIdTable) {
+          out.writeInt(ids.cardinality());
+          for (int id = ids.nextSetBit(0); id >= 0; id = ids.nextSetBit(id + 1)) {
+            out.writeInt(id);
+          }
+        }
+        knownTypesTrie.writeTo(out);
+      }
+    }
+
+    public static void main(String[] args) throws IOException {
+      if (args.length < 1) {
+        throw new IllegalArgumentException("Expected: resources-dir");
+      }
+
+      Path resourcesDir = Paths.get(args[0]).toAbsolutePath();
+
+      // satisfy some instrumenters that cache matchers in initializers
+      HierarchyMatchers.registerIfAbsent(HierarchyMatchers.simpleChecks());
+      SharedTypePools.registerIfAbsent(SharedTypePools.simpleCache());
+
+      IndexGenerator indexGenerator = new IndexGenerator();
+      indexGenerator.buildIndex();
+      indexGenerator.writeIndex(resourcesDir.resolve(KNOWN_TYPES_INDEX_NAME));
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/instrumentation.gradle
+++ b/dd-java-agent/instrumentation/instrumentation.gradle
@@ -106,3 +106,24 @@ tasks.named('shadowJar').configure {
   dependencies deps.excludeShared
 }
 
+tasks.register('generateKnownTypesIndex', JavaExec) {
+  // temporary config to add slf4j-simple so we get logging from instrumenters while indexing
+  def slf4jSimple = project.configurations.create('slf4j-simple')
+  project.dependencies.add('slf4j-simple', "org.slf4j:slf4j-simple:${versions.slf4j}")
+
+  def resourcesDir = "${sourceSets.main.output.resourcesDir}"
+  def indexFile = "${resourcesDir}/known-types.index"
+
+  it.group = 'Build'
+  it.description = "Generate known-types.index"
+  it.mainClass = 'datadog.trace.agent.tooling.KnownTypesIndex$IndexGenerator'
+  it.classpath = project.configurations.runtimeClasspath + slf4jSimple
+  it.inputs.files(it.classpath)
+  it.outputs.files(indexFile)
+  it.args = [resourcesDir]
+
+  dependsOn 'processResources'
+}
+
+shadowJar.dependsOn 'generateKnownTypesIndex'
+

--- a/internal-api/src/main/java/datadog/trace/util/ClassNameTrie.java
+++ b/internal-api/src/main/java/datadog/trace/util/ClassNameTrie.java
@@ -258,11 +258,11 @@ public final class ClassNameTrie {
 
     /** Allow querying while the class-name trie is being built. */
     public int apply(String key) {
-      return ClassNameTrie.apply(trieData, longJumps, key);
+      return trieLength > 0 ? ClassNameTrie.apply(trieData, longJumps, key) : -1;
     }
 
     public ClassNameTrie buildTrie() {
-      if (null == trieData) {
+      if (trieLength == 0) {
         return EMPTY_TRIE;
       }
       // avoid unnecessary allocation when compaction isn't required


### PR DESCRIPTION
# What Does This Do

1. Generates a build-time mapping from known-types to their matching instrumentation id(s)
2. Uses generated index to query once per transformed-type and populate matched instrumentation ids 
3. Replaces individual `named` matchers with one that checks the matched instrumentation ids 

# Motivation

This is faster than the current approach which involves repeated `String.equals` checks.
