### PR TITLE
exclude problematic package from spotbugs scanning

### DIFF
--- a/gradle/spotbugFilters/exclude.xml
+++ b/gradle/spotbugFilters/exclude.xml
@@ -19,6 +19,7 @@
       <Package name="com.datadog.appsec.report.raw.contexts.tags" />
       <Package name="com.datadog.appsec.report.raw.contexts.trace" />
       <Package name="com.datadog.appsec.report.raw.events" />
+      <Package name="datadog.trace.agent.test.checkpoints" />
     </Or>
   </Match>
 </FindBugsFilter>


### PR DESCRIPTION
# What Does This Do

# Motivation

avoid 

```
Detector edu.umd.cs.findbugs.detect.FindUnrelatedTypesInGenericContainer caught exception while analyzing datadog.trace.agent.test.checkpoints.IntervalValidator$SpanInterval.<init> : (JLdatadog/trace/agent/test/checkpoints/Event;I)V
    edu.umd.cs.findbugs.ba.CFGBuilderException: Invalid stack at   90: lload[22](2) 9 when checking   95: putfield[181](3) 68
      At edu.umd.cs.findbugs.ba.BetterCFGBuilder2.isPEI(BetterCFGBuilder2.java:1032)
      At edu.umd.cs.findbugs.ba.BetterCFGBuilder2.build(BetterCFGBuilder2.java:914)
      At edu.umd.cs.findbugs.ba.BetterCFGBuilder2.build(BetterCFGBuilder2.java:777)
      At edu.umd.cs.findbugs.classfile.engine.bcel.CFGFactory.analyze(CFGFactory.java:94)

```

# Additional Notes
