### PR TITLE
Telemetry lazy loading

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/RequestBuilderSupplier.java
+++ b/telemetry/src/main/java/datadog/telemetry/RequestBuilderSupplier.java
@@ -1,0 +1,21 @@
+package datadog.telemetry;
+
+import datadog.trace.api.function.Supplier;
+import okhttp3.HttpUrl;
+
+class RequestBuilderSupplier implements Supplier<RequestBuilder> {
+  private final HttpUrl httpUrl;
+  private RequestBuilder requestBuilder;
+
+  RequestBuilderSupplier(HttpUrl httpUrl) {
+    this.httpUrl = httpUrl;
+  }
+
+  @Override
+  public RequestBuilder get() {
+    if (requestBuilder == null) {
+      requestBuilder = new RequestBuilder(httpUrl);
+    }
+    return requestBuilder;
+  }
+}

--- a/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
@@ -51,10 +51,9 @@ public class TelemetrySystem {
       Instrumentation instrumentation, SharedCommunicationObjects sco) {
     try {
       DependencyService dependencyService = createDependencyService(instrumentation);
-      RequestBuilder requestBuilder = new RequestBuilder(sco.agentUrl);
       TelemetryService telemetryService =
           new TelemetryServiceImpl(
-              requestBuilder,
+              new RequestBuilderSupplier(sco.agentUrl),
               SystemTimeSource.INSTANCE,
               Config.get().getTelemetryHeartbeatInterval());
       TELEMETRY_THREAD =

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
@@ -9,6 +9,7 @@ import datadog.telemetry.api.GenerateMetrics
 import datadog.telemetry.api.Integration
 import datadog.telemetry.api.Metric
 import datadog.telemetry.api.RequestType
+import datadog.trace.api.function.Supplier
 import datadog.trace.api.time.TimeSource
 import datadog.trace.test.util.DDSpecification
 import okhttp3.Request
@@ -21,8 +22,14 @@ class TelemetryServiceSpecification extends DDSpecification {
   RequestBuilder requestBuilder = Mock {
     build(_ as RequestType) >> REQUEST
   }
+  Supplier<RequestBuilder> requestBuilderSupplier = new Supplier<RequestBuilder>() {
+    @Override
+    RequestBuilder get() {
+      return requestBuilder
+    }
+  }
   TelemetryServiceImpl telemetryService =
-  new TelemetryServiceImpl(requestBuilder, timeSource, 1)
+  new TelemetryServiceImpl(requestBuilderSupplier, timeSource, 1)
 
   void 'heartbeat interval every 1 sec'() {
     // Time: 0 seconds - no packets yet


### PR DESCRIPTION
# What Does This Do
JRN and RequestBuilder initialisation moved into separated thread to reduce startup overhead

# Motivation

# Additional Notes
Benchmarks:
<img width="1100" alt="Screenshot 2022-10-14 at 17 57 34" src="https://user-images.githubusercontent.com/7569471/195878465-e9fecf66-9bf6-453c-9190-e199ba38bd67.png">
