### PR TITLE
Clarify required env vars

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,9 @@ To build the full project from the command line:
 * `JAVA_8_HOME` must point to the JDK-8 location.
 * `JAVA_11_HOME` must point to the JDK-11 location.
 * The JDK-8 `bin` directory must be the only JDK on the PATH (e.g. `$JAVA_8_HOME/bin`).
-* `JAVA_HOME` must be unset or point to JDK-8 (same as `JAVA_8_HOME`).
+* `JAVA_HOME` may be unset. If set, it must point to JDK-8 (same as `JAVA_8_HOME`).
+
+MacOS users, remember that `/usr/libexec/java_home` may control which JDK is in your path. 
 
 In contrast to the [IntelliJ IDEA setup](#intellij-idea) the default JVM to build and run tests from the command line should be Java 8.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ To build the full project from the command line:
 * The JDK-8 `bin` directory must be the only JDK on the PATH (e.g. `$JAVA_8_HOME/bin`).
 * `JAVA_HOME` may be unset. If set, it must point to JDK-8 (same as `JAVA_8_HOME`).
 
-MacOS users, remember that `/usr/libexec/java_home` may control which JDK is in your path. 
+MacOS users, remember that `/usr/libexec/java_home` may control which JDK is in your path.
 
 In contrast to the [IntelliJ IDEA setup](#intellij-idea) the default JVM to build and run tests from the command line should be Java 8.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,14 @@ and discuss your ideas or propose the changes you wish to make. After a resoluti
 
 ## Requirements
 
-To build the full project from the command line you need to have JDK versions for 8 and 11 installed on your machine, as well as the following environment variables set up: `JAVA_8_HOME, JAVA_11_HOME`, pointing to the respective JDK.
+To build the full project from the command line:
+
+* JDK version 8 must be installed.
+* JDK version 11 must be installed.
+* `JAVA_8_HOME` must point to the JDK-8 location.
+* `JAVA_11_HOME` must point to the JDK-11 location.
+* The JDK-8 `bin` directory must be the only JDK on the PATH (e.g. `$JAVA_8_HOME/bin`).
+* `JAVA_HOME` must be unset or point to JDK-8 (same as `JAVA_8_HOME`).
 
 In contrast to the [IntelliJ IDEA setup](#intellij-idea) the default JVM to build and run tests from the command line should be Java 8.
 


### PR DESCRIPTION
# What Does This Do

Clarifies required environment variables for command line build.  The build requires PATH, JAVA_8_HOME, JAVA_11_HOME and JAVA_HOME, if present, all being set correctly.   If either JAVA_HOME or PATH point to a different JDK the build will fail.
