### PR TITLE
Limit heap of java exec tasks and compile tasks to 256M

### DIFF
--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -234,9 +234,15 @@ project.afterEvaluate {
     tasks.withType(type).configureEach {
       if (options.fork) {
         options.forkOptions.with {
-          memoryMaximumSize = "512M"
+          memoryMaximumSize = "256M"
         }
       }
+    }
+  }
+
+  tasks.withType(JavaExec).configureEach {
+    if (!it.maxHeapSize) {
+      it.maxHeapSize('256M')
     }
   }
 }


### PR DESCRIPTION
# What Does This Do

# Motivation

# Additional Notes
