### PR TITLE
Appsec: support parameterization of blocking responses

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/blocking/BlockingActionHelper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/blocking/BlockingActionHelper.java
@@ -5,6 +5,7 @@ import static datadog.trace.api.config.AppSecConfig.APPSEC_HTTP_BLOCKED_TEMPLATE
 import static java.lang.ClassLoader.getSystemClassLoader;
 
 import datadog.trace.api.Config;
+import datadog.trace.api.gateway.Flow;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -55,7 +56,15 @@ public class BlockingActionHelper {
     }
   }
 
-  public static TemplateType determineTemplateType(String acceptHeader) {
+  public static TemplateType determineTemplateType(
+      Flow.Action.BlockingContentType blockingContentType, String acceptHeader) {
+    if (blockingContentType == Flow.Action.BlockingContentType.HTML) {
+      return TemplateType.HTML;
+    }
+    if (blockingContentType == Flow.Action.BlockingContentType.JSON) {
+      return TemplateType.JSON;
+    }
+
     float jsonPref = 0;
     Specificity curJsonSpecificity = Specificity.UNSPECIFIED;
     float htmlPref = 0;

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -96,8 +96,8 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
     AgentSpan span =
         tracer().startSpan(spanName(), callIGCallbackStart(context), true).setMeasured(true);
     Flow<Void> flow = callIGCallbackRequestHeaders(span, carrier);
-    if (flow.getAction().isBlocking()) {
-      span.markForBlocking();
+    if (flow.getAction() instanceof Flow.Action.RequestBlockingAction) {
+      span.setRequestBlockingAction((Flow.Action.RequestBlockingAction) flow.getAction());
     }
     return span;
   }
@@ -162,8 +162,8 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
             span.setTag(DDTags.HTTP_FRAGMENT, url.fragment());
           }
           Flow<Void> flow = callIGCallbackURI(span, url, method);
-          if (flow.getAction().isBlocking()) {
-            span.markForBlocking();
+          if (flow.getAction() instanceof Flow.Action.RequestBlockingAction) {
+            span.setRequestBlockingAction((Flow.Action.RequestBlockingAction) flow.getAction());
           }
           if (SHOULD_SET_URL_RESOURCE_NAME) {
             HTTP_RESOURCE_DECORATOR.withServerPath(span, method, path, encoded);
@@ -207,8 +207,8 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
     }
     setPeerPort(span, port);
     Flow<Void> flow = callIGCallbackAddressAndPort(span, ip, port, inferredAddressStr);
-    if (flow.getAction().isBlocking()) {
-      span.markForBlocking();
+    if (flow.getAction() instanceof Flow.Action.RequestBlockingAction) {
+      span.setRequestBlockingAction((Flow.Action.RequestBlockingAction) flow.getAction());
     }
 
     return span;

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/blocking/BlockingActionHelperSpecification.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/blocking/BlockingActionHelperSpecification.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.bootstrap.blocking
 
 import datadog.trace.api.Config
+import datadog.trace.api.gateway.Flow
 import datadog.trace.test.util.DDSpecification
 
 import java.nio.charset.StandardCharsets
@@ -10,12 +11,12 @@ import static datadog.trace.bootstrap.blocking.BlockingActionHelper.TemplateType
 
 class BlockingActionHelperSpecification extends DDSpecification {
 
-  void 'determineTemplate returns #templateType for "#userAgent"'() {
+  void 'determineTemplate with auto returns #templateType for "#accept"'() {
     expect:
-    BlockingActionHelper.determineTemplateType(userAgent) == templateType
+    BlockingActionHelper.determineTemplateType(Flow.Action.BlockingContentType.AUTO, accept) == templateType
 
     where:
-    userAgent   | templateType
+    accept   | templateType
     null        | JSON
     ''          | JSON
     '*/*'       | JSON
@@ -30,6 +31,16 @@ class BlockingActionHelperSpecification extends DDSpecification {
     '*/*;q=0.8, text/*;q=0.9' | HTML
     '*/*;q=0.8, text/*;q=0.9, text/html ; q=0.7' | JSON
     'aaaa,text/html' | JSON // gives up after error
+  }
+
+  void 'determineTemplate with json'() {
+    expect:
+    BlockingActionHelper.determineTemplateType(Flow.Action.BlockingContentType.JSON, 'text/html') == JSON
+  }
+
+  void 'determineTemplate with html'() {
+    expect:
+    BlockingActionHelper.determineTemplateType(Flow.Action.BlockingContentType.HTML, 'application/json') == HTML
   }
 
   void 'getHttpCode return #result for #input'() {

--- a/dd-java-agent/agent-profiling/profiling-context/src/test/java/com/datadog/profiling/context/TestSpan.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/test/java/com/datadog/profiling/context/TestSpan.java
@@ -1,6 +1,7 @@
 package com.datadog.profiling.context;
 
 import datadog.trace.api.DDId;
+import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -37,11 +38,11 @@ public final class TestSpan implements AgentSpan {
   }
 
   @Override
-  public void markForBlocking() {}
+  public void setRequestBlockingAction(Flow.Action.RequestBlockingAction rba) {}
 
   @Override
-  public boolean isToBeBlocked() {
-    return false;
+  public Flow.Action.RequestBlockingAction getRequestBlockingAction() {
+    return null;
   }
 
   @Override

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -65,7 +65,6 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   private volatile StoredBodySupplier storedRequestBodySupplier;
 
   private int responseStatus;
-  private boolean blocked;
 
   private boolean reqDataPublished;
   private boolean rawReqBodyPublished;
@@ -291,14 +290,6 @@ public class AppSecRequestContext implements DataBundle, Closeable {
 
   public void setResponseStatus(int responseStatus) {
     this.responseStatus = responseStatus;
-  }
-
-  public boolean isBlocked() {
-    return blocked;
-  }
-
-  public void setBlocked(boolean blocked) {
-    this.blocked = blocked;
   }
 
   public boolean isReqDataPublished() {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -112,7 +112,7 @@ public class GatewayBridge {
           if (traceSeg != null) {
             traceSeg.setTagTop("_dd.appsec.enabled", 1);
             traceSeg.setTagTop("_dd.runtime_family", "jvm");
-            if (spanInfo.isToBeBlocked()) {
+            if (spanInfo.getRequestBlockingAction() != null) {
               traceSeg.setTagTop("appsec.blocked", "true");
             }
 

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/EventDispatcherSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/EventDispatcherSpecification.groovy
@@ -105,8 +105,6 @@ class EventDispatcherSpecification extends DDSpecification {
   }
 
   void 'blocking interrupts data listener calls'() {
-    def exception = new RuntimeException()
-
     given:
     DataListener dataListener1 = Mock()
     DataListener dataListener2 = Mock()
@@ -127,11 +125,12 @@ class EventDispatcherSpecification extends DDSpecification {
     then:
     1 * dataListener1.onDataAvailable(_ as Flow, ctx, _ as DataBundle, true) >> {
       ChangeableFlow flow = it.first()
-      flow.action = new Flow.Action.Throw(exception)
+      flow.action = new Flow.Action.RequestBlockingAction(404, Flow.Action.BlockingContentType.AUTO)
     }
     0 * dataListener2.onDataAvailable(_ as Flow, ctx, _ as DataBundle, _ as boolean)
     assert resultFlow.blocking
-    assert resultFlow.action.blockingException.is(exception)
+    assert resultFlow.action.statusCode == 404
+    assert resultFlow.action.blockingContentType == Flow.Action.BlockingContentType.AUTO
   }
 
   void 'non transient data publishing saves the bundle in the context'() {

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
@@ -100,9 +100,10 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getWafMetrics() >> metrics
     1 * ctx.closeAdditive()
     1 * ctx.reportEvents(_, _)
-    1 * ctx.setBlocked(true)
     0 * ctx._(*_)
     flow.blocking == true
+    flow.action.statusCode == 418
+    flow.action.blockingContentType == Flow.Action.BlockingContentType.HTML
   }
 
   void 'no metrics are set if waf metrics are off'() {
@@ -121,7 +122,6 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getWafMetrics() >> null
     1 * ctx.closeAdditive()
     1 * ctx.reportEvents(_, _)
-    1 * ctx.setBlocked(true)
     0 * ctx._(*_)
     metrics == null
   }
@@ -172,7 +172,6 @@ class PowerWAFModuleSpecification extends DDSpecification {
     }
     1 * ctx.getWafMetrics() >> metrics
     1 * ctx.reportEvents(*_)
-    1 * ctx.setBlocked(true)
     0 * ctx._(*_)
     flow.blocking == true
   }
@@ -366,7 +365,6 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getOrCreateAdditive(_, true) >> { it[0].openAdditive() }
     1 * ctx.reportEvents(_ as Collection<AppSecEvent100>, _)
     1 * ctx.getWafMetrics()
-    1 * ctx.setBlocked(true)
     1 * flow.setAction({ it.blocking })
     1 * ctx.closeAdditive()
     0 * _
@@ -402,7 +400,6 @@ class PowerWAFModuleSpecification extends DDSpecification {
     then:
     1 * ctx.getOrCreateAdditive(_, true) >> { it[0].openAdditive() }
     1 * ctx.getWafMetrics()
-    1 * ctx.setBlocked(true)
     1 * flow.setAction({ it.blocking })
     1 * ctx.reportEvents(_ as Collection<AppSecEvent100>, _)
     1 * ctx.closeAdditive()

--- a/dd-java-agent/appsec/src/test/resources/test_multi_config.json
+++ b/dd-java-agent/appsec/src/test/resources/test_multi_config.json
@@ -3,6 +3,16 @@
   "metadata": {
     "rules_version": "0.42.0"
   },
+  "actions": [
+    {
+      "id": "block",
+      "type": "block_request",
+      "parameters": {
+        "status_code": 418,
+        "type": "html"
+      }
+    }
+  ],
   "rules": [
     {
       "id": "bad rule"

--- a/dd-java-agent/instrumentation/jetty-9/jetty-9.gradle
+++ b/dd-java-agent/instrumentation/jetty-9/jetty-9.gradle
@@ -46,3 +46,7 @@ dependencies {
   latestDepTestImplementation group: 'org.eclipse.jetty', name: 'jetty-continuation', version: '9.+'
   latestDepTestImplementation project(':dd-java-agent:instrumentation:jetty-appsec-9.3')
 }
+latestDepTest {
+  jvmArgs += "-Dnet.bytebuddy.dump=/tmp/abc"
+}
+

--- a/dd-java-agent/instrumentation/jetty-9/jetty-9.gradle
+++ b/dd-java-agent/instrumentation/jetty-9/jetty-9.gradle
@@ -46,7 +46,4 @@ dependencies {
   latestDepTestImplementation group: 'org.eclipse.jetty', name: 'jetty-continuation', version: '9.+'
   latestDepTestImplementation project(':dd-java-agent:instrumentation:jetty-appsec-9.3')
 }
-latestDepTest {
-  jvmArgs += "-Dnet.bytebuddy.dump=/tmp/abc"
-}
 

--- a/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/ServletBlockingHelper.java
+++ b/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/ServletBlockingHelper.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.servlet;
 
+import datadog.trace.api.gateway.Flow;
 import datadog.trace.bootstrap.blocking.BlockingActionHelper;
 import datadog.trace.bootstrap.blocking.BlockingActionHelper.TemplateType;
 import java.io.IOException;
@@ -13,14 +14,17 @@ public class ServletBlockingHelper {
   private static final Logger log = LoggerFactory.getLogger(ServletBlockingHelper.class);
 
   public static void commitBlockingResponse(
-      HttpServletRequest httpServletRequest, HttpServletResponse resp) {
-    int statusCode = BlockingActionHelper.getHttpCode(0);
+      HttpServletRequest httpServletRequest,
+      HttpServletResponse resp,
+      Flow.Action.RequestBlockingAction rba) {
+    int statusCode = BlockingActionHelper.getHttpCode(rba.getStatusCode());
     if (!start(resp, statusCode)) {
       return;
     }
 
     String acceptHeader = httpServletRequest.getHeader("Accept");
-    TemplateType type = BlockingActionHelper.determineTemplateType(acceptHeader);
+    TemplateType type =
+        BlockingActionHelper.determineTemplateType(rba.getBlockingContentType(), acceptHeader);
     byte[] template = BlockingActionHelper.getTemplate(type);
     String contentType = BlockingActionHelper.getContentType(type);
 

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
@@ -8,6 +8,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.CorrelationIdentifier;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.GlobalTracer;
+import datadog.trace.api.gateway.Flow;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -61,9 +62,10 @@ public class Servlet2Advice {
     httpServletRequest.setAttribute(
         CorrelationIdentifier.getSpanIdKey(), GlobalTracer.get().getSpanId());
 
-    if (span.isToBeBlocked()) {
+    Flow.Action.RequestBlockingAction rba = span.getRequestBlockingAction();
+    if (rba != null) {
       ServletBlockingHelper.commitBlockingResponse(
-          httpServletRequest, (HttpServletResponse) response);
+          httpServletRequest, (HttpServletResponse) response, rba);
       return true; // skip method body
     }
 

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
@@ -9,6 +9,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.CorrelationIdentifier;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.GlobalTracer;
+import datadog.trace.api.gateway.Flow;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.servlet.ServletBlockingHelper;
@@ -73,8 +74,9 @@ public class Servlet3Advice {
     httpServletRequest.setAttribute(
         CorrelationIdentifier.getSpanIdKey(), GlobalTracer.get().getSpanId());
 
-    if (span.isToBeBlocked()) {
-      ServletBlockingHelper.commitBlockingResponse(httpServletRequest, httpServletResponse);
+    Flow.Action.RequestBlockingAction rba = span.getRequestBlockingAction();
+    if (rba != null) {
+      ServletBlockingHelper.commitBlockingResponse(httpServletRequest, httpServletResponse, rba);
       return true; // skip method body
     }
 

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/TomcatBlockingHelper.java
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/TomcatBlockingHelper.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.tomcat;
 
+import datadog.trace.api.gateway.Flow;
 import datadog.trace.bootstrap.blocking.BlockingActionHelper;
 import datadog.trace.bootstrap.blocking.BlockingActionHelper.TemplateType;
 import java.io.OutputStream;
@@ -26,13 +27,16 @@ public class TomcatBlockingHelper {
     GET_OUTPUT_STREAM = mh;
   }
 
-  public static void commitBlockingResponse(Request request, Response resp) {
-    int httpCode = BlockingActionHelper.getHttpCode(0);
+  public static void commitBlockingResponse(
+      Request request, Response resp, Flow.Action.RequestBlockingAction rba) {
+    int httpCode = BlockingActionHelper.getHttpCode(rba.getStatusCode());
     if (!start(resp, httpCode) || GET_OUTPUT_STREAM == null) {
       return;
     }
 
-    TemplateType type = BlockingActionHelper.determineTemplateType(request.getHeader("Accept"));
+    TemplateType type =
+        BlockingActionHelper.determineTemplateType(
+            rba.getBlockingContentType(), request.getHeader("Accept"));
     byte[] template = BlockingActionHelper.getTemplate(type);
 
     resp.setHeader("Content-length", Integer.toString(template.length));

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/TomcatServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/TomcatServerInstrumentation.java
@@ -17,6 +17,7 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.muzzle.Reference;
 import datadog.trace.api.CorrelationIdentifier;
 import datadog.trace.api.GlobalTracer;
+import datadog.trace.api.gateway.Flow;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
@@ -167,8 +168,9 @@ public final class TomcatServerInstrumentation extends Instrumenter.Tracing
                 ? (AgentSpan.Context.Extracted) ctxObj
                 : null;
         DECORATE.onRequest(span, req, req, ctx);
-        if (span.isToBeBlocked()) {
-          TomcatBlockingHelper.commitBlockingResponse(req, resp);
+        Flow.Action.RequestBlockingAction rba = span.getRequestBlockingAction();
+        if (rba != null) {
+          TomcatBlockingHelper.commitBlockingResponse(req, resp, rba);
           ret = false; // skip pipeline
         }
       }

--- a/dd-java-agent/instrumentation/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/HandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/HandlerInstrumentation.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.undertow;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.instrumentation.undertow.UndertowBlockingHandler.REQUEST_BLOCKING_DATA;
 import static datadog.trace.instrumentation.undertow.UndertowDecorator.DD_HTTPSERVEREXCHANGE_DISPATCH;
 import static datadog.trace.instrumentation.undertow.UndertowDecorator.DD_UNDERTOW_SPAN;
 import static datadog.trace.instrumentation.undertow.UndertowDecorator.DECORATE;
@@ -12,6 +13,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.gateway.Flow.Action.RequestBlockingAction;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import io.undertow.server.HttpServerExchange;
@@ -88,7 +90,9 @@ public final class HandlerInstrumentation extends Instrumenter.Tracing
       // exchange.getRequestHeaders().add(
       //   new HttpString(CorrelationIdentifier.getSpanIdKey()), GlobalTracer.get().getSpanId());
 
-      if (span.isToBeBlocked()) {
+      RequestBlockingAction rab = span.getRequestBlockingAction();
+      if (rab != null) {
+        exchange.putAttachment(REQUEST_BLOCKING_DATA, rab);
         if (exchange.isInIoThread()) {
           exchange.dispatch(UndertowBlockingHandler.INSTANCE);
         } else {

--- a/dd-java-agent/instrumentation/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/UndertowBlockingHandler.java
+++ b/dd-java-agent/instrumentation/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/UndertowBlockingHandler.java
@@ -1,9 +1,11 @@
 package datadog.trace.instrumentation.undertow;
 
+import datadog.trace.api.gateway.Flow;
 import datadog.trace.bootstrap.blocking.BlockingActionHelper;
 import datadog.trace.bootstrap.blocking.BlockingActionHelper.TemplateType;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
+import io.undertow.util.AttachmentKey;
 import io.undertow.util.HeaderMap;
 import io.undertow.util.Headers;
 import java.nio.ByteBuffer;
@@ -15,24 +17,30 @@ public class UndertowBlockingHandler implements HttpHandler {
 
   private static final Logger log = LoggerFactory.getLogger(UndertowBlockingHandler.class);
 
+  public static final AttachmentKey<Flow.Action.RequestBlockingAction> REQUEST_BLOCKING_DATA =
+      AttachmentKey.create(Flow.Action.RequestBlockingAction.class);
+
   private UndertowBlockingHandler() {}
 
   @Override
   public void handleRequest(HttpServerExchange exchange) {
-    commitBlockingResponse(exchange);
+    Flow.Action.RequestBlockingAction rba = exchange.getAttachment(REQUEST_BLOCKING_DATA);
+    commitBlockingResponse(exchange, rba);
   }
 
-  private static void commitBlockingResponse(HttpServerExchange xchg) {
+  private static void commitBlockingResponse(
+      HttpServerExchange xchg, Flow.Action.RequestBlockingAction rba) {
     if (xchg.isResponseStarted()) {
       log.warn("response already committed, we can't change it");
       return;
     }
 
     try {
-      xchg.setStatusCode(BlockingActionHelper.getHttpCode(0));
+      xchg.setStatusCode(BlockingActionHelper.getHttpCode(rba.getStatusCode()));
       HeaderMap headers = xchg.getResponseHeaders();
       String acceptHeader = xchg.getRequestHeaders().get(Headers.ACCEPT).peekLast();
-      TemplateType type = BlockingActionHelper.determineTemplateType(acceptHeader);
+      TemplateType type =
+          BlockingActionHelper.determineTemplateType(rba.getBlockingContentType(), acceptHeader);
       byte[] template = BlockingActionHelper.getTemplate(type);
 
       headers.remove(Headers.CONTENT_LENGTH);

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -13,6 +13,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.DDId;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.function.ToIntFunction;
+import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.profiling.TracingContextTracker;
 import datadog.trace.api.profiling.TracingContextTrackerFactory;
@@ -101,7 +102,7 @@ public class DDSpan
       AtomicReferenceFieldUpdater.newUpdater(DDSpan.class, Object.class, "wrapper");
 
   // the request is to be blocked (AppSec)
-  private volatile boolean blocked;
+  private volatile Flow.Action.RequestBlockingAction requestBlockingAction;
 
   /**
    * Spans should be constructed using the builder, not by calling the constructor directly.
@@ -427,13 +428,13 @@ public class DDSpan
   }
 
   @Override
-  public void markForBlocking() {
-    this.blocked = true;
+  public void setRequestBlockingAction(Flow.Action.RequestBlockingAction rba) {
+    this.requestBlockingAction = rba;
   }
 
   @Override
-  public boolean isToBeBlocked() {
-    return blocked;
+  public Flow.Action.RequestBlockingAction getRequestBlockingAction() {
+    return requestBlockingAction;
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/api/gateway/Flow.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/Flow.java
@@ -23,19 +23,33 @@ public interface Flow<T> {
       }
     }
 
-    final class Throw implements Action {
-      private final Exception exception;
+    enum BlockingContentType {
+      AUTO,
+      HTML,
+      JSON,
+    }
 
-      public Throw(Exception exception) {
-        this.exception = exception;
+    class RequestBlockingAction implements Action {
+      private final int statusCode;
+
+      private final BlockingContentType blockingContentType;
+
+      public RequestBlockingAction(int statusCode, BlockingContentType blockingContentType) {
+        this.statusCode = statusCode;
+        this.blockingContentType = blockingContentType;
       }
 
+      @Override
       public boolean isBlocking() {
         return true;
       }
 
-      public Exception getBlockingException() {
-        return this.exception;
+      public int getStatusCode() {
+        return statusCode;
+      }
+
+      public BlockingContentType getBlockingContentType() {
+        return blockingContentType;
       }
     }
   }

--- a/internal-api/src/main/java/datadog/trace/api/gateway/IGSpanInfo.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/IGSpanInfo.java
@@ -13,7 +13,7 @@ public interface IGSpanInfo {
 
   AgentSpan setTag(String key, boolean value);
 
-  void markForBlocking();
+  void setRequestBlockingAction(Flow.Action.RequestBlockingAction rba);
 
-  boolean isToBeBlocked();
+  Flow.Action.RequestBlockingAction getRequestBlockingAction();
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -8,6 +8,7 @@ import datadog.trace.api.PropagationStyle;
 import datadog.trace.api.SpanCheckpointer;
 import datadog.trace.api.function.Consumer;
 import datadog.trace.api.gateway.CallbackProvider;
+import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.gateway.SubscriptionService;
@@ -442,11 +443,11 @@ public class AgentTracer {
     }
 
     @Override
-    public void markForBlocking() {}
+    public void setRequestBlockingAction(Flow.Action.RequestBlockingAction rba) {}
 
     @Override
-    public boolean isToBeBlocked() {
-      return false;
+    public Flow.Action.RequestBlockingAction getRequestBlockingAction() {
+      return null;
     }
 
     @Override

--- a/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
@@ -121,10 +121,12 @@ public class InstrumentationGatewayTest {
   }
 
   @Test
-  public void testThrownAction() {
-    Flow.Action.Throw thrown = new Flow.Action.Throw(new Exception("my message"));
-    assertThat(thrown.isBlocking()).isTrue();
-    assertThat(thrown.getBlockingException().getMessage()).isEqualTo("my message");
+  public void testRequestBlockingAction() {
+    Flow.Action.RequestBlockingAction rba =
+        new Flow.Action.RequestBlockingAction(400, Flow.Action.BlockingContentType.HTML);
+    assertThat(rba.isBlocking()).isTrue();
+    assertThat(rba.getStatusCode()).isEqualTo(400);
+    assertThat(rba.getBlockingContentType()).isEqualTo(Flow.Action.BlockingContentType.HTML);
   }
 
   @Test
@@ -323,7 +325,7 @@ public class InstrumentationGatewayTest {
         new Flow.ResultFlow<Void>(null) {
           @Override
           public Action getAction() {
-            return new Action.Throw(new Exception());
+            return new Action.RequestBlockingAction(410, Action.BlockingContentType.AUTO);
           }
         };
 


### PR DESCRIPTION
# What Does This Do
Instead of hardcoding the presumed ids of actions that should elicit blocking a request, the spec is fully implemented. The action returned by the WAF is actually interpreted as an action id and the that id is looked up in the "actions" entry of the WAF configuration. Then the type of the action is looked up, and "block_request" is recognized. The parameters of the action (http response code to send and the content type of the response: one of html, json and out) are also taken into account.
