### PR TITLE
Fix the async-profiler context tracking

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-context/profiling-context.gradle
+++ b/dd-java-agent/agent-profiling/profiling-context/profiling-context.gradle
@@ -10,6 +10,7 @@ ext {
     "com.datadog.profiling.context.JfrTimestampPatch",
     // jacoco does not allow per-method excludes so, here we go
     "com.datadog.profiling.context.AsyncProfilerTracingContextTracker",
+    "com.datadog.profiling.context.AsyncProfilerTracingContextTracker.1",
     "com.datadog.profiling.context.AsyncProfilerTracingContextTracker.Context",
     "com.datadog.profiling.context.AsyncProfilerTracingContextTrackerFactory*",
     "com.datadog.profiling.context.PerSpanTracingContextTrackerFactory*",

--- a/dd-java-agent/agent-profiling/profiling-context/profiling-context.gradle
+++ b/dd-java-agent/agent-profiling/profiling-context/profiling-context.gradle
@@ -11,7 +11,7 @@ ext {
     // jacoco does not allow per-method excludes so, here we go
     "com.datadog.profiling.context.AsyncProfilerTracingContextTracker",
     "com.datadog.profiling.context.AsyncProfilerTracingContextTracker.Context",
-    "com.datadog.profiling.context.AsyncProfilerTracingContextTrackerFactory",
+    "com.datadog.profiling.context.AsyncProfilerTracingContextTrackerFactory*",
     "com.datadog.profiling.context.PerSpanTracingContextTrackerFactory*",
     "com.datadog.profiling.context.PerSpanTracingContextTracker.TimeTicksProvider*",
     "com.datadog.profiling.context.StatsDAccessor"

--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/AsyncProfilerTracingContextTracker.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/AsyncProfilerTracingContextTracker.java
@@ -34,12 +34,7 @@ public final class AsyncProfilerTracingContextTracker implements TracingContextT
   }
 
   private static final ThreadLocal<ArrayDeque<Context>> contextsThreadLocal =
-      new ThreadLocal<ArrayDeque<Context>>() {
-        @Override
-        protected ArrayDeque<Context> initialValue() {
-          return new ArrayDeque<Context>();
-        }
-      };
+      ThreadLocal.withInitial(() -> new ArrayDeque<>());
 
   private final long spanId;
   private final long rootSpanId;

--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/AsyncProfilerTracingContextTracker.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/AsyncProfilerTracingContextTracker.java
@@ -6,12 +6,8 @@ import datadog.trace.api.profiling.TracingContextTracker;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class AsyncProfilerTracingContextTracker implements TracingContextTracker {
-  private static final Logger log =
-      LoggerFactory.getLogger(AsyncProfilerTracingContextTracker.class);
 
   private static final AsyncProfiler ASYNC_PROFILER = AsyncProfiler.getInstance();
 

--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/AsyncProfilerTracingContextTracker.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/AsyncProfilerTracingContextTracker.java
@@ -6,8 +6,12 @@ import datadog.trace.api.profiling.TracingContextTracker;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class AsyncProfilerTracingContextTracker implements TracingContextTracker {
+  private static final Logger log =
+      LoggerFactory.getLogger(AsyncProfilerTracingContextTracker.class);
 
   private static final AsyncProfiler ASYNC_PROFILER = AsyncProfiler.getInstance();
 
@@ -50,8 +54,6 @@ public final class AsyncProfilerTracingContextTracker implements TracingContextT
         span != null
             ? span.getLocalRootSpan() != null ? span.getLocalRootSpan().getSpanId().toLong() : -1
             : -1;
-
-    activateAsyncProfilerContext();
   }
 
   @Override
@@ -66,7 +68,7 @@ public final class AsyncProfilerTracingContextTracker implements TracingContextT
 
   @Override
   public void maybeDeactivateContext() {
-    deactivateAsyncProfilerContext();
+    // safe to ignore
   }
 
   private void activateAsyncProfilerContext() {


### PR DESCRIPTION
# What Does This Do
Removes the implicit context activation in the tracker constructor

# Motivation
A concurrent change in the context tracking code made this activation redundant and, in fact, it will cause weird span activation intervals.

# Additional Notes
