### PR TITLE
Taint propagation for String.trim

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/StringModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/StringModuleImpl.java
@@ -342,4 +342,42 @@ public class StringModuleImpl extends IastModuleBase implements StringModule {
   private static Range[] getRanges(final TaintedObject taintedObject) {
     return taintedObject == null ? Ranges.EMPTY : taintedObject.getRanges();
   }
+
+  @Override
+  @SuppressFBWarnings
+  public void onStringTrim(@Nonnull final String self, @Nullable final String result) {
+    if (!canBeTainted(result)) {
+      return;
+    }
+    if (self == result) {
+      return;
+    }
+    final IastRequestContext ctx = IastRequestContext.get();
+    if (ctx == null) {
+      return;
+    }
+    final TaintedObjects taintedObjects = ctx.getTaintedObjects();
+    final TaintedObject taintedSelf = taintedObjects.get(self);
+    if (taintedSelf == null) {
+      return;
+    }
+
+    int offset = 0;
+    while ((offset < self.length()) && (self.charAt(offset) <= ' ')) {
+      offset++;
+    }
+
+    int resultLength = result.length();
+
+    final Range[] rangesSelf = taintedSelf.getRanges();
+    if (null == rangesSelf || rangesSelf.length == 0) {
+      return;
+    }
+
+    final Range[] newRanges = Ranges.forSubstring(offset, resultLength, rangesSelf);
+
+    if (null != newRanges) {
+      taintedObjects.taint(result, newRanges);
+    }
+  }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/Ranges.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/Ranges.java
@@ -237,4 +237,36 @@ public final class Ranges {
       return items.get(index);
     }
   }
+
+  public static Range createIfDifferent(Range range, int start, int length) {
+    if (start != range.getStart() || length != range.getLength()) {
+      return new Range(start, length, range.getSource());
+    } else {
+      return range;
+    }
+  }
+
+  static int calculateSubstringSkippedRanges(int offset, int length, @Nonnull Range[] ranges) {
+    // calculate how many skipped ranges are there
+    int skippedRanges = 0;
+    for (int rangeIndex = 0; rangeIndex < ranges.length; rangeIndex++) {
+      final Range rangeSelf = ranges[rangeIndex];
+      if (rangeSelf.getStart() + rangeSelf.getLength() <= offset) {
+        skippedRanges++;
+      } else {
+        break;
+      }
+    }
+
+    for (int rangeIndex = ranges.length - 1; rangeIndex >= 0; rangeIndex--) {
+      final Range rangeSelf = ranges[rangeIndex];
+      if (rangeSelf.getStart() - offset >= length) {
+        skippedRanges++;
+      } else {
+        break;
+      }
+    }
+
+    return skippedRanges;
+  }
 }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/IastModuleImplOnStringTrimTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/IastModuleImplOnStringTrimTest.groovy
@@ -1,0 +1,122 @@
+package com.datadog.iast.propagation
+
+import com.datadog.iast.IastModuleImplTestBase
+import com.datadog.iast.IastRequestContext
+import datadog.trace.api.gateway.RequestContext
+import datadog.trace.api.gateway.RequestContextSlot
+import datadog.trace.api.iast.propagation.StringModule
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+
+import static com.datadog.iast.taint.TaintUtils.addFromTaintFormat
+import static com.datadog.iast.taint.TaintUtils.taintFormat
+
+class IastModuleImplOnStringTrimTest extends IastModuleImplTestBase {
+  private StringModule module
+
+
+  def setup() {
+    module = registerDependencies(new StringModuleImpl())
+  }
+
+  void 'make sure IastRequestContext is called'() {
+    given:
+
+    final span = Mock(AgentSpan)
+    tracer.activeSpan() >> span
+    final reqCtx = Mock(RequestContext)
+    span.getRequestContext() >> reqCtx
+    final ctx = new IastRequestContext()
+    reqCtx.getData(RequestContextSlot.IAST) >> ctx
+    final taintedObjects = ctx.getTaintedObjects()
+    def self = addFromTaintFormat(taintedObjects, testString)
+    def result = self.trim()
+
+
+    when:
+    module.onStringTrim(self, result)
+    def taintedObject = taintedObjects.get(result)
+
+    then:
+    1 * tracer.activeSpan() >> span
+    1 * span.getRequestContext() >> reqCtx
+    1 * reqCtx.getData(RequestContextSlot.IAST) >> ctx
+    taintFormat(result, taintedObject.getRanges()) == expected
+
+    where:
+    testString     | expected
+    "==>123<==   " | "==>123<=="
+  }
+
+  void 'test trim for not empty string cases'() {
+    given:
+
+    final span = Mock(AgentSpan)
+    tracer.activeSpan() >> span
+    final reqCtx = Mock(RequestContext)
+    span.getRequestContext() >> reqCtx
+    final ctx = new IastRequestContext()
+    reqCtx.getData(RequestContextSlot.IAST) >> ctx
+    final taintedObjects = ctx.getTaintedObjects()
+    def self = addFromTaintFormat(taintedObjects, testString)
+    def result = self.trim()
+
+
+    when:
+    module.onStringTrim(self, result)
+    def taintedObject = taintedObjects.get(result)
+
+    then:
+    taintFormat(result, taintedObject.getRanges()) == expected
+
+    where:
+    testString                                                     | expected
+    " ==>   <== ==>   <== ==>456<== ==>ABC<== ==>   <== ==>   <==" | "==>456<== ==>ABC<=="
+    " ==>   <== ==>   <== ==>456<== ==>   <== ==>   <=="           | "==>456<=="
+    " ==>   <== ==>   <== ==>456<== ==>   <== "                    | "==>456<=="
+    " ==>   <== ==>   <== ==>456<== "                              | "==>456<=="
+    "==>   <== ==>   <== ==>456<== "                               | "==>456<=="
+    "==>ABC<==123==>456<== "                                       | "==>ABC<==123==>456<=="
+    "==>ABC<==123   ==>   <== "                                    | "==>ABC<==123"
+    "==>ABC<==   ==>   <== "                                       | "==>ABC<=="
+    "==>ABC<==   ==>   <=="                                        | "==>ABC<=="
+    " ==>   <== 789==>456<== "                                     | "789==>456<=="
+    "==>   <== 789==>456<== "                                      | "789==>456<=="
+    "==>   <== ==>456<== "                                         | "==>456<=="
+    "==>   <== ==>456<=="                                          | "==>456<=="
+    "==>   <====>456<=="                                           | "==>456<=="
+    "==>123<=="                                                    | "==>123<=="
+    "   ==>123<=="                                                 | "==>123<=="
+    "==>123<==   "                                                 | "==>123<=="
+  }
+
+  void 'test trim for empty string cases'() {
+    given:
+
+    final span = Mock(AgentSpan)
+    tracer.activeSpan() >> span
+    final reqCtx = Mock(RequestContext)
+    span.getRequestContext() >> reqCtx
+    final ctx = new IastRequestContext()
+    reqCtx.getData(RequestContextSlot.IAST) >> ctx
+    final taintedObjects = ctx.getTaintedObjects()
+    def self = addFromTaintFormat(taintedObjects, testString)
+    def result = self.trim()
+
+
+    when:
+    module.onStringTrim(self, result)
+
+    then:
+    null == taintedObjects.get(result)
+    result == expected
+
+    where:
+    testString              | expected
+    " ==>   <== "           | ""
+    ""                      | ""
+    " ==>   <== ==>   <== " | ""
+    "==>   <== ==>   <=="   | ""
+    "123"                   | "123"
+    " 123 "                 | "123"
+  }
+}

--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringCallSite.java
@@ -7,6 +7,7 @@ import datadog.trace.api.iast.propagation.StringModule;
 import datadog.trace.util.stacktrace.StackUtils;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 

--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringCallSite.java
@@ -7,7 +7,6 @@ import datadog.trace.api.iast.propagation.StringModule;
 import datadog.trace.util.stacktrace.StackUtils;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -180,6 +179,20 @@ public class StringCallSite {
       }
     } catch (final Throwable e) {
       module.onUnexpectedException("afterToLowerCase threw", e);
+    }
+    return result;
+  }
+
+  @CallSite.After("java.lang.String java.lang.String.trim()")
+  public static String afterTrim(
+      @CallSite.This final String self, @CallSite.Return final String result) {
+    final StringModule module = InstrumentationBridge.STRING;
+    try {
+      if (module != null) {
+        module.onStringTrim(self, result);
+      }
+    } catch (final Throwable e) {
+      module.onUnexpectedException("afetConcat threw", e);
     }
     return result;
   }

--- a/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/StringCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/StringCallSiteTest.groovy
@@ -151,4 +151,18 @@ class StringCallSiteTest extends AgentTestRunner {
     1 * iterable.forEach(_) >> { throw new Error('Boom!!!') }
     thrown Error
   }
+
+  def 'test string trim call site'() {
+    setup:
+    final module = Mock(StringModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    final result = TestStringSuite.stringTrim(' hello ')
+
+    then:
+    result == 'hello'
+    1 * module.onStringTrim(' hello ', 'hello')
+    0 * _
+  }
 }

--- a/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringSuite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringSuite.java
@@ -75,4 +75,11 @@ public class TestStringSuite {
       return result;
     }
   }
+
+  public static String stringTrim(final String self) {
+    LOGGER.debug("Before string trim {} ", self);
+    final String result = self.trim();
+    LOGGER.debug("After string trim {}", result);
+    return result;
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/propagation/StringModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/propagation/StringModule.java
@@ -1,6 +1,7 @@
 package datadog.trace.api.iast.propagation;
 
 import datadog.trace.api.iast.IastModule;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -30,4 +31,6 @@ public interface StringModule extends IastModule {
   void onStringToUpperCase(@Nonnull String self, @Nullable String result);
 
   void onStringToLowerCase(@Nonnull String self, @Nullable String result);
+
+  void onStringTrim(@NonNull String self, @Nullable String result);
 }


### PR DESCRIPTION
# What Does This Do
Instrument the String.trim() function so we can track tainted objects for iast vulnerability detection

# Motivation
This is part of an effort to instrument all of the String and StringBuilder calls that will require taint object tracking instrumentation.

# Additional Notes
~This depends on a lot of non reviewed PRs so I am marking it as draft for now until we can rebase it after the other PRs are merged.~
