### PR TITLE
profile tests

### DIFF
--- a/.circleci/collect_profiles.sh
+++ b/.circleci/collect_profiles.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Save all important profiles into (project-root)/profiles
+# This folder will be saved by circleci and available after test runs.
+
+set -e
+#Enable '**' support
+shopt -s globstar
+
+PROFILES_DIR=./profiles
+mkdir -p $PROFILES_DIR >/dev/null 2>&1
+
+cp /tmp/*.jfr $PROFILES_DIR || true
+
+function save_profiles () {
+    project_to_save=$1
+    echo "saving profiles for $project_to_save"
+
+    profile_path=$PROFILES_DIR/$project_to_save
+    mkdir -p $profile_path
+    cp workspace/$project_to_save/build/*.jfr $profile_path/ || true
+}
+
+shopt -s globstar
+
+for profile_path in workspace/**/build/profiles; do
+    profile_path=${profile_path//workspace\//}
+    profile_path=${profile_path//\/build\/profiles/}
+    save_profiles $profiles
+done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,6 +355,9 @@ jobs:
       maxWorkers:
         type: integer
         default: 2
+      profile:
+        type: boolean
+        default: false
 
 
 
@@ -381,8 +384,13 @@ jobs:
       - run:
           name: Run tests
           command: >-
+            if [[ << parameters.profile >> ]] && [[ << parameters.testJvm >> != "IBM8" ]] && [[ << parameters.testJvm >> != "ORACLE8" ]]; 
+            then
+              PROFILER_COMMAND="-XX:StartFlightRecording=settings=profile,filename=/tmp/<< parameters.stage >>-<< parameters.testJvm >>.jfr,dumponexit=true"
+            fi
+            
             MAVEN_OPTS="-Xms64M -Xmx512M"
-            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms<< parameters.maxHeapSize >> -Xmx<< parameters.maxHeapSize >> -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp' -Ddatadog.forkedMaxHeapSize=768M -Ddatadog.forkedMinHeapSize=128M"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms<< parameters.maxHeapSize >> -Xmx<< parameters.maxHeapSize >> $PROFILER_COMMAND -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp' -Ddatadog.forkedMaxHeapSize=768M -Ddatadog.forkedMinHeapSize=128M"
             ./gradlew <<# parameters.gradleTarget >><< parameters.gradleTarget >>:<</ parameters.gradleTarget >><< parameters.testTask >> << parameters.gradleParameters >>
             <<# parameters.testJvm >>-PtestJvm=<< parameters.testJvm >><</ parameters.testJvm >>
             << pipeline.parameters.gradle_flags >>
@@ -396,6 +404,18 @@ jobs:
 
       - store_artifacts:
           path: ./reports
+
+      - when:
+          condition:
+            equal: [true, << parameters.profile >>]
+          steps:
+            - run:
+                name: Collect profiles
+                when: always
+                command: .circleci/collect_profiles.sh
+
+            - store_artifacts:
+                path: ./profiles
 
       - run:
           name: Collect test results


### PR DESCRIPTION
# What Does This Do

Allows setting `profile: true` on a non-IBM8/non-ORACLE8 test job to collect a JFR

# Motivation
Diagnose test reliability/test problems
# Additional Notes
