### PR TITLE
Introduce a hard limit for in-flight spans with tracked context

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/PerSpanTracingContextTracker.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/PerSpanTracingContextTracker.java
@@ -13,6 +13,7 @@ import java.util.Random;
 import java.util.concurrent.Delayed;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
@@ -146,6 +147,8 @@ public final class PerSpanTracingContextTracker implements TracingContextTracker
 
   private volatile DelayedTrackerImpl delayedTrackerRef = null;
 
+  private final AtomicInteger inFlightSpans;
+
   static {
     SPAN_ACTIVATION_DATA_LIMIT =
         ConfigProvider.getInstance()
@@ -160,7 +163,7 @@ public final class PerSpanTracingContextTracker implements TracingContextTracker
       TimeTicksProvider timeTicksProvider,
       IntervalSequencePruner sequencePruner,
       int maxDataSize) {
-    this(allocator, span, timeTicksProvider, sequencePruner, -1L, maxDataSize);
+    this(allocator, span, timeTicksProvider, sequencePruner, -1L, maxDataSize, null);
   }
 
   PerSpanTracingContextTracker(
@@ -175,7 +178,8 @@ public final class PerSpanTracingContextTracker implements TracingContextTracker
         timeTicksProvider,
         sequencePruner,
         inactivityDelay,
-        SPAN_ACTIVATION_DATA_LIMIT);
+        SPAN_ACTIVATION_DATA_LIMIT,
+        null);
   }
 
   PerSpanTracingContextTracker(
@@ -184,7 +188,8 @@ public final class PerSpanTracingContextTracker implements TracingContextTracker
       TimeTicksProvider timeTicksProvider,
       IntervalSequencePruner sequencePruner,
       long inactivityDelay,
-      int maxDataSize) {
+      int maxDataSize,
+      AtomicInteger inFlightSpans) {
     this.startTimestampTicks = timeTicksProvider.ticks();
     this.startTimestampNanos = currentTimeNanos();
     this.timeTicksProvider = timeTicksProvider;
@@ -196,6 +201,7 @@ public final class PerSpanTracingContextTracker implements TracingContextTracker
     this.inactivityDelay = inactivityDelay;
     this.delayedActivationTimestamp = timeTicksProvider.ticks();
     this.maxDataSize = maxDataSize;
+    this.inFlightSpans = inFlightSpans;
   }
 
   private static long currentTimeNanos() {
@@ -302,6 +308,9 @@ public final class PerSpanTracingContextTracker implements TracingContextTracker
   public boolean release() {
     boolean result = releaseThreadSequences();
     releaseDelayed();
+    if (inFlightSpans != null) {
+      inFlightSpans.decrementAndGet();
+    }
     return result;
   }
 

--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/PerSpanTracingContextTrackerFactory.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/PerSpanTracingContextTrackerFactory.java
@@ -7,6 +7,7 @@ import datadog.trace.api.profiling.TracingContextTracker;
 import datadog.trace.api.profiling.TracingContextTrackerFactory;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.relocate.api.RatelimitedLogger;
 import datadog.trace.util.AgentTaskScheduler;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -15,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.DelayQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,8 +24,9 @@ public final class PerSpanTracingContextTrackerFactory
     implements TracingContextTrackerFactory.Implementation {
   private static final Logger log =
       LoggerFactory.getLogger(PerSpanTracingContextTrackerFactory.class);
+  private static final RatelimitedLogger warnlog = new RatelimitedLogger(log, 30, TimeUnit.SECONDS);
 
-  private final DelayQueue<TracingContextTracker.DelayedTracker> delayQueue = new DelayQueue<>();
+  private final DelayQueue<TracingContextTracker.DelayedTracker>[] delayQueues;
   private final StatsDClient statsd = StatsDAccessor.getStatsdClient();
 
   public static boolean isEnabled(ConfigProvider configProvider) {
@@ -69,7 +72,9 @@ public final class PerSpanTracingContextTrackerFactory
           Collection<TracingContextTracker.DelayedTracker> timeouts = new ArrayList<>(capacity);
           int drainedAll = 0;
           int drained = 0;
-          while ((drained = target.drainTo(timeouts, capacity)) > 0) {
+          int queue = 0;
+          while (queue < target.length
+              && (drained = target[queue++].drainTo(timeouts, capacity)) > 0) {
             if (log.isDebugEnabled()) {
               log.debug("Drained {} inactive trackers", drained);
             }
@@ -81,7 +86,7 @@ public final class PerSpanTracingContextTrackerFactory
             statsd.count("tracing.context.spans.drained_inactive", drainedAll);
           }
         },
-        delayQueue,
+        delayQueues,
         refreshRateMs,
         refreshRateMs,
         TimeUnit.MILLISECONDS);
@@ -91,12 +96,17 @@ public final class PerSpanTracingContextTrackerFactory
   private final IntervalSequencePruner sequencePruner = new IntervalSequencePruner();
   private final PerSpanTracingContextTracker.TimeTicksProvider timeTicksProvider;
   private final long inactivityDelay;
+  private final AtomicInteger inFlightSpans = new AtomicInteger(0);
+  private final int maxInFlightSpans;
+
+  private volatile boolean trackingEnabled = true;
 
   PerSpanTracingContextTrackerFactory(
       long inactivityDelayNs, long inactivityCheckPeriodMs, int reservedMemorySize) {
     this(inactivityDelayNs, inactivityCheckPeriodMs, reservedMemorySize, "heap");
   }
 
+  @SuppressWarnings("unchecked")
   PerSpanTracingContextTrackerFactory(
       long inactivityDelayNs,
       long inactivityCheckPeriodMs,
@@ -109,6 +119,16 @@ public final class PerSpanTracingContextTrackerFactory
             ? Allocators.directAllocator(reservedMemorySize, 32)
             : Allocators.heapAllocator(reservedMemorySize, 32);
     this.inactivityDelay = inactivityDelayNs;
+    int numDelayQueues = Math.min(Math.max(Runtime.getRuntime().availableProcessors() / 2, 2), 8);
+    this.delayQueues = new DelayQueue[numDelayQueues];
+    for (int i = 0; i < numDelayQueues; i++) {
+      delayQueues[i] = new DelayQueue<>();
+    }
+    this.maxInFlightSpans =
+        ConfigProvider.getInstance()
+            .getInteger(
+                ProfilingConfig.PROFILING_TRACING_CONTEXT_MAX_SPANS,
+                ProfilingConfig.PROFILING_TRACING_CONTEXT_MAX_SPANS_DEFAULT);
 
     if (inactivityDelay > 0) {
       initializeInactiveTrackerCleanup(inactivityCheckPeriodMs);
@@ -167,15 +187,23 @@ public final class PerSpanTracingContextTrackerFactory
 
   @Override
   public TracingContextTracker instance(AgentSpan span) {
-    if (span != null && span.eligibleForDropping()) {
+    if ((span != null && span.eligibleForDropping()) || !trackingEnabled) {
       return TracingContextTracker.EMPTY;
     }
     PerSpanTracingContextTracker instance =
         new PerSpanTracingContextTracker(
             allocator, span, timeTicksProvider, sequencePruner, inactivityDelay);
+    DelayQueue<TracingContextTracker.DelayedTracker> delayQueue =
+        delayQueues[(int) (Thread.currentThread().getId() % delayQueues.length)];
     if (inactivityDelay > 0) {
       statsd.incrementCounter("tracing.context.spans.tracked");
       delayQueue.offer(instance.asDelayed());
+    }
+    if (inFlightSpans.incrementAndGet() > maxInFlightSpans) {
+      warnlog.warn(
+          "The amount of in-flight spans is too high (max. {} in-flight spans) for the per-span context tracking. Disabling the tracking.",
+          maxInFlightSpans);
+      trackingEnabled = false;
     }
     return instance;
   }

--- a/dd-java-agent/agent-profiling/profiling-context/src/test/java/com/datadog/profiling/context/PerSpanTracingContextTrackerFactoryTest.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/test/java/com/datadog/profiling/context/PerSpanTracingContextTrackerFactoryTest.java
@@ -31,7 +31,7 @@ class PerSpanTracingContextTrackerFactoryTest {
 
   @Test
   void testReleasedAfterInactivity() throws Exception {
-    long inactivityMs = 100;
+    long inactivityMs = 200;
     PerSpanTracingContextTrackerFactory instance =
         new PerSpanTracingContextTrackerFactory(
             TimeUnit.NANOSECONDS.convert(inactivityMs, TimeUnit.MILLISECONDS), 10L, 512);

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -109,6 +109,10 @@ public final class ProfilingConfig {
   public static final int PROFILING_TRACING_CONTEXT_SPAN_INACTIVITY_CHECK_DEFAULT =
       5_000; // 5 secs default
 
+  public static final String PROFILING_TRACING_CONTEXT_MAX_SPANS =
+      "profiling.tracing_context.inflight_spans.max";
+  public static final int PROFILING_TRACING_CONTEXT_MAX_SPANS_DEFAULT = 1_000_000;
+
   public static final String PROFILING_LEGACY_TRACING_INTEGRATION =
       "profiling.legacy.tracing.integration";
   public static final boolean PROFILING_LEGACY_TRACING_INTEGRATION_DEFAULT = true;


### PR DESCRIPTION
# What Does This Do
This is adding another config knob for the maximum number of in-flight spans which will be tracked by the per-span context tracking mechanism.
Once the limit is reached the per-span context tracking will be automatically disabled for the application as there is a good chance the application is rapidly generating high number of spans and tracking them would blow up the memory and cost a lot of CPU in terms of GC and maintaining the delay queues. This kind of application is simply not possible to use with the per-span context tracking and therefore turning it off as soon as possible is the best thing we can do.

# Motivation
There are applications out there generating 10s of 1000s of spans per second. This is putting a huge strain on the per-span context tracking because we need to keep extra data attached to each tracked span - both in terms of extra memory and extra CPU cycles. In the end the profiled/traced application can experience overhead of several 100s of percent which is definitely not something we want to see. In such cases it is better to turn off the tracking as soon as we detect a possible problem.

# Additional Notes
