### PR TITLE
Remove an extra field converter from OT Wrappers

### DIFF
--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTTracer.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTTracer.java
@@ -41,7 +41,7 @@ public class OTTracer implements Tracer {
 
   @Override
   public SpanBuilder buildSpan(final String operationName) {
-    return new OTSpanBuilder(tracer.buildSpan(operationName), converter);
+    return new OTSpanBuilder(tracer.buildSpan(operationName));
   }
 
   @Override
@@ -70,11 +70,9 @@ public class OTTracer implements Tracer {
 
   public class OTSpanBuilder implements Tracer.SpanBuilder {
     private final AgentTracer.SpanBuilder delegate;
-    private final TypeConverter converter;
 
-    public OTSpanBuilder(final AgentTracer.SpanBuilder delegate, final TypeConverter converter) {
+    public OTSpanBuilder(final AgentTracer.SpanBuilder delegate) {
       this.delegate = delegate;
-      this.converter = converter;
     }
 
     @Override

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTTracer.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTTracer.java
@@ -53,7 +53,7 @@ public class OTTracer implements Tracer {
 
   @Override
   public SpanBuilder buildSpan(final String operationName) {
-    return new OTSpanBuilder(tracer.buildSpan(operationName), converter);
+    return new OTSpanBuilder(tracer.buildSpan(operationName));
   }
 
   @Override
@@ -87,11 +87,9 @@ public class OTTracer implements Tracer {
 
   public class OTSpanBuilder implements Tracer.SpanBuilder {
     private final AgentTracer.SpanBuilder delegate;
-    private final TypeConverter converter;
 
-    public OTSpanBuilder(final AgentTracer.SpanBuilder delegate, final TypeConverter converter) {
+    public OTSpanBuilder(final AgentTracer.SpanBuilder delegate) {
       this.delegate = delegate;
-      this.converter = converter;
     }
 
     @Override


### PR DESCRIPTION
# What Does This Do

Reduce OT Wrappers footprint by removing the converter field
