### PR TITLE
Add config knob for collapsing wallclock samples

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
@@ -254,7 +254,11 @@ public final class AsyncProfiler {
     }
     if (profilingModes.contains(ProfilingMode.WALL)) {
       // wall profiling is enabled.
-      cmd.append(",wall=").append(getWallInterval()).append('m');
+      cmd.append(",wall=");
+      if (isCollapsingWallclock()) {
+        cmd.append('~'); // this prefix will turn on wall-clock collapsing feature
+      }
+      cmd.append(getWallInterval()).append('m');
       if (getWallFilterOnContext()) {
         cmd.append(",wallfilter");
       }
@@ -299,6 +303,12 @@ public final class AsyncProfiler {
     return configProvider.getBoolean(
         ProfilingConfig.PROFILING_ASYNC_WALL_FILTER_ON_CONTEXT,
         ProfilingConfig.PROFILING_ASYNC_WALL_FILTER_ON_CONTEXT_DEFAULT);
+  }
+
+  public boolean isCollapsingWallclock() {
+    return configProvider.getBoolean(
+        ProfilingConfig.PROFILING_ASYNC_WALL_COLLAPSE_SAMPLES,
+        ProfilingConfig.PROFILING_ASYNC_WALL_COLLAPSE_SAMPLES_DEFAULT);
   }
 
   private int getStackDepth() {

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -72,6 +72,11 @@ public final class ProfilingConfig {
   public static final String PROFILING_ASYNC_WALL_FILTER_ON_CONTEXT =
       "profiling.async.wall.filter-on-context";
   public static final boolean PROFILING_ASYNC_WALL_FILTER_ON_CONTEXT_DEFAULT = true;
+
+  public static final String PROFILING_ASYNC_WALL_COLLAPSE_SAMPLES =
+      "profiling.async.wall.collapse.samples";
+  public static final boolean PROFILING_ASYNC_WALL_COLLAPSE_SAMPLES_DEFAULT = true;
+
   public static final String PROFILING_ASYNC_STACKDEPTH = "profiling.async.stackdepth";
   public static final int PROFILING_ASYNC_STACKDEPTH_DEFAULT = 512;
   public static final String PROFILING_ASYNC_CSTACK = "profiling.async.cstack";


### PR DESCRIPTION
# What Does This Do
Adds a config option to enable/disable wallclock sample collapsing

# Motivation

# Additional Notes
