### PR TITLE
Collect error logs and heap dumps during CI build

### DIFF
--- a/.circleci/collect_libs.sh
+++ b/.circleci/collect_libs.sh
@@ -9,6 +9,9 @@ set -e
 LIBS_DIR=./libs/
 mkdir -p $LIBS_DIR >/dev/null 2>&1
 
+cp /tmp/hs_err_pid*.log $LIBS_DIR || true
+cp /tmp/java_pid*.hprof $LIBS_DIR || true
+
 for lib_path in workspace/*/build/libs; do
     echo "saving libs in $lib_path"
     cp $lib_path/*.jar $LIBS_DIR/


### PR DESCRIPTION
# What Does This Do

Tries to save any error log files or heap dumps that happen during the build of the project on CI

# Motivation

# Additional Notes
