### PR TITLE
Fix debugger smoke test flakiness

### DIFF
--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ServerDebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ServerDebuggerIntegrationTest.java
@@ -204,7 +204,11 @@ public class ServerDebuggerIntegrationTest extends BaseIntegrationTest {
   }
 
   private void stopApp(String appUrl) throws IOException {
-    sendRequest(appUrl + "/stop");
+    try {
+      sendRequest(appUrl + "/stop");
+    } catch (Exception ex) {
+      LOG.warn("Exception while stopping server app", ex);
+    }
     LOG.info("Stop done");
   }
 


### PR DESCRIPTION
# What Does This Do
`TracerDebuggerIntegrationTest` seems to face a race between Tracer instrumentation and Debugger instrumentation:
while a class is loading
(`org.springframework.web.servlet.DispatcherServlet`), Tracer is transforming it while Debugger receiving configuration and add new transformer, but this transformer will not be take into account because class is already transforming and after that will be considered as loaded.
Debugger perform also a retransformation for already loaded classes but as this class is currently transforming with Tracer it is not part of loaded classes.
Workaround is to try to re-instrument the class.

While topping Server app for `ServerDebuggerIntegrationTest`, Http server could be stopped before sending Http response. Catch exception as it is not an issue.


# Motivation
Smoke test flakiness

# Additional Notes
