### PR TITLE
[WIP] test with clean environment variables

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ allprojects {
 
   apply from: "$rootDir/gradle/dependencies.gradle"
   apply from: "$rootDir/gradle/util.gradle"
+  apply from: "$rootDir/gradle/clean_env.gradle"
 
   compileTask.configure {
     dependsOn tasks.withType(AbstractCompile)

--- a/gradle/clean_env.gradle
+++ b/gradle/clean_env.gradle
@@ -1,5 +1,5 @@
 
-// This environment variable can hold a comma-separated list of environment variable names that will be passed to tests.
+// This environment variable can hold a space-separated list of environment variable names that will be passed to tests.
 final passEnvKey = "PASS_ENV"
 
 // List of environment variables that are always passed to tests.
@@ -18,7 +18,7 @@ def passEnv = [
 
 def customPassEnv = System.getenv(passEnvKey)
 if (customPassEnv != null && !customPassEnv.trim().isEmpty()) {
-  passEnv += ystem.getenv(passEnvKey).split(",").collect { it.trim() }
+  passEnv += ystem.getenv(passEnvKey).split(" ").collect { it.trim() }
 }
 
 tasks.withType(Test).configureEach {

--- a/gradle/clean_env.gradle
+++ b/gradle/clean_env.gradle
@@ -1,0 +1,30 @@
+
+// This environment variable can hold a comma-separated list of environment variable names that will be passed to tests.
+final passEnvKey = "PASS_ENV"
+
+// List of environment variables that are always passed to tests.
+def passEnv = [
+  'HOME',
+  'PATH',
+  'PWD',
+  'CI',
+  'DOCKER_HOST',
+  'DOCKER_TLS_VERIFY',
+  'DOCKER_CERT_PATH',
+  'TESTCONTAINERS_HOST_OVERRIDE',
+  'TESTCONTAINERS_RYUK_DISABLED',
+  'TEST_LIBASYNC',
+]
+
+def customPassEnv = System.getenv(passEnvKey)
+if (customPassEnv != null && !customPassEnv.trim().isEmpty()) {
+  passEnv += ystem.getenv(passEnvKey).split(",").collect { it.trim() }
+}
+
+tasks.withType(Test).configureEach {
+  System.getenv().each { key, value ->
+    if (!passEnv.contains(key)) {
+      environment.remove(key)
+    }
+  }
+}

--- a/gradle/clean_env.gradle
+++ b/gradle/clean_env.gradle
@@ -18,6 +18,14 @@ def passEnv = [
   'SONATYPE_PASSWORD',
   'GPG_PRIVATE_KEY',
   'GPG_PASSWORD',
+
+  // Test
+  'USER',
+  'LANG',
+  'LANGUAGE',
+  'SHELL',
+  'LC_ALL',
+  'JAVA_HOME'
 ]
 
 def customPassEnv = System.getenv(passEnvKey)

--- a/gradle/clean_env.gradle
+++ b/gradle/clean_env.gradle
@@ -14,18 +14,6 @@ def passEnv = [
   'TESTCONTAINERS_HOST_OVERRIDE',
   'TESTCONTAINERS_RYUK_DISABLED',
   'TEST_LIBASYNC',
-  'SONATYPE_USERNAME',
-  'SONATYPE_PASSWORD',
-  'GPG_PRIVATE_KEY',
-  'GPG_PASSWORD',
-
-  // Test
-  'USER',
-  'LANG',
-  'LANGUAGE',
-  'SHELL',
-  'LC_ALL',
-  'JAVA_HOME'
 ]
 
 def customPassEnv = System.getenv(passEnvKey)
@@ -36,9 +24,7 @@ if (customPassEnv != null && !customPassEnv.trim().isEmpty()) {
 tasks.withType(Test).configureEach {
   System.getenv().each { key, value ->
     if (!passEnv.contains(key)) {
-      logger.warn("Dropping environment variable: ${key}")
-      environment.remove(key)
+      it.environment.remove(key)
     }
   }
-  environment.put('LC_ALL', 'en_EN.UTF-8')
 }

--- a/gradle/clean_env.gradle
+++ b/gradle/clean_env.gradle
@@ -28,7 +28,9 @@ if (customPassEnv != null && !customPassEnv.trim().isEmpty()) {
 tasks.withType(Test).configureEach {
   System.getenv().each { key, value ->
     if (!passEnv.contains(key)) {
+      logger.warn("Dropping environment variable: ${key}")
       environment.remove(key)
     }
   }
+  environment.put('LC_ALL', 'en_EN.UTF-8')
 }

--- a/gradle/clean_env.gradle
+++ b/gradle/clean_env.gradle
@@ -22,7 +22,7 @@ def passEnv = [
 
 def customPassEnv = System.getenv(passEnvKey)
 if (customPassEnv != null && !customPassEnv.trim().isEmpty()) {
-  passEnv += ystem.getenv(passEnvKey).split(" ").collect { it.trim() }
+  passEnv += System.getenv(passEnvKey).split(" ").collect { it.trim() }
 }
 
 tasks.withType(Test).configureEach {

--- a/gradle/clean_env.gradle
+++ b/gradle/clean_env.gradle
@@ -14,6 +14,10 @@ def passEnv = [
   'TESTCONTAINERS_HOST_OVERRIDE',
   'TESTCONTAINERS_RYUK_DISABLED',
   'TEST_LIBASYNC',
+  'SONATYPE_USERNAME',
+  'SONATYPE_PASSWORD',
+  'GPG_PRIVATE_KEY',
+  'GPG_PASSWORD',
 ]
 
 def customPassEnv = System.getenv(passEnvKey)


### PR DESCRIPTION
# What Does This Do
Avoid environment variables interfering in the test process in unexpected ways.

# Motivation
This is particularly important for `DD_` since these are often set in DataDog environments and make the build fail.

# Additional Notes
