### PR TITLE
Add defensive check to Netty 3.8 advice in case future.getChannel() is null

### DIFF
--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/ChannelFutureListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/ChannelFutureListenerInstrumentation.java
@@ -76,10 +76,10 @@ public class ChannelFutureListenerInstrumentation extends Instrumenter.Tracing
       /*
       Idea here is:
        - To return scope only if we have captured it.
-       - To capture scope only in case of error.
+       - To capture scope only in case of error on a non-null channel.
        */
       final Throwable cause = future.getCause();
-      if (cause == null) {
+      if (cause == null || future.getChannel() == null) {
         return null;
       }
 


### PR DESCRIPTION
# What Does This Do

Since we use the future's channel as a context-store key, and context-store keys must be non-null.

# Motivation

Without this check the inserted advice would throw a NPE if `future.getChannel()` was ever null.