### PR TITLE
Add a CircleCI job named required that github can enforce

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -627,6 +627,21 @@ build_test_jobs: &build_test_jobs
       requires:
         - build
 
+  # This job requires all the jobs needed for a successful build, so github only needs to enforce this one
+  # and it will be simpler to require different JVM versions for different branches and old releases
+  - fan_in:
+      requires:
+        - check
+        - agent_integration_tests
+        - test_7
+        - test_8
+        - test_11
+        - test_15
+        - test_17
+        - test_ZULU8
+      name: required
+      testJvm: "required tasks" # only used in a print statement
+
 workflows:
   build_test:
     jobs:


### PR DESCRIPTION
# What Does This Do

Adds a CircleCI fan-in job named `required` that depends on all the other CircleCI jobs that are required for a PR to be merged on github.

# Motivation

When we start having multiple versions with different JVM requirements et.c. it would be easier to maintain github branch protection if it only needs to care about one CircleCI job.

# Additional Notes
