### PR TITLE
Set initial capacity for StringBuilder in tests

### DIFF
--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
@@ -174,7 +174,7 @@ public class DebuggerSinkTest {
   public void splitDiagnosticsBatch() {
     when(config.getDebuggerUploadBatchSize()).thenReturn(100);
     DebuggerSink sink = new DebuggerSink(config, batchUploader);
-    StringBuilder largeMessageBuilder = new StringBuilder();
+    StringBuilder largeMessageBuilder = new StringBuilder(100_001);
     for (int i = 0; i < 100_000; i++) {
       largeMessageBuilder.append("f");
     }
@@ -193,7 +193,7 @@ public class DebuggerSinkTest {
   public void tooLargeDiagnostic() {
     when(config.getDebuggerUploadBatchSize()).thenReturn(100);
     DebuggerSink sink = new DebuggerSink(config, batchUploader);
-    StringBuilder tooLargeMessageBuilder = new StringBuilder();
+    StringBuilder tooLargeMessageBuilder = new StringBuilder(MAX_PAYLOAD + 1);
     for (int i = 0; i < MAX_PAYLOAD; i++) {
       tooLargeMessageBuilder.append("f");
     }
@@ -207,8 +207,8 @@ public class DebuggerSinkTest {
   public void tooLargeUTF8Diagnostic() {
     when(config.getDebuggerUploadBatchSize()).thenReturn(100);
     DebuggerSink sink = new DebuggerSink(config, batchUploader);
-    StringBuilder tooLargeMessageBuilder = new StringBuilder();
-    for (int i = 0; i < MAX_PAYLOAD / 2; i++) {
+    StringBuilder tooLargeMessageBuilder = new StringBuilder(MAX_PAYLOAD + 4);
+    for (int i = 0; i < MAX_PAYLOAD; i += 4) {
       tooLargeMessageBuilder.append("\uD80C\uDCF0"); // 4 bytes
     }
     String tooLargeMessage = tooLargeMessageBuilder.toString();

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/TagsHelperTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/TagsHelperTest.java
@@ -39,7 +39,7 @@ public class TagsHelperTest {
 
   @Test
   public void tagTrimmedToMaxLength() {
-    StringBuilder tag = new StringBuilder();
+    StringBuilder tag = new StringBuilder(401);
     for (int i = 0; i < 400; i++) {
       tag.append("a");
     }
@@ -49,7 +49,7 @@ public class TagsHelperTest {
 
   @Test
   public void tagTrimmedToMaxLengthWorkWithUnicode() {
-    StringBuilder tag = new StringBuilder();
+    StringBuilder tag = new StringBuilder(401);
     for (int i = 0; i < 400; i++) {
       tag.append("\u1234");
     }

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/CompressionTypeTest.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/CompressionTypeTest.java
@@ -38,7 +38,7 @@ class CompressionTypeTest {
     // use bit operations to generate permutations
     long mask = 0L;
     for (int i = 0; i < input.length(); i++) {
-      final StringBuilder sb = new StringBuilder();
+      final StringBuilder sb = new StringBuilder(input.length());
       mask += 1;
       long check = mask;
       for (int j = 0; j < input.length(); j++) {

--- a/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySmokeTest.groovy
+++ b/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySmokeTest.groovy
@@ -68,9 +68,9 @@ class SpringBootOpenLibertySmokeTest extends AbstractServerSmokeTest {
   def "Test concurrent high load requests to Spring Boot running Open Liberty"() {
     def url = "http://localhost:${httpPort}/connect/0"
     def formBody = new FormBody.Builder()
-    def value = new StringBuilder()
+    def value = new StringBuilder(10_001 * 10)
     for (int i = 0; i < 10000; i++) {
-      value.append("@@@@@@@@@@")
+      value.append("@@@@@@@@@@") // 10 chars
     }
     for (int i = 0; i < 100; i++) {
       formBody.add("test" + i, value.toString())

--- a/internal-api/src/test/java/datadog/trace/util/TagsHelperTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/TagsHelperTest.java
@@ -39,7 +39,7 @@ public class TagsHelperTest {
 
   @Test
   public void tagTrimmedToMaxLength() {
-    StringBuilder tag = new StringBuilder();
+    StringBuilder tag = new StringBuilder(401);
     for (int i = 0; i < 400; i++) {
       tag.append("a");
     }
@@ -49,7 +49,7 @@ public class TagsHelperTest {
 
   @Test
   public void tagTrimmedToMaxLengthWorkWithUnicode() {
-    StringBuilder tag = new StringBuilder();
+    StringBuilder tag = new StringBuilder(401);
     for (int i = 0; i < 400; i++) {
       tag.append("\u1234");
     }


### PR DESCRIPTION
# What Does This Do

Sets the initial capacity in tests with largish or humongous `StringBuilder` instances

# Motivation

Don't stress the heap

# Additional Notes
