### PR TITLE
allow xlarge images for some tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,6 +377,10 @@ jobs:
           when: always
           command: .circleci/upload_ciapp.sh << parameters.stage >> << parameters.testJvm >> || true
 
+  xlarge_tests:
+    <<: *tests
+    resource_class: xlarge
+
   # The only way to do fan-in in CircleCI seems to have a proper job, so let's have one that
   # doesn't consume so many resources. The execution time for this including spin up seems to
   # be around 6 seconds.
@@ -559,7 +563,7 @@ jobs:
 build_test_jobs: &build_test_jobs
   - build
 
-  - tests:
+  - xlarge_tests:
       requires:
         - build
       name: z_test_<< matrix.testJvm >>_base
@@ -571,7 +575,7 @@ build_test_jobs: &build_test_jobs
       matrix:
         <<: *test_matrix
 
-  - tests:
+  - xlarge_tests:
       requires:
         - build
       name: z_test_8_base
@@ -583,7 +587,7 @@ build_test_jobs: &build_test_jobs
       maxWorkers: 6
       testJvm: "8"
 
-  - tests:
+  - xlarge_tests:
       requires:
         - build
       name: z_test_<< matrix.testJvm >>_inst
@@ -595,7 +599,7 @@ build_test_jobs: &build_test_jobs
       matrix:
         <<: *test_matrix
 
-  - tests:
+  - xlarge_tests:
       requires:
         - build
       name: z_test_8_inst
@@ -606,7 +610,7 @@ build_test_jobs: &build_test_jobs
       maxWorkers: 8
       testJvm: "8"
 
-  - tests:
+  - xlarge_tests:
       requires:
         - build
       name: test_8_inst_latest
@@ -653,7 +657,7 @@ build_test_jobs: &build_test_jobs
       matrix:
         <<: *profiling_test_matrix
 
-  - tests:
+  - xlarge_tests:
       requires:
         - build
       name: z_test_<< matrix.testJvm >>_smoke


### PR DESCRIPTION
# What Does This Do

Reintroduces xlarge images for jobs, because instrumentation, smoke and base tests are CPU bound on large images

# Motivation

# Additional Notes
