### PR TITLE
Fix capture deserialization for snapshot probes

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/SnapshotProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/SnapshotProbe.java
@@ -4,6 +4,8 @@ import com.datadog.debugger.el.ProbeCondition;
 import com.datadog.debugger.instrumentation.MethodProbeInstrumentor;
 import com.squareup.moshi.Json;
 import datadog.trace.bootstrap.debugger.DiagnosticMessage;
+import datadog.trace.bootstrap.debugger.FieldExtractor;
+import datadog.trace.bootstrap.debugger.ValueConverter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -16,11 +18,15 @@ public class SnapshotProbe extends ProbeDefinition {
 
   /** Stores capture limits */
   public static final class Capture {
-    private final int maxReferenceDepth;
-    private final int maxCollectionSize;
-    private final int maxLength;
-    private final int maxFieldDepth;
-    private final int maxFieldCount;
+    private int maxReferenceDepth = ValueConverter.DEFAULT_REFERENCE_DEPTH;
+    private int maxCollectionSize = ValueConverter.DEFAULT_COLLECTION_SIZE;
+    private int maxLength = ValueConverter.DEFAULT_LENGTH;
+    private int maxFieldDepth = FieldExtractor.DEFAULT_FIELD_DEPTH;
+    private int maxFieldCount = ValueConverter.DEFAULT_FIELD_COUNT;
+
+    private Capture() {
+      // for Moshi to assign default values
+    }
 
     public Capture(
         int maxReferenceDepth,

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
@@ -25,6 +25,70 @@ public class ConfigurationTest {
     deserialize(buffer);
   }
 
+  @Test
+  public void captureDeserialization() throws IOException {
+    doCaptureDeserialization(
+        "{\"maxReferenceDepth\":3,\"maxCollectionSize\":123,\"maxLength\":242,\"maxFieldDepth\":7,\"maxFieldCount\":2}",
+        3,
+        123,
+        242,
+        7,
+        2);
+    doCaptureDeserialization(
+        "{\"maxReferenceDepth\":3}",
+        3,
+        ValueConverter.DEFAULT_COLLECTION_SIZE,
+        ValueConverter.DEFAULT_LENGTH,
+        FieldExtractor.DEFAULT_FIELD_DEPTH,
+        ValueConverter.DEFAULT_FIELD_COUNT);
+    doCaptureDeserialization(
+        "{\"maxCollectionSize\":123}",
+        ValueConverter.DEFAULT_REFERENCE_DEPTH,
+        123,
+        ValueConverter.DEFAULT_LENGTH,
+        FieldExtractor.DEFAULT_FIELD_DEPTH,
+        ValueConverter.DEFAULT_FIELD_COUNT);
+    doCaptureDeserialization(
+        "{\"maxLength\":242}",
+        ValueConverter.DEFAULT_REFERENCE_DEPTH,
+        ValueConverter.DEFAULT_COLLECTION_SIZE,
+        242,
+        FieldExtractor.DEFAULT_FIELD_DEPTH,
+        ValueConverter.DEFAULT_FIELD_COUNT);
+    doCaptureDeserialization(
+        "{\"maxFieldDepth\":7}",
+        ValueConverter.DEFAULT_REFERENCE_DEPTH,
+        ValueConverter.DEFAULT_COLLECTION_SIZE,
+        ValueConverter.DEFAULT_LENGTH,
+        7,
+        ValueConverter.DEFAULT_FIELD_COUNT);
+    doCaptureDeserialization(
+        "{\"maxFieldCount\":2}",
+        ValueConverter.DEFAULT_REFERENCE_DEPTH,
+        ValueConverter.DEFAULT_COLLECTION_SIZE,
+        ValueConverter.DEFAULT_LENGTH,
+        FieldExtractor.DEFAULT_FIELD_DEPTH,
+        2);
+  }
+
+  private void doCaptureDeserialization(
+      String json,
+      int expectedMaxRef,
+      int expectedMaxCol,
+      int expectedMaxLen,
+      int expectedMaxFieldDepth,
+      int expectedMaxFieldCount)
+      throws IOException {
+    JsonAdapter<SnapshotProbe.Capture> adapter =
+        MoshiHelper.createMoshiConfig().adapter(SnapshotProbe.Capture.class);
+    SnapshotProbe.Capture capture = adapter.fromJson(json);
+    assertEquals(expectedMaxRef, capture.getMaxReferenceDepth());
+    assertEquals(expectedMaxCol, capture.getMaxCollectionSize());
+    assertEquals(expectedMaxLen, capture.getMaxLength());
+    assertEquals(expectedMaxFieldDepth, capture.getMaxFieldDepth());
+    assertEquals(expectedMaxFieldCount, capture.getMaxFieldCount());
+  }
+
   private String serialize() throws IOException {
     SnapshotProbe probe1 =
         createProbe("probe1", "service1", "java.lang.String", "indexOf", "(String)");


### PR DESCRIPTION
# What Does This Do
If only one field is present, the others get the default values.
We have added default values for `SnapshotProbe.Capture` class and a private no-arg constructor for Moshi to trigger execution of this constructor ans assign default values

# Motivation
with only one value in Json configuration, the other values for `SnapshotProbe.Capture` are 0 which is not expected