### PR TITLE
compress and upload .trc and .dmp files for IBM JVMs, compress collected profiles

### DIFF
--- a/.circleci/collect_profiles.sh
+++ b/.circleci/collect_profiles.sh
@@ -28,3 +28,5 @@ for profile_path in workspace/**/build/profiles; do
     profile_path=${profile_path//\/build\/profiles/}
     save_profiles $profiles
 done
+
+tar -cvzf profiles.tar $PROFILES_DIR

--- a/.circleci/collect_reports.sh
+++ b/.circleci/collect_reports.sh
@@ -38,6 +38,8 @@ mkdir -p $REPORTS_DIR >/dev/null 2>&1
 cp /tmp/hs_err_pid*.log $REPORTS_DIR || true
 cp /tmp/java_pid*.hprof $REPORTS_DIR || true
 cp /tmp/javacore.* $REPORTS_DIR || true
+cp /tmp/*.trc $REPORTS_DIR || true
+cp /tmp/*.dmp $REPORTS_DIR || true
 
 function process_reports () {
     project_to_save=$1
@@ -69,3 +71,5 @@ for report_path in workspace/**/build/reports; do
     report_path=${report_path//\/build\/reports/}
     process_reports $report_path
 done
+
+tar -cvzf reports.tar $REPORTS_DIR

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -411,7 +411,7 @@ jobs:
           command: .circleci/collect_reports.sh
 
       - store_artifacts:
-          path: ./reports
+          path: ./reports.tar
 
       - when:
           condition:
@@ -423,7 +423,7 @@ jobs:
                 command: .circleci/collect_profiles.sh
 
             - store_artifacts:
-                path: ./profiles
+                path: ./profiles.tar
 
       - run:
           name: Collect test results


### PR DESCRIPTION
# What Does This Do
tars uploaded large files (coredumps, profiles etc.) see example [here](https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/16857/workflows/493a8288-d31f-453c-85e6-4a219e38bb3d/jobs/395323/artifacts)
# Motivation
reduces upload time and storage in circleci
# Additional Notes
