### PR TITLE
Allow the 'start-force-first' option on newer JDKs

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-async/src/main/java/com/datadog/profiling/auxiliary/async/AuxiliaryAsyncProfiler.java
@@ -39,7 +39,6 @@ final class AuxiliaryAsyncProfiler implements AuxiliaryImplementation {
   private final AtomicBoolean recordingFlag = new AtomicBoolean(false);
   private final ConfigProvider configProvider;
   private final AsyncProfiler asyncProfiler;
-  private final Set<ProfilingMode> profilingModes = EnumSet.noneOf(ProfilingMode.class);
 
   AuxiliaryAsyncProfiler(ConfigProvider configProvider) {
     this.configProvider = configProvider;
@@ -66,13 +65,13 @@ final class AuxiliaryAsyncProfiler implements AuxiliaryImplementation {
               asyncProfiler.getAllocationInterval(),
               asyncProfiler.getMemleakInterval(),
               asyncProfiler.getMemleakCapacity(),
-              ProfilingMode.mask(profilingModes))
+              ProfilingMode.mask(asyncProfiler.enabledModes()))
           .commit();
     } catch (Throwable t) {
       if (log.isDebugEnabled()) {
         log.warn("Exception occurred while attempting to emit config event", t);
       } else {
-        log.warn("Exception occurred while attempting to emit config event", t.toString());
+        log.warn("Exception occurred while attempting to emit config event: {}", t.toString());
       }
       throw t;
     }

--- a/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
+++ b/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
@@ -46,9 +46,15 @@ public class ProfilingAgent {
       final Config config = Config.get();
       final ConfigProvider configProvider = ConfigProvider.getInstance();
 
-      final boolean startForceFirst =
+      boolean startForceFirst =
           configProvider.getBoolean(
               PROFILING_START_FORCE_FIRST, PROFILING_START_FORCE_FIRST_DEFAULT);
+
+      if (!isStartForceFirstSafe()) {
+        log.debug(
+            "Starting profiling in premain can lead to crashes in this JDK. Delaying the startup.");
+        startForceFirst = false;
+      }
 
       if (isStartingFirst && !startForceFirst) {
         log.debug("Profiling: not starting first");
@@ -117,6 +123,13 @@ public class ProfilingAgent {
         log.debug("Failed to initialize profiling agent!", e);
       }
     }
+  }
+
+  private static boolean isStartForceFirstSafe() {
+    return Platform.isJavaVersionAtLeast(14)
+        || (Platform.isJavaVersion(13) && Platform.isJavaVersionAtLeast(13, 0, 4))
+        || (Platform.isJavaVersion(11) && Platform.isJavaVersionAtLeast(11, 0, 8))
+        || (Platform.isJavaVersion(8) && Platform.isJavaVersion(8, 0, 272));
   }
 
   public static void shutdown() {

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -27,10 +27,7 @@ public final class ProfilingConfig {
   public static final String PROFILING_TAGS = "profiling.tags";
   public static final String PROFILING_START_DELAY = "profiling.start-delay";
   public static final int PROFILING_START_DELAY_DEFAULT = 10;
-  // DANGEROUS! May lead on sigsegv on JVMs before 14
-  // Not intended for production use
-  public static final String PROFILING_START_FORCE_FIRST =
-      "profiling.experimental.start-force-first";
+  public static final String PROFILING_START_FORCE_FIRST = "profiling.start-force-first";
   public static final boolean PROFILING_START_FORCE_FIRST_DEFAULT = false;
   public static final String PROFILING_UPLOAD_PERIOD = "profiling.upload.period";
   public static final int PROFILING_UPLOAD_PERIOD_DEFAULT = 60;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -22,8 +22,6 @@ public final class ProfilingConfig {
   public static final String PROFILING_API_KEY_VERY_OLD = "profiling.apikey";
   @Deprecated // Use dd.api-key-file instead
   public static final String PROFILING_API_KEY_FILE_VERY_OLD = "profiling.apikey.file";
-  public static final String PROFILING_TEMPLATE = "profiling.template";
-  public static final String PROFILING_TEMPLATE_DEFAULT = "default";
   public static final String PROFILING_TAGS = "profiling.tags";
   public static final String PROFILING_START_DELAY = "profiling.start-delay";
   public static final int PROFILING_START_DELAY_DEFAULT = 10;
@@ -85,10 +83,6 @@ public final class ProfilingConfig {
   public static final String PROFILING_ASYNC_MEMLEAK_INTERVAL = "profiling.async.memleak.interval";
   public static final String PROFILING_ASYNC_MEMLEAK_CAPACITY = "profiling.async.memleak.capacity";
   public static final int PROFILING_ASYNC_MEMLEAK_CAPACITY_DEFAULT = 1024;
-  public static final String PROFILING_ASYNC_TRACING_CONTEXT_ENABLED =
-      "profiling.async.tracing_context.enabled";
-  public static final boolean PROFILING_ASYNC_TRACING_CONTEXT_ENABLED_DEFAULT = false;
-
   public static final String PROFILING_TRACING_CONTEXT_ENABLED =
       "profiling.tracing_context.enabled";
   public static final boolean PROFILING_TRACING_CONTEXT_ENABLED_DEFAULT = false;


### PR DESCRIPTION
# What Does This Do
It turns the `profiling.start-force-first` option from experimental to a regular one.

# Motivation
After https://bugs.openjdk.org/browse/JDK-8233197 fixed we have a good choice of JDKs where this option would be safely supported. Allowing the option with a safety-break when we detect an unsupported JDK seems like the right way to go.

# Additional Notes
The PR also contains some additional cleanups discovered while working on the main feature.