### PR TITLE
com.gradle.enterprise:3.11.1

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'com.gradle.enterprise' version '3.0'
+  id 'com.gradle.enterprise' version '3.11.1'
 }
 
 def isCI = System.getenv("CI") != null


### PR DESCRIPTION
# What Does This Do

Upgrade to the latest https://plugins.gradle.org/plugin/com.gradle.enterprise

# Motivation

Should avoid this message seen occasionally at the end of local builds (note doesn't affect the build, just log-spam)

```
A build scan cannot be produced as an error occurred gathering build data.
Please report this problem via https://gradle.com/scans/help/plugin and include the following via copy/paste:

----------
Gradle version: 7.5
Plugin version: 3.0

java.lang.IllegalStateException: Attempt to dispose ID for 'com.gradle.scan.plugin.internal.b.e.g@137352bd' without previously assigning ID.
        at com.gradle.scan.plugin.internal.h.a.e(SourceFile:122)
        at com.gradle.scan.plugin.internal.h.f.c(SourceFile:28)
        at com.gradle.scan.plugin.internal.b.e.i.a(SourceFile:179)
        at com.gradle.scan.plugin.internal.k.a.f.a(SourceFile:12)
        at com.gradle.scan.plugin.internal.k.a$c.finished(SourceFile:154)
        at com.gradle.scan.plugin.internal.k.a.a(SourceFile:65)
        at com.gradle.scan.plugin.internal.k.i.a(SourceFile:58)
        at com.gradle.scan.plugin.internal.k.d.a(SourceFile:103)
        at com.gradle.scan.plugin.internal.k.f.a(SourceFile:48)
        at com.gradle.scan.plugin.internal.p.a$a.a(SourceFile:31)
        at com.gradle.scan.plugin.internal.p.a$a.a(SourceFile:20)
        at com.gradle.scan.plugin.internal.p.a.c(SourceFile:67)
----------
```