### PR TITLE
Fix when filenames are matching partially

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/TransformerDefinitionMatcher.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/TransformerDefinitionMatcher.java
@@ -62,7 +62,7 @@ public class TransformerDefinitionMatcher {
         continue;
       }
       List<ProbeDefinition> definitionByFileName =
-          resultMap.computeIfAbsent(fileName, key -> new ArrayList<>());
+          resultMap.computeIfAbsent("/" + fileName, key -> new ArrayList<>());
       definitionByFileName.add(definition);
     }
     return resultMap;
@@ -148,10 +148,10 @@ public class TransformerDefinitionMatcher {
     if (sourceFileName == null) {
       return Collections.emptyList();
     }
-    String reversedSourceFileName = reverseStr(sourceFileName);
+    String reversedSourceFileName = reverseStr("/" + sourceFileName);
     StringBuilder sb = new StringBuilder(reversedSourceFileName);
     if (hasPackageName) {
-      sb.append('/').append(reversedPackageName);
+      sb.append(reversedPackageName);
     }
     String reversedFileName = sb.toString();
     String fullFileName = reverseStr(definitionFileNames.getStringStartingWith(reversedFileName));

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/TransformerDefinitionMatcherTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/TransformerDefinitionMatcherTest.java
@@ -71,6 +71,16 @@ public class TransformerDefinitionMatcherTest {
   }
 
   @Test
+  public void sourceFileAbsoluteFileName() {
+    SnapshotProbe probe = createProbe(PROBE_ID1, "/home/user/project/src/main/java/java/lang/String.java", 23);
+    TransformerDefinitionMatcher matcher =
+        createMatcher(Arrays.asList(probe), Collections.emptyList());
+    List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
+    assertEquals(1, probeDefinitions.size());
+    assertEquals(PROBE_ID1, probeDefinitions.get(0).getId());
+  }
+
+  @Test
   public void sourceFileSimpleFileName() {
     SnapshotProbe probe = createProbe(PROBE_ID1, "String.java", 23);
     TransformerDefinitionMatcher matcher =
@@ -138,6 +148,15 @@ public class TransformerDefinitionMatcherTest {
     assertEquals(2, probeDefinitions.size());
     assertEquals(PROBE_ID1, probeDefinitions.get(0).getId());
     assertEquals(PROBE_ID2, probeDefinitions.get(1).getId());
+  }
+
+  @Test
+  public void partialSimpleNameShouldNotMatch() {
+    SnapshotProbe probe1 = createProbe(PROBE_ID1, "SuperString.java", 11);
+    TransformerDefinitionMatcher matcher =
+        createMatcher(Arrays.asList(probe1), Collections.emptyList());
+    List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
+    assertEquals(0, probeDefinitions.size());
   }
 
   private TransformerDefinitionMatcher createMatcher(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/TransformerDefinitionMatcherTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/TransformerDefinitionMatcherTest.java
@@ -72,7 +72,8 @@ public class TransformerDefinitionMatcherTest {
 
   @Test
   public void sourceFileAbsoluteFileName() {
-    SnapshotProbe probe = createProbe(PROBE_ID1, "/home/user/project/src/main/java/java/lang/String.java", 23);
+    SnapshotProbe probe =
+        createProbe(PROBE_ID1, "/home/user/project/src/main/java/java/lang/String.java", 23);
     TransformerDefinitionMatcher matcher =
         createMatcher(Arrays.asList(probe), Collections.emptyList());
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);


### PR DESCRIPTION
# What Does This Do
We are using the path delimiter to anchor the filename and match it correctly inside the reversed trie.

# Motivation
Fix matching issue for source filenames that may match partially the probe filename. For example a probe for `VetController.java` will match for `Controller.java`. 

