### PR TITLE
[WIP] Global Ignore exclusion list changes needed for IAST

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentTransformerBuilder.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentTransformerBuilder.java
@@ -17,6 +17,7 @@ import datadog.trace.agent.tooling.bytebuddy.matcher.KnownTypesMatcher;
 import datadog.trace.agent.tooling.bytebuddy.matcher.MuzzleMatcher;
 import datadog.trace.agent.tooling.bytebuddy.matcher.ShouldInjectFieldsRawMatcher;
 import datadog.trace.agent.tooling.bytebuddy.matcher.SingleTypeMatcher;
+import datadog.trace.agent.tooling.bytebuddy.matcher.TargetSystemAwareMatcher;
 import datadog.trace.agent.tooling.context.FieldBackedContextInjector;
 import datadog.trace.agent.tooling.context.FieldBackedContextRequestRewriter;
 import datadog.trace.api.InstrumenterConfig;
@@ -76,7 +77,7 @@ public class AgentTransformerBuilder
     ignoreMatcher = instrumenter.methodIgnoreMatcher();
     adviceBuilder =
         agentBuilder
-            .type(typeMatcher(instrumenter))
+            .type(new TargetSystemAwareMatcher(instrumenter, typeMatcher(instrumenter)))
             .and(NOT_DECORATOR_MATCHER)
             .and(new MuzzleMatcher(instrumenter))
             .transform(defaultTransformers());

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -112,6 +112,8 @@ public interface Instrumenter {
    */
   boolean isApplicable(Set<TargetSystem> enabledSystems);
 
+  TargetSystem getTargetSystem();
+
   /**
    * Adds this instrumentation to a {@link TransformerBuilder}.
    *
@@ -290,8 +292,14 @@ public interface Instrumenter {
     }
 
     @Override
-    public boolean isApplicable(Set<TargetSystem> enabledSystems) {
-      return false;
+    public boolean isApplicable(final Set<TargetSystem> enabledSystems) {
+      final TargetSystem targetSystem = getTargetSystem();
+      return targetSystem != null && enabledSystems.contains(targetSystem);
+    }
+
+    @Override
+    public TargetSystem getTargetSystem() {
+      return null;
     }
 
     protected final boolean isShortcutMatchingEnabled(boolean defaultToShortcut) {
@@ -307,8 +315,8 @@ public interface Instrumenter {
     }
 
     @Override
-    public boolean isApplicable(Set<TargetSystem> enabledSystems) {
-      return enabledSystems.contains(TargetSystem.TRACING);
+    public TargetSystem getTargetSystem() {
+      return TargetSystem.TRACING;
     }
   }
 
@@ -319,8 +327,8 @@ public interface Instrumenter {
     }
 
     @Override
-    public boolean isApplicable(Set<TargetSystem> enabledSystems) {
-      return enabledSystems.contains(TargetSystem.PROFILING);
+    public TargetSystem getTargetSystem() {
+      return TargetSystem.PROFILING;
     }
   }
 
@@ -331,8 +339,8 @@ public interface Instrumenter {
     }
 
     @Override
-    public boolean isApplicable(Set<TargetSystem> enabledSystems) {
-      return enabledSystems.contains(TargetSystem.APPSEC);
+    public TargetSystem getTargetSystem() {
+      return TargetSystem.APPSEC;
     }
   }
 
@@ -343,8 +351,8 @@ public interface Instrumenter {
     }
 
     @Override
-    public boolean isApplicable(Set<TargetSystem> enabledSystems) {
-      return enabledSystems.contains(TargetSystem.IAST);
+    public TargetSystem getTargetSystem() {
+      return TargetSystem.IAST;
     }
   }
 
@@ -356,8 +364,8 @@ public interface Instrumenter {
     }
 
     @Override
-    public boolean isApplicable(Set<TargetSystem> enabledSystems) {
-      return enabledSystems.contains(TargetSystem.CIVISIBILITY);
+    public TargetSystem getTargetSystem() {
+      return TargetSystem.CIVISIBILITY;
     }
   }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnores.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnores.java
@@ -1,5 +1,7 @@
 package datadog.trace.agent.tooling.bytebuddy.matcher;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.TargetSystemAwareMatcher.IAST_ENABLED_FLAG;
+
 /**
  * Global ignores used by the agent.
  *
@@ -16,7 +18,9 @@ public class GlobalIgnores {
 
   public static boolean isIgnored(String name, boolean skipAdditionalIgnores) {
     // ignored classes/packages are now maintained in the 'ignored_class_name.trie' resource
-    switch (IgnoredClassNameTrie.apply(name)) {
+    // try to get value from cache otherwise use apply
+    Integer allowCode = GlobalIgnoresCache.getAllowCode(name);
+    switch (allowCode) {
       case 0:
         return false; // global allow
       case 1:
@@ -27,6 +31,8 @@ public class GlobalIgnores {
         return name.endsWith("Proxy");
       case 4:
         return !name.endsWith("HttpMessageConverter");
+      case IAST_ENABLED_FLAG:
+        return false;
       default:
         break;
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresCache.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresCache.java
@@ -1,0 +1,39 @@
+package datadog.trace.agent.tooling.bytebuddy.matcher;
+
+public class GlobalIgnoresCache {
+
+  private static long cache = 0;
+
+  private static void store(long newCache) {
+    cache = newCache;
+  }
+
+  private static Long getCachedValue() {
+    return cache;
+  }
+
+  private static long build(String key, int allowCode) {
+    return (((long) allowCode) << 32) | (System.identityHashCode(key) & 0xffffffffL);
+  }
+
+  private static int getAllowCode(long cached) {
+    return (int) (cached >> 32);
+  }
+
+  private static int getIdentityHash(long cached) {
+    return (int) cached;
+  }
+
+  public static int getAllowCode(String name) {
+    Integer allowCode = null;
+    Long cachedValue = getCachedValue();
+    if (getIdentityHash(cachedValue) == System.identityHashCode(name)) {
+      allowCode = getAllowCode(cachedValue);
+    }
+    if (null == allowCode) {
+      allowCode = IgnoredClassNameTrie.apply(name);
+      store(GlobalIgnoresCache.build(name, allowCode));
+    }
+    return allowCode;
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/TargetSystemAwareMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/TargetSystemAwareMatcher.java
@@ -1,0 +1,40 @@
+package datadog.trace.agent.tooling.bytebuddy.matcher;
+
+import datadog.trace.agent.tooling.Instrumenter;
+import java.security.ProtectionDomain;
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.utility.JavaModule;
+
+public class TargetSystemAwareMatcher implements AgentBuilder.RawMatcher {
+
+  public static final int IAST_ENABLED_FLAG = 5;
+
+  private final Instrumenter instrumenter;
+
+  private final AgentBuilder.RawMatcher delegate;
+
+  public TargetSystemAwareMatcher(
+      final Instrumenter instrumenter, final AgentBuilder.RawMatcher delegate) {
+    this.instrumenter = instrumenter;
+    this.delegate = delegate;
+  }
+
+  @Override
+  public boolean matches(
+      final TypeDescription typeDescription,
+      final ClassLoader classLoader,
+      final JavaModule module,
+      final Class<?> classBeingRedefined,
+      final ProtectionDomain protectionDomain) {
+
+    // try to get value from cache otherwise use apply
+    Integer allowCode = GlobalIgnoresCache.getAllowCode(typeDescription.getName());
+    if (allowCode == IAST_ENABLED_FLAG
+        && instrumenter.getTargetSystem() != Instrumenter.TargetSystem.IAST) {
+      return false;
+    }
+    return delegate.matches(
+        typeDescription, classLoader, module, classBeingRedefined, protectionDomain);
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
+++ b/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
@@ -37,7 +37,9 @@
 # remove this once https://github.com/raphw/byte-buddy/issues/558 is fixed
 0 datadog.trace.bootstrap.instrumentation.java.concurrent.RunnableWrapper
 1 datadog.trace.core.*
-1 io.micrometer.*
+1 datadog.smoketest.controller.*
+5 datadog.smoketest.controller.*
+ io.micrometer.*
 1 io.micronaut.tracing.*
 1 java.*
 # allow exception profiling instrumentation

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/ElasticsearchBreakTraceInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/ElasticsearchBreakTraceInstrumentation.java
@@ -19,6 +19,11 @@ public class ElasticsearchBreakTraceInstrumentation extends TestInstrumentation 
   }
 
   @Override
+  public TargetSystem getTargetSystem() {
+    return TargetSystem.TRACING;
+  }
+
+  @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     // this method changed to executeLocally in 5+
     transformation.applyAdvice(named("doExecute"), ShadowExistingScopeAdvice.class.getName());

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/ElasticsearchBreakTraceInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/ElasticsearchBreakTraceInstrumentation.java
@@ -19,6 +19,11 @@ public class ElasticsearchBreakTraceInstrumentation extends TestInstrumentation 
   }
 
   @Override
+  public TargetSystem getTargetSystem() {
+    return TargetSystem.TRACING;
+  }
+
+  @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     // this method changed to executeLocally in 5+
     transformation.applyAdvice(named("doExecute"), ShadowExistingScopeAdvice.class.getName());

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/ElasticsearchBreakTraceInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/ElasticsearchBreakTraceInstrumentation.java
@@ -19,6 +19,11 @@ public class ElasticsearchBreakTraceInstrumentation extends TestInstrumentation 
   }
 
   @Override
+  public TargetSystem getTargetSystem() {
+    return TargetSystem.TRACING;
+  }
+
+  @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(named("executeLocally"), ShadowExistingScopeAdvice.class.getName());
   }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/ElasticsearchBreakTraceInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/ElasticsearchBreakTraceInstrumentation.java
@@ -19,6 +19,11 @@ public class ElasticsearchBreakTraceInstrumentation extends TestInstrumentation 
   }
 
   @Override
+  public TargetSystem getTargetSystem() {
+    return TargetSystem.TRACING;
+  }
+
+  @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(named("executeLocally"), ShadowExistingScopeAdvice.class.getName());
   }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/ElasticsearchBreakTraceInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/ElasticsearchBreakTraceInstrumentation.java
@@ -19,6 +19,11 @@ public class ElasticsearchBreakTraceInstrumentation extends TestInstrumentation 
   }
 
   @Override
+  public TargetSystem getTargetSystem() {
+    return TargetSystem.TRACING;
+  }
+
+  @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(named("executeLocally"), ShadowExistingScopeAdvice.class.getName());
   }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-7.3/src/test/groovy/ElasticsearchBreakTraceInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-7.3/src/test/groovy/ElasticsearchBreakTraceInstrumentation.java
@@ -19,6 +19,11 @@ public class ElasticsearchBreakTraceInstrumentation extends TestInstrumentation 
   }
 
   @Override
+  public TargetSystem getTargetSystem() {
+    return TargetSystem.TRACING;
+  }
+
+  @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(named("executeLocally"), ShadowExistingScopeAdvice.class.getName());
   }

--- a/dd-java-agent/instrumentation/iast-instrumenter/src/main/java/datadog/trace/instrumentation/iastinstrumenter/IastInstrumenter.java
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/main/java/datadog/trace/instrumentation/iastinstrumenter/IastInstrumenter.java
@@ -30,4 +30,9 @@ public class IastInstrumenter extends CallSiteInstrumenter
   public boolean isApplicable(final Set<TargetSystem> enabledSystems) {
     return enabledSystems.contains(TargetSystem.IAST);
   }
+
+  @Override
+  public TargetSystem getTargetSystem() {
+    return TargetSystem.IAST;
+  }
 }

--- a/dd-java-agent/instrumentation/mongo/src/test/java/NoOpInstrumentation.java
+++ b/dd-java-agent/instrumentation/mongo/src/test/java/NoOpInstrumentation.java
@@ -10,6 +10,11 @@ public class NoOpInstrumentation implements Instrumenter {
   }
 
   @Override
+  public TargetSystem getTargetSystem() {
+    return TargetSystem.TRACING;
+  }
+
+  @Override
   public void instrument(TransformerBuilder transformerBuilder) {
     // no-op
   }

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
@@ -178,6 +178,11 @@ public class TraceConfigInstrumentation implements Instrumenter {
   }
 
   @Override
+  public TargetSystem getTargetSystem() {
+    return TargetSystem.TRACING;
+  }
+
+  @Override
   public void instrument(TransformerBuilder transformerBuilder) {
     if (classMethodsToTrace.isEmpty()) {
       return;

--- a/dd-java-agent/testing/src/test/java/locator/ClassInjectingTestInstrumentation.java
+++ b/dd-java-agent/testing/src/test/java/locator/ClassInjectingTestInstrumentation.java
@@ -19,6 +19,11 @@ public class ClassInjectingTestInstrumentation extends TestInstrumentation {
     transformation.applyAdvice(isConstructor(), getClass().getName() + "$ConstructorAdvice");
   }
 
+  @Override
+  public TargetSystem getTargetSystem() {
+    return TargetSystem.TRACING;
+  }
+
   public static class ConstructorAdvice {
     @Advice.OnMethodEnter
     public static void appendToMessage(


### PR DESCRIPTION
# What Does This Do
Add a new id on the global ignore list stating if a package is to be instrumented by the IAST system only. Add a cache to the Global Ignore so if two consecutive calls are made with the same key, the second and subsequent calls will receive the cached result.

# Motivation
In some cases, packages that are marked as ignored by apm need to be instrumented by the IAST system. A mechanism is needed so this can be expressed.

# Additional Notes
