### PR TITLE
[IAST] Add support for invoke dynamic csi advices

### DIFF
--- a/dd-java-agent/agent-tooling/agent-tooling.gradle
+++ b/dd-java-agent/agent-tooling/agent-tooling.gradle
@@ -7,12 +7,30 @@ apply from: "$rootDir/gradle/tries.gradle"
 minimumBranchCoverage = 0.6
 excludedClassesCoverage += ['datadog.trace.agent.tooling.*']
 
+sourceSets {
+  test_java11 {
+    java {
+      srcDirs = [file('src/test/java11')]
+    }
+  }
+  test {
+    groovy {
+      compileClasspath += sourceSets.test_java11.output
+      runtimeClasspath += sourceSets.test_java11.output
+    }
+  }
+}
+
 configurations {
   // classpath used by the instrumentation muzzle plugin
   instrumentationMuzzle {
     canBeConsumed = true
     canBeResolved = false
     extendsFrom implementation
+  }
+
+  test_java11Implementation {
+    extendsFrom testImplementation
   }
 }
 
@@ -49,8 +67,19 @@ forbiddenApisJmh {
   ignoreFailures = true
 }
 
-final compileTestJava = project.tasks.compileTestJava
-compileTestJava.dependsOn(project.tasks.generateTestClassNameTries)
+forbiddenApisTest_java11 {
+  // it will fail due to missing JDK >= 9 classes
+  // java.lang.ClassNotFoundException: java.lang.invoke.StringConcatFactory
+  failOnMissingClasses = false
+}
+
+project.tasks.compileTestJava.dependsOn(project.tasks.generateTestClassNameTries)
+project.tasks.compileTestGroovy.dependsOn(project.tasks.compileTest_java11Java)
+project.tasks.compileTest_java11Java.configure {
+  sourceCompatibility = JavaVersion.VERSION_11
+  targetCompatibility = JavaVersion.VERSION_11
+  setJavaVersion(it, 11)
+}
 
 final jmh = project.tasks.jmh
 jmh.outputs.upToDateWhen { false }

--- a/dd-java-agent/agent-tooling/src/jmh/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteBenchmarkInstrumenter.java
+++ b/dd-java-agent/agent-tooling/src/jmh/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteBenchmarkInstrumenter.java
@@ -2,12 +2,13 @@ package datadog.trace.agent.tooling.bytebuddy.csi;
 
 import datadog.trace.agent.tooling.csi.CallSiteAdvice;
 import datadog.trace.agent.tooling.csi.CallSiteAdvice.HasHelpers;
+import datadog.trace.agent.tooling.csi.InvokeAdvice;
 import datadog.trace.agent.tooling.csi.Pointcut;
+import datadog.trace.agent.tooling.muzzle.ReferenceMatcher;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.jar.asm.MethodVisitor;
 import net.bytebuddy.jar.asm.Opcodes;
 import net.bytebuddy.matcher.ElementMatcher;
 
@@ -42,7 +43,7 @@ public class CallSiteBenchmarkInstrumenter extends CallSiteInstrumenter
     return Collections.<CallSiteAdvice>singletonList(new GetParameterCallSite());
   }
 
-  private static class GetParameterCallSite implements CallSiteAdvice, HasHelpers, Pointcut {
+  private static class GetParameterCallSite implements InvokeAdvice, HasHelpers, Pointcut {
 
     @Override
     public Pointcut pointcut() {
@@ -51,13 +52,13 @@ public class CallSiteBenchmarkInstrumenter extends CallSiteInstrumenter
 
     @Override
     public void apply(
-        final MethodVisitor mv,
+        final MethodHandler handler,
         final int opcode,
         final String owner,
         final String name,
         final String descriptor,
         final boolean isInterface) {
-      mv.visitMethodInsn(
+      handler.method(
           Opcodes.INVOKESTATIC,
           "datadog/trace/agent/tooling/bytebuddy/csi/CallSiteBenchmarkHelper",
           "adviceCallSite",
@@ -85,4 +86,6 @@ public class CallSiteBenchmarkInstrumenter extends CallSiteInstrumenter
       return "(Ljava/lang/String;)Ljava/lang/String;";
     }
   }
+
+  public static class Muzzle extends ReferenceMatcher {}
 }

--- a/dd-java-agent/agent-tooling/src/jmh/java/datadog/trace/agent/tooling/bytebuddy/csi/CalleeBenchmarkInstrumenter.java
+++ b/dd-java-agent/agent-tooling/src/jmh/java/datadog/trace/agent/tooling/bytebuddy/csi/CalleeBenchmarkInstrumenter.java
@@ -5,6 +5,7 @@ import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.muzzle.ReferenceMatcher;
 import java.util.Set;
 
 public class CalleeBenchmarkInstrumenter extends Instrumenter.Default
@@ -40,4 +41,6 @@ public class CalleeBenchmarkInstrumenter extends Instrumenter.Default
   public boolean isApplicable(final Set<TargetSystem> enabledSystems) {
     return true;
   }
+
+  public static class Muzzle extends ReferenceMatcher {}
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/Advices.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/Advices.java
@@ -1,5 +1,9 @@
 package datadog.trace.agent.tooling.bytebuddy.csi;
 
+import static datadog.trace.agent.tooling.bytebuddy.csi.ConstantPool.CONSTANT_INTERFACE_METHODREF_TAG;
+import static datadog.trace.agent.tooling.bytebuddy.csi.ConstantPool.CONSTANT_METHODREF_TAG;
+import static datadog.trace.agent.tooling.csi.CallSiteAdvice.HasFlags.COMPUTE_MAX_STACK;
+
 import datadog.trace.agent.tooling.bytebuddy.ClassFileLocators;
 import datadog.trace.agent.tooling.csi.CallSiteAdvice;
 import datadog.trace.agent.tooling.csi.Pointcut;
@@ -12,8 +16,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.ClassFileLocator;
-import net.bytebuddy.jar.asm.ClassReader;
-import net.bytebuddy.utility.OpenedClassReader;
+import net.bytebuddy.jar.asm.Handle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,6 +32,7 @@ public class Advices {
       new Advices(
           Collections.<String, Map<String, Map<String, CallSiteAdvice>>>emptyMap(),
           new String[0],
+          0,
           AdviceIntrospector.NoOpAdviceInstrospector.INSTANCE) {
         @Override
         public boolean isEmpty() {
@@ -42,12 +46,16 @@ public class Advices {
 
   private final AdviceIntrospector introspector;
 
+  private final int flags;
+
   private Advices(
       final Map<String, Map<String, Map<String, CallSiteAdvice>>> advices,
       final String[] helpers,
+      final int flags,
       final AdviceIntrospector introspector) {
     this.advices = Collections.unmodifiableMap(advices);
     this.helpers = helpers;
+    this.flags = flags;
     this.introspector = introspector;
   }
 
@@ -64,15 +72,16 @@ public class Advices {
       @Nonnull final AdviceIntrospector introspector) {
     final Map<String, Map<String, Map<String, CallSiteAdvice>>> adviceMap = new HashMap<>();
     final Set<String> helperSet = new HashSet<>();
-    for (CallSiteAdvice advice : advices) {
-      addAdvice(adviceMap, helperSet, advice);
+    int flags = 0;
+    for (final CallSiteAdvice advice : advices) {
+      flags |= addAdvice(adviceMap, helperSet, advice);
     }
     return adviceMap.isEmpty()
         ? EMPTY
-        : new Advices(adviceMap, helperSet.toArray(new String[0]), introspector);
+        : new Advices(adviceMap, helperSet.toArray(new String[0]), flags, introspector);
   }
 
-  private static void addAdvice(
+  private static int addAdvice(
       @Nonnull final Map<String, Map<String, Map<String, CallSiteAdvice>>> advices,
       @Nonnull final Set<String> helpers,
       @Nonnull final CallSiteAdvice advice) {
@@ -100,6 +109,9 @@ public class Advices {
         Collections.addAll(helpers, helperClassNames);
       }
     }
+    return advice instanceof CallSiteAdvice.HasFlags
+        ? ((CallSiteAdvice.HasFlags) advice).flags()
+        : 0;
   }
 
   /**
@@ -116,6 +128,10 @@ public class Advices {
   // used for testing
   public CallSiteAdvice findAdvice(@Nonnull final Pointcut pointcut) {
     return findAdvice(pointcut.type(), pointcut.method(), pointcut.descriptor());
+  }
+
+  public CallSiteAdvice findAdvice(@Nonnull final Handle handle) {
+    return findAdvice(handle.getOwner(), handle.getName(), handle.getDesc());
   }
 
   /**
@@ -152,6 +168,14 @@ public class Advices {
     return advices.isEmpty();
   }
 
+  public boolean hasFlag(final int flag) {
+    return (this.flags & flag) > 0;
+  }
+
+  public boolean computeMaxStack() {
+    return hasFlag(COMPUTE_MAX_STACK);
+  }
+
   /**
    * Instance of this class will try to discover the advices required to instrument a class before
    * visiting it
@@ -185,16 +209,13 @@ public class Advices {
 
       public static final AdviceIntrospector INSTANCE = new ConstantPoolInstrospector();
 
-      private static final int CONSTANT_METHOD_REF = 10;
-      private static final int CONSTANT_INTERFACE_METHOD_REF = 11;
-
       private static final Map<Integer, ConstantPoolHandler> CP_HANDLERS;
 
       static {
-        final Map<Integer, ConstantPoolHandler> handlers = new HashMap<>(2);
+        final Map<Integer, ConstantPoolHandler> handlers = new HashMap<>(4);
         final ConstantPoolHandler methodRefHandler = new MethodRefHandler();
-        handlers.put(CONSTANT_METHOD_REF, methodRefHandler);
-        handlers.put(CONSTANT_INTERFACE_METHOD_REF, methodRefHandler);
+        handlers.put(CONSTANT_METHODREF_TAG, methodRefHandler);
+        handlers.put(CONSTANT_INTERFACE_METHODREF_TAG, methodRefHandler);
         CP_HANDLERS = Collections.unmodifiableMap(handlers);
       }
 
@@ -208,27 +229,17 @@ public class Advices {
           if (!resolution.isResolved()) {
             return advices; // cannot resolve class file so don't apply any filtering
           }
-          final Map<String, Map<String, Map<String, CallSiteAdvice>>> adviceMap = new HashMap<>();
-          final Set<String> helperSet = new HashSet<>();
-          final ClassReader reader = OpenedClassReader.of(resolution.resolve());
-          final char[] buffer = new char[reader.getMaxStringLength()];
-          for (int i = 0; i < reader.getItemCount(); i++) {
-            final int offset = reader.getItem(i);
-            if (offset > 0) {
-              final int referenceType = reader.readByte(offset - 1);
-              final ConstantPoolHandler handler = CP_HANDLERS.get(referenceType);
-              if (handler != null) {
-                final CallSiteAdvice advice = handler.findAdvice(advices, reader, offset, buffer);
-                if (advice != null) {
-                  addAdvice(adviceMap, helperSet, advice);
-                }
-              }
+          final ConstantPool cp = new ConstantPool(resolution.resolve());
+          for (int index = 1; index < cp.getCount(); index++) {
+            final int referenceType = cp.getType(index);
+            final ConstantPoolHandler handler = CP_HANDLERS.get(referenceType);
+            // short circuit when any advice is found
+            if (handler != null && handler.findAdvice(advices, cp, index) != null) {
+              return advices;
             }
           }
-          return adviceMap.isEmpty()
-              ? EMPTY
-              : new Advices(adviceMap, helperSet.toArray(new String[0]), this);
-        } catch (Throwable e) {
+          return EMPTY;
+        } catch (final Throwable e) {
           if (LOG.isErrorEnabled()) {
             LOG.error(String.format("Failed to introspect %s constant pool", type), e);
           }
@@ -238,11 +249,7 @@ public class Advices {
 
       /** Handler for a particular type of constant pool type (MethodRef, InvokeDynamic, ...) */
       private interface ConstantPoolHandler {
-        CallSiteAdvice findAdvice(
-            @Nonnull Advices advices,
-            @Nonnull ClassReader reader,
-            int offset,
-            @Nonnull char[] buffer);
+        CallSiteAdvice findAdvice(@Nonnull Advices advices, @Nonnull ConstantPool cp, int index);
       }
 
       /**
@@ -255,18 +262,31 @@ public class Advices {
 
         @Override
         public CallSiteAdvice findAdvice(
-            @Nonnull final Advices advices,
-            @Nonnull final ClassReader reader,
-            final int offset,
-            @Nonnull final char[] buffer) {
-          final int classIndex = reader.readUnsignedShort(offset);
-          final int classOffset = reader.getItem(classIndex);
-          final String className = reader.readUTF8(classOffset, buffer);
-          final int nameAndTypeIndex = reader.readUnsignedShort(offset + 2);
-          final int nameAndTypeOffset = reader.getItem(nameAndTypeIndex);
-          final String name = reader.readUTF8(nameAndTypeOffset, buffer);
-          final String descriptor = reader.readUTF8(nameAndTypeOffset + 2, buffer);
-          return advices.findAdvice(className, name, descriptor);
+            @Nonnull final Advices advices, @Nonnull final ConstantPool cp, final int index) {
+          final int offset = cp.getOffset(index);
+
+          // u2 class_index;
+          final int classIndex = cp.readUnsignedShort(offset);
+          final int classNameIndex = cp.readUnsignedShort(cp.getOffset(classIndex));
+          final String className = cp.readUTF8(cp.getOffset(classNameIndex));
+          final Map<String, Map<String, CallSiteAdvice>> calleeAdvices =
+              advices.advices.get(className);
+          if (calleeAdvices == null) {
+            return null;
+          }
+
+          // u2 name_and_type_index;
+          final int nameAndTypeIndex = cp.readUnsignedShort(offset + 2);
+          final int nameAndTypeOffset = cp.getOffset(nameAndTypeIndex);
+          final int nameIndex = cp.readUnsignedShort(nameAndTypeOffset);
+          final String name = cp.readUTF8(cp.getOffset(nameIndex));
+          final Map<String, CallSiteAdvice> methodAdvices = calleeAdvices.get(name);
+          if (methodAdvices == null) {
+            return null;
+          }
+          final int descriptorIndex = cp.readUnsignedShort(nameAndTypeOffset + 2);
+          final String descriptor = cp.readUTF8(cp.getOffset(descriptorIndex));
+          return methodAdvices.get(descriptor);
         }
       }
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteInstrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteInstrumenter.java
@@ -38,8 +38,8 @@ public abstract class CallSiteInstrumenter extends Instrumenter.Default
   @SuppressWarnings("unchecked")
   private static Iterable<CallSiteAdvice> fetchAdvicesFromSpi(
       @Nonnull final Class<?> spiInterface) {
-    return (ServiceLoader<CallSiteAdvice>)
-        ServiceLoader.load(spiInterface, spiInterface.getClassLoader());
+    final ClassLoader targetClassLoader = CallSiteInstrumenter.class.getClassLoader();
+    return (ServiceLoader<CallSiteAdvice>) ServiceLoader.load(spiInterface, targetClassLoader);
   }
 
   @Override

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteTransformer.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteTransformer.java
@@ -4,6 +4,9 @@ import static net.bytebuddy.jar.asm.ClassWriter.COMPUTE_MAXS;
 
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.csi.CallSiteAdvice;
+import datadog.trace.agent.tooling.csi.CallSiteAdvice.StackDupMode;
+import datadog.trace.agent.tooling.csi.InvokeAdvice;
+import datadog.trace.agent.tooling.csi.InvokeDynamicAdvice;
 import java.security.ProtectionDomain;
 import javax.annotation.Nonnull;
 import net.bytebuddy.asm.AsmVisitorWrapper;
@@ -14,8 +17,10 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.implementation.Implementation;
 import net.bytebuddy.jar.asm.ClassVisitor;
+import net.bytebuddy.jar.asm.Handle;
 import net.bytebuddy.jar.asm.MethodVisitor;
 import net.bytebuddy.jar.asm.Opcodes;
+import net.bytebuddy.jar.asm.Type;
 import net.bytebuddy.pool.TypePool;
 import net.bytebuddy.utility.JavaModule;
 
@@ -50,7 +55,7 @@ public class CallSiteTransformer implements Instrumenter.AdviceTransformer {
 
     @Override
     public int mergeWriter(final int flags) {
-      return flags | COMPUTE_MAXS;
+      return advices.computeMaxStack() ? flags | COMPUTE_MAXS : flags;
     }
 
     @Override
@@ -90,7 +95,8 @@ public class CallSiteTransformer implements Instrumenter.AdviceTransformer {
     }
   }
 
-  private static class CallSiteMethodVisitor extends MethodVisitor {
+  private static class CallSiteMethodVisitor extends MethodVisitor
+      implements CallSiteAdvice.MethodHandler {
     private final Advices advices;
 
     private CallSiteMethodVisitor(
@@ -107,11 +113,81 @@ public class CallSiteTransformer implements Instrumenter.AdviceTransformer {
         final String descriptor,
         final boolean isInterface) {
       CallSiteAdvice advice = advices.findAdvice(owner, name, descriptor);
-      if (advice != null) {
-        advice.apply(mv, opcode, owner, name, descriptor, isInterface);
+      if (advice instanceof InvokeAdvice) {
+        ((InvokeAdvice) advice).apply(this, opcode, owner, name, descriptor, isInterface);
       } else {
         mv.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
       }
+    }
+
+    @Override
+    public void visitInvokeDynamicInsn(
+        final String name,
+        final String descriptor,
+        final Handle bootstrapMethodHandle,
+        final Object... bootstrapMethodArguments) {
+      CallSiteAdvice advice = advices.findAdvice(bootstrapMethodHandle);
+      if (advice instanceof InvokeDynamicAdvice) {
+        ((InvokeDynamicAdvice) advice)
+            .apply(this, name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments);
+      } else {
+        mv.visitInvokeDynamicInsn(
+            name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments);
+      }
+    }
+
+    @Override
+    public void instruction(final int opcode) {
+      mv.visitInsn(opcode);
+    }
+
+    @Override
+    public void loadConstant(final Object constant) {
+      mv.visitLdcInsn(constant);
+    }
+
+    @Override
+    public void loadConstantArray(final Object[] array) {
+      CallSiteUtils.pushConstantArray(mv, array);
+    }
+
+    @Override
+    public void method(
+        final int opcode,
+        final String owner,
+        final String name,
+        final String descriptor,
+        final boolean isInterface) {
+      mv.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+    }
+
+    @Override
+    public void invokeDynamic(
+        final String name,
+        final String descriptor,
+        final Handle bootstrapMethodHandle,
+        final Object... bootstrapMethodArguments) {
+      mv.visitInvokeDynamicInsn(name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments);
+    }
+
+    @Override
+    public void dupParameters(final String methodDescriptor, final StackDupMode mode) {
+      final Type method = Type.getMethodType(methodDescriptor);
+      if (method.getArgumentTypes().length == 0) {
+        return;
+      }
+      CallSiteUtils.dup(mv, method.getArgumentTypes(), mode);
+    }
+
+    @Override
+    public void dupInvoke(
+        final String owner, final String methodDescriptor, final StackDupMode mode) {
+      final Type method = Type.getMethodType(methodDescriptor);
+      Type ownerType = Type.getType("L" + owner + ";");
+      final Type[] parameters = new Type[method.getArgumentTypes().length + 1];
+      parameters[0] = ownerType;
+      System.arraycopy(method.getArgumentTypes(), 0, parameters, 1, parameters.length - 1);
+      CallSiteUtils.dup(mv, parameters, mode);
     }
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteUtils.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteUtils.java
@@ -1,0 +1,310 @@
+package datadog.trace.agent.tooling.bytebuddy.csi;
+
+import static datadog.trace.agent.tooling.csi.CallSiteAdvice.StackDupMode.COPY;
+
+import datadog.trace.agent.tooling.csi.CallSiteAdvice.StackDupMode;
+import net.bytebuddy.jar.asm.MethodVisitor;
+import net.bytebuddy.jar.asm.Opcodes;
+import net.bytebuddy.jar.asm.Type;
+
+public abstract class CallSiteUtils {
+
+  public static final String OBJET_TYPE = "java/lang/Object";
+  private static final BoxingHandler[] BOX_HANDLERS = new BoxingHandler[Type.METHOD + 1];
+
+  static {
+    BOX_HANDLERS[Type.BOOLEAN] = new JdkBoxingHandler("java/lang/Boolean", "Z", "booleanValue");
+    BOX_HANDLERS[Type.CHAR] = new JdkBoxingHandler("java/lang/Character", "C", "charValue");
+    BOX_HANDLERS[Type.BYTE] = new JdkBoxingHandler("java/lang/Byte", "B", "byteValue");
+    BOX_HANDLERS[Type.SHORT] = new JdkBoxingHandler("java/lang/Short", "S", "shortValue");
+    BOX_HANDLERS[Type.INT] = new JdkBoxingHandler("java/lang/Integer", "I", "intValue");
+    BOX_HANDLERS[Type.FLOAT] = new JdkBoxingHandler("java/lang/Float", "F", "floatValue");
+    BOX_HANDLERS[Type.LONG] = new JdkBoxingHandler("java/lang/Long", "J", "longValue");
+    BOX_HANDLERS[Type.DOUBLE] = new JdkBoxingHandler("java/lang/Double", "D", "doubleValue");
+  }
+
+  private CallSiteUtils() {}
+
+  public static void swap(final MethodVisitor mv, final int secondToLastSize, final int lastSize) {
+    if (secondToLastSize == 1 && lastSize == 1) {
+      mv.visitInsn(Opcodes.SWAP);
+    } else if (secondToLastSize == 2 && lastSize == 2) {
+      mv.visitInsn(Opcodes.DUP2_X2);
+      mv.visitInsn(Opcodes.POP2);
+    } else if (lastSize == 1) {
+      mv.visitInsn(Opcodes.DUP_X2);
+      mv.visitInsn(Opcodes.POP);
+    } else {
+      mv.visitInsn(Opcodes.DUP2_X1);
+      mv.visitInsn(Opcodes.POP2);
+    }
+  }
+
+  public static void pushInteger(final MethodVisitor mv, final int value) {
+    switch (value) {
+      case -1:
+        mv.visitInsn(Opcodes.ICONST_M1);
+        break;
+      case 0:
+        mv.visitInsn(Opcodes.ICONST_0);
+        break;
+      case 1:
+        mv.visitInsn(Opcodes.ICONST_1);
+        break;
+      case 2:
+        mv.visitInsn(Opcodes.ICONST_2);
+        break;
+      case 3:
+        mv.visitInsn(Opcodes.ICONST_3);
+        break;
+      case 4:
+        mv.visitInsn(Opcodes.ICONST_4);
+        break;
+      case 5:
+        mv.visitInsn(Opcodes.ICONST_5);
+        break;
+      default:
+        if (value < Short.MIN_VALUE || value > Short.MAX_VALUE) {
+          mv.visitLdcInsn(value);
+        } else if (value < Byte.MIN_VALUE || value > Byte.MAX_VALUE) {
+          mv.visitIntInsn(Opcodes.SIPUSH, value);
+        } else {
+          mv.visitIntInsn(Opcodes.BIPUSH, value);
+        }
+        break;
+    }
+  }
+
+  public static void pushConstantArray(final MethodVisitor mv, final Object[] constants) {
+    if (constants == null) {
+      mv.visitInsn(Opcodes.ACONST_NULL);
+      return;
+    }
+    pushInteger(mv, constants.length);
+    mv.visitTypeInsn(Opcodes.ANEWARRAY, OBJET_TYPE);
+    for (int i = 0; i < constants.length; i++) {
+      final Object constant = constants[i];
+      if (constant != null) {
+        mv.visitInsn(Opcodes.DUP);
+        pushInteger(mv, i);
+        mv.visitLdcInsn(constant);
+        box(mv, Type.getType(constant.getClass()));
+        mv.visitInsn(Opcodes.AASTORE);
+      }
+    }
+  }
+
+  public static void dup(final MethodVisitor mv, final Type[] parameters, final StackDupMode mode) {
+    switch (mode) {
+      case COPY:
+        dup(mv, parameters);
+        break;
+      case PREPEND_ARRAY:
+      case APPEND_ARRAY:
+        dupN(mv, parameters, mode);
+        break;
+    }
+  }
+
+  private static void dup(final MethodVisitor mv, final Type[] parameters) {
+    int stackSize = 0;
+    for (final Type param : parameters) {
+      stackSize += param.getSize();
+    }
+    switch (stackSize) {
+      case 0:
+        break;
+      case 1:
+        mv.visitInsn(Opcodes.DUP);
+        break;
+      case 2:
+        mv.visitInsn(Opcodes.DUP2);
+        break;
+      case 3:
+        if (parameters.length == 3 || parameters[0].getSize() == 2) {
+          dup3(mv);
+        } else {
+          dup3_C1_C2(mv);
+        }
+        break;
+      case 4:
+        if (parameters.length != 3 || parameters[1].getSize() == 1) {
+          dup4(mv);
+        } else {
+          // the case [C1, C2, C1] cannot be solved with regular stack operations
+          dupN(mv, parameters, COPY);
+        }
+        break;
+      default:
+        dupN(mv, parameters, COPY);
+        break;
+    }
+  }
+
+  private static void dup3(final MethodVisitor mv) {
+    mv.visitInsn(Opcodes.DUP);
+    mv.visitInsn(Opcodes.DUP2_X2);
+    mv.visitInsn(Opcodes.POP2);
+    mv.visitInsn(Opcodes.DUP2_X2);
+    mv.visitInsn(Opcodes.DUP2_X1);
+    mv.visitInsn(Opcodes.POP2);
+  }
+
+  private static void dup3_C1_C2(final MethodVisitor mv) {
+    mv.visitInsn(Opcodes.DUP2_X1);
+    mv.visitInsn(Opcodes.POP2);
+    mv.visitInsn(Opcodes.DUP);
+    mv.visitInsn(Opcodes.DUP2_X2);
+    mv.visitInsn(Opcodes.POP2);
+    mv.visitInsn(Opcodes.DUP2_X1);
+  }
+
+  private static void dup4(final MethodVisitor mv) {
+    mv.visitInsn(Opcodes.DUP2_X2);
+    mv.visitInsn(Opcodes.POP2);
+    mv.visitInsn(Opcodes.DUP2_X2);
+    mv.visitInsn(Opcodes.DUP2_X2);
+    mv.visitInsn(Opcodes.POP2);
+    mv.visitInsn(Opcodes.DUP2_X2);
+  }
+
+  /**
+   * This method duplicates the parameters in the stack by using a temporal array that will only
+   * live in the stack
+   */
+  private static void dupN(
+      final MethodVisitor mv, final Type[] parameters, final StackDupMode mode) {
+    final int arraySize = parameters.length;
+    pushArray(mv, arraySize, parameters);
+    switch (mode) {
+      case PREPEND_ARRAY:
+        mv.visitInsn(Opcodes.DUP);
+        loadArray(mv, arraySize, parameters);
+        mv.visitInsn(Opcodes.POP);
+        break;
+      case APPEND_ARRAY:
+        loadArray(mv, arraySize, parameters);
+        break;
+      case COPY:
+        loadArray(mv, arraySize, parameters);
+        loadArray(mv, arraySize, parameters);
+        mv.visitInsn(Opcodes.POP);
+        break;
+    }
+  }
+
+  private static void pushArray(
+      final MethodVisitor mv, final int arraySize, final Type[] parameters) {
+    pushInteger(mv, arraySize);
+    mv.visitTypeInsn(Opcodes.ANEWARRAY, OBJET_TYPE);
+    for (int i = parameters.length - 1; i >= 0; i--) {
+      final Type param = parameters[i];
+      final int stackObjectSize = param.getSize();
+      // 1. duplicate the array
+      mv.visitInsn(stackObjectSize == 1 ? Opcodes.DUP_X1 : Opcodes.DUP_X2);
+      swap(mv, stackObjectSize, 1); // [..., STACK_OBJECT, ARRAY]
+      // 2. store the index in the array
+      mv.visitIntInsn(Opcodes.BIPUSH, i);
+      swap(mv, stackObjectSize, 1); // [..., STACK_OBJECT, INDEX]
+      // 3. add the element to the array
+      box(mv, param);
+      mv.visitInsn(Opcodes.AASTORE);
+    }
+  }
+
+  private static void loadArray(
+      final MethodVisitor mv, final int arraySize, final Type[] parameters) {
+    for (int i = 0; i < arraySize; i++) {
+      final Type param = parameters[i];
+      final int stackObjectSize = param.getSize();
+      // 1. duplicate the array
+      mv.visitInsn(Opcodes.DUP);
+      // 2. load the element from the array
+      pushInteger(mv, i);
+      mv.visitInsn(Opcodes.AALOAD);
+      // 3. cast it to the proper value
+      if (!OBJET_TYPE.equals(param.getInternalName())) {
+        checkCast(mv, param);
+        unbox(mv, param);
+      }
+      // 4. move the array to the end of the stack
+      swap(mv, 1, stackObjectSize); // [..., ARRAY, STACK_OBJECT]
+    }
+  }
+
+  private static void checkCast(final MethodVisitor mv, final Type parameter) {
+    if (parameter.getSort() == Type.OBJECT) {
+      mv.visitTypeInsn(Opcodes.CHECKCAST, parameter.getInternalName());
+    } else {
+      final BoxingHandler handler = BOX_HANDLERS[parameter.getSort()];
+      if (handler != null) {
+        mv.visitTypeInsn(Opcodes.CHECKCAST, handler.getBoxedType());
+      } else {
+        throw new IllegalArgumentException("Invalid type for 'CHECKCAST' operation: " + parameter);
+      }
+    }
+  }
+
+  private static void box(final MethodVisitor mv, final Type parameter) {
+    final BoxingHandler handler = BOX_HANDLERS[parameter.getSort()];
+    if (handler != null) {
+      handler.box(mv);
+    }
+  }
+
+  private static void unbox(final MethodVisitor mv, final Type parameter) {
+    final BoxingHandler handler = BOX_HANDLERS[parameter.getSort()];
+    if (handler != null) {
+      handler.unbox(mv);
+    }
+  }
+
+  private interface BoxingHandler {
+    void box(MethodVisitor mv);
+
+    void unbox(MethodVisitor mv);
+
+    String getBoxedType();
+  }
+
+  private static class JdkBoxingHandler implements BoxingHandler {
+    private final String boxedType;
+    private final String boxMethod;
+    private final String unboxMethod;
+
+    private final String boxDescriptor;
+    private final String unboxDescriptor;
+
+    private JdkBoxingHandler(
+        final String boxedType, final String primitiveType, final String unboxMethod) {
+      this(boxedType, primitiveType, "valueOf", unboxMethod);
+    }
+
+    private JdkBoxingHandler(
+        final String boxedType,
+        final String primitiveType,
+        final String boxMethod,
+        final String unboxMethod) {
+      this.boxedType = boxedType;
+      this.boxMethod = boxMethod;
+      this.unboxMethod = unboxMethod;
+      this.boxDescriptor = "(" + primitiveType + ")L" + boxedType + ";";
+      this.unboxDescriptor = "()" + primitiveType;
+    }
+
+    @Override
+    public void box(final MethodVisitor mv) {
+      mv.visitMethodInsn(Opcodes.INVOKESTATIC, boxedType, boxMethod, boxDescriptor, false);
+    }
+
+    @Override
+    public void unbox(final MethodVisitor mv) {
+      mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, boxedType, unboxMethod, unboxDescriptor, false);
+    }
+
+    @Override
+    public String getBoxedType() {
+      return boxedType;
+    }
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/ConstantPool.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/ConstantPool.java
@@ -1,0 +1,131 @@
+package datadog.trace.agent.tooling.bytebuddy.csi;
+
+import javax.annotation.Nonnull;
+
+public class ConstantPool {
+
+  public static final int CONSTANT_CLASS_TAG = 7;
+  public static final int CONSTANT_FIELDREF_TAG = 9;
+  public static final int CONSTANT_METHODREF_TAG = 10;
+  public static final int CONSTANT_INTERFACE_METHODREF_TAG = 11;
+  public static final int CONSTANT_STRING_TAG = 8;
+  public static final int CONSTANT_INTEGER_TAG = 3;
+  public static final int CONSTANT_FLOAT_TAG = 4;
+  public static final int CONSTANT_LONG_TAG = 5;
+  public static final int CONSTANT_DOUBLE_TAG = 6;
+  public static final int CONSTANT_NAME_AND_TYPE_TAG = 12;
+  public static final int CONSTANT_UTF8_TAG = 1;
+  public static final int CONSTANT_METHOD_HANDLE_TAG = 15;
+  public static final int CONSTANT_METHOD_TYPE_TAG = 16;
+  public static final int CONSTANT_DYNAMIC_TAG = 17;
+  public static final int CONSTANT_INVOKE_DYNAMIC_TAG = 18;
+  public static final int CONSTANT_MODULE_TAG = 19;
+  public static final int CONSTANT_PACKAGE_TAG = 20;
+
+  private static final int CONSTANT_POOL_START = 8;
+
+  private final byte[] classBuffer;
+  private final int[] offsets;
+  private final int count;
+  private final char[] charBuffer;
+
+  public ConstantPool(@Nonnull final byte[] classBuffer) {
+    this.classBuffer = classBuffer;
+    count = readUnsignedShort(CONSTANT_POOL_START);
+    offsets = new int[count];
+    final int maxStringLength = initConstantPool(count);
+    charBuffer = new char[maxStringLength];
+  }
+
+  private int initConstantPool(final int cpInfoCount) {
+    int cpInfoOffset = CONSTANT_POOL_START + 2;
+    int cpInfoIndex = 1;
+    int maxStringLength = 0;
+    while (cpInfoIndex < cpInfoCount) {
+      final int type = classBuffer[cpInfoOffset++];
+      offsets[cpInfoIndex] = cpInfoOffset;
+      cpInfoIndex += 1;
+      switch (type) {
+        case CONSTANT_LONG_TAG:
+        case CONSTANT_DOUBLE_TAG:
+          cpInfoOffset += 8;
+          cpInfoIndex += 1;
+          break;
+        case CONSTANT_METHODREF_TAG:
+        case CONSTANT_INTERFACE_METHODREF_TAG:
+        case CONSTANT_FIELDREF_TAG:
+        case CONSTANT_INTEGER_TAG:
+        case CONSTANT_FLOAT_TAG:
+        case CONSTANT_NAME_AND_TYPE_TAG:
+        case CONSTANT_DYNAMIC_TAG:
+        case CONSTANT_INVOKE_DYNAMIC_TAG:
+          cpInfoOffset += 4;
+          break;
+        case CONSTANT_UTF8_TAG:
+          final int strSize = readUnsignedShort(cpInfoOffset);
+          cpInfoOffset += 2;
+          cpInfoOffset += strSize;
+          if (strSize > maxStringLength) {
+            maxStringLength = strSize;
+          }
+          break;
+        case CONSTANT_METHOD_HANDLE_TAG:
+          cpInfoOffset += 3;
+          break;
+        case CONSTANT_CLASS_TAG:
+        case CONSTANT_STRING_TAG:
+        case CONSTANT_METHOD_TYPE_TAG:
+        case CONSTANT_PACKAGE_TAG:
+        case CONSTANT_MODULE_TAG:
+          cpInfoOffset += 2;
+          break;
+        default:
+          throw new IllegalArgumentException();
+      }
+    }
+    return maxStringLength;
+  }
+
+  public int getCount() {
+    return count;
+  }
+
+  public int getType(final int index) {
+    final int offset = offsets[index] - 1;
+    if (offset < 0) {
+      return -1; // can happen for long and double (they take two spots in the constant pool)
+    }
+    return classBuffer[offset];
+  }
+
+  public int getOffset(final int index) {
+    return offsets[index];
+  }
+
+  public int readUnsignedShort(final int offset) {
+    return ((classBuffer[offset] & 0xFF) << 8) | (classBuffer[offset + 1] & 0xFF);
+  }
+
+  public String readUTF8(final int offset) {
+    final int length = readUnsignedShort(offset);
+    int currentOffset = offset + 2;
+    int endOffset = currentOffset + length;
+    int strLength = 0;
+    while (currentOffset < endOffset) {
+      int currentByte = classBuffer[currentOffset++];
+      if ((currentByte & 0x80) == 0) {
+        charBuffer[strLength++] = (char) (currentByte & 0x7F);
+      } else if ((currentByte & 0xE0) == 0xC0) {
+        charBuffer[strLength++] =
+            (char) (((currentByte & 0x1F) << 6) + (classBuffer[currentOffset++] & 0x3F));
+      } else {
+        charBuffer[strLength++] =
+            (char)
+                (((currentByte & 0xF) << 12)
+                    + ((classBuffer[currentOffset++] & 0x3F) << 6)
+                    + (classBuffer[currentOffset++] & 0x3F));
+      }
+    }
+    return new String(charBuffer, 0, strLength);
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/csi/CallSiteAdvice.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/csi/CallSiteAdvice.java
@@ -1,25 +1,60 @@
 package datadog.trace.agent.tooling.csi;
 
-import net.bytebuddy.jar.asm.MethodVisitor;
+import net.bytebuddy.jar.asm.Handle;
 
-/**
- * Interface to implement by call site advices, the {@link CallSiteAdvice#apply(MethodVisitor, int,
- * String, String, String, boolean)} method will be used by ByteBuddy to perform the actual
- * instrumentation.
- */
 public interface CallSiteAdvice {
 
   Pointcut pointcut();
 
-  void apply(
-      MethodVisitor mv,
-      int opcode,
-      String owner,
-      String name,
-      String descriptor,
-      boolean isInterface);
-
   interface HasHelpers {
     String[] helperClassNames();
+  }
+
+  interface HasFlags {
+    int COMPUTE_MAX_STACK = 1;
+
+    int flags();
+  }
+
+  /** Interface to isolate advices from ASM */
+  interface MethodHandler {
+
+    /** Executes an instruction without parameters */
+    void instruction(int opcode);
+
+    /** Loads a constant into the stack */
+    void loadConstant(Object constant);
+
+    /** Loads an array of constants into the stack as a reference of type <code>Object[]</code> */
+    void loadConstantArray(Object[] array);
+
+    /** Performs a method invocation (static, special, virtual, interface...) */
+    void method(int opcode, String owner, String name, String descriptor, boolean isInterface);
+
+    /** Performs a dynamic method invocation */
+    void invokeDynamic(
+        String name,
+        String descriptor,
+        Handle bootstrapMethodHandle,
+        Object... bootstrapMethodArguments);
+
+    /** Duplicates all the method parameters in the stack just before the method is invoked. */
+    void dupParameters(String methodDescriptor, StackDupMode mode);
+
+    /**
+     * Duplicates the <code>this</code> reference and all the method parameters in the stack just
+     * before the method is invoked (only for instance methods for obvious reasons).
+     */
+    void dupInvoke(String owner, String methodDescriptor, StackDupMode mode);
+  }
+
+  /** This enumeration describes how to duplicate the parameters in the stack */
+  enum StackDupMode {
+    /** Create a 1-1 copy of the parameters */
+    COPY,
+    /** Copies the parameters in an array and prepends it */
+    PREPEND_ARRAY,
+    /** Copies the parameters in an array and appends it */
+    APPEND_ARRAY
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/csi/InvokeAdvice.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/csi/InvokeAdvice.java
@@ -1,0 +1,16 @@
+package datadog.trace.agent.tooling.csi;
+
+/**
+ * Interface to implement by call site advices, the {@link InvokeAdvice#apply(MethodHandler, int,
+ * String, String, String, boolean)} method will be used to perform the actual instrumentation.
+ */
+public interface InvokeAdvice extends CallSiteAdvice {
+
+  void apply(
+      MethodHandler handler,
+      int opcode,
+      String owner,
+      String name,
+      String descriptor,
+      boolean isInterface);
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/csi/InvokeDynamicAdvice.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/csi/InvokeDynamicAdvice.java
@@ -1,0 +1,18 @@
+package datadog.trace.agent.tooling.csi;
+
+import net.bytebuddy.jar.asm.Handle;
+
+/**
+ * Interface to implement by call site advices for invoke dynamic, the {@link
+ * InvokeDynamicAdvice#apply(MethodHandler, String, String, Handle, Object...)} method will be used
+ * to perform the actual instrumentation.
+ */
+public interface InvokeDynamicAdvice extends CallSiteAdvice {
+
+  void apply(
+      MethodHandler handler,
+      String name,
+      String descriptor,
+      Handle bootstrapMethodHandle,
+      Object... bootstrapMethodArguments);
+}

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/AdvicesInvokeDynamicTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/AdvicesInvokeDynamicTest.groovy
@@ -1,0 +1,63 @@
+package datadog.trace.agent.tooling.csi
+
+import datadog.trace.agent.tooling.bytebuddy.csi.Advices
+import net.bytebuddy.description.type.TypeDescription
+import spock.lang.Requires
+
+@Requires({
+  jvm.java9Compatible
+})
+class AdvicesInvokeDynamicTest extends BaseCallSiteTest {
+
+  def 'test constant pool introspector with invoke dynamic'(final Pointcut pointcutMock,
+    final boolean emptyAdvices,
+    final boolean adviceFound) {
+    setup:
+    final target = StringPlusExample
+    final targetType = Mock(TypeDescription) {
+      getName() >> target.name
+    }
+    final advice = mockInvokeDynamicAdvice(pointcutMock)
+    final advices = Advices.fromCallSites(advice)
+    final introspector = Advices.AdviceIntrospector.ConstantPoolInstrospector.INSTANCE
+
+    when:
+    final result = introspector.findAdvices(advices, targetType, StringPlusExample.classLoader)
+    final found = result.findAdvice(pointcutMock) != null
+
+    then:
+    result.empty == emptyAdvices
+    found == adviceFound
+
+    where:
+    pointcutMock                  | emptyAdvices | adviceFound
+    stringConcatPointcut()        | true         | false
+    stringConcatFactoryPointcut() | false        | true
+  }
+
+  def 'test constant pool introspector with invoke dynamic and constants'(final Pointcut pointcutMock,
+    final boolean emptyAdvices,
+    final boolean adviceFound) {
+    setup:
+    final target = StringPlusConstantsExample
+    final targetType = Mock(TypeDescription) {
+      getName() >> target.name
+    }
+    final advice = mockInvokeDynamicAdvice(pointcutMock)
+    final advices = Advices.fromCallSites(advice)
+    final introspector = Advices.AdviceIntrospector.ConstantPoolInstrospector.INSTANCE
+
+    when:
+    final result = introspector.findAdvices(advices, targetType, StringPlusConstantsExample.classLoader)
+    final found = result.findAdvice(pointcutMock) != null
+
+    then:
+    result.empty == emptyAdvices
+    found == adviceFound
+
+    where:
+    pointcutMock                  | emptyAdvices | adviceFound
+    stringConcatPointcut()        | true         | false
+    stringConcatFactoryPointcut() | false        | true
+  }
+}

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/BaseCallSiteTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/BaseCallSiteTest.groovy
@@ -8,10 +8,20 @@ import net.bytebuddy.agent.builder.AgentBuilder
 import net.bytebuddy.description.type.TypeDescription
 import net.bytebuddy.dynamic.DynamicType
 import net.bytebuddy.dynamic.loading.ByteArrayClassLoader
+import net.bytebuddy.jar.asm.Handle
 import net.bytebuddy.jar.asm.Type
 import net.bytebuddy.matcher.ElementMatcher
 import net.bytebuddy.utility.JavaModule
 import net.bytebuddy.utility.nullability.MaybeNull
+import datadog.trace.agent.tooling.csi.CallSiteAdvice.HasHelpers
+import datadog.trace.agent.tooling.csi.CallSiteAdvice.HasFlags
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+import java.security.MessageDigest
+
+import static datadog.trace.agent.tooling.csi.CallSiteAdvice.HasFlags.COMPUTE_MAX_STACK
+
 
 import java.lang.reflect.Method
 import java.security.ProtectionDomain
@@ -21,50 +31,129 @@ import static net.bytebuddy.matcher.ElementMatchers.named
 
 class BaseCallSiteTest extends DDSpecification {
 
-  protected CallSiteAdvice mockAdvice(final Pointcut target) {
-    return Mock(CallSiteAdvice) {
+  protected static final Logger LOG = LoggerFactory.getLogger(CallSiteTransformerInvokeDynamicTest)
+
+
+  protected InvokeAdvice mockInvokeAdvice(final Pointcut target) {
+    return Mock(InvokeAdvice) {
       pointcut() >> target
     }
   }
 
-  protected CallSiteAdvice mockAdvice(final Pointcut target, final String... helpers) {
-    return Mock(CallSiteAdviceWithHelpers) {
+  protected InvokeDynamicAdvice mockInvokeDynamicAdvice(final Pointcut target) {
+    return Mock(InvokeDynamicAdvice) {
+      pointcut() >> target
+    }
+  }
+
+  protected InvokeAdvice mockInvokeAdvice(final Pointcut target, final int flagsValue) {
+    return Mock(InvokeAdviceWithFlags) {
+      pointcut() >> target
+      flags() >> flagsValue
+    }
+  }
+
+  protected InvokeDynamicAdvice mockInvokeDynamicAdvice(final Pointcut target, final int flagsValue) {
+    return Mock(InvokeDynamicAdviceWithFlags) {
+      pointcut() >> target
+      flags() >> flagsValue
+    }
+  }
+
+  protected InvokeAdvice mockInvokeAdvice(final Pointcut target, final String... helpers) {
+    return Mock(InvokeAdviceWithHelpers) {
       pointcut() >> target
       helperClassNames() >> helpers
     }
   }
 
-  protected Advices mockAdvices(final Collection<CallSiteAdvice> advices) {
-    return Mock(Advices) {
-      isEmpty() >> advices.isEmpty()
-      findAdvices(_ as TypeDescription, _ as ClassLoader) >> it
-      findAdvice(_ as String, _ as String, _ as String) >> { params ->
-        final Object[] args = params as Object[]
-        advices.find {
-          final pointcut = it.pointcut()
-          return pointcut.type() == args[0] as String &&
-            pointcut.method() == args[1] as String &&
-            pointcut.descriptor() == args[2] as String
-        }
-      }
+  protected InvokeDynamicAdvice mockInvokeDynamicAdvice(final Pointcut target, final String... helpers) {
+    return Mock(InvokeDynamicAdviceWithHelpers) {
+      pointcut() >> target
+      helperClassNames() >> helpers
     }
   }
 
+  protected InvokeAdvice mockInvokeAdvice(final Pointcut target, final int flagsValue, final String... helpers) {
+    return Mock(InvokeAdviceWithFlagsAndHelpers) {
+      pointcut() >> target
+      flags() >> flagsValue
+      helperClassNames() >> helpers
+    }
+  }
+
+  protected InvokeDynamicAdvice mockInvokeDynamicAdvice(final Pointcut target, final int flagsValue, final String... helpers) {
+    return Mock(InvokeDynamicAdviceWithFlagsAndHelpers) {
+      pointcut() >> target
+      flags() >> flagsValue
+      helperClassNames() >> helpers
+    }
+  }
+
+  protected Advices mockAdvices(final Collection<CallSiteAdvice> advices) {
+    final computedFlags = advices.inject(0) { result, advice ->
+      return advice instanceof HasFlags ? (result | (advice as HasFlags).flags()) : result
+    }
+    final adviceFinder = { final String owner, final String name, final String desc ->
+      return advices.find {
+        final pointcut = it.pointcut()
+        return pointcut.type() == owner && pointcut.method() == name && pointcut.descriptor() == desc
+      }
+    }
+    return Mock(Advices) {
+      isEmpty() >> advices.isEmpty()
+      findAdvices(_ as TypeDescription, _ as ClassLoader) >> it
+      findAdvice(_ as Pointcut) >> { params ->
+        final pointcut = (params as Object[])[0] as Pointcut
+        adviceFinder.call(pointcut.type(), pointcut.method(), pointcut.descriptor())
+      }
+      findAdvice(_ as Handle) >> { params ->
+        final handle = (params as Object[])[0] as Handle
+        adviceFinder.call(handle.getOwner(), handle.getName(), handle.getDesc())
+      }
+      findAdvice(_ as String, _ as String, _ as String) >> { params ->
+        final Object[] args = params as Object[]
+        adviceFinder.call(args[0] as String, args[1] as String, args[2] as String)
+      }
+      hasFlag(_ as int) >> { params -> (params as Object[])[0] as int & computedFlags}
+      computeMaxStack() >> { COMPUTE_MAX_STACK & computedFlags}
+    }
+  }
+
+  protected static Pointcut stringConcatPointcut() {
+    return buildPointcut(String.getDeclaredMethod('concat', String))
+  }
+
+  protected static Pointcut messageDigestGetInstancePointcut() {
+    return buildPointcut(MessageDigest.getDeclaredMethod('getInstance', String))
+  }
+
+  protected static Pointcut stringConcatFactoryPointcut() {
+    return buildPointcut(
+      'java/lang/invoke/StringConcatFactory',
+      'makeConcatWithConstants',
+      '(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/invoke/CallSite;')
+  }
+
   protected static Pointcut buildPointcut(final Method executable) {
+    return buildPointcut(Type.getType(executable.getDeclaringClass()).internalName, executable.name, Type.getType(executable).descriptor)
+  }
+
+  protected static Pointcut buildPointcut(final String type, final String method, final String descriptor) {
     return new Pointcut() {
         @Override
         String type() {
-          return Type.getType(executable.getDeclaringClass()).internalName
+          return type
         }
 
         @Override
         String method() {
-          return executable.name
+          return method
         }
 
         @Override
         String descriptor() {
-          return Type.getType(executable).descriptor
+          return descriptor
         }
       }
   }
@@ -87,6 +176,10 @@ class BaseCallSiteTest extends DDSpecification {
           return callerType
         }
       }
+  }
+
+  protected static Type renameType(final Type sourceType, final String suffix) {
+    return Type.getType(sourceType.descriptor.replace(';', "${suffix};"))
   }
 
   protected static Object loadType(final Type type,
@@ -120,6 +213,21 @@ class BaseCallSiteTest extends DDSpecification {
     return classFileTransformer.transform(loader, source.className, null, null, classContent)
   }
 
-  interface CallSiteAdviceWithHelpers extends CallSiteAdvice, CallSiteAdvice.HasHelpers {
+  interface InvokeAdviceWithHelpers extends InvokeAdvice, HasHelpers {
+  }
+
+  interface InvokeDynamicAdviceWithHelpers extends InvokeDynamicAdvice, HasHelpers {
+  }
+
+  interface InvokeAdviceWithFlags extends InvokeAdvice, HasFlags {
+  }
+
+  interface InvokeDynamicAdviceWithFlags extends InvokeDynamicAdvice, HasFlags {
+  }
+
+  interface InvokeAdviceWithFlagsAndHelpers extends InvokeAdvice, HasFlags, HasHelpers {
+  }
+
+  interface InvokeDynamicAdviceWithFlagsAndHelpers extends InvokeDynamicAdvice, HasFlags, HasHelpers {
   }
 }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteInstrumenterTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteInstrumenterTest.groovy
@@ -4,13 +4,12 @@ import datadog.trace.agent.tooling.Instrumenter
 import net.bytebuddy.asm.AsmVisitorWrapper
 import net.bytebuddy.description.type.TypeDescription
 import net.bytebuddy.dynamic.DynamicType
-import net.bytebuddy.jar.asm.MethodVisitor
 
 class CallSiteInstrumenterTest extends BaseCallSiteTest {
 
   def 'test instrumenter creates transformer'() {
     setup:
-    final advice = mockAdvice(buildPointcut(String.getDeclaredMethod('concat', String)))
+    final advice = mockInvokeAdvice(stringConcatPointcut())
     final instrumenter = buildInstrumenter([advice])
     final builder = Mock(DynamicType.Builder)
     final type = Mock(TypeDescription) {
@@ -28,7 +27,7 @@ class CallSiteInstrumenterTest extends BaseCallSiteTest {
 
   def 'test instrumenter adds no transformations'() {
     setup:
-    final advice = mockAdvice(buildPointcut(String.getDeclaredMethod('concat', String)))
+    final advice = mockInvokeAdvice(stringConcatPointcut())
     final instrumenter = buildInstrumenter([advice])
     final mock = Mock(Instrumenter.AdviceTransformation)
 
@@ -41,8 +40,8 @@ class CallSiteInstrumenterTest extends BaseCallSiteTest {
 
   def 'test helper class names'() {
     setup:
-    final advice1 = mockAdvice(buildPointcut(String.getDeclaredMethod('concat', String)), 'foo.bar.Helper1')
-    final advice2 = mockAdvice(buildPointcut(StringBuilder.getDeclaredMethod('append', String)), 'foo.bar.Helper1', 'foo.bar.Helper2', 'foo.bar.Helper3')
+    final advice1 = mockInvokeAdvice(stringConcatPointcut(), 'foo.bar.Helper1')
+    final advice2 = mockInvokeAdvice(messageDigestGetInstancePointcut(), 'foo.bar.Helper1', 'foo.bar.Helper2', 'foo.bar.Helper3')
     final instrumenter = buildInstrumenter([advice1, advice2])
 
     when:
@@ -86,22 +85,22 @@ class CallSiteInstrumenterTest extends BaseCallSiteTest {
     0 * builder.visit(_ as AsmVisitorWrapper) >> builder
   }
 
-  static class StringConcatAdvice implements TestCallSiteAdvice {
+  static class StringConcatAdvice implements TestCallSiteAdvice, InvokeAdvice {
 
     @Override
     Pointcut pointcut() {
-      return buildPointcut(String.getDeclaredMethod('concat', String))
+      return stringConcatPointcut()
     }
 
     @Override
     void apply(
-      final MethodVisitor mv,
+      final MethodHandler handler,
       final int opcode,
       final String owner,
       final String name,
       final String descriptor,
       final boolean isInterface) {
-      mv.visitMethodInsn(opcode, owner, name, descriptor, isInterface)
+      handler.method(opcode, owner, name, descriptor, isInterface)
     }
   }
 }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteTransformerInvokeDynamicTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteTransformerInvokeDynamicTest.groovy
@@ -1,0 +1,301 @@
+package datadog.trace.agent.tooling.csi
+
+import datadog.trace.agent.tooling.bytebuddy.csi.CallSiteTransformer
+import datadog.trace.agent.tooling.csi.CallSiteAdvice.StackDupMode
+import datadog.trace.api.function.Consumer
+import datadog.trace.api.function.Supplier
+import datadog.trace.api.function.TriConsumer
+import datadog.trace.api.function.TriFunction
+import net.bytebuddy.jar.asm.Handle
+import net.bytebuddy.jar.asm.Opcodes
+import net.bytebuddy.jar.asm.Type
+import org.spockframework.runtime.ConditionNotSatisfiedError
+import spock.lang.Requires
+import datadog.trace.agent.tooling.csi.CallSiteAdvice.MethodHandler
+
+import static datadog.trace.agent.tooling.csi.CallSiteAdvice.HasFlags.COMPUTE_MAX_STACK
+import static datadog.trace.agent.tooling.csi.CallSiteAdvice.StackDupMode.APPEND_ARRAY
+import static datadog.trace.agent.tooling.csi.CallSiteAdvice.StackDupMode.PREPEND_ARRAY
+import static datadog.trace.agent.tooling.csi.CallSiteAdvice.StackDupMode.COPY
+
+@Requires({
+  jvm.java9Compatible
+})
+class CallSiteTransformerInvokeDynamicTest extends BaseCallSiteTest {
+
+  def 'test call site transformer with invoke dynamic'() {
+    setup:
+    final source = Type.getType(StringPlusExample)
+    final target = renameType(source, 'Test')
+    final pointcut = stringConcatFactoryPointcut()
+    final callSite = mockInvokeDynamicAdvice(pointcut)
+    final callSiteTransformer = new CallSiteTransformer(mockAdvices([callSite]))
+
+    when:
+    final transformedClass = transformType(source, target, callSiteTransformer)
+    final instance = loadType(target, transformedClass) as TriFunction<String, String, String, String>
+    final result = instance.apply("Hello ", "World", "!")
+
+    then:
+    1 * callSite.apply(_ as MethodHandler, 'makeConcatWithConstants', '(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;', _ as Handle, _ as Object[]) >> { params ->
+      final args = params as Object[]
+      final handler = args[0] as MethodHandler
+      handler.instruction(Opcodes.SWAP)
+      handler.instruction(Opcodes.POP)
+      handler.loadConstant("Friend")
+      handler.instruction(Opcodes.SWAP)
+      handler.invokeDynamic(args[1] as String, args[2] as String, args[3] as Handle, args[4] as Object[])
+    }
+    result == "Hello Friend!"
+  }
+
+  def 'test call site with invoke dynamic with non matching advices'() {
+    setup:
+    final source = Type.getType(StringPlusExample)
+    final target = renameType(source, 'TestNoAdvices')
+    final callSiteTransformer = new CallSiteTransformer(mockAdvices([]))
+
+    when:
+    final transformedClass = transformType(source, target, callSiteTransformer)
+    final instance = loadType(target, transformedClass) as TriFunction<String, String, String, String>
+    final result = instance.apply("Hello ", "World", "!")
+
+    then:
+    result == "Hello World!"
+  }
+
+  def 'test call site transformer with invoke dynamic and constants'() {
+    setup:
+    final source = Type.getType(StringPlusConstantsExample)
+    final target = renameType(source, 'Test')
+    final pointcut = stringConcatFactoryPointcut()
+    final callSite = mockInvokeDynamicAdvice(pointcut)
+    final callSiteTransformer = new CallSiteTransformer(mockAdvices([callSite]))
+
+    when:
+    final transformedClass = transformType(source, target, callSiteTransformer)
+    final instance = loadType(target, transformedClass) as TriFunction<String, String, String, String>
+    final result = instance.apply('Hello', 'World', '!')
+
+    then:
+    1 * callSite.apply(_ as MethodHandler, 'makeConcatWithConstants', '(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;', _ as Handle, _ as Object[]) >> { params ->
+      final args = params as Object[]
+      final handler = args[0] as MethodHandler
+      handler.instruction(Opcodes.SWAP)
+      handler.instruction(Opcodes.POP)
+      handler.loadConstant("Friend")
+      handler.instruction(Opcodes.SWAP)
+      final dynamicArguments = ['\u0001_\u0001-\u0001'] as Object[]
+      handler.invokeDynamic(args[1] as String, args[2] as String, args[3] as Handle, dynamicArguments)
+    }
+    result == "Hello_Friend-!"
+  }
+
+  def 'test call site with invoke dynamic and constants and non matching advices'() {
+    setup:
+    final source = Type.getType(StringPlusConstantsExample)
+    final target = renameType(source, 'TestNoAdvices')
+    final callSiteTransformer = new CallSiteTransformer(mockAdvices([]))
+
+    when:
+    final transformedClass = transformType(source, target, callSiteTransformer)
+    final instance = loadType(target, transformedClass) as TriFunction<String, String, String, String>
+    final result = instance.apply("Hello", "World", "!")
+
+    then:
+    result == "Hello World !"
+  }
+
+  def 'test modifying stack advices with compute max stack? #computeMax'(final boolean computeMax,
+    final Class<? extends Exception> expectedThrown) {
+    setup:
+    final source = Type.getType(StringPlusConstantsExample)
+    final target = renameType(source, 'Test')
+    final helperType = Type.getType(StringPlusHelper)
+    final helperMethod = Type.getType(StringPlusHelper.getDeclaredMethod("onConcat", String, String, String))
+    final pointcut = stringConcatFactoryPointcut()
+    final callSite = mockInvokeDynamicAdvice(pointcut, COMPUTE_MAX_STACK, helperType.className)
+    final advices = mockAdvices([callSite])
+    final callSiteTransformer = new CallSiteTransformer(advices)
+    final callbackArguments = new Object[3]
+    StringPlusHelper.callback = { Object[] args ->  System.arraycopy(args, 0, callbackArguments, 0, args.length) }
+
+    when:
+    // spock exception handling should be toplevel so we do a custom try/catch check
+    try {
+      final transformedClass = transformType(source, target, callSiteTransformer)
+      final instance = loadType(target, transformedClass) as TriFunction<String, String, String, String>
+      instance.apply('Hello', 'World', '!')
+      assert expectedThrown == null: 'Method should throw an exception'
+      assert callbackArguments[0] == 'Hello'
+      assert callbackArguments[1] == 'World'
+      assert callbackArguments[2] == '!'
+    } catch (ConditionNotSatisfiedError e) {
+      throw e
+    } catch (Throwable e) {
+      assert e.getClass() == expectedThrown
+    }
+
+    then:
+    1 * advices.computeMaxStack() >> computeMax
+    1 * callSite.apply(_ as MethodHandler, 'makeConcatWithConstants', '(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;', _ as Handle, _ as Object[]) >> { params ->
+      final args = params as Object[]
+      final handler = args[0] as MethodHandler
+      final String descriptor = args[2] as String
+      handler.dupParameters(descriptor, COPY)
+      handler.method(Opcodes.INVOKESTATIC, helperType.internalName, 'onConcat', helperMethod.descriptor, false)
+      handler.invokeDynamic(args[1] as String, descriptor, args[3] as Handle, args[4] as Object[])
+    }
+
+    where:
+    computeMax | expectedThrown
+    true       | null
+    false      | VerifyError
+  }
+
+  def 'test unknown arity example with stack dup #mode'(final StackDupMode mode, final Class<?> helper) {
+    setup:
+    final source = Type.getType(UnknownArityExample)
+    final target = renameType(source, 'Test')
+    final helperType = Type.getType(helper)
+    final helperMethod = Type.getType(helper.getDeclaredMethods().find { it.name == 'onConcat' })
+    final pointcut = stringConcatFactoryPointcut()
+    final callSite = mockInvokeDynamicAdvice(pointcut, COMPUTE_MAX_STACK, helperType.className)
+    final advices = mockAdvices([callSite])
+    final callSiteTransformer = new CallSiteTransformer(advices)
+    final callbackArguments = new Object[4]
+    final callback = { Object[] args ->  System.arraycopy(args, 0, callbackArguments, 0, args.length) }
+    if (helper == UnknownArityHelperBefore) {
+      UnknownArityHelperBefore.callback = callback
+    } else {
+      UnknownArityHelperAfter.callback = callback
+    }
+
+    when:
+    final transformedClass = transformType(source, target, callSiteTransformer)
+    final instance = loadType(target, transformedClass) as Supplier<String>
+    final result = instance.get()
+
+    then:
+    final matcher = result =~ /My name is (?<name>[\w\-]+), I'm (?<age>\d+) years old, (?<height>\d+) cm tall and I weight (?<weight>[\d\.]+) kg/
+    matcher.matches()
+    callbackArguments[0] == matcher.group('name')
+    callbackArguments[1] == Integer.valueOf(matcher.group('age'))
+    callbackArguments[2] == Long.valueOf(matcher.group('height'))
+    callbackArguments[3] == Double.valueOf(matcher.group('weight'))
+    1 * advices.computeMaxStack() >> true
+    1 * callSite.apply(_ as MethodHandler, 'makeConcatWithConstants', '(Ljava/lang/String;IJD)Ljava/lang/String;', _ as Handle, _ as Object[]) >> { params ->
+      final args = params as Object[]
+      final handler = args[0] as MethodHandler
+      final String descriptor = args[2] as String
+      handler.dupParameters(descriptor, mode)
+      if (mode == APPEND_ARRAY) {
+        handler.method(Opcodes.INVOKESTATIC, helperType.internalName, 'onConcat', helperMethod.descriptor, false)
+        handler.invokeDynamic(args[1] as String, descriptor, args[3] as Handle, args[4] as Object[])
+      } else {
+        handler.invokeDynamic(args[1] as String, descriptor, args[3] as Handle, args[4] as Object[])
+        handler.method(Opcodes.INVOKESTATIC, helperType.internalName, 'onConcat', helperMethod.descriptor, false)
+      }
+    }
+
+    where:
+    mode          | helper
+    APPEND_ARRAY  | UnknownArityHelperBefore
+    PREPEND_ARRAY | UnknownArityHelperAfter
+  }
+
+  def 'test adding boostrap constants to the stack'() {
+    setup:
+    final source = Type.getType(StringPlusLoadWithTagsExample)
+    final target = renameType(source, 'Test')
+    final helperType = Type.getType(StringPlusHelperWithConstants)
+    final helperMethod = Type.getType(StringPlusHelperWithConstants.getDeclaredMethods().find { it.name == 'onConcat' })
+    final pointcut = stringConcatFactoryPointcut()
+    final callSite = mockInvokeDynamicAdvice(pointcut, COMPUTE_MAX_STACK, helperType.className)
+    final advices = mockAdvices([callSite])
+    final callSiteTransformer = new CallSiteTransformer(advices)
+    final callbackArguments = new Object[3]
+    final callbackResult = new String[1]
+    final callbackConstants = new Object[3]
+    final callback = { Object[] arguments, String result, Object[] constants ->
+      System.arraycopy(arguments, 0, callbackArguments, 0, arguments.length)
+      callbackResult[0] = result
+      System.arraycopy(constants, 0, callbackConstants, 0, constants.length)
+    }
+    StringPlusHelperWithConstants.callback = callback
+
+    when:
+    final transformedClass = transformType(source, target, callSiteTransformer)
+    final instance = loadType(target, transformedClass) as TriFunction<String, String, String, String>
+    final result = instance.apply('Hello \u0001', 'World \u0002', '!')
+
+    then:
+    result == 'Hello \u0001 \u0002 World \u0002 \u0001 !'
+    callbackArguments[0] == 'Hello \u0001'
+    callbackArguments[1] == 'World \u0002'
+    callbackArguments[2] == '!'
+    callbackResult[0] == result
+    // \u0001 is the place holder for the string concat arguments
+    // \u0002 is used as a place holder for internal arguments, when the JDK finds an \u0001 or \u0002 in the string
+    // template, it replaces the current entry with a \u0002 and introduces a new boostrap argument with the pattern
+    callbackConstants[0] == '\u0001\u0002\u0001\u0002\u0001'
+    callbackConstants[1] == ' \u0002 '
+    callbackConstants[2] == ' \u0001 '
+    1 * advices.computeMaxStack() >> true
+    1 * callSite.apply(_ as MethodHandler, 'makeConcatWithConstants', '(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;', _ as Handle, _ as Object[]) >> { params ->
+      final args = params as Object[]
+      final handler = args[0] as MethodHandler
+      final String descriptor = args[2] as String
+      handler.dupParameters(descriptor, PREPEND_ARRAY)
+      handler.invokeDynamic(args[1] as String, descriptor, args[3] as Handle, args[4] as Object[])
+      final Object[] bootstrapMethodConstants = args[4] as Object[]
+      handler.loadConstantArray(bootstrapMethodConstants)
+      handler.method(Opcodes.INVOKESTATIC, helperType.internalName, 'onConcat', helperMethod.descriptor, false)
+    }
+  }
+
+  static class StringPlusHelper {
+    private static Consumer<Object[]> callback = null // codenarc forces the lowercase name
+
+    static void onConcat(final String first, final String second, final String third) {
+      if (callback != null) {
+        callback.accept([first, second, third] as Object[])
+      }
+    }
+  }
+
+  static class UnknownArityHelperBefore {
+
+    private static Consumer<Object[]> callback = null // codenarc forces the lowercase name
+
+    static void onConcat(final Object[] parameters) {
+      if (callback != null) {
+        callback.accept(parameters)
+      }
+    }
+  }
+
+  static class UnknownArityHelperAfter {
+
+    private static Consumer<Object[]> callback = null // codenarc forces the lowercase name
+
+    static String onConcat(final Object[] parameters, final String result) {
+      if (callback != null) {
+        callback.accept(parameters)
+      }
+      return result
+    }
+  }
+
+  static class StringPlusHelperWithConstants {
+
+    private static TriConsumer<Object[], String, Object[]> callback = null // codenarc forces the lowercase name
+
+    static String onConcat(final Object[] parameters, final String result, final Object[] constants) {
+      if (callback != null) {
+        callback.accept(parameters, result, constants)
+      }
+      return result
+    }
+  }
+}

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteUtilsTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteUtilsTest.groovy
@@ -1,0 +1,607 @@
+package datadog.trace.agent.tooling.csi
+
+import datadog.trace.agent.tooling.bytebuddy.csi.CallSiteUtils
+import datadog.trace.test.util.DDSpecification
+import net.bytebuddy.jar.asm.MethodVisitor
+import net.bytebuddy.jar.asm.Opcodes
+import net.bytebuddy.jar.asm.Type
+import sun.reflect.generics.reflectiveObjects.NotImplementedException
+
+import static datadog.trace.agent.tooling.csi.CallSiteAdvice.StackDupMode.APPEND_ARRAY
+import static datadog.trace.agent.tooling.csi.CallSiteAdvice.StackDupMode.PREPEND_ARRAY
+import static datadog.trace.agent.tooling.csi.CallSiteAdvice.StackDupMode.COPY
+import static datadog.trace.agent.tooling.csi.CallSiteUtilsTest.StackObject.forBoolean
+import static datadog.trace.agent.tooling.csi.CallSiteUtilsTest.StackObject.forByte
+import static datadog.trace.agent.tooling.csi.CallSiteUtilsTest.StackObject.forChar
+import static datadog.trace.agent.tooling.csi.CallSiteUtilsTest.StackObject.forDouble
+import static datadog.trace.agent.tooling.csi.CallSiteUtilsTest.StackObject.forFloat
+import static datadog.trace.agent.tooling.csi.CallSiteUtilsTest.StackObject.forInt
+import static datadog.trace.agent.tooling.csi.CallSiteUtilsTest.StackObject.forLong
+import static datadog.trace.agent.tooling.csi.CallSiteUtilsTest.StackObject.forObject
+import static datadog.trace.agent.tooling.csi.CallSiteUtilsTest.StackObject.forShort
+import static net.bytebuddy.jar.asm.Type.BOOLEAN_TYPE
+import static net.bytebuddy.jar.asm.Type.BYTE_TYPE
+import static net.bytebuddy.jar.asm.Type.CHAR_TYPE
+import static net.bytebuddy.jar.asm.Type.DOUBLE_TYPE
+import static net.bytebuddy.jar.asm.Type.FLOAT_TYPE
+import static net.bytebuddy.jar.asm.Type.INT_TYPE
+import static net.bytebuddy.jar.asm.Type.LONG_TYPE
+import static net.bytebuddy.jar.asm.Type.SHORT_TYPE
+
+class CallSiteUtilsTest extends DDSpecification {
+
+  def 'test push int value "#value" onto stack'(final int value, final int opcode) {
+    setup:
+    final visitor = Mock(MethodVisitor)
+
+    when:
+    CallSiteUtils.pushInteger(visitor, value)
+
+    then:
+    if (opcode >= Opcodes.ICONST_M1 && opcode <= Opcodes.ICONST_5) {
+      1 * visitor.visitInsn(opcode)
+    } else {
+      if (opcode == Opcodes.LDC) {
+        1 * visitor.visitLdcInsn(value)
+      } else {
+        1 * visitor.visitIntInsn(opcode, value)
+      }
+    }
+    0 * _
+
+    where:
+    value               | opcode
+    -1                  | Opcodes.ICONST_M1
+    0                   | Opcodes.ICONST_0
+    1                   | Opcodes.ICONST_1
+    2                   | Opcodes.ICONST_2
+    3                   | Opcodes.ICONST_3
+    4                   | Opcodes.ICONST_4
+    5                   | Opcodes.ICONST_5
+    Short.MIN_VALUE - 1 | Opcodes.LDC
+    Short.MIN_VALUE     | Opcodes.SIPUSH
+    Short.MAX_VALUE + 1 | Opcodes.LDC
+    Short.MAX_VALUE     | Opcodes.SIPUSH
+    Byte.MIN_VALUE - 1  | Opcodes.SIPUSH
+    Byte.MIN_VALUE      | Opcodes.BIPUSH
+    Byte.MAX_VALUE + 1  | Opcodes.SIPUSH
+    Byte.MAX_VALUE      | Opcodes.BIPUSH
+  }
+
+  def 'test swap [..., #secondToLastSize, #lastSize]'(final int secondToLastSize,
+    final int lastSize,
+    final List<Integer> opcodes) {
+    setup:
+    final visitor = Mock(MethodVisitor)
+
+    when:
+    CallSiteUtils.swap(visitor, secondToLastSize, lastSize)
+
+    then:
+    opcodes.each {
+      1 * visitor.visitInsn(it)
+    }
+    0 * _
+
+    where:
+    secondToLastSize | lastSize | opcodes
+    1                | 1        | [Opcodes.SWAP]
+    2                | 2        | [Opcodes.DUP2_X2, Opcodes.POP2]
+    1                | 2        | [Opcodes.DUP2_X1, Opcodes.POP2]
+    2                | 1        | [Opcodes.DUP_X2, Opcodes.POP]
+  }
+
+  def 'test stack clone of #items'(final List<StackObject> items, final List<StackObject> expected) {
+    setup:
+    final stack = buildStack(items)
+    final visitor = mockMethodVisitor(stack)
+
+    when:
+    CallSiteUtils.dup(visitor, items.collect { it.type } as Type[], COPY)
+
+    then:
+    final result = fromStack(stack)
+    result == expected
+
+    where:
+    items                                                                         | expected
+    [forInt(1)]                                                                   | items + items
+    [forInt(1), forInt(2)]                                                        | items + items
+    [forLong(1L)]                                                                 | items + items
+    [forLong(1L), forLong(2L)]                                                    | items + items
+    [forInt(1), forLong(2L)]                                                      | items + items
+    [forInt(1), forInt(2), forLong(3L)]                                           | items + items
+    [forInt(1), forInt(2), forInt(3), forLong(4L)]                                | items + items
+    [forObject('PI = '), forDouble(3.14D), forChar((char) '?'), forBoolean(true)] | items + items
+  }
+
+  def 'test stack dup with array before of #items'(final List<StackObject> items, final List<StackObject> expected) {
+    setup:
+    final stack = buildStack(items)
+    final visitor = mockMethodVisitor(stack)
+
+    when:
+    CallSiteUtils.dup(visitor, items.collect { it.type } as Type[], PREPEND_ARRAY)
+
+    then: 'the first element of the stack should be an array with the parameters'
+    final arrayFromStack = stack.remove(0)
+    arrayFromStack.type.descriptor == "[Ljava/lang/Object;"
+    final array = (arrayFromStack.value as Object[]).toList() as List<StackObject>
+    [array, expected].transpose().each { arrayItem, expectedItem ->
+      assert arrayItem.value == expectedItem.value // some of the items might be boxed so be careful
+    }
+
+    then: 'the rest of the array should contain the expected values'
+    final result = fromStack(stack)
+    result == expected
+
+    where:
+    items                                                                         | expected
+    [forInt(1)]                                                                   | items
+    [forInt(1), forInt(2)]                                                        | items
+    [forLong(1L)]                                                                 | items
+    [forLong(1L), forLong(2L)]                                                    | items
+    [forInt(1), forLong(2L)]                                                      | items
+    [forInt(1), forInt(2), forLong(3L)]                                           | items
+    [forInt(1), forInt(2), forInt(3), forLong(4L)]                                | items
+    [forObject('PI = '), forDouble(3.14D), forChar((char) '?'), forBoolean(true)] | items
+  }
+
+  def 'test stack dup with array after of #items'(final List<StackObject> items, final List<StackObject> expected) {
+    setup:
+    final stack = buildStack(items)
+    final visitor = mockMethodVisitor(stack)
+
+    when:
+    CallSiteUtils.dup(visitor, items.collect { it.type } as Type[], APPEND_ARRAY)
+
+    then: 'the last element of the stack should be an array with the parameters'
+    final arrayFromStack = stack.remove(stack.size() - 1)
+    arrayFromStack.type.descriptor == "[Ljava/lang/Object;"
+    final array = (arrayFromStack.value as Object[]).toList() as List<StackObject>
+    [array, expected].transpose().each { arrayItem, expectedItem ->
+      assert arrayItem.value == expectedItem.value // some of the items might be boxed so be careful
+    }
+
+    then: 'the rest of the array should contain the expected values'
+    final result = fromStack(stack)
+    result == expected
+
+    where:
+    items                                                                         | expected
+    [forInt(1)]                                                                   | items
+    [forInt(1), forInt(2)]                                                        | items
+    [forLong(1L)]                                                                 | items
+    [forLong(1L), forLong(2L)]                                                    | items
+    [forInt(1), forLong(2L)]                                                      | items
+    [forInt(1), forInt(2), forLong(3L)]                                           | items
+    [forInt(1), forInt(2), forInt(3), forLong(4L)]                                | items
+    [forObject('PI = '), forDouble(3.14D), forChar((char) '?'), forBoolean(true)] | items
+  }
+
+  private MethodVisitor mockMethodVisitor(final List<StackObject> stack) {
+    return Mock(MethodVisitor) {
+      visitInsn(Opcodes.DUP) >> { handleDUP(stack) }
+      visitInsn(Opcodes.DUP_X1) >> { handleDUP_X1(stack) }
+      visitInsn(Opcodes.DUP_X2) >> { handleDUP_X2(stack) }
+      visitInsn(Opcodes.DUP2) >> { handleDUP2(stack) }
+      visitInsn(Opcodes.DUP2_X1) >> { handleDUP2_X1(stack) }
+      visitInsn(Opcodes.DUP2_X2) >> { handleDUP2_X2(stack) }
+      visitInsn(Opcodes.POP) >> { handlePOP(stack) }
+      visitInsn(Opcodes.POP2) >> { handlePOP2(stack) }
+      visitInsn(Opcodes.SWAP) >> { handleSWAP(stack) }
+      visitInsn(Opcodes.ICONST_M1) >> { stack.add(forInt(-1)) }
+      visitInsn(Opcodes.ICONST_0) >> { stack.add(forInt(0)) }
+      visitInsn(Opcodes.ICONST_1) >> { stack.add(forInt(1)) }
+      visitInsn(Opcodes.ICONST_2) >> { stack.add(forInt(2)) }
+      visitInsn(Opcodes.ICONST_3) >> { stack.add(forInt(3)) }
+      visitInsn(Opcodes.ICONST_4) >> { stack.add(forInt(4)) }
+      visitInsn(Opcodes.ICONST_5) >> { stack.add(forInt(5)) }
+      visitIntInsn(Opcodes.BIPUSH, _) >> { stack.add(forInt(it[1] as int)) }
+      visitTypeInsn(Opcodes.ANEWARRAY, 'java/lang/Object') >> { handleNewArray(stack) }
+      visitInsn(Opcodes.AASTORE) >> { handleArrayStore(stack) }
+      visitInsn(Opcodes.AALOAD) >> { handleArrayLoad(stack) }
+      visitTypeInsn(Opcodes.CHECKCAST, _) >> { handleCheckCast(stack, it[1] as String) }
+      visitMethodInsn(Opcodes.INVOKESTATIC, _, 'valueOf', _, false) >> { handleBoxing(stack, it[1] as String) }
+      visitMethodInsn(Opcodes.INVOKEVIRTUAL, _, _, _, false) >> {
+        final method = it[2] as String
+        if (method ==~ /(:?char|boolean|byte|short|int|long|float|double)Value/) {
+          handleUnBoxing(stack, it[1] as String, method)
+        } else {
+          throw new NotImplementedException()
+        }
+      }
+      _ >> { throw new IllegalArgumentException('Not yet implemented') }
+    }
+  }
+
+  private static void handleDUP(final List<StackObject> stack) {
+    final last = stack.get(stack.size() - 1)
+    if (!isCategoryOne(last)) {
+      throw new IllegalArgumentException()
+    }
+    stack.add(stack.size() - 1, last)
+  }
+
+  private static void handleDUP_X1(final List<StackObject> stack) {
+    final value1 = stack.get(stack.size() - 1)
+    final value2 = stack.get(stack.size() - 2)
+    if (!isCategoryOne(value1) || !isCategoryOne(value2)) {
+      throw new IllegalArgumentException()
+    }
+    stack.add(stack.size() - 2, value1)
+  }
+
+  private static void handleDUP_X2(final List<StackObject> stack) {
+    final value1 = stack.get(stack.size() - 1)
+    final value2 = stack.get(stack.size() - 2)
+    final value3 = stack.get(stack.size() - 3)
+    boolean valid = false
+    if (isCategoryOne(value1) && isCategoryOne(value2) && isCategoryOne(value3)) {
+      valid = true
+    } else if (isCategoryOne(value1) && isCategoryTwo(value2, value3)) {
+      valid = true
+    }
+    if (!valid) {
+      throw new IllegalArgumentException()
+    }
+    stack.add(stack.size() - 3, value1)
+  }
+
+  private static void handleDUP2(final List<StackObject> stack) {
+    final value1 = stack.get(stack.size() - 1)
+    final value2 = stack.get(stack.size() - 2)
+    boolean valid = false
+    if (isCategoryOne(value1) && isCategoryOne(value2)) {
+      valid = true
+    } else if (isCategoryTwo(value1, value2)) {
+      valid = true
+    }
+    if (!valid) {
+      throw new IllegalArgumentException()
+    }
+    stack.add(stack.size() - 2, value2)
+    stack.add(stack.size() - 2, value1)
+  }
+
+  private static void handleDUP2_X1(final List<StackObject> stack) {
+    final value1 = stack.get(stack.size() - 1)
+    final value2 = stack.get(stack.size() - 2)
+    final value3 = stack.get(stack.size() - 3)
+    boolean valid = false
+    if (isCategoryOne(value1) && isCategoryOne(value2) && isCategoryOne(value3)) {
+      valid = true
+    } else if (isCategoryTwo(value1, value2) && isCategoryOne(value3)) {
+      valid = true
+    }
+    if (!valid) {
+      throw new IllegalArgumentException()
+    }
+    stack.add(stack.size() - 3, value2)
+    stack.add(stack.size() - 3, value1)
+  }
+
+  private static void handleDUP2_X2(final List<StackObject> stack) {
+    final value1 = stack.get(stack.size() - 1)
+    final value2 = stack.get(stack.size() - 2)
+    final value3 = stack.get(stack.size() - 3)
+    final value4 = stack.get(stack.size() - 4)
+    boolean valid = false
+    if (isCategoryOne(value1) && isCategoryOne(value2) && isCategoryOne(value3) && isCategoryOne(value4)) {
+      valid = true
+    } else if (isCategoryTwo(value1, value2) && isCategoryOne(value3) && isCategoryOne(value4)) {
+      valid = true
+    } else if (isCategoryOne(value1) && isCategoryOne(value2) && isCategoryTwo(value3, value4)) {
+      valid = true
+    } else if (isCategoryTwo(value1, value2) && isCategoryTwo(value3, value4)) {
+      valid = true
+    }
+    if (!valid) {
+      throw new IllegalArgumentException()
+    }
+    stack.add(stack.size() - 4, value2)
+    stack.add(stack.size() - 4, value1)
+  }
+
+  private static void handlePOP(final List<StackObject> stack) {
+    final last = stack.get(stack.size() - 1)
+    if (!isCategoryOne(last)) {
+      throw new IllegalArgumentException()
+    }
+    stack.remove(stack.size() - 1)
+  }
+
+  private static void handlePOP2(final List<StackObject> stack) {
+    final value1 = stack.get(stack.size() - 1)
+    final value2 = stack.get(stack.size() - 2)
+    boolean valid = false
+    if (isCategoryOne(value1) && isCategoryOne(value2)) {
+      valid = true
+    } else if (isCategoryTwo(value1, value2)) {
+      valid = true
+    }
+    if (!valid) {
+      throw new IllegalArgumentException()
+    }
+    stack.remove(stack.size() - 1)
+    stack.remove(stack.size() - 1)
+  }
+
+  private static void handleSWAP(final List<StackObject> stack) {
+    final value1 = stack.get(stack.size() - 1)
+    final value2 = stack.get(stack.size() - 2)
+    boolean valid = false
+    if (isCategoryOne(value1) && isCategoryOne(value2)) {
+      valid = true
+    }
+    if (!valid) {
+      throw new IllegalArgumentException()
+    }
+    stack.remove(stack.size() - 1)
+    stack.remove(stack.size() - 1)
+    stack.add(value1)
+    stack.add(value2)
+  }
+
+  private static void handleNewArray(final List<StackObject> stack) {
+    final size = stack.remove(stack.size() - 1)
+    assert size.type == INT_TYPE
+    stack.add(forObject(new Object[size.intValue]))
+  }
+
+  private static void handleArrayStore(final List<StackObject> stack) {
+    final target = stack.remove(stack.size() - 1)
+    if (target.categoryTwo) {
+      stack.remove(stack.size() - 1)
+    }
+    final indexStack = stack.remove(stack.size() - 1)
+    final arrayStack = stack.remove(stack.size() - 1)
+
+    assert target.type.sort == Type.OBJECT
+    assert indexStack.type == INT_TYPE
+    assert arrayStack.type == Type.getType(Object[].class)
+
+    final index = indexStack.intValue
+    final array = arrayStack.objectValue as Object[]
+    array[index] = target
+  }
+
+  private static void handleArrayLoad(final List<StackObject> stack) {
+    final indexStack = stack.remove(stack.size() - 1)
+    final arrayStack = stack.remove(stack.size() - 1)
+
+    assert indexStack.type == INT_TYPE
+    assert arrayStack.type == Type.getType(Object[].class)
+
+    final index = indexStack.intValue
+    final array = arrayStack.objectValue as Object[]
+    final item = array[index] as StackObject
+
+    assert item.type.sort == Type.OBJECT
+
+    item.addToStack(stack)
+  }
+
+  private static void handleCheckCast(final List<StackObject> stack, final String typeDescriptor) {
+    final item = stack.get(stack.size() - 1)
+    assert item.type.internalName == typeDescriptor
+  }
+
+  private static void handleBoxing(final List<StackObject> stack, final String typeDescriptor) {
+    final item = stack.remove(stack.size() - 1)
+    if (item.categoryTwo) {
+      stack.remove(stack.size() - 1)
+    }
+    StackObject boxed
+    switch (item.type.sort) {
+      case Type.BOOLEAN:
+        assert typeDescriptor == 'java/lang/Boolean'
+        boxed = forObject(Boolean.valueOf(item.booleanValue))
+        break
+      case Type.CHAR:
+        assert typeDescriptor == 'java/lang/Character'
+        boxed = forObject(Character.valueOf(item.charValue))
+        break
+      case Type.BYTE:
+        assert typeDescriptor == 'java/lang/Byte'
+        boxed = forObject(Byte.valueOf(item.byteValue))
+        break
+      case Type.SHORT:
+        assert typeDescriptor == 'java/lang/Short'
+        boxed = forObject(Short.valueOf(item.shortValue))
+        break
+      case Type.INT:
+        assert typeDescriptor == 'java/lang/Integer'
+        boxed = forObject(Integer.valueOf(item.intValue))
+        break
+      case Type.FLOAT:
+        assert typeDescriptor == 'java/lang/Float'
+        boxed = forObject(Float.valueOf(item.floatValue))
+        break
+      case Type.LONG:
+        assert typeDescriptor == 'java/lang/Long'
+        boxed = forObject(Long.valueOf(item.longValue))
+        break
+      case Type.DOUBLE:
+        assert typeDescriptor == 'java/lang/Double'
+        boxed = forObject(Double.valueOf(item.doubleValue))
+        break
+      default:
+        throw new IllegalArgumentException()
+    }
+    boxed.addToStack(stack)
+  }
+
+  private static void handleUnBoxing(final List<StackObject> stack, final String typeDescriptor, final String method) {
+    final item = stack.remove(stack.size() - 1)
+    if (item.categoryTwo) {
+      stack.remove(stack.size() - 1)
+    }
+    StackObject unboxed
+    if (item.type.internalName == 'java/lang/Boolean') {
+      assert typeDescriptor == 'java/lang/Boolean'
+      assert method == 'booleanValue'
+      unboxed = forBoolean(((Boolean) item.objectValue).booleanValue())
+    } else if (item.type.internalName == 'java/lang/Character') {
+      assert typeDescriptor == 'java/lang/Character'
+      assert method == 'charValue'
+      unboxed = forChar(((Character) item.objectValue).charValue())
+    } else if (item.type.internalName == 'java/lang/Byte') {
+      assert typeDescriptor == 'java/lang/Byte'
+      assert method == 'byteValue'
+      unboxed = forByte(((Byte) item.objectValue).byteValue())
+    } else if (item.type.internalName == 'java/lang/Short') {
+      assert typeDescriptor == 'java/lang/Short'
+      assert method == 'shortValue'
+      unboxed = forShort(((Short) item.objectValue).shortValue())
+    } else if (item.type.internalName == 'java/lang/Integer') {
+      assert typeDescriptor == 'java/lang/Integer'
+      assert method == 'intValue'
+      unboxed = forInt(((Integer) item.objectValue).intValue())
+    } else if (item.type.internalName == 'java/lang/Float') {
+      assert typeDescriptor == 'java/lang/Float'
+      assert method == 'floatValue'
+      unboxed = forFloat(((Float) item.objectValue).floatValue())
+    } else if (item.type.internalName == 'java/lang/Long') {
+      assert typeDescriptor == 'java/lang/Long'
+      assert method == 'longValue'
+      unboxed = forLong(((Long) item.objectValue).longValue())
+    } else if (item.type.internalName == 'java/lang/Double') {
+      assert typeDescriptor == 'java/lang/Double'
+      assert method == 'doubleValue'
+      unboxed = forDouble(((Double) item.objectValue).doubleValue())
+    } else {
+      throw new IllegalArgumentException()
+    }
+    unboxed.addToStack(stack)
+  }
+
+  private static boolean isCategoryOne(final StackObject value) {
+    return !value.categoryTwo
+  }
+
+  private static boolean isCategoryTwo(final StackObject value1, final StackObject value2) {
+    return value1 == value2 && value1.categoryTwo
+  }
+
+  private static List<StackObject> buildStack(final List<StackObject> items) {
+    final stack = [] as List<StackObject>
+    items.each { value ->
+      value.addToStack(stack)
+    }
+    return stack
+  }
+
+  private static List<StackObject> fromStack(final List<StackObject> list) {
+    final result = [] as List<StackObject>
+    for (def i = 0; i < list.size(); i++) {
+      final stack = list.get(i)
+      result.add(stack)
+      if (stack.categoryTwo) {
+        final next = list.get(++i)
+        assert next == stack: "Category II objects take two places in the stack"
+      }
+    }
+    return result
+  }
+
+  private static class StackObject {
+    boolean booleanValue
+    byte byteValue
+    char charValue
+    short shortValue
+    int intValue
+    long longValue
+    float floatValue
+    double doubleValue
+    Object objectValue
+    Type type
+
+    boolean isCategoryTwo() {
+      return type == LONG_TYPE || type == DOUBLE_TYPE
+    }
+
+    void addToStack(final List<StackObject> stack) {
+      stack.add(this)
+      if (isCategoryTwo()) {
+        stack.add(this)
+      }
+    }
+
+    static StackObject forBoolean(final boolean value) {
+      return new StackObject(booleanValue: value, type: BOOLEAN_TYPE)
+    }
+
+    static StackObject forChar(final char value) {
+      return new StackObject(charValue: value, type: CHAR_TYPE)
+    }
+
+    static StackObject forByte(final byte value) {
+      return new StackObject(byteValue: value, type: BYTE_TYPE)
+    }
+
+    static StackObject forShort(final short value) {
+      return new StackObject(shortValue: value, type: SHORT_TYPE)
+    }
+
+    static StackObject forInt(final int value) {
+      return new StackObject(intValue: value, type: INT_TYPE)
+    }
+
+    static StackObject forLong(final long value) {
+      return new StackObject(longValue: value, type: LONG_TYPE)
+    }
+
+    static StackObject forFloat(final float value) {
+      return new StackObject(floatValue: value, type: FLOAT_TYPE)
+    }
+
+    static StackObject forDouble(final double value) {
+      return new StackObject(doubleValue: value, type: DOUBLE_TYPE)
+    }
+
+    static StackObject forObject(final Object value) {
+      return new StackObject(objectValue: value, type: Type.getType(value.getClass()))
+    }
+
+    Object getValue() {
+      switch (type.sort) {
+        case Type.BOOLEAN:
+          return booleanValue
+        case Type.CHAR:
+          return charValue
+        case Type.BYTE:
+          return byteValue
+        case Type.SHORT:
+          return shortValue
+        case Type.INT:
+          return intValue
+        case Type.FLOAT:
+          return floatValue
+        case Type.LONG:
+          return longValue
+        case Type.DOUBLE:
+          return doubleValue
+        default:
+          return objectValue
+      }
+    }
+
+    @Override
+    String toString() {
+      return "Stack: $value"
+    }
+
+    @Override
+    boolean equals(final Object other) {
+      if (!(other instanceof StackObject)) {
+        return false
+      }
+      final otherStack = (StackObject) other
+      if (type != otherStack.type) {
+        return false
+      }
+      return value == otherStack.value
+    }
+  }
+}

--- a/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/csi/StringConcatCategory2Example.java
+++ b/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/csi/StringConcatCategory2Example.java
@@ -4,14 +4,14 @@ import datadog.trace.api.function.BiFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class StringConcatExample implements BiFunction<String, String, String> {
+public class StringConcatCategory2Example implements BiFunction<String, String, String> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(StringConcatExample.class);
 
   public String apply(final String first, final String second) {
-    LOGGER.debug("Before apply");
+    LOGGER.debug("Before apply : " + (System.currentTimeMillis() / 1000L));
     final String result = first.concat(second);
-    LOGGER.debug("After apply " + result);
+    LOGGER.debug("After apply : " + (System.currentTimeMillis() / 1000L));
     return result;
   }
 }

--- a/dd-java-agent/agent-tooling/src/test/java11/datadog/trace/agent/tooling/csi/StringPlusConstantsExample.java
+++ b/dd-java-agent/agent-tooling/src/test/java11/datadog/trace/agent/tooling/csi/StringPlusConstantsExample.java
@@ -1,0 +1,17 @@
+package datadog.trace.agent.tooling.csi;
+
+import datadog.trace.api.function.TriFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StringPlusConstantsExample implements TriFunction<String, String, String, String> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(StringPlusConstantsExample.class);
+
+  public String apply(final String first, final String second, final String third) {
+    LOGGER.debug("Before apply");
+    final String result = first + " " + second + " " + third;
+    LOGGER.debug("After apply " + result);
+    return result;
+  }
+}

--- a/dd-java-agent/agent-tooling/src/test/java11/datadog/trace/agent/tooling/csi/StringPlusExample.java
+++ b/dd-java-agent/agent-tooling/src/test/java11/datadog/trace/agent/tooling/csi/StringPlusExample.java
@@ -1,0 +1,17 @@
+package datadog.trace.agent.tooling.csi;
+
+import datadog.trace.api.function.TriFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StringPlusExample implements TriFunction<String, String, String, String> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(StringPlusExample.class);
+
+  public String apply(final String first, final String second, final String third) {
+    LOGGER.debug("Before apply");
+    final String result = first + second + third;
+    LOGGER.debug("After apply " + result);
+    return result;
+  }
+}

--- a/dd-java-agent/agent-tooling/src/test/java11/datadog/trace/agent/tooling/csi/StringPlusLoadWithTagsExample.java
+++ b/dd-java-agent/agent-tooling/src/test/java11/datadog/trace/agent/tooling/csi/StringPlusLoadWithTagsExample.java
@@ -1,0 +1,17 @@
+package datadog.trace.agent.tooling.csi;
+
+import datadog.trace.api.function.TriFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StringPlusLoadWithTagsExample implements TriFunction<String, String, String, String> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(StringPlusConstantsExample.class);
+
+  public String apply(final String first, final String second, final String third) {
+    LOGGER.debug("Before apply");
+    final String result = first + " \u0002 " + second + " \u0001 " + third;
+    LOGGER.debug("After apply " + result);
+    return result;
+  }
+}

--- a/dd-java-agent/agent-tooling/src/test/java11/datadog/trace/agent/tooling/csi/UnknownArityExample.java
+++ b/dd-java-agent/agent-tooling/src/test/java11/datadog/trace/agent/tooling/csi/UnknownArityExample.java
@@ -1,0 +1,24 @@
+package datadog.trace.agent.tooling.csi;
+
+import datadog.trace.api.function.Supplier;
+import java.util.UUID;
+
+public class UnknownArityExample implements Supplier<String> {
+
+  @Override
+  public String get() {
+    final String name = UUID.randomUUID().toString();
+    final long height = Math.round(Math.random() * 200);
+    final double weight = Math.random() * 100;
+    final int age = (int) Math.round(Math.random() * 100);
+    return "My name is "
+        + name
+        + ", I'm "
+        + age
+        + " years old, "
+        + height
+        + " cm tall and I weight "
+        + weight
+        + " kg";
+  }
+}


### PR DESCRIPTION
# What Does This Do
Add support for Invoke Dynamic instructions to the Call Site instrumenter

# Motivation
From JDKs >= 9 the solution for `+` concatenation is based on invoke dynamic instructions instead of the traditional `StringBuilder` approach
