### PR TITLE
Create ArrayLists of the right size in DebuggerSinkTest to avoid many large objects

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
@@ -28,7 +28,7 @@ public class Snapshot {
   private final transient int version;
   private final long timestamp;
   private transient long duration;
-  private final List<CapturedStackFrame> stack = new ArrayList<>();
+  private final List<CapturedStackFrame> stack;
   private final Captures captures;
   private final ProbeDetails probe;
   private final String language;
@@ -46,6 +46,7 @@ public class Snapshot {
     this.language = LANGUAGE;
     this.thread = new CapturedThread(thread);
     this.probe = probe;
+    this.stack = new ArrayList<>();
   }
 
   public Snapshot(
@@ -65,13 +66,24 @@ public class Snapshot {
     this.version = version;
     this.timestamp = timestamp;
     this.duration = duration;
-    this.stack.addAll(stack);
+    this.stack = new ArrayList<>(stack);
     this.captures = captures;
     this.probe = probeDetails;
     this.language = language;
     this.thread = thread;
     this.traceId = traceId;
     this.spanId = spanId;
+  }
+
+  public Snapshot(java.lang.Thread thread, ProbeDetails probe, int stackSize) {
+    this.startTs = System.nanoTime();
+    this.version = VERSION;
+    this.timestamp = System.currentTimeMillis();
+    this.captures = new Captures();
+    this.language = LANGUAGE;
+    this.thread = new CapturedThread(thread);
+    this.probe = probe;
+    this.stack = new ArrayList<>(stackSize);
   }
 
   public void setEntry(CapturedContext context) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
@@ -94,7 +94,8 @@ public class DebuggerSinkTest {
     when(config.getDebuggerUploadBatchSize()).thenReturn(10);
     DebuggerSink sink = new DebuggerSink(config, batchUploader);
     Snapshot largeSnapshot =
-        new Snapshot(Thread.currentThread(), new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION));
+        new Snapshot(
+            Thread.currentThread(), new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION), 15_000);
     for (int i = 0; i < 15_000; i++) {
       largeSnapshot.getStack().add(new CapturedStackFrame("f" + i, i));
     }
@@ -112,7 +113,8 @@ public class DebuggerSinkTest {
   public void tooLargeSnapshot() {
     DebuggerSink sink = new DebuggerSink(config, batchUploader);
     Snapshot largeSnapshot =
-        new Snapshot(Thread.currentThread(), new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION));
+        new Snapshot(
+            Thread.currentThread(), new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION), 150_000);
     for (int i = 0; i < 150_000; i++) {
       largeSnapshot.getStack().add(new CapturedStackFrame("f" + i, i));
     }
@@ -125,7 +127,8 @@ public class DebuggerSinkTest {
   public void tooLargeUTF8Snapshot() {
     DebuggerSink sink = new DebuggerSink(config, batchUploader);
     Snapshot largeSnapshot =
-        new Snapshot(Thread.currentThread(), new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION));
+        new Snapshot(
+            Thread.currentThread(), new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION), 140_000);
     for (int i = 0; i < 140_000; i++) {
       largeSnapshot.getStack().add(new CapturedStackFrame("f€" + i, i));
     }


### PR DESCRIPTION
# What Does This Do

Tries to avoid OOM in tests due to excessive allocation of large arrays.

# Motivation

# Additional Notes
