### PR TITLE
Fix issue with array handling for boxing / unboxing in CSI

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteUtils.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteUtils.java
@@ -233,7 +233,7 @@ public abstract class CallSiteUtils {
   }
 
   private static void checkCast(final MethodVisitor mv, final Type parameter) {
-    if (parameter.getSort() == Type.OBJECT) {
+    if (parameter.getSort() == Type.OBJECT || parameter.getSort() == Type.ARRAY) {
       mv.visitTypeInsn(Opcodes.CHECKCAST, parameter.getInternalName());
     } else {
       final BoxingHandler handler = BOX_HANDLERS[parameter.getSort()];

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/BaseCallSiteTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/BaseCallSiteTest.groovy
@@ -128,6 +128,10 @@ class BaseCallSiteTest extends DDSpecification {
     return buildPointcut(MessageDigest.getDeclaredMethod('getInstance', String))
   }
 
+  protected static Pointcut stringBuilderInsertPointcut() {
+    return buildPointcut(StringBuilder.getDeclaredMethod('insert', int, char[], int, int))
+  }
+
   protected static Pointcut stringConcatFactoryPointcut() {
     return buildPointcut(
       'java/lang/invoke/StringConcatFactory',

--- a/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/csi/CallSiteWithArraysExample.java
+++ b/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/csi/CallSiteWithArraysExample.java
@@ -1,0 +1,11 @@
+package datadog.trace.agent.tooling.csi;
+
+import datadog.trace.api.function.TriFunction;
+
+public class CallSiteWithArraysExample implements TriFunction<String, Integer, Integer, String> {
+
+  @Override
+  public String apply(final String text, final Integer offset, final Integer length) {
+    return new StringBuilder().insert(0, text.toCharArray(), offset, length).toString();
+  }
+}


### PR DESCRIPTION
# What Does This Do
When the arity of a method forces CSI to duplicate parameters in the stack using an array, we have to take care of boxing/unboxing of the elements that will be inserted in the array. 

One condition was missing for when a parameter of the stack is of array type, causing those methods to fail.

# Motivation

# Additional Notes
