### PR TITLE
Ignore everything under BOOTSTRAP_PACKAGE_PREFIXES when recording muzzle references

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceCreator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceCreator.java
@@ -450,7 +450,12 @@ public class ReferenceCreator extends ClassVisitor {
     String dottedName = name.replace('/', '.');
     // drop any array prefix, so we can check the actual component type
     if (dottedName.startsWith("[")) {
-      dottedName = dottedName.substring(dottedName.lastIndexOf("[L") + 2);
+      int componentMarker = dottedName.lastIndexOf("[L");
+      if (componentMarker < 0) {
+        return true; // ignore primitive array references
+      } else {
+        dottedName = dottedName.substring(componentMarker + 2);
+      }
     }
     // ignore references to core JDK types (see existing check in addReference)
     if (dottedName.startsWith("java.")) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceCreator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceCreator.java
@@ -3,6 +3,7 @@ package datadog.trace.agent.tooling.muzzle;
 import static datadog.trace.util.Strings.getClassName;
 import static datadog.trace.util.Strings.getResourceName;
 
+import datadog.trace.bootstrap.Constants;
 import java.io.InputStream;
 import java.util.ArrayDeque;
 import java.util.HashSet;
@@ -446,10 +447,28 @@ public class ReferenceCreator extends ClassVisitor {
    * <p>Optimization to avoid storing and checking muzzle references that will never fail.
    */
   private static boolean ignoreReference(String name) {
-    return name.equals("datadog/trace/bootstrap/CallDepthThreadLocalMap")
-        || name.equals("datadog/trace/bootstrap/ContextStore")
-        || name.equals("datadog/trace/bootstrap/InstrumentationContext")
-        || name.startsWith("datadog/trace/bootstrap/instrumentation/api/") // AgentSpan/Scope etc.
-        || name.startsWith("org/slf4j/"); // will be relocated to datadog/slf4j/
+    String dottedName = name.replace('/', '.');
+    // drop any array prefix, so we can check the actual component type
+    if (dottedName.startsWith("[")) {
+      dottedName = dottedName.substring(dottedName.lastIndexOf("[L") + 2);
+    }
+    // ignore references to core JDK types (see existing check in addReference)
+    if (dottedName.startsWith("java.")) {
+      return true;
+    }
+    // ignore SLF4J references which will be changed to datadog.slf4j in final jar
+    if (dottedName.startsWith("org.slf4j.")) {
+      return true;
+    }
+    // trace-annotation's muzzle check relies on this annotation type
+    if (dottedName.equals("datadog.trace.api.Trace")) {
+      return false;
+    }
+    for (String prefix : Constants.BOOTSTRAP_PACKAGE_PREFIXES) {
+      if (dottedName.startsWith(prefix)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -238,7 +238,7 @@ tasks.register('checkAgentJarSize').configure {
   doLast {
     // Arbitrary limit to prevent unintentional increases to the agent jar size
     // Raise or lower as required
-    def megs = (project.rootProject.hasProperty("agentIncludeCwsTls") && agentIncludeCwsTls) ? 23 : 21
+    def megs = (project.rootProject.hasProperty("agentIncludeCwsTls") && agentIncludeCwsTls) ? 22 : 20
     assert shadowJar.archiveFile.get().getAsFile().length() <= megs * 1024 * 1024
   }
 


### PR DESCRIPTION
# What Does This Do

Widens the list of ignored muzzle prefixes from an explicit subset to cover all prefixes that the Java Tracer delegates to the boostrap class-loader. By definition everything under these prefixes will always be available and doesn't need to be included in the generated muzzle references.

# Motivation

Fewer muzzle references to check (~800 less) as well as smaller muzzle classes (saves ~300KB uncompressed)