### PR TITLE
[WIP] strip 'v' from version tag

### DIFF
--- a/.github/workflows/add-assets-to-release.yaml
+++ b/.github/workflows/add-assets-to-release.yaml
@@ -3,11 +3,13 @@ on:
   release:
     types: [published]
 env:
-  VERSION: ${{ github.event.release.name }}  #Can't use GITHUB_REF because it starts with a "v"
+  TAG_NAME: ${{ github.event.release.tag_name }}
 jobs:
   dd-java-agent:
     runs-on: ubuntu-latest
     steps:
+      - name: Strip leading 'v' from tag, if present
+        run: echo "VERSION=$(echo ${TAG_NAME/#v/})" >> $GITHUB_ENV
       - name: Download from Sonatype
         run: |
           wget https://oss.sonatype.org/service/local/repositories/releases/content/com/datadoghq/dd-java-agent/$VERSION/dd-java-agent-$VERSION.jar
@@ -33,6 +35,8 @@ jobs:
   dd-trace-api:
     runs-on: ubuntu-latest
     steps:
+      - name: Strip leading 'v' from tag, if present
+        run: echo "VERSION=$(echo ${TAG_NAME/#v/})" >> $GITHUB_ENV
       - name: Download from Sonatype
         run: |
           wget https://oss.sonatype.org/service/local/repositories/releases/content/com/datadoghq/dd-trace-api/$VERSION/dd-trace-api-$VERSION.jar
@@ -48,6 +52,8 @@ jobs:
   dd-trace-ot:
     runs-on: ubuntu-latest
     steps:
+      - name: Strip leading 'v' from tag, if present
+        run: echo "VERSION=$(echo ${TAG_NAME/#v/})" >> $GITHUB_ENV
       - name: Download from Sonatype
         run: |
           wget https://oss.sonatype.org/service/local/repositories/releases/content/com/datadoghq/dd-trace-ot/$VERSION/dd-trace-ot-$VERSION.jar


### PR DESCRIPTION
# What Does This Do

Gets the `$VERSION` (e.g "0.123.0") from the `tag` instead of the user supplied _Release Name_ field and strips the leading 'v' automatically.  

# Motivation

Currently the user must remove the 'v' from the tag like "v0.123.0" -> "0.123.0" and put this new value in the _Release Title_ field.  The value later populates $VERSION.  If the user does not strip the 'v', subsequent release steps fail.  

Releases could even have names unrelated to the tag if desired however [update-issues-on-release.yaml](https://github.com/DataDog/dd-trace-java/blob/master/.github/workflows/update-issues-on-release.yaml#:~:text=github.event.release.name) and [update-download-releases.yaml](https://github.com/DataDog/dd-trace-java/blob/master/.github/workflows/update-download-releases.yaml#:~:text=github.event.release.name) also depend on `github.event.release.name`
