### PR TITLE
Introduce class loader masks

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakCache.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakCache.java
@@ -9,6 +9,8 @@ public interface WeakCache<K, V> {
 
   void put(final K key, final V value);
 
+  void clear();
+
   abstract class Supplier {
     private static volatile Supplier SUPPLIER;
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/WeakCaches.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/WeakCaches.java
@@ -76,6 +76,11 @@ public class WeakCaches {
       weakMap.put(key, value);
     }
 
+    @Override
+    public void clear() {
+      weakMap.clear();
+    }
+
     private void expungeIfNecessary() {
       if (weakMap.approximateSize() >= maxSize) {
         weakMap.expungeStaleEntries();

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ClassLoaderMatchers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ClassLoaderMatchers.java
@@ -30,7 +30,7 @@ public final class ClassLoaderMatchers {
       !Config.get().getExcludedClassLoaders().isEmpty();
 
   /* Cache of classloader-instance -> (true|false). True = skip instrumentation. False = safe to instrument. */
-  private static final WeakCache<ClassLoader, Boolean> skipCache = WeakCaches.newWeakCache();
+  private static final WeakCache<ClassLoader, Boolean> skipCache = WeakCaches.newWeakCache(64);
 
   /** A private constructor that must not be invoked. */
   private ClassLoaderMatchers() {
@@ -151,7 +151,7 @@ public final class ClassLoaderMatchers {
   static final List<String> hasClassResourceNames = new ArrayList<>();
 
   /** Cache of classloader-instance -> has-class mask. */
-  static final WeakCache<ClassLoader, BitSet> hasClassCache = WeakCaches.newWeakCache();
+  static final WeakCache<ClassLoader, BitSet> hasClassCache = WeakCaches.newWeakCache(64);
 
   static final BitSet NO_CLASS_NAME_MATCHES = new BitSet();
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
@@ -4,6 +4,7 @@ import datadog.trace.agent.tooling.HelperInjector;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.Instrumenters;
 import datadog.trace.agent.tooling.bytebuddy.SharedTypePools;
+import datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers;
 import datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers;
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -58,6 +59,8 @@ public class MuzzleVersionScanPlugin {
         final ReferenceMatcher muzzle = (ReferenceMatcher) m.invoke(instrumenter);
         final List<Reference.Mismatch> mismatches =
             muzzle.getMismatchedReferenceSources(userClassLoader);
+
+        ClassLoaderMatchers.reset();
 
         final boolean classLoaderMatch =
             ((Instrumenter.Default) instrumenter).classLoaderMatcher().matches(userClassLoader);


### PR DESCRIPTION
[ depends on #3802 and #3804 ]

* Replaces multiple class-loader matcher caches with single cache of 'hasClass' masks
  * this saves space, because we only need to have one compressed mapping per-class-loader
* Performs all class-loader matches in a single sweep for each class-loader, rather than on-demand
  * while this can mean more up-front resource checks, it also means less context-switching
  * simple tests show a startup improvement of half a second off an overall startup time of 10 seconds