### PR TITLE
Fix custom logger delay on IBM JDKs

### DIFF
--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomLogManagerTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomLogManagerTest.groovy
@@ -2,13 +2,10 @@ package datadog.trace.agent
 
 import datadog.trace.agent.test.IntegrationTestUtils
 import jvmbootstraptest.LogManagerSetter
-import spock.lang.Requires
 import spock.lang.Specification
 import spock.lang.Timeout
 
 @Timeout(30)
-// Note: this test is fails on IBM JVM, we would need to investigate this at some point
-@Requires({ !System.getProperty("java.vm.name").contains("IBM J9 VM") })
 class CustomLogManagerTest extends Specification {
 
   private static final String DEFAULT_LOG_LEVEL = "debug"

--- a/dd-java-agent/src/test/java/jvmbootstraptest/LogManagerSetter.java
+++ b/dd-java-agent/src/test/java/jvmbootstraptest/LogManagerSetter.java
@@ -148,7 +148,7 @@ public class LogManagerSetter {
   }
 
   private static void assertTraceInstallationDelayed(final String message) {
-    if (isJavaBefore9WithJFR()) {
+    if (okHttpMayIndirectlyLoadJUL()) {
       customAssert(isTracerInstalled(false), false, message);
     } else {
       customAssert(
@@ -159,7 +159,7 @@ public class LogManagerSetter {
   }
 
   private static void assertProfilingStartupDelayed(final String message) {
-    if (isJavaBefore9WithJFR()) {
+    if (okHttpMayIndirectlyLoadJUL()) {
       customAssert(isProfilingStarted(false), false, message);
     } else {
       customAssert(
@@ -215,17 +215,18 @@ public class LogManagerSetter {
     return false;
   }
 
-  private static boolean isJavaBefore9WithJFR() {
-    if (!System.getProperty("java.version").startsWith("1.")) {
-      return false;
+  private static boolean okHttpMayIndirectlyLoadJUL() {
+    if ("IBM Corporation".equals(System.getProperty("java.vendor"))) {
+      return true; // IBM JDKs ship with 'IBMSASL' which will load JUL when OkHttp accesses TLS
     }
-
-    return isJFRSupported();
+    if (!System.getProperty("java.version").startsWith("1.")) {
+      return false; // JDKs since 9 have reworked JFR to use a different logging facility, not JUL
+    }
+    return isJFRSupported(); // assume OkHttp will indirectly load JUL via its JFR events
   }
 
   private static boolean isJFRSupported() {
-    final String jfrClassResourceName = "jdk.jfr.Recording".replace('.', '/') + ".class";
-    return Thread.currentThread().getContextClassLoader().getResourceAsStream(jfrClassResourceName)
+    return Thread.currentThread().getContextClassLoader().getResource("jdk/jfr/Recording.class")
         != null;
   }
 }


### PR DESCRIPTION
# What Does This Do

Delays starting tracer/profiler when custom `LogManager` is detected and we're running on an IBM JDK.

# Motivation

IBM JDKs don't currently include JFR, so don't suffer from the indirect loading of JUL via JFR that happens with Java 8.

However they do include an IBM specific security provider, `IBMSASL`, which touches JUL when our embedded OkHttp instance uses TLS. For this reason we should always delay starting the tracer and profiler when a custom `LogManager` is detected and we're running on an IBM JDK.

This PR also cleans up some method names to make it a bit clearer what we're checking and why.