### PR TITLE
Remove HelperInjector.injectBootstrapClassLoader

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
@@ -2,22 +2,12 @@ package datadog.trace.agent.tooling;
 
 import static datadog.trace.bootstrap.AgentClassLoading.INJECTING_HELPERS;
 
-import datadog.trace.api.Config;
 import datadog.trace.util.Strings;
-import java.io.File;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.ProtectionDomain;
-import java.security.SecureClassLoader;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -36,20 +26,6 @@ import org.slf4j.LoggerFactory;
 /** Injects instrumentation helper classes into the user's classloader. */
 public class HelperInjector implements Instrumenter.AdviceTransformer {
   private static final Logger log = LoggerFactory.getLogger(HelperInjector.class);
-  // Need this because we can't put null into the injectedClassLoaders map.
-  private static final ClassLoader BOOTSTRAP_CLASSLOADER_PLACEHOLDER =
-      new SecureClassLoader(null) {
-        @Override
-        public String toString() {
-          return "<bootstrap>";
-        }
-      };
-
-  static {
-    if (Config.get().isTempJarsCleanOnBoot()) {
-      cleanTempJars();
-    }
-  }
 
   private final String requestingName;
 
@@ -82,15 +58,6 @@ public class HelperInjector implements Instrumenter.AdviceTransformer {
     dynamicTypeMap.putAll(helperMap);
   }
 
-  public static HelperInjector forDynamicTypes(
-      final String requestingName, final Collection<DynamicType.Unloaded<?>> helpers) {
-    final Map<String, byte[]> helperMap = new HashMap<>(helpers.size());
-    for (final DynamicType.Unloaded<?> helper : helpers) {
-      helperMap.put(helper.getTypeDescription().getName(), helper.getBytes());
-    }
-    return new HelperInjector(requestingName, helperMap);
-  }
-
   private Map<String, byte[]> getHelperMap() throws IOException {
     if (dynamicTypeMap.isEmpty()) {
       final Map<String, byte[]> classnameToBytes = new LinkedHashMap<>();
@@ -118,7 +85,10 @@ public class HelperInjector implements Instrumenter.AdviceTransformer {
       final ProtectionDomain pd) {
     if (!helperClassNames.isEmpty()) {
       if (classLoader == null) {
-        classLoader = BOOTSTRAP_CLASSLOADER_PLACEHOLDER;
+        throw new UnsupportedOperationException(
+            "Cannot inject helper classes onto boot-class-path; move "
+                + Strings.join(",", helperClassNames)
+                + " to agent-bootstrap");
       }
 
       if (!injectedClassLoaders.containsKey(classLoader)) {
@@ -132,12 +102,7 @@ public class HelperInjector implements Instrumenter.AdviceTransformer {
           }
 
           final Map<String, byte[]> classnameToBytes = getHelperMap();
-          final Map<String, Class<?>> classes;
-          if (classLoader == BOOTSTRAP_CLASSLOADER_PLACEHOLDER) {
-            classes = injectBootstrapClassLoader(classnameToBytes);
-          } else {
-            classes = injectClassLoader(classLoader, classnameToBytes);
-          }
+          final Map<String, Class<?>> classes = injectClassLoader(classLoader, classnameToBytes);
 
           // All datadog helper classes are in the unnamed module
           // And there's exactly one unnamed module per classloader
@@ -164,28 +129,6 @@ public class HelperInjector implements Instrumenter.AdviceTransformer {
       ensureModuleCanReadHelperModules(module);
     }
     return builder;
-  }
-
-  private Map<String, Class<?>> injectBootstrapClassLoader(
-      final Map<String, byte[]> classnameToBytes) throws IOException {
-    // Mar 2020: Since we're proactively cleaning up tempDirs, we cannot share dirs per thread.
-    // If this proves expensive, we could do a per-process tempDir with
-    // a reference count -- but for now, starting simple.
-
-    // Failures to create a tempDir are propagated as IOException and handled by transform
-    final File tempDir = createTempDir();
-    INJECTING_HELPERS.begin();
-    try {
-      return ClassInjector.UsingInstrumentation.of(
-              tempDir,
-              ClassInjector.UsingInstrumentation.Target.BOOTSTRAP,
-              Utils.getInstrumentation())
-          .injectRaw(classnameToBytes);
-    } finally {
-      INJECTING_HELPERS.end();
-      // Delete fails silently
-      deleteTempDir(tempDir);
-    }
   }
 
   private Map<String, Class<?>> injectClassLoader(
@@ -218,79 +161,6 @@ public class HelperInjector implements Instrumenter.AdviceTransformer {
           }
         }
       }
-    }
-  }
-
-  private static File createTempDir() throws IOException {
-    try {
-      return Files.createTempDirectory(DATADOG_TEMP_JARS).toFile();
-    } catch (final IOException e) {
-      if (log.isErrorEnabled()) {
-        log.error(
-            "Unable to create temporary folder for injection.  Please ensure that `{}` specified by the system property `java.io.tmpdir` exists and is writable by this process",
-            System.getProperty("java.io.tmpdir"));
-      }
-
-      throw e;
-    }
-  }
-
-  private static void deleteTempDir(final File file) {
-    // Not using Files.delete for deleting the directory because failures
-    // create Exceptions which may prove expensive.  Instead using the
-    // older File API which simply returns a boolean.
-    final boolean deleted = file.delete();
-    if (!deleted) {
-      file.deleteOnExit();
-      log.debug("file '{}' added to shutdown delete hook", file);
-    } else {
-      log.debug("file '{}' deleted", file);
-    }
-  }
-
-  private static final String DATADOG_TEMP_JARS = "datadog-temp-jars";
-  private static final int MAX_CLEANUP_MILLIS = 1_000;
-
-  private static void cleanTempJars() {
-    try {
-      final Path tmpDir = Paths.get(System.getProperty("java.io.tmpdir"));
-      log.debug("Cleaning temp jar directories under {}", tmpDir);
-
-      final long maxTimeMillis = System.currentTimeMillis() + MAX_CLEANUP_MILLIS;
-      try (final DirectoryStream<Path> paths =
-          Files.newDirectoryStream(tmpDir, DATADOG_TEMP_JARS + "*")) {
-        for (final Path dir : paths) {
-          if (System.currentTimeMillis() > maxTimeMillis) {
-            break; // avoid attempting too much cleanup on boot
-          }
-          cleanTempJars(dir.toFile());
-        }
-      }
-    } catch (final Throwable e) {
-      log.debug("Problem cleaning temp jar directories", e);
-    }
-  }
-
-  private static void cleanTempJars(final File tempJarDir) {
-    final File[] tempJars =
-        tempJarDir.listFiles(
-            new FilenameFilter() {
-              @Override
-              public boolean accept(final File dir, final String name) {
-                return name.startsWith("jar") && name.endsWith(".jar");
-              }
-            });
-
-    if (tempJars != null) {
-      for (final File jar : tempJars) {
-        if (jar.delete()) {
-          log.debug("file '{}' deleted", jar);
-        }
-      }
-    }
-
-    if (tempJarDir.delete()) {
-      log.debug("file '{}' deleted", tempJarDir);
     }
   }
 }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/HelperInjectionTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/HelperInjectionTest.groovy
@@ -3,7 +3,6 @@ package datadog.trace.agent.test
 import datadog.trace.agent.tooling.HelperInjector
 import datadog.trace.agent.tooling.Utils
 import datadog.trace.test.util.DDSpecification
-import net.bytebuddy.agent.ByteBuddyAgent
 import net.bytebuddy.description.type.TypeDescription
 import net.bytebuddy.dynamic.ClassFileLocator
 import net.bytebuddy.dynamic.loading.ClassInjector
@@ -13,7 +12,6 @@ import java.lang.ref.WeakReference
 import java.util.concurrent.atomic.AtomicReference
 
 import static datadog.trace.agent.test.utils.ClasspathUtils.isClassLoaded
-import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.BOOTSTRAP_CLASSLOADER
 import static datadog.trace.test.util.GCUtils.awaitGC
 
 class HelperInjectionTest extends DDSpecification {
@@ -47,24 +45,6 @@ class HelperInjectionTest extends DDSpecification {
 
     then: "HelperInjector doesn't prevent it from being collected"
     null == ref.get()
-  }
-
-  def "helpers injected on bootstrap classloader"() {
-    setup:
-    Utils.setInstrumentation(ByteBuddyAgent.install())
-    HelperInjector injector = new HelperInjector("test", HELPER_CLASS_NAME)
-    URLClassLoader bootstrapChild = new URLClassLoader(new URL[0], (ClassLoader) null)
-
-    when:
-    bootstrapChild.loadClass(HELPER_CLASS_NAME)
-    then:
-    thrown ClassNotFoundException
-
-    when:
-    injector.transform(null, null, BOOTSTRAP_CLASSLOADER, null, null)
-    Class<?> helperClass = bootstrapChild.loadClass(HELPER_CLASS_NAME)
-    then:
-    helperClass.getClassLoader() == BOOTSTRAP_CLASSLOADER
   }
 
   @Retry

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -87,8 +87,6 @@ public final class TraceInstrumentationConfig {
   public static final String SERVLET_ROOT_CONTEXT_SERVICE_NAME =
       "trace.servlet.root-context.service.name";
 
-  public static final String TEMP_JARS_CLEAN_ON_BOOT = "temp.jars.clean.on.boot";
-
   public static final String RESOLVER_OUTLINE_POOL_ENABLED = "resolver.outline.pool.enabled";
   public static final String RESOLVER_OUTLINE_POOL_SIZE = "resolver.outline.pool.size";
   public static final String RESOLVER_TYPE_POOL_SIZE = "resolver.type.pool.size";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -256,7 +256,6 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.SERIALVERSIONU
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ASYNC_TIMEOUT_ERROR;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_PRINCIPAL_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ROOT_CONTEXT_SERVICE_NAME;
-import static datadog.trace.api.config.TraceInstrumentationConfig.TEMP_JARS_CLEAN_ON_BOOT;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ANNOTATIONS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE_FILE;
@@ -589,8 +588,6 @@ public class Config {
   private final boolean servletAsyncTimeoutError;
 
   private final int xDatadogTagsMaxLength;
-
-  private final boolean tempJarsCleanOnBoot;
 
   private final boolean traceAgentV05Enabled;
 
@@ -1255,9 +1252,6 @@ public class Config {
             TRACE_X_DATADOG_TAGS_MAX_LENGTH, DEFAULT_TRACE_X_DATADOG_TAGS_MAX_LENGTH);
 
     servletAsyncTimeoutError = configProvider.getBoolean(SERVLET_ASYNC_TIMEOUT_ERROR, true);
-
-    tempJarsCleanOnBoot =
-        configProvider.getBoolean(TEMP_JARS_CLEAN_ON_BOOT, false) && isWindowsOS();
 
     debugEnabled = isDebugMode();
 
@@ -2000,10 +1994,6 @@ public class Config {
 
   public boolean isServletAsyncTimeoutError() {
     return servletAsyncTimeoutError;
-  }
-
-  public boolean isTempJarsCleanOnBoot() {
-    return tempJarsCleanOnBoot;
   }
 
   public boolean isTraceAgentV05Enabled() {
@@ -3021,8 +3011,6 @@ public class Config {
         + servletAsyncTimeoutError
         + ", datadogTagsLimit="
         + xDatadogTagsMaxLength
-        + ", tempJarsCleanOnBoot="
-        + tempJarsCleanOnBoot
         + ", traceAgentV05Enabled="
         + traceAgentV05Enabled
         + ", debugEnabled="


### PR DESCRIPTION
# What Does This Do

Removes support for late injection of helper classes onto the boot-class-path. After this is merged any request to inject a helper class where the target class-loader is the boot-loader (ie. `null`) will result in a transformation exception in the logs and the relevant transformation will not be applied.

Note: no exception will leak out to the application, it's only the transfiormation that will be blocked.

For example. this is what happens when the `ShutdownHelper` fix is temporarily reverted:
```
[dd.trace 2022-09-30 11:37:38:035 +0100] [main] DEBUG datadog.trace.agent.tooling.AgentInstaller$TransformLoggingListener - Transformation failed - instrumentation.target.class=java.lang.Shutdown instrumentation.target.classloader=null
java.lang.UnsupportedOperationException: Cannot inject helper classes onto boot-class-path; move datadog.trace.instrumentation.shutdown.ShutdownHelper to agent-bootstrap
        at datadog.trace.agent.tooling.HelperInjector.transform(HelperInjector.java:90)
        ... etc ...
```

# Motivation

This functionality is no longer used because it requires a writable file-system, we should remove it to avoid accidentally depending on it again. Removing this feature also means we can clean up a bunch of related logic and utilities.