### PR TITLE
Use async-profiler snapshot api

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
@@ -43,7 +43,7 @@ public final class AsyncProfiler {
     try {
       instance = new AsyncProfiler();
     } catch (Throwable t) {
-      instance = new AsyncProfiler((Void)null);
+      instance = new AsyncProfiler((Void) null);
     }
     return instance;
   }
@@ -53,7 +53,7 @@ public final class AsyncProfiler {
     try {
       instance = new AsyncProfiler(configProvider);
     } catch (Throwable t) {
-      instance = new AsyncProfiler((Void)null);
+      instance = new AsyncProfiler((Void) null);
     }
     return instance;
   }
@@ -221,6 +221,14 @@ public final class AsyncProfiler {
     return null;
   }
 
+  boolean snapshot(Path snapshotPath) {
+    if (asyncProfiler != null) {
+      log.debug("Creating JFR snapshot");
+      return asyncProfiler.dumpJfr(snapshotPath);
+    }
+    return false;
+  }
+
   /** A call-back from {@linkplain AsyncProfilerRecording#stop()} */
   void stopProfiler() {
     if (asyncProfiler != null) {
@@ -237,7 +245,7 @@ public final class AsyncProfiler {
   }
 
   public Set<ProfilingMode> enabledModes() {
-    return profilingModes;
+    return asyncProfiler != null ? profilingModes : Collections.emptySet();
   }
 
   public boolean isAvailable() {

--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
@@ -15,6 +15,7 @@ import java.lang.management.ManagementFactory;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -42,7 +43,7 @@ public final class AsyncProfiler {
     try {
       instance = new AsyncProfiler();
     } catch (Throwable t) {
-      instance = new AsyncProfiler((Void) null);
+      instance = new AsyncProfiler((Void)null);
     }
     return instance;
   }
@@ -52,7 +53,7 @@ public final class AsyncProfiler {
     try {
       instance = new AsyncProfiler(configProvider);
     } catch (Throwable t) {
-      instance = new AsyncProfiler((Void) null);
+      instance = new AsyncProfiler((Void)null);
     }
     return instance;
   }

--- a/dd-java-agent/agent-profiling/profiling-controller-async/src/main/java/com/datadog/profiling/controller/async/AsyncOngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-async/src/main/java/com/datadog/profiling/controller/async/AsyncOngoingRecording.java
@@ -21,6 +21,7 @@ import com.datadog.profiling.controller.RecordingData;
 import com.datadog.profiling.controller.UnsupportedEnvironmentException;
 import datadog.trace.api.profiling.ProfilingSnapshot;
 import java.time.Instant;
+import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +52,7 @@ public class AsyncOngoingRecording implements OngoingRecording {
   }
 
   @Override
-  public RecordingData snapshot(final Instant start, ProfilingSnapshot.Kind kind) {
+  public RecordingData snapshot(@Nonnull final Instant start, ProfilingSnapshot.Kind kind) {
     return recording.snapshot(start, kind);
   }
 

--- a/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkOngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkOngoingRecording.java
@@ -58,7 +58,6 @@ public class OracleJdkOngoingRecording implements OngoingRecording {
   }
 
   @Override
-  @Nonnull
   public OracleJdkRecordingData snapshot(
       @Nonnull final Instant start, @Nonnull ProfilingSnapshot.Kind kind) {
     log.debug("Taking recording snapshot for time range {} - {}", start, Instant.now());

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/OngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/OngoingRecording.java
@@ -22,9 +22,8 @@ public interface OngoingRecording extends Closeable {
    *
    * @param start start time of the snapshot
    * @param kind the snapshot reason
-   * @return {@link RecordingData} with snapshot information
+   * @return {@link RecordingData} with snapshot information or {@literal null}
    */
-  @Nonnull
   RecordingData snapshot(@Nonnull final Instant start, ProfilingSnapshot.Kind kind);
 
   /** Close recording without capturing any data */


### PR DESCRIPTION
# What Does This Do
Adjusts the async-profiler integration to use the lightweight call to dump JFR data.

# Motivation
Reduce the overhead related to stopping and starting async-profiler engine just to obtain the JFR data.

# Additional Notes
