### PR TITLE
Bumping test forked max heap to 768MB

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,7 +231,7 @@ jobs:
           name: Run tests
           command: >-
             MAVEN_OPTS="-Xms64M -Xmx512M"
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1940M -Xms512M -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp' -Ddatadog.forkedMaxHeapSize=512M -Ddatadog.forkedMinHeapSize=128M"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1940M -Xms512M -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp' -Ddatadog.forkedMaxHeapSize=768M -Ddatadog.forkedMinHeapSize=128M"
             ./gradlew << parameters.testTask >> -PskipInstTests -PskipSmokeTests
             <<# parameters.testJvm >>-PtestJvm=<< parameters.testJvm >><</ parameters.testJvm >>
             << pipeline.parameters.gradle_flags >>


### PR DESCRIPTION
# What Does This Do
Add more heap for tests.
Looking closely to heap dump after test OOM shows that there is just not enough heap to hold all required objects in memory. Special tests like
`com.datadog.debugger.sink.DebuggerSinkTest#splitSnapshotBatch`, `com.datadog.debugger.sink.DebuggerSinkTest#tooLargeSnapshot` or
`com.datadog.debugger.sink.DebuggerSinkTest#tooLargeUTF8Snapshot`
 require more memory than usual, without leaking.


# Motivation

fix OOME

# Additional Notes
