### PR TITLE
Fix spurious buffer underflow error in per-span context serialization

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/IntervalEncoder.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/IntervalEncoder.java
@@ -287,7 +287,8 @@ final class IntervalEncoder {
                 + leb128Support.varintSize(freqMultiplier));
     this.dataChunkBuffer = ByteBuffer.allocate(maxDataSize * 8 + 4);
     this.groupVarintMapBuffer =
-        ByteBuffer.allocate(leb128Support.align((int) (Math.ceil(maxDataSize / 8d) * 3), 4));
+        ByteBuffer.allocate(
+            leb128Support.align((((maxDataSize / 8) + (maxDataSize % 8 == 0 ? 0 : 1)) * 3), 4));
 
     prologueBuffer.put((byte) 0); // pre-allocated space for the truncated flag
     prologueBuffer.putInt(0); // pre-allocate space for the datachunk offset

--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/IntervalSequencePruner.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/IntervalSequencePruner.java
@@ -141,6 +141,7 @@ final class IntervalSequencePruner {
           "Dangling 'started' transition. Creating synthetic 'finished' transition @{} delta",
           timestampDelta);
       sequence.add(PerSpanTracingContextTracker.maskDeactivation(timestampDelta, false));
+      sequence.adjustCapturedSize(8); // adjust the captured size
     }
     return new PruningLongIterator(sequence.iterator());
   }

--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/LongSequence.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/LongSequence.java
@@ -273,6 +273,10 @@ final class LongSequence {
     return capturedSize;
   }
 
+  void adjustCapturedSize(int diff) {
+    capturedSize += diff;
+  }
+
   public int sizeInBytes() {
     return sizeInBytes;
   }

--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/LongSequence.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/LongSequence.java
@@ -2,7 +2,7 @@ package com.datadog.profiling.context;
 
 import com.datadog.profiling.context.allocator.AllocatedBuffer;
 import java.util.Arrays;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,11 +22,36 @@ final class LongSequence {
   private class LongIteratorImpl implements LongIterator {
     int bufferReadSlot = 0;
     int allIndex = 0;
+
+    final AllocatedBuffer[] buffers;
+
     LongIterator currentIterator = null;
+    boolean released = false;
+
+    LongIteratorImpl() {
+      // check'n'update the state - if it is non-negative, increment the counter and proceed,
+      // otherwise bail out
+      if (STATE_UPDATER.updateAndGet(LongSequence.this, prev -> prev >= 0 ? prev + 1 : prev) < 0) {
+        // bail out if this instance was already released
+        this.buffers = null;
+        released = true;
+      } else {
+        this.buffers = LongSequence.this.buffers;
+      }
+    }
 
     @Override
     public boolean hasNext() {
+      if (released || buffers == null) {
+        return false;
+      }
       if (bufferReadSlot > bufferWriteSlot || allIndex >= size) {
+        // check'n'update the state - if it is negative before update, perform release, otherwise
+        // just decrement the counter
+        if (STATE_UPDATER.getAndUpdate(LongSequence.this, prev -> prev > 0 ? prev - 1 : prev) < 0) {
+          released = true;
+          doRelease();
+        }
         return false;
       }
       if (currentIterator == null) {
@@ -74,7 +99,10 @@ final class LongSequence {
     return (int) (Math.ceil(size / 8d) * 8);
   }
 
-  private AtomicInteger state = new AtomicInteger(0);
+  private volatile int state = 0;
+  private static final AtomicIntegerFieldUpdater<LongSequence> STATE_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(LongSequence.class, "state");
+
   private final int limit;
   private int capturedSize = -1;
 
@@ -85,7 +113,6 @@ final class LongSequence {
   public LongSequence(Allocator allocator, int limit) {
     this.allocator = allocator;
     this.limit = limit;
-    this.bufferWriteSlot = -1;
     Arrays.fill(bufferBoundaryMap, Integer.MAX_VALUE);
   }
 
@@ -96,7 +123,7 @@ final class LongSequence {
   public int add(long value, boolean obeyLimit) {
     // check'n'update the state - if it is non-negative, increment the counter and proceed,
     // otherwise bail out
-    if (state.updateAndGet(prev -> prev >= 0 ? prev + 1 : prev) < 0) {
+    if (STATE_UPDATER.updateAndGet(this, prev -> prev >= 0 ? prev + 1 : prev) < 0) {
       // bail out if this instance was already released
       return -1;
     }
@@ -161,7 +188,7 @@ final class LongSequence {
     } finally {
       // check'n'update the state - if it is negative before update, perform release, otherwise just
       // decrement the counter
-      if (state.getAndUpdate(prev -> prev > 0 ? prev - 1 : prev) < 0) {
+      if (STATE_UPDATER.getAndUpdate(this, prev -> prev > 0 ? prev - 1 : prev) < 0) {
         doRelease();
       }
     }
@@ -170,7 +197,7 @@ final class LongSequence {
   public boolean set(int index, long value) {
     // check'n'update the state - if it is non-negative, increment the counter and proceed,
     // otherwise bail out
-    if (state.updateAndGet(prev -> prev >= 0 ? prev + 1 : prev) < 0) {
+    if (STATE_UPDATER.updateAndGet(this, prev -> prev >= 0 ? prev + 1 : prev) < 0) {
       // bail out if this instance was already released
       return false;
     }
@@ -188,7 +215,7 @@ final class LongSequence {
     } finally {
       // check'n'update the state - if it is negative before update, perform release, otherwise just
       // decrement the counter
-      if (state.getAndUpdate(prev -> prev > 0 ? prev - 1 : prev) < 0) {
+      if (STATE_UPDATER.getAndUpdate(this, prev -> prev > 0 ? prev - 1 : prev) < 0) {
         doRelease();
       }
     }
@@ -197,7 +224,7 @@ final class LongSequence {
   public long get(int index) {
     // check'n'update the state - if it is non-negative, increment the counter and proceed,
     // otherwise bail out
-    if (state.updateAndGet(prev -> prev >= 0 ? prev + 1 : prev) < 0) {
+    if (STATE_UPDATER.updateAndGet(this, prev -> prev >= 0 ? prev + 1 : prev) < 0) {
       // bail out if this instance was already released
       return Long.MIN_VALUE;
     }
@@ -215,7 +242,7 @@ final class LongSequence {
     } finally {
       // check'n'update the state - if it is negative before update, perform release, otherwise just
       // decrement the counter
-      if (state.getAndUpdate(prev -> prev > 0 ? prev - 1 : prev) < 0) {
+      if (STATE_UPDATER.getAndUpdate(this, prev -> prev > 0 ? prev - 1 : prev) < 0) {
         doRelease();
       }
     }
@@ -251,16 +278,22 @@ final class LongSequence {
   }
 
   public void release() {
-    if (state.getAndUpdate(prev -> prev > 0 ? -1 * prev : prev) == 0) {
+    if (STATE_UPDATER.getAndUpdate(this, prev -> prev > 0 ? -1 * prev : prev) == 0) {
       doRelease();
     }
   }
 
   private void doRelease() {
-    for (int i = 0; i < buffers.length; i++) {
-      AllocatedBuffer buffer = buffers[i];
-      if (buffer != null) {
-        buffer.release();
+    if (STATE_UPDATER.getAndSet(this, -1) == -1) {
+      return;
+    }
+    ;
+    if (buffers != null) {
+      for (int i = 0; i < buffers.length; i++) {
+        AllocatedBuffer buffer = buffers[i];
+        if (buffer != null) {
+          buffer.release();
+        }
       }
     }
     // clear out the buffer slots to allow the most of the retained data to be GCed
@@ -268,7 +301,6 @@ final class LongSequence {
     buffers = null;
     bufferBoundaryMap = null;
     bufferInitSlot = -1;
-    state.set(-1);
   }
 
   public LongIterator iterator() {

--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/PerSpanTracingContextTracker.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/PerSpanTracingContextTracker.java
@@ -394,7 +394,8 @@ public final class PerSpanTracingContextTracker implements TracingContextTracker
     long[] threadIds = shuffleArray(threadSequences.keySetLong());
     for (LongSequence sequence : threadSequences.values()) {
       int size = sequence.captureSize();
-      totalSequenceBufferSize += size;
+      totalSequenceBufferSize +=
+          (size + 8); // each sequence can receive a synthetic 'start' with length of 8 bytes
     }
 
     IntervalEncoder encoder =
@@ -426,6 +427,10 @@ public final class PerSpanTracingContextTracker implements TracingContextTracker
        */
       synchronized (rawIntervals) {
         LongIterator iterator = pruneIntervals(rawIntervals);
+        sequenceSize =
+            rawIntervals
+                .getCapturedSize(); // refetch the captured size as it may have been modified by
+        // pruning
         int sequenceIndex = 0;
         while (iterator.hasNext() && sequenceIndex++ < sequenceSize) {
           long from = iterator.next();


### PR DESCRIPTION
# What Does This Do

It fixes the per-span context serialization such that it properly calculates the required size of buffers.
The original implementation forgot about the pruning process possibly inserting one synthetic element and this would have lead to incorrect sizing of the serialization buffers and spurious buffer underflow exceptions.

# Motivation
Fixing the per-span context serialization.

# Additional Notes
