### PR TITLE
Extract message and kind from native Java crash

### DIFF
--- a/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/CrashUploader.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/CrashUploader.java
@@ -20,8 +20,8 @@ import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -151,17 +151,17 @@ public class CrashUploader {
     }
   }
 
-  private final static Pattern errorKindPattern =
+  private static final Pattern errorKindPattern =
       Pattern.compile(
-          String.join("",
-                "^"
-              , "("
-              , "# A fatal error has been detected by the Java Runtime Environment:"
-              , "|"
-              , "# There is insufficient memory for the Java Runtime Environment to continue\\."
-              , ")"
-              , "$"
-              ),
+          String.join(
+              "",
+              "^",
+              "(",
+              "# A fatal error has been detected by the Java Runtime Environment:",
+              "|",
+              "# There is insufficient memory for the Java Runtime Environment to continue\\.",
+              ")",
+              "$"),
           Pattern.DOTALL);
 
   private String extractErrorKind(String fileContent) {
@@ -170,28 +170,28 @@ public class CrashUploader {
       System.err.println("No match found for error.kind");
       return null;
     }
-    
+
     if (matcher.group().startsWith("# There is insufficient memory")) {
       return "OutOfMemory";
     }
     return "NativeCrash";
   }
 
-  private final static Pattern errorMessagePattern =
+  private static final Pattern errorMessagePattern =
       Pattern.compile(
-          String.join("",
-                "^"
-              , "("
-              , "# A fatal error has been detected by the Java Runtime Environment:"
-              , "|"
-              , "# There is insufficient memory for the Java Runtime Environment to continue\\."
-              , ")"
-              , "\\n"
-              , "("
-              , ".*, pid=-?\\d+, tid=-?\\d+"
-              , ")"
-              , "$"
-              ),
+          String.join(
+              "",
+              "^",
+              "(",
+              "# A fatal error has been detected by the Java Runtime Environment:",
+              "|",
+              "# There is insufficient memory for the Java Runtime Environment to continue\\.",
+              ")",
+              "\\n",
+              "(",
+              ".*, pid=-?\\d+, tid=-?\\d+",
+              ")",
+              "$"),
           Pattern.DOTALL | Pattern.MULTILINE);
 
   private String extractErrorMessage(String fileContent) {
@@ -201,21 +201,31 @@ public class CrashUploader {
       return null;
     }
     return Arrays.stream(matcher.group().split(System.lineSeparator()))
-      .filter(s ->
-          !s.equals("# A fatal error has been detected by the Java Runtime Environment:") &&
-          !s.equals("# There is insufficient memory for the Java Runtime Environment to continue."))
-      .map(s -> s.replaceFirst("^#\\s*", ""))
-      .map(s -> s.trim())
-      .collect(Collectors.joining("\n"))
-      .trim();
+        .filter(
+            s ->
+                !s.equals("# A fatal error has been detected by the Java Runtime Environment:")
+                    && !s.equals(
+                        "# There is insufficient memory for the Java Runtime Environment to continue."))
+        .map(s -> s.replaceFirst("^#\\s*", ""))
+        .map(s -> s.trim())
+        .collect(Collectors.joining("\n"))
+        .trim();
   }
 
-  private final static Pattern errorStackTracePattern =
+  private static final Pattern errorStackTracePattern =
       Pattern.compile(
-          String.join("",
-                "^"
-              , "$"
-              ),
+          String.join(
+              "",
+              "^",
+              "(",
+              "# A fatal error has been detected by the Java Runtime Environment:",
+              "|",
+              "# There is insufficient memory for the Java Runtime Environment to continue\\.",
+              ")",
+              "\n",
+              ".*",
+              ", pid=-?\\d+, tid=-?\\d+",
+              "$"),
           Pattern.DOTALL | Pattern.MULTILINE);
 
   private String extractErrorStackTrace(String fileContent) {

--- a/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/CrashUploader.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/CrashUploader.java
@@ -14,6 +14,7 @@ import datadog.common.version.VersionInfo;
 import datadog.communication.http.OkHttpUtils;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -194,6 +195,7 @@ public class CrashUploader {
               "$"),
           Pattern.DOTALL | Pattern.MULTILINE);
 
+  @SuppressForbidden
   private String extractErrorMessage(String fileContent) {
     Matcher matcher = errorMessagePattern.matcher(fileContent);
     if (!matcher.find()) {

--- a/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/CrashUploader.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/CrashUploader.java
@@ -215,12 +215,7 @@ public class CrashUploader {
   }
 
   private static final Pattern errorStackTracePattern =
-      Pattern.compile(
-          String.join(
-              "",
-              "^",
-              "$"),
-          Pattern.DOTALL | Pattern.MULTILINE);
+      Pattern.compile(String.join("", "^", "$"), Pattern.DOTALL | Pattern.MULTILINE);
 
   private String extractErrorStackTrace(String fileContent) {
     // TODO: implement errorStackTracePattern

--- a/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/CrashUploader.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/CrashUploader.java
@@ -219,24 +219,11 @@ public class CrashUploader {
           String.join(
               "",
               "^",
-              "(",
-              "# A fatal error has been detected by the Java Runtime Environment:",
-              "|",
-              "# There is insufficient memory for the Java Runtime Environment to continue\\.",
-              ")",
-              "\n",
-              ".*",
-              ", pid=-?\\d+, tid=-?\\d+",
               "$"),
           Pattern.DOTALL | Pattern.MULTILINE);
 
   private String extractErrorStackTrace(String fileContent) {
-    // Matcher matcher = errorStackTracePattern.matcher(fileContent);
-    // if (!matcher.find()) {
-    //   System.err.println("No match found for error.stack");
-    //   return null;
-    // }
-    // return matcher.group();
+    // TODO: implement errorStackTracePattern
     return null;
   }
 

--- a/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/CrashUploader.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/CrashUploader.java
@@ -42,7 +42,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Crash Reporter implementation */
-public class CrashUploader {
+public final class CrashUploader {
 
   private static final Logger log = LoggerFactory.getLogger(CrashUploader.class);
 
@@ -165,7 +165,8 @@ public class CrashUploader {
               "$"),
           Pattern.DOTALL);
 
-  private String extractErrorKind(String fileContent) {
+  // @VisibleForTesting
+  static String extractErrorKind(String fileContent) {
     Matcher matcher = errorMessagePattern.matcher(fileContent);
     if (!matcher.find()) {
       System.err.println("No match found for error.kind");
@@ -195,8 +196,9 @@ public class CrashUploader {
               "$"),
           Pattern.DOTALL | Pattern.MULTILINE);
 
+  // @VisibleForTesting
   @SuppressForbidden
-  private String extractErrorMessage(String fileContent) {
+  static String extractErrorMessage(String fileContent) {
     Matcher matcher = errorMessagePattern.matcher(fileContent);
     if (!matcher.find()) {
       System.err.println("No match found for error.message");

--- a/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/CrashUploader.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/CrashUploader.java
@@ -141,6 +141,7 @@ public class CrashUploader {
           writer.beginObject();
           writer.name("kind").value(extractErrorKind(message));
           writer.name("message").value(extractErrorMessage(message));
+          writer.name("stack").value(extractErrorStackTrace(message));
           writer.endObject();
           writer.endObject();
         }
@@ -207,6 +208,24 @@ public class CrashUploader {
       .map(s -> s.trim())
       .collect(Collectors.joining("\n"))
       .trim();
+  }
+
+  private final static Pattern errorStackTracePattern =
+      Pattern.compile(
+          String.join("",
+                "^"
+              , "$"
+              ),
+          Pattern.DOTALL | Pattern.MULTILINE);
+
+  private String extractErrorStackTrace(String fileContent) {
+    // Matcher matcher = errorStackTracePattern.matcher(fileContent);
+    // if (!matcher.find()) {
+    //   System.err.println("No match found for error.stack");
+    //   return null;
+    // }
+    // return matcher.group();
+    return null;
   }
 
   void uploadToTelemetry(@Nonnull List<String> filesContent) throws IOException {


### PR DESCRIPTION
# What Does This Do

This allows to integrate crash tracking to error tracking product by extracting a message and a kind. We also want to extract a stacktrace.