### PR TITLE
'isJavaVersion()' -> 'isJavaVersionAtLeast()'

### DIFF
--- a/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
+++ b/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
@@ -129,7 +129,7 @@ public class ProfilingAgent {
     return Platform.isJavaVersionAtLeast(14)
         || (Platform.isJavaVersion(13) && Platform.isJavaVersionAtLeast(13, 0, 4))
         || (Platform.isJavaVersion(11) && Platform.isJavaVersionAtLeast(11, 0, 8))
-        || (Platform.isJavaVersion(8) && Platform.isJavaVersion(8, 0, 272));
+        || (Platform.isJavaVersion(8) && Platform.isJavaVersionAtLeast(8, 0, 272));
   }
 
   public static void shutdown() {


### PR DESCRIPTION
# What Does This Do
An after fix for wrong method call `Platform.isJavaVersion()` instead of `Platform.isJavaVersionAtLeast()`

# Motivation

# Additional Notes
