### PR TITLE
Simplify OSGi helper to only check the first-level of bundle wiring

### DIFF
--- a/dd-java-agent/instrumentation/osgi-4.3/src/main/java/datadog/trace/instrumentation/osgi43/BundleWiringHelper.java
+++ b/dd-java-agent/instrumentation/osgi-4.3/src/main/java/datadog/trace/instrumentation/osgi43/BundleWiringHelper.java
@@ -2,13 +2,10 @@ package datadog.trace.instrumentation.osgi43;
 
 import static org.osgi.framework.wiring.BundleRevision.PACKAGE_NAMESPACE;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.function.Function;
 import java.net.URL;
-import java.util.ArrayDeque;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Queue;
 import java.util.Set;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.wiring.BundleRevision;
@@ -22,9 +19,6 @@ import org.osgi.framework.wiring.BundleWiring;
  * would have been imported if the original code had needed them.
  */
 public final class BundleWiringHelper {
-
-  // how far to take the breadth-first search of required wires (Import-Package, etc.)
-  private static final int MAX_DEPTH = Config.get().getOsgiSearchDepth();
 
   // placeholder when we want byte-buddy to skip the original call and return null
   private static final Object SKIP_REQUEST = new Object();
@@ -57,20 +51,21 @@ public final class BundleWiringHelper {
 
   /** Delegates the resource request to any bundles wired as dependencies. */
   public static URL getResource(final Bundle origin, final String resourceName) {
-    return searchTransitiveWires(
-        origin,
+    return searchDirectWires(
+        (BundleWiring) origin.adapt(BundleWiring.class),
         new Function<BundleWiring, URL>() {
           @Override
           public URL apply(final BundleWiring wiring) {
             return wiring.getBundle().getResource(resourceName);
           }
-        });
+        },
+        new HashSet<BundleRevision>());
   }
 
   /** Delegates the class-load request to any bundles wired as dependencies. */
   public static Class<?> loadClass(final Bundle origin, final String className) {
-    return searchTransitiveWires(
-        origin,
+    return searchDirectWires(
+        (BundleWiring) origin.adapt(BundleWiring.class),
         new Function<BundleWiring, Class<?>>() {
           @Override
           public Class<?> apply(final BundleWiring wiring) {
@@ -80,49 +75,18 @@ public final class BundleWiringHelper {
               return null;
             }
           }
-        });
-  }
-
-  /** Searches any bundles wired as transitive dependencies using the filter to find a match. */
-  private static <T> T searchTransitiveWires(
-      final Bundle origin, final Function<BundleWiring, T> filter) {
-    BundleWiring wiring = (BundleWiring) origin.adapt(BundleWiring.class);
-
-    Queue<BundleWiring> search = new ArrayDeque<>();
-    Set<BundleRevision> visited = new HashSet<>();
-
-    search.add(wiring);
-    visited.add(wiring.getRevision()); // avoid dependency cycles
-
-    int countToNextDepth = search.size();
-    int depth = 1;
-
-    // breadth-first search, keep track of how many bundles to search before the next level
-    while (depth <= MAX_DEPTH && !search.isEmpty()) {
-      T result = searchDirectWires(search, filter, depth < MAX_DEPTH, visited);
-      if (null != result) {
-        return result;
-      }
-
-      if (--countToNextDepth == 0) {
-        if (depth < MAX_DEPTH) {
-          countToNextDepth = search.size();
-        }
-        depth++;
-      }
-    }
-
-    return null;
+        },
+        new HashSet<BundleRevision>());
   }
 
   /** Searches a bundle's direct dependencies (Import-Package, Require-Bundle etc.) */
   private static <T> T searchDirectWires(
-      final Queue<BundleWiring> search,
+      final BundleWiring origin,
       final Function<BundleWiring, T> filter,
-      final boolean expandSearch,
       final Set<BundleRevision> visited) {
-
-    List<BundleWire> wires = search.remove().getRequiredWires(null);
+    // track which bundles we've visited to avoid dependency cycles
+    visited.add(origin.getRevision());
+    List<BundleWire> wires = origin.getRequiredWires(null);
     if (null != wires) {
       for (BundleWire wire : wires) {
         BundleWiring wiring = wire.getProviderWiring();
@@ -130,8 +94,6 @@ public final class BundleWiringHelper {
           T result = filter.apply(wiring);
           if (null != result) {
             return result;
-          } else if (expandSearch) {
-            search.add(wiring); // will be processed at the next level of search
           }
         }
       }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -77,7 +77,6 @@ public final class TraceInstrumentationConfig {
 
   public static final String IGNITE_CACHE_INCLUDE_KEYS = "ignite.cache.include_keys";
 
-  public static final String OSGI_SEARCH_DEPTH = "osgi.search.depth";
   public static final String OBFUSCATION_QUERY_STRING_REGEXP = "obfuscation.query.string.regexp";
 
   public static final String PLAY_REPORT_HTTP_STATUS = "trace.play.report-http-status";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -242,7 +242,6 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_INJECTION
 import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_MDC_TAGS_INJECTION_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.MESSAGE_BROKER_SPLIT_BY_DESTINATION;
 import static datadog.trace.api.config.TraceInstrumentationConfig.OBFUSCATION_QUERY_STRING_REGEXP;
-import static datadog.trace.api.config.TraceInstrumentationConfig.OSGI_SEARCH_DEPTH;
 import static datadog.trace.api.config.TraceInstrumentationConfig.PLAY_REPORT_HTTP_STATUS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGATION_DISABLED_EXCHANGES;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGATION_DISABLED_QUEUES;
@@ -579,7 +578,6 @@ public class Config {
 
   private final boolean igniteCacheIncludeKeys;
 
-  private final int osgiSearchDepth;
   private final String obfuscationQueryRegexp;
 
   // TODO: remove at a future point.
@@ -1229,8 +1227,6 @@ public class Config {
     hystrixMeasuredEnabled = configProvider.getBoolean(HYSTRIX_MEASURED_ENABLED, false);
 
     igniteCacheIncludeKeys = configProvider.getBoolean(IGNITE_CACHE_INCLUDE_KEYS, false);
-
-    osgiSearchDepth = configProvider.getInteger(OSGI_SEARCH_DEPTH, 1);
 
     obfuscationQueryRegexp = configProvider.getString(OBFUSCATION_QUERY_STRING_REGEXP);
 
@@ -1962,10 +1958,6 @@ public class Config {
 
   public boolean isIgniteCacheIncludeKeys() {
     return igniteCacheIncludeKeys;
-  }
-
-  public int getOsgiSearchDepth() {
-    return osgiSearchDepth;
   }
 
   public String getObfuscationQueryRegexp() {
@@ -3005,8 +2997,6 @@ public class Config {
         + hystrixMeasuredEnabled
         + ", igniteCacheIncludeKeys="
         + igniteCacheIncludeKeys
-        + ", osgiSearchDepth="
-        + osgiSearchDepth
         + ", servletPrincipalEnabled="
         + servletPrincipalEnabled
         + ", servletAsyncTimeoutError="


### PR DESCRIPTION
# Motivation

In practice we've only needed to check the first-level of OSGi dependencies and removing the search depth option makes the helper much simpler. If we ever need to support further widening of the search then a more targeted automatic approach would be better than having a manual switch that affects all OSGi resource/class lookups.