### PR TITLE
Improve IAST testability with less statics

### DIFF
--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/IastModuleImpl.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/IastModuleImpl.java
@@ -7,48 +7,68 @@ import com.datadog.iast.model.VulnerabilityType;
 import datadog.trace.api.Config;
 import datadog.trace.api.iast.IastModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.util.stacktrace.StackWalker;
 import datadog.trace.util.stacktrace.StackWalkerFactory;
+import java.util.Locale;
 
-public class IastModuleImpl implements IastModule {
+public final class IastModuleImpl implements IastModule {
+
+  private final Config config;
+  private final Reporter reporter;
+  private final StackWalker stackWalker = StackWalkerFactory.INSTANCE;
+
+  public IastModuleImpl(final Config config, final Reporter reporter) {
+    this.config = config;
+    this.reporter = reporter;
+  }
+
   public void onCipherAlgorithm(String algorithm) {
-    if (null != algorithm
-        && Config.get().getIastWeakCipherAlgorithms().contains(algorithm.toUpperCase())) {
-      // get StackTraceElement for the callee of MessageDigest
-      StackTraceElement stackTraceElement =
-          StackWalkerFactory.INSTANCE.walk(
-              stack ->
-                  stack
-                      .filter(s -> !s.getClassName().equals("javax.crypto.Cipher"))
-                      .findFirst()
-                      .get());
-
-      Vulnerability vulnerability =
-          new Vulnerability(
-              VulnerabilityType.WEAK_CIPHER,
-              Location.forStack(stackTraceElement),
-              new Evidence(algorithm));
-      Reporter.report(AgentTracer.activeSpan(), vulnerability);
+    if (algorithm == null) {
+      return;
     }
+    final String algorithmId = algorithm.toUpperCase(Locale.ROOT);
+    if (!config.getIastWeakCipherAlgorithms().contains(algorithmId)) {
+      return;
+    }
+    // get StackTraceElement for the callee of MessageDigest
+    StackTraceElement stackTraceElement =
+        stackWalker.walk(
+            stack ->
+                stack
+                    .filter(s -> !s.getClassName().equals("javax.crypto.Cipher"))
+                    .findFirst()
+                    .get());
+
+    Vulnerability vulnerability =
+        new Vulnerability(
+            VulnerabilityType.WEAK_CIPHER,
+            Location.forStack(stackTraceElement),
+            new Evidence(algorithm));
+    reporter.report(AgentTracer.activeSpan(), vulnerability);
   }
 
   public void onHashingAlgorithm(String algorithm) {
-    if (null != algorithm
-        && Config.get().getIastWeakHashAlgorithms().contains(algorithm.toUpperCase())) {
-      // get StackTraceElement for the callee of MessageDigest
-      StackTraceElement stackTraceElement =
-          StackWalkerFactory.INSTANCE.walk(
-              stack ->
-                  stack
-                      .filter(s -> !s.getClassName().equals("java.security.MessageDigest"))
-                      .findFirst()
-                      .get());
-
-      Vulnerability vulnerability =
-          new Vulnerability(
-              VulnerabilityType.WEAK_HASH,
-              Location.forStack(stackTraceElement),
-              new Evidence(algorithm));
-      Reporter.report(AgentTracer.activeSpan(), vulnerability);
+    if (algorithm == null) {
+      return;
     }
+    final String algorithmId = algorithm.toUpperCase(Locale.ROOT);
+    if (!config.getIastWeakHashAlgorithms().contains(algorithmId)) {
+      return;
+    }
+    // get StackTraceElement for the caller of MessageDigest
+    StackTraceElement stackTraceElement =
+        stackWalker.walk(
+            stack ->
+                stack
+                    .filter(s -> !s.getClassName().equals("java.security.MessageDigest"))
+                    .findFirst()
+                    .get());
+
+    Vulnerability vulnerability =
+        new Vulnerability(
+            VulnerabilityType.WEAK_HASH,
+            Location.forStack(stackTraceElement),
+            new Evidence(algorithm));
+    reporter.report(AgentTracer.activeSpan(), vulnerability);
   }
 }

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/IastSystem.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/IastSystem.java
@@ -6,6 +6,7 @@ import datadog.trace.api.gateway.EventType;
 import datadog.trace.api.gateway.Events;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.SubscriptionService;
+import datadog.trace.api.iast.IastModule;
 import datadog.trace.api.iast.InstrumentationBridge;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,9 +23,10 @@ public class IastSystem {
     }
     log.debug("IAST is starting");
 
+    final Reporter reporter = new Reporter();
+    final IastModule iastModule = new IastModuleImpl(config, reporter);
+    InstrumentationBridge.registerIastModule(iastModule);
     registerRequestStartedCallback(ss);
-
-    InstrumentationBridge.registerIastModule(new IastModuleImpl());
   }
 
   private static void registerRequestStartedCallback(final SubscriptionService ss) {

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/Reporter.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/Reporter.java
@@ -7,11 +7,11 @@ import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 
 /** Reports IAST vulnerabilities. */
-public final class Reporter {
+public class Reporter {
 
-  private Reporter() {}
+  public Reporter() {}
 
-  public static void report(final AgentSpan span, final Vulnerability vulnerability) {
+  public void report(final AgentSpan span, final Vulnerability vulnerability) {
     if (span == null) {
       return;
     }

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/model/Evidence.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/model/Evidence.java
@@ -1,5 +1,7 @@
 package com.datadog.iast.model;
 
+import java.util.Arrays;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -24,5 +26,20 @@ public final class Evidence {
 
   public Range[] getRanges() {
     return ranges;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Evidence evidence = (Evidence) o;
+    return Objects.equals(value, evidence.value) && Arrays.equals(ranges, evidence.ranges);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(value);
+    result = 31 * result + Arrays.hashCode(ranges);
+    return result;
   }
 }

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/model/Range.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/model/Range.java
@@ -1,6 +1,7 @@
 package com.datadog.iast.model;
 
 import com.datadog.iast.model.json.SourceIndex;
+import java.util.Objects;
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 
@@ -25,5 +26,18 @@ public final class Range {
 
   public Source getSource() {
     return source;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Range range = (Range) o;
+    return start == range.start && length == range.length && Objects.equals(source, range.source);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(start, length, source);
   }
 }

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/model/Source.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/model/Source.java
@@ -1,6 +1,7 @@
 package com.datadog.iast.model;
 
 import com.datadog.iast.model.json.SourceTypeString;
+import java.util.Objects;
 
 public final class Source {
   private final @SourceTypeString byte origin;
@@ -23,5 +24,20 @@ public final class Source {
 
   public String getValue() {
     return value;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Source source = (Source) o;
+    return origin == source.origin
+        && Objects.equals(name, source.name)
+        && Objects.equals(value, source.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(origin, name, value);
   }
 }

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/IastModuleImplHashTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/IastModuleImplHashTest.groovy
@@ -1,30 +1,30 @@
 package com.datadog.iast
 
+import com.datadog.iast.model.Evidence
+import com.datadog.iast.model.Vulnerability
+import com.datadog.iast.model.VulnerabilityType
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer
-import datadog.trace.test.util.DDSpecification
 
-class IastModuleImplHashTest extends DDSpecification {
+class IastModuleImplHashTest extends IastModuleImplTestBase {
 
   void 'iast module vulnerable hash algorithm'(){
     given:
-    IastModuleImpl module = new IastModuleImpl()
-    AgentSpan mockAgentSpan = Mock(AgentSpan)
-    def mockCoreTracer = Mock(AgentTracer.TracerAPI)
-    mockCoreTracer.activeSpan() >> mockAgentSpan
-    AgentTracer.forceRegister(mockCoreTracer)
-
+    final span = Mock(AgentSpan)
+    tracer.activeSpan() >> span
 
     when:
     module.onHashingAlgorithm(algorithm)
 
-
     then:
-    1 * mockAgentSpan.getRequestContext()
-
-    cleanup:
-    AgentTracer.forceRegister(AgentTracer.NOOP_TRACER)
-
+    1 * tracer.activeSpan()
+    1 * reporter.report(_, _) >> { args ->
+      Vulnerability vuln = args[1] as Vulnerability
+      assert vuln != null
+      assert vuln.getType() == VulnerabilityType.WEAK_HASH
+      assert vuln.getEvidence() == new Evidence(algorithm)
+      assert vuln.getLocation() != null
+    }
+    0 * _
 
     where:
     algorithm | _
@@ -38,40 +38,26 @@ class IastModuleImplHashTest extends DDSpecification {
 
   void 'iast module called with null argument'(){
     given:
-    IastModuleImpl module = new IastModuleImpl()
-    AgentSpan mockAgentSpan = Mock(AgentSpan)
-    def mockCoreTracer = Mock(AgentTracer.TracerAPI)
-    mockCoreTracer.activeSpan() >> mockAgentSpan
-    AgentTracer.forceRegister(mockCoreTracer)
+    final span = Mock(AgentSpan)
+    tracer.activeSpan() >> span
 
     when:
     module.onHashingAlgorithm(null)
 
-
     then:
     noExceptionThrown()
-
-    cleanup:
-    AgentTracer.forceRegister(AgentTracer.NOOP_TRACER)
+    0 * _
   }
 
   void 'iast module secure hash algorithm'(){
     given:
-    IastModuleImpl module = new IastModuleImpl()
-    AgentSpan mockAgentSpan = Mock(AgentSpan)
-    def mockCoreTracer = Mock(AgentTracer.TracerAPI)
-    mockCoreTracer.activeSpan() >> mockAgentSpan
-    AgentTracer.forceRegister(mockCoreTracer)
-
+    final span = Mock(AgentSpan)
+    tracer.activeSpan() >> span
 
     when:
     module.onHashingAlgorithm("SHA-256")
 
-
     then:
-    0 * mockAgentSpan.getRequestContext()
-
-    cleanup:
-    AgentTracer.forceRegister(AgentTracer.NOOP_TRACER)
+    0 * _
   }
 }

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/IastModuleImplTestBase.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/IastModuleImplTestBase.groovy
@@ -1,0 +1,26 @@
+package com.datadog.iast
+
+import datadog.trace.api.Config
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import datadog.trace.test.util.DDSpecification
+import spock.lang.Shared
+
+class IastModuleImplTestBase extends DDSpecification {
+
+  @Shared
+  protected static final AgentTracer.TracerAPI ORIGINAL_TRACER = AgentTracer.get()
+
+  protected Reporter reporter = Mock(Reporter)
+
+  protected IastModuleImpl module = new IastModuleImpl(Config.get(), reporter)
+
+  protected AgentTracer.TracerAPI tracer = Mock(AgentTracer.TracerAPI)
+
+  def setup() {
+    AgentTracer.forceRegister(tracer)
+  }
+
+  def cleanup() {
+    AgentTracer.forceRegister(ORIGINAL_TRACER)
+  }
+}


### PR DESCRIPTION
# What Does This Do
Since every IAST callback passes through an instance of IastModule, we
can use instances of things like `Reporter` and rely less on static
methods. This will improve testability.

Tests are adjusted and simplified accordingly.

`equals`/`hashCode` are implemented in some models to ease testing
assertions.

# Motivation

# Additional Notes
