### PR TITLE
Handle invalid URL at HTTP client creation

### DIFF
--- a/communication/src/main/java/datadog/communication/http/OkHttpUtils.java
+++ b/communication/src/main/java/datadog/communication/http/OkHttpUtils.java
@@ -64,7 +64,7 @@ public final class OkHttpUtils {
         unixDomainSocketPath,
         namedPipe,
         null,
-        !url.scheme().equals("https"),
+        url,
         null,
         null,
         null,
@@ -89,7 +89,7 @@ public final class OkHttpUtils {
         discoverApmSocket(config),
         config.getAgentNamedPipe(),
         dispatcher,
-        !url.scheme().equals("https"),
+        url,
         retryOnConnectionFailure,
         maxRunningRequests,
         proxyHost,
@@ -103,7 +103,7 @@ public final class OkHttpUtils {
       final String unixDomainSocketPath,
       final String namedPipe,
       final Dispatcher dispatcher,
-      final boolean isHttp,
+      final HttpUrl url,
       final Boolean retryOnConnectionFailure,
       final Integer maxRunningRequests,
       final String proxyHost,
@@ -129,6 +129,7 @@ public final class OkHttpUtils {
       log.debug("Using NamedPipe as http transport");
     }
 
+    boolean isHttp = url != null && "http".equals(url.scheme());
     if (isHttp) {
       // force clear text when using http to avoid failures for JVMs without TLS
       builder.connectionSpecs(Collections.singletonList(ConnectionSpec.CLEARTEXT));

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
@@ -70,7 +70,7 @@ public class BatchUploader {
     if (url == null || url.length() == 0) {
       throw new IllegalArgumentException("Snapshot url is empty");
     }
-    urlBase = HttpUrl.parse(url);
+    urlBase = HttpUrl.get(url);
     log.debug("Started SnapshotUploader with target url {}", urlBase);
     apiKey = config.getApiKey();
     responseCallback = new ResponseCallback(ratelimitedLogger, inflightRequests);


### PR DESCRIPTION
# What Does This Do

A quick change in HTTP client builder in order to support `null` URL.
Some URL might be null when using `Http.parse` instead of `HttpUrl.get` and break the client creation while testing for URL scheme.

# Motivation

# Additional Notes
