### PR TITLE
Disable latest-jdk-app in debugger-smoke-tests until jgit issue is fixed

### DIFF
--- a/dd-smoke-tests/debugger-integration-tests/debugger-integration-tests.gradle
+++ b/dd-smoke-tests/debugger-integration-tests/debugger-integration-tests.gradle
@@ -26,26 +26,28 @@ dependencies {
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
-tasks.register('buildLatestJdkApp', GradleBuild) {
-  buildFile = 'latest-jdk-app/latest-jdk-app.gradle'
-  tasks = ['shadowJar']
-}
-
-def latestJdk = '17'
+// TODO latest-jdk-app fails too often with a jgit failure, so disable until fixed
+//tasks.register('buildLatestJdkApp', GradleBuild) {
+//  buildFile = 'latest-jdk-app/latest-jdk-app.gradle'
+//  tasks = ['shadowJar']
+//}
+//
+//def latestJdk = '17'
 
 tasks.withType(Test).configureEach {
   dependsOn shadowJar
 
-  def isLatestJdk = project.findProperty("testJvm") == latestJdk
-  def latestJavaHome = System.getenv("JAVA_${latestJdk}_HOME")
-  if (isLatestJdk && latestJavaHome) {
-    dependsOn buildLatestJdkApp
-  }
-  doFirst {
-    if (isLatestJdk) {
-      jvmArgs "-Ddatadog.smoketest.shadowJar.external.path=${project(':dd-smoke-tests:debugger-integration-tests:latest-jdk-app').tasks.shadowJar.archivePath}"
-    }
-  }
+  // TODO latest-jdk-app fails too often with a jgit failure, so disable until fixed
+  //  def isLatestJdk = project.findProperty("testJvm") == latestJdk
+  //  def latestJavaHome = System.getenv("JAVA_${latestJdk}_HOME")
+  //  if (isLatestJdk && latestJavaHome) {
+  //    dependsOn buildLatestJdkApp
+  //  }
+  //  doFirst {
+  //    if (isLatestJdk) {
+  //      jvmArgs "-Ddatadog.smoketest.shadowJar.external.path=${project(':dd-smoke-tests:debugger-integration-tests:latest-jdk-app').tasks.shadowJar.archivePath}"
+  //    }
+  //  }
 
   jvmArgs "-Ddatadog.smoketest.shadowJar.path=${tasks.shadowJar.archivePath}"
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -118,7 +118,8 @@ include ':dd-smoke-tests:appsec'
 include ':dd-smoke-tests:appsec:springboot'
 include ':dd-smoke-tests:appsec:springboot-grpc'
 include ':dd-smoke-tests:debugger-integration-tests'
-include ':dd-smoke-tests:debugger-integration-tests:latest-jdk-app'
+// TODO this fails too often with a jgit failure, so disable until fixed
+//include ':dd-smoke-tests:debugger-integration-tests:latest-jdk-app'
 
 // instrumentation:
 include ':dd-java-agent:instrumentation:aerospike-4'


### PR DESCRIPTION
# What Does This Do

Disables the `latest-jdk-app` part of the `debugger-smoke-tests`.

# Motivation

The `latest-jdk-app` project fails often enough with a hard to diagnose `jgit` failure that it is affecting normal CI builds and runs. Disable the test until someone has the time to look at the build properly and fix it.

# Additional Notes
