### PR TITLE
Ensure buildSrc can be tested with JDKs > 11

### DIFF
--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -7,6 +7,11 @@ plugins {
   id("com.github.johnrengelman.shadow") version "7.1.2"
 }
 
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 spotless {
   java {
     toggleOffOn()

--- a/buildSrc/src/test/groovy/CallSiteInstrumentationPluginTest.groovy
+++ b/buildSrc/src/test/groovy/CallSiteInstrumentationPluginTest.groovy
@@ -12,6 +12,9 @@ class CallSiteInstrumentationPluginTest extends Specification {
       id 'call-site-instrumentation'
       id("com.diffplug.spotless") version "5.11.0"
     }
+    
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 
     csi {
       suffix = 'CallSiteTest'

--- a/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
+++ b/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
@@ -14,6 +14,9 @@ class InstrumentPluginTest extends Specification {
       id 'java'
       id 'net.bytebuddy.byte-buddy-gradle-plugin'
     }
+    
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 
     repositories {
       mavenCentral()


### PR DESCRIPTION
# What Does This Do
Ensure the call site instrumentation plugin is compiled for JDK8 and the same for the plugin tests.

# Motivation
Gradle compiles the code and runs all the tests in the `buildSrc` folder, so any issue completely blocks the build process, in our case a wrong JDK was causing the problem due to the tests failing.

# Additional Notes
