### PR TITLE
Update Servlet2 "sendError" matcher to reflect expectations in its advice

### DIFF
--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2ResponseStatusInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2ResponseStatusInstrumentation.java
@@ -4,6 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.im
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
@@ -45,7 +46,8 @@ public final class Servlet2ResponseStatusInstrumentation extends Instrumenter.Tr
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(
-        namedOneOf("sendError", "setStatus"), packageName + ".Servlet2ResponseStatusAdvice");
+        namedOneOf("sendError", "setStatus").and(takesArgument(0, int.class)),
+        packageName + ".Servlet2ResponseStatusAdvice");
     transformation.applyAdvice(
         named("sendRedirect"), packageName + ".Servlet2ResponseRedirectAdvice");
   }


### PR DESCRIPTION
# What Does This Do

`Servlet2ResponseStatusAdvice` expects the first argument of `sendError`/`setStatus` to be an integer status code - update the method matcher in `Servlet2ResponseStatusInstrumentation` to record that constraint

# Motivation

Avoids instrumentation warnings when sub-classes of `HttpServletResponse` overload the `sendError`/`setStatus` methods.