### PR TITLE
Populate epoch timestamp part of `X-Amzn-Trace-Id` tracing header

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/SqsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/SqsClientTest.groovy
@@ -157,9 +157,8 @@ class SqsClientTest extends AgentTestRunner {
       }
     }
 
-    assert messages[0].attributes['AWSTraceHeader'] ==
-    "Root=1-00000000-00000000${sendSpan.traceId.toHexStringPadded(16)};" +
-    "Parent=${sendSpan.spanId.toHexStringPadded(16)};Sampled=1"
+    assert messages[0].attributes['AWSTraceHeader'] =~
+    /Root=1-[0-9a-f]{8}-00000000${sendSpan.traceId.toHexStringPadded(16)};Parent=${sendSpan.spanId.toHexStringPadded(16)};Sampled=1/
 
     cleanup:
     client.shutdown()
@@ -350,9 +349,8 @@ class SqsClientTest extends AgentTestRunner {
     }
 
     def expectedTraceProperty = 'X-Amzn-Trace-Id'.toLowerCase(Locale.ENGLISH).replace('-', '__dash__')
-    assert message.getStringProperty(expectedTraceProperty) ==
-    "Root=1-00000000-00000000${sendSpan.traceId.toHexStringPadded(16)};" +
-    "Parent=${sendSpan.spanId.toHexStringPadded(16)};Sampled=1"
+    assert message.getStringProperty(expectedTraceProperty) =~
+    /Root=1-[0-9a-f]{8}-00000000${sendSpan.traceId.toHexStringPadded(16)};Parent=${sendSpan.spanId.toHexStringPadded(16)};Sampled=1/
 
     cleanup:
     session.close()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/XRayHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/XRayHttpInjectorTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.core.propagation
 
 import datadog.trace.api.DDId
+import datadog.trace.api.time.TimeSource
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopPathwayContext
 
 import static datadog.trace.api.sampling.PrioritySampling.*
@@ -20,7 +21,8 @@ class XRayHttpInjectorTest extends DDCoreSpecification {
   def "inject http headers"() {
     setup:
     def writer = new ListWriter()
-    def tracer = tracerBuilder().writer(writer).build()
+    def timeSource = Mock(TimeSource)
+    def tracer = tracerBuilder().writer(writer).timeSource(timeSource).build()
     final DDSpanContext mockedContext =
       new DDSpanContext(
       DDId.from("$traceId"),
@@ -49,6 +51,7 @@ class XRayHttpInjectorTest extends DDCoreSpecification {
     injector.inject(mockedContext, carrier, MapSetter.INSTANCE)
 
     then:
+    1 * timeSource.getCurrentTimeMillis() >> 1_664_906_869_196
     1 * carrier.put('X-Amzn-Trace-Id', "$expectedTraceHeader")
     0 * _
 
@@ -57,19 +60,20 @@ class XRayHttpInjectorTest extends DDCoreSpecification {
 
     where:
     traceId          | spanId           | samplingPriority | samplingMechanism | expectedTraceHeader
-    1G               | 2G               | UNSET            | UNKNOWN           | 'Root=1-00000000-000000000000000000000001;Parent=0000000000000002;_dd.origin=fakeOrigin;k=v'
-    2G               | 3G               | SAMPLER_KEEP     | DEFAULT           | 'Root=1-00000000-000000000000000000000002;Parent=0000000000000003;Sampled=1;_dd.origin=fakeOrigin;k=v'
-    4G               | 5G               | SAMPLER_DROP     | DEFAULT           | 'Root=1-00000000-000000000000000000000004;Parent=0000000000000005;Sampled=0;_dd.origin=fakeOrigin;k=v'
-    5G               | 6G               | USER_KEEP        | MANUAL            | 'Root=1-00000000-000000000000000000000005;Parent=0000000000000006;Sampled=1;_dd.origin=fakeOrigin;k=v'
-    6G               | 7G               | USER_DROP        | MANUAL            | 'Root=1-00000000-000000000000000000000006;Parent=0000000000000007;Sampled=0;_dd.origin=fakeOrigin;k=v'
-    TRACE_ID_MAX     | TRACE_ID_MAX - 1 | UNSET            | UNKNOWN           | 'Root=1-00000000-00000000ffffffffffffffff;Parent=fffffffffffffffe;_dd.origin=fakeOrigin;k=v'
-    TRACE_ID_MAX - 1 | TRACE_ID_MAX     | SAMPLER_KEEP     | DEFAULT           | 'Root=1-00000000-00000000fffffffffffffffe;Parent=ffffffffffffffff;Sampled=1;_dd.origin=fakeOrigin;k=v'
+    1G               | 2G               | UNSET            | UNKNOWN           | 'Root=1-633c7675-000000000000000000000001;Parent=0000000000000002;_dd.origin=fakeOrigin;k=v'
+    2G               | 3G               | SAMPLER_KEEP     | DEFAULT           | 'Root=1-633c7675-000000000000000000000002;Parent=0000000000000003;Sampled=1;_dd.origin=fakeOrigin;k=v'
+    4G               | 5G               | SAMPLER_DROP     | DEFAULT           | 'Root=1-633c7675-000000000000000000000004;Parent=0000000000000005;Sampled=0;_dd.origin=fakeOrigin;k=v'
+    5G               | 6G               | USER_KEEP        | MANUAL            | 'Root=1-633c7675-000000000000000000000005;Parent=0000000000000006;Sampled=1;_dd.origin=fakeOrigin;k=v'
+    6G               | 7G               | USER_DROP        | MANUAL            | 'Root=1-633c7675-000000000000000000000006;Parent=0000000000000007;Sampled=0;_dd.origin=fakeOrigin;k=v'
+    TRACE_ID_MAX     | TRACE_ID_MAX - 1 | UNSET            | UNKNOWN           | 'Root=1-633c7675-00000000ffffffffffffffff;Parent=fffffffffffffffe;_dd.origin=fakeOrigin;k=v'
+    TRACE_ID_MAX - 1 | TRACE_ID_MAX     | SAMPLER_KEEP     | DEFAULT           | 'Root=1-633c7675-00000000fffffffffffffffe;Parent=ffffffffffffffff;Sampled=1;_dd.origin=fakeOrigin;k=v'
   }
 
   def "inject http headers with extracted original"() {
     setup:
     def writer = new ListWriter()
-    def tracer = tracerBuilder().writer(writer).build()
+    def timeSource = Mock(TimeSource)
+    def tracer = tracerBuilder().writer(writer).timeSource(timeSource).build()
     def headers = [
       'X-Amzn-Trace-Id' : "Root=1-00000000-00000000${traceId.padLeft(16, '0')};Parent=${spanId.padLeft(16, '0')}"
     ]
@@ -102,6 +106,7 @@ class XRayHttpInjectorTest extends DDCoreSpecification {
     injector.inject(mockedContext, carrier, MapSetter.INSTANCE)
 
     then:
+    1 * timeSource.getCurrentTimeMillis() >> 1_664_906_869_196
     1 * carrier.put('X-Amzn-Trace-Id', "$expectedTraceHeader")
     0 * _
 
@@ -110,18 +115,19 @@ class XRayHttpInjectorTest extends DDCoreSpecification {
 
     where:
     traceId            | spanId             | expectedTraceHeader
-    "00001"            | "00001"            | 'Root=1-00000000-000000000000000000000001;Parent=0000000000000001;_dd.origin=fakeOrigin;k=v'
-    "463ac35c9f6413ad" | "463ac35c9f6413ad" | 'Root=1-00000000-00000000463ac35c9f6413ad;Parent=463ac35c9f6413ad;_dd.origin=fakeOrigin;k=v'
-    "48485a3953bb6124" | "1"                | 'Root=1-00000000-0000000048485a3953bb6124;Parent=0000000000000001;_dd.origin=fakeOrigin;k=v'
-    "f" * 16           | "1"                | 'Root=1-00000000-00000000ffffffffffffffff;Parent=0000000000000001;_dd.origin=fakeOrigin;k=v'
-    "a" * 8 + "f" * 8  | "1"                | 'Root=1-00000000-00000000aaaaaaaaffffffff;Parent=0000000000000001;_dd.origin=fakeOrigin;k=v'
-    "1"                | "f" * 16           | 'Root=1-00000000-000000000000000000000001;Parent=ffffffffffffffff;_dd.origin=fakeOrigin;k=v'
+    "00001"            | "00001"            | 'Root=1-633c7675-000000000000000000000001;Parent=0000000000000001;_dd.origin=fakeOrigin;k=v'
+    "463ac35c9f6413ad" | "463ac35c9f6413ad" | 'Root=1-633c7675-00000000463ac35c9f6413ad;Parent=463ac35c9f6413ad;_dd.origin=fakeOrigin;k=v'
+    "48485a3953bb6124" | "1"                | 'Root=1-633c7675-0000000048485a3953bb6124;Parent=0000000000000001;_dd.origin=fakeOrigin;k=v'
+    "f" * 16           | "1"                | 'Root=1-633c7675-00000000ffffffffffffffff;Parent=0000000000000001;_dd.origin=fakeOrigin;k=v'
+    "a" * 8 + "f" * 8  | "1"                | 'Root=1-633c7675-00000000aaaaaaaaffffffff;Parent=0000000000000001;_dd.origin=fakeOrigin;k=v'
+    "1"                | "f" * 16           | 'Root=1-633c7675-000000000000000000000001;Parent=ffffffffffffffff;_dd.origin=fakeOrigin;k=v'
   }
 
   def "inject http headers with end-to-end"() {
     setup:
     def writer = new ListWriter()
-    def tracer = tracerBuilder().writer(writer).build()
+    def timeSource = Mock(TimeSource)
+    def tracer = tracerBuilder().writer(writer).timeSource(timeSource).build()
     final DDSpanContext mockedContext =
       new DDSpanContext(
       DDId.from("1"),
@@ -143,17 +149,16 @@ class XRayHttpInjectorTest extends DDCoreSpecification {
       NoopPathwayContext.INSTANCE,
       false,
       null)
-
-    mockedContext.beginEndToEnd()
-
     final Map<String, String> carrier = Mock()
 
     when:
+    mockedContext.beginEndToEnd()
     injector.inject(mockedContext, carrier, MapSetter.INSTANCE)
 
     then:
-    1 * carrier.put('X-Amzn-Trace-Id', "Root=1-00000000-000000000000000000000001;Parent=0000000000000002;" +
-      "_dd.origin=fakeOrigin;t0=${(long) (mockedContext.endToEndStartTime / 1000000L)};k=v")
+    1 * timeSource.getCurrentTimeNanos() >> 1_664_906_869_196_787_813
+    1 * timeSource.getNanoTicks() >> 1_664_906_869_196
+    1 * carrier.put('X-Amzn-Trace-Id', "Root=1-633c7675-000000000000000000000001;Parent=0000000000000002;_dd.origin=fakeOrigin;t0=1664906869195;k=v")
     0 * _
 
     cleanup:


### PR DESCRIPTION
As recently reported in #3861:
> Per [X-Ray documentation](https://docs.aws.amazon.com/general/latest/gr/xray.html#limits_xray), trace IDs are only accepted if they are from the last 7 days, as identified by their epoch timestamp, so this trace header is not valid. To fix this issue, the SDK just needs to generate a hex epoch timestamp with the current time