### PR TITLE
Disable wallclock profiling on J9 by default

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
@@ -5,6 +5,7 @@ import com.datadog.profiling.controller.RecordingData;
 import com.datadog.profiling.controller.UnsupportedEnvironmentException;
 import com.datadog.profiling.utils.LibraryHelper;
 import com.datadog.profiling.utils.ProfilingMode;
+import datadog.trace.api.Platform;
 import datadog.trace.api.config.ProfilingConfig;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import java.io.File;
@@ -75,8 +76,7 @@ public final class AsyncProfiler {
       profilingModes.add(ProfilingMode.CPU);
     }
     if (configProvider.getBoolean(
-        ProfilingConfig.PROFILING_ASYNC_WALL_ENABLED,
-        ProfilingConfig.PROFILING_ASYNC_WALL_ENABLED_DEFAULT)) {
+        ProfilingConfig.PROFILING_ASYNC_WALL_ENABLED, getAsyncWallEnabledDefault())) {
       profilingModes.add(ProfilingMode.WALL);
     }
     try {
@@ -93,6 +93,14 @@ public final class AsyncProfiler {
 
   public static AsyncProfiler getInstance() {
     return Singleton.INSTANCE;
+  }
+
+  private static boolean getAsyncWallEnabledDefault() {
+    if (Platform.isJ9()) {
+      // wallclock profiling is useless on J9 - do not automatically enable it
+      return false;
+    }
+    return ProfilingConfig.PROFILING_ASYNC_WALL_ENABLED_DEFAULT;
   }
 
   private static one.profiler.AsyncProfiler inferFromOsAndArch()

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ControllerFactory.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ControllerFactory.java
@@ -75,13 +75,10 @@ public final class ControllerFactory {
       }
     }
     if (impl == Implementation.NONE) {
-      boolean isOpenJ9 =
-          System.getProperty("java.vendor").equals("IBM Corporation")
-              && System.getProperty("java.vm.name").contains("J9");
       if (Platform.isLinux()
           && configProvider.getBoolean(
               ProfilingConfig.PROFILING_ASYNC_ENABLED,
-              ProfilingConfig.PROFILING_ASYNC_ENABLED_DEFAULT || isOpenJ9)) {
+              ProfilingConfig.PROFILING_ASYNC_ENABLED_DEFAULT || Platform.isJ9())) {
         try {
           Class<?> asyncProfilerClass = Class.forName("com.datadog.profiling.async.AsyncProfiler");
           if ((boolean)

--- a/internal-api/src/main/java/datadog/trace/api/Platform.java
+++ b/internal-api/src/main/java/datadog/trace/api/Platform.java
@@ -225,6 +225,11 @@ public final class Platform {
         && !RUNTIME.name.contains("OpenJDK");
   }
 
+  public static boolean isJ9() {
+    return System.getProperty("java.vendor").equals("IBM Corporation")
+        && System.getProperty("java.vm.name").contains("J9");
+  }
+
   public static String getLangVersion() {
     return String.valueOf(JAVA_VERSION.major);
   }


### PR DESCRIPTION
# What Does This Do
Disables the wallclock profiler for J9 by default

# Motivation
The wallclock profiler for J9 is rather useless as of now but can easily generate large amounts of data.
It makes sense not to have it on as default.

# Additional Notes
