### PR TITLE
Added support for Greenplum JDBC

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
@@ -3,10 +3,15 @@ package datadog.trace.instrumentation.jdbc;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.Config;
+import java.util.Collections;
 
 @AutoService(Instrumenter.class)
 public class ConnectionInstrumentation extends AbstractConnectionInstrumentation
     implements Instrumenter.ForKnownTypes, Instrumenter.ForConfiguredType {
+  @Override
+  protected boolean defaultEnabled() {
+    return !Config.get().isIntegrationEnabled(Collections.singletonList("greenplum"), false);
+  }
 
   private static final String[] CONCRETE_TYPES = {
     // redshift

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/GreenplumConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/GreenplumConnectionInstrumentation.java
@@ -1,0 +1,32 @@
+package datadog.trace.instrumentation.jdbc;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(Instrumenter.class)
+public class GreenplumConnectionInstrumentation extends AbstractConnectionInstrumentation
+    implements Instrumenter.ForTypeHierarchy {
+  public GreenplumConnectionInstrumentation() {
+    super("jdbc", "greenplum");
+  }
+
+  @Override
+  protected boolean defaultEnabled() {
+    return false;
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "java.sql.Connection";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return implementsInterface(named(hierarchyMarkerType()));
+  }
+}

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/GreenplumPreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/GreenplumPreparedStatementInstrumentation.java
@@ -1,0 +1,32 @@
+package datadog.trace.instrumentation.jdbc;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(Instrumenter.class)
+public class GreenplumPreparedStatementInstrumentation
+    extends AbstractPreparedStatementInstrumentation implements Instrumenter.ForTypeHierarchy {
+  public GreenplumPreparedStatementInstrumentation() {
+    super("jdbc", "greenplum");
+  }
+
+  @Override
+  protected boolean defaultEnabled() {
+    return false;
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "java.sql.PreparedStatement";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return implementsInterface(named(hierarchyMarkerType()));
+  }
+}

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -3,10 +3,15 @@ package datadog.trace.instrumentation.jdbc;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.Config;
+import java.util.Collections;
 
 @AutoService(Instrumenter.class)
 public final class PreparedStatementInstrumentation extends AbstractPreparedStatementInstrumentation
     implements Instrumenter.ForKnownTypes, Instrumenter.ForConfiguredType {
+  @Override
+  protected boolean defaultEnabled() {
+    return !Config.get().isIntegrationEnabled(Collections.singletonList("greenplum"), false);
+  }
 
   private static final String[] CONCRETE_TYPES = {
     // redshift


### PR DESCRIPTION
# What Does This Do

Adds the option to use hierarchy matching for jdbc if the driver in use is not supported by name based matching

# Motivation
Greenplum JDBC obfuscates class names and cannot be consistently matched with name-based matching


# Additional Notes
