### PR TITLE
Upgrade async-profiler, simplify tracing context filtering

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
@@ -137,6 +137,11 @@ public final class AsyncProfiler {
             os,
             t.getMessage());
       }
+      throw new UnsupportedEnvironmentException(
+          String.format(
+              "Unable to instantiate async profiler for the detected environment: arch=%s, os=%s",
+              arch, os),
+          t);
     }
     throw new UnsupportedEnvironmentException(
         String.format(

--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
@@ -140,9 +140,8 @@ public final class AsyncProfiler {
     }
     throw new UnsupportedEnvironmentException(
         String.format(
-            "Unable to instantiate async profiler for the detected environment: arch={}, os={}",
-            arch,
-            os));
+            "Unable to instantiate async profiler for the detected environment: arch=%s, os=%s",
+            arch, os));
   }
 
   void addCurrentThread() {
@@ -273,9 +272,6 @@ public final class AsyncProfiler {
         cmd.append('~'); // this prefix will turn on wall-clock collapsing feature
       }
       cmd.append(getWallInterval()).append('m');
-      if (getWallFilterOnContext()) {
-        cmd.append(",wallfilter");
-      }
     }
     if (profilingModes.contains(ProfilingMode.ALLOCATION)) {
       // allocation profiling is enabled
@@ -311,12 +307,6 @@ public final class AsyncProfiler {
     return configProvider.getInteger(
         ProfilingConfig.PROFILING_ASYNC_WALL_INTERVAL,
         ProfilingConfig.PROFILING_ASYNC_WALL_INTERVAL_DEFAULT);
-  }
-
-  public boolean getWallFilterOnContext() {
-    return configProvider.getBoolean(
-        ProfilingConfig.PROFILING_ASYNC_WALL_FILTER_ON_CONTEXT,
-        ProfilingConfig.PROFILING_ASYNC_WALL_FILTER_ON_CONTEXT_DEFAULT);
   }
 
   public boolean isCollapsingWallclock() {

--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
@@ -272,6 +272,7 @@ public final class AsyncProfiler {
         cmd.append('~'); // this prefix will turn on wall-clock collapsing feature
       }
       cmd.append(getWallInterval()).append('m');
+      cmd.append(",filter=0");
     }
     if (profilingModes.contains(ProfilingMode.ALLOCATION)) {
       // allocation profiling is enabled

--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/AsyncProfilerTracingContextTrackerFactory.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/AsyncProfilerTracingContextTrackerFactory.java
@@ -16,11 +16,8 @@ public final class AsyncProfilerTracingContextTrackerFactory
             ProfilingConfig.PROFILING_ASYNC_ENABLED,
             ProfilingConfig.PROFILING_ASYNC_ENABLED_DEFAULT)
         && configProvider.getBoolean(
-            ProfilingConfig.PROFILING_ASYNC_WALL_ENABLED,
-            ProfilingConfig.PROFILING_ASYNC_WALL_ENABLED_DEFAULT)
-        && configProvider.getBoolean(
-            ProfilingConfig.PROFILING_ASYNC_WALL_FILTER_ON_CONTEXT,
-            ProfilingConfig.PROFILING_ASYNC_WALL_FILTER_ON_CONTEXT_DEFAULT);
+            ProfilingConfig.PROFILING_TRACING_CONTEXT_ENABLED,
+            ProfilingConfig.PROFILING_TRACING_CONTEXT_ENABLED_DEFAULT);
   }
 
   public static void register(ConfigProvider configProvider) {

--- a/dd-java-agent/agent-profiling/profiling-context/src/test/java/com/datadog/profiling/context/AsyncProfilerTracingContextTrackerFactoryTest.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/test/java/com/datadog/profiling/context/AsyncProfilerTracingContextTrackerFactoryTest.java
@@ -14,8 +14,7 @@ class AsyncProfilerTracingContextTrackerFactoryTest {
   void testTracingAvailable() {
     Properties props = new Properties();
     props.put(ProfilingConfig.PROFILING_ASYNC_ENABLED, Boolean.toString(true));
-    props.put(ProfilingConfig.PROFILING_ASYNC_WALL_ENABLED, Boolean.toString(true));
-    props.put(ProfilingConfig.PROFILING_ASYNC_WALL_FILTER_ON_CONTEXT, Boolean.toString(true));
+    props.put(ProfilingConfig.PROFILING_TRACING_CONTEXT_ENABLED, Boolean.toString(true));
     ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
 
     assertTrue(AsyncProfilerTracingContextTrackerFactory.isEnabled(configProvider));

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -69,9 +69,6 @@ public final class ProfilingConfig {
   public static final boolean PROFILING_ASYNC_WALL_ENABLED_DEFAULT = true;
   public static final String PROFILING_ASYNC_WALL_INTERVAL = "profiling.async.wall.interval.ms";
   public static final int PROFILING_ASYNC_WALL_INTERVAL_DEFAULT = 10;
-  public static final String PROFILING_ASYNC_WALL_FILTER_ON_CONTEXT =
-      "profiling.async.wall.filter-on-context";
-  public static final boolean PROFILING_ASYNC_WALL_FILTER_ON_CONTEXT_DEFAULT = true;
 
   public static final String PROFILING_ASYNC_WALL_COLLAPSE_SAMPLES =
       "profiling.async.wall.collapse.samples";

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    asyncprofiler : "2.8.3-DD-20221011",
+    asyncprofiler : "2.8.3-DD-20221019_1",
     asm           : "9.2"
   ]
 


### PR DESCRIPTION
# What Does This Do

Reuses the same config flag for tracing context enablement, and retires the old flag. No longer sends a command to async-profiler to enable context explicitly since the native side will soon be passive leaving dd-trace-java in control of whether context updates are made. 

# Motivation

# Additional Notes
