### PR TITLE
Add download release update to the asset upload workflow

### DIFF
--- a/.github/workflows/add-assets-to-release.yaml
+++ b/.github/workflows/add-assets-to-release.yaml
@@ -30,6 +30,8 @@ jobs:
           asset_path: dd-java-agent.jar
           asset_name: dd-java-agent.jar
           asset_content_type: application/java-archive
+      - name: Update download release
+        uses: DataDog/download-release-action@ea1f13c0cad08eafeebec8b7d9b2d6ee74efb92a # 0.0.2
   dd-trace-api:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# What Does This Do

This action will update the `download-latest-vX` releases body and attachment to the latest version available.

# Motivation

This action takes place in the Java 7 deprecation context.

We will need to create releases with stable tags in order to provide permanent links for download each major version.
Those releases will be based on orphan branch tagged `download-latest-vX` and will contains a copy of the latest attachment available.

On each new release, this action will update this meta release. It can also be trigger manually if needed, proving the major version to update.

# Additional Notes

This PR replaces the original one: #3757.

The related releases [Latest](https://github.com/DataDog/dd-trace-java/releases/tag/untagged-2b8162a904f048aad041) and [Latest v0](https://github.com/DataDog/dd-trace-java/releases/tag/untagged-8a544cc18ac2aa0ce00e) is also ready to be published.