### PR TITLE
Reduce allocation when matching types with no annotations

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/FieldOutline.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/FieldOutline.java
@@ -1,6 +1,7 @@
 package datadog.trace.agent.tooling.bytebuddy.outline;
 
 import static datadog.trace.agent.tooling.bytebuddy.outline.TypeFactory.findDescriptor;
+import static datadog.trace.agent.tooling.bytebuddy.outline.TypeOutline.NO_ANNOTATIONS;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -55,7 +56,9 @@ final class FieldOutline extends FieldDescription.InDefinedShape.AbstractBase {
 
   @Override
   public AnnotationList getDeclaredAnnotations() {
-    return new AnnotationList.Explicit(declaredAnnotations);
+    return declaredAnnotations.isEmpty()
+        ? NO_ANNOTATIONS
+        : new AnnotationList.Explicit(declaredAnnotations);
   }
 
   void declare(AnnotationDescription annotation) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/MethodOutline.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/MethodOutline.java
@@ -1,6 +1,8 @@
 package datadog.trace.agent.tooling.bytebuddy.outline;
 
 import static datadog.trace.agent.tooling.bytebuddy.outline.TypeFactory.findDescriptor;
+import static datadog.trace.agent.tooling.bytebuddy.outline.TypeOutline.NO_ANNOTATIONS;
+import static datadog.trace.agent.tooling.bytebuddy.outline.TypeOutline.NO_TYPES;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,6 +18,9 @@ import net.bytebuddy.description.type.TypeList;
 /** Provides an outline of a method; its name, descriptor, and modifiers. */
 final class MethodOutline extends MethodDescription.InDefinedShape.AbstractBase {
   private static final int ALLOWED_METHOD_MODIFIERS = 0x0000ffff;
+
+  private static final ParameterList<ParameterDescription.InDefinedShape> NO_PARAMETERS =
+      new ParameterList.Empty<>();
 
   private final TypeDescription declaringType;
 
@@ -44,9 +49,12 @@ final class MethodOutline extends MethodDescription.InDefinedShape.AbstractBase 
 
   @Override
   public ParameterList<ParameterDescription.InDefinedShape> getParameters() {
-    List<ParameterDescription.InDefinedShape> outlines = new ArrayList<>();
     int parameterCount = 0;
     int parameterStart = 1;
+    if (descriptor.charAt(parameterStart) == ')') {
+      return NO_PARAMETERS;
+    }
+    List<ParameterDescription.InDefinedShape> outlines = new ArrayList<>();
     while (descriptor.charAt(parameterStart) != ')') {
       int parameterEnd = parameterStart;
       while (descriptor.charAt(parameterEnd) == '[') {
@@ -78,7 +86,7 @@ final class MethodOutline extends MethodDescription.InDefinedShape.AbstractBase 
 
   @Override
   public TypeList.Generic getTypeVariables() {
-    return new TypeList.Generic.Empty();
+    return NO_TYPES;
   }
 
   @Override
@@ -88,12 +96,14 @@ final class MethodOutline extends MethodDescription.InDefinedShape.AbstractBase 
 
   @Override
   public AnnotationList getDeclaredAnnotations() {
-    return new AnnotationList.Explicit(declaredAnnotations);
+    return declaredAnnotations.isEmpty()
+        ? NO_ANNOTATIONS
+        : new AnnotationList.Explicit(declaredAnnotations);
   }
 
   @Override
   public TypeList.Generic getExceptionTypes() {
-    return new TypeList.Generic.Empty();
+    return NO_TYPES;
   }
 
   void declare(AnnotationDescription annotation) {
@@ -140,7 +150,7 @@ final class MethodOutline extends MethodDescription.InDefinedShape.AbstractBase 
 
     @Override
     public AnnotationList getDeclaredAnnotations() {
-      return new AnnotationList.Empty();
+      return NO_ANNOTATIONS;
     }
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeOutline.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeOutline.java
@@ -18,6 +18,14 @@ import net.bytebuddy.description.type.TypeList;
 final class TypeOutline extends WithName {
   private static final int ALLOWED_TYPE_MODIFIERS = 0x0000ffdf; // excludes ACC_SUPER
 
+  static final TypeList.Generic NO_TYPES = new TypeList.Generic.Empty();
+  static final AnnotationList NO_ANNOTATIONS = new AnnotationList.Empty();
+
+  private static final FieldList<FieldDescription.InDefinedShape> NO_FIELDS =
+      new FieldList.Empty<>();
+  private static final MethodList<MethodDescription.InDefinedShape> NO_METHODS =
+      new MethodList.Empty<>();
+
   private final int classFileVersion;
   private final int modifiers;
   private final String superName;
@@ -50,6 +58,9 @@ final class TypeOutline extends WithName {
 
   @Override
   public TypeList.Generic getInterfaces() {
+    if (interfaces.length == 0) {
+      return NO_TYPES;
+    }
     List<Generic> outlines = new ArrayList<>(interfaces.length);
     for (final String iface : interfaces) {
       outlines.add(findType(iface.replace('/', '.')).asGenericType());
@@ -69,17 +80,19 @@ final class TypeOutline extends WithName {
 
   @Override
   public AnnotationList getDeclaredAnnotations() {
-    return new AnnotationList.Explicit(declaredAnnotations);
+    return declaredAnnotations.isEmpty()
+        ? NO_ANNOTATIONS
+        : new AnnotationList.Explicit(declaredAnnotations);
   }
 
   @Override
   public FieldList<FieldDescription.InDefinedShape> getDeclaredFields() {
-    return new FieldList.Explicit<>(declaredFields);
+    return declaredFields.isEmpty() ? NO_FIELDS : new FieldList.Explicit<>(declaredFields);
   }
 
   @Override
   public MethodList<MethodDescription.InDefinedShape> getDeclaredMethods() {
-    return new MethodList.Explicit<>(declaredMethods);
+    return declaredMethods.isEmpty() ? NO_METHODS : new MethodList.Explicit<>(declaredMethods);
   }
 
   void declare(AnnotationDescription annotation) {


### PR DESCRIPTION
likewise if there are no fields / methods / interfaces...