### PR TITLE
Use the PR merge commit to do the diff for changed files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,16 +171,19 @@ commands:
       - run:
           name: "Check if files relevant to job have changed"
           command: |
-            if [ -n $CIRCLE_PULL_REQUEST ]; then
-              PR=$(echo https://api.github.com/repos/${CIRCLE_PULL_REQUEST:19} | sed "s/\/pull\//\/pulls\//")
-              TARGET_BRANCH=$(curl -s -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${GH_TOKEN}" $PR | jq '.base.ref' | tr -d '"')
-              if [ -z "$TARGET_BRANCH" ]; then
-                echo "Defaulting target branch to master. Set up GH_TOKEN with a valid GitHub PAT to get correct target branch"
-                TARGET_BRANCH="master"
-              fi
+            CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}"
+
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then
               BRANCH="$(git rev-parse --abbrev-ref HEAD)"
               if [[ "$BRANCH" != "master" ]] && [[ "$BRANCH" != "release/*" ]]; then
-                git diff "$TARGET_BRANCH" --name-only --no-color --pretty="" | grep -E "gradle/|<< parameters.pattern >>" || circleci step halt
+                # We know that we have checked out the PR merge branch, so the HEAD commit is a merge
+                # As a backup, if anything goes wrong with the diff, the build will fail
+                CHANGED_FILES=$(git show HEAD | grep -e "^Merge:" | cut -d ' ' -f 2- | sed 's/ /.../' | xargs git diff --name-only)
+                # Count the number of matches, and ignore if the grep doesn't match anything
+                MATCH_COUNT=$(echo "$CHANGED_FILES" | grep -c -E "gradle/|<< parameters.pattern >>") || true
+                if [[ "$MATCH_COUNT" -eq "0" ]]; then
+                  circleci step halt
+                fi
               fi
             fi
 


### PR DESCRIPTION
# What Does This Do

Uses the merge commit in the PR merge branch to find changed files. Does not depend on target branch. Also fails the build if the `git` commands fail.

# Motivation

PRs with a different base branch than `master` did not get a correct diff and failures of the `git` commands where silently swallowed.

# Additional Notes
