### PR TITLE
Remove smoke test throttle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -724,10 +724,21 @@ build_test_jobs: &build_test_jobs
         - build
       name: z_test_<< matrix.testJvm >>_smoke
       gradleTarget: "stageMainDist :dd-smoke-test"
-      maxHeapSize: "1750M"
+      maxHeapSize: "1G"
       stage: smoke
+      maxWorkers: 6
       matrix:
         <<: *test_matrix
+
+  - xlarge_tests:
+      requires:
+        - build
+      name: z_test_8_smoke
+      gradleTarget: "stageMainDist :dd-smoke-test"
+      maxHeapSize: "1G"
+      stage: smoke
+      maxWorkers: 6
+      testJvm: "8"
 
   - xlarge_tests:
       requires:
@@ -736,6 +747,7 @@ build_test_jobs: &build_test_jobs
       gradleTarget: "stageMainDist :dd-smoke-test"
       maxHeapSize: "1G"
       stage: smoke
+      maxWorkers: 6
       testJvm: "IBM11"
 
   - xlarge_tests:
@@ -745,17 +757,8 @@ build_test_jobs: &build_test_jobs
       gradleTarget: "stageMainDist :dd-smoke-test"
       maxHeapSize: "1G"
       stage: smoke
+      maxWorkers: 6
       testJvm: "IBM17"
-
-
-  - tests:
-      requires:
-        - build
-      name: z_test_8_smoke
-      gradleTarget: "stageMainDist :dd-smoke-test"
-      maxHeapSize: "1750M"
-      stage: smoke
-      testJvm: "8"
 
   - fan_in:
       requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,15 +392,15 @@ jobs:
       - run:
           name: Run tests
           command: >-
-            if [[ << parameters.profile >> ]] && [[ << parameters.testJvm >> != "IBM8" ]] && [[ << parameters.testJvm >> != "ORACLE8" ]]; 
+            if [[ << parameters.profile >> ]] && [[ << parameters.testJvm >> != "IBM8" ]] && [[ << parameters.testJvm >> != "ORACLE8" ]] && [[ << parameters.testJvm >> != "7" ]]; 
             then
-              PROFILER_COMMAND="-XX:StartFlightRecording=settings=profile,filename=/tmp/<< parameters.stage >>-<< parameters.testJvm >>.jfr,dumponexit=true"
+              PROFILER_COMMAND="-PenableProfiling"
             fi
             
             MAVEN_OPTS="-Xms64M -Xmx512M"
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms<< parameters.maxHeapSize >> -Xmx<< parameters.maxHeapSize >> $PROFILER_COMMAND -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp' -Ddatadog.forkedMaxHeapSize=768M -Ddatadog.forkedMinHeapSize=128M"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms<< parameters.maxHeapSize >> -Xmx<< parameters.maxHeapSize >> -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp' -Ddatadog.forkedMaxHeapSize=768M -Ddatadog.forkedMinHeapSize=128M"
             ./gradlew <<# parameters.gradleTarget >><< parameters.gradleTarget >>:<</ parameters.gradleTarget >><< parameters.testTask >> << parameters.gradleParameters >>
-            <<# parameters.testJvm >>-PtestJvm=<< parameters.testJvm >><</ parameters.testJvm >>
+            <<# parameters.testJvm >>-PtestJvm=<< parameters.testJvm >><</ parameters.testJvm >> $PROFILER_COMMAND
             << pipeline.parameters.gradle_flags >>
             --max-workers=<< parameters.maxWorkers >>
             --continue
@@ -726,7 +726,7 @@ build_test_jobs: &build_test_jobs
       gradleTarget: "stageMainDist :dd-smoke-test"
       maxHeapSize: "1G"
       stage: smoke
-      maxWorkers: 6
+      maxWorkers: 4
       matrix:
         <<: *test_matrix
 
@@ -737,7 +737,7 @@ build_test_jobs: &build_test_jobs
       gradleTarget: "stageMainDist :dd-smoke-test"
       maxHeapSize: "1G"
       stage: smoke
-      maxWorkers: 6
+      maxWorkers: 4
       testJvm: "8"
 
   - xlarge_tests:

--- a/dd-smoke-tests/dd-smoke-tests.gradle
+++ b/dd-smoke-tests/dd-smoke-tests.gradle
@@ -28,6 +28,13 @@ subprojects { Project subProj ->
     // The jar path for the test agent (taken from https://github.com/DataDog/dd-trace-test-agent )
     jvmArgs "-Ddatadog.smoketest.test.agent.dir=${project.getRootDir()}/dd-smoke-tests/src/main/resources/datadog.smoketest.test.agent.jar"
 
+    if (project.rootProject.hasProperty("enableProfiling")) {
+      // profile the test itself
+      jvmArgs "-XX:StartFlightRecording=settings=profile,filename=/tmp/${subProj.name}-test.jfr,dumponexit=true"
+      // propagate to the test application
+      jvmArgs "-Ddatadog.smoketest.agent.profiling.command=-XX:StartFlightRecording=settings=profile,filename=/tmp/${subProj.name}-app.jfr,dumponexit=true"
+    }
+
     // Make it so all smoke tests can be run with a single command.
     if (parent_project.hasProperty(subTask.name)) {
       parent_project.tasks.named(subTask.name).configure {

--- a/dd-smoke-tests/dd-smoke-tests.gradle
+++ b/dd-smoke-tests/dd-smoke-tests.gradle
@@ -10,10 +10,6 @@ dependencies {
   api project(':utils:test-agent-utils:decoder')
 }
 
-def smokeTestLimit = gradle.sharedServices.registerIfAbsent("smokeTestLimit", BuildService) {
-  maxParallelUsages = 2
-}
-
 Project parent_project = project
 subprojects { Project subProj ->
   // Don't need javadoc task run for internal projects.
@@ -31,9 +27,6 @@ subprojects { Project subProj ->
 
     // The jar path for the test agent (taken from https://github.com/DataDog/dd-trace-test-agent )
     jvmArgs "-Ddatadog.smoketest.test.agent.dir=${project.getRootDir()}/dd-smoke-tests/src/main/resources/datadog.smoketest.test.agent.jar"
-
-    // Only one smoke test at a time
-    usesService(smokeTestLimit)
 
     // Make it so all smoke tests can be run with a single command.
     if (parent_project.hasProperty(subTask.name)) {

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -78,6 +78,7 @@ abstract class AbstractSmokeTest extends ProcessManager {
   protected String[] defaultJavaProperties = [
     "${getMaxMemoryArgumentForFork()}",
     "${getMinMemoryArgumentForFork()}",
+    isIBM ? "" : "${profilingCommand}",
     "-javaagent:${shadowJarPath}",
     isIBM ? "-Xdump:directory=/tmp" : "-XX:ErrorFile=/tmp/hs_err_pid%p.log",
     "-Ddd.trace.agent.port=${server.address.port}",

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
@@ -23,6 +23,8 @@ abstract class ProcessManager extends Specification {
   protected String shadowJarPath = System.getProperty("datadog.smoketest.agent.shadowJar.path")
   @Shared
   protected boolean isIBM = System.getProperty("java.vendor", "").contains("IBM")
+  @Shared
+  protected String profilingCommand = System.getProperty("datadog.smoketest.agent.profiling.command")
 
   @Shared
   protected static int profilingPort = -1


### PR DESCRIPTION
# What Does This Do

Removes the throttle on the number of concurrent smoke tests and increases the number of gradle workers. Also allows a profiling command to be propagated down to smoke tests and spawned applications to emit .jfr files, but does not leave the flag on.

# Motivation

Smoke tests run on every build, gradle now respects container memory limits, so we should run as many smoke tests in parallel as we can to reduce build times.

# Additional Notes
