### PR TITLE
ASM blocking bug fix

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -400,7 +400,7 @@ public class PowerWAFModule implements AppSecModule {
                   "WAF indicated action {}, but such action id is unknown (not one from {})",
                   action,
                   ctxAndAddr.actionInfoMap.keySet());
-            } else if ("block_request".equals(actionInfo.type)) {
+            } else if ("block".equals(actionInfo.type)) {
               Flow.Action.RequestBlockingAction rba = createRequestBlockingAction(actionInfo);
               flow.setAction(rba);
               break;


### PR DESCRIPTION
# What Does This Do

Fixes a bug in ASM blocking my ensure the action name we check against matches the one in the `default_config.json`
