### PR TITLE
Fix race condition between RC and debugger

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -378,10 +378,8 @@ public class Agent {
       installDatadogTracer(scoClass, sco);
       maybeStartAppSec(scoClass, sco);
       maybeStartIast(scoClass, sco);
-      if (debuggerEnabled) {
-        // start debugger before remote config to subscribe to it before starting to poll
-        startDebuggerAgent(instrumentation, scoClass, sco);
-      }
+      // start debugger before remote config to subscribe to it before starting to poll
+      maybeStartDebugger(instrumentation, scoClass, sco);
       maybeStartRemoteConfig(scoClass, sco);
 
       if (telemetryEnabled) {
@@ -765,8 +763,19 @@ public class Agent {
     }
   }
 
+  private static void maybeStartDebugger(Instrumentation inst, Class<?> scoClass, Object sco) {
+    if (!debuggerEnabled) {
+      return;
+    }
+    if (!remoteConfigEnabled) {
+      log.warn("Cannot enable Dynamic Instrumentation because Remote Configuration is not enabled");
+      return;
+    }
+    startDebuggerAgent(inst, scoClass, sco);
+  }
+
   private static synchronized void startDebuggerAgent(
-      final Instrumentation inst, Class<?> scoClass, Object sco) {
+      Instrumentation inst, Class<?> scoClass, Object sco) {
     final ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
     try {
       Thread.currentThread().setContextClassLoader(AGENT_CLASSLOADER);

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -378,11 +378,11 @@ public class Agent {
       installDatadogTracer(scoClass, sco);
       maybeStartAppSec(scoClass, sco);
       maybeStartIast(scoClass, sco);
-      maybeStartRemoteConfig(scoClass, sco);
-
       if (debuggerEnabled) {
+        // start debugger before remote config to subscribe to it before starting to poll
         startDebuggerAgent(instrumentation, scoClass, sco);
       }
+      maybeStartRemoteConfig(scoClass, sco);
 
       if (telemetryEnabled) {
         startTelemetry(instrumentation, scoClass, sco);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -99,6 +99,8 @@ public class DebuggerAgent {
       } catch (final IllegalStateException ex) {
         // The JVM is already shutting down.
       }
+    } else {
+      log.warn("No configuration poller available from SharedCommunicationObjects");
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -100,7 +100,7 @@ public class DebuggerAgent {
         // The JVM is already shutting down.
       }
     } else {
-      log.warn("No configuration poller available from SharedCommunicationObjects");
+      log.debug("No configuration poller available from SharedCommunicationObjects");
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -87,7 +87,6 @@ public class DebuggerAgent {
     configurationPoller = (ConfigurationPoller) sco.configurationPoller(config);
     if (configurationPoller != null) {
       subscribeConfigurationPoller(configurationUpdater);
-      configurationPoller.start();
 
       try {
         /*

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerAgentTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerAgentTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import com.datadog.debugger.util.RemoteConfigHelper;
 import datadog.common.container.ContainerInfo;
 import datadog.communication.ddagent.SharedCommunicationObjects;
+import datadog.remoteconfig.ConfigurationPoller;
 import datadog.trace.api.Config;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -119,7 +120,11 @@ public class DebuggerAgentTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    DebuggerAgent.run(inst, new SharedCommunicationObjects());
+    SharedCommunicationObjects sharedCommunicationObjects = new SharedCommunicationObjects();
+    DebuggerAgent.run(inst, sharedCommunicationObjects);
+    ConfigurationPoller configurationPoller =
+        (ConfigurationPoller) sharedCommunicationObjects.configurationPoller(Config.get());
+    configurationPoller.start();
     RecordedRequest request = datadogAgentServer.takeRequest(5, TimeUnit.SECONDS);
     assertNotNull(request);
     assertEquals("/info", request.getPath());

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
@@ -116,7 +116,6 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
   public void maybeInitPoller() {
     if (!hasUserConfig && this.configurationPoller != null) {
       subscribeConfigurationPoller();
-      configurationPoller.start();
     }
   }
 

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/DebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/DebuggerIntegrationTest.java
@@ -111,7 +111,8 @@ public class DebuggerIntegrationTest extends BaseIntegrationTest {
         new MockResponse()
             .setHeadersDelay(REQUEST_WAIT_TIMEOUT * 2, TimeUnit.SECONDS)
             .setResponseCode(200));
-    targetProcess = createProcessBuilder(logFilePath, METHOD_NAME, "2").start();
+    // wait for 3 snapshots (2 status + 1 snapshot)
+    targetProcess = createProcessBuilder(logFilePath, METHOD_NAME, "3").start();
 
     RecordedRequest request = retrieveSnapshotRequest();
     assertNotNull(request);


### PR DESCRIPTION
# What Does This Do
debugger should start and subscribe to RC before starting to poll
Product (Debugger or AppSec) shouldn't start ConfigurationPoller, but only perform in one place once everybody has subscribed to it

# Motivation
fix race condition spotted by smoke tests

# Additional Notes
