### PR TITLE
enable/disable profiler events with ergonomic flags

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
@@ -60,6 +60,8 @@ public final class AsyncProfiler {
     } else {
       asyncProfiler = inferFromOsAndArch();
     }
+    // TODO enable/disable events by name (e.g. datadog.ExecutionSample), not flag, so configuration
+    //  can be consistent with JFR event control
     if (configProvider.getBoolean(
         ProfilingConfig.PROFILING_ASYNC_ALLOC_ENABLED,
         ProfilingConfig.PROFILING_ASYNC_ALLOC_ENABLED_DEFAULT)) {

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -146,5 +146,8 @@ public final class ProfilingConfig {
   public static final String PROFILING_AGENTLESS = "profiling.agentless";
   public static final boolean PROFILING_AGENTLESS_DEFAULT = false;
 
+  public static final String PROFILING_DISABLED_EVENTS = "profiling.disabled.events";
+  public static final String PROFILING_ENABLED_EVENTS = "profiling.disabled.events";
+
   private ProfilingConfig() {}
 }


### PR DESCRIPTION
# What Does This Do

Allows users to override settings more ergonomically, by providing comma separated lists of event names, e.g.

```
-Ddd.profiling.disabled.events=jdk.ClassLoaderStatistics,jdk.ObjectAllocationInNewTLAB
-Ddd.profiling.enabled.events=jdk.ExecutionSample
```

This currently only applies to JFR events, but can be extended to control events emitted by async-profiler.

# Motivation

# Additional Notes
