### PR TITLE
Move ShutdownHelper to agent-bootstrap to avoid having to inject it i…

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/shutdown/ShutdownHelper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/shutdown/ShutdownHelper.java
@@ -1,4 +1,4 @@
-package datadog.trace.instrumentation.shutdown;
+package datadog.trace.bootstrap.instrumentation.shutdown;
 
 import datadog.trace.bootstrap.Agent;
 import org.slf4j.Logger;

--- a/dd-java-agent/instrumentation/shutdown/src/main/java/datadog/trace/instrumentation/shutdown/ShutdownInstrumentation.java
+++ b/dd-java-agent/instrumentation/shutdown/src/main/java/datadog/trace/instrumentation/shutdown/ShutdownInstrumentation.java
@@ -6,12 +6,12 @@ import static net.bytebuddy.matcher.ElementMatchers.isStatic;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.instrumentation.shutdown.ShutdownHelper;
 import net.bytebuddy.asm.Advice;
 
 /**
  * This instrumentation intercepts the JVM shutdown process and allows calling an arbitrary code
  * before the shutdown hooks are called.<br>
- * The instrumentation is disabled by default.
  */
 @AutoService(Instrumenter.class)
 public class ShutdownInstrumentation extends Instrumenter.Tracing
@@ -19,11 +19,6 @@ public class ShutdownInstrumentation extends Instrumenter.Tracing
 
   public ShutdownInstrumentation() {
     super("shutdown");
-  }
-
-  @Override
-  protected boolean defaultEnabled() {
-    return true;
   }
 
   @Override
@@ -38,16 +33,11 @@ public class ShutdownInstrumentation extends Instrumenter.Tracing
         getClass().getName() + "$ShutdownAdvice");
   }
 
-  @Override
-  public String[] helperClassNames() {
-    return new String[] {ShutdownHelper.class.getName()};
-  }
-
   public static class ShutdownAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void methodEnter() {
-      // let's intercept the `runHooks` method before any of the hooks is run
+      // let's intercept the `runHooks` method before any of the hooks run
       ShutdownHelper.shutdownAgent();
     }
 


### PR DESCRIPTION
…nto the bootstrap classloader later on. (#3913)

Types under agent-bootstrap are automatically made available from the bootclasspath as part of installing the javaagent.

This avoids the need to register them as helper classes via HelperInjector. It is especially important to avoid using HelperInjector when instrumentating JDK classes because the only way we can inject types into the bootclasspath after the javaagent has been installed is to use a temporary jar file (unfortunately the only approach allowed by the JVM's instrumentation API)

Use of a temporary jar file causes issues in serverless environments, but it's worse when instrumenting j.l.Shutdown because we use File.deleteOnExit to attempt to clean up these temporary jars when the process ends (we cannot remove them while the JVM is alive because of how the JVM maps the classes into memory) and File.deleteOnExit interacts with j.l.Shutdown to register its own shutdown hook.

This results in an exception while trying to inject the helper which then leads to the following exception at shutdown:

Exception in thread "main" java.lang.NoClassDefFoundError: Could not initialize class java.io.DeleteOnExitHook
        at java.io.File.deleteOnExit(Unknown Source)

# What Does This Do

# Motivation

# Additional Notes
