### PR TITLE
[WIP] Ensure TestNG advice issues can't leak out to the test

### DIFF
--- a/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TestNGInstrumentation.java
+++ b/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TestNGInstrumentation.java
@@ -36,7 +36,7 @@ public class TestNGInstrumentation extends Instrumenter.CiVisibility
   }
 
   public static class TestNGAdvice {
-    @Advice.OnMethodExit
+    @Advice.OnMethodExit(suppress = Throwable.class)
     public static void addTracingListener(@Advice.This final TestNG testNG) {
       for (final ITestListener testListener : testNG.getTestListeners()) {
         if (testListener instanceof TracingListener) {


### PR DESCRIPTION
This should help if TestNG is ever added to the boot class-path and we don't inject the listener type (because we are now avoiding altering the boot class-path after the tracer is attached)

(we should consider making `suppress = Throwable.class` the expected default across our instrumentations)