### PR TITLE
Upgrade snakeyaml to 1.31 to mitigate CVE-2022-25857

### DIFF
--- a/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
+++ b/dd-java-agent/agent-jmxfetch/agent-jmxfetch.gradle
@@ -7,9 +7,11 @@ dependencies {
   api('com.datadoghq:jmxfetch:0.45.3') {
     exclude group: 'org.slf4j', module: 'slf4j-api'
     exclude group: 'org.slf4j', module: 'slf4j-jdk14'
+    exclude group: 'org.yaml', module: 'snakeyaml'
   }
   api deps.slf4j
   api project(':internal-api')
+  implementation 'org.yaml:snakeyaml:1.31' // override to mitigate CVE-2022-25857 until jmxfetch is fixed
 }
 
 shadowJar {


### PR DESCRIPTION
# What Does This Do

Upgrades snakeyaml that is pulled in by jmxfetch to `1.31` to mitigate [CVE-2022-25857](https://nvd.nist.gov/vuln/detail/CVE-2022-25857) until a fixed version of jmxfetch is released.

# Motivation

# Additional Notes

Reported in #3787 