### PR TITLE
Telemetry heartbeat interval option.

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -122,6 +122,7 @@ public final class ConfigDefaults {
   static final int DEFAULT_RESOLVER_TYPE_POOL_SIZE = 64;
 
   static final boolean DEFAULT_TELEMETRY_ENABLED = false;
+  static final int DEFAULT_TELEMETRY_HEARTBEAT_INTERVAL = 60; // in seconds
 
   public static final int DEFAULT_TRACE_X_DATADOG_TAGS_MAX_LENGTH = 512;
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -55,6 +55,7 @@ public final class GeneralConfig {
   public static final String DATA_STREAMS_ENABLED = "data.streams.enabled";
 
   public static final String TELEMETRY_ENABLED = "instrumentation.telemetry.enabled";
+  public static final String TELEMETRY_HEARTBEAT_INTERVAL = "telemetry.heartbeat.interval";
 
   private GeneralConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -65,6 +65,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVLET_ROOT_CONTEXT_SERVICE_NAME;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SITE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TELEMETRY_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TELEMETRY_HEARTBEAT_INTERVAL;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_PORT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_V05_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_ANALYTICS_ENABLED;
@@ -142,6 +143,7 @@ import static datadog.trace.api.config.GeneralConfig.SERVICE_NAME;
 import static datadog.trace.api.config.GeneralConfig.SITE;
 import static datadog.trace.api.config.GeneralConfig.TAGS;
 import static datadog.trace.api.config.GeneralConfig.TELEMETRY_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.TELEMETRY_HEARTBEAT_INTERVAL;
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_BUFFERING_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_IGNORED_RESOURCES;
@@ -614,6 +616,7 @@ public class Config {
   private final Pattern iastWeakCipherAlgorithms;
 
   private final boolean telemetryEnabled;
+  private final int telemetryHeartbeatInterval;
 
   private final boolean azureAppServices;
   private final String traceAgentPath;
@@ -1064,6 +1067,16 @@ public class Config {
     crashTrackingTags = configProvider.getMergedMap(CRASH_TRACKING_TAGS);
 
     telemetryEnabled = configProvider.getBoolean(TELEMETRY_ENABLED, DEFAULT_TELEMETRY_ENABLED);
+    int telemetryInterval =
+        configProvider.getInteger(
+            TELEMETRY_HEARTBEAT_INTERVAL, DEFAULT_TELEMETRY_HEARTBEAT_INTERVAL);
+    if (telemetryInterval < 1 || telemetryInterval > 3600) {
+      log.warn(
+          "Wrong Telemetry heartbeat interval: {}. The value must be in range 1-3600",
+          telemetryInterval);
+      telemetryInterval = DEFAULT_TELEMETRY_HEARTBEAT_INTERVAL;
+    }
+    telemetryHeartbeatInterval = telemetryInterval;
 
     String appSecEnabled = configProvider.getString(APPSEC_ENABLED, DEFAULT_APPSEC_ENABLED);
     this.appSecEnabled = ProductActivationConfig.fromString(appSecEnabled);
@@ -1731,6 +1744,10 @@ public class Config {
 
   public boolean isTelemetryEnabled() {
     return telemetryEnabled;
+  }
+
+  public int getTelemetryHeartbeatInterval() {
+    return telemetryHeartbeatInterval;
   }
 
   public ProductActivationConfig getAppSecEnabledConfig() {

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
@@ -91,12 +91,12 @@ public class TelemetryRunnable implements Runnable {
 
   private void successWait() {
     consecutiveFailures = 0;
-    int waitSeconds = telemetryService.getIntervalSeconds();
+    int waitMs = telemetryService.getIntervalMs();
 
     // Wait between iterations no longer than 10 seconds
-    if (waitSeconds > 10) waitSeconds = 10;
+    if (waitMs > 10000) waitMs = 10000;
 
-    sleeper.sleep(waitSeconds);
+    sleeper.sleep(waitMs);
   }
 
   private void failureWait() {

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
@@ -91,8 +91,12 @@ public class TelemetryRunnable implements Runnable {
 
   private void successWait() {
     consecutiveFailures = 0;
-    int waitSeconds = 10;
-    sleeper.sleep(waitSeconds * 1000L);
+    int waitSeconds = telemetryService.getIntervalSeconds();
+
+    // Wait between iterations no longer than 10 seconds
+    if (waitSeconds > 10) waitSeconds = 10;
+
+    sleeper.sleep(waitSeconds);
   }
 
   private void failureWait() {

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
@@ -91,7 +91,7 @@ public class TelemetryRunnable implements Runnable {
 
   private void successWait() {
     consecutiveFailures = 0;
-    int waitMs = telemetryService.getIntervalMs();
+    int waitMs = telemetryService.getHeartbeatInterval();
 
     // Wait between iterations no longer than 10 seconds
     if (waitMs > 10000) waitMs = 10000;

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
@@ -25,5 +25,5 @@ public interface TelemetryService {
 
   Queue<Request> prepareRequests();
 
-  int getIntervalMs();
+  int getHeartbeatInterval();
 }

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
@@ -24,4 +24,6 @@ public interface TelemetryService {
   boolean addMetric(Metric metric);
 
   Queue<Request> prepareRequests();
+
+  int getIntervalSeconds();
 }

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
@@ -25,5 +25,5 @@ public interface TelemetryService {
 
   Queue<Request> prepareRequests();
 
-  int getIntervalSeconds();
+  int getIntervalMs();
 }

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryServiceImpl.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryServiceImpl.java
@@ -21,13 +21,11 @@ import org.slf4j.LoggerFactory;
 
 public class TelemetryServiceImpl implements TelemetryService {
 
-  private static final int HEARTBEAT_INTERVAL_MS = 60 * 1000;
-
   private static final Logger log = LoggerFactory.getLogger(TelemetryServiceImpl.class);
 
   private final RequestBuilder requestBuilder;
   private final TimeSource timeSource;
-
+  private final int heartbeatIntervalMs;
   private final BlockingQueue<KeyValue> configurations = new LinkedBlockingQueue<>();
   private final BlockingQueue<Integration> integrations = new LinkedBlockingQueue<>();
   private final BlockingQueue<Dependency> dependencies = new LinkedBlockingQueue<>();
@@ -38,9 +36,11 @@ public class TelemetryServiceImpl implements TelemetryService {
 
   private long lastPreparationTimestamp;
 
-  public TelemetryServiceImpl(RequestBuilder requestBuilder, TimeSource timeSource) {
+  public TelemetryServiceImpl(
+      RequestBuilder requestBuilder, TimeSource timeSource, int heartBeatInterval) {
     this.requestBuilder = requestBuilder;
     this.timeSource = timeSource;
+    this.heartbeatIntervalMs = heartBeatInterval * 1000; // we use time in milliseconds
   }
 
   @Override
@@ -126,13 +126,18 @@ public class TelemetryServiceImpl implements TelemetryService {
     if (!queue.isEmpty()) {
       lastPreparationTimestamp = curTime;
     }
-    if (curTime - lastPreparationTimestamp > HEARTBEAT_INTERVAL_MS) {
+    if (curTime - lastPreparationTimestamp > heartbeatIntervalMs) {
       Request request = requestBuilder.build(RequestType.APP_HEARTBEAT);
       queue.offer(request);
       lastPreparationTimestamp = curTime;
     }
 
     return queue;
+  }
+
+  @Override
+  public int getIntervalSeconds() {
+    return heartbeatIntervalMs;
   }
 
   private static <T> List<T> drainOrNull(BlockingQueue<T> srcQueue) {

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryServiceImpl.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryServiceImpl.java
@@ -37,10 +37,10 @@ public class TelemetryServiceImpl implements TelemetryService {
   private long lastPreparationTimestamp;
 
   public TelemetryServiceImpl(
-      RequestBuilder requestBuilder, TimeSource timeSource, int heartBeatInterval) {
+      RequestBuilder requestBuilder, TimeSource timeSource, int heartBeatIntervalSec) {
     this.requestBuilder = requestBuilder;
     this.timeSource = timeSource;
-    this.heartbeatIntervalMs = heartBeatInterval * 1000; // we use time in milliseconds
+    this.heartbeatIntervalMs = heartBeatIntervalSec * 1000; // we use time in milliseconds
   }
 
   @Override
@@ -136,7 +136,7 @@ public class TelemetryServiceImpl implements TelemetryService {
   }
 
   @Override
-  public int getIntervalSeconds() {
+  public int getIntervalMs() {
     return heartbeatIntervalMs;
   }
 

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryServiceImpl.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryServiceImpl.java
@@ -136,7 +136,7 @@ public class TelemetryServiceImpl implements TelemetryService {
   }
 
   @Override
-  public int getIntervalMs() {
+  public int getHeartbeatInterval() {
     return heartbeatIntervalMs;
   }
 

--- a/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
@@ -5,6 +5,7 @@ import datadog.telemetry.dependency.DependencyPeriodicAction;
 import datadog.telemetry.dependency.DependencyService;
 import datadog.telemetry.dependency.DependencyServiceImpl;
 import datadog.telemetry.integration.IntegrationPeriodicAction;
+import datadog.trace.api.Config;
 import datadog.trace.api.time.SystemTimeSource;
 import datadog.trace.util.AgentThreadFactory;
 import java.lang.instrument.Instrumentation;
@@ -51,7 +52,10 @@ public class TelemetrySystem {
     DependencyService dependencyService = createDependencyService(instrumentation);
     RequestBuilder requestBuilder = new RequestBuilder(sco.agentUrl);
     TelemetryService telemetryService =
-        new TelemetryServiceImpl(requestBuilder, SystemTimeSource.INSTANCE);
+        new TelemetryServiceImpl(
+            requestBuilder,
+            SystemTimeSource.INSTANCE,
+            Config.get().getTelemetryHeartbeatInterval());
     TELEMETRY_THREAD =
         createTelemetryRunnable(telemetryService, sco.okHttpClient, dependencyService);
     TELEMETRY_THREAD.start();

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryRunnableSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryRunnableSpecification.groovy
@@ -19,7 +19,9 @@ class TelemetryRunnableSpecification extends DDSpecification {
 
   OkHttpClient okHttpClient = Mock()
   TelemetryRunnable.ThreadSleeper sleeper = Mock()
-  TelemetryServiceImpl telemetryService = Mock()
+  TelemetryServiceImpl telemetryService = Mock {
+    getIntervalMs() >> 10000
+  }
   TelemetryRunnable.TelemetryPeriodicAction periodicAction = Mock()
   TelemetryRunnable runnable = new TelemetryRunnable(okHttpClient, telemetryService, [periodicAction], sleeper)
   Thread t = new Thread(runnable)

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryRunnableSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryRunnableSpecification.groovy
@@ -20,7 +20,7 @@ class TelemetryRunnableSpecification extends DDSpecification {
   OkHttpClient okHttpClient = Mock()
   TelemetryRunnable.ThreadSleeper sleeper = Mock()
   TelemetryServiceImpl telemetryService = Mock {
-    getIntervalMs() >> 10000
+    getHeartbeatInterval() >> 10000
   }
   TelemetryRunnable.TelemetryPeriodicAction periodicAction = Mock()
   TelemetryRunnable runnable = new TelemetryRunnable(okHttpClient, telemetryService, [periodicAction], sleeper)

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
@@ -20,7 +20,7 @@ class TelemetryServiceSpecification extends DDSpecification {
   TimeSource timeSource = Mock()
   RequestBuilder requestBuilder = Mock()
   TelemetryServiceImpl telemetryService =
-  new TelemetryServiceImpl(requestBuilder, timeSource)
+  new TelemetryServiceImpl(requestBuilder, timeSource, 60)
 
   void 'addStartedRequest adds app_started event'() {
     when:

--- a/telemetry/src/test/resources/telemetry_intake_emu.py
+++ b/telemetry/src/test/resources/telemetry_intake_emu.py
@@ -2,6 +2,9 @@
 import http.server
 import socketserver
 from http import HTTPStatus
+from datetime import datetime
+
+PORT = 8126
 
 req_types = [
   'app-started',
@@ -12,16 +15,18 @@ req_types = [
   'generate-metrics'
 ]
 
-def print_split_line():
-    print(f'\033[0;32m════════════════════════════════════════════════════════════\033[0m')
+def print_line():
+    cur_time = datetime.now().strftime('%H:%M:%S')
+    print(f'\n\033[0;32m══[{cur_time}]════════════════════════════════════════════════\033[0m')
 
 class Handler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
+        print_line()
         print(self.headers)
         self.send_response(HTTPStatus.OK)
         self.end_headers()
-        print_split_line()
     def do_POST(self):
+        print_line()
         headers = str(self.headers)
         for type in req_types:
           headers = headers.replace(type, f'\033[0;33m{type}\033[1;30m')
@@ -36,10 +41,13 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             print(body)
             #print(f'\033[0;33m{body}\033[0m')
             #self.wfile.write(b'Hello world')
-        print_split_line()
     def log_message(self, format, *args):
         return
 
-httpd = socketserver.TCPServer(('', 8126), Handler)
-print_split_line()
+
+httpd = socketserver.TCPServer(('', PORT), Handler)
+print(f'\033[1;30m════════════════════════════════════════════════════════════')
+print(f'  Started Telemetry Intake Emulator.')
+print(f'  Listening request on port: {PORT}')
+print(f'════════════════════════════════════════════════════════════\033[0m')
 httpd.serve_forever()


### PR DESCRIPTION
# What Does This Do
Introduced `DD_TELEMETRY_HEARTBEAT_INTERVAL` option that should be used to testing purpose only. The value of the variable should determine the interval in which the client sends heartbeat updates in seconds and must be in the range of 1-3600. (The default value is 60).

# Motivation

# Additional Notes
