### PR TITLE
don't log smoke tests at debug level

### DIFF
--- a/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
+++ b/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
@@ -67,6 +67,11 @@ abstract class LogInjectionSmokeTest extends AbstractSmokeTest {
     return processBuilder
   }
 
+  @Override
+  def logLevel() {
+    return "debug"
+  }
+
   List additionalArguments() {
     return []
   }

--- a/dd-smoke-tests/osgi/src/test/groovy/datadog/smoketest/AbstractOSGiSmokeTest.groovy
+++ b/dd-smoke-tests/osgi/src/test/groovy/datadog/smoketest/AbstractOSGiSmokeTest.groovy
@@ -59,4 +59,9 @@ abstract class AbstractOSGiSmokeTest extends AbstractSmokeTest {
     instrumentedMessageClient
     !logHasErrors
   }
+
+  @Override
+  def logLevel() {
+    return "debug"
+  }
 }

--- a/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
@@ -10,6 +10,11 @@ import spock.lang.IgnoreIf
 class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
 
   @Override
+  def logLevel() {
+    return "debug"
+  }
+
+  @Override
   ProcessBuilder createProcessBuilder() {
     String springBootShadowJar = System.getProperty("datadog.smoketest.springboot.shadowJar.path")
 

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -89,8 +89,8 @@ abstract class AbstractSmokeTest extends ProcessManager {
     "-Ddd.profiling.upload.period=${PROFILING_RECORDING_UPLOAD_PERIOD_SECONDS}",
     "-Ddd.profiling.url=${getProfilingUrl()}",
     "-Ddd.profiling.async.enabled=false",
-    "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug",
-    "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"
+    "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=${logLevel()}",
+    "-Dorg.slf4j.simpleLogger.defaultLogLevel=${logLevel()}"
   ]
 
   def setup() {
@@ -136,5 +136,9 @@ abstract class AbstractSmokeTest extends ProcessManager {
 
   List<DecodedTrace> getTraces() {
     decodeTraces
+  }
+
+  def logLevel() {
+    return "info"
   }
 }


### PR DESCRIPTION
# What Does This Do

Changes the log level for smoke tests to info

# Motivation

Some smoke tests are quite resource intensive but a most of the allocation in these cases come from debug logging e.g. for springboot-grpc:
<img width="1071" alt="Screenshot 2022-10-06 at 11 59 30" src="https://user-images.githubusercontent.com/16439049/194296426-33227287-92bb-4b51-af82-1308054f6019.png">


# Additional Notes
