### PR TITLE
[data streams] Log config

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
@@ -150,6 +150,8 @@ public final class StatusLogger extends JsonAdapter<Config>
       writer.name("iast_enabled");
       writer.value(config.getIastActivation().toString());
     }
+    writer.name("data_streams_enabled");
+    writer.value(config.isDataStreamsEnabled());
     writer.endObject();
   }
 


### PR DESCRIPTION
# What Does This Do

Useful for debugging to see if data streams is enabled, when the stats aren't showing up in Datadog.

# Motivation

# Additional Notes
