### PR TITLE
Search JAVA_8_HOME for rmic

### DIFF
--- a/dd-java-agent/instrumentation/rmi/rmi.gradle
+++ b/dd-java-agent/instrumentation/rmi/rmi.gradle
@@ -25,6 +25,10 @@ String getRmicPath() {
   if (new File(rmicPath).exists()) {
     return rmicPath
   }
+  rmicPath = System.getenv('JAVA_11_HOME') + '/bin/rmic'
+  if (new File(rmicPath).exists()) {
+    return rmicPath
+  }
   return 'rmic' 
 }
 

--- a/dd-java-agent/instrumentation/rmi/rmi.gradle
+++ b/dd-java-agent/instrumentation/rmi/rmi.gradle
@@ -16,8 +16,16 @@ apply from: "$rootDir/gradle/java.gradle"
 def rmic = tasks.register('rmic') {
   dependsOn testClasses
   def clazz = 'rmi.app.ServerLegacy'
-  String command = """rmic -g -keep -classpath ${sourceSets.test.output.classesDirs.asPath} -d ${buildDir}/classes/java/test ${clazz}"""
+  String command = getRmicPath() + """ -g -keep -classpath ${sourceSets.test.output.classesDirs.asPath} -d ${buildDir}/classes/java/test ${clazz}"""
   command.execute().text
+}
+
+String getRmicPath() {
+  String rmicPath = System.getenv('JAVA_8_HOME') + '/bin/rmic'
+  if (new File(rmicPath).exists()) {
+    return rmicPath
+  }
+  return 'rmic' 
 }
 
 tasks.named("test").configure {


### PR DESCRIPTION
Checks for rmic in the required JAVA_8_HOME before expecting it in the system path.  Currently, setting JAVA_HOME, JAVA_8_HOME and JAVA_11_HOME is not sufficient to build successfully.  Users must also have rmic in the path.  This could be problematic for an increasing number of users since new JDKs omit rmic.