### PR TITLE
byte-buddy 1.12.17

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
   implementation(gradleApi())
   implementation(localGroovy())
 
-  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.12.12")
+  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.12.17")
 
   implementation("org.eclipse.aether", "aether-connector-basic", "1.1.0")
   implementation("org.eclipse.aether", "aether-transport-http", "1.1.0")

--- a/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
+++ b/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
@@ -20,7 +20,7 @@ class InstrumentPluginTest extends Specification {
     }
 
     dependencies {
-      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.12.12' // just to build TestPlugin
+      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.12.17' // just to build TestPlugin
     }
 
     apply plugin: 'instrument'

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentTransformerBuilder.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentTransformerBuilder.java
@@ -126,8 +126,10 @@ public class AgentTransformerBuilder
                     DynamicType.Builder<?> builder,
                     TypeDescription typeDescription,
                     ClassLoader classLoader,
-                    JavaModule module) {
-                  return customTransformer.transform(builder, typeDescription, classLoader, module);
+                    JavaModule module,
+                    ProtectionDomain pd) {
+                  return customTransformer.transform(
+                      builder, typeDescription, classLoader, module, pd);
                 }
               });
     }
@@ -240,7 +242,8 @@ public class AgentTransformerBuilder
           final DynamicType.Builder<?> builder,
           final TypeDescription typeDescription,
           final ClassLoader classLoader,
-          final JavaModule module) {
+          final JavaModule module,
+          final ProtectionDomain pd) {
         return builder.visit(visitor);
       }
     };

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/DDTransformers.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/DDTransformers.java
@@ -1,5 +1,6 @@
 package datadog.trace.agent.tooling.bytebuddy;
 
+import java.security.ProtectionDomain;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.TypeConstantAdjustment;
 import net.bytebuddy.description.type.TypeDescription;
@@ -15,7 +16,8 @@ public class DDTransformers {
             final DynamicType.Builder<?> builder,
             final TypeDescription typeDescription,
             final ClassLoader classLoader,
-            final JavaModule javaModule) {
+            final JavaModule javaModule,
+            final ProtectionDomain pd) {
           return builder.visit(TypeConstantAdjustment.INSTANCE);
         }
       };

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
@@ -12,6 +12,7 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.ProtectionDomain;
 import java.security.SecureClassLoader;
 import java.util.Arrays;
 import java.util.Collection;
@@ -113,7 +114,8 @@ public class HelperInjector implements Instrumenter.AdviceTransformer {
       final DynamicType.Builder<?> builder,
       final TypeDescription typeDescription,
       ClassLoader classLoader,
-      final JavaModule module) {
+      final JavaModule module,
+      final ProtectionDomain pd) {
     if (!helperClassNames.isEmpty()) {
       if (classLoader == null) {
         classLoader = BOOTSTRAP_CLASSLOADER_PLACEHOLDER;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -12,6 +12,7 @@ import datadog.trace.agent.tooling.muzzle.ReferenceProvider;
 import datadog.trace.api.Config;
 import datadog.trace.util.Strings;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.security.ProtectionDomain;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -361,6 +362,7 @@ public interface Instrumenter {
         DynamicType.Builder<?> builder,
         TypeDescription typeDescription,
         ClassLoader classLoader,
-        JavaModule module);
+        JavaModule module,
+        ProtectionDomain pd);
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteTransformer.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteTransformer.java
@@ -4,6 +4,7 @@ import static net.bytebuddy.jar.asm.ClassWriter.COMPUTE_MAXS;
 
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.csi.CallSiteAdvice;
+import java.security.ProtectionDomain;
 import javax.annotation.Nonnull;
 import net.bytebuddy.asm.AsmVisitorWrapper;
 import net.bytebuddy.description.field.FieldDescription;
@@ -33,7 +34,8 @@ public class CallSiteTransformer implements Instrumenter.AdviceTransformer {
       @Nonnull final DynamicType.Builder<?> builder,
       @Nonnull final TypeDescription type,
       final ClassLoader classLoader,
-      final JavaModule module) {
+      final JavaModule module,
+      final ProtectionDomain pd) {
     Advices discovered = advices.findAdvices(type, classLoader);
     return discovered.isEmpty() ? builder : builder.visit(new CallSiteVisitorWrapper(discovered));
   }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
@@ -109,7 +109,7 @@ public class MuzzleVersionScanPlugin {
             new HelperInjector(
                     MuzzleVersionScanPlugin.class.getSimpleName(),
                     createHelperMap(defaultInstrumenter))
-                .transform(null, null, userClassLoader, null);
+                .transform(null, null, userClassLoader, null, null);
           }
         } catch (final Exception e) {
           System.err.println(

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/HelperInjectionTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/HelperInjectionTest.groovy
@@ -31,7 +31,7 @@ class HelperInjectionTest extends DDSpecification {
     thrown ClassNotFoundException
 
     when:
-    injector.transform(null, null, emptyLoader.get(), null)
+    injector.transform(null, null, emptyLoader.get(), null, null)
     emptyLoader.get().loadClass(HELPER_CLASS_NAME)
     then:
     isClassLoaded(HELPER_CLASS_NAME, emptyLoader.get())
@@ -61,7 +61,7 @@ class HelperInjectionTest extends DDSpecification {
     thrown ClassNotFoundException
 
     when:
-    injector.transform(null, null, BOOTSTRAP_CLASSLOADER, null)
+    injector.transform(null, null, BOOTSTRAP_CLASSLOADER, null, null)
     Class<?> helperClass = bootstrapChild.loadClass(HELPER_CLASS_NAME)
     then:
     helperClass.getClassLoader() == BOOTSTRAP_CLASSLOADER

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/BaseCallSiteTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/BaseCallSiteTest.groovy
@@ -14,6 +14,7 @@ import net.bytebuddy.utility.JavaModule
 import net.bytebuddy.utility.nullability.MaybeNull
 
 import java.lang.reflect.Method
+import java.security.ProtectionDomain
 
 import static net.bytebuddy.matcher.ElementMatchers.any
 import static net.bytebuddy.matcher.ElementMatchers.named
@@ -108,9 +109,10 @@ class BaseCallSiteTest extends DDSpecification {
         DynamicType.Builder<?> transform(final DynamicType.Builder<?> builder,
           final TypeDescription typeDescription,
           final @MaybeNull ClassLoader classLoader,
-          final @MaybeNull JavaModule module) {
+          final @MaybeNull JavaModule module,
+          final ProtectionDomain pd) {
           return transformer
-            .transform(builder, typeDescription, classLoader, module)
+            .transform(builder, typeDescription, classLoader, module, pd)
             .name(target.className)
         }
       })

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteInstrumenterTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteInstrumenterTest.groovy
@@ -19,7 +19,7 @@ class CallSiteInstrumenterTest extends BaseCallSiteTest {
 
     when:
     final transformer = instrumenter.transformer()
-    final result = transformer.transform(builder, type, getClass().getClassLoader(), null)
+    final result = transformer.transform(builder, type, getClass().getClassLoader(), null, null)
 
     then:
     result == builder
@@ -63,7 +63,7 @@ class CallSiteInstrumenterTest extends BaseCallSiteTest {
     when:
     final instrumenter = buildInstrumenter(TestCallSiteAdvice)
     final transformer = instrumenter.transformer()
-    transformer.transform(builder, type, getClass().getClassLoader(), null)
+    transformer.transform(builder, type, getClass().getClassLoader(), null, null)
 
     then:
     transformer != null
@@ -80,7 +80,7 @@ class CallSiteInstrumenterTest extends BaseCallSiteTest {
     when:
     final instrumenter = buildInstrumenter(CallSiteAdvice)
     final transformer = instrumenter.transformer()
-    transformer.transform(builder, type, getClass().getClassLoader(), null)
+    transformer.transform(builder, type, getClass().getClassLoader(), null, null)
 
     then:
     0 * builder.visit(_ as AsmVisitorWrapper) >> builder

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/ServletRequestBodyInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/ServletRequestBodyInstrumentation.java
@@ -26,6 +26,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.io.BufferedReader;
 import java.nio.charset.Charset;
+import java.security.ProtectionDomain;
 import java.security.SecureClassLoader;
 import java.util.Collections;
 import java.util.Map;
@@ -115,7 +116,8 @@ public class ServletRequestBodyInstrumentation extends Instrumenter.AppSec
         DynamicType.Builder<?> builder,
         TypeDescription typeDescription,
         ClassLoader classLoader,
-        JavaModule module) {
+        JavaModule module,
+        ProtectionDomain pd) {
       if (classLoader == null) {
         classLoader = BOOTSTRAP_CLASSLOADER_PLACEHOLDER;
       }
@@ -137,7 +139,7 @@ public class ServletRequestBodyInstrumentation extends Instrumenter.AppSec
         // likely servlet < 3.1
         // inject original
         return new HelperInjector("servlet-request-body", STREAM_WRAPPER_TYPE)
-            .transform(builder, typeDescription, classLoader, module);
+            .transform(builder, typeDescription, classLoader, module, pd);
       }
 
       // else at the very least servlet 3.1+ classes are available
@@ -169,7 +171,7 @@ public class ServletRequestBodyInstrumentation extends Instrumenter.AppSec
       return new HelperInjector(
               "servlet-request-body",
               Collections.singletonMap(origWrapperType.getName(), unloaded.getBytes()))
-          .transform(builder, typeDescription, classLoader, module);
+          .transform(builder, typeDescription, classLoader, module, pd);
     }
   }
 

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RequestImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RequestImplInstrumentation.java
@@ -4,6 +4,7 @@ import static net.bytebuddy.matcher.ElementMatchers.none;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import java.security.ProtectionDomain;
 import java.util.Arrays;
 import net.bytebuddy.asm.AsmVisitorWrapper;
 import net.bytebuddy.description.field.FieldDescription;
@@ -50,7 +51,8 @@ public class RequestImplInstrumentation extends Instrumenter.Tracing
         DynamicType.Builder<?> builder,
         TypeDescription typeDescription,
         ClassLoader classLoader,
-        JavaModule module) {
+        JavaModule module,
+        ProtectionDomain pd) {
       return builder.visit(
           new AsmVisitorWrapper() {
             @Override

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -55,6 +55,7 @@ import java.lang.instrument.Instrumentation
 import java.lang.reflect.InvocationTargetException
 import java.nio.ByteBuffer
 import java.nio.file.Files
+import java.security.ProtectionDomain
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
@@ -246,7 +247,12 @@ abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.L
       .type(named("datadog.trace.api.Config"))
       .transform(new AgentBuilder.Transformer() {
         @Override
-        DynamicType.Builder<?> transform(DynamicType.Builder<?> builder, TypeDescription typeDescription, ClassLoader classLoader, JavaModule module) {
+        DynamicType.Builder<?> transform(
+          DynamicType.Builder<?> builder,
+          TypeDescription typeDescription,
+          ClassLoader classLoader,
+          JavaModule module,
+          ProtectionDomain pd) {
           builder.method(named("isAppSecEnabled")).intercept(FixedValue.value(true))
         }
       }).installOn(INSTRUMENTATION)

--- a/dd-java-agent/testing/src/test/java/locator/ClassInjectingTransformer.java
+++ b/dd-java-agent/testing/src/test/java/locator/ClassInjectingTransformer.java
@@ -71,7 +71,8 @@ public class ClassInjectingTransformer implements AgentBuilder.Transformer, AsmV
       DynamicType.Builder<?> builder,
       TypeDescription typeDescription,
       ClassLoader classLoader,
-      JavaModule module) {
+      JavaModule module,
+      ProtectionDomain pd) {
 
     // First we create an interface and define it
     injectInterfaceNamed(BINARY_NAME, classLoader);

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -14,7 +14,7 @@ final class CachedData {
     junit4        : "4.13.2",
     junit5        : "5.7.1",
     logback       : "1.2.3",
-    bytebuddy     : "1.12.12",
+    bytebuddy     : "1.12.17",
     scala         : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)
     scala210      : "2.10.7",
     scala211      : "2.11.12",

--- a/utils/test-utils/src/main/groovy/datadog/trace/test/util/DDSpecification.groovy
+++ b/utils/test-utils/src/main/groovy/datadog/trace/test/util/DDSpecification.groovy
@@ -66,7 +66,7 @@ abstract class DDSpecification extends Specification {
         ClassFileLocator.ForClassLoader.ofSystemLoader()))
         .ignore(none()) // Allow transforming bootstrap classes
         .type(named(CONFIG))
-        .transform { builder, typeDescription, classLoader, module ->
+        .transform { builder, typeDescription, classLoader, module, pd ->
           builder
             .field(named("INSTANCE"))
             .transform(Transformer.ForField.withModifiers(PUBLIC, STATIC, VOLATILE))


### PR DESCRIPTION
Changes since last update:

[Byte Buddy 1.12.17](https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.12.17)
* Use decorating EntryPoint in Android Gradle plugin.
* Introduce PatchMode on AgentBuilder patching to allow for control over overlap.

[Byte Buddy 1.12.16](https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.12.16)
* Fix Gradle release script to publish plugin.

[Byte Buddy 1.12.15](https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.12.15)
* Introduce ClassVisitorFactory which allows to translate to and from class wrappers in a different ASM namespace.
* Allow builders to change to ClassVisitors.
* Add support for Android instrumentation from Gradle plugin.

[Byte Buddy 1.12.14](https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.12.14)
* Add wrap method to DynamicType.Builder that allows for the representation of a dynamic type via a ClassVisitor.
* Add ClassVisitorFactory that allows to translate between Byte Buddy's, the original, or other shaded representations of ASM.
* Fix visibility check for types in the default package.
* Return correct value for types in the default package.

[Byte Buddy 1.12.13](https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.12.13)
* Avoid duplicate application of Byte Buddy Maven plugin.
* Allow for class path discovery of Plugins when using Maven.
* Fix build cache when using Byte Buddy Gradle plugin.
* Allow Plugins to define new types prior to transformation.