### PR TITLE
Type parsing: avoid creating annotation ArrayLists that will never get populated

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/FieldOutline.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/FieldOutline.java
@@ -20,7 +20,7 @@ final class FieldOutline extends FieldDescription.InDefinedShape.AbstractBase {
   private final String name;
   private final String descriptor;
 
-  private final List<AnnotationDescription> declaredAnnotations = new ArrayList<>();
+  private List<AnnotationDescription> declaredAnnotations;
 
   FieldOutline(TypeDescription declaringType, int access, String name, String descriptor) {
     this.declaringType = declaringType;
@@ -56,13 +56,16 @@ final class FieldOutline extends FieldDescription.InDefinedShape.AbstractBase {
 
   @Override
   public AnnotationList getDeclaredAnnotations() {
-    return declaredAnnotations.isEmpty()
+    return null == declaredAnnotations
         ? NO_ANNOTATIONS
         : new AnnotationList.Explicit(declaredAnnotations);
   }
 
   void declare(AnnotationDescription annotation) {
     if (null != annotation) {
+      if (null == declaredAnnotations) {
+        declaredAnnotations = new ArrayList<>();
+      }
       declaredAnnotations.add(annotation);
     }
   }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/MethodOutline.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/MethodOutline.java
@@ -28,7 +28,7 @@ final class MethodOutline extends MethodDescription.InDefinedShape.AbstractBase 
   private final int modifiers;
   private final String name;
 
-  private final List<AnnotationDescription> declaredAnnotations = new ArrayList<>();
+  private List<AnnotationDescription> declaredAnnotations;
 
   MethodOutline(TypeDescription declaringType, int access, String name, String descriptor) {
     this.declaringType = declaringType;
@@ -96,7 +96,7 @@ final class MethodOutline extends MethodDescription.InDefinedShape.AbstractBase 
 
   @Override
   public AnnotationList getDeclaredAnnotations() {
-    return declaredAnnotations.isEmpty()
+    return null == declaredAnnotations
         ? NO_ANNOTATIONS
         : new AnnotationList.Explicit(declaredAnnotations);
   }
@@ -108,6 +108,9 @@ final class MethodOutline extends MethodDescription.InDefinedShape.AbstractBase 
 
   void declare(AnnotationDescription annotation) {
     if (null != annotation) {
+      if (null == declaredAnnotations) {
+        declaredAnnotations = new ArrayList<>();
+      }
       declaredAnnotations.add(annotation);
     }
   }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeOutline.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeOutline.java
@@ -31,7 +31,8 @@ final class TypeOutline extends WithName {
   private final String superName;
   private final String[] interfaces;
 
-  private final List<AnnotationDescription> declaredAnnotations = new ArrayList<>();
+  private List<AnnotationDescription> declaredAnnotations;
+
   private final List<FieldDescription.InDefinedShape> declaredFields = new ArrayList<>();
   private final List<MethodDescription.InDefinedShape> declaredMethods = new ArrayList<>();
 
@@ -80,7 +81,7 @@ final class TypeOutline extends WithName {
 
   @Override
   public AnnotationList getDeclaredAnnotations() {
-    return declaredAnnotations.isEmpty()
+    return null == declaredAnnotations
         ? NO_ANNOTATIONS
         : new AnnotationList.Explicit(declaredAnnotations);
   }
@@ -97,6 +98,9 @@ final class TypeOutline extends WithName {
 
   void declare(AnnotationDescription annotation) {
     if (null != annotation) {
+      if (null == declaredAnnotations) {
+        declaredAnnotations = new ArrayList<>();
+      }
       declaredAnnotations.add(annotation);
     }
   }


### PR DESCRIPTION
Since most type elements don't have any annotations, these lists remain empty for the duration of the cached type.

Delaying creation of the lists saves a few K during startup for spring-petclinic.