### PR TITLE
register ContextThreadListener earlier to capture all tracing interactions

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
@@ -23,6 +23,11 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * It is currently assumed that this class can be initialised early so that async-profiler's thread
+ * filter captures all tracing activity, which means it must not be modified to depend on JFR, so
+ * that it can be installed before tracing starts.
+ */
 public final class AsyncProfiler {
   private static final Logger log = LoggerFactory.getLogger(AsyncProfiler.class);
 

--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfilerConfig.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfilerConfig.java
@@ -1,0 +1,17 @@
+package com.datadog.profiling.async;
+
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_ASYNC_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_ASYNC_ENABLED_DEFAULT;
+
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+
+public class AsyncProfilerConfig {
+
+  private static final boolean ASYNC_PROFILER_ENABLED =
+      ConfigProvider.getInstance()
+          .getBoolean(PROFILING_ASYNC_ENABLED, PROFILING_ASYNC_ENABLED_DEFAULT);
+
+  public static boolean isAsyncProfilerEnabled() {
+    return ASYNC_PROFILER_ENABLED;
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/ContextThreadFilter.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/ContextThreadFilter.java
@@ -10,11 +10,15 @@ public class ContextThreadFilter implements ContextThreadListener {
 
   @Override
   public void onAttach() {
-    AsyncProfiler.getInstance().addCurrentThread();
+    if (AsyncProfilerConfig.isAsyncProfilerEnabled()) {
+      AsyncProfiler.getInstance().addCurrentThread();
+    }
   }
 
   @Override
   public void onDetach() {
-    AsyncProfiler.getInstance().removeCurrentThread();
+    if (AsyncProfilerConfig.isAsyncProfilerEnabled()) {
+      AsyncProfiler.getInstance().removeCurrentThread();
+    }
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/ContextThreadFilter.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/ContextThreadFilter.java
@@ -2,6 +2,10 @@ package com.datadog.profiling.async;
 
 import datadog.trace.bootstrap.instrumentation.api.ContextThreadListener;
 
+/**
+ * This class must be installed early to be able to see all scope initialisations, which means it
+ * must not be modified to depend on JFR, so that it can be installed before tracing starts.
+ */
 public class ContextThreadFilter implements ContextThreadListener {
 
   @Override


### PR DESCRIPTION
# What Does This Do

By the time the rest of the profiler gets installed, there might have been a lot of tracing, so we need to install this listener earlier. This imposes constraints on the listener, which its current implementation meets (it doesn't matter when `AsyncProfiler` is created) but care needs to be taken not to introduce a dependency on JFR here in the future.

# Motivation

# Additional Notes
