### PR TITLE
Set IBM -Xdump arg to collect smoke test crash info

### DIFF
--- a/.circleci/collect_reports.sh
+++ b/.circleci/collect_reports.sh
@@ -37,6 +37,7 @@ mkdir -p $REPORTS_DIR >/dev/null 2>&1
 
 cp /tmp/hs_err_pid*.log $REPORTS_DIR || true
 cp /tmp/java_pid*.hprof $REPORTS_DIR || true
+cp /tmp/javacore.* $REPORTS_DIR || true
 
 function process_reports () {
     project_to_save=$1

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -79,7 +79,7 @@ abstract class AbstractSmokeTest extends ProcessManager {
     "${getMaxMemoryArgumentForFork()}",
     "${getMinMemoryArgumentForFork()}",
     "-javaagent:${shadowJarPath}",
-    "-XX:ErrorFile=/tmp/hs_err_pid%p.log",
+    isIBM ? "-Xdump:directory=/tmp" : "-XX:ErrorFile=/tmp/hs_err_pid%p.log",
     "-Ddd.trace.agent.port=${server.address.port}",
     "-Ddd.service.name=${SERVICE_NAME}",
     "-Ddd.env=${ENV}",

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
@@ -21,6 +21,8 @@ abstract class ProcessManager extends Specification {
   protected String buildDirectory = System.getProperty("datadog.smoketest.builddir")
   @Shared
   protected String shadowJarPath = System.getProperty("datadog.smoketest.agent.shadowJar.path")
+  @Shared
+  protected boolean isIBM = System.getProperty("java.vendor", "").contains("IBM")
 
   @Shared
   protected static int profilingPort = -1


### PR DESCRIPTION
# What Does This Do
IBM JVMs use the setting [here](https://www.ibm.com/docs/en/sdk-java-technology/8?topic=options-xdump) to determine where crash files are written to, so the smoke tests need to set command line args when the JVM is IBM. When e.g. smoke tests crash, this change is enough to get the javacore files uploaded, e.g. [here](https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/16834/workflows/3c3832bd-9bd6-42b9-8362-077d06559420/jobs/394752/artifacts)
# Motivation

# Additional Notes
