### PR TITLE
Disable `jdk.ClassLoaderStatistics` unless running on JDK17 or later

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -16,12 +16,14 @@
 package com.datadog.profiling.controller.openjdk;
 
 import static com.datadog.profiling.controller.ProfilingSupport.*;
+import static datadog.trace.api.Platform.isJavaVersionAtLeast;
 
 import com.datadog.profiling.controller.ConfigurationException;
 import com.datadog.profiling.controller.Controller;
 import com.datadog.profiling.controller.UnsupportedEnvironmentException;
 import com.datadog.profiling.controller.jfr.JfpUtils;
 import com.datadog.profiling.controller.openjdk.events.AvailableProcessorCoresEvent;
+import datadog.trace.api.Platform;
 import datadog.trace.api.config.ProfilingConfig;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
@@ -67,28 +69,20 @@ public final class OpenJdkController implements Controller {
 
     // Toggle settings based on JDK version
 
-    if (isOldObjectSampleEnabledInRecordingSettings(recordingSettings)
-        && !isOldObjectSampleAvailable()) {
-      log.debug(
-          "Inexpensive live object profiling is not supported for this JDK. "
-              + "Disabling OldObjectSample JFR event.");
-      recordingSettings.put("jdk.OldObjectSample#enabled", "false");
+    if (!isOldObjectSampleAvailable()) {
+      disableEvent(recordingSettings, "jdk.OldObjectSample");
     }
 
-    if (isObjectAllocationSampleEnabledInRecordingSettings(recordingSettings)
-        && !isObjectAllocationSampleAvailable()) {
-      log.debug(
-          "Inexpensive allocation profiling is not supported for this JDK. "
-              + "Disabling ObjectAllocationSample JFR event.");
-      recordingSettings.put("jdk.ObjectAllocationSample#enabled", "false");
+    if (!isObjectAllocationSampleAvailable()) {
+      disableEvent(recordingSettings, "jdk.ObjectAllocationSample");
     }
 
-    if (isNativeMethodSampleEnabledInRecordingSettings(recordingSettings)
-        && !isNativeMethodSampleAvailable()) {
-      log.debug(
-          "Inexpensive native profiling is not supported for this JDK. "
-              + "Disabling NativeMethodSample JFR event.");
-      recordingSettings.put("jdk.NativeMethodSample#enabled", "false");
+    if (!isNativeMethodSampleAvailable()) {
+      disableEvent(recordingSettings, "jdk.NativeMethodSample");
+    }
+
+    if (!isJavaVersionAtLeast(17)) {
+      disableEvent(recordingSettings, "jdk.ClassLoaderStatistics");
     }
 
     // Toggle settings from override file
@@ -103,43 +97,43 @@ public final class OpenJdkController implements Controller {
 
     // Toggle settings from config
 
-    if (isOldObjectSampleEnabledInConfig(configProvider)) {
+    if (configProvider.getBoolean(
+        ProfilingConfig.PROFILING_HEAP_ENABLED, ProfilingConfig.PROFILING_HEAP_ENABLED_DEFAULT)) {
       log.debug("Enabling OldObjectSample JFR event with the config.");
       recordingSettings.put("jdk.OldObjectSample#enabled", "true");
     }
 
-    if (isObjectAllocationSampleEnabledInConfig(configProvider)) {
-      if (isObjectAllocationSampleAvailable()) {
-        // jdk.ObjectAllocationSample is available and enabled by default
-      } else {
+    if (configProvider.getBoolean(
+        ProfilingConfig.PROFILING_ALLOCATION_ENABLED, isObjectAllocationSampleAvailable())) {
+      // jdk.ObjectAllocationSample is available and enabled by default
+      if (!isObjectAllocationSampleAvailable()) {
         log.debug(
             "Enabling ObjectAllocationInNewTLAB and ObjectAllocationOutsideTLAB JFR events with the config.");
         recordingSettings.put("jdk.ObjectAllocationInNewTLAB#enabled", "true");
         recordingSettings.put("jdk.ObjectAllocationOutsideTLAB#enabled", "true");
       }
     } else {
+      // jdk.ObjectAllocationInNewTLAB and jdk.ObjectAllocationOutsideTLAB are disabled by default
       if (isObjectAllocationSampleAvailable()) {
         log.debug("Disabling ObjectAllocationSample JFR event with the config.");
         recordingSettings.put("jdk.ObjectAllocationSample#enabled", "false");
-      } else {
-        // jdk.ObjectAllocationInNewTLAB and jdk.ObjectAllocationOutsideTLAB are disabled by default
       }
     }
 
     // Warn users for expensive events
 
-    if (isOldObjectSampleEnabledInRecordingSettings(recordingSettings)
-        && !isOldObjectSampleAvailable()) {
+    if (!isOldObjectSampleAvailable()
+        && isEventEnabled(recordingSettings, "jdk.OldObjectSample#enabled")) {
       log.warn("Inexpensive heap profiling is not supported for this JDK but is enabled.");
     }
 
-    if (isObjectAllocationInNewTLABEnabledInRecordingSettings(recordingSettings)
-        || isObjectAllocationOutsideTLABEnabledInRecordingSettings(recordingSettings)) {
+    if (isEventEnabled(recordingSettings, "jdk.ObjectAllocationInNewTLAB")
+        || isEventEnabled(recordingSettings, "jdk.ObjectAllocationOutsideTLAB")) {
       log.warn("Inexpensive allocation profiling is not supported for this JDK but is enabled.");
     }
 
-    if (isNativeMethodSampleEnabledInRecordingSettings(recordingSettings)
-        && !isNativeMethodSampleAvailable()) {
+    if (!isNativeMethodSampleAvailable()
+        && isEventEnabled(recordingSettings, "jdk.NativeMethodSample")) {
       log.warn("Inexpensive native profiling is not supported for this JDK but is enabled.");
     }
 
@@ -163,46 +157,17 @@ public final class OpenJdkController implements Controller {
         recordingName, recordingSettings, getMaxSize(), RECORDING_MAX_AGE);
   }
 
-  // jdk.OldObjectSample
-
-  boolean isOldObjectSampleEnabledInConfig(ConfigProvider configProvider) {
-    return configProvider.getBoolean(
-        ProfilingConfig.PROFILING_HEAP_ENABLED, ProfilingConfig.PROFILING_HEAP_ENABLED_DEFAULT);
+  private static void disableEvent(Map<String, String> recordingSettings, String event) {
+    String wasEnabled = recordingSettings.put(event + "#enabled", "false");
+    if (Boolean.parseBoolean(wasEnabled)) {
+      log.debug(
+          "Disabling JFR event {} because it is expensive on the current version of the JVM ({}).",
+          event,
+          Platform.getRuntimeVersion());
+    }
   }
 
-  boolean isOldObjectSampleEnabledInRecordingSettings(Map<String, String> recordingSettings) {
-    return Boolean.parseBoolean(recordingSettings.get("jdk.OldObjectSample#enabled"));
-  }
-
-  // jdk.ObjectAllocationSample
-
-  boolean isObjectAllocationSampleEnabledInConfig(ConfigProvider configProvider) {
-    return configProvider.getBoolean(
-        ProfilingConfig.PROFILING_ALLOCATION_ENABLED, isObjectAllocationSampleAvailable());
-  }
-
-  boolean isObjectAllocationSampleEnabledInRecordingSettings(
-      Map<String, String> recordingSettings) {
-    return Boolean.parseBoolean(recordingSettings.get("jdk.ObjectAllocationSample#enabled"));
-  }
-
-  // jdk.ObjectAllocationInNewTLAB
-
-  boolean isObjectAllocationInNewTLABEnabledInRecordingSettings(
-      Map<String, String> recordingSettings) {
-    return Boolean.parseBoolean(recordingSettings.get("jdk.ObjectAllocationInNewTLAB#enabled"));
-  }
-
-  // jdk.ObjectAllocationOutsideTLAB
-
-  boolean isObjectAllocationOutsideTLABEnabledInRecordingSettings(
-      Map<String, String> recordingSettings) {
-    return Boolean.parseBoolean(recordingSettings.get("jdk.ObjectAllocationOutsideTLAB#enabled"));
-  }
-
-  // jdk.NativeMethodSample
-
-  boolean isNativeMethodSampleEnabledInRecordingSettings(Map<String, String> recordingSettings) {
-    return Boolean.parseBoolean(recordingSettings.get("jdk.NativeMethodSample#enabled"));
+  private static boolean isEventEnabled(Map<String, String> recordingSettings, String event) {
+    return Boolean.parseBoolean(recordingSettings.get(event + "#enabled"));
   }
 }


### PR DESCRIPTION
# What Does This Do

Simplifies the event checks in `OpenJdkController` and disables `jdk.ClassLoaderStatistics` on older JVMs

# Motivation

Prior to JDK15, `jdk.ClassLoaderStatistics` was expensive, but it was fixed in [JDK-8244733](https://bugs.openjdk.org/browse/JDK-8244733). The first LTS to support this event efficiently was JDK17, so disable the event before JDK17.

# Additional Notes
