### PR TITLE
Improve test coverage for DDIdAdapter

### DIFF
--- a/dd-java-agent/agent-iast/agent-iast.gradle
+++ b/dd-java-agent/agent-iast/agent-iast.gradle
@@ -41,6 +41,7 @@ ext {
     'com.datadog.iast.model.Vulnerability',
     // Small JsonAdapters with unimplemented fromJson
     'com.datadog.iast.model.json.SourceTypeAdapter',
+    'com.datadog.iast.model.json.DDIdAdapter',
   ]
   excludedClassesBranchCoverage = []
   excludedClassesInstructionCoverage = []

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/json/AdapterFactory.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/json/AdapterFactory.java
@@ -135,23 +135,4 @@ class AdapterFactory implements JsonAdapter.Factory {
           "VulnerabilityBatch deserialization is not supported");
     }
   }
-
-  public static class DDIdAdapter extends JsonAdapter<DDId> {
-
-    @Override
-    public void toJson(@Nonnull final JsonWriter writer, final @Nullable DDId value)
-        throws IOException {
-      if (value == null) {
-        writer.nullValue();
-        return;
-      }
-      writer.value(value.toLong());
-    }
-
-    @Nullable
-    @Override
-    public DDId fromJson(@Nonnull final JsonReader reader) throws IOException {
-      throw new UnsupportedOperationException("DDId deserialization is not supported");
-    }
-  }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/json/DDIdAdapter.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/json/DDIdAdapter.java
@@ -1,0 +1,28 @@
+package com.datadog.iast.model.json;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import datadog.trace.api.DDId;
+import java.io.IOException;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class DDIdAdapter extends JsonAdapter<DDId> {
+
+  @Override
+  public void toJson(@Nonnull final JsonWriter writer, final @Nullable DDId value)
+      throws IOException {
+    if (value == null) {
+      writer.nullValue();
+      return;
+    }
+    writer.value(value.toLong());
+  }
+
+  @Nullable
+  @Override
+  public DDId fromJson(@Nonnull final JsonReader reader) throws IOException {
+    throw new UnsupportedOperationException("DDId deserialization is not supported");
+  }
+}

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/json/VulnerabilityEncodingTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/json/VulnerabilityEncodingTest.groovy
@@ -46,6 +46,37 @@ class VulnerabilityEncodingTest extends DDSpecification {
     }''')
   }
 
+  void 'one vulnerability with no spanId'() {
+    given:
+    final slurper = new JsonSlurper()
+    final value = new VulnerabilityBatch()
+    value.add(new Vulnerability(
+      VulnerabilityType.WEAK_HASH,
+      Location.forSpanAndStack(null, new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("MD5")
+      ))
+
+    when:
+    final result = VulnerabilityEncoding.toJson(value)
+
+    then:
+    slurper.parseText(result) == slurper.parseText('''{
+      "vulnerabilities": [
+        {
+          "type": "WEAK_HASH",
+          "evidence": {
+            "value": "MD5"
+          },
+          "hash":1042880134,
+          "location": {
+            "line": 1,
+            "path": "foo"
+          }
+        }
+      ]
+    }''')
+  }
+
   void 'one vulnerability with one source'() {
     given:
     final slurper = new JsonSlurper()


### PR DESCRIPTION
# What Does This Do

* Added a test exercising serialization of null DDId.
* Extract adapter to top-level class.
* Exclude DDIdAdapter from code coverage thresholds (even after the test, it won't pass the method coverage requirements).

# Motivation
Avoid coverage errors in CI.

# Additional Notes
