### PR TITLE
Add bytebudy to deps of csi plugin

### DIFF
--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
   implementation("org.ow2.asm", "asm", "9.0")
   implementation("org.ow2.asm", "asm-tree", "9.0")
 
+  testImplementation("net.bytebuddy", "byte-buddy", "1.11.10")
   testImplementation("org.spockframework", "spock-core", "2.0-groovy-3.0")
   testImplementation("org.codehaus.groovy", "groovy-all", "3.0.10")
   testImplementation("com.github.javaparser", "javaparser-symbol-solver-core", "3.24.4")


### PR DESCRIPTION
# What Does This Do
Add byte buddy to test dependencis of the CSI plugin 

# Motivation
After upgrading CSI dynamic addvices bytebuddy is needed to run the tests of the plugin

# Additional Notes
