### PR TITLE
Fix ASM 1-click de-activation

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
@@ -105,10 +105,12 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
         Product.ASM_FEATURES,
         AppSecFeaturesDeserializer.INSTANCE,
         (configKey, newConfig, hinter) -> {
-          if (AppSecSystem.ACTIVE != newConfig.asm.enabled) {
-            log.warn("AppSec {} (runtime)", newConfig.asm.enabled ? "enabled" : "disabled");
+          final boolean newState =
+              newConfig != null && newConfig.asm != null && newConfig.asm.enabled;
+          if (AppSecSystem.ACTIVE != newState) {
+            log.warn("AppSec {} (runtime)", newState ? "enabled" : "disabled");
+            AppSecSystem.ACTIVE = newState;
           }
-          AppSecSystem.ACTIVE = newConfig.asm.enabled;
         });
 
     this.configurationPoller.addCapabilities(

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecConfigServiceImplSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecConfigServiceImplSpecification.groovy
@@ -170,6 +170,38 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
     then:
     AppSecSystem.ACTIVE == false
 
+    when: 'switch back to enabled'
+    savedFeaturesListener.accept('config_key',
+      savedFeaturesDeserializer.deserialize('{"asm":{"enabled": true}}'.bytes),
+      ConfigurationChangesListener.PollingRateHinter.NOOP)
+
+    then: 'it is enabled again'
+    AppSecSystem.ACTIVE == true
+
+    when: 'asm are not set'
+    savedFeaturesListener.accept('config_key',
+      savedFeaturesDeserializer.deserialize('{}'.bytes),
+      ConfigurationChangesListener.PollingRateHinter.NOOP)
+
+    then: 'it is disabled (<not set> == false)'
+    AppSecSystem.ACTIVE == false
+
+    when: 'switch back to enabled'
+    savedFeaturesListener.accept('config_key',
+      savedFeaturesDeserializer.deserialize('{"asm":{"enabled": true}}'.bytes),
+      ConfigurationChangesListener.PollingRateHinter.NOOP)
+
+    then: 'it is enabled again'
+    AppSecSystem.ACTIVE == true
+
+    when: 'asm features are not set'
+    savedFeaturesListener.accept('config_key',
+      null,
+      ConfigurationChangesListener.PollingRateHinter.NOOP)
+
+    then: 'it is disabled (<not set> == false)'
+    AppSecSystem.ACTIVE == false
+
     cleanup:
     AppSecSystem.ACTIVE = true
   }


### PR DESCRIPTION
# What Does This Do
On ASM_ACTIVATION, default to false if there is no payload.

# Motivation
We were expecting enable: false, but the value can also be not set.

# Additional Notes
At some point, we might want to just change the deserializer to guarantee that this is never null.