### PR TITLE
Fix missing JDK9StackWalker from final jar

### DIFF
--- a/dd-java-agent/agent-bootstrap/agent-bootstrap.gradle
+++ b/dd-java-agent/agent-bootstrap/agent-bootstrap.gradle
@@ -19,6 +19,7 @@ dependencies {
   api project(':dd-trace-api')
   api project(':internal-api')
   api project(':internal-api:internal-api-8')
+  api project(':internal-api:internal-api-9')
   api project(':dd-java-agent:agent-logging')
   api deps.slf4j
   // ^ Generally a bad idea for libraries, but we're shadowing.

--- a/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
@@ -41,6 +41,11 @@ class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
       if (it.contains("IAST is starting")) {
         startMsg = it
       }
+      // Check that there's no logged exception about missing classes from Datadog.
+      // We had this problem before with JDK9StackWalker.
+      if (it.contains("java.lang.ClassNotFoundException: datadog/")) {
+        errorMsg = it
+      }
     }
 
     then: 'there are no errors in the log and IAST has started'


### PR DESCRIPTION
# What Does This Do
Ensure `internal-api-9` is included in the final jar.

# Motivation
We were logging a ClassNotFound exception for `JDK9StackWalker`, because the class was not included in the final jar.

# Additional Notes
