### PR TITLE
Enable telemetry by default

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -79,7 +79,7 @@ public class Agent {
     CWS("dd.cws.enabled", false),
     CIVISIBILITY("dd.civisibility.enabled", false),
     CIVISIBILITY_AGENTLESS("dd.civisibility.agentless.enabled", false),
-    TELEMETRY("dd.instrumentation.telemetry.enabled", false),
+    TELEMETRY("dd.instrumentation.telemetry.enabled", true),
     DEBUGGER("dd." + DEBUGGER_ENABLED, false);
 
     private final String systemProp;
@@ -120,7 +120,7 @@ public class Agent {
   private static boolean iastEnabled = false;
   private static boolean cwsEnabled = false;
   private static boolean ciVisibilityEnabled = false;
-  private static boolean telemetryEnabled = false;
+  private static boolean telemetryEnabled = true;
   private static boolean debuggerEnabled = false;
 
   public static void start(final Instrumentation inst, final URL agentJarURL) {

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
@@ -47,6 +47,7 @@ public abstract class BaseIntegrationTest {
       "{\"endpoints\": [\"v0.4/traces\", \"debugger/v1/input\", \"v0.7/config\"]}";
   private static final MockResponse agentInfoResponse =
       new MockResponse().setResponseCode(200).setBody(INFO_CONTENT);
+  private static final MockResponse telemetryResponse = new MockResponse().setResponseCode(202);
 
   protected MockWebServer datadogAgentServer;
   private MockDispatcher probeMockDispatcher;
@@ -155,6 +156,10 @@ public abstract class BaseIntegrationTest {
   private MockResponse datadogAgentDispatch(RecordedRequest request) {
     if (request.getPath().equals("/info")) {
       return agentInfoResponse;
+    }
+    if (request.getPath().equals("telemetry/proxy/api/v2/apmtelemetry")) {
+      // Ack every telemetry request. This is needed if telemetry is enabled in the tests.
+      return telemetryResponse;
     }
     if (request.getPath().startsWith(SNAPSHOT_URL_PATH)) {
       return new MockResponse().setResponseCode(200);

--- a/telemetry/src/main/java/datadog/telemetry/dependency/LocationsCollectingTransformer.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/LocationsCollectingTransformer.java
@@ -5,8 +5,8 @@ import java.net.URL;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.util.Collections;
-import java.util.IdentityHashMap;
 import java.util.Set;
+import java.util.WeakHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,7 +15,7 @@ class LocationsCollectingTransformer implements ClassFileTransformer {
 
   private final DependencyServiceImpl dependencyService;
   private final Set<ProtectionDomain> seenDomains =
-      Collections.newSetFromMap(new IdentityHashMap<ProtectionDomain, Boolean>());
+      Collections.newSetFromMap(new WeakHashMap<ProtectionDomain, Boolean>());
 
   public LocationsCollectingTransformer(DependencyServiceImpl dependencyService) {
     this.dependencyService = dependencyService;
@@ -34,6 +34,7 @@ class LocationsCollectingTransformer implements ClassFileTransformer {
     if (!seenDomains.add(protectionDomain)) {
       return null;
     }
+    log.debug("Saw new protection domain: {}", protectionDomain);
 
     CodeSource codeSource = protectionDomain.getCodeSource();
     if (codeSource == null) {

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetrySystemSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetrySystemSpecification.groovy
@@ -15,9 +15,6 @@ class TelemetrySystemSpecification extends DDSpecification {
   Instrumentation inst = Mock()
 
   void 'installs dependencies transformer'() {
-    setup:
-    injectSysConfig('dd.instrumentation.telemetry.enabled', 'true')
-
     when:
     def depService = TelemetrySystem.createDependencyService(inst)
 


### PR DESCRIPTION
# What Does This Do
Enables telemetry by default (take 2). Changes tests for Telemetry to assume it's on by default.

# Motivation
In 0.113.0 we changed the default of the telemetry setting in Config to true, but that's not enough, as it needs to be updated in `Agent` too.

# Additional Notes
