### PR TITLE
strip 'v' from version tag

### DIFF
--- a/.github/workflows/add-assets-to-release.yaml
+++ b/.github/workflows/add-assets-to-release.yaml
@@ -2,11 +2,48 @@ name: Add assets to release
 on:
   release:
     types: [published]
-env:
-  VERSION: ${{ github.event.release.name }}  #Can't use GITHUB_REF because it starts with a "v"
 jobs:
-  dd-java-agent:
+  get-version:
+      runs-on: ubuntu-latest
+      env:
+        TAG_NAME: ${{ github.event.release.tag_name }}
+      steps:
+        - name: Strip leading 'v' from tag and return as output
+          id: version_name
+          run: echo "version=$(echo ${TAG_NAME/#v/})" >> $GITHUB_OUTPUT
+      outputs:
+        ver: ${{ steps.version_name.outputs.version }}
+  test-and-set-version:
+    needs: get-version
     runs-on: ubuntu-latest
+    env: 
+      VERSION: ${{needs.get-version.outputs.ver}}
+      VERSIONED_RELEASE: v${{needs.get-version.outputs.ver}}
+      RELEASE_ID: ${{ github.event.release.id }}
+    steps:
+      - name: If release name is set and does not correspond correctly to tag (mismatch versioning in release name and tag), exit.
+        if: ${{ github.event.release.name != '' && github.event.release.name != env.VERSION && github.event.release.name != env.VERSIONED_RELEASE }}
+        run: |
+          echo "Release name not equivilant to the version!"
+          echo "Failing job."
+          exit 1
+      - name: Update release name
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { VERSION, VERSIONED_RELEASE, RELEASE_ID } = process.env
+            
+            github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: `${RELEASE_ID}`,
+              name: `${VERSION}`
+            })        
+  dd-java-agent:
+    needs: get-version
+    runs-on: ubuntu-latest
+    env: 
+      VERSION: ${{needs.get-version.outputs.ver}}
     steps:
       - name: Download from Sonatype
         run: |
@@ -31,7 +68,10 @@ jobs:
           asset_name: dd-java-agent.jar
           asset_content_type: application/java-archive
   dd-trace-api:
+    needs: get-version
     runs-on: ubuntu-latest
+    env: 
+      VERSION: ${{needs.get-version.outputs.ver}}
     steps:
       - name: Download from Sonatype
         run: |
@@ -46,7 +86,10 @@ jobs:
           asset_name: dd-trace-api-${{ env.VERSION }}.jar
           asset_content_type: application/java-archive
   dd-trace-ot:
+    needs: get-version
     runs-on: ubuntu-latest
+    env: 
+      VERSION: ${{needs.get-version.outputs.ver}}
     steps:
       - name: Download from Sonatype
         run: |

--- a/.github/workflows/add-assets-to-release.yaml
+++ b/.github/workflows/add-assets-to-release.yaml
@@ -39,16 +39,11 @@ jobs:
               release_id: `${RELEASE_ID}`,
               name: `${VERSION}`
             })        
-      - name: Return clean version as output
-        id: version_name
-        run: echo "version=${VERSION}" >> $GITHUB_OUTPUT
-    outputs:
-      ver: ${{ steps.version_name.outputs.version }}
   dd-java-agent:
-    needs: test-and-set-version
+    needs: [get-version, test-and-set-version]
     runs-on: ubuntu-latest
     env: 
-      VERSION: ${{needs.test-and-set-version.outputs.ver}}
+      VERSION: ${{needs.get-version.outputs.ver}}
     steps:
       - name: Download from Sonatype
         run: |
@@ -73,10 +68,10 @@ jobs:
           asset_name: dd-java-agent.jar
           asset_content_type: application/java-archive
   dd-trace-api:
-    needs: test-and-set-version
+    needs: [get-version, test-and-set-version]
     runs-on: ubuntu-latest
     env: 
-      VERSION: ${{needs.test-and-set-version.outputs.ver}}
+      VERSION: ${{needs.get-version.outputs.ver}}
     steps:
       - name: Download from Sonatype
         run: |
@@ -91,10 +86,10 @@ jobs:
           asset_name: dd-trace-api-${{ env.VERSION }}.jar
           asset_content_type: application/java-archive
   dd-trace-ot:
-    needs: test-and-set-version
+    needs: [get-version, test-and-set-version]
     runs-on: ubuntu-latest
     env: 
-      VERSION: ${{needs.test-and-set-version.outputs.ver}}
+      VERSION: ${{needs.get-version.outputs.ver}}
     steps:
       - name: Download from Sonatype
         run: |

--- a/.github/workflows/add-assets-to-release.yaml
+++ b/.github/workflows/add-assets-to-release.yaml
@@ -19,19 +19,19 @@ jobs:
     env: 
       VERSION: ${{needs.get-version.outputs.ver}}
       VERSIONED_RELEASE: v${{needs.get-version.outputs.ver}}
-      RELEASE_ID: ${{ github.event.release.id }}
+      RELEASE_ID: ${{github.event.release.id}}
     steps:
       - name: If release name is set and does not correspond correctly to tag (mismatch versioning in release name and tag), exit.
         if: ${{ github.event.release.name != '' && github.event.release.name != env.VERSION && github.event.release.name != env.VERSIONED_RELEASE }}
         run: |
-          echo "Release name not equivilant to the version!"
-          echo "Failing job."
+          echo "Failing job. Release name is invalid for this tag. Clear the contents of the Release Name field and retry."
           exit 1
       - name: Update release name
         uses: actions/github-script@v6
         with:
           script: |
-            const { VERSION, VERSIONED_RELEASE, RELEASE_ID } = process.env
+            const VERSION = process.env.VERSION
+            const RELEASE_ID = process.env.RELEASE_ID
             
             github.rest.repos.updateRelease({
               owner: context.repo.owner,
@@ -39,11 +39,16 @@ jobs:
               release_id: `${RELEASE_ID}`,
               name: `${VERSION}`
             })        
+      - name: Return clean version as output
+        id: version_name
+        run: echo "version=${VERSION}" >> $GITHUB_OUTPUT
+    outputs:
+      ver: ${{ steps.version_name.outputs.version }}
   dd-java-agent:
-    needs: get-version
+    needs: test-and-set-version
     runs-on: ubuntu-latest
     env: 
-      VERSION: ${{needs.get-version.outputs.ver}}
+      VERSION: ${{needs.test-and-set-version.outputs.ver}}
     steps:
       - name: Download from Sonatype
         run: |
@@ -68,10 +73,10 @@ jobs:
           asset_name: dd-java-agent.jar
           asset_content_type: application/java-archive
   dd-trace-api:
-    needs: get-version
+    needs: test-and-set-version
     runs-on: ubuntu-latest
     env: 
-      VERSION: ${{needs.get-version.outputs.ver}}
+      VERSION: ${{needs.test-and-set-version.outputs.ver}}
     steps:
       - name: Download from Sonatype
         run: |
@@ -86,10 +91,10 @@ jobs:
           asset_name: dd-trace-api-${{ env.VERSION }}.jar
           asset_content_type: application/java-archive
   dd-trace-ot:
-    needs: get-version
+    needs: test-and-set-version
     runs-on: ubuntu-latest
     env: 
-      VERSION: ${{needs.get-version.outputs.ver}}
+      VERSION: ${{needs.test-and-set-version.outputs.ver}}
     steps:
       - name: Download from Sonatype
         run: |


### PR DESCRIPTION
# What Does This Do
Gets the $VERSION (e.g "0.123.0") from the tag instead of the user supplied Release Name field and strips the leading 'v' automatically. Release Name will be populated automatically so the user should leave it empty when drafting the release. 
In the case that Release Name is populated however, if it does not match up with stripped $VERSION, the workflow will be forced to fail.

# Motivation

Currently the user must remove the 'v' from the tag like "v0.123.0" -> "0.123.0" and put this new value in the _Release Title_ field.  The value later populates $VERSION.  If the user does not strip the 'v', subsequent release steps fail.  

Currently [update-issues-on-release.yaml](https://github.com/DataDog/dd-trace-java/blob/master/.github/workflows/update-issues-on-release.yaml#:~:text=github.event.release.name) and [update-download-releases.yaml](https://github.com/DataDog/dd-trace-java/blob/master/.github/workflows/update-download-releases.yaml#:~:text=github.event.release.name) also read `github.event.release.name`.  Maybe those can also be changed to depend directly on the `tag` instead.
