### PR TITLE
Taint tracking API

### DIFF
--- a/dd-java-agent/iast/iast.gradle
+++ b/dd-java-agent/iast/iast.gradle
@@ -15,6 +15,8 @@ dependencies {
 
   testImplementation deps.bytebuddy
   testImplementation project(':utils:test-utils')
+
+  jmh project(':utils:test-utils')
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8

--- a/dd-java-agent/iast/src/jmh/java/com/datadog/iast/taint/TaintedMapEmptyBenchmark.java
+++ b/dd-java-agent/iast/src/jmh/java/com/datadog/iast/taint/TaintedMapEmptyBenchmark.java
@@ -1,0 +1,44 @@
+package com.datadog.iast.taint;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@Warmup(iterations = 2, time = 1000, timeUnit = MILLISECONDS)
+@Measurement(iterations = 3, time = 1000, timeUnit = MILLISECONDS)
+@Fork(3)
+@OutputTimeUnit(NANOSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@State(Scope.Benchmark)
+public class TaintedMapEmptyBenchmark {
+
+  private static final int OP_COUNT = 1024;
+  private TaintedMap map;
+  private final Object anyObject = new Object();
+
+  @Setup(Level.Iteration)
+  public void setup() {
+    map = new DefaultTaintedMap();
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(OP_COUNT)
+  public void getFromEmptyMap(final Blackhole bh) {
+    for (int i = 0; i < OP_COUNT; i++) {
+      bh.consume(map.get(anyObject));
+    }
+  }
+}

--- a/dd-java-agent/iast/src/jmh/java/com/datadog/iast/taint/TaintedMapGetsBenchmark.java
+++ b/dd-java-agent/iast/src/jmh/java/com/datadog/iast/taint/TaintedMapGetsBenchmark.java
@@ -1,0 +1,70 @@
+package com.datadog.iast.taint;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import com.datadog.iast.model.Range;
+import java.util.ArrayList;
+import java.util.List;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@Warmup(iterations = 1, time = 1000, timeUnit = MILLISECONDS)
+@Measurement(iterations = 3, time = 1000, timeUnit = MILLISECONDS)
+@Fork(3)
+@OutputTimeUnit(NANOSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@State(Scope.Benchmark)
+public class TaintedMapGetsBenchmark {
+
+  private static final int INITIAL_OP_COUNT = DefaultTaintedMap.DEFAULT_FLAT_MODE_THRESHOLD;
+  private static final int OP_COUNT = 1024;
+
+  private TaintedMap map;
+  private List<Object> objectList;
+  private List<Object> initialObjectList;
+
+  @Setup(Level.Iteration)
+  public void setup() {
+    map = new DefaultTaintedMap();
+    initialObjectList = new ArrayList<>(INITIAL_OP_COUNT);
+    objectList = new ArrayList<>(OP_COUNT);
+    for (int i = 0; i < INITIAL_OP_COUNT; i++) {
+      final Object k = new Object();
+      initialObjectList.add(k);
+      map.put(new TaintedObject(k, new Range[0], map.getReferenceQueue()));
+    }
+    for (int i = 0; i < OP_COUNT; i++) {
+      final Object k = new Object();
+      objectList.add(k);
+      map.put(new TaintedObject(k, new Range[0], map.getReferenceQueue()));
+    }
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(OP_COUNT)
+  public void getsBaseline(final Blackhole bh) {
+    for (int i = 0; i < OP_COUNT; i++) {
+      bh.consume(objectList.get(i));
+    }
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(OP_COUNT)
+  public void gets(final Blackhole bh) {
+    for (int i = 0; i < OP_COUNT; i++) {
+      bh.consume(map.get(objectList.get(i)));
+    }
+  }
+}

--- a/dd-java-agent/iast/src/jmh/java/com/datadog/iast/taint/TaintedMapPutsBenchmark.java
+++ b/dd-java-agent/iast/src/jmh/java/com/datadog/iast/taint/TaintedMapPutsBenchmark.java
@@ -1,0 +1,74 @@
+package com.datadog.iast.taint;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import com.datadog.iast.model.Range;
+import datadog.trace.test.util.CircularBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Timeout;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@Warmup(iterations = 1, time = 1000, timeUnit = MILLISECONDS)
+@Measurement(iterations = 3, time = 1000, timeUnit = MILLISECONDS)
+@Timeout(time = 10000, timeUnit = MILLISECONDS)
+@Fork(3)
+@OutputTimeUnit(NANOSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@State(Scope.Benchmark)
+public class TaintedMapPutsBenchmark {
+
+  private static final int INITIAL_OP_COUNT = DefaultTaintedMap.DEFAULT_FLAT_MODE_THRESHOLD;
+  private static final int OP_COUNT = 1024;
+
+  private static final Range[] EMPTY_RANGES = new Range[0];
+
+  private TaintedMap map;
+  private List<Object> initialObjectList;
+  private CircularBuffer<Object> objectBuffer;
+
+  @Setup(Level.Iteration)
+  public void setup() {
+    map = new DefaultTaintedMap();
+    objectBuffer = new CircularBuffer<>(OP_COUNT);
+    initialObjectList = new ArrayList<>(INITIAL_OP_COUNT);
+    for (int i = 0; i < INITIAL_OP_COUNT; i++) {
+      final Object k = new Object();
+      initialObjectList.add(k);
+      map.put(new TaintedObject(k, EMPTY_RANGES, map.getReferenceQueue()));
+    }
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(OP_COUNT)
+  public void putsBaseline(final Blackhole bh) {
+    for (int i = 0; i < OP_COUNT; i++) {
+      final Object k = new Object();
+      objectBuffer.add(k);
+      bh.consume(new TaintedObject(k, EMPTY_RANGES, map.getReferenceQueue()));
+    }
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(OP_COUNT)
+  public void puts() {
+    for (int i = 0; i < OP_COUNT; i++) {
+      final Object k = new Object();
+      objectBuffer.add(k);
+      map.put(new TaintedObject(k, EMPTY_RANGES, map.getReferenceQueue()));
+    }
+  }
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/IastModuleImpl.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/IastModuleImpl.java
@@ -2,10 +2,16 @@ package com.datadog.iast;
 
 import com.datadog.iast.model.Evidence;
 import com.datadog.iast.model.Location;
+import com.datadog.iast.model.Range;
+import com.datadog.iast.model.Source;
+import com.datadog.iast.model.SourceType;
 import com.datadog.iast.model.Vulnerability;
 import com.datadog.iast.model.VulnerabilityType;
 import com.datadog.iast.overhead.Operations;
 import com.datadog.iast.overhead.OverheadController;
+import com.datadog.iast.taint.Ranges;
+import com.datadog.iast.taint.TaintedObject;
+import com.datadog.iast.taint.TaintedObjects;
 import datadog.trace.api.Config;
 import datadog.trace.api.iast.IastModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -13,6 +19,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.util.stacktrace.StackWalker;
 import datadog.trace.util.stacktrace.StackWalkerFactory;
 import java.util.Locale;
+import javax.annotation.Nullable;
 
 public final class IastModuleImpl implements IastModule {
 
@@ -84,5 +91,85 @@ public final class IastModuleImpl implements IastModule {
             Location.forStack(stackTraceElement),
             new Evidence(algorithm));
     reporter.report(span, vulnerability);
+  }
+
+  @Override
+  public void onParameterName(final @Nullable String paramName) {
+    if (paramName == null || paramName.isEmpty()) {
+      return;
+    }
+    final IastRequestContext ctx = IastRequestContext.get();
+    if (ctx == null) {
+      return;
+    }
+    final TaintedObjects taintedObjects = ctx.getTaintedObjects();
+    taintedObjects.taintInputString(
+        paramName, new Source(SourceType.REQUEST_PARAMETER_NAME, paramName, null));
+  }
+
+  @Override
+  public void onParameterValue(
+      final @Nullable String paramName, final @Nullable String paramValue) {
+    if (paramValue == null || paramValue.isEmpty()) {
+      return;
+    }
+    final IastRequestContext ctx = IastRequestContext.get();
+    if (ctx == null) {
+      return;
+    }
+    final TaintedObjects taintedObjects = ctx.getTaintedObjects();
+    taintedObjects.taintInputString(
+        paramValue, new Source(SourceType.REQUEST_PARAMETER_VALUE, paramName, paramValue));
+  }
+
+  @Override
+  public void onConcat(
+      @Nullable String left, @Nullable String right, final @Nullable String result) {
+    if (!canBeTainted(result)) {
+      return;
+    }
+    if (!canBeTainted(left) && !canBeTainted(right)) {
+      return;
+    }
+    final IastRequestContext ctx = IastRequestContext.get();
+    if (ctx == null) {
+      return;
+    }
+    final TaintedObjects taintedObjects = ctx.getTaintedObjects();
+    final Range[] rangesLeft;
+    if (left == null) {
+      rangesLeft = Ranges.EMPTY;
+      left = "null";
+    } else {
+      final TaintedObject to = taintedObjects.get(left);
+      rangesLeft = (to == null) ? Ranges.EMPTY : to.getRanges();
+    }
+    final Range[] rangesRight;
+    if (left == right) {
+      rangesRight = rangesLeft;
+    } else if (right == null) {
+      rangesRight = Ranges.EMPTY;
+      right = "null";
+    } else {
+      final TaintedObject to = taintedObjects.get(right);
+      rangesRight = (to == null) ? Ranges.EMPTY : to.getRanges();
+    }
+    final int nRanges = rangesLeft.length + rangesRight.length;
+    if (nRanges == 0) {
+      return;
+    }
+    final Range[] ranges = new Range[nRanges];
+    if (rangesLeft.length > 0) {
+      System.arraycopy(rangesLeft, 0, ranges, 0, rangesLeft.length);
+    }
+    if (rangesRight.length > 0) {
+      final int offset = left.length();
+      Ranges.copyShift(rangesRight, ranges, rangesLeft.length, offset);
+    }
+    taintedObjects.taint(result, ranges);
+  }
+
+  private boolean canBeTainted(final String s) {
+    return s != null && !s.isEmpty();
   }
 }

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/IastModuleImpl.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/IastModuleImpl.java
@@ -169,7 +169,7 @@ public final class IastModuleImpl implements IastModule {
     taintedObjects.taint(result, ranges);
   }
 
-  private boolean canBeTainted(final String s) {
+  private static boolean canBeTainted(final String s) {
     return s != null && !s.isEmpty();
   }
 }

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/IastRequestContext.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/IastRequestContext.java
@@ -2,20 +2,26 @@ package com.datadog.iast;
 
 import com.datadog.iast.model.VulnerabilityBatch;
 import com.datadog.iast.overhead.OverheadContext;
+import com.datadog.iast.taint.TaintedObjects;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
 
 public class IastRequestContext {
 
   private final VulnerabilityBatch vulnerabilityBatch;
-
   private final AtomicBoolean spanDataIsSet;
-
+  private final TaintedObjects taintedObjects;
   private final OverheadContext overheadContext;
 
   public IastRequestContext() {
     this.vulnerabilityBatch = new VulnerabilityBatch();
     this.spanDataIsSet = new AtomicBoolean(false);
     this.overheadContext = new OverheadContext();
+    this.taintedObjects = new TaintedObjects();
   }
 
   public VulnerabilityBatch getVulnerabilityBatch() {
@@ -28,5 +34,30 @@ public class IastRequestContext {
 
   public OverheadContext getOverheadContext() {
     return overheadContext;
+  }
+
+  public TaintedObjects getTaintedObjects() {
+    return taintedObjects;
+  }
+
+  @Nullable
+  public static IastRequestContext get() {
+    return get(AgentTracer.activeSpan());
+  }
+
+  @Nullable
+  public static IastRequestContext get(final AgentSpan span) {
+    if (span == null) {
+      return null;
+    }
+    return get(span.getRequestContext());
+  }
+
+  @Nullable
+  public static IastRequestContext get(final RequestContext reqCtx) {
+    if (reqCtx == null) {
+      return null;
+    }
+    return reqCtx.getData(RequestContextSlot.IAST);
   }
 }

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/model/Range.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/model/Range.java
@@ -40,4 +40,15 @@ public final class Range {
   public int hashCode() {
     return Objects.hash(start, length, source);
   }
+
+  public boolean isValid() {
+    return start >= 0 && length >= 0 && source != null;
+  }
+
+  public Range shift(final int offset) {
+    if (offset == 0) {
+      return this;
+    }
+    return new Range(start + offset, length, source);
+  }
 }

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/model/SourceType.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/model/SourceType.java
@@ -10,6 +10,10 @@ public final class SourceType {
   private static final String REQUEST_QUERY_PARAMETER_STRING = "http.url_details.queryString";
   public static final byte REQUEST_PATH = 2;
   private static final String REQUEST_PATH_STRING = "http.url_details.path";
+  public static final byte REQUEST_PARAMETER_NAME = 3;
+  private static final String REQUEST_PARAMETER_NAME_STRING = "http.param.name";
+  public static final byte REQUEST_PARAMETER_VALUE = 4;
+  private static final String REQUEST_PARAMETER_VALUE_STRING = "http.param.value";
 
   public static String toString(final byte sourceType) {
     switch (sourceType) {
@@ -17,6 +21,10 @@ public final class SourceType {
         return REQUEST_QUERY_PARAMETER_STRING;
       case REQUEST_PATH:
         return REQUEST_PATH_STRING;
+      case REQUEST_PARAMETER_NAME:
+        return REQUEST_PARAMETER_NAME_STRING;
+      case REQUEST_PARAMETER_VALUE:
+        return REQUEST_PARAMETER_VALUE_STRING;
       default:
         return null;
     }

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/model/SourceType.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/model/SourceType.java
@@ -7,13 +7,13 @@ public final class SourceType {
   public static final byte NONE = 0;
 
   public static final byte REQUEST_QUERY_PARAMETER = 1;
-  private static final String REQUEST_QUERY_PARAMETER_STRING = "http.url_details.queryString";
+  static final String REQUEST_QUERY_PARAMETER_STRING = "http.url_details.queryString";
   public static final byte REQUEST_PATH = 2;
-  private static final String REQUEST_PATH_STRING = "http.url_details.path";
+  static final String REQUEST_PATH_STRING = "http.url_details.path";
   public static final byte REQUEST_PARAMETER_NAME = 3;
-  private static final String REQUEST_PARAMETER_NAME_STRING = "http.param.name";
+  static final String REQUEST_PARAMETER_NAME_STRING = "http.param.name";
   public static final byte REQUEST_PARAMETER_VALUE = 4;
-  private static final String REQUEST_PARAMETER_VALUE_STRING = "http.param.value";
+  static final String REQUEST_PARAMETER_VALUE_STRING = "http.param.value";
 
   public static String toString(final byte sourceType) {
     switch (sourceType) {

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/taint/DefaultTaintedMap.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/taint/DefaultTaintedMap.java
@@ -172,6 +172,17 @@ public final class DefaultTaintedMap implements TaintedMap {
    * @return Number of removed elements.
    */
   private int remove(final TaintedObject entry) {
+    // A remove might be lost when it is concurrent to puts. If that happens, the object will not be
+    // removed again,
+    // (until the map goes to flat mode). When a remove is lost under concurrency, this method will
+    // still return 1, and
+    // it will still be subtracted from the map size estimate. If this is infrequent enough, this
+    // would lead to a
+    // performance degradation of get opertions. If this happens extremely frequently, like number
+    // of lost removals
+    // close to number of puts, it could prevent the map from ever going into flat mode, and its
+    // size might become
+    // effectively unbound.
     final int index = index(entry.positiveHashCode);
     TaintedObject cur = table[index];
     if (cur == entry) {

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/taint/DefaultTaintedMap.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/taint/DefaultTaintedMap.java
@@ -265,4 +265,9 @@ public final class DefaultTaintedMap implements TaintedMap {
   public Iterator<TaintedObject> iterator() {
     return iterator(0, table.length);
   }
+
+  /** Testing only. */
+  boolean isFlat() {
+    return isFlat;
+  }
 }

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/taint/DefaultTaintedMap.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/taint/DefaultTaintedMap.java
@@ -173,15 +173,11 @@ public final class DefaultTaintedMap implements TaintedMap {
    */
   private int remove(final TaintedObject entry) {
     // A remove might be lost when it is concurrent to puts. If that happens, the object will not be
-    // removed again,
-    // (until the map goes to flat mode). When a remove is lost under concurrency, this method will
-    // still return 1, and
-    // it will still be subtracted from the map size estimate. If this is infrequent enough, this
-    // would lead to a
-    // performance degradation of get opertions. If this happens extremely frequently, like number
-    // of lost removals
-    // close to number of puts, it could prevent the map from ever going into flat mode, and its
-    // size might become
+    // removed again, (until the map goes to flat mode). When a remove is lost under concurrency,
+    // this method will still return 1, and it will still be subtracted from the map size estimate.
+    // If this is infrequent enough, this would lead to a performance degradation of get opertions.
+    // If this happens extremely frequently, like number of lost removals close to number of puts,
+    // it could prevent the map from ever going into flat mode, and its size might become
     // effectively unbound.
     final int index = index(entry.positiveHashCode);
     TaintedObject cur = table[index];

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/taint/DefaultTaintedMap.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/taint/DefaultTaintedMap.java
@@ -1,0 +1,257 @@
+package com.datadog.iast.taint;
+
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Default implementation for {@link TaintedMap}. It is optimized for low concurrency scenarios, but
+ * never fail with high concurrency.
+ *
+ * <p><i>Capacity</i> is fixed, so there is no rehashing. Once it reaches a <i>flat mode
+ * threshold</i>, the table switches to flat mode. In this mode, every new put will be inserted at
+ * the head of the bucket, and any tail (colliding entries) will be discarded. Once a map switches
+ * to flat mode, it never goes back from it. Note that entries for garbage collected entries are
+ * removed before this threshold is checked.
+ *
+ * <p>This implementation works reasonably well under high concurrency, but it will lose some writes
+ * in that case.
+ */
+public final class DefaultTaintedMap implements TaintedMap {
+
+  /** Default capacity. It MUST be a power of 2. */
+  public static final int DEFAULT_CAPACITY = 1 << 14;
+  /** Default flat mode threshold. */
+  public static final int DEFAULT_FLAT_MODE_THRESHOLD = 1 << 13;
+  /** Periodicity of table purges, as number of put operations. It MUST be a power of two. */
+  private static final int PURGE_COUNT = 1 << 6;
+  /** Bitmask for fast modulo with PURGE_COUNT. */
+  private static final int PURGE_MASK = PURGE_COUNT - 1;
+  /** Bitmask to convert hashes to positive integers. */
+  static final int POSITIVE_MASK = Integer.MAX_VALUE;
+
+  private final TaintedObject[] table;
+  /** Bitmask for fast modulo with table length. */
+  private final int lengthMask;
+  /** Flag to ensure we do not run multiple purges concurrently. */
+  private final AtomicBoolean isPurging = new AtomicBoolean(false);
+  /**
+   * Estimated number of hash table entries. If the hash table switches to flat mode, it stops
+   * counting elements.
+   */
+  private final AtomicInteger estimatedSize = new AtomicInteger(0);
+  /** Reference queue for garbage-collected entries. */
+  private final ReferenceQueue<Object> referenceQueue = new ReferenceQueue<>();
+  /**
+   * Whether flat mode is enabled or not. Once this is true, it is not set to false again unless
+   * {@link #clear()} is called.
+   */
+  private boolean isFlat = false;
+  /** Number of elements in the hash table before switching to flat mode. */
+  private final int flatModeThreshold;
+
+  /**
+   * Default constructor. Uses {@link #DEFAULT_CAPACITY} and {@link #DEFAULT_FLAT_MODE_THRESHOLD}.
+   */
+  public DefaultTaintedMap() {
+    this(DEFAULT_CAPACITY, DEFAULT_FLAT_MODE_THRESHOLD);
+  }
+
+  /**
+   * Create a new hash map with the given capacity and flat mode threshold.
+   *
+   * @param capacity Capacity of the internal array. It must be a power of 2.
+   * @param flatModeThreshold Limit of entries before switching to flat mode.
+   */
+  @SuppressWarnings("unchecked")
+  private DefaultTaintedMap(final int capacity, final int flatModeThreshold) {
+    table = new TaintedObject[capacity];
+    lengthMask = table.length - 1;
+    this.flatModeThreshold = flatModeThreshold;
+  }
+
+  /**
+   * Returns the {@link TaintedObject} for the given input object.
+   *
+   * @param key Key object.
+   * @return The {@link TaintedObject} if it exists, {@code null} otherwise.
+   */
+  @Override
+  @Nullable
+  public TaintedObject get(final @Nonnull Object key) {
+    final int index = indexObject(key);
+    TaintedObject entry = table[index];
+    while (entry != null) {
+      if (key == entry.get()) {
+        return entry;
+      }
+      entry = entry.next;
+    }
+    return null;
+  }
+
+  /**
+   * Put a new {@link TaintedObject} in the hash table.
+   *
+   * @param entry Tainted object.
+   */
+  @Override
+  public void put(final @Nonnull TaintedObject entry) {
+    final int index = index(entry.positiveHashCode);
+    if (isFlat) {
+      // If we flipped to flat mode:
+      // - Always override elements ignoring chaining.
+      // - Stop updating the estimated size.
+
+      // TODO: Fix the pathological case where all puts have the same identityHashCode (e.g. limit
+      // chain length?)
+      table[index] = entry;
+      if ((entry.positiveHashCode & PURGE_MASK) == 0) {
+        purge();
+      }
+    } else {
+      // By default, add the new entry to the head of the chain.
+      // We do not control duplicate keys (although we expect they are generally not used).
+      entry.next = table[index];
+      table[index] = entry;
+      if ((entry.positiveHashCode & PURGE_MASK) == 0) {
+        // To mitigate the cost of maintaining an atomic counter, we only update the size every
+        // <PURGE_COUNT> puts. This is just an approximation, we rely on key's identity hash code as
+        // if it was a random number generator, and we assume duplicate keys are rarely inserted.
+        estimatedSize.addAndGet(PURGE_COUNT);
+        purge();
+      }
+    }
+  }
+
+  /**
+   * Purge entries that have been garbage collected. Only one concurrent call to this method is
+   * allowed, further concurrent calls will be ignored.
+   */
+  void purge() {
+    // Ensure we enter only once concurrently.
+    if (!isPurging.compareAndSet(false, true)) {
+      return;
+    }
+
+    // Remove GC'd entries.
+    Reference<?> ref;
+    int removedCount = 0;
+    while ((ref = referenceQueue.poll()) != null) {
+      // This would be an extremely rare bug, and maybe it should produce a health metric or
+      // warning.
+      if (!(ref instanceof TaintedObject)) {
+        continue;
+      }
+      final TaintedObject entry = (TaintedObject) ref;
+      removedCount += remove(entry);
+    }
+
+    if (estimatedSize.addAndGet(-removedCount) > flatModeThreshold) {
+      isFlat = true;
+    }
+
+    // Reset purging flag.
+    isPurging.set(false);
+  }
+
+  /**
+   * Removes a {@link TaintedObject} from the hash table.
+   *
+   * @param entry
+   * @return Number of removed elements.
+   */
+  private int remove(final TaintedObject entry) {
+    final int index = index(entry.positiveHashCode);
+    TaintedObject cur = table[index];
+    if (cur == entry) {
+      table[index] = cur.next;
+      return 1;
+    }
+    if (cur == null) {
+      return 0;
+    }
+    for (TaintedObject prev = cur.next; cur != null; prev = cur, cur = cur.next) {
+      if (cur == entry) {
+        prev.next = cur.next;
+        return 1;
+      }
+    }
+    // If we reach this point, the entry was already removed or put was lost.
+    return 0;
+  }
+
+  @Override
+  public void clear() {
+    while (referenceQueue.poll() != null) {}
+    isFlat = false;
+    estimatedSize.set(0);
+    Arrays.fill(table, null);
+  }
+
+  @Override
+  public ReferenceQueue<Object> getReferenceQueue() {
+    return referenceQueue;
+  }
+
+  private int indexObject(final Object obj) {
+    return index(positiveHashCode(System.identityHashCode(obj)));
+  }
+
+  private int positiveHashCode(final int h) {
+    return h & POSITIVE_MASK;
+  }
+
+  private int index(int h) {
+    return h & lengthMask;
+  }
+
+  private Iterator<TaintedObject> iterator(final int start, final int stop) {
+    return new Iterator<TaintedObject>() {
+      int currentIndex = start;
+      TaintedObject currentSubPos;
+
+      @Override
+      public boolean hasNext() {
+        if (currentSubPos != null) {
+          return true;
+        }
+        for (; currentIndex < stop; currentIndex++) {
+          if (table[currentIndex] != null) {
+            return true;
+          }
+        }
+        return false;
+      }
+
+      @Override
+      public TaintedObject next() {
+        if (currentSubPos != null) {
+          TaintedObject toReturn = currentSubPos;
+          currentSubPos = toReturn.next;
+          return toReturn;
+        }
+        for (; currentIndex < stop; currentIndex++) {
+          final TaintedObject entry = table[currentIndex];
+          if (entry != null) {
+            currentSubPos = entry.next;
+            currentIndex++;
+            return entry;
+          }
+        }
+        throw new NoSuchElementException();
+      }
+    };
+  }
+
+  @Override
+  public Iterator<TaintedObject> iterator() {
+    return iterator(0, table.length);
+  }
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/taint/DefaultTaintedMap.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/taint/DefaultTaintedMap.java
@@ -97,7 +97,8 @@ public final class DefaultTaintedMap implements TaintedMap {
   }
 
   /**
-   * Put a new {@link TaintedObject} in the hash table.
+   * Put a new {@link TaintedObject} in the hash table. This method will lose puts in concurrent
+   * scenarios.
    *
    * @param entry Tainted object.
    */
@@ -164,7 +165,8 @@ public final class DefaultTaintedMap implements TaintedMap {
   }
 
   /**
-   * Removes a {@link TaintedObject} from the hash table.
+   * Removes a {@link TaintedObject} from the hash table. This method will lose puts in concurrent
+   * scenarios.
    *
    * @param entry
    * @return Number of removed elements.

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/taint/Ranges.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/taint/Ranges.java
@@ -1,0 +1,24 @@
+package com.datadog.iast.taint;
+
+import com.datadog.iast.model.Range;
+import com.datadog.iast.model.Source;
+import javax.annotation.Nonnull;
+
+/** Utilities to work with {@link Range} instances. */
+public final class Ranges {
+
+  public static final Range[] EMPTY = new Range[0];
+
+  private Ranges() {}
+
+  public static Range[] forString(final @Nonnull String obj, final @Nonnull Source source) {
+    return new Range[] {new Range(0, obj.length(), source)};
+  }
+
+  public static void copyShift(
+      final @Nonnull Range[] src, final @Nonnull Range[] dst, final int dstPos, final int shift) {
+    for (int iSrc = 0, iDst = dstPos; iSrc < src.length; iSrc++, iDst++) {
+      dst[iDst] = src[iSrc].shift(shift);
+    }
+  }
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/taint/TaintedMap.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/taint/TaintedMap.java
@@ -1,0 +1,30 @@
+package com.datadog.iast.taint;
+
+import java.lang.ref.ReferenceQueue;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Interface for maps optimized for taint tracking workflows.
+ *
+ * <p>This is intentionally a smaller API compared to {@link java.util.Map}. It is a hardcoded
+ * interface for {@link TaintedObject} entries, which can be used themselves directly as hash table
+ * entries and weak references.
+ *
+ * <p>Any implementation is subject to the following characteristics:
+ * <li>Keys MUST be compared with identity.
+ * <li>Entries SHOULD be removed when key objects are garbage-collected.
+ * <li>All operations MUST NOT throw, even with concurrent access and modification.
+ * <li>Put operations MAY be lost under concurrent modification.
+ */
+public interface TaintedMap extends Iterable<TaintedObject> {
+
+  void put(@Nonnull TaintedObject to);
+
+  @Nullable
+  TaintedObject get(@Nonnull Object key);
+
+  void clear();
+
+  ReferenceQueue<Object> getReferenceQueue();
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/taint/TaintedObject.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/taint/TaintedObject.java
@@ -1,0 +1,33 @@
+package com.datadog.iast.taint;
+
+import static com.datadog.iast.taint.DefaultTaintedMap.POSITIVE_MASK;
+
+import com.datadog.iast.model.Range;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class TaintedObject extends WeakReference<Object> {
+  final int positiveHashCode;
+  TaintedObject next;
+  private final Range[] ranges;
+
+  public TaintedObject(
+      final @Nonnull Object obj,
+      final @Nonnull Range[] ranges,
+      final @Nullable ReferenceQueue<Object> queue) {
+    super(obj, queue);
+    this.positiveHashCode = System.identityHashCode(obj) & POSITIVE_MASK;
+    this.ranges = ranges;
+  }
+
+  /**
+   * Get ranges. The array or its elements MUST NOT be mutated. This may be reused in multiple
+   * instances.
+   */
+  @Nonnull
+  public Range[] getRanges() {
+    return ranges;
+  }
+}

--- a/dd-java-agent/iast/src/main/java/com/datadog/iast/taint/TaintedObjects.java
+++ b/dd-java-agent/iast/src/main/java/com/datadog/iast/taint/TaintedObjects.java
@@ -1,0 +1,30 @@
+package com.datadog.iast.taint;
+
+import com.datadog.iast.model.Range;
+import com.datadog.iast.model.Source;
+import javax.annotation.Nonnull;
+
+public class TaintedObjects {
+
+  private final TaintedMap map;
+
+  public TaintedObjects() {
+    this(new DefaultTaintedMap());
+  }
+
+  public TaintedObjects(final @Nonnull TaintedMap map) {
+    this.map = map;
+  }
+
+  public void taintInputString(final @Nonnull String obj, final @Nonnull Source source) {
+    map.put(new TaintedObject(obj, Ranges.forString(obj, source), map.getReferenceQueue()));
+  }
+
+  public void taint(final @Nonnull Object obj, final @Nonnull Range[] ranges) {
+    map.put(new TaintedObject(obj, ranges, map.getReferenceQueue()));
+  }
+
+  public TaintedObject get(final @Nonnull Object obj) {
+    return map.get(obj);
+  }
+}

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/IastModuleImplOnConcatTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/IastModuleImplOnConcatTest.groovy
@@ -1,0 +1,97 @@
+package com.datadog.iast
+
+import datadog.trace.api.gateway.RequestContext
+import datadog.trace.api.gateway.RequestContextSlot
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+
+import static com.datadog.iast.taint.TaintUtils.*
+
+class IastModuleImplOnConcatTest extends IastModuleImplTestBase {
+
+  def objectHolder = new ArrayList()
+
+  void 'onConcat null or empty'() {
+    given:
+    final result = left + right
+
+    when:
+    module.onConcat(left, right, result)
+
+    then:
+    0 * _
+
+    where:
+    left | right
+    ""   | null
+    null | ""
+    ""   | ""
+  }
+
+  void 'onConcat without span'() {
+    given:
+    final result = left + right
+
+    when:
+    module.onConcat(left, right, result)
+
+    then:
+    1 * tracer.activeSpan() >> null
+    0 * _
+
+    where:
+    left | right
+    "1"  | null
+    null | "2"
+    "3"  | "4"
+  }
+
+  void 'onConcat'() {
+    given:
+    final span = Mock(AgentSpan)
+    tracer.activeSpan() >> span
+    final reqCtx = Mock(RequestContext)
+    span.getRequestContext() >> reqCtx
+    final ctx = new IastRequestContext()
+    reqCtx.getData(RequestContextSlot.IAST) >> ctx
+
+    and:
+    final taintedObjects = ctx.getTaintedObjects()
+    left = addFromTaintFormat(taintedObjects, left)
+    objectHolder.add(left)
+    right = addFromTaintFormat(taintedObjects, right)
+    objectHolder.add(right)
+
+    and:
+    final result = getStringFromTaintFormat(expected)
+    objectHolder.add(result)
+    final shouldBeTainted = fromTaintFormat(expected) != null
+
+    when:
+    module.onConcat(left, right, result)
+
+    then:
+    1 * tracer.activeSpan() >> span
+    1 * span.getRequestContext() >> reqCtx
+    1 * reqCtx.getData(RequestContextSlot.IAST) >> ctx
+    0 * _
+    def to = ctx.getTaintedObjects().get(result)
+    if (shouldBeTainted) {
+      assert to != null
+      assert to.get() == result
+      assert taintFormat(to.get() as String, to.getRanges()) == expected
+    } else {
+      assert to == null
+    }
+
+    where:
+    left        | right       | expected
+    "123"       | null        | "123null"
+    null        | "123"       | "null123"
+    "123"       | "456"       | "123456"
+    "==>123<==" | null        | "==>123<==null"
+    null        | "==>123<==" | "null==>123<=="
+    "==>123<==" | "456"       | "==>123<==456"
+    "123"       | "==>456<==" | "123==>456<=="
+    "==>123<==" | "==>456<==" | "==>123<====>456<=="
+  }
+}

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/IastModuleImplOnParameterNameTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/IastModuleImplOnParameterNameTest.groovy
@@ -1,0 +1,66 @@
+package com.datadog.iast
+
+import com.datadog.iast.model.Source
+import com.datadog.iast.model.SourceType
+import datadog.trace.api.gateway.RequestContext
+import datadog.trace.api.gateway.RequestContextSlot
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+
+class IastModuleImplOnParameterNameTest extends IastModuleImplTestBase {
+
+  void 'onParameterName null or empty'() {
+    when:
+    module.onParameterName(paramName)
+
+    then:
+    0 * _
+
+    where:
+    paramName | _
+    null      | _
+    ""        | _
+  }
+
+  void 'onParameterName without span'() {
+    when:
+    module.onParameterName(paramName)
+
+    then:
+    1 * tracer.activeSpan() >> null
+    0 * _
+
+    where:
+    paramName | _
+    "param"   | _
+  }
+
+  void 'onParameterName'() {
+    given:
+    final span = Mock(AgentSpan)
+    tracer.activeSpan() >> span
+    final reqCtx = Mock(RequestContext)
+    span.getRequestContext() >> reqCtx
+    final ctx = new IastRequestContext()
+    reqCtx.getData(RequestContextSlot.IAST) >> ctx
+
+    when:
+    module.onParameterName(paramName)
+
+    then:
+    1 * tracer.activeSpan() >> span
+    1 * span.getRequestContext() >> reqCtx
+    1 * reqCtx.getData(RequestContextSlot.IAST) >> ctx
+    0 * _
+    def to = ctx.getTaintedObjects().get(paramName)
+    to != null
+    to.get() == paramName
+    to.ranges.size() == 1
+    to.ranges[0].start == 0
+    to.ranges[0].length == paramName.length()
+    to.ranges[0].source == new Source(SourceType.REQUEST_PARAMETER_NAME, paramName, null)
+
+    where:
+    paramName | _
+    "param"   | _
+  }
+}

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/IastModuleImplOnParameterValueTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/IastModuleImplOnParameterValueTest.groovy
@@ -1,0 +1,75 @@
+package com.datadog.iast
+
+import com.datadog.iast.model.Source
+import com.datadog.iast.model.SourceType
+import datadog.trace.api.gateway.RequestContext
+import datadog.trace.api.gateway.RequestContextSlot
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+
+class IastModuleImplOnParameterValueTest extends IastModuleImplTestBase {
+
+  void 'onParameterValue null or empty'() {
+    when:
+    module.onParameterValue(paramName, paramValue)
+
+    then:
+    0 * _
+
+    where:
+    paramName | paramValue
+    null      | null
+    null      | ""
+    ""        | null
+    ""        | ""
+    "param"   | null
+    "param"   | ""
+  }
+
+  void 'onParameterValue without span'() {
+    when:
+    module.onParameterValue(paramName, paramValue)
+
+    then:
+    1 * tracer.activeSpan() >> null
+    0 * _
+
+    where:
+    paramName | paramValue
+    null      | "value"
+    ""        | "value"
+    "param"   | "value"
+  }
+
+  void 'onParameterValue'() {
+    given:
+    final span = Mock(AgentSpan)
+    tracer.activeSpan() >> span
+    final reqCtx = Mock(RequestContext)
+    span.getRequestContext() >> reqCtx
+    final ctx = new IastRequestContext()
+    reqCtx.getData(RequestContextSlot.IAST) >> ctx
+
+    when:
+    module.onParameterValue(paramName, paramValue)
+
+    then:
+    1 * tracer.activeSpan() >> span
+    1 * span.getRequestContext() >> reqCtx
+    1 * reqCtx.getData(RequestContextSlot.IAST) >> ctx
+    0 * _
+    ctx.getTaintedObjects().get(paramName) == null
+    def to = ctx.getTaintedObjects().get(paramValue)
+    to != null
+    to.get() == paramValue
+    to.ranges.size() == 1
+    to.ranges[0].start == 0
+    to.ranges[0].length == paramValue.length()
+    to.ranges[0].source == new Source(SourceType.REQUEST_PARAMETER_VALUE, paramName, paramValue)
+
+    where:
+    paramName | paramValue
+    null      | "value"
+    ""        | "value"
+    "param"   | "value"
+  }
+}

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/model/RangeTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/model/RangeTest.groovy
@@ -1,0 +1,43 @@
+package com.datadog.iast.model
+
+import datadog.trace.test.util.DDSpecification
+
+class RangeTest extends DDSpecification {
+
+  def 'shift'() {
+    given:
+    final source = new Source(SourceType.NONE, null, null)
+    final orig = new Range(start, length, source)
+
+    when:
+    final result = orig.shift(shift)
+
+    then:
+    result != null
+    result.source == source
+    result.start == startResult
+    result.length == lengthResult
+    result.isValid() == valid
+
+    where:
+    start | length | shift | startResult | lengthResult | valid
+    0     | 1      | 0     | 0           | 1            | true
+    0     | 1      | 1     | 1           | 1            | true
+    0     | 1      | -1    | -1          | 1            | false
+    1     | 1      | 0     | 1           | 1            | true
+    1     | 1      | 1     | 2           | 1            | true
+    1     | 1      | -1    | 0           | 1            | true
+  }
+
+  def 'shift zero'() {
+    given:
+    final source = new Source(SourceType.NONE, null, null)
+    final orig = new Range(0, 1, source)
+
+    when:
+    final result = orig.shift(0)
+
+    then:
+    result.is(orig)
+  }
+}

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/model/SourceTypeTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/model/SourceTypeTest.groovy
@@ -1,0 +1,22 @@
+package com.datadog.iast.model
+
+import datadog.trace.test.util.DDSpecification
+
+class SourceTypeTest extends DDSpecification {
+
+  def 'test toString'() {
+    when:
+    final s = SourceType.toString(input)
+
+    then:
+    s == output
+
+    where:
+    input                              | output
+    SourceType.NONE                    | null
+    SourceType.REQUEST_PARAMETER_VALUE | SourceType.REQUEST_PARAMETER_VALUE_STRING
+    SourceType.REQUEST_PARAMETER_NAME  | SourceType.REQUEST_PARAMETER_NAME_STRING
+    SourceType.REQUEST_PATH            | SourceType.REQUEST_PATH_STRING
+    SourceType.REQUEST_QUERY_PARAMETER | SourceType.REQUEST_QUERY_PARAMETER_STRING
+  }
+}

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/taint/HashCodeTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/taint/HashCodeTest.groovy
@@ -1,0 +1,58 @@
+package com.datadog.iast.taint
+
+import datadog.trace.test.util.DDSpecification
+import spock.lang.IgnoreIf
+import spock.lang.Shared
+
+/**
+ * Test our assumptions about identity hash codes in tested JVMs.
+ */
+class HashCodeTest extends DDSpecification {
+
+  @Shared
+  private static final int N_HASHES = 1 << 16
+
+  @Shared
+  private static final List<Integer> HASH_CODES = genHashCodes(N_HASHES)
+
+  @IgnoreIf({ !System.getProperty("java.vm.name").contains("OpenJDK") })
+  def 'Identity hash codes are always positive in OpenJDK'() {
+    expect:
+    HASH_CODES.every {
+      it > 0
+    }
+  }
+
+  @IgnoreIf({ !System.getProperty("java.vm.name").contains("OpenJ9") })
+  def 'Identity hash can be negative on OpenJ9'() {
+    expect:
+    HASH_CODES.any {
+      it < 0
+    }
+  }
+
+  def 'Identity hash codes are uniformly distributed'() {
+    setup:
+    final nBuckets = 64
+    final expectedPerBucket = N_HASHES / nBuckets
+
+    when:
+    final positiveHashCodes = HASH_CODES.collect {
+      it & Integer.MAX_VALUE
+    }
+    final buckets = positiveHashCodes.groupBy { it % nBuckets }
+    final nPerBucket = buckets.collect { it.getValue().size() }
+
+    then:
+    nPerBucket.each {
+      assert it <= expectedPerBucket * 1.1
+      assert it >= expectedPerBucket * 0.9
+    }
+  }
+
+  private static List<Integer> genHashCodes(final int n) {
+    (1..n).collect {
+      System.identityHashCode(Double.toString(Math.random()))
+    }
+  }
+}

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/taint/RangesTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/taint/RangesTest.groovy
@@ -1,0 +1,77 @@
+package com.datadog.iast.taint
+
+import com.datadog.iast.model.Range
+import com.datadog.iast.model.Source
+import com.datadog.iast.model.SourceType
+import datadog.trace.test.util.DDSpecification
+
+class RangesTest extends DDSpecification {
+
+  def 'forString'() {
+    given:
+    final source = new Source(SourceType.NONE, null, null)
+
+    when:
+    final result = Ranges.forString(s, source)
+
+    then:
+    result != null
+    result.length == 1
+    result[0].start == 0
+    result[0].length == s.length()
+    result[0].source == source
+
+    where:
+    s    | _
+    ""   | _
+    "x"  | _
+    "xx" | _
+  }
+
+  def 'copyShift'() {
+    given:
+    def src = rangesFromSpec(srcSpec)
+    def dst = new Range[dstLen] as Range[]
+    def exp = rangesFromSpec(expSpec)
+
+    when:
+    Ranges.copyShift(src, dst, dstPos, shift)
+
+    then:
+    dst == exp
+
+    where:
+    dstPos | dstLen | shift | srcSpec  | expSpec
+    0      | 0      | 0     | []       | []
+    0      | 0      | 1     | []       | []
+    0      | 0      | -1    | []       | []
+    0      | 1      | 0     | []       | [null]
+    0      | 1      | 1     | []       | [null]
+    0      | 1      | -1    | []       | [null]
+    0      | 1      | 0     | [[1, 1]] | [[1, 1]]
+    0      | 1      | 1     | [[1, 1]] | [[2, 1]]
+    0      | 1      | -1    | [[1, 1]] | [[0, 1]]
+    0      | 2      | 0     | [[1, 1]] | [[1, 1], null]
+    0      | 2      | 1     | [[1, 1]] | [[2, 1], null]
+    0      | 2      | -1    | [[1, 1]] | [[0, 1], null]
+    1      | 2      | 0     | [[1, 1]] | [null, [1, 1]]
+    1      | 2      | 1     | [[1, 1]] | [null, [2, 1]]
+    1      | 2      | -1    | [[1, 1]] | [null, [0, 1]]
+  }
+
+  Range[] rangesFromSpec(List<List<Object>> spec) {
+    def ranges = new Range[spec.size()]
+    int j = 0
+    for (int i = 0; i < spec.size(); i++) {
+      if (spec[i] == null) {
+        continue
+      }
+      ranges[i] = new Range(
+        spec[i][0] as int,
+        spec[i][1] as int,
+        new Source(SourceType.NONE, String.valueOf(j), null))
+      j++
+    }
+    ranges
+  }
+}

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/taint/TaintUtils.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/taint/TaintUtils.groovy
@@ -1,0 +1,93 @@
+package com.datadog.iast.taint
+
+import com.datadog.iast.model.Range
+import com.datadog.iast.model.Source
+import com.datadog.iast.model.SourceType
+
+class TaintUtils {
+
+  static final String OPEN_MARK = "==>"
+
+  static final String CLOSE_MARK = "<=="
+
+  static String taintFormat(final String s, final Range[] ranges) {
+    if (ranges == null || ranges.length == 0) {
+      return s
+    }
+    if (s == null || s.isEmpty()) {
+      return s
+    }
+    int pos = 0
+    String res = ""
+    for (int i = 0; i < ranges.length; i++) {
+      final Range cur = ranges[i]
+      if (cur.start > pos) {
+        res += s[pos..cur.start - 1]
+        pos = cur.start
+      }
+      res += OPEN_MARK
+      res += s[cur.start..cur.start + cur.length - 1]
+      res += CLOSE_MARK
+      pos = cur.start + cur.length
+    }
+    if (pos < s.length()) {
+      res += s[pos..s.length()-1]
+    }
+    res
+  }
+
+  static Range[] fromTaintFormat(final String s) {
+    if (s == null || s.isEmpty()) {
+      return null
+    }
+    def ranges = new ArrayList<Range>()
+    int pos = 0
+    for (int i = 0; i < s.length(); i++) {
+      if (s.startsWith(OPEN_MARK, i)) {
+        int upTo = s.indexOf(CLOSE_MARK, i + OPEN_MARK.length())
+        assert upTo > i + OPEN_MARK.length()
+        int start = pos
+        int length = (upTo - i) - OPEN_MARK.length()
+        assert length >= 0
+        ranges.add(new Range(start, length, new Source(SourceType.NONE, null, null)))
+        pos += length
+        i += OPEN_MARK.length() + length + CLOSE_MARK.length() - 1
+      } else {
+        pos++
+      }
+    }
+    return (ranges.size() == 0)? null : ranges as Range[]
+  }
+
+  static String getStringFromTaintFormat(final String s) {
+    if (s == null) {
+      return null
+    }
+    new String(s.replace(OPEN_MARK, "").replace(CLOSE_MARK, ""))
+  }
+
+  static String addFromTaintFormat(final TaintedObjects tos, final String s) {
+    final ranges = fromTaintFormat(s)
+    if (ranges == null || ranges.length == 0) {
+      return s
+    }
+    final resultString = getStringFromTaintFormat(s)
+    tos.taint(resultString, ranges)
+    return resultString
+  }
+
+  static Range toRange(List<Integer> lst) {
+    toRange(lst.get(0), lst.get(1))
+  }
+
+  static Range toRange(int start, int length) {
+    new Range(start, length, new Source(SourceType.NONE, null, null))
+  }
+
+  static Range[] toRanges(List<List<Integer>> lst) {
+    if (lst == null) {
+      return null
+    }
+    lst.collect { toRange(it) } as Range[]
+  }
+}

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/taint/TaintUtilsTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/taint/TaintUtilsTest.groovy
@@ -1,0 +1,36 @@
+package com.datadog.iast.taint
+
+import spock.lang.Specification
+import static com.datadog.iast.taint.TaintUtils.*
+
+class TaintUtilsTest extends Specification {
+
+  void 'taintFormat with empty ranges'() {
+    expect:
+    taintFormat(s, toRanges(ranges)) == result
+
+    where:
+    s     | ranges | result
+    "123" | []     | "123"
+  }
+
+  void 'taintFormat amd fromTaintFormat'() {
+    expect:
+    taintFormat(s, toRanges(ranges)) == result
+
+    and:
+    fromTaintFormat(result) == toRanges(ranges)
+
+    where:
+    s     | ranges                   | result
+    null  | null                     | null
+    ""    | null                     | ""
+    "123" | null                     | "123"
+    "123" | [[0, 1]]                 | "==>1<==23"
+    "123" | [[0, 2]]                 | "==>12<==3"
+    "123" | [[0, 3]]                 | "==>123<=="
+    "123" | [[1, 1]]                 | "1==>2<==3"
+    "123" | [[1, 2]]                 | "1==>23<=="
+    "123" | [[0, 1], [1, 1], [2, 1]] | "==>1<====>2<====>3<=="
+  }
+}

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/taint/TaintedMapTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/taint/TaintedMapTest.groovy
@@ -1,0 +1,203 @@
+package com.datadog.iast.taint
+
+import com.datadog.iast.model.Range
+import datadog.trace.test.util.CircularBuffer
+import datadog.trace.test.util.DDSpecification
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+
+class TaintedMapTest extends DDSpecification {
+
+  def 'simple workflow'() {
+    given:
+    def map = new DefaultTaintedMap()
+    final o = new Object()
+    final to = new TaintedObject(o, [] as Range[], map.getReferenceQueue())
+
+    expect:
+    map.size() == 0
+    map.toList().size() == 0
+
+    when:
+    map.put(to)
+
+    then:
+    map.toList().size() == 1
+
+    and:
+    map.get(o) != null
+    map.get(o).get() == o
+
+    when:
+    map.clear()
+
+    then:
+    map.toList().size() == 0
+  }
+
+  def 'last put always exists'() {
+    given:
+    int nTotalObjects = DefaultTaintedMap.DEFAULT_CAPACITY
+    def map = new DefaultTaintedMap()
+
+    expect:
+    (1..nTotalObjects).each { i ->
+      final o = new Object()
+      final to = new TaintedObject(o, [] as Range[], map.getReferenceQueue())
+      map.put(to)
+      assert map.get(o) == to
+    }
+  }
+
+  def 'single-threaded put-intensive workflow without garbage collection interaction and under max size'() {
+    given:
+    int nTotalObjects = 1024
+    int nRetainedObjects = 1024
+    def map = new DefaultTaintedMap()
+    def objectBuffer = new CircularBuffer<Tuple2<Object, TaintedObject>>(nRetainedObjects)
+
+    when: 'perform puts'
+    (1..nTotalObjects).each { i ->
+      final o = new Object()
+      final to = new TaintedObject(o, [] as Range[], map.getReferenceQueue())
+      objectBuffer.add(new Tuple2(o, to))
+      map.put(to)
+    }
+
+    then: 'map contains exact amount of objects'
+    map.toList().size() == nTotalObjects
+
+    and: 'all objects are as expected'
+    objectBuffer.each {
+      assert map.get(it.get(0)) == it.get(1)
+    }
+  }
+
+  def 'single-threaded put-intensive workflow with garbage collection interaction and under max size'() {
+    given:
+    int nTotalObjects = 1024 * 2
+    int nRetainedObjects = 1024
+    def map = new DefaultTaintedMap()
+    def objectBuffer = new CircularBuffer<Tuple2<Object, TaintedObject>>(nRetainedObjects)
+
+    when: 'perform puts'
+    (1..nTotalObjects).each { i ->
+      final o = new Object()
+      final to = new TaintedObject(o, [] as Range[], map.getReferenceQueue())
+      objectBuffer.add(new Tuple2(o, to))
+      map.put(to)
+    }
+
+    then: 'map contains exact amount of objects'
+    map.toList().size() == nTotalObjects
+
+    and: 'all objects are as expected'
+    objectBuffer.each {
+      assert map.get(it.get(0)) == it.get(1)
+    }
+  }
+
+  def 'single-threaded put-intensive workflow without garbage collection interaction and over max size'() {
+    given:
+    int nTotalObjects = DefaultTaintedMap.DEFAULT_FLAT_MODE_THRESHOLD * 4
+    int nRetainedObjects = nTotalObjects
+    def map = new DefaultTaintedMap()
+    def objectBuffer = new CircularBuffer<Tuple2<Object, TaintedObject>>(nRetainedObjects)
+
+    when: 'perform puts'
+    (1..nTotalObjects).each { i ->
+      final o = new Object()
+      final to = new TaintedObject(o, [] as Range[], map.getReferenceQueue())
+      objectBuffer.add(new Tuple2(o, to))
+      map.put(to)
+    }
+
+    then: 'map contains enough objects'
+    map.toList().size() >= DefaultTaintedMap.DEFAULT_FLAT_MODE_THRESHOLD * 0.9
+
+    and: 'all objects are as expected'
+    int presentObjects = objectBuffer.count {
+      map.get(it.get(0)) == it.get(1)
+    }
+    presentObjects >= DefaultTaintedMap.DEFAULT_FLAT_MODE_THRESHOLD * 0.9
+  }
+
+  def 'single-threaded put-intensive workflow with garbage collection interaction and over max size'() {
+    given:
+    int nTotalObjects = DefaultTaintedMap.DEFAULT_FLAT_MODE_THRESHOLD * 4
+    int nRetainedObjects = 1024
+    def map = new DefaultTaintedMap()
+    def objectBuffer = new CircularBuffer<Tuple2<Object, Object>>(nRetainedObjects)
+
+    when: 'perform puts'
+    (1..nTotalObjects).each { i ->
+      final o = new Object()
+      final to = new TaintedObject(o, [] as Range[], map.getReferenceQueue())
+      objectBuffer.add(new Tuple2(o, to))
+      map.put(to)
+    }
+
+    then: 'map contains enough objects'
+    map.toList().size() >= DefaultTaintedMap.DEFAULT_FLAT_MODE_THRESHOLD * 0.6
+
+    and: 'all objects are as expected'
+    // FIXME: This might need improvement, we remove too many new objects.
+    int presentObjects = objectBuffer.count {
+      map.get(it.get(0)) == it.get(1)
+    }
+    presentObjects >= nRetainedObjects * 0.9
+  }
+
+  def 'multi-threaded put-intensive workflow without garbage collection interaction and under max size'() {
+    given:
+    int maxAcceptableLoss = 100
+    int nThreads = 32
+    int nObjectsPerThread = (int) Math.floor((DefaultTaintedMap.DEFAULT_FLAT_MODE_THRESHOLD - 4096) / nThreads)
+    int nTotalObjects = nThreads * nObjectsPerThread
+    def executorService = Executors.newFixedThreadPool(nThreads)
+    def startLatch = new CountDownLatch(nThreads)
+    def map = new DefaultTaintedMap()
+
+    // Holder to avoid objects being garbage collected
+    def objectHolder = new ConcurrentHashMap<Object, TaintedObject>()
+
+    when: 'perform a high amount of concurrent puts'
+    def futures = (1..nThreads).collect { thread ->
+      executorService.submit({
+        ->
+        final tuples = new ArrayList<Tuple2<Object, TaintedObject>>(nObjectsPerThread)
+        for (int i = 1; i <= nObjectsPerThread; i++) {
+          final o = new Object()
+          final to = new TaintedObject(o, [] as Range[], map.getReferenceQueue())
+          tuples.add(new Tuple2<Object, TaintedObject>(o, to))
+          objectHolder.put(o, to)
+        }
+        startLatch.countDown()
+        startLatch.await()
+        tuples.each { map.put(it.get(1)) }
+      } as Runnable)
+    }
+    futures.collect({
+      it.get()
+    })
+
+    then: 'map does not contain extra objects'
+    map.toList().size() <= nTotalObjects
+
+    and: 'map did not lose too many objects'
+    map.toList().size() >= nTotalObjects - maxAcceptableLoss
+
+    and: 'sanity check'
+    objectHolder.size() == nTotalObjects
+
+    and: 'all objects are as expected'
+    objectHolder.count {
+      map.get(it.getKey()) == it.getValue()
+    } >= nTotalObjects - maxAcceptableLoss
+
+    cleanup:
+    executorService?.shutdown()
+  }
+}

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/taint/TaintedMapTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/taint/TaintedMapTest.groovy
@@ -247,7 +247,6 @@ class TaintedMapTest extends DDSpecification {
     int nThreads = 32
     int nObjectsPerThread = (int) Math.floor((DefaultTaintedMap.DEFAULT_FLAT_MODE_THRESHOLD - 4096) / nThreads)
     int nRetainedObjectsPerThread = 16
-    int nTotalObjects = nThreads * nObjectsPerThread
     def executorService = Executors.newFixedThreadPool(nThreads)
     def startLatch = new CountDownLatch(nThreads)
     def map = new DefaultTaintedMap()

--- a/dd-java-agent/iast/src/test/groovy/com/datadog/iast/taint/TaintedMapTest.groovy
+++ b/dd-java-agent/iast/src/test/groovy/com/datadog/iast/taint/TaintedMapTest.groovy
@@ -328,7 +328,7 @@ class TaintedMapTest extends DDSpecification {
     and: 'all objects are as expected'
     for (final CircularBuffer<Object> objectHolder : objectHolders) {
       assert objectHolder.count {
-        map.get(it).get() == it
+        map.get(it) != null && map.get(it).get() == it
       } >= nRetainedObjectsPerThread * maxAcceptableLossPerThread
     }
 

--- a/internal-api/src/main/java/datadog/trace/api/iast/IastModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/IastModule.java
@@ -1,10 +1,25 @@
 package datadog.trace.api.iast;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public interface IastModule {
 
   void onCipherAlgorithm(@Nonnull String algorithm);
 
   void onHashingAlgorithm(@Nonnull String algorithm);
+
+  /**
+   * An HTTP request parameter name is used. This should be used when it cannot be determined
+   * whether the parameter comes in the query string or body (e.g. servlet's getParameter).
+   */
+  void onParameterName(@Nullable String paramName);
+
+  /**
+   * An HTTP request parameter value is used. This should be used when it cannot be determined
+   * whether the parameter comes in the query string or body (e.g. servlet's getParameter).
+   */
+  void onParameterValue(@Nullable String paramName, @Nullable String paramValue);
+
+  void onConcat(@Nullable String left, @Nullable String right, @Nullable String result);
 }

--- a/utils/test-utils/src/main/java/datadog/trace/test/util/CircularBuffer.java
+++ b/utils/test-utils/src/main/java/datadog/trace/test/util/CircularBuffer.java
@@ -1,0 +1,47 @@
+package datadog.trace.test.util;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Circular buffer to prevent last N objects from being garbage-collected. This is not thread-safe.
+ * Iterable by insertion order. The iterator omits nulls.
+ */
+public class CircularBuffer<T> implements Iterable<T> {
+  private int index;
+  private final int lengthMask;
+  private final T[] buffer;
+
+  public CircularBuffer(final int capacity) {
+    assert capacity > 0;
+    // Stick to power of 2
+    assert (capacity & (capacity - 1)) == 0;
+    lengthMask = capacity - 1;
+    index = 0;
+    buffer = createBuffer(capacity);
+  }
+
+  public void add(final T obj) {
+    buffer[index] = obj;
+    index = (index + 1) & lengthMask;
+  }
+
+  public Iterator<T> iterator() {
+    final List<T> list = new ArrayList<>();
+    int iterIndex = (index + 1) & lengthMask;
+    for (int i = 0; i < buffer.length; i++) {
+      final T el = buffer[iterIndex];
+      if (el != null) {
+        list.add(el);
+      }
+      iterIndex = (iterIndex + 1) & lengthMask;
+    }
+    return list.iterator();
+  }
+
+  @SuppressWarnings("unchecked")
+  private T[] createBuffer(final int capacity) {
+    return (T[]) new Object[capacity];
+  }
+}


### PR DESCRIPTION
# What Does This Do
Add taint tracking API
    
Includes:
    
- A hash map implementation optimized to store tainted objets. This is a
  weak identity hash map, with fixed capacity, some concurrency
  guarantees (it can lose concurrent writes, but not throw), and
  self-purging.
- Callbacks to taint HTTP parameter names and values (in taint tracking
   jargon: sources), and propagate taints on string concatenation.

# Motivation
This is one of the main building blocks to do taint tracking for IAST:

# Additional Notes
