### PR TITLE
Bump async-profiler to 20221010

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    asyncprofiler : "2.8.3-DD-20221005",
+    asyncprofiler : "2.8.3-DD-20221010",
     asm           : "9.2"
   ]
 


### PR DESCRIPTION
# What Does This Do
^

# Motivation
The new release contains a fix preventing SEGFAULT due to mishandling of input arguments

# Additional Notes
