### PR TITLE
Make SafeRequestBuilderTest check that header values don't leak

### DIFF
--- a/communication/communication.gradle
+++ b/communication/communication.gradle
@@ -14,6 +14,8 @@ dependencies {
   implementation group: 'com.datadoghq', name: 'java-dogstatsd-client', version: "${versions.dogstatsd}"
 
   testImplementation project(':utils:test-utils')
+  testImplementation deps.junit4
+  testImplementation deps.truth
   testImplementation deps.bytebuddy
   testImplementation group: 'org.msgpack', name: 'msgpack-core', version: '0.8.20'
   testImplementation group: 'org.msgpack', name: 'jackson-dataformat-msgpack', version: '0.8.20'

--- a/communication/src/test/groovy/datadog/communication/http/SafeRequestBuilderTest.groovy
+++ b/communication/src/test/groovy/datadog/communication/http/SafeRequestBuilderTest.groovy
@@ -7,6 +7,7 @@ import okhttp3.Request
 import okhttp3.RequestBody
 import org.junit.Test
 import org.junit.Assert
+import com.google.common.truth.Truth
 
 class SafeRequestBuilderTest {
   SafeRequestBuilder testBuilder = new SafeRequestBuilder()
@@ -27,18 +28,36 @@ class SafeRequestBuilderTest {
     builder = SafeRequestBuilder.addHeader(builder,"test","test")
     Assert.assertEquals(builder.build().headers().get("test"),"test")
   }
-  @Test (expected = IllegalArgumentException)
+  @Test
   void "test bad static add header"(){
+    def name = 'bad_s'
+    def password = 'very-secret-password'
     Request.Builder builder = new Request.Builder().url("http://localhost")
-    builder = SafeRequestBuilder.addHeader(builder,"\n\n","\n\n")
+    IllegalArgumentException ex = Assert.assertThrows(IllegalArgumentException, {
+      builder = SafeRequestBuilder.addHeader(builder, name, "$password\n")
+    })
+    Truth.assertThat(ex).hasMessageThat().contains(name)
+    Truth.assertThat(ex).hasMessageThat().doesNotContain(password)
   }
-  @Test(expected = IllegalArgumentException)
+  @Test
   void "test adding bad header"(){
-    testBuilder.url("http:localhost").addHeader("\n\n","\n\n")
+    def name = 'bad'
+    def password = 'very-secret-password'
+    IllegalArgumentException ex = Assert.assertThrows(IllegalArgumentException, {
+      testBuilder.url("http:localhost").addHeader(name, "$password\n")
+    })
+    Truth.assertThat(ex).hasMessageThat().contains(name)
+    Truth.assertThat(ex).hasMessageThat().doesNotContain(password)
   }
-  @Test (expected = IllegalArgumentException)
+  @Test
   void "test adding bad header2"(){
-    testBuilder.url("localhost").header("\u0019","\u0080")
+    def name = '\u0019'
+    def password = 'very-secret-password'
+    IllegalArgumentException ex = Assert.assertThrows(IllegalArgumentException, {
+      testBuilder.url("http:localhost").addHeader(name, "\u0080$password")
+    })
+    Truth.assertThat(ex).hasMessageThat().contains(name)
+    Truth.assertThat(ex).hasMessageThat().doesNotContain(password)
   }
   @Test
   void "test building result"(){

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,6 +11,7 @@ final class CachedData {
 
     spock         : "1.3-groovy-$spockGroovyVer",
     groovy        : groovyVer,
+    junit4        : "4.13.2",
     junit5        : "5.7.1",
     logback       : "1.2.3",
     bytebuddy     : "1.12.12",
@@ -19,6 +20,7 @@ final class CachedData {
     scala211      : "2.11.12",
     scala212      : "2.12.12",
     scala213      : "2.13.4",
+    truth         : "1.1.3",
     kotlin        : "1.3.72",
     coroutines    : "1.3.0",
     dogstatsd     : "4.0.0",
@@ -62,6 +64,7 @@ final class CachedData {
       "org.objenesis:objenesis:2.6" // Last version to support Java7
     ],
     groovy               : "org.codehaus.groovy:groovy-all:${versions.groovy}",
+    junit4               : "junit:junit:${versions.junit4}",
     junit5               : [
       "org.junit.jupiter:junit-jupiter:${versions.junit5}",
       "org.junit.jupiter:junit-jupiter-params:${versions.junit5}"
@@ -82,6 +85,7 @@ final class CachedData {
     scala211             : "org.scala-lang:scala-library:${versions.scala211}",
     scala212             : "org.scala-lang:scala-library:${versions.scala212}",
     scala213             : "org.scala-lang:scala-library:${versions.scala213}",
+    truth                : "com.google.truth:truth:${versions.truth}",
     kotlin               : "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}",
     coroutines           : "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.coroutines}",
 

--- a/utils/test-agent-utils/decoder/decoder.gradle
+++ b/utils/test-agent-utils/decoder/decoder.gradle
@@ -7,6 +7,6 @@ ext {
 
 dependencies {
   implementation group: 'org.msgpack', name: 'msgpack-core', version: '0.8.24'
-  testImplementation 'junit:junit:4.13.2'
-  testImplementation 'com.google.truth:truth:1.1.3'
+  testImplementation deps.junit4
+  testImplementation deps.truth
 }


### PR DESCRIPTION
# What Does This Do

Adds checks for the exception message content for the `SafeRequestBuilder` to make sure that sensitive header values don't leak.

# Motivation

Show that the mitigations for header value leaking in OkHttp3 [SNYK-JAVA-COMSQUAREUPOKHTTP3-2958044](https://security.snyk.io/vuln/SNYK-JAVA-COMSQUAREUPOKHTTP3-2958044) added in #3682 is effective.

# Additional Notes
