### PR TITLE
jetty blocking: fix calling of old method

### DIFF
--- a/dd-java-agent/instrumentation/jetty-common/jetty-common.gradle
+++ b/dd-java-agent/instrumentation/jetty-common/jetty-common.gradle
@@ -1,5 +1,22 @@
+ext {
+  minJavaVersionForTests = JavaVersion.VERSION_1_8
+}
+
 apply from: "$rootDir/gradle/java.gradle"
+apply plugin: 'org.unbroken-dome.test-sets'
+
+testSets {
+  latestDepTest {
+    dirName = 'test'
+  }
+}
 
 dependencies {
   compileOnly group: 'org.eclipse.jetty', name: 'jetty-server', version: '7.0.0.v20091005'
+
+  testImplementation project(':dd-java-agent:testing'), {
+    exclude group: 'org.eclipse.jetty'
+  }
+  testImplementation group: 'org.eclipse.jetty', name: 'jetty-server', version: '7.0.0.v20091005'
+  latestDepTestImplementation group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.+'
 }

--- a/dd-java-agent/instrumentation/jetty-common/src/main/java/datadog/trace/instrumentation/jetty/JettyBlockingHelper.java
+++ b/dd-java-agent/instrumentation/jetty-common/src/main/java/datadog/trace/instrumentation/jetty/JettyBlockingHelper.java
@@ -1,5 +1,7 @@
 package datadog.trace.instrumentation.jetty;
 
+import static java.lang.invoke.MethodType.methodType;
+
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.bootstrap.blocking.BlockingActionHelper;
 import java.io.OutputStream;
@@ -14,23 +16,41 @@ import org.slf4j.LoggerFactory;
 public class JettyBlockingHelper {
   private static final Logger log = LoggerFactory.getLogger(JettyBlockingHelper.class);
   private static final MethodHandle GET_OUTPUT_STREAM;
+  private static final MethodHandle CLOSE_OUTPUT;
 
   static {
-    MethodHandle mh = null;
+    MethodHandle getOutputStreamMH = null;
+    MethodHandle closeOutputMH = null;
     try {
       Method getOutputStream = Response.class.getMethod("getOutputStream");
-      mh = MethodHandles.lookup().unreflect(getOutputStream);
-    } catch (IllegalAccessException | NoSuchMethodException e) {
-      log.error("Lookup of getOutputStream failed. Will be unable to commit blocking response");
+      getOutputStreamMH = MethodHandles.lookup().unreflect(getOutputStream);
+    } catch (IllegalAccessException | NoSuchMethodException | RuntimeException e) {
+      log.error("Lookup of getOutputStream failed. Will be unable to commit blocking response", e);
     }
-    GET_OUTPUT_STREAM = mh;
+    try {
+      closeOutputMH =
+          MethodHandles.lookup().findVirtual(Response.class, "complete", methodType(void.class));
+    } catch (IllegalAccessException | NoSuchMethodException | RuntimeException e) {
+      try {
+        closeOutputMH =
+            MethodHandles.lookup()
+                .findVirtual(Response.class, "closeOutput", methodType(void.class));
+      } catch (IllegalAccessException | NoSuchMethodException | RuntimeException e2) {
+        log.error(
+            "Lookup of closeOutput/complete failed. Will be unable to commit blocking response",
+            e2);
+      }
+    }
+
+    GET_OUTPUT_STREAM = getOutputStreamMH;
+    CLOSE_OUTPUT = closeOutputMH;
   }
 
   private JettyBlockingHelper() {}
 
   public static void block(
       Request request, Response response, Flow.Action.RequestBlockingAction rba) {
-    if (GET_OUTPUT_STREAM != null && !response.isCommitted()) {
+    if (GET_OUTPUT_STREAM != null && CLOSE_OUTPUT != null && !response.isCommitted()) {
       try {
         OutputStream os = (OutputStream) GET_OUTPUT_STREAM.invoke(response);
         response.setStatus(BlockingActionHelper.getHttpCode(rba.getStatusCode()));
@@ -42,7 +62,7 @@ public class JettyBlockingHelper {
         response.setHeader("Content-length", Integer.toString(template.length));
         os.write(template);
         os.close();
-        response.complete();
+        CLOSE_OUTPUT.invoke(response);
       } catch (Throwable e) {
         log.info("Error committing blocking response", e);
       }

--- a/dd-java-agent/instrumentation/jetty-common/src/test/groovy/datadog/trace/instrumentation/jetty/JettyBlockingHelperSpecification.groovy
+++ b/dd-java-agent/instrumentation/jetty-common/src/test/groovy/datadog/trace/instrumentation/jetty/JettyBlockingHelperSpecification.groovy
@@ -1,0 +1,37 @@
+package datadog.trace.instrumentation.jetty
+
+import datadog.trace.api.gateway.Flow
+import datadog.trace.test.util.DDSpecification
+import org.eclipse.jetty.server.Request
+import org.eclipse.jetty.server.Response
+
+import javax.servlet.ServletOutputStream
+
+import static datadog.trace.api.gateway.Flow.Action.BlockingContentType.AUTO
+
+class JettyBlockingHelperSpecification extends DDSpecification {
+  void 'block completes successfully'() {
+    setup:
+    Request req = Mock()
+    Response resp = Mock()
+    ServletOutputStream os = Mock()
+
+    when:
+    JettyBlockingHelper.block(req, resp, new Flow.Action.RequestBlockingAction(402, AUTO))
+
+    then:
+    1 * resp.isCommitted() >> false
+    1 * resp.setStatus(402)
+    1 * req.getHeader('Accept') >> 'text/html'
+    1 * resp.setHeader('Content-type', 'text/html;charset=utf-8')
+    1 * resp.setHeader('Content-length', _)
+    1 * resp.getOutputStream() >> os
+    1 * os.write(_)
+    1 * os.close()
+    if (resp.respondsTo('complete')) {
+      1 * resp.complete()
+    } else {
+      1 * resp.closeOutput()
+    }
+  }
+}


### PR DESCRIPTION
Jetty replaced Response.complete() with Response.closeOutput() some time ago. See https://github.com/eclipse/jetty.project/commit/bacff75b311
