### PR TITLE
Fix capturing of vertx.route-handler spans

### DIFF
--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java8/datadog/trace/instrumentation/vertx_3_4/server/EndHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java8/datadog/trace/instrumentation/vertx_3_4/server/EndHandlerWrapper.java
@@ -13,7 +13,7 @@ import io.vertx.ext.web.RoutingContext;
 public class EndHandlerWrapper implements Handler<Void> {
   private final RoutingContext routingContext;
 
-  Handler<Void> actual;
+  public Handler<Void> actual;
 
   EndHandlerWrapper(RoutingContext routingContext) {
     this.routingContext = routingContext;

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/EndHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java8/datadog/trace/instrumentation/vertx_4_0/server/EndHandlerWrapper.java
@@ -13,7 +13,7 @@ import io.vertx.ext.web.RoutingContext;
 public class EndHandlerWrapper implements Handler<Void> {
   private final RoutingContext routingContext;
 
-  Handler<Void> actual;
+  public Handler<Void> actual;
 
   EndHandlerWrapper(RoutingContext routingContext) {
     this.routingContext = routingContext;

--- a/dd-smoke-tests/quarkus/src/test/groovy/datadog/smoketest/QuarkusSmokeTest.groovy
+++ b/dd-smoke-tests/quarkus/src/test/groovy/datadog/smoketest/QuarkusSmokeTest.groovy
@@ -59,6 +59,8 @@ abstract class QuarkusSmokeTest extends AbstractServerSmokeTest {
     // TODO quarkus requests are split in two, so we need to wait for the double amount
     waitForTraceCount(2 * totalInvocations) == 2 * totalInvocations
     validateLogInjection(resourceName()) == totalInvocations
+    checkLog()
+    !logHasErrors
   }
 
   void doAndValidateRequest(int id) {

--- a/dd-smoke-tests/quarkus/src/test/groovy/datadog/smoketest/QuarkusSmokeTest.groovy
+++ b/dd-smoke-tests/quarkus/src/test/groovy/datadog/smoketest/QuarkusSmokeTest.groovy
@@ -35,7 +35,7 @@ abstract class QuarkusSmokeTest extends AbstractServerSmokeTest {
   @Override
   protected Set<String> expectedTraces() {
     // TODO is this really how quarkus requests should look?
-    return ["[jax-rs.request]", "[netty.request]"].toSet()
+    return ["[jax-rs.request]", "[netty.request[vertx.route-handler]]"].toSet()
   }
 
   @Shared

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
@@ -152,7 +152,7 @@ abstract class ProcessManager extends Specification {
         checker(it)
       }
       if (hasError) {
-        println "Test application log is containing errors. See full run logs in ${lfp}"
+        println "Test application log contains errors. See full run logs in ${lfp}"
       }
     }
   }

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
@@ -144,7 +144,8 @@ abstract class ProcessManager extends Specification {
     logFilePaths.each { lfp ->
       def hasError = false
       new File(lfp).eachLine {
-        if (it.contains("ERROR") || it.contains("ASSERTION FAILED")) {
+        if (it.contains("ERROR") || it.contains("ASSERTION FAILED")
+          || it.contains("Failed to handle exception in instrumentation")) {
           println it
           hasError = logHasErrors = true
         }


### PR DESCRIPTION
injected helper will be in different package to modified VertX class, so cannot rely on package-private access

Error seen in quarkus smoke test logs before this fix:
```
[dd.trace 2022-08-22 18:12:21:819 +0000] [executor-thread-1] DEBUG datadog.trace.bootstrap.ExceptionLogger - Failed to handle exception in instrumentation for io.vertx.core.http.impl.HttpServerResponseImpl
java.lang.IllegalAccessError: Class io/vertx/core/http/impl/HttpServerResponseImpl illegally accessing "package private" member of class datadog/trace/instrumentation/vertx_3_4/server/EndHandlerWrapper
	at io.vertx.core.http.impl.HttpServerResponseImpl.endHandler(HttpServerResponseImpl.java:297)
	at io.quarkus.resteasy.runtime.standalone.VertxBlockingOutput.<init>(VertxBlockingOutput.java:45)
	at io.quarkus.resteasy.runtime.standalone.VertxRequestHandler$1.run(VertxRequestHandler.java:94)
	at org.jboss.threads.ContextClassLoaderSavingRunnable.run(ContextClassLoaderSavingRunnable.java:35)
	at org.jboss.threads.EnhancedQueueExecutor.safeRun(EnhancedQueueExecutor.java:2046)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.doRunTask(EnhancedQueueExecutor.java:1578)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1452)
	at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:29)
	at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:29)
	at java.lang.Thread.run(Thread.java:830)
	at org.jboss.threads.JBossThread.run(JBossThread.java:479)
```