### PR TITLE
add sanity check for embedded JFR event context, enable profiling context integration for all smoke tests

### DIFF
--- a/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
+++ b/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
@@ -70,7 +70,7 @@ public class ProfilingAgent {
             "Profiling: API key doesn't match expected format, expected to get a 32 character hex string. Profiling is disabled.");
         return;
       }
-      if (Platform.isJavaVersionAtLeast(9)) {
+      if (Platform.isJavaVersionAtLeast(9) && Platform.hasJfr()) {
         JfrTimestampPatch.execute(agentClasLoader);
       }
 

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -88,7 +88,8 @@ abstract class AbstractSmokeTest extends ProcessManager {
     "-Ddd.profiling.start-delay=${PROFILING_START_DELAY_SECONDS}",
     "-Ddd.profiling.upload.period=${PROFILING_RECORDING_UPLOAD_PERIOD_SECONDS}",
     "-Ddd.profiling.url=${getProfilingUrl()}",
-    "-Ddd.profiling.async.enabled=false",
+    "-Ddd.profiling.async.enabled=true",
+    "-Ddd.profiling.tracing_context.enabled=true",
     "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=${logLevel()}",
     "-Dorg.slf4j.simpleLogger.defaultLogLevel=${logLevel()}"
   ]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    asyncprofiler : "2.8.3-DD-20221020",
+    asyncprofiler : "2.8.3-DD-20221020_2",
     asm           : "9.2"
   ]
 


### PR DESCRIPTION
# What Does This Do

* Enables context tracking in all smoke tests, just in case it crashes something
* Adds a sanity check for embedded context in Datadog events whenever they are emitted in `ProfilingIntegrationTest`

# Motivation

# Additional Notes
