### PR TITLE
Shade third party dependencies

### DIFF
--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -32,6 +32,22 @@ ext.generalShadowJarConfig = {
 
   exclude '**/module-info.class'
 
+  // Shade third party dependencies behind a 'ddlib.' prefix
+  relocate 'cafe.', 'ddlib.cafe.'
+  relocate('com.', 'ddlib.com.') {
+    exclude 'com.datadog.**'
+    exclude 'com.datadoghq.**'
+  }
+  relocate 'io.', 'ddlib.io.'
+  relocate 'jnr.', 'ddlib.jnr.'
+  relocate 'net.', 'ddlib.net.'
+  relocate 'okhttp3.', 'ddlib.okhttp3.'
+  relocate 'okio.', 'ddlib.okio.'
+  relocate 'one.', 'ddlib.one.'
+  relocate('org.', 'ddlib.org.') {
+    exclude 'org.slf4j.**'
+    exclude 'org.datadog.**'
+  }
   // Prevents conflict with other SLF4J instances. Important for premain.
   relocate 'org.slf4j', 'datadog.slf4j'
   // rewrite dependencies calling Logger.getLogger


### PR DESCRIPTION
# What Does This Do

This PR shades the agent third party dependencies.

# Motivation

Shading dependencies will decrease compatibility issue when running the agent with `native-image`.

# Additional Notes

I used relocation patterns with a leading dot (`.`) on purpose.
I come across an issue where the shading gradle plugin was transforming Java AtomicXXXFieldUpdater constructor calls by updating the field names (it should only update the first parameter which is the class name but sadly, it also applies it to the second parameter: the field name).  
So in `PendingTraces` class, we have:
```java
 private volatile int completedSpanCount = 0;
  private static final AtomicIntegerFieldUpdater<PendingTrace> COMPLETED_SPAN_COUNT =
      AtomicIntegerFieldUpdater.newUpdater(PendingTrace.class, "completedSpanCount");
```
which was transformed in:
```java
 private volatile int completedSpanCount = 0;
  private static final AtomicIntegerFieldUpdater<PendingTrace> COMPLETED_SPAN_COUNT =
      AtomicIntegerFieldUpdater.newUpdater(PendingTrace.class, "ddlib.completedSpanCount");
```
Because `"completeSpanCount"` matches `com` in the following relocation rule:
```java
relocate('com', 'ddlib.com')
```

Using patched rule `relocate('com.', 'ddlib.com.')` do not trigger this issue.