### PR TITLE
Enforce max size on cached key string

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/DBQueryInfo.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/DBQueryInfo.java
@@ -7,7 +7,7 @@ import datadog.trace.api.normalize.SQLNormalizer;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 
 public final class DBQueryInfo {
-  
+
   private static final int MAX_SQL_LENGTH_TO_CACHE = 4096;
 
   private static final DDCache<String, DBQueryInfo> CACHED_PREPARED_STATEMENTS =
@@ -26,7 +26,7 @@ public final class DBQueryInfo {
   }
 
   public static DBQueryInfo ofPreparedStatement(String sql) {
-    if (sql.length() > MAX_SQL_LENGTH_TO_CACHE){
+    if (sql.length() > MAX_SQL_LENGTH_TO_CACHE) {
       return NORMALIZE.apply(sql);
     } else {
       return CACHED_PREPARED_STATEMENTS.computeIfAbsent(sql, NORMALIZE);

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/DBQueryInfo.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/DBQueryInfo.java
@@ -22,12 +22,12 @@ public final class DBQueryInfo {
       };
 
   public static DBQueryInfo ofStatement(String sql) {
-    return new DBQueryInfo(sql);
+    return NORMALIZE.apply(sql);
   }
 
   public static DBQueryInfo ofPreparedStatement(String sql) {
     if (sql.length() > MAX_SQL_LENGTH_TO_CACHE){
-      return new DBQueryInfo(sql);
+      return NORMALIZE.apply(sql);
     } else {
       return CACHED_PREPARED_STATEMENTS.computeIfAbsent(sql, NORMALIZE);
     }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/DBQueryInfo.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/DBQueryInfo.java
@@ -7,6 +7,8 @@ import datadog.trace.api.normalize.SQLNormalizer;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 
 public final class DBQueryInfo {
+  
+  private static final int MAX_SQL_LENGTH_TO_CACHE = 4096;
 
   private static final DDCache<String, DBQueryInfo> CACHED_PREPARED_STATEMENTS =
       DDCaches.newFixedSizeCache(512);
@@ -24,7 +26,11 @@ public final class DBQueryInfo {
   }
 
   public static DBQueryInfo ofPreparedStatement(String sql) {
-    return CACHED_PREPARED_STATEMENTS.computeIfAbsent(sql, NORMALIZE);
+    if (sql.length() > MAX_SQL_LENGTH_TO_CACHE){
+      return new DBQueryInfo(sql);
+    } else {
+      return CACHED_PREPARED_STATEMENTS.computeIfAbsent(sql, NORMALIZE);
+    }
   }
 
   private final UTF8BytesString operation;


### PR DESCRIPTION
Prevents storing extremely large SQL input strings in memory as cache keys. 
