### PR TITLE
Remote config enabled by default

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -92,7 +92,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_CIVISIBILITY_ENABLED = false;
   static final boolean DEFAULT_CIVISIBILITY_AGENTLESS_ENABLED = false;
 
-  static final boolean DEFAULT_REMOTE_CONFIG_ENABLED = false;
+  static final boolean DEFAULT_REMOTE_CONFIG_ENABLED = true;
   static final boolean DEFAULT_REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED = false;
   static final int DEFAULT_REMOTE_CONFIG_MAX_PAYLOAD_SIZE = 1024; // KiB
   static final int DEFAULT_REMOTE_CONFIG_INITIAL_POLL_INTERVAL = 5; // s


### PR DESCRIPTION
# What Does This Do
Enabled remote config by default.
To disable it explicitly - use env variable `DD_REMOTE_CONFIG_ENABLED=false` or startup option `-Ddd.remote_config.enabled=false`

# Motivation

# Additional Notes
