### PR TITLE
Track instrumentation state

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -163,6 +163,7 @@ public class AgentInstaller {
       log.debug("Installed {} instrumenter(s)", installedCount);
     }
 
+    InstrumenterState.resetDefaultState();
     try {
       return transformerBuilder.installOn(inst);
     } finally {

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -119,8 +119,10 @@ public class AgentInstaller {
       agentBuilder = agentBuilder.with(listener);
     }
 
-    Iterable<Instrumenter> instrumenters =
-        Instrumenters.load(AgentInstaller.class.getClassLoader());
+    Instrumenters instrumenters = Instrumenters.load(AgentInstaller.class.getClassLoader());
+
+    // pre-size state before registering instrumentations to reduce number of allocations
+    InstrumenterState.setMaxInstrumentationId(instrumenters.maxInstrumentationId());
 
     // This needs to be a separate loop through all the instrumenters before we start adding
     // advice so that we can exclude field injection, since that will try to check exclusion

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -8,6 +8,7 @@ import datadog.trace.agent.tooling.bytebuddy.DDOutlinePoolStrategy;
 import datadog.trace.agent.tooling.bytebuddy.SharedTypePools;
 import datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers;
 import datadog.trace.api.Config;
+import datadog.trace.api.IntegrationsCollector;
 import datadog.trace.api.ProductActivationConfig;
 import datadog.trace.bootstrap.FieldBackedContextAccessor;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
@@ -161,6 +162,16 @@ public class AgentInstaller {
     }
     if (DEBUG) {
       log.debug("Installed {} instrumenter(s)", installedCount);
+    }
+
+    if (Config.get().isTelemetryEnabled()) {
+      InstrumenterState.setObserver(
+          new InstrumenterState.Observer() {
+            @Override
+            public void applied(Iterable<String> instrumentationNames) {
+              IntegrationsCollector.get().update(instrumentationNames, true);
+            }
+          });
     }
 
     InstrumenterState.resetDefaultState();

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentTransformerBuilder.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentTransformerBuilder.java
@@ -73,12 +73,13 @@ public class AgentTransformerBuilder
   }
 
   private AgentBuilder buildInstrumentation(final Instrumenter.Default instrumenter) {
-    AgentBuilder.RawMatcher matcher = matcher(instrumenter);
+    InstrumenterState.registerInstrumentationNames(
+        instrumenter.instrumentationId(), instrumenter.names());
 
     ignoreMatcher = instrumenter.methodIgnoreMatcher();
     adviceBuilder =
         agentBuilder
-            .type(matcher)
+            .type(typeMatcher(instrumenter))
             .and(NOT_DECORATOR_MATCHER)
             .and(new MuzzleMatcher(instrumenter))
             .transform(defaultTransformers());
@@ -124,7 +125,7 @@ public class AgentTransformerBuilder
     return adviceBuilder;
   }
 
-  private AgentBuilder.RawMatcher matcher(Instrumenter.Default instrumenter) {
+  private AgentBuilder.RawMatcher typeMatcher(Instrumenter.Default instrumenter) {
     ElementMatcher<? super TypeDescription> typeMatcher;
     String hierarchyHint = null;
 

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/MuzzleMatcher.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/MuzzleMatcher.java
@@ -1,0 +1,31 @@
+package datadog.trace.agent.tooling.bytebuddy.matcher;
+
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Config;
+import datadog.trace.api.IntegrationsCollector;
+import java.security.ProtectionDomain;
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.utility.JavaModule;
+
+public final class MuzzleMatcher implements AgentBuilder.RawMatcher {
+  private final Instrumenter.Default instrumenter;
+
+  public MuzzleMatcher(Instrumenter.Default instrumenter) {
+    this.instrumenter = instrumenter;
+  }
+
+  @Override
+  public boolean matches(
+      TypeDescription typeDescription,
+      ClassLoader classLoader,
+      JavaModule module,
+      Class<?> classBeingRedefined,
+      ProtectionDomain protectionDomain) {
+    boolean isMatch = instrumenter.muzzleMatches(classLoader, classBeingRedefined);
+    if (isMatch && Config.get().isTelemetryEnabled()) {
+      IntegrationsCollector.get().update(instrumenter.names(), true);
+    }
+    return isMatch;
+  }
+}

--- a/dd-java-agent/agent-builder/src/test/groovy/datadog/trace/agent/test/DefaultInstrumenterForkedTest.groovy
+++ b/dd-java-agent/agent-builder/src/test/groovy/datadog/trace/agent/test/DefaultInstrumenterForkedTest.groovy
@@ -1,15 +1,10 @@
 package datadog.trace.agent.test
 
-import datadog.trace.agent.tooling.AgentTransformerBuilder
 import datadog.trace.agent.tooling.Instrumenter
 import datadog.trace.agent.tooling.bytebuddy.DDCachingPoolStrategy
 import datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers
 import datadog.trace.test.util.DDSpecification
-import net.bytebuddy.agent.builder.AgentBuilder
-import net.bytebuddy.description.type.TypeDescription
-import net.bytebuddy.matcher.ElementMatcher
-
-import static net.bytebuddy.matcher.ElementMatchers.none
+import spock.lang.Shared
 
 class DefaultInstrumenterForkedTest extends DDSpecification {
   static {
@@ -17,10 +12,13 @@ class DefaultInstrumenterForkedTest extends DDSpecification {
     DDElementMatchers.registerAsSupplier()
   }
 
+  @Shared
+  Instrumenter.TransformerBuilder testAdviceBuilder = { it.adviceTransformations({}) }
+
   def "default enabled"() {
     setup:
     def target = new TestDefaultInstrumenter("test")
-    target.instrument(new AgentTransformerBuilder(new AgentBuilder.Default()))
+    target.instrument(testAdviceBuilder)
 
     expect:
     target.enabled
@@ -29,7 +27,7 @@ class DefaultInstrumenterForkedTest extends DDSpecification {
 
   def "default enabled override"() {
     setup:
-    target.instrument(new AgentTransformerBuilder(new AgentBuilder.Default()))
+    target.instrument(testAdviceBuilder)
 
     expect:
     target.enabled == enabled
@@ -60,7 +58,7 @@ class DefaultInstrumenterForkedTest extends DDSpecification {
           return false
         }
       }
-    target.instrument(new AgentTransformerBuilder(new AgentBuilder.Default()))
+    target.instrument(testAdviceBuilder)
 
     expect:
     target.enabled == enabled
@@ -76,7 +74,7 @@ class DefaultInstrumenterForkedTest extends DDSpecification {
 
     when:
     def target = new TestDefaultInstrumenter("test")
-    target.instrument(new AgentTransformerBuilder(new AgentBuilder.Default()))
+    target.instrument(testAdviceBuilder)
 
     then:
     target.enabled == enabled
@@ -93,7 +91,7 @@ class DefaultInstrumenterForkedTest extends DDSpecification {
     setup:
     injectEnvConfig("DD_INTEGRATIONS_ENABLED", value)
     def target = new TestDefaultInstrumenter("test")
-    target.instrument(new AgentTransformerBuilder(new AgentBuilder.Default()))
+    target.instrument(testAdviceBuilder)
 
     expect:
     target.enabled == enabled
@@ -111,7 +109,7 @@ class DefaultInstrumenterForkedTest extends DDSpecification {
     injectSysConfig("integrations.enabled", "false")
     injectSysConfig("integration.${value}.enabled", "true")
     def target = new TestDefaultInstrumenter(name, altName)
-    target.instrument(new AgentTransformerBuilder(new AgentBuilder.Default()))
+    target.instrument(testAdviceBuilder)
 
     expect:
     target.enabled == enabled
@@ -135,7 +133,7 @@ class DefaultInstrumenterForkedTest extends DDSpecification {
 
     when:
     def target = new TestDefaultInstrumenter(name, altName)
-    target.instrument(new AgentTransformerBuilder(new AgentBuilder.Default()))
+    target.instrument(testAdviceBuilder)
 
     then:
     System.getenv("DD_INTEGRATION_${value}_ENABLED") == "true"
@@ -153,7 +151,7 @@ class DefaultInstrumenterForkedTest extends DDSpecification {
     "PERIOD_TEST"     | true    | "period.test" | "asdf"
   }
 
-  class TestDefaultInstrumenter extends Instrumenter.Tracing implements Instrumenter.ForTypeHierarchy {
+  class TestDefaultInstrumenter extends Instrumenter.Tracing {
     boolean applyCalled = false
 
     TestDefaultInstrumenter(String instrumentationName) {
@@ -165,18 +163,8 @@ class DefaultInstrumenterForkedTest extends DDSpecification {
     }
 
     @Override
-    String hierarchyMarkerType() {
-      return null
-    }
-
-    @Override
-    ElementMatcher<? super TypeDescription> hierarchyMatcher() {
-      applyCalled = true
-      return none()
-    }
-
-    @Override
     void adviceTransformations(AdviceTransformation transformation) {
+      applyCalled = true
     }
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -140,6 +140,10 @@ public interface Instrumenter {
       enabled = Config.get().isIntegrationEnabled(instrumentationNames, defaultEnabled());
     }
 
+    public int instrumentationId() {
+      return instrumentationId;
+    }
+
     public String name() {
       return instrumentationPrimaryName;
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -155,7 +155,6 @@ public interface Instrumenter {
     @Override
     public final void instrument(TransformerBuilder transformerBuilder) {
       if (isEnabled()) {
-        InstrumenterState.registerInstrumentationNames(instrumentationId, instrumentationNames);
         transformerBuilder.applyInstrumentation(this);
       } else {
         if (log.isDebugEnabled()) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -123,6 +123,7 @@ public interface Instrumenter {
   abstract class Default implements Instrumenter, HasAdvice {
     private static final Logger log = LoggerFactory.getLogger(Default.class);
 
+    private final int instrumentationId;
     private final List<String> instrumentationNames;
     private final String instrumentationPrimaryName;
     private final boolean enabled;
@@ -130,6 +131,7 @@ public interface Instrumenter {
     protected final String packageName = Strings.getPackageName(getClass().getName());
 
     public Default(final String instrumentationName, final String... additionalNames) {
+      instrumentationId = Instrumenters.currentInstrumentationId();
       instrumentationNames = new ArrayList<>(1 + additionalNames.length);
       instrumentationNames.add(instrumentationName);
       addAll(instrumentationNames, additionalNames);
@@ -149,6 +151,7 @@ public interface Instrumenter {
     @Override
     public final void instrument(TransformerBuilder transformerBuilder) {
       if (isEnabled()) {
+        InstrumenterState.registerInstrumentationNames(instrumentationId, instrumentationNames);
         transformerBuilder.applyInstrumentation(this);
       } else {
         if (log.isDebugEnabled()) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterState.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterState.java
@@ -1,0 +1,89 @@
+package datadog.trace.agent.tooling;
+
+import datadog.trace.api.function.Function;
+import datadog.trace.bootstrap.WeakCache;
+import java.util.concurrent.atomic.AtomicLongArray;
+
+/** Tracks {@link Instrumenter} state, such as where it was applied and where it was blocked. */
+public final class InstrumenterState {
+
+  // constants for representing a bitset as a series of words
+  private static final int ADDRESS_BITS_PER_WORD = 6;
+  private static final int BITS_PER_WORD = 1 << ADDRESS_BITS_PER_WORD;
+  private static final int BIT_INDEX_MASK = BITS_PER_WORD - 1;
+
+  // represent each status as 2 adjacent bits
+  private static final int BLOCKED = 0b01;
+  private static final int APPLIED = 0b10;
+
+  private static final int STATUS_BITS = 0b11;
+
+  static int wordsPerClassLoaderState;
+
+  /** Tracks which instrumentations were applied (per-class-loader) and which were blocked. */
+  private static final WeakCache<ClassLoader, AtomicLongArray> classLoaderStates =
+      WeakCaches.newWeakCache(64);
+
+  private static final Function<ClassLoader, AtomicLongArray> buildClassLoaderState =
+      new Function<ClassLoader, AtomicLongArray>() {
+        @Override
+        public AtomicLongArray apply(ClassLoader input) {
+          return new AtomicLongArray(wordsPerClassLoaderState);
+        }
+      };
+
+  private InstrumenterState() {}
+
+  /** Pre-sizes internals to fit the largest expected instrumentation-id. */
+  public static void presize(int maxInstrumentationId) {
+    wordsPerClassLoaderState =
+        ((maxInstrumentationId << 1) + BITS_PER_WORD - 1) >> ADDRESS_BITS_PER_WORD;
+  }
+
+  /**
+   * Does the instrumentation apply to the given class-loader?
+   *
+   * @return {@code null} if checks such as muzzle are still pending
+   */
+  public static Boolean isApplicable(ClassLoader classLoader, int instrumentationId) {
+    int status = currentState(classLoader, instrumentationId);
+    return status == 0 ? null : status == APPLIED;
+  }
+
+  /** Record that the instrumentation was applied to the given class-loader. */
+  public static void applyInstrumentation(ClassLoader classLoader, int instrumentationId) {
+    updateState(classLoader, instrumentationId, APPLIED);
+  }
+
+  /** Record that the instrumentation was blocked for the given class-loader. */
+  public static void blockInstrumentation(ClassLoader classLoader, int instrumentationId) {
+    updateState(classLoader, instrumentationId, BLOCKED);
+  }
+
+  private static int currentState(ClassLoader classLoader, int instrumentationId) {
+    return currentState(classLoaderState(classLoader), instrumentationId << 1);
+  }
+
+  private static void updateState(ClassLoader classLoader, int instrumentationId, int status) {
+    updateState(classLoaderState(classLoader), instrumentationId << 1, status);
+  }
+
+  private static AtomicLongArray classLoaderState(ClassLoader classLoader) {
+    return classLoaderStates.computeIfAbsent(
+        null != classLoader ? classLoader : Utils.getBootstrapProxy(), buildClassLoaderState);
+  }
+
+  private static int currentState(AtomicLongArray state, int bitIndex) {
+    int wordIndex = bitIndex >> ADDRESS_BITS_PER_WORD;
+    return STATUS_BITS & (int) (state.get(wordIndex) >> (bitIndex & BIT_INDEX_MASK));
+  }
+
+  private static void updateState(AtomicLongArray state, int bitIndex, int status) {
+    int wordIndex = bitIndex >> ADDRESS_BITS_PER_WORD;
+    long bitsToSet = ((long) status) << (bitIndex & BIT_INDEX_MASK);
+    long wordState = state.get(wordIndex);
+    while (!state.compareAndSet(wordIndex, wordState, wordState | bitsToSet)) {
+      wordState = state.get(wordIndex);
+    }
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenters.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenters.java
@@ -39,6 +39,10 @@ public final class Instrumenters implements Iterable<Instrumenter> {
     this.instrumenters = new Instrumenter[names.length];
   }
 
+  public int maxInstrumentationId() {
+    return instrumenters.length;
+  }
+
   /** Returns the id of the {@link Instrumenter} currently being installed. */
   public static int currentInstrumentationId() {
     return currentInstrumentationId;

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/muzzle/ReferenceMatcherTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/muzzle/ReferenceMatcherTest.groovy
@@ -65,43 +65,6 @@ class ReferenceMatcherTest extends DDSpecification {
     MuzzleWeakReferenceTest.classLoaderRefIsGarbageCollected()
   }
 
-  private static class CountingClassLoader extends URLClassLoader {
-    int count = 0
-
-    CountingClassLoader(URL[] urls, ClassLoader parent) {
-      super(urls, (ClassLoader) parent)
-    }
-
-    @Override
-    URL getResource(String name) {
-      count++
-      return super.getResource(name)
-    }
-  }
-
-  def "muzzle results are cached"() {
-    setup:
-    ClassLoader cl = new CountingClassLoader(
-      [
-        ClasspathUtils.createJarWithClasses(MethodBodyAdvice.A,
-        MethodBodyAdvice.B,
-        MethodBodyAdvice.SomeInterface,
-        MethodBodyAdvice.SkipLevel,
-        MethodBodyAdvice.HasMethod,
-        MethodBodyAdvice.SomeImplementation)
-      ] as URL[],
-      (ClassLoader) null)
-    Reference[] refs = ReferenceCreator.createReferencesFrom(MethodBodyAdvice.getName(), testClasspath).values().toArray(new Reference[0])
-    ReferenceMatcher refMatcher = new ReferenceMatcher(refs)
-    assert refMatcher.matches(cl)
-    int countAfterFirstMatch = cl.count
-    // re-running the muzzle matcher against the same classloader should use the result cache
-    assert refMatcher.matches(cl)
-
-    expect:
-    cl.count == countAfterFirstMatch
-  }
-
   def "matching ref #referenceName #referenceFlags against #classToCheck produces #expectedMismatches"() {
     setup:
     Reference.Builder builder = new Reference.Builder(referenceName)


### PR DESCRIPTION
# What Does This Do

Tracks instrumentation state in a single place, rather than have a muzzle cache per-instrumentation.

# Motivation

More compact - this refactoring also lets us have a clean way to notify when an instrumentation is applied, rather than as a hack inside the muzzle matcher.
