### PR TITLE
Enable remote config by default

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -75,7 +75,7 @@ public class Agent {
     PROFILING("dd.profiling.enabled", false),
     APPSEC("dd.appsec.enabled", false),
     IAST("dd.iast.enabled", false),
-    REMOTE_CONFIG("dd.remote_config.enabled", false),
+    REMOTE_CONFIG("dd.remote_config.enabled", true),
     CWS("dd.cws.enabled", false),
     CIVISIBILITY("dd.civisibility.enabled", false),
     CIVISIBILITY_AGENTLESS("dd.civisibility.agentless.enabled", false),
@@ -116,7 +116,7 @@ public class Agent {
   private static boolean profilingEnabled = false;
   private static boolean appSecEnabled;
   private static boolean appSecFullyDisabled;
-  private static boolean remoteConfigEnabled;
+  private static boolean remoteConfigEnabled = true;
   private static boolean iastEnabled = false;
   private static boolean cwsEnabled = false;
   private static boolean ciVisibilityEnabled = false;

--- a/dd-smoke-tests/appsec/src/main/groovy/datadog/smoketest/appsec/AbstractAppSecServerSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/src/main/groovy/datadog/smoketest/appsec/AbstractAppSecServerSmokeTest.groovy
@@ -45,9 +45,8 @@ abstract class AbstractAppSecServerSmokeTest extends AbstractServerSmokeTest {
     // disable AppSec rate limit
     "-Ddd.appsec.trace.rate.limit=-1"
   ] + (System.getProperty('smoke_test.appsec.enabled') == 'inactive' ?
-  // enable remote config so that appsec is partially enabled
+  // enable remote config so that appsec is partially enabled (rc is now enabled by default)
   [
-    '-Ddd.remote_config.enabled=true',
     '-Ddd.remote_config.url=https://127.0.0.1:54670/invalid_endpoint',
     '-Ddd.remote_config.initial.poll.interval=3600'
   ]:

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
@@ -106,7 +106,7 @@ public abstract class BaseIntegrationTest {
             "-Ddd.jmxfetch.start-delay=0",
             "-Ddd.jmxfetch.enabled=false",
             "-Ddd.dynamic.instrumentation.enabled=true",
-            "-Ddd.remote_config.enabled=true",
+            // "-Ddd.remote_config.enabled=true", // default
             "-Ddd.remote_config.initial.poll.interval=1",
             /*"-Ddd.remote_config.integrity_check.enabled=false",
             "-Ddd.dynamic.instrumentation.probe.url=http://localhost:"

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractTestAgentSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractTestAgentSmokeTest.groovy
@@ -47,6 +47,8 @@ abstract class AbstractTestAgentSmokeTest extends ProcessManager {
     "-Ddd.${ProfilingConfig.PROFILING_CHECKPOINTS_SAMPLER_RATE_LIMIT}=0",
     "-Ddd.test.no.early.discovery=true",
     "-Ddd.trace.client-ip.enabled=true",
+    // The mock agent cannot cope with feature discovery or remote config requests.
+    "-Ddd.remote_config.enabled=false",
     "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug",
     "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"
   ]


### PR DESCRIPTION
# What Does This Do

Enable remote config by default.

Also:

* Make sure that smoke tests for remote activation run on gradle test task.
* Tweak tests to avoid explicit remote config enablement.

# Motivation

In 0.113.0 we changed the default of the telemetry setting in Config to true, but that's not enough, as it needs to be updated in `Agent` too.

# Additional Notes
