### PR TITLE
fix: use custom shell scripts to run lib injection system tests

### DIFF
--- a/.github/workflows/lib-injection.yaml
+++ b/.github/workflows/lib-injection.yaml
@@ -70,7 +70,6 @@ jobs:
     env:
       TEST_LIBRARY: java
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
-      LIBRARY_INJECTION_ENABLED: ${{ matrix.lib-injection-enabled }}
       LIBRARY_INJECTION_CONNECTION: ${{ matrix.lib-injection-connection }}
       LIBRARY_INJECTION_ADMISSION_CONTROLLER: ${{ matrix.lib-injection-admission-controller }}
       LIBRARY_INJECTION_INIT_IMAGE: ghcr.io/datadog/dd-trace-java/dd-lib-java-init:${{ github.sha }}
@@ -89,10 +88,10 @@ jobs:
           path: 'binaries/dd-trace-java'
 
       - name: Build
-        run: ./build.sh
+        run: ./lib-injection/build.sh
 
       - name: Run
-        run: ./run.sh
+        run: ./lib-injection/run.sh
 
       - name: Compress artifact
         if: ${{ always() }}

--- a/.github/workflows/lib-injection.yaml
+++ b/.github/workflows/lib-injection.yaml
@@ -91,7 +91,7 @@ jobs:
         run: ./lib-injection/build.sh
 
       - name: Run
-        run: ./lib-injection/run.sh
+        run: ./lib-injection/run-lib-injection.sh
 
       - name: Compress artifact
         if: ${{ always() }}


### PR DESCRIPTION
# What Does This Do

Address Charles comment: https://github.com/DataDog/system-tests/pull/453#issuecomment-1231452953.

# Motivation

The library injection tests do not reuse any system test code. They're effectively two cocolated projects. Charles recommends using different build and run scripts to fully isolate the library injection tests. This should improve the readability and maintainability.

# Additional Notes
