### PR TITLE
Rename debugger config properties

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -3,6 +3,7 @@ package datadog.trace.bootstrap;
 import static datadog.trace.api.Platform.getRuntimeVendor;
 import static datadog.trace.api.Platform.isJavaVersionAtLeast;
 import static datadog.trace.api.Platform.isOracleJDK8;
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_ENABLED;
 import static datadog.trace.bootstrap.Library.WILDFLY;
 import static datadog.trace.bootstrap.Library.detectLibraries;
 import static datadog.trace.util.AgentThreadFactory.AgentThread.JMX_STARTUP;
@@ -76,7 +77,7 @@ public class Agent {
     CIVISIBILITY("dd.civisibility.enabled", false),
     CIVISIBILITY_AGENTLESS("dd.civisibility.agentless.enabled", false),
     TELEMETRY("dd.instrumentation.telemetry.enabled", false),
-    DEBUGGER("dd.debugger.enabled", false);
+    DEBUGGER("dd." + DEBUGGER_ENABLED, false);
 
     private final String systemProp;
     private final boolean enabledByDefault;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/StatsdMetricForwarder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/StatsdMetricForwarder.java
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory;
 public class StatsdMetricForwarder
     implements DebuggerContext.MetricForwarder, StatsDClientErrorHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(StatsdMetricForwarder.class);
-  private static final String METRICPROBE_PREFIX = "debugger.metric.probe";
+  private static final String METRICPROBE_PREFIX = "dynamic.instrumentation.metric.probe";
 
   private final StatsDClient statsd;
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerAgentTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerAgentTest.java
@@ -86,10 +86,10 @@ public class DebuggerAgentTest {
   public void runDisabled() {
     setFieldInConfig(Config.get(), "debuggerEnabled", false);
     URL probeDefinitionUrl = DebuggerAgentTest.class.getResource("/test_probe.json");
-    System.setProperty("dd.debugger.config-file", probeDefinitionUrl.getFile());
+    System.setProperty("dd.dynamic.instrumentation.config-file", probeDefinitionUrl.getFile());
     DebuggerAgent.run(inst, new SharedCommunicationObjects());
     verify(inst, never()).addTransformer(any(), eq(true));
-    System.clearProperty("dd.debugger.config-file");
+    System.clearProperty("dd.dynamic.instrumentation.config-file");
   }
 
   @Test

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
@@ -114,16 +114,20 @@ public abstract class BaseIntegrationTest {
             "-Dorg.slf4j.simpleLogger.defaultLogLevel=info",
             "-Ddd.jmxfetch.start-delay=0",
             "-Ddd.jmxfetch.enabled=false",
-            "-Ddd.debugger.enabled=true",
+            "-Ddd.dynamic.instrumentation.enabled=true",
             "-Ddd.remote_config.enabled=true",
             "-Ddd.remote_config.initial.poll.interval=1",
-            "-Ddd.debugger.probe.url=http://localhost:" + probeServer.getPort() + PROBE_URL_PATH,
-            "-Ddd.debugger.snapshot.url=http://localhost:"
+            "-Ddd.dynamic.instrumentation.probe.url=http://localhost:"
+                + probeServer.getPort()
+                + PROBE_URL_PATH,
+            "-Ddd.dynamic.instrumentation.snapshot.url=http://localhost:"
                 + snapshotServer.getPort()
                 + SNAPSHOT_URL_PATH,
             "-Ddd.trace.agent.url=http://localhost:" + probeServer.getPort(),
-            "-Ddd.debugger.upload.batch.size=1", // to verify each snapshot upload one by one
-            "-Ddd.debugger.upload.flush.interval=100" // flush uploads every 100ms to have quick
+            "-Ddd.dynamic.instrumentation.upload.batch.size=1", // to verify each snapshot upload
+            // one by one
+            "-Ddd.dynamic.instrumentation.upload.flush.interval=100" // flush uploads every 100ms to
+            // have quick
             // tests
             ));
   }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
@@ -1,21 +1,21 @@
 package datadog.trace.api.config;
 
 public final class DebuggerConfig {
-  public static final String DEBUGGER_ENABLED = "debugger.enabled";
-  public static final String DEBUGGER_SNAPSHOT_URL = "debugger.snapshot.url";
-  public static final String DEBUGGER_PROBE_URL = "debugger.probe.url";
-  public static final String DEBUGGER_PROBE_FILE_LOCATION = "debugger.probe.file";
-  public static final String DEBUGGER_UPLOAD_TIMEOUT = "debugger.upload.timeout";
-  public static final String DEBUGGER_UPLOAD_FLUSH_INTERVAL = "debugger.upload.flush.interval";
-  public static final String DEBUGGER_UPLOAD_BATCH_SIZE = "debugger.upload.batch.size";
-  public static final String DEBUGGER_MAX_PAYLOAD_SIZE = "debugger.max.payload.size";
-  public static final String DEBUGGER_METRICS_ENABLED = "debugger.metrics.enabled";
-  public static final String DEBUGGER_CLASSFILE_DUMP_ENABLED = "debugger.classfile.dump.enabled";
-  public static final String DEBUGGER_POLL_INTERVAL = "debugger.poll.interval";
-  public static final String DEBUGGER_DIAGNOSTICS_INTERVAL = "debugger.diagnostics.interval";
-  public static final String DEBUGGER_VERIFY_BYTECODE = "debugger.verify.bytecode";
-  public static final String DEBUGGER_INSTRUMENT_THE_WORLD = "debugger.instrument.the.world";
-  public static final String DEBUGGER_EXCLUDE_FILE = "debugger.exclude.file";
+  public static final String DEBUGGER_ENABLED = "dynamic.instrumentation.enabled";
+  public static final String DEBUGGER_SNAPSHOT_URL = "dynamic.instrumentation.snapshot.url";
+  public static final String DEBUGGER_PROBE_URL = "dynamic.instrumentation.probe.url";
+  public static final String DEBUGGER_PROBE_FILE_LOCATION = "dynamic.instrumentation.probe.file";
+  public static final String DEBUGGER_UPLOAD_TIMEOUT = "dynamic.instrumentation.upload.timeout";
+  public static final String DEBUGGER_UPLOAD_FLUSH_INTERVAL = "dynamic.instrumentation.upload.flush.interval";
+  public static final String DEBUGGER_UPLOAD_BATCH_SIZE = "dynamic.instrumentation.upload.batch.size";
+  public static final String DEBUGGER_MAX_PAYLOAD_SIZE = "dynamic.instrumentation.max.payload.size";
+  public static final String DEBUGGER_METRICS_ENABLED = "dynamic.instrumentation.metrics.enabled";
+  public static final String DEBUGGER_CLASSFILE_DUMP_ENABLED = "dynamic.instrumentation.classfile.dump.enabled";
+  public static final String DEBUGGER_POLL_INTERVAL = "dynamic.instrumentation.poll.interval";
+  public static final String DEBUGGER_DIAGNOSTICS_INTERVAL = "dynamic.instrumentation.diagnostics.interval";
+  public static final String DEBUGGER_VERIFY_BYTECODE = "dynamic.instrumentation.verify.bytecode";
+  public static final String DEBUGGER_INSTRUMENT_THE_WORLD = "dynamic.instrumentation.instrument.the.world";
+  public static final String DEBUGGER_EXCLUDE_FILE = "dynamic.instrumentation.exclude.file";
 
   private DebuggerConfig() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
@@ -6,15 +6,20 @@ public final class DebuggerConfig {
   public static final String DEBUGGER_PROBE_URL = "dynamic.instrumentation.probe.url";
   public static final String DEBUGGER_PROBE_FILE_LOCATION = "dynamic.instrumentation.probe.file";
   public static final String DEBUGGER_UPLOAD_TIMEOUT = "dynamic.instrumentation.upload.timeout";
-  public static final String DEBUGGER_UPLOAD_FLUSH_INTERVAL = "dynamic.instrumentation.upload.flush.interval";
-  public static final String DEBUGGER_UPLOAD_BATCH_SIZE = "dynamic.instrumentation.upload.batch.size";
+  public static final String DEBUGGER_UPLOAD_FLUSH_INTERVAL =
+      "dynamic.instrumentation.upload.flush.interval";
+  public static final String DEBUGGER_UPLOAD_BATCH_SIZE =
+      "dynamic.instrumentation.upload.batch.size";
   public static final String DEBUGGER_MAX_PAYLOAD_SIZE = "dynamic.instrumentation.max.payload.size";
   public static final String DEBUGGER_METRICS_ENABLED = "dynamic.instrumentation.metrics.enabled";
-  public static final String DEBUGGER_CLASSFILE_DUMP_ENABLED = "dynamic.instrumentation.classfile.dump.enabled";
+  public static final String DEBUGGER_CLASSFILE_DUMP_ENABLED =
+      "dynamic.instrumentation.classfile.dump.enabled";
   public static final String DEBUGGER_POLL_INTERVAL = "dynamic.instrumentation.poll.interval";
-  public static final String DEBUGGER_DIAGNOSTICS_INTERVAL = "dynamic.instrumentation.diagnostics.interval";
+  public static final String DEBUGGER_DIAGNOSTICS_INTERVAL =
+      "dynamic.instrumentation.diagnostics.interval";
   public static final String DEBUGGER_VERIFY_BYTECODE = "dynamic.instrumentation.verify.bytecode";
-  public static final String DEBUGGER_INSTRUMENT_THE_WORLD = "dynamic.instrumentation.instrument.the.world";
+  public static final String DEBUGGER_INSTRUMENT_THE_WORLD =
+      "dynamic.instrumentation.instrument.the.world";
   public static final String DEBUGGER_EXCLUDE_FILE = "dynamic.instrumentation.exclude.file";
 
   private DebuggerConfig() {}


### PR DESCRIPTION
# What Does This Do
`debugger` -> `dynamic.instrumentation`

# Motivation

debugger product is renamed dynamic instrumentation

# Additional Notes
