### PR TITLE
Fix issue in default stack walker implementation

### DIFF
--- a/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/AbstractStackWalker.java
+++ b/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/AbstractStackWalker.java
@@ -1,15 +1,9 @@
 package datadog.trace.util.stacktrace;
 
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 public abstract class AbstractStackWalker implements StackWalker {
-
-  private static final Predicate<StackTraceElement> NOT_DD_TRACE_STACK_ELEMENT =
-      (stackTraceElement) ->
-          !stackTraceElement.getClassName().startsWith("datadog.trace.")
-              && !stackTraceElement.getClassName().startsWith("com.datadog.iast.");
 
   @Override
   public <T> T walk(Function<Stream<StackTraceElement>, T> consumer) {
@@ -17,8 +11,13 @@ public abstract class AbstractStackWalker implements StackWalker {
   }
 
   final Stream<StackTraceElement> doFilterStack(Stream<StackTraceElement> stream) {
-    return stream.filter(NOT_DD_TRACE_STACK_ELEMENT);
+    return stream.filter(AbstractStackWalker::isNotDatadogTraceStackElement);
   }
 
   abstract <T> T doGetStack(Function<Stream<StackTraceElement>, T> consumer);
+
+  private static boolean isNotDatadogTraceStackElement(final StackTraceElement el) {
+    final String clazz = el.getClassName();
+    return !clazz.startsWith("datadog.trace.") && !clazz.startsWith("com.datadog.iast.");
+  }
 }

--- a/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/DefaultStackWalker.java
+++ b/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/DefaultStackWalker.java
@@ -15,6 +15,6 @@ public class DefaultStackWalker extends AbstractStackWalker {
 
   @Override
   <T> T doGetStack(final Function<Stream<StackTraceElement>, T> consumer) {
-    return consumer.apply(Arrays.stream(Thread.currentThread().getStackTrace()));
+    return consumer.apply(Arrays.stream(new Throwable().getStackTrace()));
   }
 }

--- a/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/HotSpotStackWalkerTest.java
+++ b/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/HotSpotStackWalkerTest.java
@@ -1,7 +1,13 @@
 package datadog.trace.util.stacktrace;
 
+import static datadog.trace.util.stacktrace.StackWalkerTestUtil.DD_CLASS_NAME;
+import static datadog.trace.util.stacktrace.StackWalkerTestUtil.DD_IAST_CLASS_NAME;
+import static datadog.trace.util.stacktrace.StackWalkerTestUtil.NOT_DD_CLASS_NAME;
+import static datadog.trace.util.stacktrace.StackWalkerTestUtil.getStackWalkFrom;
 import static datadog.trace.util.stacktrace.StackWalkerTestUtil.isRunningJDK8WithHotSpot;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -10,10 +16,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class HotSpotStackWalkerTest {
+
+  private final StackWalker stackWalker = new HotSpotStackWalker();
 
   @BeforeAll
   public static void setUp() {
@@ -22,15 +31,34 @@ public class HotSpotStackWalkerTest {
 
   @Test
   public void hotSpotStackWalker_must_be_enabled_for_JDK8_with_hotspot() {
-    assertTrue(new HotSpotStackWalker().isEnabled());
+    assertTrue(stackWalker.isEnabled());
   }
 
   @Test
-  public void get_stack_trace() {
+  public void walk_from_non_datadog_class() {
     // When
-    List<StackTraceElement> list = new HotSpotStackWalker().doGetStack(StackWalkerTestUtil::toList);
+    final List<StackTraceElement> stack = getStackWalkFrom(stackWalker, NOT_DD_CLASS_NAME);
     // Then
-    assertFalse(list.isEmpty());
+    assertFalse(stack.isEmpty());
+    assertEquals(NOT_DD_CLASS_NAME, stack.get(0).getClassName());
+  }
+
+  @Test
+  public void walk_from_datadog_class() {
+    // When
+    final List<StackTraceElement> stack = getStackWalkFrom(stackWalker, DD_CLASS_NAME);
+    // Then
+    assertFalse(stack.isEmpty());
+    assertNotEquals(DD_CLASS_NAME, stack.get(0).getClassName());
+  }
+
+  @Test
+  public void walk_from_datadog_iast_class() {
+    // When
+    final List<StackTraceElement> stack = getStackWalkFrom(stackWalker, DD_IAST_CLASS_NAME);
+    // Then
+    assertFalse(stack.isEmpty());
+    assertNotEquals(DD_IAST_CLASS_NAME, stack.get(0).getClassName());
   }
 
   @Test
@@ -57,7 +85,7 @@ public class HotSpotStackWalkerTest {
   @Test
   public void iterable_from_HotSpotStackWalker_doGetStack_is_not_in_the_filtered_stack() {
     // When
-    List<StackTraceElement> list = new HotSpotStackWalker().doGetStack(StackWalkerTestUtil::toList);
+    List<StackTraceElement> list = stackWalker.walk(s -> s.collect(Collectors.toList()));
     // Then
     assertFalse(
         list.stream()

--- a/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/StackWalkerTestUtil.java
+++ b/internal-api/internal-api-8/src/test/java/datadog/trace/util/stacktrace/StackWalkerTestUtil.java
@@ -1,13 +1,20 @@
 package datadog.trace.util.stacktrace;
 
 import datadog.trace.api.Platform;
+import datadog.trace.test.util.AnyStackRunner;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import sun.misc.JavaLangAccess;
 import sun.misc.SharedSecrets;
 
 public class StackWalkerTestUtil {
+
+  public static final String DD_CLASS_NAME = "datadog.trace.SynthTestClass";
+
+  public static final String DD_IAST_CLASS_NAME = "com.datadog.iast.SynthTestClass";
+
+  public static final String NOT_DD_CLASS_NAME = "external.test.SynthTestClass";
 
   private StackWalkerTestUtil() {}
 
@@ -20,7 +27,14 @@ public class StackWalkerTestUtil {
     }
   }
 
-  public static List<StackTraceElement> toList(final Stream<StackTraceElement> stack) {
-    return stack.collect(Collectors.toList());
+  public static List<StackTraceElement> getStackWalkFrom(
+      final StackWalker walker, final String clazz) {
+    final AtomicReference<List<StackTraceElement>> result = new AtomicReference<>();
+    AnyStackRunner.callWithinStack(
+        clazz,
+        () -> {
+          result.set(walker.walk(s -> s.collect(Collectors.toList())));
+        });
+    return result.get();
   }
 }

--- a/internal-api/internal-api-9/src/test/groovy/datadog/trace/util/stacktrace/JDK9StackWalkerTest.groovy
+++ b/internal-api/internal-api-9/src/test/groovy/datadog/trace/util/stacktrace/JDK9StackWalkerTest.groovy
@@ -6,10 +6,9 @@ import java.util.stream.Collectors
 
 class JDK9StackWalkerTest extends DDSpecification {
 
-  def 'stack walker enabled'() {
-    given:
-    final walker = new JDK9StackWalker()
+  final walker = new JDK9StackWalker()
 
+  def 'stack walker enabled'() {
     when:
     final enabled = walker.isEnabled()
 
@@ -18,11 +17,8 @@ class JDK9StackWalkerTest extends DDSpecification {
   }
 
   def 'walk retrieves stackTraceElements'() {
-    given:
-    final walker = new JDK9StackWalker()
-
     when:
-    final stream = walker.walk { it.collect() }
+    final stream = getStackTrace()
 
     then:
     !stream.empty
@@ -30,13 +26,14 @@ class JDK9StackWalkerTest extends DDSpecification {
 
 
   def 'walk retrieves no datadog stack elements'() {
-    given:
-    final walker = new JDK9StackWalker()
-
     when:
-    final stream = walker.walk { it.collect(Collectors.toList()) }
+    final stream = getStackTrace()
 
     then:
     stream.findAll { it.className.startsWith('datadog') } == []
+  }
+
+  List<StackTraceElement> getStackTrace() {
+    walker.walk { it.collect(Collectors.toList()) }
   }
 }

--- a/utils/test-utils/src/main/java/datadog/trace/test/util/AnyStackRunner.java
+++ b/utils/test-utils/src/main/java/datadog/trace/test/util/AnyStackRunner.java
@@ -1,0 +1,48 @@
+package datadog.trace.test.util;
+
+import net.bytebuddy.ByteBuddy;
+
+/**
+ * Utilities to call methods from callers with arbitrary class names.
+ *
+ * <p>This is useful to test functionality that depends on stack walking.
+ */
+public class AnyStackRunner {
+
+  /**
+   * Call the given runnable from a class with the given name.
+   *
+   * @param parentClass Caller class.
+   * @param runnable Runnable to call.
+   */
+  public static void callWithinStack(final String parentClass, final Runnable runnable) {
+    // Create a copy of the RunnerRunner template class with the given name.
+    final Class<?> dynamicType =
+        new ByteBuddy()
+            .redefine(RunnerRunner.class)
+            .name(parentClass)
+            .make()
+            .load(AnyStackRunner.class.getClassLoader())
+            .getLoaded();
+    try {
+      Consumer<Runnable> obj =
+          (Consumer<Runnable>) dynamicType.getDeclaredConstructor().newInstance();
+      obj.accept(runnable);
+    } catch (ReflectiveOperationException ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+
+  /** Public to ease code-generation. Not meant to be used out of the parent class. */
+  public interface Consumer<T> {
+    void accept(T arg);
+  }
+
+  /** Public to ease code-generation. Not meant to be used out of the parent class. */
+  public static class RunnerRunner implements Consumer<Runnable> {
+    @Override
+    public void accept(final Runnable runnable) {
+      runnable.run();
+    }
+  }
+}


### PR DESCRIPTION
# What Does This Do
`Thread.currentThread().getStackTrace()` seems to be the same as `new
Throwable.getStackTrace()` for the general case, but it results in an
additional frame. This might result in a slight performance loss, and
also was the source of a bug where we got an unexpected result.

Refactored stack walker tests to spot this kind of issue.

# Motivation

# Additional Notes

This is a follow up to https://github.com/DataDog/dd-trace-java/pull/3647
