### PR TITLE
String taint tracking - join methods

### DIFF
--- a/dd-java-agent/agent-iast/src/jmh/java/com/datadog/iast/propagation/StringJoinBenchmark.java
+++ b/dd-java-agent/agent-iast/src/jmh/java/com/datadog/iast/propagation/StringJoinBenchmark.java
@@ -1,0 +1,96 @@
+package com.datadog.iast.propagation;
+
+import com.datadog.iast.IastRequestContext;
+import com.datadog.iast.model.Range;
+import com.datadog.iast.model.Source;
+import datadog.trace.api.iast.InstrumentationBridge;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+
+public class StringJoinBenchmark extends AbstractBenchmark<StringJoinBenchmark.Context> {
+  @Override
+  protected StringJoinBenchmark.Context initializeContext() {
+    final String notTainted = new String("I am not a tainted string");
+    final String notTaintedDelimiter = new String("-");
+    final IastRequestContext iastRequestContext = new IastRequestContext();
+
+    final String tainted = new String("I am a tainted string");
+    iastRequestContext
+        .getTaintedObjects()
+        .taint(
+            tainted,
+            new Range[] {new Range(0, tainted.length(), new Source((byte) 0, "key", "value"))});
+
+    final String taintedDelimiter = new String("-");
+    iastRequestContext
+        .getTaintedObjects()
+        .taint(
+            taintedDelimiter,
+            new Range[] {
+              new Range(0, taintedDelimiter.length(), new Source((byte) 1, "key", "value"))
+            });
+
+    return new StringJoinBenchmark.Context(
+        iastRequestContext, notTainted, tainted, notTaintedDelimiter, taintedDelimiter);
+  }
+
+  @Benchmark
+  @Fork(jvmArgsAppend = {"-Ddd.iast.enabled=false"})
+  public String baseline() {
+    final String delimiter = context.noTaintedDelimiter;
+    final String element = context.notTainted;
+    return String.join(delimiter, element, element, element, element, element);
+  }
+
+  @Benchmark
+  @Fork(jvmArgsAppend = {"-Ddd.iast.enabled=false"})
+  public String iastDisabled() {
+    final String delimiter = context.noTaintedDelimiter;
+    final String element = context.notTainted;
+    return instrumentStringJoin(delimiter, element);
+  }
+
+  @Benchmark
+  @Fork(jvmArgsAppend = {"-Ddd.iast.enabled=true"})
+  public String notTainted() {
+    final String delimiter = context.noTaintedDelimiter;
+    final String element = context.notTainted;
+    return instrumentStringJoin(delimiter, element);
+  }
+
+  @Benchmark
+  @Fork(jvmArgsAppend = {"-Ddd.iast.enabled=true"})
+  public String tainted() {
+    final String delimiter = context.taintedDelimiter;
+    final String element = context.tainted;
+    return instrumentStringJoin(delimiter, element);
+  }
+
+  private static String instrumentStringJoin(final String delimiter, final String element) {
+    final String result = String.join(delimiter, element, element, element, element, element);
+    InstrumentationBridge.STRING.onStringJoin(
+        result, delimiter, new String[] {element, element, element, element, element});
+    return result;
+  }
+
+  protected static class Context extends AbstractBenchmark.BenchmarkContext {
+
+    private final String notTainted;
+    private final String tainted;
+    private final String taintedDelimiter;
+    private final String noTaintedDelimiter;
+
+    protected Context(
+        final IastRequestContext iasContext,
+        final String notTainted,
+        final String tainted,
+        final String noTaintedDelimiter,
+        final String taintedDelimiter) {
+      super(iasContext);
+      this.notTainted = notTainted;
+      this.tainted = tainted;
+      this.noTaintedDelimiter = noTaintedDelimiter;
+      this.taintedDelimiter = taintedDelimiter;
+    }
+  }
+}

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/StringModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/StringModuleTest.groovy
@@ -545,6 +545,115 @@ class StringModuleTest extends IastModuleImplTestBase {
     "01==>234<==5==>678<==90" | 4          | 8        | "==>4<==5==>67<=="
   }
 
+  void 'onStringJoin without null delimiter or elements (#delimiter, #elements)'(final CharSequence delimiter, final CharSequence[] elements) {
+    when:
+    String.join(delimiter, elements)
+
+    then:
+    thrown(NullPointerException)
+
+    where:
+    delimiter | elements
+    null      | ["123", "456"]
+    ""        | null
+    null      | null
+  }
+
+  void 'onStringJoin without span (#delimiter, #elements)'(final CharSequence delimiter, final CharSequence[] elements, final int mockCalls) {
+    given:
+    final result = String.join(delimiter, elements)
+
+    when:
+    module.onStringJoin(result, delimiter, elements)
+
+    then:
+    mockCalls * tracer.activeSpan() >> null
+    0 * _
+
+    where:
+    delimiter              | elements                                             | mockCalls
+    ""                     | ["123", "456"]                                       | 1
+    "-"                    | ["123", "456"]                                       | 1
+    ""                     | []                                                   | 0
+    "-"                    | []                                                   | 0
+    ""                     | [new StringBuilder("123"), new StringBuilder("456")] | 1
+    "-"                    | [new StringBuilder("123"), new StringBuilder("456")] | 1
+    new StringBuilder()    | ["123", "456"]                                       | 1
+    new StringBuilder("-") | ["123", "456"]                                       | 1
+    new StringBuilder()    | []                                                   | 0
+    new StringBuilder("-") | []                                                   | 0
+    new StringBuilder("")  | [new StringBuilder("123"), new StringBuilder("456")] | 1
+    new StringBuilder("-") | [new StringBuilder("123"), new StringBuilder("456")] | 1
+  }
+
+  void 'onStringJoin (#delimiter, #elements)'(final CharSequence delimiter, final CharSequence[] elements, final String expected) {
+    given:
+    final span = Mock(AgentSpan)
+    tracer.activeSpan() >> span
+    final reqCtx = Mock(RequestContext)
+    span.getRequestContext() >> reqCtx
+    final ctx = new IastRequestContext()
+    reqCtx.getData(RequestContextSlot.IAST) >> ctx
+
+    and:
+    final result = getStringFromTaintFormat(expected)
+    objectHolder.add(expected)
+    final shouldBeTainted = fromTaintFormat(expected) != null
+
+    and:
+    final taintedObjects = ctx.getTaintedObjects()
+    final fromTaintedDelimiter = addFromTaintFormat(taintedObjects, delimiter)
+    objectHolder.add(fromTaintedDelimiter)
+
+    and:
+    final fromTaintedElements = new CharSequence[elements.length]
+    elements.eachWithIndex { element, i ->
+      def el = addFromTaintFormat(taintedObjects, element)
+      objectHolder.add(el)
+      fromTaintedElements[i] = el
+    }
+
+    when:
+    module.onStringJoin(result, fromTaintedDelimiter, fromTaintedElements)
+
+    then:
+    assert result == String.join(fromTaintedDelimiter, fromTaintedElements)
+    1 * tracer.activeSpan() >> span
+    1 * span.getRequestContext() >> reqCtx
+    1 * reqCtx.getData(RequestContextSlot.IAST) >> ctx
+    0 * _
+    def to = ctx.getTaintedObjects().get(result)
+    if (shouldBeTainted) {
+      assert to != null
+      assert to.get() == result
+      assert taintFormat(to.get() as String, to.getRanges()) == expected
+    } else {
+      assert to == null
+    }
+
+    where:
+    delimiter              | elements                                                                                    | expected
+    " "                    | ["==>Hello<==", null, "==>World<=="]                                                        | "==>Hello<== null ==>World<=="
+    " "                    | ["==>Hello<==", null, "a", "==>b<==", "c"]                                                  | "==>Hello<== null a ==>b<== c"
+    ""                     | ["0==>12<==3", "456", "7==>89<=="]                                                          | "0==>12<==34567==>89<=="
+    "-"                    | ["0==>12<==3", "456", "7==>89<=="]                                                          | "0==>12<==3-456-7==>89<=="
+    "-"                    | [new StringBuilder("0==>12<==3"), new StringBuilder("456"), new StringBuilder("7==>89<==")] | "0==>12<==3-456-7==>89<=="
+    new StringBuilder("-") | ["0==>12<==3", "456", "7==>89<=="]                                                          | "0==>12<==3-456-7==>89<=="
+    new StringBuilder("-") | [new StringBuilder("0==>12<==3"), new StringBuilder("456"), new StringBuilder("7==>89<==")] | "0==>12<==3-456-7==>89<=="
+    "-"                    | ["0123", "456", "789"]                                                                      | "0123-456-789"
+    "==>TAINTED<=="        | ["0123", "456", "789"]                                                                      | "0123==>TAINTED<==456==>TAINTED<==789"
+    ", "                   | ["untainted", null]                                                                         | "untainted, null"
+    ", "                   | ["untainted", "another"]                                                                    | "untainted, another"
+    ", "                   | ["stringParam==>taintedString<==", "another"]                                               | "stringParam==>taintedString<==, another"
+    ", "                   | ["stringParam==>taintedString<==", null]                                                    | "stringParam==>taintedString<==, null"
+    ", "                   | ["stringParam:another", "==>taintedString<=="]                                              | "stringParam:another, ==>taintedString<=="
+    ", "                   | [
+      "stringParam1,stringParam2,stringParam3:==>taintedString<==",
+      "==>taintedString<==",
+      "==>taintedString<=="
+    ]                                                                                                                    | "stringParam1,stringParam2,stringParam3:==>taintedString<==, ==>taintedString<==, ==>taintedString<=="
+  }
+
   private static StringBuilder sb() {
     return sb('')
   }

--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringCallSite.java
@@ -4,6 +4,9 @@ import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastAdvice;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.propagation.StringModule;
+import datadog.trace.util.stacktrace.StackUtils;
+import java.util.ArrayList;
+import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -70,6 +73,49 @@ public class StringCallSite {
     try {
       if (module != null) {
         module.onStringSubSequence(self, beginIndex, endIndex, result);
+      }
+    } catch (final Throwable e) {
+      module.onUnexpectedException("afterSubSequence threw", e);
+    }
+    return result;
+  }
+
+  @CallSite.After(
+      "java.lang.String java.lang.String.join(java.lang.CharSequence, java.lang.CharSequence[])")
+  public static String afterJoin(
+      @CallSite.Argument final CharSequence delimiter,
+      @CallSite.Argument final CharSequence[] elements,
+      @CallSite.Return final String result) {
+    final StringModule module = InstrumentationBridge.STRING;
+    try {
+      if (module != null) {
+        module.onStringJoin(result, delimiter, elements);
+      }
+    } catch (final Throwable e) {
+      module.onUnexpectedException("afterJoin threw", e);
+    }
+    return result;
+  }
+
+  @CallSite.Around(
+      "java.lang.String java.lang.String.join(java.lang.CharSequence, java.lang.Iterable)")
+  public static String aroundJoin(
+      @CallSite.Argument final CharSequence delimiter,
+      @CallSite.Argument final Iterable<? extends CharSequence> elements)
+      throws Throwable {
+    // Iterate the iterable to guarantee the default behavior for custom mutable Iterables
+    List<CharSequence> copy = new ArrayList<>();
+    String result;
+    try {
+      elements.forEach(copy::add);
+      result = String.join(delimiter, copy);
+    } catch (final Throwable e) {
+      throw StackUtils.filterDatadog(e);
+    }
+    final StringModule module = InstrumentationBridge.STRING;
+    try {
+      if (module != null) {
+        module.onStringJoin(result, delimiter, copy.toArray(new CharSequence[copy.size()]));
       }
     } catch (final Throwable e) {
       module.onUnexpectedException("afterSubSequence threw", e);

--- a/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/StringCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/StringCallSiteTest.groovy
@@ -73,4 +73,48 @@ class StringCallSiteTest extends AgentTestRunner {
     1 * iastModule.onStringSubSequence(self, 1, 5, expected)
     0 * _
   }
+
+  def 'test string join call site'() {
+    setup:
+    final iastModule = Mock(StringModule)
+    final expected = '012-345'
+    InstrumentationBridge.registerIastModule(iastModule)
+
+    when:
+    final result = TestStringSuite.join('-', '012', '345')
+
+    then:
+    result == expected
+    1 * iastModule.onStringJoin(expected, '-', '012', '345')
+    0 * _
+  }
+
+  def 'test string join with Iterable call site'() {
+    setup:
+    final iastModule = Mock(StringModule)
+    final expected = '012-345'
+    InstrumentationBridge.registerIastModule(iastModule)
+    final iterable = Arrays.asList('012', '345')
+
+    when:
+    final result = TestStringSuite.join('-', iterable)
+
+    then:
+    result == expected
+    1 * iastModule.onStringJoin(expected, '-', '012', '345')
+    0 * _
+  }
+
+  def 'test string join with Iterable fail on iterable copy'() {
+
+    given:
+    final iterable = Mock(Iterable)
+
+    when:
+    TestStringSuite.join('-', iterable)
+
+    then:
+    1 * iterable.forEach(_) >> { throw new Error('Boom!!!') }
+    thrown Error
+  }
 }

--- a/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringSuite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringSuite.java
@@ -34,4 +34,18 @@ public class TestStringSuite {
     LOGGER.debug("After string subSequence {}", result);
     return result;
   }
+
+  public static String join(CharSequence delimiter, CharSequence[] elements) {
+    LOGGER.debug("Before string join {} with {}", elements, delimiter);
+    final String result = String.join(delimiter, elements);
+    LOGGER.debug("After string join {}", result);
+    return result;
+  }
+
+  public static String join(CharSequence delimiter, Iterable<? extends CharSequence> elements) {
+    LOGGER.debug("Before string join {} with {}", elements, delimiter);
+    final String result = String.join(delimiter, elements);
+    LOGGER.debug("After string join {}", result);
+    return result;
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/propagation/StringModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/propagation/StringModule.java
@@ -23,4 +23,7 @@ public interface StringModule extends IastModule {
 
   void onStringSubSequence(
       @Nonnull String self, int beginIndex, int endIndex, @Nullable CharSequence result);
+
+  void onStringJoin(
+      @Nullable String result, @Nonnull CharSequence delimiter, @Nonnull CharSequence[] elements);
 }


### PR DESCRIPTION
# What Does This Do
Adds all the instrumentation needed to perform taint tacking in join operations for String objects

# Motivation
IAST requires to track all modifications that happen to strings in the code, this PR implements the join operations for String class

# Additional Notes
The instrumentation for the join method with the iterable param is based on the premise of iterating only once since these iterators may not be immutable.

Don't panic for te use of `new ArrayList<>()` in `StringCallSite.java` 😅  it has been discussed with @anderruiz and @smola and we have decided to assume the List overhead to keep it simple in this first iteration.



# Performance

|Benchmark |                                                                   Mode|    Cnt|       Score |    Error|   Units|
| --- | ---| ---|---|---| ---|
|StringJoinBenchmark.baseline    |                             ss  |15000 |    223.055| ±  13.490 |  ns/op
|StringJoinBenchmark.iastDisabled      |                       ss | 15000|     234.211| ±  11.259 |  ns/op
|StringJoinBenchmark.notTainted   |                            ss | 15000 |    574.520 |±  28.334 |  ns/op
|StringJoinBenchmark.tainted        |                          ss  |15000|     591.596| ±  20.990|   ns/op




