### PR TITLE
Update AppSec WAF to 4.4.0

### DIFF
--- a/dd-java-agent/appsec/appsec.gradle
+++ b/dd-java-agent/appsec/appsec.gradle
@@ -24,7 +24,7 @@ dependencies {
   implementation project(':internal-api')
   implementation project(':communication')
   implementation project(':telemetry')
-  implementation group: 'io.sqreen', name: 'libsqreen', version: '4.2.0'
+  implementation group: 'io.sqreen', name: 'libsqreen', version: '4.4.0'
   implementation group: 'com.squareup.moshi', name: 'moshi', version: versions.moshi
 
   annotationProcessor deps.autoserviceProcessor

--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -233,7 +233,7 @@ tasks.register('checkAgentJarSize').configure {
   doLast {
     // Arbitrary limit to prevent unintentional increases to the agent jar size
     // Raise or lower as required
-    assert shadowJar.archiveFile.get().getAsFile().length() < 20 * 1024 * 1024
+    assert shadowJar.archiveFile.get().getAsFile().length() < 21 * 1024 * 1024
   }
 
   dependsOn "shadowJar"


### PR DESCRIPTION
# What Does This Do
Update AppSec WAF to 4.4.0

Changes:
- Support for ARM processors (Linux/MacOS)
- Updated WAF to version 1.5.0 ([see changes](https://github.com/DataDog/libddwaf/releases/tag/1.5.0-alpha0))

# Motivation

# Additional Notes
