### PR TITLE
Make sure GRPC->IG test callbacks return values of the expected type

### DIFF
--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -68,10 +68,12 @@ abstract class GrpcTest extends AgentTestRunner {
     } as TriConsumer<RequestContext, String, String>)
     ig.registerCallback(EVENTS.requestHeaderDone(),{
       appSecHeaderDone = true
+      Flow.ResultFlow.empty()
     } as Function<RequestContext, Flow<Void>>)
     ig.registerCallback(EVENTS.grpcServerRequestMessage(), { reqCtx, obj ->
       collectedAppSecReqMsgs << obj
-    } as BiFunction<RequestContext, Object>)
+      Flow.ResultFlow.empty()
+    } as BiFunction<RequestContext, Object, Flow<Void>>)
   }
 
   def cleanup() {


### PR DESCRIPTION
This avoids some `ClassCastException`s from littering the test logs