### PR TITLE
Remove JDK 8 from the list of versions safe to 'force-start-first'

### DIFF
--- a/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
+++ b/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
@@ -128,8 +128,7 @@ public class ProfilingAgent {
   private static boolean isStartForceFirstSafe() {
     return Platform.isJavaVersionAtLeast(14)
         || (Platform.isJavaVersion(13) && Platform.isJavaVersionAtLeast(13, 0, 4))
-        || (Platform.isJavaVersion(11) && Platform.isJavaVersionAtLeast(11, 0, 8))
-        || (Platform.isJavaVersion(8) && Platform.isJavaVersionAtLeast(8, 0, 272));
+        || (Platform.isJavaVersion(11) && Platform.isJavaVersionAtLeast(11, 0, 8));
   }
 
   public static void shutdown() {


### PR DESCRIPTION
# What Does This Do
It removes JDK 8 from the list of versions to 'force-start-first' profiler.

# Motivation
Although the original issue https://bugs.openjdk.org/browse/JDK-8233197 seems to be backported to JDK 8 it is not the case as the fix was later reverted because it was breaking JVMTI spec.

# Additional Notes
This change is not going to affect anyone else but users having set `dd.profiling.start-force-first` system property to true and running on JDK 8 - I expect that the number of such users is very close to zero.