### PR TITLE
Telemetry enabled by default

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -131,7 +131,7 @@ public final class ConfigDefaults {
   static final int DEFAULT_RESOLVER_OUTLINE_POOL_SIZE = 128;
   static final int DEFAULT_RESOLVER_TYPE_POOL_SIZE = 64;
 
-  static final boolean DEFAULT_TELEMETRY_ENABLED = false;
+  static final boolean DEFAULT_TELEMETRY_ENABLED = true;
   static final int DEFAULT_TELEMETRY_HEARTBEAT_INTERVAL = 60; // in seconds
 
   public static final int DEFAULT_TRACE_X_DATADOG_TAGS_MAX_LENGTH = 512;


### PR DESCRIPTION
# What Does This Do
Enabled telemetry by default. 
To disable it explicitly - use env variable `DD_INSTRUMENTATION_TELEMETRY_ENABLED=false` or startup option `-Ddd.instrumentation.telemetry.enabled=false`

# Motivation

# Additional Notes
