### PR TITLE
disable flaky debugger test

### DIFF
--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/DebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/DebuggerIntegrationTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Ignore("flaky test: close https://github.com/DataDog/dd-trace-java/issues/3948 when fixed")
 public class DebuggerIntegrationTest extends BaseIntegrationTest {
   private static final Logger LOG = LoggerFactory.getLogger(DebuggerIntegrationTest.class);
   private static final String DEBUGGER_TEST_APP_CLASS =
@@ -121,7 +122,6 @@ public class DebuggerIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test
-  @Ignore("flaky test: close https://github.com/DataDog/dd-trace-java/issues/3948 when fixed")
   @DisplayName("testInaccessibleObject")
   void testInaccessibleObject() throws Exception {
     final String METHOD_NAME = "managementMethod";

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/DebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/DebuggerIntegrationTest.java
@@ -24,13 +24,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Ignore("flaky test: close https://github.com/DataDog/dd-trace-java/issues/3948 when fixed")
+@Disabled("flaky test: close https://github.com/DataDog/dd-trace-java/issues/3948 when fixed")
 public class DebuggerIntegrationTest extends BaseIntegrationTest {
   private static final Logger LOG = LoggerFactory.getLogger(DebuggerIntegrationTest.class);
   private static final String DEBUGGER_TEST_APP_CLASS =

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/DebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/DebuggerIntegrationTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Ignore;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -120,6 +121,7 @@ public class DebuggerIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test
+  @Ignore("flaky test: close https://github.com/DataDog/dd-trace-java/issues/3948 when fixed")
   @DisplayName("testInaccessibleObject")
   void testInaccessibleObject() throws Exception {
     final String METHOD_NAME = "managementMethod";


### PR DESCRIPTION
# What Does This Do

Disables a flaky debugger integration test which fails frequently, #3948

# Motivation

Developer experience and productivity

# Additional Notes
