### PR TITLE
allocate fewer large strings in openliberty test

### DIFF
--- a/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySmokeTest.groovy
+++ b/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySmokeTest.groovy
@@ -68,12 +68,9 @@ class SpringBootOpenLibertySmokeTest extends AbstractServerSmokeTest {
   def "Test concurrent high load requests to Spring Boot running Open Liberty"() {
     def url = "http://localhost:${httpPort}/connect/0"
     def formBody = new FormBody.Builder()
-    def value = new StringBuilder(10_001 * 10)
-    for (int i = 0; i < 10000; i++) {
-      value.append("@@@@@@@@@@") // 10 chars
-    }
+    def value = "not too big!"
     for (int i = 0; i < 100; i++) {
-      formBody.add("test" + i, value.toString())
+      formBody.add("test" + i, value)
     }
     def request = new Request.Builder().url(url).post(formBody.build()).build()
 


### PR DESCRIPTION
# What Does This Do

Makes the openliberty smoke test lighter weight by not allocating huge strings (which need to be converted to UTF-8) over and over again

# Motivation

Reduce resource requirement for smoke tests so they can run faster => faster, more reliable CI

This is from a profile of just the test side of the openliberty smoke test:

<img width="1196" alt="Screenshot 2022-10-05 at 21 02 08" src="https://user-images.githubusercontent.com/16439049/194152182-0a48470b-c797-4794-be49-9aa3abde7f79.png">


# Additional Notes
