### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/add-assets-to-release.yaml
+++ b/.github/workflows/add-assets-to-release.yaml
@@ -30,8 +30,6 @@ jobs:
           asset_path: dd-java-agent.jar
           asset_name: dd-java-agent.jar
           asset_content_type: application/java-archive
-      - name: Update download releases
-        uses: DataDog/download-release-action@ea1f13c0cad08eafeebec8b7d9b2d6ee74efb92a # 0.0.2
   dd-trace-api:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-download-releases.yaml
+++ b/.github/workflows/update-download-releases.yaml
@@ -1,8 +1,13 @@
 name: Update download releases
-on: workflow_dispatch
+on: 
+  release:
+    types:
+      - released
+  workflow_dispatch:
 jobs:
   update-releases:
     runs-on: ubuntu-latest
     steps:
       - name: Update download releases
+        if: ${{ github.event_name == 'workflow_dispatch' || ( !github.event.release.draft && !github.event.release.prerelease && !startsWith(github.event.release.name, 'download-latest') ) }}
         uses: DataDog/download-release-action@ea1f13c0cad08eafeebec8b7d9b2d6ee74efb92a # 0.0.2


### PR DESCRIPTION
# What Does This Do

Download releases will be updated when releases are promoted as non pre-release status.

# Motivation

The current workflow runs when releases are published in pre-release state.
So they are filtered from eligible releases to update `download-latest*` releases.

# Additional Notes
