### PR TITLE
Fix wall time profiler filter parameter

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
@@ -248,7 +248,7 @@ public final class AsyncProfiler {
       // wall profiling is enabled.
       cmd.append(",wall=").append(getWallInterval()).append('m');
       if (getWallFilterOnContext()) {
-        cmd.append(",context");
+        cmd.append(",wallfilter");
       }
     }
     if (profilingModes.contains(ProfilingMode.ALLOCATION)) {


### PR DESCRIPTION
The argument name was changed in async-profiler but not in dd-trace-java