### PR TITLE
Upload profile on JVM exit

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfilerRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfilerRecording.java
@@ -2,6 +2,7 @@ package com.datadog.profiling.async;
 
 import com.datadog.profiling.controller.OngoingRecording;
 import com.datadog.profiling.controller.RecordingData;
+import datadog.trace.api.profiling.ProfilingSnapshot;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -18,7 +19,7 @@ final class AsyncProfilerRecording implements OngoingRecording {
   private final Instant started = Instant.now();
 
   /**
-   * Do not use this constructor directly. Rather use {@linkplain AuxiliaryAsyncProfiler#start()}
+   * Do not use this constructor directly. Rather use {@linkplain AsyncProfiler#start()}
    *
    * @param profiler the associated profiler
    * @throws IOException
@@ -32,14 +33,22 @@ final class AsyncProfilerRecording implements OngoingRecording {
   @Override
   public RecordingData stop() {
     profiler.stopProfiler();
-    return new AsyncProfilerRecordingData(recordingFile, started, Instant.now());
+    return new AsyncProfilerRecordingData(
+        recordingFile, started, Instant.now(), ProfilingSnapshot.SnapshotReason.REGULAR);
+  }
+
+  // @VisibleForTesting
+  final RecordingData snapshot(@Nonnull Instant start) {
+    return snapshot(start, ProfilingSnapshot.SnapshotReason.REGULAR);
   }
 
   @Nonnull
   @Override
-  public RecordingData snapshot(@Nonnull Instant start) {
+  public RecordingData snapshot(
+      @Nonnull Instant start, @Nonnull ProfilingSnapshot.SnapshotReason reason) {
     profiler.stop(this);
-    RecordingData data = new AsyncProfilerRecordingData(recordingFile, start, Instant.now());
+    RecordingData data =
+        new AsyncProfilerRecordingData(recordingFile, start, Instant.now(), reason);
     try {
       recordingFile = profiler.newRecording();
     } catch (IOException | IllegalStateException e) {

--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfilerRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfilerRecording.java
@@ -44,8 +44,7 @@ final class AsyncProfilerRecording implements OngoingRecording {
 
   @Nonnull
   @Override
-  public RecordingData snapshot(
-      @Nonnull Instant start, @Nonnull ProfilingSnapshot.Kind kind) {
+  public RecordingData snapshot(@Nonnull Instant start, @Nonnull ProfilingSnapshot.Kind kind) {
     profiler.stop(this);
     RecordingData data = new AsyncProfilerRecordingData(recordingFile, start, Instant.now(), kind);
     try {

--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfilerRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfilerRecording.java
@@ -34,21 +34,20 @@ final class AsyncProfilerRecording implements OngoingRecording {
   public RecordingData stop() {
     profiler.stopProfiler();
     return new AsyncProfilerRecordingData(
-        recordingFile, started, Instant.now(), ProfilingSnapshot.SnapshotReason.REGULAR);
+        recordingFile, started, Instant.now(), ProfilingSnapshot.SnapshotKind.PERIODIC);
   }
 
   // @VisibleForTesting
   final RecordingData snapshot(@Nonnull Instant start) {
-    return snapshot(start, ProfilingSnapshot.SnapshotReason.REGULAR);
+    return snapshot(start, ProfilingSnapshot.SnapshotKind.PERIODIC);
   }
 
   @Nonnull
   @Override
   public RecordingData snapshot(
-      @Nonnull Instant start, @Nonnull ProfilingSnapshot.SnapshotReason reason) {
+      @Nonnull Instant start, @Nonnull ProfilingSnapshot.SnapshotKind kind) {
     profiler.stop(this);
-    RecordingData data =
-        new AsyncProfilerRecordingData(recordingFile, start, Instant.now(), reason);
+    RecordingData data = new AsyncProfilerRecordingData(recordingFile, start, Instant.now(), kind);
     try {
       recordingFile = profiler.newRecording();
     } catch (IOException | IllegalStateException e) {

--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfilerRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfilerRecording.java
@@ -34,18 +34,18 @@ final class AsyncProfilerRecording implements OngoingRecording {
   public RecordingData stop() {
     profiler.stopProfiler();
     return new AsyncProfilerRecordingData(
-        recordingFile, started, Instant.now(), ProfilingSnapshot.SnapshotKind.PERIODIC);
+        recordingFile, started, Instant.now(), ProfilingSnapshot.Kind.PERIODIC);
   }
 
   // @VisibleForTesting
   final RecordingData snapshot(@Nonnull Instant start) {
-    return snapshot(start, ProfilingSnapshot.SnapshotKind.PERIODIC);
+    return snapshot(start, ProfilingSnapshot.Kind.PERIODIC);
   }
 
   @Nonnull
   @Override
   public RecordingData snapshot(
-      @Nonnull Instant start, @Nonnull ProfilingSnapshot.SnapshotKind kind) {
+      @Nonnull Instant start, @Nonnull ProfilingSnapshot.Kind kind) {
     profiler.stop(this);
     RecordingData data = new AsyncProfilerRecordingData(recordingFile, start, Instant.now(), kind);
     try {

--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfilerRecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfilerRecordingData.java
@@ -12,7 +12,7 @@ final class AsyncProfilerRecordingData extends RecordingData {
   private final Path recordingFile;
 
   public AsyncProfilerRecordingData(
-      Path recordingFile, Instant start, Instant end, SnapshotKind kind) {
+      Path recordingFile, Instant start, Instant end, Kind kind) {
     super(start, end, kind);
     this.recordingFile = recordingFile;
   }

--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfilerRecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfilerRecordingData.java
@@ -12,8 +12,8 @@ final class AsyncProfilerRecordingData extends RecordingData {
   private final Path recordingFile;
 
   public AsyncProfilerRecordingData(
-      Path recordingFile, Instant start, Instant end, SnapshotReason reason) {
-    super(start, end, reason);
+      Path recordingFile, Instant start, Instant end, SnapshotKind kind) {
+    super(start, end, kind);
     this.recordingFile = recordingFile;
   }
 

--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfilerRecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfilerRecordingData.java
@@ -11,8 +11,7 @@ import javax.annotation.Nonnull;
 final class AsyncProfilerRecordingData extends RecordingData {
   private final Path recordingFile;
 
-  public AsyncProfilerRecordingData(
-      Path recordingFile, Instant start, Instant end, Kind kind) {
+  public AsyncProfilerRecordingData(Path recordingFile, Instant start, Instant end, Kind kind) {
     super(start, end, kind);
     this.recordingFile = recordingFile;
   }

--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfilerRecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfilerRecordingData.java
@@ -11,8 +11,9 @@ import javax.annotation.Nonnull;
 final class AsyncProfilerRecordingData extends RecordingData {
   private final Path recordingFile;
 
-  public AsyncProfilerRecordingData(Path recordingFile, Instant start, Instant end) {
-    super(start, end);
+  public AsyncProfilerRecordingData(
+      Path recordingFile, Instant start, Instant end, SnapshotReason reason) {
+    super(start, end, reason);
     this.recordingFile = recordingFile;
   }
 

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingData.java
@@ -16,8 +16,12 @@ public final class AuxiliaryRecordingData extends RecordingData {
   private final RecordingData[] secondaryData;
 
   public AuxiliaryRecordingData(
-      Instant start, Instant end, @Nonnull RecordingData main, RecordingData... secondary) {
-    super(start, end);
+      Instant start,
+      Instant end,
+      SnapshotReason reason,
+      @Nonnull RecordingData main,
+      RecordingData... secondary) {
+    super(start, end, reason);
     if (main == null) {
       throw new IllegalArgumentException("Main data must be specified and not null");
     }

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingData.java
@@ -18,10 +18,10 @@ public final class AuxiliaryRecordingData extends RecordingData {
   public AuxiliaryRecordingData(
       Instant start,
       Instant end,
-      SnapshotReason reason,
+      SnapshotKind kind,
       @Nonnull RecordingData main,
       RecordingData... secondary) {
-    super(start, end, reason);
+    super(start, end, kind);
     if (main == null) {
       throw new IllegalArgumentException("Main data must be specified and not null");
     }

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingData.java
@@ -18,7 +18,7 @@ public final class AuxiliaryRecordingData extends RecordingData {
   public AuxiliaryRecordingData(
       Instant start,
       Instant end,
-      SnapshotKind kind,
+      Kind kind,
       @Nonnull RecordingData main,
       RecordingData... secondary) {
     super(start, end, kind);

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingDataTest.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingDataTest.java
@@ -24,8 +24,7 @@ class AuxiliaryRecordingDataTest {
     private final byte[] testData;
     volatile boolean isReleased = false;
 
-    public TestRecordingData(
-        String name, Instant start, Instant end, Kind kind, byte[] testData) {
+    public TestRecordingData(String name, Instant start, Instant end, Kind kind, byte[] testData) {
       super(start, end, kind);
       this.name = name;
       this.testData = testData;

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingDataTest.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingDataTest.java
@@ -25,7 +25,7 @@ class AuxiliaryRecordingDataTest {
     volatile boolean isReleased = false;
 
     public TestRecordingData(
-        String name, Instant start, Instant end, SnapshotKind kind, byte[] testData) {
+        String name, Instant start, Instant end, Kind kind, byte[] testData) {
       super(start, end, kind);
       this.name = name;
       this.testData = testData;
@@ -50,16 +50,16 @@ class AuxiliaryRecordingDataTest {
   }
 
   @ParameterizedTest
-  @EnumSource(ProfilingSnapshot.SnapshotKind.class)
-  void testNullMaindata(ProfilingSnapshot.SnapshotKind kind) {
+  @EnumSource(ProfilingSnapshot.Kind.class)
+  void testNullMaindata(ProfilingSnapshot.Kind kind) {
     assertThrows(
         IllegalArgumentException.class,
         () -> new AuxiliaryRecordingData(Instant.now(), Instant.now(), kind, null));
   }
 
   @ParameterizedTest
-  @EnumSource(ProfilingSnapshot.SnapshotKind.class)
-  void testMainDataThrowing(ProfilingSnapshot.SnapshotKind kind) throws IOException {
+  @EnumSource(ProfilingSnapshot.Kind.class)
+  void testMainDataThrowing(ProfilingSnapshot.Kind kind) throws IOException {
     RecordingData mainData = Mockito.mock(RecordingData.class);
     RecordingData auxiliaryData = Mockito.mock(RecordingData.class);
 
@@ -78,8 +78,8 @@ class AuxiliaryRecordingDataTest {
   }
 
   @ParameterizedTest
-  @EnumSource(ProfilingSnapshot.SnapshotKind.class)
-  void testAuxiliaryDataThrowing(ProfilingSnapshot.SnapshotKind kind) throws IOException {
+  @EnumSource(ProfilingSnapshot.Kind.class)
+  void testAuxiliaryDataThrowing(ProfilingSnapshot.Kind kind) throws IOException {
     RecordingData mainData = Mockito.mock(RecordingData.class);
     RecordingData auxiliaryData = Mockito.mock(RecordingData.class);
 
@@ -108,8 +108,8 @@ class AuxiliaryRecordingDataTest {
   }
 
   @ParameterizedTest
-  @EnumSource(ProfilingSnapshot.SnapshotKind.class)
-  void testMainDataOnly(ProfilingSnapshot.SnapshotKind kind) throws IOException {
+  @EnumSource(ProfilingSnapshot.Kind.class)
+  void testMainDataOnly(ProfilingSnapshot.Kind kind) throws IOException {
     String mainName = "main";
     TestRecordingData mainData =
         new TestRecordingData(
@@ -131,8 +131,8 @@ class AuxiliaryRecordingDataTest {
   }
 
   @ParameterizedTest
-  @EnumSource(ProfilingSnapshot.SnapshotKind.class)
-  void testCombinedData(ProfilingSnapshot.SnapshotKind kind) throws IOException {
+  @EnumSource(ProfilingSnapshot.Kind.class)
+  void testCombinedData(ProfilingSnapshot.Kind kind) throws IOException {
     String mainName = "main";
     String auxName = "auxiliary";
     TestRecordingData mainData =

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingDataTest.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingDataTest.java
@@ -4,13 +4,15 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.profiling.controller.RecordingData;
 import com.datadog.profiling.controller.RecordingInputStream;
+import datadog.trace.api.profiling.ProfilingSnapshot;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import javax.annotation.Nonnull;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mockito;
 
 class AuxiliaryRecordingDataTest {
@@ -22,8 +24,9 @@ class AuxiliaryRecordingDataTest {
     private final byte[] testData;
     volatile boolean isReleased = false;
 
-    public TestRecordingData(String name, Instant start, Instant end, byte[] testData) {
-      super(start, end);
+    public TestRecordingData(
+        String name, Instant start, Instant end, SnapshotReason reason, byte[] testData) {
+      super(start, end, reason);
       this.name = name;
       this.testData = testData;
     }
@@ -46,17 +49,22 @@ class AuxiliaryRecordingDataTest {
     }
   }
 
-  @Test
-  void testNullMaindata() {
+  @ParameterizedTest
+  @EnumSource(ProfilingSnapshot.SnapshotReason.class)
+  void testNullMaindata(ProfilingSnapshot.SnapshotReason reason) {
     assertThrows(
         IllegalArgumentException.class,
-        () -> new AuxiliaryRecordingData(Instant.now(), Instant.now(), null));
+        () -> new AuxiliaryRecordingData(Instant.now(), Instant.now(), reason, null));
   }
 
-  @Test
-  void testMainDataThrowing() throws IOException {
+  @ParameterizedTest
+  @EnumSource(ProfilingSnapshot.SnapshotReason.class)
+  void testMainDataThrowing(ProfilingSnapshot.SnapshotReason reason) throws IOException {
     RecordingData mainData = Mockito.mock(RecordingData.class);
     RecordingData auxiliaryData = Mockito.mock(RecordingData.class);
+
+    Mockito.when(mainData.getReason()).thenReturn(reason);
+    Mockito.when(auxiliaryData.getReason()).thenReturn(reason);
 
     byte[] auxDataRaw = new byte[10];
     Mockito.when(mainData.getStream()).thenThrow(new IOException());
@@ -64,15 +72,19 @@ class AuxiliaryRecordingDataTest {
         .thenReturn(new RecordingInputStream(new ByteArrayInputStream(auxDataRaw)));
 
     AuxiliaryRecordingData combined =
-        new AuxiliaryRecordingData(Instant.now(), Instant.now(), mainData, auxiliaryData);
+        new AuxiliaryRecordingData(Instant.now(), Instant.now(), reason, mainData, auxiliaryData);
 
     assertEquals(0, readFromStream(combined.getStream()));
   }
 
-  @Test
-  void testAuxiliaryDataThrowing() throws IOException {
+  @ParameterizedTest
+  @EnumSource(ProfilingSnapshot.SnapshotReason.class)
+  void testAuxiliaryDataThrowing(ProfilingSnapshot.SnapshotReason reason) throws IOException {
     RecordingData mainData = Mockito.mock(RecordingData.class);
     RecordingData auxiliaryData = Mockito.mock(RecordingData.class);
+
+    Mockito.when(mainData.getReason()).thenReturn(reason);
+    Mockito.when(auxiliaryData.getReason()).thenReturn(reason);
 
     byte[] mainDataRaw = new byte[10];
     Mockito.when(mainData.getStream())
@@ -80,7 +92,7 @@ class AuxiliaryRecordingDataTest {
     Mockito.when(auxiliaryData.getStream()).thenThrow(new IOException());
 
     AuxiliaryRecordingData combined =
-        new AuxiliaryRecordingData(Instant.now(), Instant.now(), mainData, auxiliaryData);
+        new AuxiliaryRecordingData(Instant.now(), Instant.now(), reason, mainData, auxiliaryData);
 
     assertEquals(mainDataRaw.length, readFromStream(combined.getStream()));
   }
@@ -95,15 +107,16 @@ class AuxiliaryRecordingDataTest {
     return allBytes;
   }
 
-  @Test
-  void testMainDataOnly() throws IOException {
+  @ParameterizedTest
+  @EnumSource(ProfilingSnapshot.SnapshotReason.class)
+  void testMainDataOnly(ProfilingSnapshot.SnapshotReason reason) throws IOException {
     String mainName = "main";
     TestRecordingData mainData =
         new TestRecordingData(
-            mainName, Instant.now(), Instant.now().plus(5, ChronoUnit.MINUTES), MAIN_DATA);
+            mainName, Instant.now(), Instant.now().plus(5, ChronoUnit.MINUTES), reason, MAIN_DATA);
     AuxiliaryRecordingData data =
         new AuxiliaryRecordingData(
-            Instant.now(), Instant.now().plus(5, ChronoUnit.MINUTES), mainData);
+            Instant.now(), Instant.now().plus(5, ChronoUnit.MINUTES), reason, mainData);
 
     assertEquals(mainName, data.getName());
     assertFalse(mainData.isReleased);
@@ -117,20 +130,29 @@ class AuxiliaryRecordingDataTest {
     assertTrue(mainData.isReleased);
   }
 
-  @Test
-  void testCombinedData() throws IOException {
+  @ParameterizedTest
+  @EnumSource(ProfilingSnapshot.SnapshotReason.class)
+  void testCombinedData(ProfilingSnapshot.SnapshotReason reason) throws IOException {
     String mainName = "main";
     String auxName = "auxiliary";
     TestRecordingData mainData =
         new TestRecordingData(
-            mainName, Instant.now(), Instant.now().plus(5, ChronoUnit.MINUTES), MAIN_DATA);
+            mainName, Instant.now(), Instant.now().plus(5, ChronoUnit.MINUTES), reason, MAIN_DATA);
     TestRecordingData auxiliaryData =
         new TestRecordingData(
-            auxName, Instant.now(), Instant.now().plus(5, ChronoUnit.MINUTES), AUXILIARY_DATA);
+            auxName,
+            Instant.now(),
+            Instant.now().plus(5, ChronoUnit.MINUTES),
+            reason,
+            AUXILIARY_DATA);
 
     AuxiliaryRecordingData data =
         new AuxiliaryRecordingData(
-            Instant.now(), Instant.now().plus(5, ChronoUnit.MINUTES), mainData, auxiliaryData);
+            Instant.now(),
+            Instant.now().plus(5, ChronoUnit.MINUTES),
+            reason,
+            mainData,
+            auxiliaryData);
 
     assertEquals(mainName, data.getName());
     assertFalse(mainData.isReleased);

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingDataTest.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/java/com/datadog/profiling/auxiliary/AuxiliaryRecordingDataTest.java
@@ -25,8 +25,8 @@ class AuxiliaryRecordingDataTest {
     volatile boolean isReleased = false;
 
     public TestRecordingData(
-        String name, Instant start, Instant end, SnapshotReason reason, byte[] testData) {
-      super(start, end, reason);
+        String name, Instant start, Instant end, SnapshotKind kind, byte[] testData) {
+      super(start, end, kind);
       this.name = name;
       this.testData = testData;
     }
@@ -50,21 +50,21 @@ class AuxiliaryRecordingDataTest {
   }
 
   @ParameterizedTest
-  @EnumSource(ProfilingSnapshot.SnapshotReason.class)
-  void testNullMaindata(ProfilingSnapshot.SnapshotReason reason) {
+  @EnumSource(ProfilingSnapshot.SnapshotKind.class)
+  void testNullMaindata(ProfilingSnapshot.SnapshotKind kind) {
     assertThrows(
         IllegalArgumentException.class,
-        () -> new AuxiliaryRecordingData(Instant.now(), Instant.now(), reason, null));
+        () -> new AuxiliaryRecordingData(Instant.now(), Instant.now(), kind, null));
   }
 
   @ParameterizedTest
-  @EnumSource(ProfilingSnapshot.SnapshotReason.class)
-  void testMainDataThrowing(ProfilingSnapshot.SnapshotReason reason) throws IOException {
+  @EnumSource(ProfilingSnapshot.SnapshotKind.class)
+  void testMainDataThrowing(ProfilingSnapshot.SnapshotKind kind) throws IOException {
     RecordingData mainData = Mockito.mock(RecordingData.class);
     RecordingData auxiliaryData = Mockito.mock(RecordingData.class);
 
-    Mockito.when(mainData.getReason()).thenReturn(reason);
-    Mockito.when(auxiliaryData.getReason()).thenReturn(reason);
+    Mockito.when(mainData.getKind()).thenReturn(kind);
+    Mockito.when(auxiliaryData.getKind()).thenReturn(kind);
 
     byte[] auxDataRaw = new byte[10];
     Mockito.when(mainData.getStream()).thenThrow(new IOException());
@@ -72,19 +72,19 @@ class AuxiliaryRecordingDataTest {
         .thenReturn(new RecordingInputStream(new ByteArrayInputStream(auxDataRaw)));
 
     AuxiliaryRecordingData combined =
-        new AuxiliaryRecordingData(Instant.now(), Instant.now(), reason, mainData, auxiliaryData);
+        new AuxiliaryRecordingData(Instant.now(), Instant.now(), kind, mainData, auxiliaryData);
 
     assertEquals(0, readFromStream(combined.getStream()));
   }
 
   @ParameterizedTest
-  @EnumSource(ProfilingSnapshot.SnapshotReason.class)
-  void testAuxiliaryDataThrowing(ProfilingSnapshot.SnapshotReason reason) throws IOException {
+  @EnumSource(ProfilingSnapshot.SnapshotKind.class)
+  void testAuxiliaryDataThrowing(ProfilingSnapshot.SnapshotKind kind) throws IOException {
     RecordingData mainData = Mockito.mock(RecordingData.class);
     RecordingData auxiliaryData = Mockito.mock(RecordingData.class);
 
-    Mockito.when(mainData.getReason()).thenReturn(reason);
-    Mockito.when(auxiliaryData.getReason()).thenReturn(reason);
+    Mockito.when(mainData.getKind()).thenReturn(kind);
+    Mockito.when(auxiliaryData.getKind()).thenReturn(kind);
 
     byte[] mainDataRaw = new byte[10];
     Mockito.when(mainData.getStream())
@@ -92,7 +92,7 @@ class AuxiliaryRecordingDataTest {
     Mockito.when(auxiliaryData.getStream()).thenThrow(new IOException());
 
     AuxiliaryRecordingData combined =
-        new AuxiliaryRecordingData(Instant.now(), Instant.now(), reason, mainData, auxiliaryData);
+        new AuxiliaryRecordingData(Instant.now(), Instant.now(), kind, mainData, auxiliaryData);
 
     assertEquals(mainDataRaw.length, readFromStream(combined.getStream()));
   }
@@ -108,15 +108,15 @@ class AuxiliaryRecordingDataTest {
   }
 
   @ParameterizedTest
-  @EnumSource(ProfilingSnapshot.SnapshotReason.class)
-  void testMainDataOnly(ProfilingSnapshot.SnapshotReason reason) throws IOException {
+  @EnumSource(ProfilingSnapshot.SnapshotKind.class)
+  void testMainDataOnly(ProfilingSnapshot.SnapshotKind kind) throws IOException {
     String mainName = "main";
     TestRecordingData mainData =
         new TestRecordingData(
-            mainName, Instant.now(), Instant.now().plus(5, ChronoUnit.MINUTES), reason, MAIN_DATA);
+            mainName, Instant.now(), Instant.now().plus(5, ChronoUnit.MINUTES), kind, MAIN_DATA);
     AuxiliaryRecordingData data =
         new AuxiliaryRecordingData(
-            Instant.now(), Instant.now().plus(5, ChronoUnit.MINUTES), reason, mainData);
+            Instant.now(), Instant.now().plus(5, ChronoUnit.MINUTES), kind, mainData);
 
     assertEquals(mainName, data.getName());
     assertFalse(mainData.isReleased);
@@ -131,26 +131,26 @@ class AuxiliaryRecordingDataTest {
   }
 
   @ParameterizedTest
-  @EnumSource(ProfilingSnapshot.SnapshotReason.class)
-  void testCombinedData(ProfilingSnapshot.SnapshotReason reason) throws IOException {
+  @EnumSource(ProfilingSnapshot.SnapshotKind.class)
+  void testCombinedData(ProfilingSnapshot.SnapshotKind kind) throws IOException {
     String mainName = "main";
     String auxName = "auxiliary";
     TestRecordingData mainData =
         new TestRecordingData(
-            mainName, Instant.now(), Instant.now().plus(5, ChronoUnit.MINUTES), reason, MAIN_DATA);
+            mainName, Instant.now(), Instant.now().plus(5, ChronoUnit.MINUTES), kind, MAIN_DATA);
     TestRecordingData auxiliaryData =
         new TestRecordingData(
             auxName,
             Instant.now(),
             Instant.now().plus(5, ChronoUnit.MINUTES),
-            reason,
+            kind,
             AUXILIARY_DATA);
 
     AuxiliaryRecordingData data =
         new AuxiliaryRecordingData(
             Instant.now(),
             Instant.now().plus(5, ChronoUnit.MINUTES),
-            reason,
+            kind,
             mainData,
             auxiliaryData);
 

--- a/dd-java-agent/agent-profiling/profiling-controller-async/src/main/java/com/datadog/profiling/controller/async/AsyncOngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-async/src/main/java/com/datadog/profiling/controller/async/AsyncOngoingRecording.java
@@ -47,11 +47,11 @@ public class AsyncOngoingRecording implements OngoingRecording {
 
   // @VisibleForTesting
   final RecordingData snapshot(final Instant start) {
-    return snapshot(start, ProfilingSnapshot.SnapshotKind.PERIODIC);
+    return snapshot(start, ProfilingSnapshot.Kind.PERIODIC);
   }
 
   @Override
-  public RecordingData snapshot(final Instant start, ProfilingSnapshot.SnapshotKind kind) {
+  public RecordingData snapshot(final Instant start, ProfilingSnapshot.Kind kind) {
     return recording.snapshot(start, kind);
   }
 

--- a/dd-java-agent/agent-profiling/profiling-controller-async/src/main/java/com/datadog/profiling/controller/async/AsyncOngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-async/src/main/java/com/datadog/profiling/controller/async/AsyncOngoingRecording.java
@@ -47,12 +47,12 @@ public class AsyncOngoingRecording implements OngoingRecording {
 
   // @VisibleForTesting
   final RecordingData snapshot(final Instant start) {
-    return snapshot(start, ProfilingSnapshot.SnapshotReason.REGULAR);
+    return snapshot(start, ProfilingSnapshot.SnapshotKind.PERIODIC);
   }
 
   @Override
-  public RecordingData snapshot(final Instant start, ProfilingSnapshot.SnapshotReason reason) {
-    return recording.snapshot(start, reason);
+  public RecordingData snapshot(final Instant start, ProfilingSnapshot.SnapshotKind kind) {
+    return recording.snapshot(start, kind);
   }
 
   @Override

--- a/dd-java-agent/agent-profiling/profiling-controller-async/src/main/java/com/datadog/profiling/controller/async/AsyncOngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-async/src/main/java/com/datadog/profiling/controller/async/AsyncOngoingRecording.java
@@ -19,6 +19,7 @@ import com.datadog.profiling.async.AsyncProfiler;
 import com.datadog.profiling.controller.OngoingRecording;
 import com.datadog.profiling.controller.RecordingData;
 import com.datadog.profiling.controller.UnsupportedEnvironmentException;
+import datadog.trace.api.profiling.ProfilingSnapshot;
 import java.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,9 +45,14 @@ public class AsyncOngoingRecording implements OngoingRecording {
     return recording.stop();
   }
 
+  // @VisibleForTesting
+  final RecordingData snapshot(final Instant start) {
+    return snapshot(start, ProfilingSnapshot.SnapshotReason.REGULAR);
+  }
+
   @Override
-  public RecordingData snapshot(final Instant start) {
-    return recording.snapshot(start);
+  public RecordingData snapshot(final Instant start, ProfilingSnapshot.SnapshotReason reason) {
+    return recording.snapshot(start, reason);
   }
 
   @Override

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecording.java
@@ -10,6 +10,7 @@ import datadog.trace.api.profiling.ProfilingSnapshot;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import jdk.jfr.FlightRecorder;
 import jdk.jfr.Recording;
 import jdk.jfr.RecordingState;
@@ -110,15 +111,26 @@ public class OpenJdkOngoingRecording implements OngoingRecording {
     CONFIG_MEMENTO.publish();
 
     recording.stop();
-    OpenJdkRecordingData mainData = new OpenJdkRecordingData(recording);
+    OpenJdkRecordingData mainData =
+        new OpenJdkRecordingData(recording, ProfilingSnapshot.SnapshotReason.REGULAR);
     return auxiliaryRecording != null
         ? new AuxiliaryRecordingData(
-            mainData.getStart(), mainData.getEnd(), mainData, auxiliaryRecording.stop())
+            mainData.getStart(),
+            mainData.getEnd(),
+            ProfilingSnapshot.SnapshotReason.REGULAR,
+            mainData,
+            auxiliaryRecording.stop())
         : mainData;
   }
 
+  // @VisibleForTesting
+  final RecordingData snapshot(@Nonnull final Instant start) {
+    return snapshot(start, ProfilingSnapshot.SnapshotReason.REGULAR);
+  }
+
   @Override
-  public RecordingData snapshot(final Instant start) {
+  public RecordingData snapshot(
+      @Nonnull final Instant start, @Nonnull ProfilingSnapshot.SnapshotReason reason) {
     if (recording.getState() != RecordingState.RUNNING) {
       throw new IllegalStateException("Cannot snapshot recording that is not running");
     }
@@ -131,11 +143,15 @@ public class OpenJdkOngoingRecording implements OngoingRecording {
     // very close to now, so use that end time to minimize the risk of gaps or
     // overlaps in the data.
     OpenJdkRecordingData openJdkData =
-        new OpenJdkRecordingData(snapshot, start, snapshot.getStopTime());
+        new OpenJdkRecordingData(snapshot, start, snapshot.getStopTime(), reason);
     RecordingData ret =
         auxiliaryRecording != null
             ? new AuxiliaryRecordingData(
-                start, snapshot.getStopTime(), openJdkData, auxiliaryRecording.snapshot(start))
+                start,
+                snapshot.getStopTime(),
+                reason,
+                openJdkData,
+                auxiliaryRecording.snapshot(start, reason))
             : openJdkData;
 
     ProfilingListenersRegistry.getHost(ProfilingSnapshot.class).fireOnData(ret);

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecording.java
@@ -112,12 +112,12 @@ public class OpenJdkOngoingRecording implements OngoingRecording {
 
     recording.stop();
     OpenJdkRecordingData mainData =
-        new OpenJdkRecordingData(recording, ProfilingSnapshot.SnapshotKind.PERIODIC);
+        new OpenJdkRecordingData(recording, ProfilingSnapshot.Kind.PERIODIC);
     return auxiliaryRecording != null
         ? new AuxiliaryRecordingData(
             mainData.getStart(),
             mainData.getEnd(),
-            ProfilingSnapshot.SnapshotKind.PERIODIC,
+            ProfilingSnapshot.Kind.PERIODIC,
             mainData,
             auxiliaryRecording.stop())
         : mainData;
@@ -125,12 +125,12 @@ public class OpenJdkOngoingRecording implements OngoingRecording {
 
   // @VisibleForTesting
   final RecordingData snapshot(@Nonnull final Instant start) {
-    return snapshot(start, ProfilingSnapshot.SnapshotKind.PERIODIC);
+    return snapshot(start, ProfilingSnapshot.Kind.PERIODIC);
   }
 
   @Override
   public RecordingData snapshot(
-      @Nonnull final Instant start, @Nonnull ProfilingSnapshot.SnapshotKind kind) {
+      @Nonnull final Instant start, @Nonnull ProfilingSnapshot.Kind kind) {
     if (recording.getState() != RecordingState.RUNNING) {
       throw new IllegalStateException("Cannot snapshot recording that is not running");
     }

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecording.java
@@ -112,12 +112,12 @@ public class OpenJdkOngoingRecording implements OngoingRecording {
 
     recording.stop();
     OpenJdkRecordingData mainData =
-        new OpenJdkRecordingData(recording, ProfilingSnapshot.SnapshotReason.REGULAR);
+        new OpenJdkRecordingData(recording, ProfilingSnapshot.SnapshotKind.PERIODIC);
     return auxiliaryRecording != null
         ? new AuxiliaryRecordingData(
             mainData.getStart(),
             mainData.getEnd(),
-            ProfilingSnapshot.SnapshotReason.REGULAR,
+            ProfilingSnapshot.SnapshotKind.PERIODIC,
             mainData,
             auxiliaryRecording.stop())
         : mainData;
@@ -125,12 +125,12 @@ public class OpenJdkOngoingRecording implements OngoingRecording {
 
   // @VisibleForTesting
   final RecordingData snapshot(@Nonnull final Instant start) {
-    return snapshot(start, ProfilingSnapshot.SnapshotReason.REGULAR);
+    return snapshot(start, ProfilingSnapshot.SnapshotKind.PERIODIC);
   }
 
   @Override
   public RecordingData snapshot(
-      @Nonnull final Instant start, @Nonnull ProfilingSnapshot.SnapshotReason reason) {
+      @Nonnull final Instant start, @Nonnull ProfilingSnapshot.SnapshotKind kind) {
     if (recording.getState() != RecordingState.RUNNING) {
       throw new IllegalStateException("Cannot snapshot recording that is not running");
     }
@@ -143,15 +143,15 @@ public class OpenJdkOngoingRecording implements OngoingRecording {
     // very close to now, so use that end time to minimize the risk of gaps or
     // overlaps in the data.
     OpenJdkRecordingData openJdkData =
-        new OpenJdkRecordingData(snapshot, start, snapshot.getStopTime(), reason);
+        new OpenJdkRecordingData(snapshot, start, snapshot.getStopTime(), kind);
     RecordingData ret =
         auxiliaryRecording != null
             ? new AuxiliaryRecordingData(
                 start,
                 snapshot.getStopTime(),
-                reason,
+                kind,
                 openJdkData,
-                auxiliaryRecording.snapshot(start, reason))
+                auxiliaryRecording.snapshot(start, kind))
             : openJdkData;
 
     ProfilingListenersRegistry.getHost(ProfilingSnapshot.class).fireOnData(ret);

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkRecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkRecordingData.java
@@ -27,13 +27,13 @@ public class OpenJdkRecordingData extends RecordingData {
 
   private final Recording recording;
 
-  OpenJdkRecordingData(final Recording recording, SnapshotReason reason) {
-    this(recording, recording.getStartTime(), recording.getStopTime(), reason);
+  OpenJdkRecordingData(final Recording recording, SnapshotKind kind) {
+    this(recording, recording.getStartTime(), recording.getStopTime(), kind);
   }
 
   OpenJdkRecordingData(
-      final Recording recording, final Instant start, final Instant end, SnapshotReason reason) {
-    super(start, end, reason);
+      final Recording recording, final Instant start, final Instant end, SnapshotKind kind) {
+    super(start, end, kind);
     this.recording = recording;
   }
 

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkRecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkRecordingData.java
@@ -27,12 +27,12 @@ public class OpenJdkRecordingData extends RecordingData {
 
   private final Recording recording;
 
-  OpenJdkRecordingData(final Recording recording, SnapshotKind kind) {
+  OpenJdkRecordingData(final Recording recording, Kind kind) {
     this(recording, recording.getStartTime(), recording.getStopTime(), kind);
   }
 
   OpenJdkRecordingData(
-      final Recording recording, final Instant start, final Instant end, SnapshotKind kind) {
+      final Recording recording, final Instant start, final Instant end, Kind kind) {
     super(start, end, kind);
     this.recording = recording;
   }

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkRecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkRecordingData.java
@@ -54,11 +54,6 @@ public class OpenJdkRecordingData extends RecordingData {
     return recording.getName();
   }
 
-  @Override
-  public String toString() {
-    return "OpenJdkRecording: " + getName();
-  }
-
   // Visible for testing
   Recording getRecording() {
     return recording;

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkRecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkRecordingData.java
@@ -27,12 +27,13 @@ public class OpenJdkRecordingData extends RecordingData {
 
   private final Recording recording;
 
-  OpenJdkRecordingData(final Recording recording) {
-    this(recording, recording.getStartTime(), recording.getStopTime());
+  OpenJdkRecordingData(final Recording recording, SnapshotReason reason) {
+    this(recording, recording.getStartTime(), recording.getStopTime(), reason);
   }
 
-  OpenJdkRecordingData(final Recording recording, final Instant start, final Instant end) {
-    super(start, end);
+  OpenJdkRecordingData(
+      final Recording recording, final Instant start, final Instant end, SnapshotReason reason) {
+    super(start, end, reason);
     this.recording = recording;
   }
 

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkRecordingDataTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkRecordingDataTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import datadog.trace.api.profiling.ProfilingSnapshot;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
@@ -47,8 +48,10 @@ public class OpenJdkRecordingDataTest {
     when(recording.getStopTime()).thenReturn(end);
     when(recording.getName()).thenReturn(TEST_NAME);
 
-    recordingData = new OpenJdkRecordingData(recording);
-    customRecordingData = new OpenJdkRecordingData(recording, customStart, customEnd);
+    recordingData = new OpenJdkRecordingData(recording, ProfilingSnapshot.SnapshotReason.REGULAR);
+    customRecordingData =
+        new OpenJdkRecordingData(
+            recording, customStart, customEnd, ProfilingSnapshot.SnapshotReason.REGULAR);
   }
 
   @Test

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkRecordingDataTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkRecordingDataTest.java
@@ -48,10 +48,10 @@ public class OpenJdkRecordingDataTest {
     when(recording.getStopTime()).thenReturn(end);
     when(recording.getName()).thenReturn(TEST_NAME);
 
-    recordingData = new OpenJdkRecordingData(recording, ProfilingSnapshot.SnapshotReason.REGULAR);
+    recordingData = new OpenJdkRecordingData(recording, ProfilingSnapshot.SnapshotKind.PERIODIC);
     customRecordingData =
         new OpenJdkRecordingData(
-            recording, customStart, customEnd, ProfilingSnapshot.SnapshotReason.REGULAR);
+            recording, customStart, customEnd, ProfilingSnapshot.SnapshotKind.PERIODIC);
   }
 
   @Test

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkRecordingDataTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkRecordingDataTest.java
@@ -48,10 +48,10 @@ public class OpenJdkRecordingDataTest {
     when(recording.getStopTime()).thenReturn(end);
     when(recording.getName()).thenReturn(TEST_NAME);
 
-    recordingData = new OpenJdkRecordingData(recording, ProfilingSnapshot.SnapshotKind.PERIODIC);
+    recordingData = new OpenJdkRecordingData(recording, ProfilingSnapshot.Kind.PERIODIC);
     customRecordingData =
         new OpenJdkRecordingData(
-            recording, customStart, customEnd, ProfilingSnapshot.SnapshotKind.PERIODIC);
+            recording, customStart, customEnd, ProfilingSnapshot.Kind.PERIODIC);
   }
 
   @Test

--- a/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkOngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkOngoingRecording.java
@@ -43,7 +43,7 @@ public class OracleJdkOngoingRecording implements OngoingRecording {
               recordingId,
               start,
               getEndTime(helper, recordingId, Instant.now()),
-              ProfilingSnapshot.SnapshotReason.REGULAR,
+              ProfilingSnapshot.SnapshotKind.PERIODIC,
               helper);
       log.debug("Recording {} has been stopped and its data collected", name);
       return data;
@@ -54,13 +54,13 @@ public class OracleJdkOngoingRecording implements OngoingRecording {
 
   // @VisibleForTesting
   final OracleJdkRecordingData snapshot(@Nonnull final Instant start) {
-    return snapshot(start, ProfilingSnapshot.SnapshotReason.REGULAR);
+    return snapshot(start, ProfilingSnapshot.SnapshotKind.PERIODIC);
   }
 
   @Override
   @Nonnull
   public OracleJdkRecordingData snapshot(
-      @Nonnull final Instant start, @Nonnull ProfilingSnapshot.SnapshotReason reason) {
+      @Nonnull final Instant start, @Nonnull ProfilingSnapshot.SnapshotKind kind) {
     log.debug("Taking recording snapshot for time range {} - {}", start, Instant.now());
     ObjectName targetName = recordingId;
     try {
@@ -70,7 +70,7 @@ public class OracleJdkOngoingRecording implements OngoingRecording {
 
       targetName = helper.cloneRecording(targetName);
       return new OracleJdkRecordingData(
-          name, targetName, start, getEndTime(helper, targetName, Instant.now()), reason, helper);
+          name, targetName, start, getEndTime(helper, targetName, Instant.now()), kind, helper);
     } catch (IOException e) {
       throw new RuntimeException("Unable to take snapshot for recording " + name, e);
     }

--- a/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkOngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkOngoingRecording.java
@@ -43,7 +43,7 @@ public class OracleJdkOngoingRecording implements OngoingRecording {
               recordingId,
               start,
               getEndTime(helper, recordingId, Instant.now()),
-              ProfilingSnapshot.SnapshotKind.PERIODIC,
+              ProfilingSnapshot.Kind.PERIODIC,
               helper);
       log.debug("Recording {} has been stopped and its data collected", name);
       return data;
@@ -54,13 +54,13 @@ public class OracleJdkOngoingRecording implements OngoingRecording {
 
   // @VisibleForTesting
   final OracleJdkRecordingData snapshot(@Nonnull final Instant start) {
-    return snapshot(start, ProfilingSnapshot.SnapshotKind.PERIODIC);
+    return snapshot(start, ProfilingSnapshot.Kind.PERIODIC);
   }
 
   @Override
   @Nonnull
   public OracleJdkRecordingData snapshot(
-      @Nonnull final Instant start, @Nonnull ProfilingSnapshot.SnapshotKind kind) {
+      @Nonnull final Instant start, @Nonnull ProfilingSnapshot.Kind kind) {
     log.debug("Taking recording snapshot for time range {} - {}", start, Instant.now());
     ObjectName targetName = recordingId;
     try {

--- a/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkRecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkRecordingData.java
@@ -36,8 +36,9 @@ public class OracleJdkRecordingData extends RecordingData {
       @Nonnull ObjectName recordingId,
       @Nonnull Instant start,
       @Nonnull Instant end,
+      @Nonnull SnapshotReason reason,
       @Nonnull JfrMBeanHelper helper) {
-    super(start, end);
+    super(start, end, reason);
     this.name = name;
     this.recordingId = recordingId;
     this.helper = helper;

--- a/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkRecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkRecordingData.java
@@ -36,7 +36,7 @@ public class OracleJdkRecordingData extends RecordingData {
       @Nonnull ObjectName recordingId,
       @Nonnull Instant start,
       @Nonnull Instant end,
-      @Nonnull SnapshotKind kind,
+      @Nonnull Kind kind,
       @Nonnull JfrMBeanHelper helper) {
     super(start, end, kind);
     this.name = name;

--- a/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkRecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkRecordingData.java
@@ -61,11 +61,6 @@ public class OracleJdkRecordingData extends RecordingData {
     return name;
   }
 
-  @Override
-  public String toString() {
-    return "OracleJdkRecording: " + getName();
-  }
-
   private class JfrRecordingStream extends InputStream {
     private byte[] buf = new byte[0];
     private int count = 0;

--- a/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkRecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkRecordingData.java
@@ -36,9 +36,9 @@ public class OracleJdkRecordingData extends RecordingData {
       @Nonnull ObjectName recordingId,
       @Nonnull Instant start,
       @Nonnull Instant end,
-      @Nonnull SnapshotReason reason,
+      @Nonnull SnapshotKind kind,
       @Nonnull JfrMBeanHelper helper) {
-    super(start, end, reason);
+    super(start, end, kind);
     this.name = name;
     this.recordingId = recordingId;
     this.helper = helper;

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/OngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/OngoingRecording.java
@@ -1,5 +1,6 @@
 package com.datadog.profiling.controller;
 
+import datadog.trace.api.profiling.ProfilingSnapshot;
 import java.io.Closeable;
 import java.time.Instant;
 import javax.annotation.Nonnull;
@@ -20,10 +21,11 @@ public interface OngoingRecording extends Closeable {
    * called.
    *
    * @param start start time of the snapshot
+   * @param reason the snapshot reason
    * @return {@link RecordingData} with snapshot information
    */
   @Nonnull
-  RecordingData snapshot(@Nonnull final Instant start);
+  RecordingData snapshot(@Nonnull final Instant start, ProfilingSnapshot.SnapshotReason reason);
 
   /** Close recording without capturing any data */
   @Override

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/OngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/OngoingRecording.java
@@ -25,7 +25,7 @@ public interface OngoingRecording extends Closeable {
    * @return {@link RecordingData} with snapshot information
    */
   @Nonnull
-  RecordingData snapshot(@Nonnull final Instant start, ProfilingSnapshot.SnapshotKind kind);
+  RecordingData snapshot(@Nonnull final Instant start, ProfilingSnapshot.Kind kind);
 
   /** Close recording without capturing any data */
   @Override

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/OngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/OngoingRecording.java
@@ -21,11 +21,11 @@ public interface OngoingRecording extends Closeable {
    * called.
    *
    * @param start start time of the snapshot
-   * @param reason the snapshot reason
+   * @param kind the snapshot reason
    * @return {@link RecordingData} with snapshot information
    */
   @Nonnull
-  RecordingData snapshot(@Nonnull final Instant start, ProfilingSnapshot.SnapshotReason reason);
+  RecordingData snapshot(@Nonnull final Instant start, ProfilingSnapshot.SnapshotKind kind);
 
   /** Close recording without capturing any data */
   @Override

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
@@ -17,6 +17,7 @@ package com.datadog.profiling.controller;
 
 import static datadog.trace.util.AgentThreadFactory.AgentThread.PROFILER_RECORDING_SCHEDULER;
 
+import datadog.trace.api.profiling.ProfilingSnapshot;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import datadog.trace.util.AgentTaskScheduler;
 import java.time.Duration;
@@ -232,18 +233,23 @@ public final class ProfilingSystem {
       snapshot(false);
     }
 
-    public void snapshot(boolean sync) {
+    public void snapshot(boolean onShutdown) {
       final RecordingType recordingType = RecordingType.CONTINUOUS;
       try {
         log.debug("Creating profiler snapshot");
-        final RecordingData recordingData = recording.snapshot(lastSnapshot);
+        final RecordingData recordingData =
+            recording.snapshot(
+                lastSnapshot,
+                onShutdown
+                    ? ProfilingSnapshot.SnapshotReason.ON_SHUTDOWN
+                    : ProfilingSnapshot.SnapshotReason.REGULAR);
         if (recordingData != null) {
           // To make sure that we don't get data twice, we say that the next start should be
           // the last recording end time plus one nano second. The reason for this is that when
           // JFR is filtering the stream it will only discard earlier chunks that have an end
           // time that is before (not before or equal to) the requested start time of the filter.
           lastSnapshot = recordingData.getEnd().plus(ONE_NANO);
-          dataListener.onNewData(recordingType, recordingData, sync);
+          dataListener.onNewData(recordingType, recordingData, onShutdown);
         } else {
           lastSnapshot = Instant.now();
         }

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
@@ -240,9 +240,8 @@ public final class ProfilingSystem {
         final RecordingData recordingData =
             recording.snapshot(
                 lastSnapshot,
-                onShutdown
-                    ? ProfilingSnapshot.Kind.ON_SHUTDOWN
-                    : ProfilingSnapshot.Kind.PERIODIC);
+                onShutdown ? ProfilingSnapshot.Kind.ON_SHUTDOWN : ProfilingSnapshot.Kind.PERIODIC);
+        log.debug("Snapshot created: {}", recordingData);
         if (recordingData != null) {
           // To make sure that we don't get data twice, we say that the next start should be
           // the last recording end time plus one nano second. The reason for this is that when

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
@@ -241,8 +241,8 @@ public final class ProfilingSystem {
             recording.snapshot(
                 lastSnapshot,
                 onShutdown
-                    ? ProfilingSnapshot.SnapshotReason.ON_SHUTDOWN
-                    : ProfilingSnapshot.SnapshotReason.REGULAR);
+                    ? ProfilingSnapshot.SnapshotKind.ON_SHUTDOWN
+                    : ProfilingSnapshot.SnapshotKind.PERIODIC);
         if (recordingData != null) {
           // To make sure that we don't get data twice, we say that the next start should be
           // the last recording end time plus one nano second. The reason for this is that when

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
@@ -241,8 +241,8 @@ public final class ProfilingSystem {
             recording.snapshot(
                 lastSnapshot,
                 onShutdown
-                    ? ProfilingSnapshot.SnapshotKind.ON_SHUTDOWN
-                    : ProfilingSnapshot.SnapshotKind.PERIODIC);
+                    ? ProfilingSnapshot.Kind.ON_SHUTDOWN
+                    : ProfilingSnapshot.Kind.PERIODIC);
         if (recordingData != null) {
           // To make sure that we don't get data twice, we say that the next start should be
           // the last recording end time plus one nano second. The reason for this is that when

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/RecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/RecordingData.java
@@ -20,14 +20,16 @@ import java.io.IOException;
 import java.time.Instant;
 import javax.annotation.Nonnull;
 
-/** Platform agnostic API for operations required when retrieving data using the ProfilingSystem. */
+/** Platform-agnostic API for operations required when retrieving data using the ProfilingSystem. */
 public abstract class RecordingData implements ProfilingSnapshot {
   protected final Instant start;
   protected final Instant end;
+  protected final SnapshotReason reason;
 
-  public RecordingData(final Instant start, final Instant end) {
+  public RecordingData(final Instant start, final Instant end, SnapshotReason reason) {
     this.start = start;
     this.end = end;
+    this.reason = reason;
   }
 
   /**
@@ -81,5 +83,10 @@ public abstract class RecordingData implements ProfilingSnapshot {
   @Nonnull
   public final Instant getEnd() {
     return end;
+  }
+
+  @Nonnull
+  public final SnapshotReason getReason() {
+    return reason;
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/RecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/RecordingData.java
@@ -24,9 +24,9 @@ import javax.annotation.Nonnull;
 public abstract class RecordingData implements ProfilingSnapshot {
   protected final Instant start;
   protected final Instant end;
-  protected final SnapshotKind kind;
+  protected final Kind kind;
 
-  public RecordingData(final Instant start, final Instant end, SnapshotKind kind) {
+  public RecordingData(final Instant start, final Instant end, Kind kind) {
     this.start = start;
     this.end = end;
     this.kind = kind;
@@ -86,7 +86,7 @@ public abstract class RecordingData implements ProfilingSnapshot {
   }
 
   @Nonnull
-  public final SnapshotKind getKind() {
+  public final Kind getKind() {
     return kind;
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/RecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/RecordingData.java
@@ -89,4 +89,9 @@ public abstract class RecordingData implements ProfilingSnapshot {
   public final Kind getKind() {
     return kind;
   }
+
+  @Override
+  public final String toString() {
+    return "name=" + getName() + ", kind=" + getKind();
+  }
 }

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/RecordingData.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/RecordingData.java
@@ -24,12 +24,12 @@ import javax.annotation.Nonnull;
 public abstract class RecordingData implements ProfilingSnapshot {
   protected final Instant start;
   protected final Instant end;
-  protected final SnapshotReason reason;
+  protected final SnapshotKind kind;
 
-  public RecordingData(final Instant start, final Instant end, SnapshotReason reason) {
+  public RecordingData(final Instant start, final Instant end, SnapshotKind kind) {
     this.start = start;
     this.end = end;
-    this.reason = reason;
+    this.kind = kind;
   }
 
   /**
@@ -86,7 +86,7 @@ public abstract class RecordingData implements ProfilingSnapshot {
   }
 
   @Nonnull
-  public final SnapshotReason getReason() {
-    return reason;
+  public final SnapshotKind getKind() {
+    return kind;
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ProfilingSystemTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/test/java/com/datadog/profiling/controller/ProfilingSystemTest.java
@@ -328,7 +328,7 @@ public class ProfilingSystemTest {
   @Test
   public void testDoesntSendPeriodicRecordingIfPeriodicRecordingIsDisabled()
       throws InterruptedException, ConfigurationException {
-    when(recording.snapshot(any())).thenReturn(recordingData);
+    when(recording.snapshot(any(), any())).thenReturn(recordingData);
     final ProfilingSystem system =
         new ProfilingSystem(
             configProvider,
@@ -397,7 +397,7 @@ public class ProfilingSystemTest {
   public void testRecordingSnapshotError() throws ConfigurationException {
     final Duration uploadPeriod = Duration.ofMillis(300);
     final List<RecordingData> generatedRecordingData = new ArrayList<>();
-    when(recording.snapshot(any()))
+    when(recording.snapshot(any(), any()))
         .thenThrow(new RuntimeException("Test"))
         .thenAnswer(generateMockRecordingData(generatedRecordingData));
 
@@ -426,7 +426,7 @@ public class ProfilingSystemTest {
   public void testRecordingSnapshotNoData() throws ConfigurationException {
     final Duration uploadPeriod = Duration.ofMillis(300);
     final List<RecordingData> generatedRecordingData = new ArrayList<>();
-    when(recording.snapshot(any()))
+    when(recording.snapshot(any(), any()))
         .thenReturn(null)
         .thenAnswer(generateMockRecordingData(generatedRecordingData));
 

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
@@ -29,13 +29,16 @@ import datadog.trace.relocate.api.IOLogger;
 import datadog.trace.util.AgentThreadFactory;
 import java.io.IOException;
 import java.io.InterruptedIOException;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import okhttp3.Call;
@@ -107,6 +110,8 @@ public final class ProfileUploader {
   private final CompressionType compressionType;
   private final String tags;
 
+  private final Duration uploadTimeout;
+
   public ProfileUploader(final Config config, final ConfigProvider configProvider) {
     this(config, configProvider, new IOLogger(log), TERMINATION_TIMEOUT_SEC);
   }
@@ -147,6 +152,7 @@ public final class ProfileUploader {
     }
     // Comma separated tags string for V2.4 format
     tags = String.join(",", tagsToList(tagsMap));
+    this.uploadTimeout = Duration.ofSeconds(config.getProfilingUploadTimeout());
 
     // This is the same thing OkHttp Dispatcher is doing except thread naming and daemonization
     okHttpExecutorService =
@@ -169,7 +175,7 @@ public final class ProfileUploader {
             config.getProfilingProxyPort(),
             config.getProfilingProxyUsername(),
             config.getProfilingProxyPassword(),
-            TimeUnit.SECONDS.toMillis(config.getProfilingUploadTimeout()));
+            uploadTimeout.toMillis());
 
     compressionType = CompressionType.of(config.getProfilingUploadCompression());
   }
@@ -232,31 +238,51 @@ public final class ProfileUploader {
     }
 
     Call call = makeRequest(type, data);
+    CountDownLatch latch = new CountDownLatch(sync ? 1 : 0);
+    AtomicBoolean handled = new AtomicBoolean(false);
+
+    call.enqueue(
+        new Callback() {
+          @Override
+          public void onResponse(final Call call, final Response response) throws IOException {
+            if (handled.compareAndSet(false, true)) {
+              handleResponse(call, response, data, onCompletion);
+              latch.countDown();
+            }
+          }
+
+          @Override
+          public void onFailure(final Call call, final IOException e) {
+            if (handled.compareAndSet(false, true)) {
+              handleFailure(call, e, data, onCompletion);
+              latch.countDown();
+            }
+          }
+        });
     if (sync) {
       try {
-        handleResponse(call, call.execute(), data, onCompletion);
-      } catch (IOException e) {
-        handleFailure(call, e, data, onCompletion);
+        log.debug("Waiting at most {} seconds for upload to finish", uploadTimeout.plusSeconds(1));
+        if (!latch.await(uploadTimeout.plusSeconds(1).toMillis(), TimeUnit.MILLISECONDS)) {
+          // Usually this should not happen and timeouts should be handled by the client.
+          // But, in any case, we have this safety-break in place to prevent blocking finishing the
+          // sync request to a misbehaving server.
+          if (handled.compareAndSet(false, true)) {
+            handleFailure(call, null, data, onCompletion);
+          }
+        }
+      } catch (InterruptedException e) {
+        if (handled.compareAndSet(false, true)) {
+          handleFailure(call, e, data, onCompletion);
+        }
+        // reset the interrupted flag
+        Thread.currentThread().interrupt();
       }
-    } else {
-      call.enqueue(
-          new Callback() {
-            @Override
-            public void onResponse(final Call call, final Response response) throws IOException {
-              handleResponse(call, response, data, onCompletion);
-            }
-
-            @Override
-            public void onFailure(final Call call, final IOException e) {
-              handleFailure(call, e, data, onCompletion);
-            }
-          });
     }
   }
 
   private void handleFailure(
       final Call call,
-      final IOException e,
+      final Exception e,
       final RecordingData data,
       @Nonnull final Runnable onCompletion) {
     if (isEmptyReplyFromServer(e)) {
@@ -315,15 +341,16 @@ public final class ProfileUploader {
     return null;
   }
 
-  private static boolean isEmptyReplyFromServer(final IOException e) {
+  private static boolean isEmptyReplyFromServer(final Exception e) {
     // The server in datadog-agent triggers 'unexpected end of stream' caused by
     // EOFException.
     // The MockWebServer in tests triggers an InterruptedIOException with SocketPolicy
     // NO_RESPONSE. This is because in tests we can't cleanly terminate the connection
     // on the
     // server side without resetting.
-    return (e instanceof InterruptedIOException)
-        || (e.getCause() != null && e.getCause() instanceof java.io.EOFException);
+    return e != null
+        && ((e instanceof InterruptedIOException)
+            || (e.getCause() != null && e.getCause() instanceof java.io.EOFException));
   }
 
   public void shutdown() {

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
@@ -342,7 +342,14 @@ public final class ProfileUploader {
     final StringBuilder os = new StringBuilder();
     os.append("{");
     os.append("\"attachments\":[\"" + V4_ATTACHMENT_FILENAME + "\"],");
-    os.append("\"" + V4_PROFILE_TAGS_PARAM + "\":\"" + tags + "\",");
+    os.append(
+        "\""
+            + V4_PROFILE_TAGS_PARAM
+            + "\":\""
+            + tags
+            + ",snapshot:"
+            + data.getReason().name().toLowerCase()
+            + "\",");
     os.append("\"" + V4_PROFILE_START_PARAM + "\":\"" + data.getStart() + "\",");
     os.append("\"" + V4_PROFILE_END_PARAM + "\":\"" + data.getEnd() + "\",");
     os.append("\"family\":\"" + V4_FAMILY + "\",");

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
@@ -348,7 +348,7 @@ public final class ProfileUploader {
             + "\":\""
             + tags
             + ",snapshot:"
-            + data.getReason().name().toLowerCase()
+            + data.getKind().name().toLowerCase()
             + "\",");
     os.append("\"" + V4_PROFILE_START_PARAM + "\":\"" + data.getStart() + "\",");
     os.append("\"" + V4_PROFILE_END_PARAM + "\":\"" + data.getEnd() + "\",");

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
@@ -43,6 +43,7 @@ import com.google.common.io.ByteStreams;
 import datadog.common.process.PidHelper;
 import datadog.common.version.VersionInfo;
 import datadog.trace.api.Config;
+import datadog.trace.api.profiling.ProfilingSnapshot;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import datadog.trace.relocate.api.IOLogger;
 import delight.fileupload.FileUpload;
@@ -61,6 +62,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPInputStream;
@@ -80,6 +82,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.internal.verification.VerificationModeFactory;
@@ -110,17 +113,14 @@ public class ProfileUploaderTest {
 
   // We sort tags to have expected parameters to have expected result
   private static final Map<String, String> EXPECTED_TAGS =
-      ImmutableMap.of(
-          "baz",
-          "123",
-          "foo",
-          "bar",
-          PidHelper.PID_TAG,
-          PidHelper.PID.toString(),
-          VersionInfo.PROFILER_VERSION_TAG,
-          VersionInfo.VERSION,
-          VersionInfo.LIBRARY_VERSION_TAG,
-          VersionInfo.VERSION);
+      ImmutableMap.<String, String>builder()
+          .put("baz", "123")
+          .put("foo", "bar")
+          .put("snapshot", "regular")
+          .put(PidHelper.PID_TAG, PidHelper.PID.toString())
+          .put(VersionInfo.PROFILER_VERSION_TAG, VersionInfo.VERSION)
+          .put(VersionInfo.LIBRARY_VERSION_TAG, VersionInfo.VERSION)
+          .build();
 
   private static final int SEQUENCE_NUMBER = 123;
   private static final int PROFILE_START = 1000;
@@ -171,15 +171,16 @@ public class ProfileUploaderTest {
     }
   }
 
-  @Test
-  public void testHappyPath() throws Exception {
+  @ParameterizedTest
+  @EnumSource(ProfilingSnapshot.SnapshotReason.class)
+  public void testHappyPath(ProfilingSnapshot.SnapshotReason reason) throws Exception {
     // Given
     when(config.getProfilingUploadTimeout()).thenReturn(500000);
 
     // When
     uploader = new ProfileUploader(config, configProvider);
     server.enqueue(new MockResponse().setResponseCode(200));
-    uploadAndWait(RECORDING_TYPE, mockRecordingData(true));
+    uploadAndWait(RECORDING_TYPE, mockRecordingData(true, reason));
     final RecordedRequest recordedRequest = server.takeRequest(5, TimeUnit.SECONDS);
 
     // Then
@@ -214,14 +215,17 @@ public class ProfileUploaderTest {
         event.get(V4_PROFILE_START_PARAM).asText());
     assertEquals(
         Instant.ofEpochSecond(PROFILE_END).toString(), event.get(V4_PROFILE_END_PARAM).asText());
+    Map<String, String> expectedTags = new TreeMap<>(EXPECTED_TAGS);
+    expectedTags.put("snapshot", reason.name().toLowerCase());
     assertEquals(
-        EXPECTED_TAGS,
+        expectedTags,
         ProfilingTestUtils.parseTags(
             Arrays.asList(event.get("tags_profiler").asText().split(","))));
   }
 
-  @Test
-  public void testHappyPathSync() throws Exception {
+  @ParameterizedTest
+  @EnumSource(ProfilingSnapshot.SnapshotReason.class)
+  public void testHappyPathSync(ProfilingSnapshot.SnapshotReason reason) throws Exception {
     // Given
     when(config.getProfilingUploadTimeout()).thenReturn(500000);
 
@@ -229,7 +233,7 @@ public class ProfileUploaderTest {
     uploader = new ProfileUploader(config, configProvider);
     server.enqueue(new MockResponse().setResponseCode(200));
     // upload synchronously
-    uploader.upload(RECORDING_TYPE, mockRecordingData(true), true);
+    uploader.upload(RECORDING_TYPE, mockRecordingData(true, reason), true);
     final RecordedRequest recordedRequest = server.takeRequest(5, TimeUnit.SECONDS);
 
     // Then
@@ -264,8 +268,10 @@ public class ProfileUploaderTest {
         event.get(V4_PROFILE_START_PARAM).asText());
     assertEquals(
         Instant.ofEpochSecond(PROFILE_END).toString(), event.get(V4_PROFILE_END_PARAM).asText());
+    Map<String, String> expectedTags = new TreeMap<>(EXPECTED_TAGS);
+    expectedTags.put("snapshot", reason.name().toLowerCase());
     assertEquals(
-        EXPECTED_TAGS,
+        expectedTags,
         ProfilingTestUtils.parseTags(
             Arrays.asList(event.get("tags_profiler").asText().split(","))));
   }
@@ -775,10 +781,15 @@ public class ProfileUploaderTest {
   }
 
   private RecordingData mockRecordingData() throws IOException {
-    return mockRecordingData(false);
+    return mockRecordingData(false, ProfilingSnapshot.SnapshotReason.REGULAR);
   }
 
   private RecordingData mockRecordingData(final boolean zip) throws IOException {
+    return mockRecordingData(zip, ProfilingSnapshot.SnapshotReason.REGULAR);
+  }
+
+  private RecordingData mockRecordingData(
+      final boolean zip, ProfilingSnapshot.SnapshotReason reason) throws IOException {
     final RecordingData recordingData = mock(RecordingData.class, withSettings().lenient());
     when(recordingData.getStream())
         .then(
@@ -787,6 +798,7 @@ public class ProfileUploaderTest {
     when(recordingData.getName()).thenReturn(RECORDING_NAME_PREFIX + SEQUENCE_NUMBER);
     when(recordingData.getStart()).thenReturn(Instant.ofEpochSecond(PROFILE_START));
     when(recordingData.getEnd()).thenReturn(Instant.ofEpochSecond(PROFILE_END));
+    when(recordingData.getReason()).thenReturn(reason);
     return recordingData;
   }
 

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
@@ -175,8 +175,8 @@ public class ProfileUploaderTest {
   }
 
   @ParameterizedTest
-  @EnumSource(ProfilingSnapshot.SnapshotKind.class)
-  public void testHappyPath(ProfilingSnapshot.SnapshotKind kind) throws Exception {
+  @EnumSource(ProfilingSnapshot.Kind.class)
+  public void testHappyPath(ProfilingSnapshot.Kind kind) throws Exception {
     // Given
     when(config.getProfilingUploadTimeout()).thenReturn(500000);
 
@@ -227,8 +227,8 @@ public class ProfileUploaderTest {
   }
 
   @ParameterizedTest
-  @EnumSource(ProfilingSnapshot.SnapshotKind.class)
-  public void testHappyPathSync(ProfilingSnapshot.SnapshotKind kind) throws Exception {
+  @EnumSource(ProfilingSnapshot.Kind.class)
+  public void testHappyPathSync(ProfilingSnapshot.Kind kind) throws Exception {
     // Given
     when(config.getProfilingUploadTimeout()).thenReturn(500000);
 
@@ -784,14 +784,14 @@ public class ProfileUploaderTest {
   }
 
   private RecordingData mockRecordingData() throws IOException {
-    return mockRecordingData(false, ProfilingSnapshot.SnapshotKind.PERIODIC);
+    return mockRecordingData(false, ProfilingSnapshot.Kind.PERIODIC);
   }
 
   private RecordingData mockRecordingData(final boolean zip) throws IOException {
-    return mockRecordingData(zip, ProfilingSnapshot.SnapshotKind.PERIODIC);
+    return mockRecordingData(zip, ProfilingSnapshot.Kind.PERIODIC);
   }
 
-  private RecordingData mockRecordingData(final boolean zip, ProfilingSnapshot.SnapshotKind kind)
+  private RecordingData mockRecordingData(final boolean zip, ProfilingSnapshot.Kind kind)
       throws IOException {
     final RecordingData recordingData = mock(RecordingData.class, withSettings().lenient());
     when(recordingData.getStream())

--- a/dd-java-agent/instrumentation/shutdown/src/main/java/datadog/trace/instrumentation/shutdown/ShutdownInstrumentation.java
+++ b/dd-java-agent/instrumentation/shutdown/src/main/java/datadog/trace/instrumentation/shutdown/ShutdownInstrumentation.java
@@ -23,7 +23,7 @@ public class ShutdownInstrumentation extends Instrumenter.Tracing
 
   @Override
   protected boolean defaultEnabled() {
-    return false;
+    return true;
   }
 
   @Override

--- a/dd-smoke-tests/profiling-integration-tests/src/main/java/datadog/smoketest/profiling/ProfilingTestApplication.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/main/java/datadog/smoketest/profiling/ProfilingTestApplication.java
@@ -13,19 +13,19 @@ public class ProfilingTestApplication {
   private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
 
   public static void main(final String[] args) throws InterruptedException {
-    long exitDelay = -1;
+    long duration = -1;
     if (args.length > 0) {
-      exitDelay = TimeUnit.SECONDS.toMillis(Long.parseLong(args[0]));
+      duration = TimeUnit.SECONDS.toMillis(Long.parseLong(args[0]));
     }
     setupDeadlock();
     final long startTime = System.currentTimeMillis();
     while (true) {
       tracedMethod();
-      if (exitDelay > 0 && exitDelay + startTime < System.currentTimeMillis()) {
+      if (duration > 0 && duration + startTime < System.currentTimeMillis()) {
         break;
       }
     }
-    System.out.println("Exiting (" + exitDelay + ")");
+    System.out.println("Exiting (" + duration + ")");
   }
 
   @Trace

--- a/internal-api/internal-api.gradle
+++ b/internal-api/internal-api.gradle
@@ -15,6 +15,7 @@ excludedClassesCoverage += [
   "datadog.trace.api.TraceSegment.NoOp",
   "datadog.trace.api.intake.TrackType",
   "datadog.trace.api.gateway.Events.ET",
+  "datadog.trace.api.profiling.ProfilingSnapshot.Kind", // an enum
   "datadog.trace.api.sampling.AdaptiveSampler",
   // this one is covered by tests in internal-api-8 together with AdaptiveSampler8
   "datadog.trace.api.sampling.AdaptiveSampler7*",

--- a/internal-api/internal-api.gradle
+++ b/internal-api/internal-api.gradle
@@ -15,7 +15,8 @@ excludedClassesCoverage += [
   "datadog.trace.api.TraceSegment.NoOp",
   "datadog.trace.api.intake.TrackType",
   "datadog.trace.api.gateway.Events.ET",
-  "datadog.trace.api.profiling.ProfilingSnapshot.Kind", // an enum
+  "datadog.trace.api.profiling.ProfilingSnapshot.Kind",
+  // an enum
   "datadog.trace.api.sampling.AdaptiveSampler",
   // this one is covered by tests in internal-api-8 together with AdaptiveSampler8
   "datadog.trace.api.sampling.AdaptiveSampler7*",

--- a/internal-api/src/main/java/datadog/trace/api/profiling/ProfilingSnapshot.java
+++ b/internal-api/src/main/java/datadog/trace/api/profiling/ProfilingSnapshot.java
@@ -1,7 +1,7 @@
 package datadog.trace.api.profiling;
 
 public interface ProfilingSnapshot extends ObservableType {
-  enum SnapshotKind {
+  enum Kind {
     PERIODIC,
     ON_SHUTDOWN
   }

--- a/internal-api/src/main/java/datadog/trace/api/profiling/ProfilingSnapshot.java
+++ b/internal-api/src/main/java/datadog/trace/api/profiling/ProfilingSnapshot.java
@@ -1,8 +1,8 @@
 package datadog.trace.api.profiling;
 
 public interface ProfilingSnapshot extends ObservableType {
-  enum SnapshotReason {
-    REGULAR,
+  enum SnapshotKind {
+    PERIODIC,
     ON_SHUTDOWN
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/profiling/ProfilingSnapshot.java
+++ b/internal-api/src/main/java/datadog/trace/api/profiling/ProfilingSnapshot.java
@@ -1,3 +1,8 @@
 package datadog.trace.api.profiling;
 
-public interface ProfilingSnapshot extends ObservableType {}
+public interface ProfilingSnapshot extends ObservableType {
+  enum SnapshotReason {
+    REGULAR,
+    ON_SHUTDOWN
+  }
+}


### PR DESCRIPTION
# What Does This Do
Extends the functionality created for the CI integration to always upload the active profile on orderly JVM exit.
An orderly JVM exit is observed when the application exits either voluntarily or due to a Java exception, and also when the process is 'soft' killed (eg. JVM has a chance to clean up).
'Hard' kills and VM crashes will not be handled since the JVM is stopped immediately and there is nothing left running that could take care of uploading the profile.

# Motivation
Reusing the existing functionality to provide better profiling coverage.

# Additional Notes
