### PR TITLE
Disable flaky test NettyResteasyAppsecTest

### DIFF
--- a/dd-java-agent/instrumentation/resteasy-appsec/src/nettyTest/groovy/datadog/trace/instrumentation/resteasy/NettyResteasyAppsecTest.groovy
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/nettyTest/groovy/datadog/trace/instrumentation/resteasy/NettyResteasyAppsecTest.groovy
@@ -2,8 +2,10 @@ package datadog.trace.instrumentation.resteasy
 
 import org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer
 import org.jboss.resteasy.spi.ResteasyDeployment
+import spock.lang.Ignore
 import spock.lang.Shared
 
+@Ignore("Regularly times out the build completely https://github.com/DataDog/dd-trace-java/issues/3862")
 class NettyResteasyAppsecTest extends AbstractResteasyAppsecTest {
   private final static int PORT = 59152
 


### PR DESCRIPTION
# What Does This Do

Disables flaky test

# Motivation

Flaky tests are flaky

# Additional Notes
