### PR TITLE
Limit memory for compile groovy and kotlin tasks

### DIFF
--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -230,11 +230,21 @@ project.afterEvaluate {
     }
   }
 
-  [JavaCompile, ScalaCompile].each { type ->
+  [JavaCompile, ScalaCompile, GroovyCompile].each { type ->
     tasks.withType(type).configureEach {
       if (options.fork) {
         options.forkOptions.with {
           memoryMaximumSize = "256M"
+        }
+      }
+    }
+  }
+
+  if (project.plugins.hasPlugin('kotlin')) {
+    ['compileKotlin', 'compileTestKotlin'].each { type ->
+      tasks.named(type).configure {
+        kotlinOptions {
+          freeCompilerArgs += '-Xmx256m'
         }
       }
     }


### PR DESCRIPTION
# What Does This Do
Limits the amount of memory the tasks to compile Groovy and Kotlin can use

# Motivation
The build of the project in CircleCI started to fail due to memory issues. The max memory for compile Java and Scala was limited to 256M but it was missing Groovy and Kotlin


