### PR TITLE
enable async-profiler by default on x86/x64

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/Arch.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/Arch.java
@@ -6,7 +6,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /** A simple implementation to detect the current architecture */
-enum Arch {
+public enum Arch {
   x64("x86_64", "amd64", "k8"),
   x86("x86", "i386", "i486", "i586", "i686"),
   arm("ARM", "arm64"),

--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
@@ -31,8 +31,6 @@ import org.slf4j.LoggerFactory;
 public final class AsyncProfiler {
   private static final Logger log = LoggerFactory.getLogger(AsyncProfiler.class);
 
-  public static final String TYPE = "async";
-
   private static final class Singleton {
     private static final AsyncProfiler INSTANCE = newInstance();
   }
@@ -113,7 +111,7 @@ public final class AsyncProfiler {
 
     long maxheap = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax();
     this.memleakIntervalDefault =
-        maxheap <= 0 ? 1 * 1024 * 1024 : maxheap / Math.max(1, getMemleakCapacity());
+        maxheap <= 0 ? 1024 * 1024 : maxheap / Math.max(1, getMemleakCapacity());
   }
 
   public static AsyncProfiler getInstance() {

--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfilerConfig.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfilerConfig.java
@@ -1,19 +1,16 @@
 package com.datadog.profiling.async;
 
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_ASYNC_ENABLED;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_ASYNC_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_ASYNC_LOG_LEVEL;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_ASYNC_LOG_LEVEL_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_ASYNC_WALL_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_ASYNC_WALL_ENABLED_DEFAULT;
 
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 
 public class AsyncProfilerConfig {
 
-  private static final boolean ASYNC_PROFILER_ENABLED =
-      ConfigProvider.getInstance()
-          .getBoolean(PROFILING_ASYNC_ENABLED, PROFILING_ASYNC_ENABLED_DEFAULT);
+  private static final boolean ASYNC_PROFILER_ENABLED = Config.get().isAsyncProfilerEnabled();
 
   private static final boolean ASYNC_PROFILER_WALLCLOCK_ENABLED =
       ConfigProvider.getInstance()

--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/OperatingSystem.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/OperatingSystem.java
@@ -6,7 +6,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /** A simple way to detect the current operating system */
-enum OperatingSystem {
+public enum OperatingSystem {
   linux("Linux", "linux"),
   macos("Mac OS X", "macOS", "mac"),
   unknown();

--- a/dd-java-agent/agent-profiling/profiling-controller/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller/build.gradle
@@ -22,6 +22,7 @@ excludedClassesCoverage += [
 dependencies {
   api deps.slf4j
   api project(':internal-api')
+  api project(':dd-java-agent:agent-profiling:profiling-utils')
 
   testImplementation deps.junit5
   testImplementation deps.guava

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ControllerFactory.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ControllerFactory.java
@@ -15,8 +15,8 @@
  */
 package com.datadog.profiling.controller;
 
+import datadog.trace.api.Config;
 import datadog.trace.api.Platform;
-import datadog.trace.api.config.ProfilingConfig;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.lang.reflect.InvocationTargetException;
@@ -75,10 +75,7 @@ public final class ControllerFactory {
       }
     }
     if (impl == Implementation.NONE) {
-      if (Platform.isLinux()
-          && configProvider.getBoolean(
-              ProfilingConfig.PROFILING_ASYNC_ENABLED,
-              ProfilingConfig.PROFILING_ASYNC_ENABLED_DEFAULT || Platform.isJ9())) {
+      if (Platform.isLinux() && Config.get().isAsyncProfilerEnabled()) {
         try {
           Class<?> asyncProfilerClass = Class.forName("com.datadog.profiling.async.AsyncProfiler");
           if ((boolean)

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSystem.java
@@ -149,6 +149,10 @@ public final class ProfilingSystem {
           uploadPeriod.toMillis(),
           TimeUnit.MILLISECONDS);
       started = true;
+    } catch (UnsupportedEnvironmentException unsupported) {
+      log.warn(
+          "Datadog Profiling was enabled on an unsupported JVM, will not profile application. See {} for more details about supported JVMs.",
+          "https://docs.datadoghq.com/profiler/enabling/java/?tab=commandarguments#requirements");
     } catch (Throwable t) {
       if (t instanceof RuntimeException) {
         // Possibly a wrapped exception related to Oracle JDK 8 JFR MX beans

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -91,7 +91,6 @@ abstract class AbstractSmokeTest extends ProcessManager {
     "-Ddd.profiling.start-delay=${PROFILING_START_DELAY_SECONDS}",
     "-Ddd.profiling.upload.period=${PROFILING_RECORDING_UPLOAD_PERIOD_SECONDS}",
     "-Ddd.profiling.url=${getProfilingUrl()}",
-    "-Ddd.profiling.async.enabled=true",
     "-Ddd.profiling.async.wall.enabled=true",
     "-Ddd.profiling.async.alloc.enabled=" + !isIBM,
     "-Ddd.profiling.async.cstack=dwarf",


### PR DESCRIPTION
# What Does This Do

Enables async-profiler on any JVM running on x86/x64 or J9

# Motivation

# Additional Notes

Depends on #3992 because this needs to be tested on more J9 and OpenJ9 distributions
