### PR TITLE
Add release update workflow

### DIFF
--- a/.github/workflows/update-latest-release.yml
+++ b/.github/workflows/update-latest-release.yml
@@ -186,14 +186,31 @@ jobs:
             }).catch(error => {
               core.setFailed('Failed to find release: ' + error.message);
             });
+            // Get the current release asset
             const assetFile = 'dd-java-agent.jar';
             const newAssetFile = 'dd-java-agent-${{ steps.check-update.outputs.tag }}.jar';
+            const asset = await github.rest.repos.listReleaseAssets({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release.id
+            }).then(response => {
+              if (response.status === 200) {
+                for (const asset of response.data) {
+                  if (asset.name === assetFile) {
+                    return asset;
+                  }
+                }
+                return false;
+              } else {
+                core.setFailed('Failed to list release assets.');
+              }
+            });
             // Upload the new version to the release
             const newAsset = await github.rest.repos.uploadReleaseAsset({
               owner: context.repo.owner,
               repo: context.repo.repo,
               release_id: release.id,
-              name: newAssetFile,
+              name: asset ? newAssetFile : assetFile,
               data: fs.readFileSync(assetFile)
             }).then(response => {
               if (response.status === 201) {
@@ -204,53 +221,39 @@ jobs:
             }).catch(error => {
               core.setFailed('Failed to upload asset: ' + error.message);
             });
-            // Delete the old asset from the release then rename the new one
-            github.rest.repos.listReleaseAssets({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              release_id: release.id
-            }).then(response => {
-              if (response.status === 200) {
-                for (const asset of response.data) {
-                  if (asset.name === assetFile) {
-                    return asset.id;
-                  }
-                }
-                core.setFailed('Failed to find release asset id.');
-              } else {
-                core.setFailed('Failed to list release assets.');
-              }
-            }).then(assetId => {
-              return github.rest.repos.deleteReleaseAsset({
+            // Delete the old asset if exists, then rename the new one
+            if (asset) {
+              github.rest.repos.deleteReleaseAsset({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                asset_id: assetId
+                asset_id: asset.id
+              }).then(response => {
+                if (response.status === 204) {
+                  return github.rest.repos.updateReleaseAsset({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    asset_id: newAsset.id,
+                    name: assetFile
+                  });
+                } else {
+                  core.setFailed('Failed to delete old asset.');
+                }
+              }).then(response => {
+                if (response.status !== 200) {
+                  core.setFailed('Failed to update new asset name as default asset.');
+                }
+              }).catch(error => {
+                core.setFailed('Failed to rename release asset: ' + error.message);
               });
-            }).then(response => {
-              if (response.status === 204) {
-                return github.rest.repos.updateReleaseAsset({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  asset_id: newAsset.id,
-                  name: assetFile
-                })
-              } else {
-                core.setFailed('Failed to delete old asset.');
-              }
-            }).then(response => {
-              if (response.status === 200) {
-                // Update release body with new version
-                return github.rest.repos.updateRelease({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  release_id: release.id,
-                  body: '# Download\n' +
-                        '\n' +
-                        'This release tracks the latest v' + major + ' available, currently ${{ steps.check-update.outputs.tag }}.'
-                });
-              } else {
-                core.setFailed('Failed to update new asset name as default asset.');
-              }
+            }
+            // Update release body with new version
+            github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release.id,
+              body: '# Download\n' +
+                    '\n' +
+                    'This release tracks the latest v' + major + ' available, currently ${{ steps.check-update.outputs.tag }}.'
             }).then(response => {
               if (response.status !== 200) {
                 core.setFailed('Failed to update latest release body.');

--- a/.github/workflows/update-latest-release.yml
+++ b/.github/workflows/update-latest-release.yml
@@ -24,7 +24,6 @@ jobs:
         name: Get latest releases
         uses: actions/github-script@d50f485531ba88479582bc2da03ff424389af5c1 # v6.1.1
         with:
-          debug: true
           script: |
             const latest = await github.paginate(
               "GET /repos/{owner}/{repo}/releases",
@@ -91,7 +90,6 @@ jobs:
         name: Check if release update is needed
         uses: actions/github-script@d50f485531ba88479582bc2da03ff424389af5c1 # v6.1.1
         with:
-          debug: true
           script: |
             const latest = ${{ steps.get-latest.outputs.result }};
             var needUpdate = false;
@@ -164,7 +162,6 @@ jobs:
         if: ${{ steps.check-update.outputs.result == 'true' }}
         uses: actions/github-script@d50f485531ba88479582bc2da03ff424389af5c1 # v6.1.1
         with:
-          debug: true
           script: |
             const fs = require('fs');
             const major = '${{ steps.check-update.outputs.major}}';

--- a/.github/workflows/update-latest-release.yml
+++ b/.github/workflows/update-latest-release.yml
@@ -11,8 +11,8 @@ on:
         type: 'choice'
         options:
         - 'v0'
-        - 'v1'
-        default: 'v1'
+        # - 'v1'
+        default: 'v0'
 
 jobs:
   update-release:

--- a/.github/workflows/update-latest-release.yml
+++ b/.github/workflows/update-latest-release.yml
@@ -31,7 +31,7 @@ jobs:
               { owner: context.repo.owner, repo: context.repo.repo }
             ).then((releases) => {
               const versionPattern = /v(\d+)\.(\d+)\.(\d+)/;
-              const downloadLatestPattern = /download-latest-v\d+/;
+              const downloadLatestPattern = /download-latest-v(\d+)/;
               const publishedVersions = releases.filter(release => !release.draft && !release.prerelease)
                                                 .map(release => release.tag_name);
               // Find latest published version, indexed by major version
@@ -52,15 +52,21 @@ jobs:
               }, {});
               // Find "download latest" releases, indexed by major version
               const latestReleases = releases.reduce((releases, release) => {
-                if (release.tag_name.match(downloadLatestPattern)) {
+                const match = release.tag_name.match(downloadLatestPattern);
+                if (match) {
+                  const releaseMajor = parseInt(match[1]);
                   // Look for the linked version from release body
                   for (const bodyLine of release.body.split('\n')) {
-                    const match = bodyLine.match(versionPattern);
-                    if (match) {
-                      const tag = match[0]
-                      const major = parseInt(match[1]);
-                      const minor = parseInt(match[2]);
-                      const bugfix = parseInt(match[3]);
+                    const lineMatch = bodyLine.match(versionPattern);
+                    if (lineMatch) {
+                      const tag = lineMatch[0]
+                      const major = parseInt(lineMatch[1]);
+                      const minor = parseInt(lineMatch[2]);
+                      const bugfix = parseInt(lineMatch[3]);
+                      if (releaseMajor !== major) {
+                        throw 'Latest release \'download-latest-v' + releaseMajor + '\' for version ' + releaseMajor +
+                              ' contains a mismatching link to the version ' + major + ': ' + tag + '.';
+                      }
                       releases[major] = { tag, major, minor, bugfix };
                       break;
                     }

--- a/.github/workflows/update-latest-release.yml
+++ b/.github/workflows/update-latest-release.yml
@@ -91,12 +91,14 @@ jobs:
         uses: actions/github-script@d50f485531ba88479582bc2da03ff424389af5c1 # v6.1.1
         with:
           script: |
+            core.summary.addHeading('Update check', 5);
             const latest = ${{ steps.get-latest.outputs.result }};
             var needUpdate = false;
             var outputTag, outputMajor;
             // Check if update is needed from this new release
             if (context.eventName === 'release') {
               const tag = '${{ github.event.release.tag_name }}';
+              core.summary.addRaw('Start by release push: ' + tag + '. ')
               const versionPattern = /v(\d+)\.(\d+)\.(\d+)/;
               const match = tag.match(versionPattern);
               if (match) {
@@ -120,6 +122,7 @@ jobs:
             // Check if there is a more recent version for this release
             else if (context.eventName === 'workflow_dispatch') {
               const major = parseInt("${{ inputs.version }}".substring(1));
+              core.summary.addRaw('Start manually for v' + major + '. ')
               const latestVersion = latest.versions[major];
               const latestRelease = latest.releases[major];
               // Ensure there is an existing matching version
@@ -140,14 +143,13 @@ jobs:
                 outputMajor = major;
               }
             }
-            // Write summay and step outputs
-            core.summary.addHeading('Update check', 5)
+            // Write summay and set outputs
             if (needUpdate) {
               core.setOutput('tag', outputTag);
               core.setOutput('major', outputMajor);
               core.summary.addRaw('Updating release v' + outputMajor + ' to version ' + outputTag + '.');
             } else {
-              core.summary.addRaw('All releases are up-to-date.');
+              core.summary.addRaw('No update found.');
             }
             core.summary.write();
             return needUpdate;

--- a/.github/workflows/update-latest-release.yml
+++ b/.github/workflows/update-latest-release.yml
@@ -54,6 +54,11 @@ jobs:
                 const match = release.tag_name.match(downloadLatestPattern);
                 if (match) {
                   const releaseMajor = parseInt(match[1]);
+                  releases[releaseMajor] = {
+                    tag: 'v' + releaseMajor + '.0.0',
+                    minor: 0,
+                    bugfix: 0
+                  };
                   // Look for the linked version from release body
                   for (const bodyLine of release.body.split('\n')) {
                     const lineMatch = bodyLine.match(versionPattern);
@@ -111,7 +116,7 @@ jobs:
                 }
                 // Check if the tag is newer than the one used in the latest release
                 if (latest.releases[major].minor < minor
-                  || (latest.releases[major].minor == minor && latest.releases[major].bugfix < bugfix)
+                  || (latest.releases[major].minor == minor && latest.releases[major].bugfix <= bugfix)
                 ) {
                   needUpdate = true;
                   outputTag = tag;

--- a/.github/workflows/update-latest-release.yml
+++ b/.github/workflows/update-latest-release.yml
@@ -1,0 +1,250 @@
+name: Update latest release
+
+on:
+  release:
+    types: [ "released" ]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version to force update'
+        required: true
+        type: 'choice'
+        options:
+        - 'v0'
+        - 'v1'
+        default: 'v1'
+
+jobs:
+  update-release:
+    name: Update latest release
+    runs-on: ubuntu-latest
+    steps:
+
+      - id: get-latest
+        name: Get latest releases
+        uses: actions/github-script@d50f485531ba88479582bc2da03ff424389af5c1 # v6.1.1
+        with:
+          debug: true
+          script: |
+            const latest = await github.paginate(
+              "GET /repos/{owner}/{repo}/releases",
+              { owner: context.repo.owner, repo: context.repo.repo }
+            ).then((releases) => {
+              const versionPattern = /v(\d+)\.(\d+)\.(\d+)/;
+              const downloadLatestPattern = /download-latest-v\d+/;
+              const publishedVersions = releases.filter(release => !release.draft && !release.prerelease)
+                                                .map(release => release.tag_name);
+              // Find latest published version, indexed by major version
+              const latestVersions = publishedVersions.reduce((versions, tag) => {
+                const match = tag.match(versionPattern);
+                if (match) {
+                  const major = parseInt(match[1]);
+                  const minor = parseInt(match[2]);
+                  const bugfix = parseInt(match[3]);
+                  if (!versions[major] // If there is no similar major version
+                    || versions[major].minor < minor // Or if there is an older minor version
+                    || (versions[major].minor == minor && versions[major].bugfix < bugfix) // Of if there is an older bugfix version
+                  ) {
+                    versions[major] = { tag, major, minor, bugfix };
+                  }
+                }
+                return versions;
+              }, {});
+              // Find "download latest" releases, indexed by major version
+              const latestReleases = releases.reduce((releases, release) => {
+                if (release.tag_name.match(downloadLatestPattern)) {
+                  // Look for the linked version from release body
+                  for (const bodyLine of release.body.split('\n')) {
+                    const match = bodyLine.match(versionPattern);
+                    if (match) {
+                      const tag = match[0]
+                      const major = parseInt(match[1]);
+                      const minor = parseInt(match[2]);
+                      const bugfix = parseInt(match[3]);
+                      releases[major] = { tag, major, minor, bugfix };
+                      break;
+                    }
+                  }
+                }
+                return releases;
+              }, {});
+              return {
+                versions: latestVersions,
+                releases: latestReleases
+              };
+            });
+            core.summary.addHeading('Version Discovery', 5)
+                        .addRaw('Latest versions found:')
+                        .addList(Object.values(latest.versions).map(v => v.tag))
+                        .addRaw('Latest releases found:')
+                        .addList(Object.values(latest.releases).map(v => v.tag))
+                        .write();
+            return latest;
+
+      - id: check-update
+        name: Check if release update is needed
+        uses: actions/github-script@d50f485531ba88479582bc2da03ff424389af5c1 # v6.1.1
+        with:
+          debug: true
+          script: |
+            const latest = ${{ steps.get-latest.outputs.result }};
+            var needUpdate = false;
+            var outputTag, outputMajor;
+            // Check if update is needed from this new release
+            if (context.eventName === 'release') {
+              const tag = '${{ github.event.release.tag_name }}';
+              const versionPattern = /v(\d+)\.(\d+)\.(\d+)/;
+              const match = tag.match(versionPattern);
+              if (match) {
+                const major = parseInt(match[1]);
+                const minor = parseInt(match[2]);
+                const bugfix = parseInt(match[3]);
+                // Ensure there is a related major latest release
+                if (!latest.releases[major]) {
+                  throw "Latest release 'download-latest-v" + major + "' for version " + major + " does not exit. Please create it first."
+                }
+                // Check if the tag is newer than the one used in the latest release
+                if (latest.releases[major].minor < minor
+                  || (latest.releases[major].minor == minor && latest.releases[major].bugfix < bugfix)
+                ) {
+                  needUpdate = true;
+                  outputTag = tag;
+                  outputMajor = major;
+                }
+              }
+            } 
+            // Check if there is a more recent version for this release
+            else if (context.eventName === 'workflow_dispatch') {
+              const major = parseInt("${{ inputs.version }}".substring(1));
+              const latestVersion = latest.versions[major];
+              const latestRelease = latest.releases[major];
+              // Ensure there is an existing matching version
+              if (!latestVersion) {
+                throw new "No version found for version " + major + ".";
+              }
+              const tag = latestVersion.tag;
+              // Ensure there is a related major latest release
+              if (!latest.releases[major]) {
+                throw "Latest release for version " + major + " does not exit. Create it first.";
+              }
+              // Check if the version is newer than the one used in the latest release
+              if (latestRelease.minor < latestVersion.minor
+                || (latestRelease.minor == latestVersion.minor && latestRelease.bugfix < latestVersion.bugfix)
+              ) {
+                needUpdate = true;
+                outputTag = tag;
+                outputMajor = major;
+              }
+            }
+            // Write summay and step outputs
+            core.summary.addHeading('Update check', 5)
+            if (needUpdate) {
+              core.setOutput('tag', outputTag);
+              core.setOutput('major', outputMajor);
+              core.summary.addRaw('Updating release v' + outputMajor + ' to version ' + outputTag + '.');
+            } else {
+              core.summary.addRaw('All releases are up-to-date.');
+            }
+            core.summary.write();
+            return needUpdate;
+
+      - id: fetch-release-asset
+        name: Fetch latest release asset
+        if: ${{ steps.check-update.outputs.result == 'true' }}
+        run: wget https://github.com/${GITHUB_REPOSITORY}/releases/download/${{ steps.check-update.outputs.tag }}/dd-java-agent.jar
+
+      - id: Update-release
+        name: Update latest release
+        if: ${{ steps.check-update.outputs.result == 'true' }}
+        uses: actions/github-script@d50f485531ba88479582bc2da03ff424389af5c1 # v6.1.1
+        with:
+          debug: true
+          script: |
+            const fs = require('fs');
+            const major = '${{ steps.check-update.outputs.major}}';
+            const downloadLatestTag = 'download-latest-v' + major;
+            const release = await github.rest.repos.getReleaseByTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag: downloadLatestTag
+            }).then(response => {
+              if (response.status === 200) {
+                return response.data;
+              } else {
+                core.setFailed('Failed to find release from tag: ' + downloadLatestTag + '.');
+              }
+            }).catch(error => {
+              core.setFailed('Failed to find release: ' + error.message);
+            });
+            const assetFile = 'dd-java-agent.jar';
+            const newAssetFile = 'dd-java-agent-${{ steps.check-update.outputs.tag }}.jar';
+            // Upload the new version to the release
+            const newAsset = await github.rest.repos.uploadReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release.id,
+              name: newAssetFile,
+              data: fs.readFileSync(assetFile)
+            }).then(response => {
+              if (response.status === 201) {
+                return response.data;
+              } else {
+                core.setFailed('Failed to upload ' + newAssetFile + ' to release ' + downloadLatestTag + '.');
+              }
+            }).catch(error => {
+              core.setFailed('Failed to upload asset: ' + error.message);
+            });
+            // Delete the old asset from the release then rename the new one
+            github.rest.repos.listReleaseAssets({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release.id
+            }).then(response => {
+              if (response.status === 200) {
+                for (const asset of response.data) {
+                  if (asset.name === assetFile) {
+                    return asset.id;
+                  }
+                }
+                core.setFailed('Failed to find release asset id.');
+              } else {
+                core.setFailed('Failed to list release assets.');
+              }
+            }).then(assetId => {
+              return github.rest.repos.deleteReleaseAsset({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                asset_id: assetId
+              });
+            }).then(response => {
+              if (response.status === 204) {
+                return github.rest.repos.updateReleaseAsset({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  asset_id: newAsset.id,
+                  name: assetFile
+                })
+              } else {
+                core.setFailed('Failed to delete old asset.');
+              }
+            }).then(response => {
+              if (response.status === 200) {
+                // Update release body with new version
+                return github.rest.repos.updateRelease({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  release_id: release.id,
+                  body: '# Download\n' +
+                        '\n' +
+                        'This release tracks the latest v' + major + ' available, currently ${{ steps.check-update.outputs.tag }}.'
+                });
+              } else {
+                core.setFailed('Failed to update new asset name as default asset.');
+              }
+            }).then(response => {
+              if (response.status !== 200) {
+                core.setFailed('Failed to update latest release body.');
+              }
+            }).catch(error => {
+              core.setFailed('Failed to update release: ' + error.message);
+            });


### PR DESCRIPTION

# What Does This Do

This action will update the `download-latest-vX` releases body and attachment to the latest version available.

# Motivation

This action takes place in the Java 7 deprecation context.

We will need to create releases with stable tags in order to provide permanent links for download each major version.
Those releases will be based on orphan branch tagged `download-latest-vX` and will contains a copy of the latest attachment available.

On each new release, this action will update this meta release. It can also be trigger manually if needed, proving the major version to update.

# Additional Notes

Most of the logic rely on GitHub script actions and octokit library.
I wonder how to improve readability and maintenance. Feel free to share any idea to improve it.