### PR TITLE
retry all kafka clients tests

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTest.groovy
@@ -22,6 +22,7 @@ import org.springframework.kafka.test.EmbeddedKafkaBroker
 import org.springframework.kafka.test.rule.EmbeddedKafkaRule
 import org.springframework.kafka.test.utils.ContainerTestUtils
 import org.springframework.kafka.test.utils.KafkaTestUtils
+import spock.lang.Retry
 import spock.lang.Unroll
 
 import java.util.concurrent.LinkedBlockingQueue
@@ -31,6 +32,7 @@ import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
 
+@Retry(count = 5, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class KafkaClientTest extends AgentTestRunner {
   static final SHARED_TOPIC = "shared.topic"
 

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
@@ -24,6 +24,7 @@ import org.springframework.kafka.test.rule.KafkaEmbedded
 import org.springframework.kafka.test.utils.ContainerTestUtils
 import org.springframework.kafka.test.utils.KafkaTestUtils
 import spock.lang.Requires
+import spock.lang.Retry
 import spock.lang.Unroll
 
 import java.util.concurrent.LinkedBlockingQueue
@@ -870,6 +871,7 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
   }
 }
 
+@Retry(count = 5, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class KafkaClientForkedTest extends KafkaClientTestBase {
   @Override
   void configurePreAgent() {
@@ -894,6 +896,7 @@ class KafkaClientForkedTest extends KafkaClientTestBase {
   }
 }
 
+@Retry(count = 5, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class KafkaClientSplitByDestinationForkedTest extends KafkaClientTestBase {
   @Override
   void configurePreAgent() {
@@ -919,6 +922,7 @@ class KafkaClientSplitByDestinationForkedTest extends KafkaClientTestBase {
   }
 }
 
+@Retry(count = 5, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class KafkaClientLegacyTracingForkedTest extends KafkaClientTestBase {
   @Override
   void configurePreAgent() {
@@ -942,6 +946,7 @@ class KafkaClientLegacyTracingForkedTest extends KafkaClientTestBase {
   }
 }
 
+@Retry(count = 5, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class KafkaClientDataStreamsDisabledForkedTest extends KafkaClientTestBase {
   @Override
   void configurePreAgent() {

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/latestDepTest/groovy/KafkaStreamsTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/latestDepTest/groovy/KafkaStreamsTest.groovy
@@ -24,11 +24,13 @@ import org.springframework.kafka.test.EmbeddedKafkaBroker
 import org.springframework.kafka.test.rule.EmbeddedKafkaRule
 import org.springframework.kafka.test.utils.ContainerTestUtils
 import org.springframework.kafka.test.utils.KafkaTestUtils
+import spock.lang.Retry
 import spock.lang.Shared
 
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 
+@Retry(count = 5, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class KafkaStreamsTest extends AgentTestRunner {
   static final STREAM_PENDING = "test.pending"
   static final STREAM_PROCESSED = "test.processed"

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTestBase.groovy
@@ -22,6 +22,7 @@ import org.springframework.kafka.listener.config.ContainerProperties
 import org.springframework.kafka.test.rule.KafkaEmbedded
 import org.springframework.kafka.test.utils.ContainerTestUtils
 import org.springframework.kafka.test.utils.KafkaTestUtils
+import spock.lang.Retry
 import spock.lang.Shared
 
 import java.util.concurrent.LinkedBlockingQueue
@@ -283,6 +284,7 @@ abstract class KafkaStreamsTestBase extends AgentTestRunner {
   }
 }
 
+@Retry(count = 5, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class KafkaStreamsForkedTest extends KafkaStreamsTestBase {
   @Override
   void configurePreAgent() {
@@ -307,6 +309,7 @@ class KafkaStreamsForkedTest extends KafkaStreamsTestBase {
   }
 }
 
+@Retry(count = 5, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class KafkaStreamsSplitByDestinationForkedTest extends KafkaStreamsTestBase {
   @Override
   void configurePreAgent() {
@@ -332,6 +335,7 @@ class KafkaStreamsSplitByDestinationForkedTest extends KafkaStreamsTestBase {
   }
 }
 
+@Retry(count = 5, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class KafkaStreamsLegacyTracingForkedTest extends KafkaStreamsTestBase {
   @Override
   void configurePreAgent() {
@@ -355,6 +359,7 @@ class KafkaStreamsLegacyTracingForkedTest extends KafkaStreamsTestBase {
   }
 }
 
+@Retry(count = 5, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class KafkaStreamsDataStreamsDisabledForkedTest extends KafkaStreamsTestBase {
   @Override
   void configurePreAgent() {


### PR DESCRIPTION
# What Does This Do

Retry kafka based tests

# Motivation

These tests appear to be pretty flaky, which should be investigated, but their failures block unrelated work.

# Additional Notes
