### PR TITLE
Prevent interference between tests using JPA

### DIFF
--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/SpringJpaTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/SpringJpaTest.groovy
@@ -2,9 +2,9 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import spock.lang.Shared
-import spring.jpa.Customer
-import spring.jpa.CustomerRepository
-import spring.jpa.PersistenceConfig
+import spring.hibernate.jpa.Customer
+import spring.hibernate.jpa.CustomerRepository
+import spring.hibernate.jpa.PersistenceConfig
 
 
 /**

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/java/spring/hibernate/jpa/Customer.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/java/spring/hibernate/jpa/Customer.java
@@ -1,4 +1,4 @@
-package spring.jpa;
+package spring.hibernate.jpa;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/java/spring/hibernate/jpa/CustomerRepository.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/java/spring/hibernate/jpa/CustomerRepository.java
@@ -1,4 +1,4 @@
-package spring.jpa;
+package spring.hibernate.jpa;
 
 import java.util.List;
 import org.springframework.data.repository.CrudRepository;

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/java/spring/hibernate/jpa/PersistenceConfig.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/java/spring/hibernate/jpa/PersistenceConfig.java
@@ -1,4 +1,4 @@
-package spring.jpa;
+package spring.hibernate.jpa;
 
 import java.util.Properties;
 import javax.sql.DataSource;
@@ -11,7 +11,7 @@ import org.springframework.orm.jpa.vendor.Database;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.transaction.PlatformTransactionManager;
 
-@EnableJpaRepositories(basePackages = "spring/jpa")
+@EnableJpaRepositories(basePackages = "spring/hibernate/jpa")
 public class PersistenceConfig {
 
   @Bean(name = "transactionManager")
@@ -30,7 +30,7 @@ public class PersistenceConfig {
 
     final LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
     em.setDataSource(dataSource());
-    em.setPackagesToScan("spring/jpa");
+    em.setPackagesToScan("spring/hibernate/jpa");
     em.setJpaVendorAdapter(vendorAdapter);
     em.setJpaProperties(additionalProperties());
 


### PR DESCRIPTION
# What Does This Do
Moves the hibernate specific JPA test support classes to a separate package.

# Motivation
The JPA related tests were using 'spring.jpa' package to scan for JPA configs/repos etc.
This could have lead to interference between Spring Core and Spring Hibernate tests when one would pick the others stuff by accident, resulting in flaky tests.

# Additional Notes
