### PR TITLE
Debugger EL evaluation before sampling

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Fields.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Fields.java
@@ -32,7 +32,7 @@ public class Fields {
         processing.accept(field, value, maxDepth);
         processedFieldCount++;
         if (processedFieldCount >= maxFieldCount) {
-          int total = (int) Arrays.stream(fields).filter(f -> filteringIn.test(f)).count();
+          int total = (int) Arrays.stream(fields).filter(filteringIn::test).count();
           onMaxFieldCount.accept(field, total);
           break;
         }

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
@@ -608,17 +608,15 @@ public class Snapshot {
           } else {
             CapturedValue capturedTarget = ((CapturedValue) target);
             target = capturedTarget.getValue();
-            CapturedValue cValue = null;
             if (target != null) {
               // resolve to a CapturedValue instance
-              cValue = ReflectiveFieldValueResolver.resolve(capturedTarget, target, parts[i]);
-              target = cValue.getValue();
+              target = ReflectiveFieldValueResolver.resolve(target, target.getClass(), parts[i]);
             } else {
               target = Values.UNDEFINED_OBJECT;
             }
           }
         } else {
-          target = ReflectiveFieldValueResolver.resolveObject(target, target.getClass(), parts[i]);
+          target = ReflectiveFieldValueResolver.resolve(target, target.getClass(), parts[i]);
         }
       }
       return target;

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/SnapshotProvider.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/SnapshotProvider.java
@@ -16,10 +16,6 @@ public final class SnapshotProvider {
       LOG.info("Cannot resolve the probe: {}", uuid);
       probeDetails = Snapshot.ProbeDetails.UNKNOWN;
     }
-    if (!ProbeRateLimiter.tryProbe(probeDetails.getId())) {
-      DebuggerContext.skipSnapshot(probeDetails.getId(), DebuggerContext.SkipCause.RATE);
-      return null;
-    }
     return new Snapshot(Thread.currentThread(), probeDetails);
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ReflectiveFieldValueResolver.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ReflectiveFieldValueResolver.java
@@ -1,13 +1,11 @@
 package datadog.trace.bootstrap.debugger.el;
 
-import datadog.trace.bootstrap.debugger.Limits;
-import datadog.trace.bootstrap.debugger.Snapshot;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
 /** A helper class to resolve a reference path using reflection. */
 public final class ReflectiveFieldValueResolver {
-  public static Object resolveObject(Object target, Class<?> targetType, String fldName) {
+  public static Object resolve(Object target, Class<?> targetType, String fldName) {
     Field fld = getField(targetType, fldName);
     if (fld == null) {
       return Values.UNDEFINED_OBJECT;
@@ -16,32 +14,6 @@ public final class ReflectiveFieldValueResolver {
       return Modifier.isStatic(fld.getModifiers()) ? fld.get(null) : fld.get(target);
     } catch (IllegalAccessException | IllegalArgumentException ignored) {
       return Values.UNDEFINED_OBJECT;
-    }
-  }
-
-  public static Snapshot.CapturedValue resolve(
-      Snapshot.CapturedValue capturedTarget, Object target, String fldName) {
-    if (target == null) {
-      return Snapshot.CapturedValue.UNDEFINED;
-    }
-    Field fld = getField(target.getClass(), fldName);
-    if (fld == null) {
-      return Snapshot.CapturedValue.UNDEFINED;
-    }
-    String typeName = fld.getType().getName();
-    try {
-      Object val = Modifier.isStatic(fld.getModifiers()) ? fld.get(null) : fld.get(target);
-      Limits limits = capturedTarget.getLimits();
-      return Snapshot.CapturedValue.of(
-          fldName,
-          typeName,
-          val,
-          limits.maxReferenceDepth - 1,
-          limits.maxCollectionSize,
-          limits.maxLength,
-          limits.maxFieldCount);
-    } catch (IllegalAccessException | IllegalArgumentException ignored) {
-      return Snapshot.CapturedValue.UNDEFINED;
     }
   }
 

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ReflectiveFieldValueResolver.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ReflectiveFieldValueResolver.java
@@ -1,11 +1,13 @@
 package datadog.trace.bootstrap.debugger.el;
 
+import datadog.trace.bootstrap.debugger.Limits;
+import datadog.trace.bootstrap.debugger.Snapshot;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
 /** A helper class to resolve a reference path using reflection. */
 public final class ReflectiveFieldValueResolver {
-  public static Object resolve(Object target, Class<?> targetType, String fldName) {
+  public static Object resolveObject(Object target, Class<?> targetType, String fldName) {
     Field fld = getField(targetType, fldName);
     if (fld == null) {
       return Values.UNDEFINED_OBJECT;
@@ -14,6 +16,32 @@ public final class ReflectiveFieldValueResolver {
       return Modifier.isStatic(fld.getModifiers()) ? fld.get(null) : fld.get(target);
     } catch (IllegalAccessException | IllegalArgumentException ignored) {
       return Values.UNDEFINED_OBJECT;
+    }
+  }
+
+  public static Snapshot.CapturedValue resolve(
+      Snapshot.CapturedValue capturedTarget, Object target, String fldName) {
+    if (target == null) {
+      return Snapshot.CapturedValue.UNDEFINED;
+    }
+    Field fld = getField(target.getClass(), fldName);
+    if (fld == null) {
+      return Snapshot.CapturedValue.UNDEFINED;
+    }
+    String typeName = fld.getType().getName();
+    try {
+      Object val = Modifier.isStatic(fld.getModifiers()) ? fld.get(null) : fld.get(target);
+      Limits limits = capturedTarget.getLimits();
+      return Snapshot.CapturedValue.of(
+          fldName,
+          typeName,
+          val,
+          limits.maxReferenceDepth - 1,
+          limits.maxCollectionSize,
+          limits.maxLength,
+          limits.maxFieldCount);
+    } catch (IllegalAccessException | IllegalArgumentException ignored) {
+      return Snapshot.CapturedValue.UNDEFINED;
     }
   }
 

--- a/dd-java-agent/agent-debugger/debugger-el/debugger-el.gradle
+++ b/dd-java-agent/agent-debugger/debugger-el/debugger-el.gradle
@@ -28,6 +28,7 @@ dependencies {
 
   implementation deps.slf4j
   implementation deps.moshi
-  testImplementation("org.junit.jupiter:junit-jupiter-params:5.7.0")
+  testImplementation deps.junit5
+  testImplementation("org.junit.jupiter:junit-jupiter-params:5.8.1")
   testImplementation deps.mockito
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/StaticValueRefResolver.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/StaticValueRefResolver.java
@@ -49,7 +49,7 @@ public class StaticValueRefResolver implements ValueReferenceResolver {
     }
     Object target;
     if (isField) {
-      target = ReflectiveFieldValueResolver.resolveObject(self, self.getClass(), parts[0]);
+      target = ReflectiveFieldValueResolver.resolve(self, self.getClass(), parts[0]);
     } else {
       target = valueMap.getOrDefault(parts[0], Values.UNDEFINED_OBJECT);
     }
@@ -60,7 +60,7 @@ public class StaticValueRefResolver implements ValueReferenceResolver {
       if (target instanceof ObjectValue) {
         target = ((ObjectValue) target).getValue();
       }
-      target = ReflectiveFieldValueResolver.resolveObject(target, target.getClass(), parts[i]);
+      target = ReflectiveFieldValueResolver.resolve(target, target.getClass(), parts[i]);
     }
     return target;
   }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/StaticValueRefResolver.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/StaticValueRefResolver.java
@@ -49,9 +49,9 @@ public class StaticValueRefResolver implements ValueReferenceResolver {
     }
     Object target;
     if (isField) {
-      target = ReflectiveFieldValueResolver.resolve(self, self.getClass(), parts[0]);
+      target = ReflectiveFieldValueResolver.resolveObject(self, self.getClass(), parts[0]);
     } else {
-      target = valueMap.containsKey(parts[0]) ? valueMap.get(parts[0]) : Values.UNDEFINED_OBJECT;
+      target = valueMap.getOrDefault(parts[0], Values.UNDEFINED_OBJECT);
     }
     for (int i = 1; i < parts.length; i++) {
       if (target == Values.UNDEFINED_OBJECT) {
@@ -60,7 +60,7 @@ public class StaticValueRefResolver implements ValueReferenceResolver {
       if (target instanceof ObjectValue) {
         target = ((ObjectValue) target).getValue();
       }
-      target = ReflectiveFieldValueResolver.resolve(target, target.getClass(), parts[i]);
+      target = ReflectiveFieldValueResolver.resolveObject(target, target.getClass(), parts[i]);
     }
     return target;
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MethodProbeInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MethodProbeInstrumentor.java
@@ -219,7 +219,7 @@ public final class MethodProbeInstrumentor extends Instrumentor {
     insnList.add(new InsnNode(Opcodes.DUP)); // stack: [snapshot, capturedcontext, capturedcontext]
     invokeConstructor(insnList, CAPTURE_CONTEXT_TYPE);
     collectArguments(insnList); // stack: [snapshot, capturedcontext]
-    collectFields(insnList); // stack: [snapshot, capturecontetx]
+    collectFields(insnList); // stack: [snapshot, capturedcontext]
     if (kind != Snapshot.Kind.UNHANDLED_EXCEPTION && kind != Snapshot.Kind.HANDLED_EXCEPTION) {
       /*
        * It makes no sense collecting local variables for exceptions - the ones contributing to the exception

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
@@ -190,6 +190,9 @@ public class DebuggerTransformerTest {
             new InputStreamReader(
                 DebuggerTransformerTest.class.getResourceAsStream("/TargetClass.ftlh")),
             cfg);
+    // TODO asserts are operating on 'toString()' which requires keeping the underlying object so we
+    // just disable serialization for now
+    DebuggerContext.initSnapshotSerializer(null);
   }
 
   @AfterEach

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
@@ -380,6 +380,8 @@ public class SnapshotSerializationTest {
     assertNotCaptured(
         objFieldFields, "complexObjField", AnotherClass.class.getName(), DEPTH_REASON);
     assertNotCaptured(
+        objFieldFields, "complexObjField", AnotherClass.class.getName(), DEPTH_REASON);
+    assertNotCaptured(
         objFieldFields,
         "this$0",
         "com.datadog.debugger.agent.SnapshotSerializationTest",
@@ -394,6 +396,8 @@ public class SnapshotSerializationTest {
     Map<String, Object> objLocalFields = (Map<String, Object>) objLocal.get(FIELDS);
     assertPrimitiveValue(objLocalFields, "complexIntField", "int", "21");
     assertPrimitiveValue(objLocalFields, "complexStrField", String.class.getName(), "bar");
+    assertNotCaptured(
+        objLocalFields, "complexObjField", AnotherClass.class.getName(), DEPTH_REASON);
     assertNotCaptured(
         objLocalFields, "complexObjField", AnotherClass.class.getName(), DEPTH_REASON);
     assertNotCaptured(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/el/ELIntegrationSanityTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/el/ELIntegrationSanityTest.java
@@ -1,0 +1,84 @@
+package com.datadog.debugger.el;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.datadog.debugger.agent.JsonSnapshotSerializer;
+import datadog.trace.bootstrap.debugger.DebuggerContext;
+import datadog.trace.bootstrap.debugger.FieldExtractor;
+import datadog.trace.bootstrap.debugger.Limits;
+import datadog.trace.bootstrap.debugger.Snapshot;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+
+public class ELIntegrationSanityTest {
+  static class Name {
+    private String value;
+
+    public Name(String value) {
+      this.value = value;
+    }
+  }
+
+  static class Person {
+    private static final String C1 = "constant1";
+    private static final int C2 = 42;
+    private static List<String> list = new ArrayList<>();
+    private String strVal = "strval";
+    private int intVal = 24;
+    private Map<String, String> mapVal = new HashMap<>();
+    private Object[] objArray = new Object[] {new AtomicLong()};
+    private Name name = new Name("name");
+  }
+
+  @Test
+  void extractAfterEl() {
+    JsonSnapshotSerializer serializer =
+        new JsonSnapshotSerializer(); // Mockito.spy(new JsonSnapshotSerializer());
+    DebuggerContext.initSnapshotSerializer(serializer);
+    Person p = new Person();
+    // set the limit not to follow references to fields
+    Limits limits = new Limits(1, 0, Integer.MAX_VALUE, Integer.MAX_VALUE);
+    // create new captured context
+    Snapshot.CapturedContext capturedContext = new Snapshot.CapturedContext();
+    // this will resolve only the first-level fields of the given object
+    List<Snapshot.CapturedValue> flds = new ArrayList<>();
+    FieldExtractor.extract(
+        p,
+        limits,
+        (field, value, maxDepth) -> {
+          flds.add(
+              Snapshot.CapturedValue.of(
+                  field.getName(),
+                  field.getType().getName(),
+                  value,
+                  maxDepth,
+                  limits.maxCollectionSize,
+                  limits.maxLength,
+                  limits.maxFieldCount));
+        },
+        (e, field) -> {},
+        (field, value) -> {});
+
+    capturedContext.addFields(flds.toArray(new Snapshot.CapturedValue[0]));
+
+    // '.name.value' is not present in the snapshot - it needs to be retrieved via reflection
+    Value<?> val = DSL.ref(".name.value").evaluate(capturedContext);
+    // make sure the nested field was properly resolved
+    assertEquals(p.name.value, val.getValue());
+
+    // freeze the captured context
+    capturedContext.freeze();
+
+    // after freezing the original value is removed and only the serialized json representation
+    // remains
+    assertNull(capturedContext.getFields().get("name").getValue());
+    assertEquals(
+        "{\"type\":\"com.datadog.debugger.el.ELIntegrationSanityTest$Name\",\"fields\":{\"value\":{\"type\":\"java.lang.String\",\"value\":\"name\"}}}",
+        capturedContext.getFields().get("name").getStrValue());
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
@@ -270,7 +270,7 @@ public class DebuggerSinkTest {
           Snapshot.CapturedValue.of("dd.trace_id", "java.lang.String", "123"),
           Snapshot.CapturedValue.of("dd.span_id", "java.lang.String", "456"),
         });
-    SNAPSHOT.getCaptures().setEntry(entry);
+    SNAPSHOT.setEntry(entry);
     sink.addSnapshot(SNAPSHOT);
     String fixtureContent =
         getFixtureContent(SINK_FIXTURE_PREFIX + "/snapshotWithCorrelationIdsRegex.txt");

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/SnapshotSummaryTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/SnapshotSummaryTest.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -25,6 +26,11 @@ public class SnapshotSummaryTest {
       new ProbeLocation("com.datadog.debugger.SomeClass", "someMethod", null, null);
   private static final ProbeDetails PROBE_DETAILS =
       new ProbeDetails(UUID.randomUUID().toString(), PROBE_LOCATION);
+
+  @BeforeAll
+  public static void staticSetup() {
+    DebuggerContext.initSnapshotSerializer(null);
+  }
 
   @BeforeEach
   public void setup() {

--- a/dd-java-agent/agent-debugger/src/test/java/datadog/trace/bootstrap/debugger/FieldExtractorTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/datadog/trace/bootstrap/debugger/FieldExtractorTest.java
@@ -41,7 +41,8 @@ public class FieldExtractorTest {
                 limits.maxLength,
                 limits.maxFieldCount));
     Snapshot.CapturedValue capturedValue =
-        Snapshot.CapturedValue.raw(field.getType().getName(), value, limits, subFields, null);
+        Snapshot.CapturedValue.raw(
+            field.getName(), field.getType().getName(), value, limits, subFields, null);
     results.put(field.getName(), capturedValue);
   }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,7 @@ final class CachedData {
     spock         : "1.3-groovy-$spockGroovyVer",
     groovy        : groovyVer,
     junit4        : "4.13.2",
-    junit5        : "5.7.1",
+    junit5        : "5.8.1",
     logback       : "1.2.3",
     bytebuddy     : "1.12.17",
     scala         : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)


### PR DESCRIPTION
# What Does This Do
The changes in this PR allow the debugger EL engine to evaluate early using only the runtime values (no cached snapshot is available at that time). The evaluation will happen before the rate limiting sampling can kick in, increasing the chance of capturing 'interesting' snapshots.

# Motivation
Change the order of EL evaluation and sampling to reduce the chance of missing interesting snapshots due to rate limiting.

# Additional Notes
The EL evaluation is possible only while the captured values were not 'frozen' - freezing a captured value will effectively serialize the Java instance it is pointing to to a JSON in order to prevent subsequent changes to that instance affecting the  previously captured data.
Since the value is represented as JSON only after freezing, evaluating EL against such value would be possible only if the JSON is temporarily deserialized - this might be potentially expensive and there really does not seem to be a need for that as of now.