### PR TITLE
Avoid warning when using StackWalker on JDK <9

### DIFF
--- a/internal-api/internal-api-8/internal-api-8.gradle
+++ b/internal-api/internal-api-8/internal-api-8.gradle
@@ -25,7 +25,10 @@ minimumInstructionCoverage = 0.8
 
 excludedClassesCoverage += ["datadog.trace.api.sampling.ConstantSampler"]
 
-excludedClassesBranchCoverage = ['datadog.trace.util.stacktrace.HotSpotStackWalker']
+excludedClassesBranchCoverage = [
+  'datadog.trace.util.stacktrace.HotSpotStackWalker',
+  'datadog.trace.util.stacktrace.StackWalkerFactory'
+]
 
 excludedClassesInstructionCoverage = ['datadog.trace.util.stacktrace.StackWalkerFactory']
 

--- a/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/StackWalkerFactory.java
+++ b/internal-api/internal-api-8/src/main/java/datadog/trace/util/stacktrace/StackWalkerFactory.java
@@ -1,5 +1,6 @@
 package datadog.trace.util.stacktrace;
 
+import datadog.trace.api.Platform;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -29,11 +30,19 @@ public class StackWalkerFactory {
   }
 
   private static Supplier<StackWalker> hotspot() {
-    return HotSpotStackWalker::new;
+    return () -> {
+      if (!Platform.isJavaVersion(8)) {
+        return null;
+      }
+      return new HotSpotStackWalker();
+    };
   }
 
   private static Supplier<StackWalker> jdk9() {
     return () -> {
+      if (!Platform.isJavaVersionAtLeast(9)) {
+        return null;
+      }
       try {
         return (StackWalker)
             Class.forName("datadog.trace.util.stacktrace.JDK9StackWalker")


### PR DESCRIPTION
# What Does This Do
If we cannot instantiate JDK9StackWalker, a warning is printed, which is
fair if we're on JDK 9+, but pointless otherwise. Check the JDK version
for trying to instantiate StackWalker implementations, to avoid
unnecessary noise.

# Motivation

# Additional Notes

cc @robertomonteromiguel this removes the warning you found