### PR TITLE
Add CODEOWNERS entry for the IAST team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,3 +18,8 @@ dd-java-agent/instrumentation/testng-6.4/                              @DataDog/
 
 # @DataDog/debugger-java (Live Debugger)
 dd-java-agent/agent-debugger/ @DataDog/debugger-java
+
+# @DataDog/iast-java
+**/iast/          @DataDog/iast-java
+**/Iast*.java     @DataDog/iast-java
+**/Iast*.groovy   @DataDog/iast-java


### PR DESCRIPTION
# What Does This Do
Add CODEOWNERS entry for the @DataDog/iast-java team.

# Motivation

# Additional Notes
