### PR TITLE
Add missing argument constraint to ThreadPoolExecutorInstrumentation.execute

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorInstrumentation.java
@@ -91,7 +91,10 @@ public final class ThreadPoolExecutorInstrumentation extends Instrumenter.Tracin
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(isConstructor(), getClass().getName() + "$Init");
     transformation.applyAdvice(
-        named("execute").and(isMethod()).and(NO_WRAPPING_BEFORE_DELEGATION),
+        named("execute")
+            .and(isMethod())
+            .and(NO_WRAPPING_BEFORE_DELEGATION)
+            .and(takesArgument(0, named(Runnable.class.getName()))),
         getClass().getName() + "$Execute");
     transformation.applyAdvice(
         named("beforeExecute")


### PR DESCRIPTION
# Motivation

The advice expects a `Runnable` as the first method argument, so the method matcher should check that (we don't expect to wrap overloaded `execute` methods that have sub-types of `Runnable`)