### PR TITLE
Stub for Telemetry running on aarch64

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
@@ -49,16 +49,26 @@ public class TelemetrySystem {
 
   public static void startTelemetry(
       Instrumentation instrumentation, SharedCommunicationObjects sco) {
-    DependencyService dependencyService = createDependencyService(instrumentation);
-    RequestBuilder requestBuilder = new RequestBuilder(sco.agentUrl);
-    TelemetryService telemetryService =
-        new TelemetryServiceImpl(
-            requestBuilder,
-            SystemTimeSource.INSTANCE,
-            Config.get().getTelemetryHeartbeatInterval());
-    TELEMETRY_THREAD =
-        createTelemetryRunnable(telemetryService, sco.okHttpClient, dependencyService);
-    TELEMETRY_THREAD.start();
+    try {
+      DependencyService dependencyService = createDependencyService(instrumentation);
+      RequestBuilder requestBuilder = new RequestBuilder(sco.agentUrl);
+      TelemetryService telemetryService =
+          new TelemetryServiceImpl(
+              requestBuilder,
+              SystemTimeSource.INSTANCE,
+              Config.get().getTelemetryHeartbeatInterval());
+      TELEMETRY_THREAD =
+          createTelemetryRunnable(telemetryService, sco.okHttpClient, dependencyService);
+      TELEMETRY_THREAD.start();
+    } catch (UnsatisfiedLinkError e) {
+      // TODO: update jnr_ffi and jnr_unixsocket to version that supports aarch64
+      final String arch = System.getProperty("os.arch").toLowerCase();
+      if (!arch.equals("x86") && !arch.equals("amd64")) {
+        log.error("Can't start telemetry. Unsupported architecture: '{}'", arch);
+      } else {
+        throw e;
+      }
+    }
   }
 
   public static void stop() {


### PR DESCRIPTION
# What Does This Do
Provides graceful Error message instead of Exception while run Telemetry on aarch64.
To make Telemetry works we need update `jnr_ffi` to latest version after get rid of Java 7 support.
We will need to remove that try/catch after.

# Motivation

# Additional Notes
