### PR TITLE
Correct broken default behavior in collect_reports

### DIFF
--- a/.circleci/collect_reports.sh
+++ b/.circleci/collect_reports.sh
@@ -9,7 +9,7 @@ shopt -s globstar
 
 REPORTS_DIR=./reports
 MOVE=false
-DELETE=true
+DELETE=false
 
 while [[ $# -gt 0 ]]; do
   case $1 in


### PR DESCRIPTION
# What Does This Do

Changes broken default behavior in `collect_reports.sh` that deleted reports instead of saving them.

# Motivation

# Additional Notes
