### PR TITLE
Tracer version now corresponds Semantic Versioning 2.0.0

### DIFF
--- a/remote-config/src/main/java/datadog/remoteconfig/PollerRequestFactory.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/PollerRequestFactory.java
@@ -45,7 +45,8 @@ public class PollerRequestFactory {
     this.env = config.getEnv();
     this.ddVersion = config.getVersion();
     this.hostName = config.getHostName();
-    this.tracerVersion = tracerVersion;
+    // Semantic Versioning requires build separated with `+`
+    this.tracerVersion = tracerVersion.replace('~', '+');
     this.containerId = containerId;
     this.url = parseUrl(url);
     this.moshi = moshi;


### PR DESCRIPTION
# What Does This Do
Backend expects tracer version to be reported in format of Semantic Versioning 2.0.0
https://semver.org/spec/v2.0.0.html#spec-item-10
A build version must be separated with `+` instead of `~`. 
Ex: `0.109.0+bf0a771b10`

# Motivation

# Additional Notes
