### PR TITLE
remove deprecated gradle usage in jacocoTestReport

### DIFF
--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -22,8 +22,8 @@ tasks.register('forkedTestJacocoData') {
 tasks.named('jacocoTestReport').configure {
   dependsOn('test', 'forkedTestJacocoData')
   reports {
-    xml.enabled true
-    csv.enabled false
+    xml.required true
+    csv.required false
     html.destination file("${buildDir}/reports/jacoco/")
   }
 }


### PR DESCRIPTION
# What Does This Do

Remove another deprecation warning from the build scan (which seems to report new deprecations when old ones are removed?)

# Motivation

Find out which other deprecations the build has?

# Additional Notes
