### PR TITLE
Add workflow to update download releases

### DIFF
--- a/.github/workflows/add-assets-to-release.yaml
+++ b/.github/workflows/add-assets-to-release.yaml
@@ -30,7 +30,7 @@ jobs:
           asset_path: dd-java-agent.jar
           asset_name: dd-java-agent.jar
           asset_content_type: application/java-archive
-      - name: Update download release
+      - name: Update download releases
         uses: DataDog/download-release-action@ea1f13c0cad08eafeebec8b7d9b2d6ee74efb92a # 0.0.2
   dd-trace-api:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-download-releases.yaml
+++ b/.github/workflows/update-download-releases.yaml
@@ -1,0 +1,8 @@
+name: Update download releases
+on: workflow_dispatch
+jobs:
+  update-releases:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update download releases
+        uses: DataDog/download-release-action@ea1f13c0cad08eafeebec8b7d9b2d6ee74efb92a # 0.0.2


### PR DESCRIPTION
# What Does This Do

Add a workflow to update download releases that can be manually triggered.
So it can update or fix download releases when needed.

# Motivation

It was requested by Bjorn.

# Additional Notes

This workflow is not triggered on release publication as it is not safe to assume the upload asset workflow will finish before this one starts. 