### PR TITLE
Compile for Java 8, and don't test on Java 7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ save_cache_paths: &save_cache_paths
 
 test_matrix: &test_matrix
   parameters:
-    testJvm: [ "7", "IBM8", "ZULU8","ORACLE8", "11", "ZULU11", "ZULU13", "15", "17" ]
+    testJvm: [ "IBM8", "ZULU8","ORACLE8", "11", "ZULU11", "ZULU13", "15", "17" ]
 
 parameters:
   gradle_flags:
@@ -633,7 +633,6 @@ build_test_jobs: &build_test_jobs
       requires:
         - check
         - agent_integration_tests
-        - test_7
         - test_8
         - test_11
         - test_15

--- a/communication/communication.gradle
+++ b/communication/communication.gradle
@@ -39,5 +39,4 @@ ext {
     'datadog.communication.ddagent.SharedCommunicationObjects',
     'datadog.communication.ddagent.TracerVersion',
   ]
-  minJavaVersionForTests = JavaVersion.VERSION_1_7
 }

--- a/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyTest.groovy
@@ -35,7 +35,7 @@ class GrizzlyTest extends HttpServerTest<HttpServer> {
     injectSysConfig("dd.integration.grizzly.enabled", "true")
   }
 
-  private class GrizzlyServer implements datadog.trace.agent.test.base.HttpServer {
+  protected class GrizzlyServer implements datadog.trace.agent.test.base.HttpServer {
     final HttpServer server
     int port = 0
 

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -71,7 +71,7 @@ abstract class GrpcTest extends AgentTestRunner {
     } as Function<RequestContext, Flow<Void>>)
     ig.registerCallback(EVENTS.grpcServerRequestMessage(), { reqCtx, obj ->
       collectedAppSecReqMsgs << obj
-    } as BiFunction<RequestContext, Object>)
+    } as BiFunction<RequestContext, Object, Flow<Void>>)
   }
 
   def cleanup() {

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/core-4.3.gradle
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/core-4.3.gradle
@@ -30,7 +30,8 @@ dependencies {
   testImplementation group: 'org.hibernate', name: 'hibernate-core', version: '4.3.0.Final'
   testImplementation group: 'org.hibernate', name: 'hibernate-entitymanager', version: '4.3.0.Final'
   testImplementation group: 'org.hsqldb', name: 'hsqldb', version: '2.0.0'
-  testImplementation group: 'org.springframework.data', name: 'spring-data-jpa', version: '1.5.1.RELEASE'
+  // First version that supports Java 8
+  testImplementation group: 'org.springframework.data', name: 'spring-data-jpa', version: '1.6.0.RELEASE'
 
   latestDepTestImplementation group: 'org.hibernate', name: 'hibernate-core', version: '(,6.0.0.Final)'
   latestDepTestImplementation group: 'org.hibernate', name: 'hibernate-entitymanager', version: '(,6.0.0.Final)'

--- a/dd-java-agent/instrumentation/instrumentation.gradle
+++ b/dd-java-agent/instrumentation/instrumentation.gradle
@@ -39,6 +39,7 @@ subprojects { Project subProj ->
 
   subProj.afterEvaluate {
     String jdkCompile = null
+    // TODO:java8 this should be changed and the *_java8 directories folded into the main directory
     if (project.hasProperty('minJavaVersionForTests') && project.getProperty('minJavaVersionForTests') != JavaVersion.VERSION_1_7) {
       def version = JavaVersion.toVersion(project.getProperty('minJavaVersionForTests'))
       def name = "java$version.majorVersion"

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -33,8 +33,8 @@ if (applyCodeCoverage) {
   apply from: "$rootDir/gradle/jacoco.gradle"
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 // when building with Java 9+, lazily set compiler --release flag to match target
 def skipSettingCompilerRelease = project.findProperty('skipSettingCompilerRelease')
@@ -44,6 +44,7 @@ if (!skipSettingCompilerRelease && JavaVersion.current().isJava9Compatible()) {
   }
 }
 
+// TODO:java8 this should be changed and the *_java8 directories folded into the main directory
 if (project.hasProperty('minJavaVersionForTests') && project.getProperty('minJavaVersionForTests') != JavaVersion.VERSION_1_7) {
   def version = JavaVersion.toVersion(project.getProperty('minJavaVersionForTests'))
   def name = "java$version.majorVersion"
@@ -85,23 +86,6 @@ java {
   disableAutoTargetJvm()
   withJavadocJar()
   withSourcesJar()
-}
-
-[JavaCompile, ScalaCompile].each { type ->
-  tasks.withType(type).configureEach {
-    doFirst {
-      // We do this specifically for Java7 bytecode generation because we would like to be able to compile
-      // with Java8+ compiler. This likely would require some modifications when we switch to java11 compiler.
-      // Using proper Java7 bootstrap and extensions allows to be sure our code will run on real Java7.
-      if (JavaVersion.toVersion(sourceCompatibility) == JavaVersion.VERSION_1_7
-        && JavaVersion.current() != JavaVersion.VERSION_1_7
-        && System.env.JAVA_7_HOME != null) {
-        options.fork = true
-        options.bootstrapClasspath = fileTree(include: ['*.jar'], dir: "${System.env.JAVA_7_HOME}/jre/lib/")
-        options.extensionDirs = "${System.env.JAVA_7_HOME}/jre/lib/ext/"
-      }
-    }
-  }
 }
 
 jar {

--- a/telemetry/telemetry.gradle
+++ b/telemetry/telemetry.gradle
@@ -33,7 +33,6 @@ ext {
     'datadog.telemetry.HostInfo.Os',
   ]
   excludedClassesInstructionCoverage = []
-  minJavaVersionForTests = JavaVersion.VERSION_1_7
 }
 
 openApiGenerate {


### PR DESCRIPTION
# What Does This Do
 
Changes source and destination target to Java 8 and removes the Java 7 test job from CircleCI

# Motivation

Version 1.x of dd-trace-java will have Java 8 as a minimum so we can upgrade dependencies

# Additional Notes

Upgraded dependencies and other changes in the build will follow in subsequent PRs