### PR TITLE
Add testJvm for agent_integration_tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -754,6 +754,7 @@ build_test_jobs: &build_test_jobs
         - build
       triggeredBy: *agent_integration_tests_modules
       testTask: traceAgentTest
+      testJvm: "8"
 
   - test_published_artifacts:
       requires:


### PR DESCRIPTION
# What Does This Do

Adds the `testJvm` setting to the `agent_integration_tests` job so the `bash` checks don't fail when it tries to run.

# Motivation

# Additional Notes

Failing on `master` https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/16664/workflows/72d70af2-4427-4f9a-899e-57d747ad2480/jobs/389440

Success triggered by dummy commit https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/16667/workflows/cbce97de-2379-49a3-8d6c-c7d483e1b9df/jobs/389496