### PR TITLE
Improve tracer stats behavior

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -40,4 +40,5 @@ public class DDTags {
   public static final String ORIGIN_KEY = "_dd.origin";
   public static final String LIBRARY_VERSION_TAG_KEY = "library_version";
   public static final String CI_ENV_VARS = "_dd.ci.env_vars";
+  public static final String MEASURED = "_dd.measured";
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -16,14 +16,14 @@ public class DDTags {
 
   public static final String ERROR_MSG = "error.msg"; // string representing the error message
   public static final String ERROR_TYPE = "error.type"; // string representing the type of the error
-  public static final String ERROR_STACK = "error.stack"; // human readable version of the stack
+  public static final String ERROR_STACK = "error.stack"; // human-readable version of the stack
 
   public static final String ANALYTICS_SAMPLE_RATE = "_dd1.sr.eausr";
   @Deprecated public static final String EVENT_SAMPLE_RATE = ANALYTICS_SAMPLE_RATE;
 
   /** Manually force tracer to be keep the trace */
   public static final String MANUAL_KEEP = "manual.keep";
-  /** Manually force tracer to be drop the trace */
+  /** Manually force tracer to be dropped the trace */
   public static final String MANUAL_DROP = "manual.drop";
 
   public static final String TRACE_START_TIME = "t0";

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -21,9 +21,9 @@ public class DDTags {
   public static final String ANALYTICS_SAMPLE_RATE = "_dd1.sr.eausr";
   @Deprecated public static final String EVENT_SAMPLE_RATE = ANALYTICS_SAMPLE_RATE;
 
-  /** Manually force tracer to be keep the trace */
+  /** Manually force tracer to keep the trace */
   public static final String MANUAL_KEEP = "manual.keep";
-  /** Manually force tracer to be dropped the trace */
+  /** Manually force tracer to drop the trace */
   public static final String MANUAL_DROP = "manual.drop";
 
   public static final String TRACE_START_TIME = "t0";

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Batch.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Batch.java
@@ -23,8 +23,12 @@ public final class Batch {
   static final Batch REPORT = new Batch((AtomicLongArray) null);
 
   /**
-   * This counter has two states 1 - negative - the batch has been used, must not add values 2 -
-   * otherwise - the number of values added to the batch
+   * This counter has two states:
+   *
+   * <ol>
+   *   <li>negative: the batch has been used, must not add values
+   *   <li>otherwise: the number of values added to the batch
+   * </ol>
    */
   private volatile int count = 0;
   /** incremented when a duration has been added. */

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
@@ -11,6 +11,7 @@ public final class MetricKey {
   private final UTF8BytesString operationName;
   private final UTF8BytesString type;
   private final int httpStatusCode;
+  private final boolean synthetics;
   private final int hash;
 
   public MetricKey(
@@ -18,20 +19,23 @@ public final class MetricKey {
       CharSequence service,
       CharSequence operationName,
       CharSequence type,
-      int httpStatusCode) {
+      int httpStatusCode,
+      boolean synthetics) {
     this.resource = null == resource ? EMPTY : UTF8BytesString.create(resource);
     this.service = null == service ? EMPTY : UTF8BytesString.create(service);
     this.operationName = null == operationName ? EMPTY : UTF8BytesString.create(operationName);
     this.type = null == type ? EMPTY : UTF8BytesString.create(type);
     this.httpStatusCode = httpStatusCode;
+    this.synthetics = synthetics;
     // unrolled polynomial hashcode which avoids allocating varargs
-    // the constants are 31^4, 31^3, 31^2, 31^1, 31^0
+    // the constants are 31^5, 31^4, 31^3, 31^2, 31^1, 31^0
     this.hash =
         923521 * this.resource.hashCode()
             + 29791 * this.service.hashCode()
             + 961 * this.operationName.hashCode()
             + 31 * this.type.hashCode()
-            + httpStatusCode;
+            + httpStatusCode
+            + (this.synthetics ? 28629151 : 0);
   }
 
   public UTF8BytesString getResource() {
@@ -54,6 +58,10 @@ public final class MetricKey {
     return httpStatusCode;
   }
 
+  public boolean isSynthetics() {
+    return synthetics;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -62,6 +70,7 @@ public final class MetricKey {
     if ((o instanceof MetricKey)) {
       MetricKey metricKey = (MetricKey) o;
       return hash == metricKey.hash
+          && synthetics == metricKey.synthetics
           && httpStatusCode == metricKey.httpStatusCode
           && resource.equals(metricKey.resource)
           && service.equals(metricKey.service)

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricKey.java
@@ -30,12 +30,12 @@ public final class MetricKey {
     // unrolled polynomial hashcode which avoids allocating varargs
     // the constants are 31^5, 31^4, 31^3, 31^2, 31^1, 31^0
     this.hash =
-        923521 * this.resource.hashCode()
-            + 29791 * this.service.hashCode()
-            + 961 * this.operationName.hashCode()
-            + 31 * this.type.hashCode()
-            + httpStatusCode
-            + (this.synthetics ? 28629151 : 0);
+        28629151 * this.resource.hashCode()
+            + 923521 * this.service.hashCode()
+            + 29791 * this.operationName.hashCode()
+            + 961 * this.type.hashCode()
+            + 31 * httpStatusCode
+            + (this.synthetics ? 1 : 0);
   }
 
   public UTF8BytesString getResource() {

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/SerializingMetricWriter.java
@@ -23,6 +23,7 @@ public final class SerializingMetricWriter implements MetricWriter {
   private static final byte[] DURATION = "Duration".getBytes(ISO_8859_1);
   private static final byte[] TYPE = "Type".getBytes(ISO_8859_1);
   private static final byte[] HTTP_STATUS_CODE = "HTTPStatusCode".getBytes(ISO_8859_1);
+  private static final byte[] SYNTHETICS = "Synthetics".getBytes(ISO_8859_1);
   private static final byte[] START = "Start".getBytes(ISO_8859_1);
   private static final byte[] STATS = "Stats".getBytes(ISO_8859_1);
   private static final byte[] OK_SUMMARY = "OkSummary".getBytes(ISO_8859_1);
@@ -82,7 +83,7 @@ public final class SerializingMetricWriter implements MetricWriter {
   @Override
   public void add(MetricKey key, AggregateMetric aggregate) {
 
-    writer.startMap(11);
+    writer.startMap(12);
 
     writer.writeUTF8(NAME);
     writer.writeUTF8(key.getOperationName());
@@ -98,6 +99,9 @@ public final class SerializingMetricWriter implements MetricWriter {
 
     writer.writeUTF8(HTTP_STATUS_CODE);
     writer.writeInt(key.getHttpStatusCode());
+
+    writer.writeUTF8(SYNTHETICS);
+    writer.writeBoolean(key.isSynthetics());
 
     writer.writeUTF8(HITS);
     writer.writeInt(aggregate.getHitCount());

--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/TagInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/TagInterceptor.java
@@ -1,6 +1,7 @@
 package datadog.trace.core.taginterceptor;
 
 import static datadog.trace.api.DDTags.ANALYTICS_SAMPLE_RATE;
+import static datadog.trace.api.DDTags.MEASURED;
 import static datadog.trace.api.DDTags.ORIGIN_KEY;
 import static datadog.trace.api.DDTags.SPAN_TYPE;
 import static datadog.trace.api.sampling.PrioritySampling.USER_DROP;
@@ -83,6 +84,8 @@ public class TagInterceptor {
         return interceptHttpStatusCode(span, value);
       case ORIGIN_KEY:
         return interceptOrigin(span, value);
+      case MEASURED:
+        return interceptMeasured(span, value);
       default:
         return intercept(span, tag, value);
     }
@@ -212,6 +215,14 @@ public class TagInterceptor {
       span.setOrigin(String.valueOf(origin));
     }
     return true;
+  }
+
+  private static boolean interceptMeasured(DDSpanContext span, Object value) {
+    if ((value instanceof Number && ((Number) value).intValue() > 0) || asBoolean(value)) {
+      span.setMeasured(true);
+      return true;
+    }
+    return false;
   }
 
   private static boolean asBoolean(Object value) {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AggregateMetricTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AggregateMetricTest.groovy
@@ -57,7 +57,7 @@ class AggregateMetricTest extends DDSpecification {
     given:
     AggregateMetric aggregate = new AggregateMetric().recordDurations(3, new AtomicLongArray(0L, 0L, 0L | ERROR_TAG | TOP_LEVEL_TAG))
 
-    Batch batch = new Batch().reset(new MetricKey("foo", "bar", "qux", "type", 0))
+    Batch batch = new Batch().reset(new MetricKey("foo", "bar", "qux", "type", 0, false))
     batch.add(0L, 10)
     batch.add(0L, 10)
     batch.add(0L, 10)
@@ -132,7 +132,7 @@ class AggregateMetricTest extends DDSpecification {
   def "consistent under concurrent attempts to read and write"() {
     given:
     AggregateMetric aggregate = new AggregateMetric()
-    MetricKey key = new MetricKey("foo", "bar", "qux", "type", 0)
+    MetricKey key = new MetricKey("foo", "bar", "qux", "type", 0, false)
     BlockingDeque<Batch> queue = new LinkedBlockingDeque<>(1000)
     ExecutorService reader = Executors.newSingleThreadExecutor()
     int writerCount = 10

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
@@ -111,7 +111,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
 
     then:
     1 * writer.startBucket(1, _, _)
-    1 * writer.add(new MetricKey("resource", "service", "operation", "type", HTTP_OK), _) >> { MetricKey key, AggregateMetric value ->
+    1 * writer.add(new MetricKey("resource", "service", "operation", "type", HTTP_OK, false), _) >> { MetricKey key, AggregateMetric value ->
       value.getHitCount() == 1 && value.getTopLevelCount() == 1 && value.getDuration() == 100
     }
     1 * writer.finishBucket() >> { latch.countDown() }
@@ -140,7 +140,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
 
     then:
     1 * writer.startBucket(1, _, _)
-    1 * writer.add(new MetricKey("resource", "service", "operation", "type", HTTP_OK), _) >> { MetricKey key, AggregateMetric value ->
+    1 * writer.add(new MetricKey("resource", "service", "operation", "type", HTTP_OK, false), _) >> { MetricKey key, AggregateMetric value ->
       value.getHitCount() == 1 && value.getTopLevelCount() == topLevelCount && value.getDuration() == 100
     }
     1 * writer.finishBucket() >> { latch.countDown() }
@@ -183,10 +183,10 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     then: "metrics should be conflated"
     1 * writer.finishBucket() >> { latch.countDown() }
     1 * writer.startBucket(2, _, SECONDS.toNanos(reportingInterval))
-    1 * writer.add(new MetricKey("resource", "service", "operation", "type", HTTP_OK), _) >> { MetricKey key, AggregateMetric value ->
+    1 * writer.add(new MetricKey("resource", "service", "operation", "type", HTTP_OK, false), _) >> { MetricKey key, AggregateMetric value ->
       value.getHitCount() == count && value.getDuration() == count * duration
     }
-    1 * writer.add(new MetricKey("resource2", "service2", "operation2", "type", HTTP_OK), _) >> { MetricKey key, AggregateMetric value ->
+    1 * writer.add(new MetricKey("resource2", "service2", "operation2", "type", HTTP_OK, false), _) >> { MetricKey key, AggregateMetric value ->
       value.getHitCount() == count && value.getDuration() == count * duration * 2
     }
 
@@ -222,11 +222,11 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     then: "the first aggregate should be dropped but the rest reported"
     1 * writer.startBucket(10, _, SECONDS.toNanos(reportingInterval))
     for (int i = 1; i < 11; ++i) {
-      1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", HTTP_OK), _) >> { MetricKey key, AggregateMetric value ->
+      1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", HTTP_OK, false), _) >> { MetricKey key, AggregateMetric value ->
         value.getHitCount() == 1 && value.getDuration() == duration
       }
     }
-    0 * writer.add(new MetricKey("resource", "service0", "operation", "type", HTTP_OK), _)
+    0 * writer.add(new MetricKey("resource", "service0", "operation", "type", HTTP_OK, false), _)
     1 * writer.finishBucket() >> { latch.countDown() }
 
     cleanup:
@@ -258,7 +258,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     then: "all aggregates should be reported"
     1 * writer.startBucket(5, _, SECONDS.toNanos(reportingInterval))
     for (int i = 0; i < 5; ++i) {
-      1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", HTTP_OK), _) >> { MetricKey key, AggregateMetric value ->
+      1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", HTTP_OK, false), _) >> { MetricKey key, AggregateMetric value ->
         value.getHitCount() == 1 && value.getDuration() == duration
       }
     }
@@ -277,11 +277,11 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     then: "aggregate not updated in cycle is not reported"
     1 * writer.startBucket(4, _, SECONDS.toNanos(reportingInterval))
     for (int i = 1; i < 5; ++i) {
-      1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", HTTP_OK), _) >> { MetricKey key, AggregateMetric value ->
+      1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", HTTP_OK, false), _) >> { MetricKey key, AggregateMetric value ->
         value.getHitCount() == 1 && value.getDuration() == duration
       }
     }
-    0 * writer.add(new MetricKey("resource", "service0", "operation", "type", HTTP_OK), _)
+    0 * writer.add(new MetricKey("resource", "service0", "operation", "type", HTTP_OK, false), _)
     1 * writer.finishBucket() >> { latch.countDown() }
 
     cleanup:
@@ -313,7 +313,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     then: "all aggregates should be reported"
     1 * writer.startBucket(5, _, SECONDS.toNanos(reportingInterval))
     for (int i = 0; i < 5; ++i) {
-      1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", HTTP_OK), _) >> { MetricKey key, AggregateMetric value ->
+      1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", HTTP_OK, false), _) >> { MetricKey key, AggregateMetric value ->
         value.getHitCount() == 1 && value.getDuration() == duration
       }
     }
@@ -355,7 +355,7 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
     then: "all aggregates should be reported"
     1 * writer.startBucket(5, _, SECONDS.toNanos(1))
     for (int i = 0; i < 5; ++i) {
-      1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", HTTP_OK), _) >> { MetricKey key, AggregateMetric value ->
+      1 * writer.add(new MetricKey("resource", "service" + i, "operation", "type", HTTP_OK, false), _) >> { MetricKey key, AggregateMetric value ->
         value.getHitCount() == 1 && value.getDuration() == duration
       }
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
@@ -41,11 +41,11 @@ class SerializingMetricWriterTest extends DDSpecification {
     where:
     content << [
       [
-        Pair.of(new MetricKey("resource1", "service1", "operation1", "type", 0), new AggregateMetric().recordDurations(10, new AtomicLongArray(1L))),
-        Pair.of(new MetricKey("resource2", "service2", "operation2", "type2", 200), new AggregateMetric().recordDurations(9, new AtomicLongArray(1L)))
+        Pair.of(new MetricKey("resource1", "service1", "operation1", "type", 0, false), new AggregateMetric().recordDurations(10, new AtomicLongArray(1L))),
+        Pair.of(new MetricKey("resource2", "service2", "operation2", "type2", 200, true), new AggregateMetric().recordDurations(9, new AtomicLongArray(1L)))
       ],
       (0..10000).collect({ i ->
-        Pair.of(new MetricKey("resource" + i, "service" + i, "operation" + i, "type", 0), new AggregateMetric().recordDurations(10, new AtomicLongArray(1L)))
+        Pair.of(new MetricKey("resource" + i, "service" + i, "operation" + i, "type", 0, false), new AggregateMetric().recordDurations(10, new AtomicLongArray(1L)))
       })
     ]
   }
@@ -101,7 +101,7 @@ class SerializingMetricWriterTest extends DDSpecification {
         MetricKey key = pair.getLeft()
         AggregateMetric value = pair.getRight()
         int size = unpacker.unpackMapHeader()
-        assert size == 11
+        assert size == 12
         int elementCount = 0
         assert unpacker.unpackString() == "Name"
         assert unpacker.unpackString() == key.getOperationName() as String
@@ -117,6 +117,9 @@ class SerializingMetricWriterTest extends DDSpecification {
         ++elementCount
         assert unpacker.unpackString() == "HTTPStatusCode"
         assert unpacker.unpackInt() == key.getHttpStatusCode()
+        ++elementCount
+        assert unpacker.unpackString() == "Synthetics"
+        assert unpacker.unpackBoolean() == key.isSynthetics()
         ++elementCount
         assert unpacker.unpackString() == "Hits"
         assert unpacker.unpackInt() == value.getHitCount()

--- a/dd-trace-core/src/traceAgentTest/groovy/MetricsIntegrationTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/MetricsIntegrationTest.groovy
@@ -40,11 +40,11 @@ class MetricsIntegrationTest extends DDSpecification {
       )
     writer.startBucket(2, System.nanoTime(), SECONDS.toNanos(10))
     writer.add(
-      new MetricKey("resource1", "service1", "operation1", "sql", 0),
+      new MetricKey("resource1", "service1", "operation1", "sql", 0, false),
       new AggregateMetric().recordDurations(5, new AtomicLongArray(2, 1, 2, 250, 4, 5))
       )
     writer.add(
-      new MetricKey("resource2", "service2", "operation2", "web", 200),
+      new MetricKey("resource2", "service2", "operation2", "web", 200, false),
       new AggregateMetric().recordDurations(10, new AtomicLongArray(1, 1, 200, 2, 3, 4, 5, 6, 7, 8, 9))
       )
     writer.finishBucket()


### PR DESCRIPTION
# What Does This Do

This PR improve the stats behavior by:
- Adding missing `synthetic` to the aggregation key,
- Support the `_dd.measured` custom tag to mark span as measured.
  Measured spans will take part of stats like top level span.

# Motivation

Those changes improves the results of [Java tracer system tests](https://github.com/DataDog/system-tests/pull/504).

# Additional Notes

Synthetic span detection is based on `origin` value comparison.
The comparison I use calls `CharSequence.toString()`. I fear there might be unnecessary allocation behind it but I didn't think I can rely on `CharSequence.equals` according to the Javadoc:

> The result of comparing two objects that implement CharSequence is therefore, in general, undefined.

Let me know if there is a better solution for this comparison.
