### PR TITLE
Standarize IAST config flags

### DIFF
--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/IastModuleImpl.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/IastModuleImpl.java
@@ -12,7 +12,7 @@ import datadog.trace.util.stacktrace.StackWalkerFactory;
 public class IastModuleImpl implements IastModule {
   public void onCipherAlgorithm(String algorithm) {
     if (null != algorithm
-        && Config.get().getWeakCipherAlgorithms().contains(algorithm.toUpperCase())) {
+        && Config.get().getIastWeakCipherAlgorithms().contains(algorithm.toUpperCase())) {
       // get StackTraceElement for the callee of MessageDigest
       StackTraceElement stackTraceElement =
           StackWalkerFactory.INSTANCE.walk(
@@ -33,7 +33,7 @@ public class IastModuleImpl implements IastModule {
 
   public void onHashingAlgorithm(String algorithm) {
     if (null != algorithm
-        && Config.get().getWeakHashingAlgorithms().contains(algorithm.toUpperCase())) {
+        && Config.get().getIastWeakHashAlgorithms().contains(algorithm.toUpperCase())) {
       // get StackTraceElement for the callee of MessageDigest
       StackTraceElement stackTraceElement =
           StackWalkerFactory.INSTANCE.walk(

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -79,6 +79,34 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_APPSEC_WAF_METRICS = true;
 
   static final boolean DEFAULT_IAST_ENABLED = false;
+  static final Set<String> DEFAULT_IAST_WEAK_HASH_ALGORITHMS =
+      new HashSet<>(Arrays.asList("MD2", "MD5", "RIPEMD128", "MD4"));
+  static final Set<String> DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS =
+      new HashSet<>(
+          Arrays.asList(
+              "DES",
+              "DESEDE",
+              "DESEDEWRAP",
+              "PBEWITHMD5ANDDES",
+              "PBEWITHMD5ANDTRIPLEDES",
+              "PBEWITHSHA1ANDDESEDE",
+              "PBEWITHSHA1ANDRC2_40",
+              "PBEWITHSHA1ANDRC2_128",
+              "PBEWITHSHA1ANDRC4_40",
+              "PBEWITHSHA1ANDRC4_128",
+              "PBEWITHHMACSHA1ANDAES_128",
+              "PBEWITHHMACSHA224ANDAES_128",
+              "PBEWITHHMACSHA256ANDAES_128",
+              "PBEWITHHMACSHA384ANDAES_128",
+              "PBEWITHHMACSHA512ANDAES_128",
+              "PBEWITHHMACSHA1ANDAES_256",
+              "PBEWITHHMACSHA224ANDAES_256",
+              "PBEWITHHMACSHA256ANDAES_256",
+              "PBEWITHHMACSHA384ANDAES_256",
+              "PBEWITHHMACSHA512ANDAES_256",
+              "RC2",
+              "BLOWFISH",
+              "ARCFOUR"));
 
   static final boolean DEFAULT_CIVISIBILITY_ENABLED = false;
   static final boolean DEFAULT_CIVISIBILITY_AGENTLESS_ENABLED = false;
@@ -116,35 +144,6 @@ public final class ConfigDefaults {
 
   static final int DEFAULT_RESOLVER_OUTLINE_POOL_SIZE = 128;
   static final int DEFAULT_RESOLVER_TYPE_POOL_SIZE = 64;
-
-  static final Set<String> DEFAULT_IAST_WEAK_HASHING_ALGORITHMS =
-      new HashSet<>(Arrays.asList("MD2", "MD5", "RIPEMD128", "MD4"));
-  static final Set<String> DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS =
-      new HashSet<>(
-          Arrays.asList(
-              "DES",
-              "DESEDE",
-              "DESEDEWRAP",
-              "PBEWITHMD5ANDDES",
-              "PBEWITHMD5ANDTRIPLEDES",
-              "PBEWITHSHA1ANDDESEDE",
-              "PBEWITHSHA1ANDRC2_40",
-              "PBEWITHSHA1ANDRC2_128",
-              "PBEWITHSHA1ANDRC4_40",
-              "PBEWITHSHA1ANDRC4_128",
-              "PBEWITHHMACSHA1ANDAES_128",
-              "PBEWITHHMACSHA224ANDAES_128",
-              "PBEWITHHMACSHA256ANDAES_128",
-              "PBEWITHHMACSHA384ANDAES_128",
-              "PBEWITHHMACSHA512ANDAES_128",
-              "PBEWITHHMACSHA1ANDAES_256",
-              "PBEWITHHMACSHA224ANDAES_256",
-              "PBEWITHHMACSHA256ANDAES_256",
-              "PBEWITHHMACSHA384ANDAES_256",
-              "PBEWITHHMACSHA512ANDAES_256",
-              "RC2",
-              "BLOWFISH",
-              "ARCFOUR"));
 
   static final boolean DEFAULT_TELEMETRY_ENABLED = false;
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/AppSecConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/AppSecConfig.java
@@ -15,10 +15,5 @@ public final class AppSecConfig {
   public static final String APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP =
       "appsec.obfuscation.parameter_value_regexp";
 
-  public static final String APPSEC_IAST_WEAK_HASHING_ALGORITHMS =
-      "appsec.iast.weak_hashing_algorithms";
-  public static final String APPSEC_IAST_WEAK_CIPHER_ALGORITHMS =
-      "appsec.iast.weak_cipher_algorithms";
-
   private AppSecConfig() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/IastConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/IastConfig.java
@@ -4,6 +4,8 @@ package datadog.trace.api.config;
 public final class IastConfig {
 
   public static final String IAST_ENABLED = "iast.enabled";
+  public static final String IAST_WEAK_HASH_ALGORITHMS = "iast.weak-hash.algorithms";
+  public static final String IAST_WEAK_CIPHER_ALGORITHMS = "iast.weak-cipher.algorithms";
 
   private IastConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -39,7 +39,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_ROUTE_BASED_N
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_TAG_QUERY_STRING;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_WEAK_HASHING_ALGORITHMS;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_WEAK_HASH_ALGORITHMS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_INTEGRATIONS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_JMX_FETCH_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_ENABLED;
@@ -87,8 +87,6 @@ import static datadog.trace.api.DDTags.SERVICE_TAG;
 import static datadog.trace.api.IdGenerationStrategy.RANDOM;
 import static datadog.trace.api.Platform.isJavaVersionAtLeast;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_ENABLED;
-import static datadog.trace.api.config.AppSecConfig.APPSEC_IAST_WEAK_CIPHER_ALGORITHMS;
-import static datadog.trace.api.config.AppSecConfig.APPSEC_IAST_WEAK_HASHING_ALGORITHMS;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_IP_ADDR_HEADER;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP;
@@ -151,6 +149,8 @@ import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_AGGREGAT
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_PENDING;
 import static datadog.trace.api.config.GeneralConfig.VERSION;
 import static datadog.trace.api.config.IastConfig.IAST_ENABLED;
+import static datadog.trace.api.config.IastConfig.IAST_WEAK_CIPHER_ALGORITHMS;
+import static datadog.trace.api.config.IastConfig.IAST_WEAK_HASH_ALGORITHMS;
 import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_CHECK_PERIOD;
 import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_CONFIG;
 import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_CONFIG_DIR;
@@ -608,9 +608,9 @@ public class Config {
 
   private final boolean dataStreamsEnabled;
 
-  private final Set<String> weakHashingAlgorithms;
+  private final Set<String> iastWeakHashAlgorithms;
 
-  private final Set<String> weakCipherAlgorithms;
+  private final Set<String> iastWeakCipherAlgorithms;
 
   private final boolean telemetryEnabled;
 
@@ -987,16 +987,6 @@ public class Config {
             PROFILING_LEGACY_TRACING_INTEGRATION, PROFILING_LEGACY_TRACING_INTEGRATION_DEFAULT);
     profilingUrl = configProvider.getString(PROFILING_URL);
 
-    weakHashingAlgorithms =
-        tryMakeImmutableSet(
-            configProvider.getSet(
-                APPSEC_IAST_WEAK_HASHING_ALGORITHMS, DEFAULT_IAST_WEAK_HASHING_ALGORITHMS));
-
-    weakCipherAlgorithms =
-        tryMakeImmutableSet(
-            configProvider.getSet(
-                APPSEC_IAST_WEAK_CIPHER_ALGORITHMS, DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS));
-
     if (tmpApiKey == null) {
       final String oldProfilingApiKeyFile = configProvider.getString(PROFILING_API_KEY_FILE_OLD);
       tmpApiKey = getEnv(propertyNameToEnvironmentVariableName(PROFILING_API_KEY_OLD));
@@ -1094,6 +1084,13 @@ public class Config {
         configProvider.getString(APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP, null);
 
     iastEnabled = configProvider.getBoolean(IAST_ENABLED, DEFAULT_IAST_ENABLED);
+    iastWeakHashAlgorithms =
+        tryMakeImmutableSet(
+            configProvider.getSet(IAST_WEAK_HASH_ALGORITHMS, DEFAULT_IAST_WEAK_HASH_ALGORITHMS));
+    iastWeakCipherAlgorithms =
+        tryMakeImmutableSet(
+            configProvider.getSet(
+                IAST_WEAK_CIPHER_ALGORITHMS, DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS));
 
     ciVisibilityEnabled =
         configProvider.getBoolean(CIVISIBILITY_ENABLED, DEFAULT_CIVISIBILITY_ENABLED);
@@ -1370,12 +1367,12 @@ public class Config {
     return traceResolverEnabled;
   }
 
-  public Set<String> getWeakHashingAlgorithms() {
-    return weakHashingAlgorithms;
+  public Set<String> getIastWeakHashAlgorithms() {
+    return iastWeakHashAlgorithms;
   }
 
-  public Set<String> getWeakCipherAlgorithms() {
-    return weakCipherAlgorithms;
+  public Set<String> getIastWeakCipherAlgorithms() {
+    return iastWeakCipherAlgorithms;
   }
 
   public Map<String, String> getServiceMapping() {


### PR DESCRIPTION
# What Does This Do

* Move all keys to `IastConfig`
* Do not prefix with `AppSec`.
* Some other tweaks.

# Motivation

Ensure some degree of consistency of config flags within dd-trace-java, and also across IAST implementations in other languages (e.g. Node).

# Additional Notes
