### PR TITLE
Remove snapshot & probe URLs config

### DIFF
--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
@@ -39,8 +39,8 @@ import org.slf4j.LoggerFactory;
 public abstract class BaseIntegrationTest {
   protected static final Logger LOG = LoggerFactory.getLogger(BaseIntegrationTest.class);
   protected static final String SINGLE_EXPECTED_UPLOAD = "1";
-  protected static final String PROBE_URL_PATH = "/configurations";
-  protected static final String SNAPSHOT_URL_PATH = "/snapshots";
+  protected static final String PROBE_URL_PATH = "/v0.7/config";
+  protected static final String SNAPSHOT_URL_PATH = "/debugger/v1/input";
   protected static final int REQUEST_WAIT_TIMEOUT = 10;
   private static final Path LOG_FILE_BASE =
       Paths.get(
@@ -50,9 +50,7 @@ public abstract class BaseIntegrationTest {
   private static final MockResponse agentInfoResponse =
       new MockResponse().setResponseCode(200).setBody(INFO_CONTENT);
 
-  protected MockWebServer snapshotServer;
-  private MockDispatcher snapshotMockDispatcher;
-  protected MockWebServer probeServer;
+  protected MockWebServer datadogAgentServer;
   private MockDispatcher probeMockDispatcher;
 
   private HttpUrl probeUrl;
@@ -70,15 +68,13 @@ public abstract class BaseIntegrationTest {
 
   @BeforeEach
   void setup(TestInfo testInfo) throws Exception {
-    probeServer = new MockWebServer();
+    datadogAgentServer = new MockWebServer();
     probeMockDispatcher = new MockDispatcher();
-    probeMockDispatcher.setDispatcher(this::provideProbes);
-    probeServer.setDispatcher(probeMockDispatcher);
-    probeUrl = probeServer.url(PROBE_URL_PATH);
-    LOG.info("ProbeServer on {}", probeServer.getPort());
-    snapshotServer = new MockWebServer();
-    snapshotUrl = snapshotServer.url(SNAPSHOT_URL_PATH);
-    LOG.info("SnapshotServer on {}", snapshotServer.getPort());
+    probeMockDispatcher.setDispatcher(this::datadogAgentDispatch);
+    datadogAgentServer.setDispatcher(probeMockDispatcher);
+    probeUrl = datadogAgentServer.url(PROBE_URL_PATH);
+    LOG.info("DatadogAgentServer on {}", datadogAgentServer.getPort());
+    snapshotUrl = datadogAgentServer.url(SNAPSHOT_URL_PATH);
     logFilePath = LOG_FILE_BASE.resolve(testInfo.getDisplayName() + ".log");
   }
 
@@ -87,11 +83,7 @@ public abstract class BaseIntegrationTest {
     if (targetProcess != null) {
       targetProcess.destroyForcibly();
     }
-    try {
-      snapshotServer.shutdown();
-    } finally {
-      probeServer.shutdown();
-    }
+    datadogAgentServer.shutdown();
   }
 
   protected ProcessBuilder createProcessBuilder(Path logFilePath, String... params) {
@@ -117,19 +109,20 @@ public abstract class BaseIntegrationTest {
             "-Ddd.dynamic.instrumentation.enabled=true",
             "-Ddd.remote_config.enabled=true",
             "-Ddd.remote_config.initial.poll.interval=1",
+            // "-Ddd.remote_config.url=http://localhost:" + probeServer.getPort(),
+            /*
             "-Ddd.dynamic.instrumentation.probe.url=http://localhost:"
                 + probeServer.getPort()
                 + PROBE_URL_PATH,
             "-Ddd.dynamic.instrumentation.snapshot.url=http://localhost:"
                 + snapshotServer.getPort()
                 + SNAPSHOT_URL_PATH,
-            "-Ddd.trace.agent.url=http://localhost:" + probeServer.getPort(),
-            "-Ddd.dynamic.instrumentation.upload.batch.size=1", // to verify each snapshot upload
-            // one by one
-            "-Ddd.dynamic.instrumentation.upload.flush.interval=100" // flush uploads every 100ms to
-            // have quick
-            // tests
-            ));
+             */
+            "-Ddd.trace.agent.url=http://localhost:" + datadogAgentServer.getPort(),
+            // to verify each snapshot upload one by one
+            "-Ddd.dynamic.instrumentation.upload.batch.size=1",
+            // flush uploads every 100ms to have quick tests
+            "-Ddd.dynamic.instrumentation.upload.flush.interval=100"));
   }
 
   protected RecordedRequest retrieveSnapshotRequest() throws Exception {
@@ -137,9 +130,10 @@ public abstract class BaseIntegrationTest {
     RecordedRequest request;
 
     do {
-      request = snapshotServer.takeRequest(REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS);
+      request = datadogAgentServer.takeRequest(REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS);
     } while (request != null
-        && request.getBody().indexOf(ByteString.encodeUtf8("diagnostics")) > -1);
+        && (!request.getPath().startsWith(SNAPSHOT_URL_PATH)
+            || request.getBody().indexOf(ByteString.encodeUtf8("diagnostics")) > -1));
     long dur = System.nanoTime() - ts;
     LOG.info(
         "request retrieved in {} seconds", TimeUnit.SECONDS.convert(dur, TimeUnit.NANOSECONDS));
@@ -147,7 +141,10 @@ public abstract class BaseIntegrationTest {
   }
 
   protected ProbeStatus retrieveProbeStatusRequest() throws Exception {
-    RecordedRequest request = snapshotServer.takeRequest(REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS);
+    RecordedRequest request;
+    do {
+      request = datadogAgentServer.takeRequest(REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS);
+    } while (request != null && !request.getPath().startsWith(SNAPSHOT_URL_PATH));
     assertNotNull(request);
     JsonAdapter<List<ProbeStatus>> adapter =
         MoshiHelper.createMoshiProbeStatus()
@@ -159,9 +156,12 @@ public abstract class BaseIntegrationTest {
     return probeStatuses.get(0);
   }
 
-  private MockResponse provideProbes(RecordedRequest request) {
+  private MockResponse datadogAgentDispatch(RecordedRequest request) {
     if (request.getPath().equals("/info")) {
       return agentInfoResponse;
+    }
+    if (request.getPath().startsWith(SNAPSHOT_URL_PATH)) {
+      return new MockResponse().setResponseCode(200);
     }
     Configuration configuration;
     synchronized (configLock) {

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ServerDebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ServerDebuggerIntegrationTest.java
@@ -149,14 +149,14 @@ public class ServerDebuggerIntegrationTest extends BaseIntegrationTest {
     assertEquals(1, snapshots.size());
     assertEquals(FULL_METHOD_NAME, snapshots.get(0).getProbe().getLocation().getMethod());
 
-    snapshotServer.enqueue(EMPTY_HTTP_200); // expect BLOCKED status
+    datadogAgentServer.enqueue(EMPTY_HTTP_200); // expect BLOCKED status
     Configuration.FilterList denyList =
         new Configuration.FilterList(asList("datadog.smoketest.debugger"), Collections.emptyList());
     setCurrentConfiguration(createConfig(asList(snapshotProbe), null, denyList));
     waitForReTransformation(appUrl);
     waitForAProbeStatus(ProbeStatus.Status.BLOCKED);
 
-    snapshotServer.enqueue(EMPTY_HTTP_200); // expect INSTALLED status
+    datadogAgentServer.enqueue(EMPTY_HTTP_200); // expect INSTALLED status
     addProbe(snapshotProbe);
     // waitForInstrumentation(appUrl);
     waitForReTransformation(appUrl);
@@ -186,14 +186,14 @@ public class ServerDebuggerIntegrationTest extends BaseIntegrationTest {
     assertEquals(1, snapshots.size());
     assertEquals(FULL_METHOD_NAME, snapshots.get(0).getProbe().getLocation().getMethod());
 
-    snapshotServer.enqueue(EMPTY_HTTP_200); // expect BLOCKED status
+    datadogAgentServer.enqueue(EMPTY_HTTP_200); // expect BLOCKED status
     Configuration.FilterList allowList =
         new Configuration.FilterList(asList("datadog.not.debugger"), Collections.emptyList());
     setCurrentConfiguration(createConfig(asList(snapshotProbe), allowList, null));
     waitForReTransformation(appUrl);
     waitForAProbeStatus(ProbeStatus.Status.BLOCKED);
 
-    snapshotServer.enqueue(EMPTY_HTTP_200); // expect INSTALLED status
+    datadogAgentServer.enqueue(EMPTY_HTTP_200); // expect INSTALLED status
     addProbe(snapshotProbe);
     // waitForInstrumentation(appUrl);
     waitForReTransformation(appUrl);
@@ -251,7 +251,7 @@ public class ServerDebuggerIntegrationTest extends BaseIntegrationTest {
   }
 
   private void execute(String appUrl, String methodName) throws IOException {
-    snapshotServer.enqueue(EMPTY_HTTP_200); // expect 1 snapshot
+    datadogAgentServer.enqueue(EMPTY_HTTP_200); // expect 1 snapshot
     String url = String.format(appUrl + "/execute?methodname=%s", methodName);
     sendRequest(url);
     LOG.info("Execution done");
@@ -293,8 +293,8 @@ public class ServerDebuggerIntegrationTest extends BaseIntegrationTest {
   }
 
   private void addProbe(SnapshotProbe snapshotProbe) {
-    snapshotServer.enqueue(EMPTY_HTTP_200); // expect RECEIVED status
-    snapshotServer.enqueue(EMPTY_HTTP_200); // expect INSTALLED status
+    datadogAgentServer.enqueue(EMPTY_HTTP_200); // expect RECEIVED status
+    datadogAgentServer.enqueue(EMPTY_HTTP_200); // expect INSTALLED status
     setCurrentConfiguration(createConfig(snapshotProbe));
   }
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -117,8 +117,6 @@ import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_MAX_PAYLOAD_SIZE;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_METRICS_ENABLED;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_POLL_INTERVAL;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_PROBE_FILE_LOCATION;
-import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_PROBE_URL;
-import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_SNAPSHOT_URL;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_UPLOAD_BATCH_SIZE;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_UPLOAD_FLUSH_INTERVAL;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_UPLOAD_TIMEOUT;
@@ -543,8 +541,6 @@ public class Config {
   private final long remoteConfigMaxPayloadSize;
 
   private final boolean debuggerEnabled;
-  private final String debuggerSnapshotUrl;
-  private final String debuggerProbeUrl;
   private final int debuggerUploadTimeout;
   private final int debuggerUploadFlushInterval;
   private final boolean debuggerClassFileDumpEnabled;
@@ -1162,8 +1158,6 @@ public class Config {
             * 1024;
 
     debuggerEnabled = configProvider.getBoolean(DEBUGGER_ENABLED, DEFAULT_DEBUGGER_ENABLED);
-    debuggerSnapshotUrl = configProvider.getString(DEBUGGER_SNAPSHOT_URL);
-    debuggerProbeUrl = configProvider.getString(DEBUGGER_PROBE_URL);
     debuggerUploadTimeout =
         configProvider.getInteger(DEBUGGER_UPLOAD_TIMEOUT, DEFAULT_DEBUGGER_UPLOAD_TIMEOUT);
     debuggerUploadFlushInterval =
@@ -1902,17 +1896,11 @@ public class Config {
   }
 
   public String getFinalDebuggerProbeUrl() {
-    if (debuggerProbeUrl != null) {
-      return debuggerProbeUrl;
-    }
     // by default poll from datadog agent
     return "http://" + agentHost + ":" + agentPort;
   }
 
   public String getFinalDebuggerSnapshotUrl() {
-    if (debuggerSnapshotUrl != null) {
-      return debuggerSnapshotUrl;
-    }
     // by default send to datadog agent
     return agentUrl + "/debugger/v1/input";
   }
@@ -2956,10 +2944,6 @@ public class Config {
         + remoteConfigMaxPayloadSize
         + ", debuggerEnabled="
         + debuggerEnabled
-        + ", debuggerSnapshotUrl="
-        + debuggerSnapshotUrl
-        + ", debuggerProbeUrl="
-        + debuggerProbeUrl
         + ", debuggerUploadTimeout="
         + debuggerUploadTimeout
         + ", debuggerUploadFlushInterval="

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -211,7 +211,6 @@ class ConfigTest extends DDSpecification {
     prop.setProperty(REMOTE_CONFIG_MAX_PAYLOAD_SIZE, "2")
 
     prop.setProperty(DEBUGGER_ENABLED, "true")
-    prop.setProperty(DEBUGGER_SNAPSHOT_URL, "snapshot url")
     prop.setProperty(DEBUGGER_PROBE_FILE_LOCATION, "file location")
     prop.setProperty(DEBUGGER_UPLOAD_TIMEOUT, "10")
     prop.setProperty(DEBUGGER_UPLOAD_FLUSH_INTERVAL, "1000")
@@ -296,7 +295,7 @@ class ConfigTest extends DDSpecification {
     config.remoteConfigMaxPayloadSizeBytes == 2048
 
     config.debuggerEnabled == true
-    config.getFinalDebuggerSnapshotUrl() == "snapshot url"
+    config.getFinalDebuggerSnapshotUrl() == "http://somehost:123/debugger/v1/input"
     config.debuggerProbeFileLocation == "file location"
     config.debuggerUploadTimeout == 10
     config.debuggerUploadFlushInterval == 1000


### PR DESCRIPTION
# What Does This Do

# Motivation
no longer use URLs as everything is going through datadog agent

# Additional Notes
