### PR TITLE
Nayeem kamal/greenplum jdbc

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionHierarchyInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionHierarchyInstrumentation.java
@@ -1,4 +1,3 @@
-
 package datadog.trace.instrumentation.jdbc;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
@@ -6,15 +5,20 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Config;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-/** TODO-hide this instrumentation behind a config variable**/
 @AutoService(Instrumenter.class)
 public class ConnectionHierarchyInstrumentation extends AbstractConnectionInstrumentation
     implements Instrumenter.ForTypeHierarchy {
   public ConnectionHierarchyInstrumentation() {
     super("jdbc", "jdbcMatcher");
+  }
+
+  @Override
+  protected boolean defaultEnabled() {
+    return Config.get().getJdbcUseHierarchyMatcher() && Config.get().isIntegrationsEnabled();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionHierarchyInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionHierarchyInstrumentation.java
@@ -1,0 +1,29 @@
+
+package datadog.trace.instrumentation.jdbc;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+/** TODO-hide this instrumentation behind a config variable**/
+@AutoService(Instrumenter.class)
+public class ConnectionHierarchyInstrumentation extends AbstractConnectionInstrumentation
+    implements Instrumenter.ForTypeHierarchy {
+  public ConnectionHierarchyInstrumentation() {
+    super("jdbc", "jdbcMatcher");
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "java.sql.Connection";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return implementsInterface(named(hierarchyMarkerType()));
+  }
+}

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
@@ -8,6 +8,11 @@ import datadog.trace.api.Config;
 public class ConnectionInstrumentation extends AbstractConnectionInstrumentation
     implements Instrumenter.ForKnownTypes, Instrumenter.ForConfiguredType {
 
+  @Override
+  protected boolean defaultEnabled() {
+    return !Config.get().getJdbcUseHierarchyMatcher() && Config.get().isIntegrationsEnabled();
+  }
+
   private static final String[] CONCRETE_TYPES = {
     // redshift
     "com.amazon.redshift.jdbc.RedshiftConnectionImpl",

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementHierarchyInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementHierarchyInstrumentation.java
@@ -1,0 +1,28 @@
+package datadog.trace.instrumentation.jdbc;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+/** TODO-hide this instrumentation behind a config variable**/
+  @AutoService(Instrumenter.class)
+  public class PreparedStatementHierarchyInstrumentation extends AbstractPreparedStatementInstrumentation
+      implements Instrumenter.ForTypeHierarchy {
+    public PreparedStatementHierarchyInstrumentation() {
+      super("jdbc", "jdbcMatcher");
+    }
+
+    @Override
+    public String hierarchyMarkerType() {
+      return "java.sql.PreparedStatement";
+    }
+
+    @Override
+    public ElementMatcher<TypeDescription> hierarchyMatcher() {
+      return implementsInterface(named(hierarchyMarkerType()));
+    }
+  }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementHierarchyInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementHierarchyInstrumentation.java
@@ -5,24 +5,29 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Config;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-/** TODO-hide this instrumentation behind a config variable**/
-  @AutoService(Instrumenter.class)
-  public class PreparedStatementHierarchyInstrumentation extends AbstractPreparedStatementInstrumentation
-      implements Instrumenter.ForTypeHierarchy {
-    public PreparedStatementHierarchyInstrumentation() {
-      super("jdbc", "jdbcMatcher");
-    }
-
-    @Override
-    public String hierarchyMarkerType() {
-      return "java.sql.PreparedStatement";
-    }
-
-    @Override
-    public ElementMatcher<TypeDescription> hierarchyMatcher() {
-      return implementsInterface(named(hierarchyMarkerType()));
-    }
+@AutoService(Instrumenter.class)
+public class PreparedStatementHierarchyInstrumentation
+    extends AbstractPreparedStatementInstrumentation implements Instrumenter.ForTypeHierarchy {
+  public PreparedStatementHierarchyInstrumentation() {
+    super("jdbc", "jdbcMatcher");
   }
+
+  @Override
+  protected boolean defaultEnabled() {
+    return Config.get().getJdbcUseHierarchyMatcher() && Config.get().isIntegrationsEnabled();
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "java.sql.PreparedStatement";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return implementsInterface(named(hierarchyMarkerType()));
+  }
+}

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -7,6 +7,10 @@ import datadog.trace.api.Config;
 @AutoService(Instrumenter.class)
 public final class PreparedStatementInstrumentation extends AbstractPreparedStatementInstrumentation
     implements Instrumenter.ForKnownTypes, Instrumenter.ForConfiguredType {
+  @Override
+  protected boolean defaultEnabled() {
+    return !Config.get().getJdbcUseHierarchyMatcher() && Config.get().isIntegrationsEnabled();
+  }
 
   private static final String[] CONCRETE_TYPES = {
     // redshift

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -64,6 +64,7 @@ public final class ConfigDefaults {
 
   static final boolean DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_ENABLED = false;
   static final int DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_LIMIT = 10;
+  static final boolean DEFAULT_JDBC_USE_HIERARCHY_MATCHER = false;
 
   static final int DEFAULT_DOGSTATSD_START_DELAY = 15; // seconds
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -78,7 +78,6 @@ public final class TraceInstrumentationConfig {
 
   public static final String IGNITE_CACHE_INCLUDE_KEYS = "ignite.cache.include_keys";
 
-
   public static final String OSGI_SEARCH_DEPTH = "osgi.search.depth";
   public static final String OBFUSCATION_QUERY_STRING_REGEXP = "obfuscation.query.string.regexp";
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -42,6 +42,7 @@ public final class TraceInstrumentationConfig {
 
   public static final String JDBC_CONNECTION_CLASS_NAME = "trace.jdbc.connection.class.name";
 
+  public static final String JDBC_USE_HIERARCHY_MATCHER = "trace.jdbc.use.hierarchy.matcher";
   public static final String RUNTIME_CONTEXT_FIELD_INJECTION =
       "trace.runtime.context.field.injection";
   public static final String SERIALVERSIONUID_FIELD_INJECTION =
@@ -76,6 +77,7 @@ public final class TraceInstrumentationConfig {
   public static final String HYSTRIX_MEASURED_ENABLED = "hystrix.measured.enabled";
 
   public static final String IGNITE_CACHE_INCLUDE_KEYS = "ignite.cache.include_keys";
+
 
   public static final String OSGI_SEARCH_DEPTH = "osgi.search.depth";
   public static final String OBFUSCATION_QUERY_STRING_REGEXP = "obfuscation.query.string.regexp";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -45,6 +45,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_VULNERABILITIES_PER_
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_WEAK_HASH_ALGORITHMS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_INTEGRATIONS_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_JDBC_USE_HIERARCHY_MATCHER;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_JMX_FETCH_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_LIMIT;
@@ -236,6 +237,8 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.INTEGRATIONS_E
 import static datadog.trace.api.config.TraceInstrumentationConfig.INTEGRATION_SYNAPSE_LEGACY_OPERATION_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_CONNECTION_CLASS_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_PREPARED_STATEMENT_CLASS_NAME;
+import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_MATCHER;
+import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_USE_HIERARCHY_MATCHER;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JMS_PROPAGATION_DISABLED_QUEUES;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JMS_PROPAGATION_DISABLED_TOPICS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.KAFKA_CLIENT_BASE64_DECODING_ENABLED;
@@ -610,6 +613,7 @@ public class Config {
 
   private final String jdbcPreparedStatementClassName;
   private final String jdbcConnectionClassName;
+  private final boolean jdbcUseHierarchyMatcher;
 
   private final Set<String> grpcIgnoredInboundMethods;
   private final Set<String> grpcIgnoredOutboundMethods;
@@ -1201,6 +1205,7 @@ public class Config {
 
     jdbcConnectionClassName = configProvider.getString(JDBC_CONNECTION_CLASS_NAME, "");
 
+    jdbcUseHierarchyMatcher = configProvider.getBoolean(JDBC_USE_HIERARCHY_MATCHER,DEFAULT_JDBC_USE_HIERARCHY_MATCHER);
     awsPropagationEnabled = isPropagationEnabled(true, "aws");
     sqsPropagationEnabled = awsPropagationEnabled && isPropagationEnabled(true, "sqs");
 
@@ -2083,6 +2088,10 @@ public class Config {
 
   public String getJdbcConnectionClassName() {
     return jdbcConnectionClassName;
+  }
+
+  public boolean getJdbcUseHierarchyMatcher() {
+    return jdbcUseHierarchyMatcher;
   }
 
   public Set<String> getGrpcIgnoredInboundMethods() {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -237,7 +237,6 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.INTEGRATIONS_E
 import static datadog.trace.api.config.TraceInstrumentationConfig.INTEGRATION_SYNAPSE_LEGACY_OPERATION_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_CONNECTION_CLASS_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_PREPARED_STATEMENT_CLASS_NAME;
-import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_MATCHER;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_USE_HIERARCHY_MATCHER;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JMS_PROPAGATION_DISABLED_QUEUES;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JMS_PROPAGATION_DISABLED_TOPICS;
@@ -1205,7 +1204,8 @@ public class Config {
 
     jdbcConnectionClassName = configProvider.getString(JDBC_CONNECTION_CLASS_NAME, "");
 
-    jdbcUseHierarchyMatcher = configProvider.getBoolean(JDBC_USE_HIERARCHY_MATCHER,DEFAULT_JDBC_USE_HIERARCHY_MATCHER);
+    jdbcUseHierarchyMatcher =
+        configProvider.getBoolean(JDBC_USE_HIERARCHY_MATCHER, DEFAULT_JDBC_USE_HIERARCHY_MATCHER);
     awsPropagationEnabled = isPropagationEnabled(true, "aws");
     sqsPropagationEnabled = awsPropagationEnabled && isPropagationEnabled(true, "sqs");
 


### PR DESCRIPTION
# What Does This Do
Adds the option to use hierarchy matching for jdbc if the driver in use is not supported by name based matching

# Motivation
Greenplum JDBC obfuscates class names and cannot be consistently matched with name-based matching

# Additional Notes
