### PR TITLE
Avoid NegativeArraySizeException when printing invalid timeline sequence

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/checkpoints/TimelinePrinter.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/checkpoints/TimelinePrinter.groovy
@@ -12,11 +12,7 @@ class TimelinePrinter {
       }
       // allows rendering threads top to bottom by when they were first encountered
       Map<Thread, BitSet> timelines = new LinkedHashMap<>()
-      int maxNameLength = 0
       String[] renderings = new String[orderedEvents.size()]
-      for (Thread thread : threadEvents.keySet()) {
-        maxNameLength = Math.max(maxNameLength, thread.name.length())
-      }
       int position = 0
       for (Event event : orderedEvents) {
         if (position >= renderings.length) {
@@ -34,6 +30,10 @@ class TimelinePrinter {
           timelines[event.thread] = timeline = new BitSet()
         }
         timeline.set(position++)
+      }
+      int maxNameLength = 0
+      for (Thread thread : timelines.keySet()) {
+        maxNameLength = Math.max(maxNameLength, thread.name.length())
       }
       for (Map.Entry<Thread, BitSet> timeline : timelines) {
         Thread thread = timeline.key


### PR DESCRIPTION
# What Does This Do

Should fix this exception seen occasionally on CircleCI:
```
java.lang.NegativeArraySizeException
	at java.lang.AbstractStringBuilder.<init>(AbstractStringBuilder.java:68)
	at java.lang.StringBuilder.<init>(StringBuilder.java:107)
	at datadog.trace.agent.test.checkpoints.TimelinePrinter.repeat(TimelinePrinter.groovy:78)
	at datadog.trace.agent.test.checkpoints.TimelinePrinter.print(TimelinePrinter.groovy:42)
	at datadog.trace.agent.test.checkpoints.TimelineCheckpointer.throwOnInvalidSequence(TimelineCheckpointer.groovy:64)
	at org.spockframework.mock.runtime.ByteBuddyMethodInvoker.respond(ByteBuddyMethodInvoker.java:20)
	at org.spockframework.mock.runtime.MockInvocation.callRealMethod(MockInvocation.java:59)
	at org.spockframework.mock.CallRealMethodResponse.respond(CallRealMethodResponse.java:30)
	at org.spockframework.mock.runtime.MockController.handle(MockController.java:50)
	at org.spockframework.mock.runtime.JavaMockInterceptor.intercept(JavaMockInterceptor.java:72)
	at org.spockframework.mock.runtime.ByteBuddyInterceptorAdapter.interceptNonAbstract(ByteBuddyInterceptorAdapter.java:35)
	at datadog.trace.agent.test.AgentTestRunner.cleanup(AgentTestRunner.groovy:294)
```

Since the timeline being printed is known to be invalid we can't trust that `threadEvents` holds all the thread details - instead use `timelines.keySet()` as we know that contains all the threads we're going to print out.