### PR TITLE
Upgrade jnr_unixsocket and jnr_ffi

### DIFF
--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -236,7 +236,7 @@ tasks.register('checkAgentJarSize').configure {
   doLast {
     // Arbitrary limit to prevent unintentional increases to the agent jar size
     // Raise or lower as required
-    def megs = (project.rootProject.hasProperty("agentIncludeCwsTls") && agentIncludeCwsTls) ? 21 : 19
+    def megs = (project.rootProject.hasProperty("agentIncludeCwsTls") && agentIncludeCwsTls) ? 22 : 20
     assert shadowJar.archiveFile.get().getAsFile().length() <= megs * 1024 * 1024
   }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -25,8 +25,8 @@ final class CachedData {
     kotlin        : "1.3.72",
     coroutines    : "1.3.0",
     dogstatsd     : "4.0.0",
-    jnr_unixsocket: "0.28",
-    jnr_ffi       : '2.1.12', // dependency of jnr_unixsocket: update in tandem
+    jnr_unixsocket: "0.38.17",
+    jnr_ffi       : '2.2.12', // dependency of jnr_unixsocket: update in tandem
     commons       : "3.2",
     mockito       : '4.4.0',
     jctools       : '3.3.0',

--- a/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
@@ -49,26 +49,16 @@ public class TelemetrySystem {
 
   public static void startTelemetry(
       Instrumentation instrumentation, SharedCommunicationObjects sco) {
-    try {
-      DependencyService dependencyService = createDependencyService(instrumentation);
-      RequestBuilder requestBuilder = new RequestBuilder(sco.agentUrl);
-      TelemetryService telemetryService =
-          new TelemetryServiceImpl(
-              requestBuilder,
-              SystemTimeSource.INSTANCE,
-              Config.get().getTelemetryHeartbeatInterval());
-      TELEMETRY_THREAD =
-          createTelemetryRunnable(telemetryService, sco.okHttpClient, dependencyService);
-      TELEMETRY_THREAD.start();
-    } catch (UnsatisfiedLinkError e) {
-      // TODO: update jnr_ffi and jnr_unixsocket to version that supports aarch64
-      final String arch = System.getProperty("os.arch").toLowerCase();
-      if (!arch.equals("x86") && !arch.equals("amd64")) {
-        log.error("Can't start telemetry. Unsupported architecture: '{}'", arch);
-      } else {
-        throw e;
-      }
-    }
+    DependencyService dependencyService = createDependencyService(instrumentation);
+    RequestBuilder requestBuilder = new RequestBuilder(sco.agentUrl);
+    TelemetryService telemetryService =
+        new TelemetryServiceImpl(
+            requestBuilder,
+            SystemTimeSource.INSTANCE,
+            Config.get().getTelemetryHeartbeatInterval());
+    TELEMETRY_THREAD =
+        createTelemetryRunnable(telemetryService, sco.okHttpClient, dependencyService);
+    TELEMETRY_THREAD.start();
   }
 
   public static void stop() {


### PR DESCRIPTION
# What Does This Do

Upgrades `jnr_unixsocket` and `jnr_ffi`

# Motivation

Removes [free after use security vulnerability](https://security.snyk.io/vuln/SNYK-JAVA-COMGITHUBJNR-1570422) in `jnr_posix` that is a dependency of `jnr_unixsocket`, and allows Telemtry to work on ARM since `aarch64` is now supported.

# Additional Notes
