### PR TITLE
Split Config class to dedicated feature config

### DIFF
--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
@@ -284,7 +284,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
   }
 
   void 'disabling of key regex'() {
-    injectSysConfig(APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP, '')
+    injectSysConfig(datadog.trace.api.config.AppSecConfig.APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP, '')
     setupWithStubConfigService()
     AppSecEvent100 event
 
@@ -309,7 +309,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
   }
 
   void 'redaction of values'() {
-    injectSysConfig(APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP, 'Arachni')
+    injectSysConfig(datadog.trace.api.config.AppSecConfig.APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP, 'Arachni')
 
     setupWithStubConfigService()
     AppSecEvent100 event

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
@@ -27,9 +27,6 @@ import spock.lang.Unroll
 
 import java.util.concurrent.CountDownLatch
 
-import static datadog.trace.api.config.AppSecConfig.APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP
-import static datadog.trace.api.config.AppSecConfig.APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP
-
 class PowerWAFModuleSpecification extends DDSpecification {
   private static final DataBundle ATTACK_BUNDLE = MapDataBundle.of(KnownAddresses.HEADERS_NO_COOKIES,
   new CaseInsensitiveMap<List<String>>(['user-agent': 'Arachni/v0']))

--- a/dd-trace-api/dd-trace-api.gradle
+++ b/dd-trace-api/dd-trace-api.gradle
@@ -13,6 +13,7 @@ excludedClassesCoverage += [
   'datadog.trace.api.GlobalTracer*',
   'datadog.trace.api.PropagationStyle',
   'datadog.trace.api.SpanCorrelation*',
+  'datadog.trace.api.config.*Config', // Config keys and default value constants
 ]
 
 description = 'dd-trace-api'

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -11,7 +11,6 @@ public final class ConfigDefaults {
   public static final int DEFAULT_AGENT_TIMEOUT = 10; // timeout in seconds
   public static final String DEFAULT_SERVICE_NAME = "unnamed-java-app";
   public static final String DEFAULT_SERVLET_ROOT_CONTEXT_SERVICE_NAME = "root-servlet";
-  static final float DEFAULT_ANALYTICS_SAMPLE_RATE = 1.0f;
   public static final boolean DEFAULT_ASYNC_PROPAGATING = true;
   public static final int DEFAULT_TRACE_X_DATADOG_TAGS_MAX_LENGTH = 512;
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -1,27 +1,6 @@
 package datadog.trace.api;
 
-import java.util.Arrays;
-import java.util.BitSet;
-import java.util.HashSet;
-import java.util.Set;
-
 public final class ConfigDefaults {
-
-  static final BitSet DEFAULT_HTTP_SERVER_ERROR_STATUSES;
-  static final BitSet DEFAULT_HTTP_CLIENT_ERROR_STATUSES;
-  static final BitSet DEFAULT_GRPC_SERVER_ERROR_STATUSES;
-  static final BitSet DEFAULT_GRPC_CLIENT_ERROR_STATUSES;
-
-  static {
-    DEFAULT_HTTP_SERVER_ERROR_STATUSES = new BitSet();
-    DEFAULT_HTTP_SERVER_ERROR_STATUSES.set(500, 600);
-    DEFAULT_HTTP_CLIENT_ERROR_STATUSES = new BitSet();
-    DEFAULT_HTTP_CLIENT_ERROR_STATUSES.set(400, 500);
-    DEFAULT_GRPC_SERVER_ERROR_STATUSES = new BitSet();
-    DEFAULT_GRPC_SERVER_ERROR_STATUSES.set(2, 17);
-    DEFAULT_GRPC_CLIENT_ERROR_STATUSES = new BitSet();
-    DEFAULT_GRPC_CLIENT_ERROR_STATUSES.set(1, 17);
-  }
 
   /* These fields are made public because they're referenced elsewhere internally.  They're not intended as public API. */
   public static final String DEFAULT_AGENT_HOST = "localhost";
@@ -32,110 +11,8 @@ public final class ConfigDefaults {
   public static final int DEFAULT_AGENT_TIMEOUT = 10; // timeout in seconds
   public static final String DEFAULT_SERVICE_NAME = "unnamed-java-app";
   public static final String DEFAULT_SERVLET_ROOT_CONTEXT_SERVICE_NAME = "root-servlet";
-
-  static final String DEFAULT_SITE = "datadoghq.com";
-
-  static final boolean DEFAULT_TRACE_ENABLED = true;
-  static final boolean DEFAULT_INTEGRATIONS_ENABLED = true;
-  static final String DEFAULT_AGENT_WRITER_TYPE = "DDAgentWriter";
-
-  static final boolean DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION = true;
-  static final boolean DEFAULT_SERIALVERSIONUID_FIELD_INJECTION = true;
-
-  static final boolean DEFAULT_PRIORITY_SAMPLING_ENABLED = true;
-  static final String DEFAULT_PRIORITY_SAMPLING_FORCE = null;
-  static final boolean DEFAULT_TRACE_RESOLVER_ENABLED = true;
-  static final boolean DEFAULT_HTTP_SERVER_TAG_QUERY_STRING = true;
-  static final boolean DEFAULT_HTTP_SERVER_ROUTE_BASED_NAMING = true;
-  static final boolean DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING = false;
-  static final boolean DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN = false;
-  static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE = false;
-  static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX = false;
-  static final int DEFAULT_SCOPE_DEPTH_LIMIT = 100;
-  static final int DEFAULT_SCOPE_ITERATION_KEEP_ALIVE = 10; // in seconds
-  static final int DEFAULT_PARTIAL_FLUSH_MIN_SPANS = 1000;
-  static final boolean DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED = false;
-  static final String DEFAULT_PROPAGATION_STYLE_EXTRACT = PropagationStyle.DATADOG.name();
-  static final String DEFAULT_PROPAGATION_STYLE_INJECT = PropagationStyle.DATADOG.name();
-  static final boolean DEFAULT_JMX_FETCH_ENABLED = true;
-  static final boolean DEFAULT_TRACE_AGENT_V05_ENABLED = false;
-
-  static final boolean DEFAULT_CLIENT_IP_ENABLED = false;
-
-  static final int DEFAULT_CLOCK_SYNC_PERIOD = 30; // seconds
-
-  static final boolean DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_ENABLED = false;
-  static final int DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_LIMIT = 10;
-
-  static final int DEFAULT_DOGSTATSD_START_DELAY = 15; // seconds
-
-  static final boolean DEFAULT_HEALTH_METRICS_ENABLED = true;
-  static final boolean DEFAULT_PERF_METRICS_ENABLED = false;
-  // No default constants for metrics statsd support -- falls back to jmxfetch values
-
-  static final boolean DEFAULT_LOGS_INJECTION_ENABLED = true;
-
-  static final String DEFAULT_APPSEC_ENABLED = "inactive";
-  static final boolean DEFAULT_APPSEC_REPORTING_INBAND = false;
-  static final int DEFAULT_APPSEC_TRACE_RATE_LIMIT = 100;
-  static final boolean DEFAULT_APPSEC_WAF_METRICS = true;
-
-  static final boolean DEFAULT_IAST_ENABLED = false;
-  public static final int DEFAULT_IAST_MAX_CONCURRENT_REQUESTS = 2;
-  public static final int DEFAULT_IAST_VULNERABILITIES_PER_REQUEST = 2;
-  public static final int DEFAULT_IAST_REQUEST_SAMPLING = 30;
-  static final Set<String> DEFAULT_IAST_WEAK_HASH_ALGORITHMS =
-      new HashSet<>(Arrays.asList("MD2", "MD5", "RIPEMD128", "MD4"));
-  static final String DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS =
-      "^(?:PBEWITH(?:HMACSHA(?:2(?:24ANDAES_(?:128|256)|56ANDAES_(?:128|256))|384ANDAES_(?:128|256)|512ANDAES_(?:128|256)|1ANDAES_(?:128|256))|SHA1AND(?:RC(?:2_(?:128|40)|4_(?:128|40))|DESEDE)|MD5AND(?:TRIPLEDES|DES))|DES(?:EDE(?:WRAP)?)?|BLOWFISH|ARCFOUR|RC2).*$";
-
-  static final boolean DEFAULT_IAST_DEDUPLICATION_ENABLED = true;
-
-  static final boolean DEFAULT_CIVISIBILITY_ENABLED = false;
-  static final boolean DEFAULT_CIVISIBILITY_AGENTLESS_ENABLED = false;
-
-  static final boolean DEFAULT_REMOTE_CONFIG_ENABLED = true;
-  static final boolean DEFAULT_REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED = false;
-  static final int DEFAULT_REMOTE_CONFIG_MAX_PAYLOAD_SIZE = 1024; // KiB
-  static final int DEFAULT_REMOTE_CONFIG_INITIAL_POLL_INTERVAL = 5; // s
-  static final String DEFAULT_REMOTE_CONFIG_TARGETS_KEY_ID =
-      "5c4ece41241a1bb513f6e3e5df74ab7d5183dfffbd71bfd43127920d880569fd";
-  static final String DEFAULT_REMOTE_CONFIG_TARGETS_KEY =
-      "e3f1f98c9da02a93bb547f448b472d727e14b22455235796fe49863856252508";
-
-  static final boolean DEFAULT_DEBUGGER_ENABLED = false;
-  static final int DEFAULT_DEBUGGER_UPLOAD_TIMEOUT = 30; // seconds
-  static final int DEFAULT_DEBUGGER_UPLOAD_FLUSH_INTERVAL = 0; // ms, 0 = dynamic
-  static final boolean DEFAULT_DEBUGGER_CLASSFILE_DUMP_ENABLED = false;
-  static final int DEFAULT_DEBUGGER_POLL_INTERVAL = 1; // seconds
-  static final int DEFAULT_DEBUGGER_DIAGNOSTICS_INTERVAL = 60 * 60; // seconds
-  static final boolean DEFAULT_DEBUGGER_METRICS_ENABLED = true;
-  static final int DEFAULT_DEBUGGER_UPLOAD_BATCH_SIZE = 100;
-  static final int DEFAULT_DEBUGGER_MAX_PAYLOAD_SIZE = 1024; // KiB
-  static final boolean DEFAULT_DEBUGGER_VERIFY_BYTECODE = false;
-  static final boolean DEFAULT_DEBUGGER_INSTRUMENT_THE_WORLD = false;
-
-  static final boolean DEFAULT_TRACE_REPORT_HOSTNAME = false;
-  static final String DEFAULT_TRACE_ANNOTATIONS = null;
-  static final boolean DEFAULT_TRACE_EXECUTORS_ALL = false;
-  static final String DEFAULT_TRACE_METHODS = null;
-  static final boolean DEFAULT_TRACE_ANALYTICS_ENABLED = false;
   static final float DEFAULT_ANALYTICS_SAMPLE_RATE = 1.0f;
-  static final int DEFAULT_TRACE_RATE_LIMIT = 100;
-
   public static final boolean DEFAULT_ASYNC_PROPAGATING = true;
-
-  static final boolean DEFAULT_CWS_ENABLED = false;
-  static final int DEFAULT_CWS_TLS_REFRESH = 5000;
-
-  static final boolean DEFAULT_DATA_STREAMS_ENABLED = false;
-
-  static final int DEFAULT_RESOLVER_OUTLINE_POOL_SIZE = 128;
-  static final int DEFAULT_RESOLVER_TYPE_POOL_SIZE = 64;
-
-  static final boolean DEFAULT_TELEMETRY_ENABLED = true;
-  static final int DEFAULT_TELEMETRY_HEARTBEAT_INTERVAL = 60; // in seconds
-
   public static final int DEFAULT_TRACE_X_DATADOG_TAGS_MAX_LENGTH = 512;
 
   private ConfigDefaults() {}

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -29,12 +29,12 @@ public class DDTags {
   public static final String TRACE_START_TIME = "t0";
 
   /* Tags below are for internal use only. */
-  static final String INTERNAL_HOST_NAME = "_dd.hostname";
+  public static final String INTERNAL_HOST_NAME = "_dd.hostname";
   public static final String RUNTIME_ID_TAG = "runtime-id";
   public static final String RUNTIME_VERSION_TAG = "runtime_version";
-  static final String SERVICE = "service";
-  static final String SERVICE_TAG = SERVICE;
-  static final String HOST_TAG = "host";
+  public static final String SERVICE = "service";
+  public static final String SERVICE_TAG = SERVICE;
+  public static final String HOST_TAG = "host";
   public static final String LANGUAGE_TAG_KEY = "language";
   public static final String LANGUAGE_TAG_VALUE = "jvm";
   public static final String ORIGIN_KEY = "_dd.origin";

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/AppSecConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/AppSecConfig.java
@@ -2,7 +2,6 @@ package datadog.trace.api.config;
 
 /** Constant with names of configuration options for appsec. */
 public final class AppSecConfig {
-
   public static final String APPSEC_ENABLED = "appsec.enabled";
   public static final String APPSEC_REPORTING_INBAND = "appsec.reporting.inband";
   public static final String APPSEC_RULES_FILE = "appsec.rules";
@@ -18,6 +17,11 @@ public final class AppSecConfig {
       "appsec.http.blocked.template.html";
   public static final String APPSEC_HTTP_BLOCKED_TEMPLATE_JSON =
       "appsec.http.blocked.template.json";
+
+  static final String DEFAULT_APPSEC_ENABLED = "inactive";
+  static final boolean DEFAULT_APPSEC_REPORTING_INBAND = false;
+  static final int DEFAULT_APPSEC_TRACE_RATE_LIMIT = 100;
+  static final boolean DEFAULT_APPSEC_WAF_METRICS = true;
 
   private AppSecConfig() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
@@ -7,5 +7,8 @@ public final class CiVisibilityConfig {
   public static final String CIVISIBILITY_AGENTLESS_ENABLED = "civisibility.agentless.enabled";
   public static final String CIVISIBILITY_AGENTLESS_URL = "civisibility.agentless.url";
 
+  static final boolean DEFAULT_CIVISIBILITY_ENABLED = false;
+  static final boolean DEFAULT_CIVISIBILITY_AGENTLESS_ENABLED = false;
+
   private CiVisibilityConfig() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/CrashTrackingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/CrashTrackingConfig.java
@@ -7,12 +7,9 @@ package datadog.trace.api.config;
  * documentation for details.
  */
 public final class CrashTrackingConfig {
-
   public static final String CRASH_TRACKING_TAGS = "crashtracking.tags";
-
   public static final String CRASH_TRACKING_UPLOAD_TIMEOUT = "crashtracking.upload.timeout";
   public static final int CRASH_TRACKING_UPLOAD_TIMEOUT_DEFAULT = 30;
-
   public static final String CRASH_TRACKING_PROXY_HOST = "crashtracking.proxy.host";
   public static final String CRASH_TRACKING_PROXY_PORT = "crashtracking.proxy.port";
   public static final String CRASH_TRACKING_PROXY_USERNAME = "crashtracking.proxy.username";

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/CwsConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/CwsConfig.java
@@ -1,10 +1,11 @@
 package datadog.trace.api.config;
 
 public final class CwsConfig {
-
   public static final String CWS_ENABLED = "cws.enabled";
-
   public static final String CWS_TLS_REFRESH = "cws.tls.refresh";
+
+  static final boolean DEFAULT_CWS_ENABLED = false;
+  static final int DEFAULT_CWS_TLS_REFRESH = 5000;
 
   private CwsConfig() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
@@ -22,5 +22,17 @@ public final class DebuggerConfig {
       "dynamic.instrumentation.instrument.the.world";
   public static final String DEBUGGER_EXCLUDE_FILE = "dynamic.instrumentation.exclude.file";
 
+  static final boolean DEFAULT_DEBUGGER_ENABLED = false;
+  static final int DEFAULT_DEBUGGER_UPLOAD_TIMEOUT = 30; // seconds
+  static final int DEFAULT_DEBUGGER_UPLOAD_FLUSH_INTERVAL = 0; // ms, 0 = dynamic
+  static final boolean DEFAULT_DEBUGGER_CLASSFILE_DUMP_ENABLED = false;
+  static final int DEFAULT_DEBUGGER_POLL_INTERVAL = 1; // seconds
+  static final int DEFAULT_DEBUGGER_DIAGNOSTICS_INTERVAL = 60 * 60; // seconds
+  static final boolean DEFAULT_DEBUGGER_METRICS_ENABLED = true;
+  static final int DEFAULT_DEBUGGER_UPLOAD_BATCH_SIZE = 100;
+  static final int DEFAULT_DEBUGGER_MAX_PAYLOAD_SIZE = 1024; // KiB
+  static final boolean DEFAULT_DEBUGGER_VERIFY_BYTECODE = false;
+  static final boolean DEFAULT_DEBUGGER_INSTRUMENT_THE_WORLD = false;
+
   private DebuggerConfig() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -57,5 +57,15 @@ public final class GeneralConfig {
   public static final String TELEMETRY_ENABLED = "instrumentation.telemetry.enabled";
   public static final String TELEMETRY_HEARTBEAT_INTERVAL = "telemetry.heartbeat.interval";
 
+  static final String DEFAULT_SITE = "datadoghq.com";
+  static final int DEFAULT_DOGSTATSD_START_DELAY = 15; // seconds
+  static final boolean DEFAULT_HEALTH_METRICS_ENABLED = true;
+  static final boolean DEFAULT_PERF_METRICS_ENABLED = false;
+  // No default constants for metrics statsd support -- falls back to jmxfetch values
+  static final boolean DEFAULT_TRACE_REPORT_HOSTNAME = false;
+  static final boolean DEFAULT_DATA_STREAMS_ENABLED = false;
+  static final boolean DEFAULT_TELEMETRY_ENABLED = true;
+  static final int DEFAULT_TELEMETRY_HEARTBEAT_INTERVAL = 60; // in seconds
+
   private GeneralConfig() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/IastConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/IastConfig.java
@@ -1,8 +1,11 @@
 package datadog.trace.api.config;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 /** Constant with names of configuration options for IAST. */
 public final class IastConfig {
-
   public static final String IAST_ENABLED = "iast.enabled";
   public static final String IAST_WEAK_HASH_ALGORITHMS = "iast.weak-hash.algorithms";
   public static final String IAST_WEAK_CIPHER_ALGORITHMS = "iast.weak-cipher.algorithms";
@@ -10,6 +13,17 @@ public final class IastConfig {
   public static final String IAST_VULNERABILITIES_PER_REQUEST = "iast.vulnerabilities-per-request";
   public static final String IAST_REQUEST_SAMPLING = "iast.request-sampling";
   public static final String IAST_DEDUPLICATION_ENABLED = "iast.deduplication.enabled";
+
+  static final boolean DEFAULT_IAST_ENABLED = false;
+  public static final int DEFAULT_IAST_MAX_CONCURRENT_REQUESTS = 2;
+  public static final int DEFAULT_IAST_VULNERABILITIES_PER_REQUEST = 2;
+  public static final int DEFAULT_IAST_REQUEST_SAMPLING = 30;
+  static final Set<String> DEFAULT_IAST_WEAK_HASH_ALGORITHMS =
+      new HashSet<>(Arrays.asList("MD2", "MD5", "RIPEMD128", "MD4"));
+  static final String DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS =
+      "^(?:PBEWITH(?:HMACSHA(?:2(?:24ANDAES_(?:128|256)|56ANDAES_(?:128|256))|384ANDAES_(?:128|256)|512ANDAES_(?:128|256)|1ANDAES_(?:128|256))|SHA1AND(?:RC(?:2_(?:128|40)|4_(?:128|40))|DESEDE)|MD5AND(?:TRIPLEDES|DES))|DES(?:EDE(?:WRAP)?)?|BLOWFISH|ARCFOUR|RC2).*$";
+
+  static final boolean DEFAULT_IAST_DEDUPLICATION_ENABLED = true;
 
   private IastConfig() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/JmxFetchConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/JmxFetchConfig.java
@@ -24,5 +24,9 @@ public final class JmxFetchConfig {
   public static final String JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_LIMIT =
       "jmxfetch.multiple-runtime-services.limit";
 
+  static final boolean DEFAULT_JMX_FETCH_ENABLED = true;
+  static final boolean DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_ENABLED = false;
+  static final int DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_LIMIT = 10;
+
   private JmxFetchConfig() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/RemoteConfigConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/RemoteConfigConfig.java
@@ -13,5 +13,14 @@ public class RemoteConfigConfig {
   public static final String REMOTE_CONFIG_TARGETS_KEY_ID = "rc.targets.key.id";
   public static final String REMOTE_CONFIG_TARGETS_KEY = "rc.targets.key";
 
+  static final boolean DEFAULT_REMOTE_CONFIG_ENABLED = true;
+  static final boolean DEFAULT_REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED = false;
+  static final int DEFAULT_REMOTE_CONFIG_MAX_PAYLOAD_SIZE = 1024; // KiB
+  static final int DEFAULT_REMOTE_CONFIG_INITIAL_POLL_INTERVAL = 5; // s
+  static final String DEFAULT_REMOTE_CONFIG_TARGETS_KEY_ID =
+      "5c4ece41241a1bb513f6e3e5df74ab7d5183dfffbd71bfd43127920d880569fd";
+  static final String DEFAULT_REMOTE_CONFIG_TARGETS_KEY =
+      "e3f1f98c9da02a93bb547f448b472d727e14b22455235796fe49863856252508";
+
   private RemoteConfigConfig() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -1,5 +1,7 @@
 package datadog.trace.api.config;
 
+import java.util.BitSet;
+
 /**
  * These config options will only work with dd-java-agent, not with dd-trace-ot.
  *
@@ -91,6 +93,31 @@ public final class TraceInstrumentationConfig {
   public static final String RESOLVER_OUTLINE_POOL_SIZE = "resolver.outline.pool.size";
   public static final String RESOLVER_TYPE_POOL_SIZE = "resolver.type.pool.size";
   public static final String RESOLVER_USE_LOADCLASS = "resolver.use.loadclass";
+
+  static final boolean DEFAULT_INTEGRATIONS_ENABLED = true;
+  static final String DEFAULT_TRACE_ANNOTATIONS = null;
+  static final BitSet DEFAULT_GRPC_SERVER_ERROR_STATUSES;
+  static final BitSet DEFAULT_GRPC_CLIENT_ERROR_STATUSES;
+  static final boolean DEFAULT_LOGS_INJECTION_ENABLED = true;
+  static final String DEFAULT_TRACE_METHODS = null;
+  static final boolean DEFAULT_TRACE_EXECUTORS_ALL = false;
+  static final boolean DEFAULT_HTTP_SERVER_TAG_QUERY_STRING = true;
+  static final boolean DEFAULT_HTTP_SERVER_ROUTE_BASED_NAMING = true;
+  static final boolean DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING = false;
+  static final boolean DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN = false;
+  static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE = false;
+  static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX = false;
+  static final boolean DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION = true;
+  static final boolean DEFAULT_SERIALVERSIONUID_FIELD_INJECTION = true;
+  static final int DEFAULT_RESOLVER_OUTLINE_POOL_SIZE = 128;
+  static final int DEFAULT_RESOLVER_TYPE_POOL_SIZE = 64;
+
+  static {
+    DEFAULT_GRPC_SERVER_ERROR_STATUSES = new BitSet();
+    DEFAULT_GRPC_SERVER_ERROR_STATUSES.set(2, 17);
+    DEFAULT_GRPC_CLIENT_ERROR_STATUSES = new BitSet();
+    DEFAULT_GRPC_CLIENT_ERROR_STATUSES.set(1, 17);
+  }
 
   private TraceInstrumentationConfig() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -1,5 +1,8 @@
 package datadog.trace.api.config;
 
+import datadog.trace.api.PropagationStyle;
+import java.util.BitSet;
+
 /**
  * A list of keys to be used in a Properties instance with dd-trace-ot's DDTracer as follows:
  *
@@ -46,6 +49,7 @@ public final class TracerConfig {
   public static final String TRACE_REPORT_HOSTNAME = "trace.report-hostname";
   public static final String TRACE_CLIENT_IP_HEADER = "trace.client-ip-header";
   public static final String TRACE_CLIENT_IP_RESOLVER_ENABLED = "trace.client-ip.resolver.enabled";
+  public static final String CLIENT_IP_ENABLED = "trace.client-ip.enabled";
   public static final String HEADER_TAGS = "trace.header.tags";
   public static final String REQUEST_HEADER_TAGS = "trace.request_header.tags";
   public static final String RESPONSE_HEADER_TAGS = "trace.response_header.tags";
@@ -70,8 +74,6 @@ public final class TracerConfig {
 
   public static final String ENABLE_TRACE_AGENT_V05 = "trace.agent.v0.5.enabled";
 
-  public static final String CLIENT_IP_ENABLED = "trace.client-ip.enabled";
-
   /**
    * Disables validation that prevents invalid combinations of sampling priority and sampling
    * mechanism on the set sampling priority calls. This check is enabled by default.
@@ -86,6 +88,32 @@ public final class TracerConfig {
   public static final String TRACE_X_DATADOG_TAGS_MAX_LENGTH = "trace.x-datadog-tags.max.length";
 
   public static final String CLOCK_SYNC_PERIOD = "trace.clock.sync.period";
+
+  static final String DEFAULT_AGENT_WRITER_TYPE = "DDAgentWriter";
+  static final boolean DEFAULT_PRIORITY_SAMPLING_ENABLED = true;
+  static final String DEFAULT_PRIORITY_SAMPLING_FORCE = null;
+  static final boolean DEFAULT_TRACE_ENABLED = true;
+  static final boolean DEFAULT_TRACE_RESOLVER_ENABLED = true;
+  static final boolean DEFAULT_TRACE_ANALYTICS_ENABLED = false;
+  static final int DEFAULT_TRACE_RATE_LIMIT = 100;
+  static final boolean DEFAULT_CLIENT_IP_ENABLED = false;
+  static final BitSet DEFAULT_HTTP_SERVER_ERROR_STATUSES;
+  static final BitSet DEFAULT_HTTP_CLIENT_ERROR_STATUSES;
+  static final int DEFAULT_SCOPE_DEPTH_LIMIT = 100;
+  static final int DEFAULT_SCOPE_ITERATION_KEEP_ALIVE = 10; // in seconds
+  static final int DEFAULT_PARTIAL_FLUSH_MIN_SPANS = 1000;
+  static final boolean DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED = false;
+  static final String DEFAULT_PROPAGATION_STYLE_EXTRACT = PropagationStyle.DATADOG.name();
+  static final String DEFAULT_PROPAGATION_STYLE_INJECT = PropagationStyle.DATADOG.name();
+  static final boolean DEFAULT_TRACE_AGENT_V05_ENABLED = false;
+  static final int DEFAULT_CLOCK_SYNC_PERIOD = 30; // seconds
+
+  static {
+    DEFAULT_HTTP_SERVER_ERROR_STATUSES = new BitSet();
+    DEFAULT_HTTP_SERVER_ERROR_STATUSES.set(500, 600);
+    DEFAULT_HTTP_CLIENT_ERROR_STATUSES = new BitSet();
+    DEFAULT_HTTP_CLIENT_ERROR_STATUSES.set(400, 500);
+  }
 
   private TracerConfig() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -105,6 +105,7 @@ public final class TracerConfig {
   static final boolean DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED = false;
   static final String DEFAULT_PROPAGATION_STYLE_EXTRACT = PropagationStyle.DATADOG.name();
   static final String DEFAULT_PROPAGATION_STYLE_INJECT = PropagationStyle.DATADOG.name();
+  static final float DEFAULT_ANALYTICS_SAMPLE_RATE = 1.0f;
   static final boolean DEFAULT_TRACE_AGENT_V05_ENABLED = false;
   static final int DEFAULT_CLOCK_SYNC_PERIOD = 30; // seconds
 

--- a/internal-api/internal-api.gradle
+++ b/internal-api/internal-api.gradle
@@ -13,6 +13,7 @@ excludedClassesCoverage += [
   "datadog.trace.api.StatsDClient",
   "datadog.trace.api.NoOpStatsDClient",
   "datadog.trace.api.TraceSegment.NoOp",
+  "datadog.trace.api.config.TraceInstrumentationFeatureConfig.StaticConfig.Singleton",
   "datadog.trace.api.intake.TrackType",
   "datadog.trace.api.gateway.Events.ET",
   "datadog.trace.api.profiling.ProfilingSnapshot.Kind",

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1,6 +1,5 @@
 package datadog.trace.api;
 
-import static datadog.trace.api.ConfigDefaults.DEFAULT_ANALYTICS_SAMPLE_RATE;
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_IGNORED_RESOURCES;
 import static datadog.trace.util.CollectionUtils.tryMakeImmutableSet;
 
@@ -979,19 +978,9 @@ public class Config {
     return this.crashTrackingConfig.getMergedCrashTrackingTags();
   }
 
-  /**
-   * Returns the sample rate for the specified instrumentation or {@link
-   * ConfigDefaults#DEFAULT_ANALYTICS_SAMPLE_RATE} if none specified.
-   */
+  /** Returns the sample rate for the specified instrumentation. */
   public float getInstrumentationAnalyticsSampleRate(final String... aliases) {
-    for (final String alias : aliases) {
-      final String configKey = alias + ".analytics.sample-rate";
-      final Float rate = configProvider.getFloat("trace." + configKey, configKey);
-      if (null != rate) {
-        return rate;
-      }
-    }
-    return DEFAULT_ANALYTICS_SAMPLE_RATE;
+    return this.tracerConfig.getInstrumentationAnalyticsSampleRate(aliases);
   }
 
   public String getFinalProfilingUrl() {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1,364 +1,30 @@
 package datadog.trace.api;
 
-import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_HOST;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_TIMEOUT;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_WRITER_TYPE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_ANALYTICS_SAMPLE_RATE;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_REPORTING_INBAND;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_TRACE_RATE_LIMIT;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_WAF_METRICS;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_CIVISIBILITY_AGENTLESS_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_CIVISIBILITY_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_CLIENT_IP_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_CLOCK_SYNC_PERIOD;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_CWS_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_CWS_TLS_REFRESH;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_DATA_STREAMS_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_CLASSFILE_DUMP_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_DIAGNOSTICS_INTERVAL;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_INSTRUMENT_THE_WORLD;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_MAX_PAYLOAD_SIZE;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_METRICS_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_POLL_INTERVAL;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_UPLOAD_BATCH_SIZE;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_UPLOAD_FLUSH_INTERVAL;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_UPLOAD_TIMEOUT;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_VERIFY_BYTECODE;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_DOGSTATSD_START_DELAY;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_GRPC_CLIENT_ERROR_STATUSES;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_GRPC_SERVER_ERROR_STATUSES;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_HEALTH_METRICS_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_CLIENT_ERROR_STATUSES;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_ERROR_STATUSES;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_ROUTE_BASED_NAMING;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_TAG_QUERY_STRING;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_DEDUPLICATION_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_MAX_CONCURRENT_REQUESTS;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_REQUEST_SAMPLING;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_VULNERABILITIES_PER_REQUEST;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_WEAK_HASH_ALGORITHMS;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_INTEGRATIONS_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_JMX_FETCH_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_LIMIT;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_LOGS_INJECTION_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_PARTIAL_FLUSH_MIN_SPANS;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_PERF_METRICS_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_PRIORITY_SAMPLING_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_PRIORITY_SAMPLING_FORCE;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_PROPAGATION_STYLE_EXTRACT;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_PROPAGATION_STYLE_INJECT;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_REMOTE_CONFIG_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_REMOTE_CONFIG_INITIAL_POLL_INTERVAL;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_REMOTE_CONFIG_MAX_PAYLOAD_SIZE;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_REMOTE_CONFIG_TARGETS_KEY;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_REMOTE_CONFIG_TARGETS_KEY_ID;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_RESOLVER_OUTLINE_POOL_SIZE;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_RESOLVER_TYPE_POOL_SIZE;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_SCOPE_DEPTH_LIMIT;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_SCOPE_ITERATION_KEEP_ALIVE;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_SERIALVERSIONUID_FIELD_INJECTION;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVLET_ROOT_CONTEXT_SERVICE_NAME;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_SITE;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_TELEMETRY_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_TELEMETRY_HEARTBEAT_INTERVAL;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_PORT;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_V05_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_ANALYTICS_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_ANNOTATIONS;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_EXECUTORS_ALL;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_METHODS;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_RATE_LIMIT;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_REPORT_HOSTNAME;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_RESOLVER_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_X_DATADOG_TAGS_MAX_LENGTH;
-import static datadog.trace.api.DDTags.HOST_TAG;
-import static datadog.trace.api.DDTags.INTERNAL_HOST_NAME;
-import static datadog.trace.api.DDTags.LANGUAGE_TAG_KEY;
-import static datadog.trace.api.DDTags.LANGUAGE_TAG_VALUE;
-import static datadog.trace.api.DDTags.RUNTIME_ID_TAG;
-import static datadog.trace.api.DDTags.RUNTIME_VERSION_TAG;
-import static datadog.trace.api.DDTags.SERVICE;
-import static datadog.trace.api.DDTags.SERVICE_TAG;
-import static datadog.trace.api.IdGenerationStrategy.RANDOM;
-import static datadog.trace.api.Platform.isJavaVersionAtLeast;
-import static datadog.trace.api.config.AppSecConfig.APPSEC_ENABLED;
-import static datadog.trace.api.config.AppSecConfig.APPSEC_HTTP_BLOCKED_TEMPLATE_HTML;
-import static datadog.trace.api.config.AppSecConfig.APPSEC_HTTP_BLOCKED_TEMPLATE_JSON;
-import static datadog.trace.api.config.AppSecConfig.APPSEC_IP_ADDR_HEADER;
-import static datadog.trace.api.config.AppSecConfig.APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP;
-import static datadog.trace.api.config.AppSecConfig.APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP;
-import static datadog.trace.api.config.AppSecConfig.APPSEC_REPORTING_INBAND;
-import static datadog.trace.api.config.AppSecConfig.APPSEC_REPORT_TIMEOUT_SEC;
-import static datadog.trace.api.config.AppSecConfig.APPSEC_RULES_FILE;
-import static datadog.trace.api.config.AppSecConfig.APPSEC_TRACE_RATE_LIMIT;
-import static datadog.trace.api.config.AppSecConfig.APPSEC_WAF_METRICS;
-import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_AGENTLESS_ENABLED;
-import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_AGENTLESS_URL;
-import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_ENABLED;
-import static datadog.trace.api.config.CrashTrackingConfig.CRASH_TRACKING_AGENTLESS;
-import static datadog.trace.api.config.CrashTrackingConfig.CRASH_TRACKING_AGENTLESS_DEFAULT;
-import static datadog.trace.api.config.CrashTrackingConfig.CRASH_TRACKING_TAGS;
-import static datadog.trace.api.config.CwsConfig.CWS_ENABLED;
-import static datadog.trace.api.config.CwsConfig.CWS_TLS_REFRESH;
-import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_CLASSFILE_DUMP_ENABLED;
-import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_DIAGNOSTICS_INTERVAL;
-import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_ENABLED;
-import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_EXCLUDE_FILE;
-import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_INSTRUMENT_THE_WORLD;
-import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_MAX_PAYLOAD_SIZE;
-import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_METRICS_ENABLED;
-import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_POLL_INTERVAL;
-import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_PROBE_FILE_LOCATION;
-import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_UPLOAD_BATCH_SIZE;
-import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_UPLOAD_FLUSH_INTERVAL;
-import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_UPLOAD_TIMEOUT;
-import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_VERIFY_BYTECODE;
-import static datadog.trace.api.config.GeneralConfig.API_KEY;
-import static datadog.trace.api.config.GeneralConfig.API_KEY_FILE;
-import static datadog.trace.api.config.GeneralConfig.AZURE_APP_SERVICES;
-import static datadog.trace.api.config.GeneralConfig.DATA_STREAMS_ENABLED;
-import static datadog.trace.api.config.GeneralConfig.DOGSTATSD_ARGS;
-import static datadog.trace.api.config.GeneralConfig.DOGSTATSD_HOST;
-import static datadog.trace.api.config.GeneralConfig.DOGSTATSD_NAMED_PIPE;
-import static datadog.trace.api.config.GeneralConfig.DOGSTATSD_PATH;
-import static datadog.trace.api.config.GeneralConfig.DOGSTATSD_PORT;
-import static datadog.trace.api.config.GeneralConfig.DOGSTATSD_START_DELAY;
-import static datadog.trace.api.config.GeneralConfig.ENV;
-import static datadog.trace.api.config.GeneralConfig.GLOBAL_TAGS;
-import static datadog.trace.api.config.GeneralConfig.HEALTH_METRICS_ENABLED;
-import static datadog.trace.api.config.GeneralConfig.HEALTH_METRICS_STATSD_HOST;
-import static datadog.trace.api.config.GeneralConfig.HEALTH_METRICS_STATSD_PORT;
-import static datadog.trace.api.config.GeneralConfig.INTERNAL_EXIT_ON_FAILURE;
-import static datadog.trace.api.config.GeneralConfig.PERF_METRICS_ENABLED;
-import static datadog.trace.api.config.GeneralConfig.PRIMARY_TAG;
-import static datadog.trace.api.config.GeneralConfig.RUNTIME_ID_ENABLED;
-import static datadog.trace.api.config.GeneralConfig.RUNTIME_METRICS_ENABLED;
-import static datadog.trace.api.config.GeneralConfig.SERVICE_NAME;
-import static datadog.trace.api.config.GeneralConfig.SITE;
-import static datadog.trace.api.config.GeneralConfig.TAGS;
-import static datadog.trace.api.config.GeneralConfig.TELEMETRY_ENABLED;
-import static datadog.trace.api.config.GeneralConfig.TELEMETRY_HEARTBEAT_INTERVAL;
-import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_BUFFERING_ENABLED;
-import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_IGNORED_RESOURCES;
-import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_AGGREGATES;
-import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_PENDING;
-import static datadog.trace.api.config.GeneralConfig.VERSION;
-import static datadog.trace.api.config.IastConfig.IAST_DEDUPLICATION_ENABLED;
-import static datadog.trace.api.config.IastConfig.IAST_ENABLED;
-import static datadog.trace.api.config.IastConfig.IAST_MAX_CONCURRENT_REQUESTS;
-import static datadog.trace.api.config.IastConfig.IAST_REQUEST_SAMPLING;
-import static datadog.trace.api.config.IastConfig.IAST_VULNERABILITIES_PER_REQUEST;
-import static datadog.trace.api.config.IastConfig.IAST_WEAK_CIPHER_ALGORITHMS;
-import static datadog.trace.api.config.IastConfig.IAST_WEAK_HASH_ALGORITHMS;
-import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_CHECK_PERIOD;
-import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_CONFIG;
-import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_CONFIG_DIR;
-import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_ENABLED;
-import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_INITIAL_REFRESH_BEANS_PERIOD;
-import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_METRICS_CONFIGS;
-import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_ENABLED;
-import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_LIMIT;
-import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_REFRESH_BEANS_PERIOD;
-import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_START_DELAY;
-import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_STATSD_HOST;
-import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_STATSD_PORT;
-import static datadog.trace.api.config.JmxFetchConfig.JMX_TAGS;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_AGENTLESS;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_AGENTLESS_DEFAULT;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_API_KEY_FILE_OLD;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_API_KEY_FILE_VERY_OLD;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_API_KEY_OLD;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_API_KEY_VERY_OLD;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_ASYNC_ALLOC_ENABLED_DEFAULT;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_ASYNC_ENABLED;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_ENABLED;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_ENABLED_DEFAULT;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE_DEFAULT;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS_DEFAULT;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT_DEFAULT;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCLUDE_AGENT_THREADS;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_HOTSPOTS_ENABLED;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_LEGACY_TRACING_INTEGRATION;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_LEGACY_TRACING_INTEGRATION_DEFAULT;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_HOST;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_PASSWORD;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_PORT;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_PORT_DEFAULT;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_USERNAME;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_START_DELAY;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_START_DELAY_DEFAULT;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_START_FORCE_FIRST;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_START_FORCE_FIRST_DEFAULT;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_TAGS;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_TEMPLATE_OVERRIDE_FILE;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_COMPRESSION;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_COMPRESSION_DEFAULT;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_PERIOD;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_PERIOD_DEFAULT;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_SUMMARY_ON_413;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_SUMMARY_ON_413_DEFAULT;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_TIMEOUT;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_TIMEOUT_DEFAULT;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_URL;
-import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_ENABLED;
-import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_INITIAL_POLL_INTERVAL;
-import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED;
-import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_MAX_PAYLOAD_SIZE;
-import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_TARGETS_KEY;
-import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_TARGETS_KEY_ID;
-import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_URL;
-import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
-import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX;
-import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_CLIENT_ERROR_STATUSES;
-import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_IGNORED_INBOUND_METHODS;
-import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_IGNORED_OUTBOUND_METHODS;
-import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_SERVER_ERROR_STATUSES;
-import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_SERVER_TRIM_PACKAGE_RESOURCE;
-import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN;
-import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_CLIENT_TAG_QUERY_STRING;
-import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_RAW_QUERY_STRING;
-import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_RAW_RESOURCE;
-import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_ROUTE_BASED_NAMING;
-import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_TAG_QUERY_STRING;
-import static datadog.trace.api.config.TraceInstrumentationConfig.HYSTRIX_MEASURED_ENABLED;
-import static datadog.trace.api.config.TraceInstrumentationConfig.HYSTRIX_TAGS_ENABLED;
-import static datadog.trace.api.config.TraceInstrumentationConfig.IGNITE_CACHE_INCLUDE_KEYS;
-import static datadog.trace.api.config.TraceInstrumentationConfig.INTEGRATIONS_ENABLED;
-import static datadog.trace.api.config.TraceInstrumentationConfig.INTEGRATION_SYNAPSE_LEGACY_OPERATION_NAME;
-import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_CONNECTION_CLASS_NAME;
-import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_PREPARED_STATEMENT_CLASS_NAME;
-import static datadog.trace.api.config.TraceInstrumentationConfig.JMS_PROPAGATION_DISABLED_QUEUES;
-import static datadog.trace.api.config.TraceInstrumentationConfig.JMS_PROPAGATION_DISABLED_TOPICS;
-import static datadog.trace.api.config.TraceInstrumentationConfig.KAFKA_CLIENT_BASE64_DECODING_ENABLED;
-import static datadog.trace.api.config.TraceInstrumentationConfig.KAFKA_CLIENT_PROPAGATION_DISABLED_TOPICS;
-import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_INJECTION_ENABLED;
-import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_MDC_TAGS_INJECTION_ENABLED;
-import static datadog.trace.api.config.TraceInstrumentationConfig.MESSAGE_BROKER_SPLIT_BY_DESTINATION;
-import static datadog.trace.api.config.TraceInstrumentationConfig.OBFUSCATION_QUERY_STRING_REGEXP;
-import static datadog.trace.api.config.TraceInstrumentationConfig.PLAY_REPORT_HTTP_STATUS;
-import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGATION_DISABLED_EXCHANGES;
-import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGATION_DISABLED_QUEUES;
-import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_OUTLINE_POOL_ENABLED;
-import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_OUTLINE_POOL_SIZE;
-import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_TYPE_POOL_SIZE;
-import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_USE_LOADCLASS;
-import static datadog.trace.api.config.TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
-import static datadog.trace.api.config.TraceInstrumentationConfig.SERIALVERSIONUID_FIELD_INJECTION;
-import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ASYNC_TIMEOUT_ERROR;
-import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_PRINCIPAL_ENABLED;
-import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ROOT_CONTEXT_SERVICE_NAME;
-import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ANNOTATIONS;
-import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE;
-import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE_FILE;
-import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSLOADERS_EXCLUDE;
-import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CODESOURCES_EXCLUDE;
-import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ENABLED;
-import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_EXECUTORS;
-import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_EXECUTORS_ALL;
-import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_METHODS;
-import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_THREAD_POOL_EXECUTORS_EXCLUDE;
-import static datadog.trace.api.config.TracerConfig.AGENT_HOST;
-import static datadog.trace.api.config.TracerConfig.AGENT_NAMED_PIPE;
-import static datadog.trace.api.config.TracerConfig.AGENT_PORT_LEGACY;
-import static datadog.trace.api.config.TracerConfig.AGENT_TIMEOUT;
-import static datadog.trace.api.config.TracerConfig.AGENT_UNIX_DOMAIN_SOCKET;
-import static datadog.trace.api.config.TracerConfig.CLIENT_IP_ENABLED;
-import static datadog.trace.api.config.TracerConfig.CLOCK_SYNC_PERIOD;
-import static datadog.trace.api.config.TracerConfig.ENABLE_TRACE_AGENT_V05;
-import static datadog.trace.api.config.TracerConfig.HEADER_TAGS;
-import static datadog.trace.api.config.TracerConfig.HTTP_CLIENT_ERROR_STATUSES;
-import static datadog.trace.api.config.TracerConfig.HTTP_SERVER_ERROR_STATUSES;
-import static datadog.trace.api.config.TracerConfig.ID_GENERATION_STRATEGY;
-import static datadog.trace.api.config.TracerConfig.PARTIAL_FLUSH_MIN_SPANS;
-import static datadog.trace.api.config.TracerConfig.PRIORITY_SAMPLING;
-import static datadog.trace.api.config.TracerConfig.PRIORITY_SAMPLING_FORCE;
-import static datadog.trace.api.config.TracerConfig.PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED;
-import static datadog.trace.api.config.TracerConfig.PROPAGATION_STYLE_EXTRACT;
-import static datadog.trace.api.config.TracerConfig.PROPAGATION_STYLE_INJECT;
-import static datadog.trace.api.config.TracerConfig.PROXY_NO_PROXY;
-import static datadog.trace.api.config.TracerConfig.REQUEST_HEADER_TAGS;
-import static datadog.trace.api.config.TracerConfig.RESPONSE_HEADER_TAGS;
-import static datadog.trace.api.config.TracerConfig.SCOPE_DEPTH_LIMIT;
-import static datadog.trace.api.config.TracerConfig.SCOPE_INHERIT_ASYNC_PROPAGATION;
-import static datadog.trace.api.config.TracerConfig.SCOPE_ITERATION_KEEP_ALIVE;
-import static datadog.trace.api.config.TracerConfig.SCOPE_STRICT_MODE;
-import static datadog.trace.api.config.TracerConfig.SERVICE_MAPPING;
-import static datadog.trace.api.config.TracerConfig.SPAN_TAGS;
-import static datadog.trace.api.config.TracerConfig.SPLIT_BY_TAGS;
-import static datadog.trace.api.config.TracerConfig.TRACE_AGENT_ARGS;
-import static datadog.trace.api.config.TracerConfig.TRACE_AGENT_PATH;
-import static datadog.trace.api.config.TracerConfig.TRACE_AGENT_PORT;
-import static datadog.trace.api.config.TracerConfig.TRACE_AGENT_URL;
-import static datadog.trace.api.config.TracerConfig.TRACE_ANALYTICS_ENABLED;
-import static datadog.trace.api.config.TracerConfig.TRACE_CLIENT_IP_HEADER;
-import static datadog.trace.api.config.TracerConfig.TRACE_CLIENT_IP_RESOLVER_ENABLED;
-import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING;
-import static datadog.trace.api.config.TracerConfig.TRACE_RATE_LIMIT;
-import static datadog.trace.api.config.TracerConfig.TRACE_REPORT_HOSTNAME;
-import static datadog.trace.api.config.TracerConfig.TRACE_RESOLVER_ENABLED;
-import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLE_RATE;
-import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLING_OPERATION_RULES;
-import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLING_RULES;
-import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLING_SERVICE_RULES;
-import static datadog.trace.api.config.TracerConfig.TRACE_STRICT_WRITES_ENABLED;
-import static datadog.trace.api.config.TracerConfig.TRACE_X_DATADOG_TAGS_MAX_LENGTH;
-import static datadog.trace.api.config.TracerConfig.WRITER_TYPE;
-import static datadog.trace.util.CollectionUtils.tryMakeImmutableList;
 import static datadog.trace.util.CollectionUtils.tryMakeImmutableSet;
-import static datadog.trace.util.Strings.propertyNameToEnvironmentVariableName;
-import static datadog.trace.util.Strings.toEnvVar;
 
-import datadog.trace.api.config.GeneralConfig;
-import datadog.trace.api.config.TracerConfig;
-import datadog.trace.bootstrap.config.provider.CapturedEnvironmentConfigSource;
+import datadog.trace.api.config.AppSecFeatureConfig;
+import datadog.trace.api.config.CiVisibilityFeatureConfig;
+import datadog.trace.api.config.CrashTrackingFeatureConfig;
+import datadog.trace.api.config.CwsFeatureConfig;
+import datadog.trace.api.config.DebuggerFeatureConfig;
+import datadog.trace.api.config.GeneralFeatureConfig;
+import datadog.trace.api.config.IastFeatureConfig;
+import datadog.trace.api.config.JmxFetchFeatureConfig;
+import datadog.trace.api.config.ProfilingFeatureConfig;
+import datadog.trace.api.config.RemoteFeatureConfig;
+import datadog.trace.api.config.TraceInstrumentationFeatureConfig;
+import datadog.trace.api.config.TracerFeatureConfig;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
-import datadog.trace.bootstrap.config.provider.SystemPropertiesConfigSource;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.InetAddress;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.UnknownHostException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.BitSet;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.SortedSet;
-import java.util.UUID;
 import java.util.regex.Pattern;
-import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -368,291 +34,24 @@ import org.slf4j.LoggerFactory;
  * to ensure a valid config.
  *
  * <p>
- *
- * <p>System properties are {@link Config#PREFIX}'ed. Environment variables are the same as the
- * system property, but uppercased and '.' is replaced with '_'.
  */
 @Deprecated
 public class Config {
+  private static final Logger LOGGER = LoggerFactory.getLogger(Config.class);
+  private final GeneralFeatureConfig generalConfig;
+  private final TracerFeatureConfig tracerConfig;
+  private final IastFeatureConfig iastConfig;
+  private final JmxFetchFeatureConfig jmxFetchConfig;
+  private final TraceInstrumentationFeatureConfig traceInstrumentationConfig;
+  private final ProfilingFeatureConfig profilingConfig;
+  private final CrashTrackingFeatureConfig crashTrackingConfig;
+  private final AppSecFeatureConfig appSecConfig;
+  private final CiVisibilityFeatureConfig ciVisibilityConfig;
+  private final RemoteFeatureConfig remoteConfig;
+  private final DebuggerFeatureConfig debuggerConfig;
+  private final CwsFeatureConfig cwsConfig;
 
-  private static final Logger log = LoggerFactory.getLogger(Config.class);
-
-  private final long startTimeMillis = System.currentTimeMillis();
-
-  /**
-   * this is a random UUID that gets generated on JVM start up and is attached to every root span
-   * and every JMX metric that is sent out.
-   */
-  private final String runtimeId;
-
-  /** This is the version of the runtime, ex: 1.8.0_332, 11.0.15, 17.0.3 */
-  private final String runtimeVersion;
-
-  /**
-   * Note: this has effect only on profiling site. Traces are sent to Datadog agent and are not
-   * affected by this setting.
-   */
-  private final String apiKey;
-  /**
-   * Note: this has effect only on profiling site. Traces are sent to Datadog agent and are not
-   * affected by this setting.
-   */
-  private final String site;
-
-  private final String hostName;
-  private final String serviceName;
-  private final boolean serviceNameSetByUser;
-  private final String rootContextServiceName;
-  private final boolean traceEnabled;
-  private final boolean integrationsEnabled;
-  private final boolean integrationSynapseLegacyOperationName;
-  private final String writerType;
-  private final boolean agentConfiguredUsingDefault;
-  private final String agentUrl;
-  private final String agentHost;
-  private final int agentPort;
-  private final String agentUnixDomainSocket;
-  private final String agentNamedPipe;
-  private final int agentTimeout;
-  private final Set<String> noProxyHosts;
-  private final boolean prioritySamplingEnabled;
-  private final String prioritySamplingForce;
-  private final boolean traceResolverEnabled;
-  private final Map<String, String> serviceMapping;
-  private final Map<String, String> tags;
-  private final Map<String, String> spanTags;
-  private final Map<String, String> jmxTags;
-  private final List<String> excludedClasses;
-  private final String excludedClassesFile;
-  private final Set<String> excludedClassLoaders;
-  private final List<String> excludedCodeSources;
-  private final Map<String, String> requestHeaderTags;
-  private final Map<String, String> responseHeaderTags;
-  private final BitSet httpServerErrorStatuses;
-  private final BitSet httpClientErrorStatuses;
-  private final boolean httpServerTagQueryString;
-  private final boolean httpServerRawQueryString;
-  private final boolean httpServerRawResource;
-  private final boolean httpServerRouteBasedNaming;
-  private final Map<String, String> httpServerPathResourceNameMapping;
-  private final boolean httpClientTagQueryString;
-  private final boolean httpClientSplitByDomain;
-  private final boolean dbClientSplitByInstance;
-  private final boolean dbClientSplitByInstanceTypeSuffix;
-  private final Set<String> splitByTags;
-  private final int scopeDepthLimit;
-  private final boolean scopeStrictMode;
-  private final boolean scopeInheritAsyncPropagation;
-  private final int scopeIterationKeepAlive;
-  private final int partialFlushMinSpans;
-  private final boolean traceStrictWritesEnabled;
-  private final boolean runtimeContextFieldInjection;
-  private final boolean serialVersionUIDFieldInjection;
-  private final boolean logExtractHeaderNames;
-  private final Set<PropagationStyle> propagationStylesToExtract;
-  private final Set<PropagationStyle> propagationStylesToInject;
-  private final int clockSyncPeriod;
-
-  private final String dogStatsDNamedPipe;
-  private final int dogStatsDStartDelay;
-
-  private final boolean jmxFetchEnabled;
-  private final String jmxFetchConfigDir;
-  private final List<String> jmxFetchConfigs;
-  @Deprecated private final List<String> jmxFetchMetricsConfigs;
-  private final Integer jmxFetchCheckPeriod;
-  private final Integer jmxFetchInitialRefreshBeansPeriod;
-  private final Integer jmxFetchRefreshBeansPeriod;
-  private final String jmxFetchStatsdHost;
-  private final Integer jmxFetchStatsdPort;
-  private final boolean jmxFetchMultipleRuntimeServicesEnabled;
-  private final int jmxFetchMultipleRuntimeServicesLimit;
-
-  // These values are default-ed to those of jmx fetch values as needed
-  private final boolean healthMetricsEnabled;
-  private final String healthMetricsStatsdHost;
-  private final Integer healthMetricsStatsdPort;
-  private final boolean perfMetricsEnabled;
-
-  private final boolean tracerMetricsEnabled;
-  private final boolean tracerMetricsBufferingEnabled;
-  private final int tracerMetricsMaxAggregates;
-  private final int tracerMetricsMaxPending;
-
-  private final boolean logsInjectionEnabled;
-  private final boolean logsMDCTagsInjectionEnabled;
-  private final boolean reportHostName;
-
-  private final String traceAnnotations;
-
-  private final String traceMethods;
-
-  private final boolean traceExecutorsAll;
-  private final List<String> traceExecutors;
-
-  private final Set<String> traceThreadPoolExecutorsExclude;
-
-  private final boolean traceAnalyticsEnabled;
-  private final String traceClientIpHeader;
-  private final boolean traceClientIpResolverEnabled;
-
-  private final Map<String, String> traceSamplingServiceRules;
-  private final Map<String, String> traceSamplingOperationRules;
-  private final String traceSamplingRules;
-  private final Double traceSampleRate;
-  private final int traceRateLimit;
-
-  private final boolean profilingEnabled;
-  private final boolean profilingAgentless;
-  private final boolean profilingLegacyTracingIntegrationEnabled;
-
-  private final boolean isAsyncProfilerEnabled;
-  @Deprecated private final String profilingUrl;
-  private final Map<String, String> profilingTags;
-  private final int profilingStartDelay;
-  private final boolean profilingStartForceFirst;
-  private final int profilingUploadPeriod;
-  private final String profilingTemplateOverrideFile;
-  private final int profilingUploadTimeout;
-  private final String profilingUploadCompression;
-  private final String profilingProxyHost;
-  private final int profilingProxyPort;
-  private final String profilingProxyUsername;
-  private final String profilingProxyPassword;
-  private final int profilingExceptionSampleLimit;
-  private final int profilingExceptionHistogramTopItems;
-  private final int profilingExceptionHistogramMaxCollectionSize;
-  private final boolean profilingExcludeAgentThreads;
-  private final boolean profilingHotspotsEnabled;
-  private final boolean profilingUploadSummaryOn413Enabled;
-
-  private final boolean crashTrackingAgentless;
-  private final Map<String, String> crashTrackingTags;
-
-  private final boolean clientIpEnabled;
-
-  private final ProductActivationConfig appSecEnabled;
-  private final boolean appSecReportingInband;
-  private final String appSecRulesFile;
-  private final int appSecReportMinTimeout;
-  private final int appSecReportMaxTimeout;
-  private final int appSecTraceRateLimit;
-  private final boolean appSecWafMetrics;
-  private final String appSecObfuscationParameterKeyRegexp;
-  private final String appSecObfuscationParameterValueRegexp;
-  private final String appSecHttpBlockedTemplateHtml;
-  private final String appSecHttpBlockedTemplateJson;
-
-  private final boolean iastEnabled;
-  private final int iastMaxConcurrentRequests;
-  private final int iastVulnerabilitiesPerRequest;
-  private final float iastRequestSampling;
-
-  private final boolean ciVisibilityEnabled;
-  private final boolean ciVisibilityAgentlessEnabled;
-  private final String ciVisibilityAgentlessUrl;
-
-  private final boolean remoteConfigEnabled;
-  private final boolean remoteConfigIntegrityCheckEnabled;
-  private final String remoteConfigUrl;
-  private final int remoteConfigInitialPollInterval;
-  private final long remoteConfigMaxPayloadSize;
-  private final String remoteConfigTargetsKeyId;
-  private final String remoteConfigTargetsKey;
-
-  private final boolean debuggerEnabled;
-  private final int debuggerUploadTimeout;
-  private final int debuggerUploadFlushInterval;
-  private final boolean debuggerClassFileDumpEnabled;
-  private final int debuggerPollInterval;
-  private final int debuggerDiagnosticsInterval;
-  private final boolean debuggerMetricEnabled;
-  private final String debuggerProbeFileLocation;
-  private final int debuggerUploadBatchSize;
-  private final long debuggerMaxPayloadSize;
-  private final boolean debuggerVerifyByteCode;
-  private final boolean debuggerInstrumentTheWorld;
-  private final String debuggerExcludeFile;
-
-  private final boolean awsPropagationEnabled;
-  private final boolean sqsPropagationEnabled;
-
-  private final boolean kafkaClientPropagationEnabled;
-  private final Set<String> kafkaClientPropagationDisabledTopics;
-  private final boolean kafkaClientBase64DecodingEnabled;
-
-  private final boolean jmsPropagationEnabled;
-  private final Set<String> jmsPropagationDisabledTopics;
-  private final Set<String> jmsPropagationDisabledQueues;
-
-  private final boolean rabbitPropagationEnabled;
-  private final Set<String> rabbitPropagationDisabledQueues;
-  private final Set<String> rabbitPropagationDisabledExchanges;
-
-  private final boolean messageBrokerSplitByDestination;
-
-  private final boolean hystrixTagsEnabled;
-  private final boolean hystrixMeasuredEnabled;
-
-  private final boolean igniteCacheIncludeKeys;
-
-  private final String obfuscationQueryRegexp;
-
-  // TODO: remove at a future point.
-  private final boolean playReportHttpStatus;
-
-  private final boolean servletPrincipalEnabled;
-  private final boolean servletAsyncTimeoutError;
-
-  private final int xDatadogTagsMaxLength;
-
-  private final boolean traceAgentV05Enabled;
-
-  private final boolean debugEnabled;
   private final String configFileStatus;
-
-  private final IdGenerationStrategy idGenerationStrategy;
-
-  private final boolean internalExitOnFailure;
-
-  private final boolean resolverOutlinePoolEnabled;
-  private final int resolverOutlinePoolSize;
-  private final int resolverTypePoolSize;
-  private final boolean resolverUseLoadClassEnabled;
-
-  private final String jdbcPreparedStatementClassName;
-  private final String jdbcConnectionClassName;
-
-  private final Set<String> grpcIgnoredInboundMethods;
-  private final Set<String> grpcIgnoredOutboundMethods;
-  private final boolean grpcServerTrimPackageResource;
-  private final BitSet grpcServerErrorStatuses;
-  private final BitSet grpcClientErrorStatuses;
-
-  private final boolean cwsEnabled;
-  private final int cwsTlsRefresh;
-
-  private final boolean dataStreamsEnabled;
-
-  private final Set<String> iastWeakHashAlgorithms;
-
-  private final Pattern iastWeakCipherAlgorithms;
-
-  private final boolean iastDeduplicationEnabled;
-
-  private final boolean telemetryEnabled;
-  private final int telemetryHeartbeatInterval;
-
-  private final boolean azureAppServices;
-  private final String traceAgentPath;
-  private final List<String> traceAgentArgs;
-  private final String dogStatsDPath;
-  private final List<String> dogStatsDArgs;
-
-  private String env;
-  private String version;
-  private final String primaryTag;
-
   private final ConfigProvider configProvider;
 
   // Read order: System Properties -> Env Variables, [-> properties file], [-> default value]
@@ -662,1437 +61,822 @@ public class Config {
 
   private Config(final ConfigProvider configProvider) {
     this.configProvider = configProvider;
-    configFileStatus = configProvider.getConfigFileStatus();
-    runtimeId =
-        null != INSTANCE
-            ? INSTANCE.runtimeId
-            : configProvider.getBoolean(RUNTIME_ID_ENABLED, true)
-                ? UUID.randomUUID().toString()
-                : "";
-    runtimeVersion = System.getProperty("java.version", "unknown");
-
-    // Note: We do not want APiKey to be loaded from property for security reasons
-    // Note: we do not use defined default here
-    // FIXME: We should use better authentication mechanism
-    final String apiKeyFile = configProvider.getString(API_KEY_FILE);
-    String tmpApiKey =
-        configProvider.getStringExcludingSource(API_KEY, null, SystemPropertiesConfigSource.class);
-    if (apiKeyFile != null) {
-      try {
-        tmpApiKey =
-            new String(Files.readAllBytes(Paths.get(apiKeyFile)), StandardCharsets.UTF_8).trim();
-      } catch (final IOException e) {
-        log.error("Cannot read API key from file {}, skipping", apiKeyFile, e);
-      }
-    }
-    site = configProvider.getString(SITE, DEFAULT_SITE);
-
-    hostName = initHostName();
-
-    String userProvidedServiceName =
-        configProvider.getStringExcludingSource(
-            SERVICE, null, CapturedEnvironmentConfigSource.class, SERVICE_NAME);
-
-    if (userProvidedServiceName == null) {
-      serviceNameSetByUser = false;
-      serviceName = configProvider.getString(SERVICE, DEFAULT_SERVICE_NAME, SERVICE_NAME);
-    } else {
-      serviceNameSetByUser = true;
-      serviceName = userProvidedServiceName;
-    }
-
-    rootContextServiceName =
-        configProvider.getString(
-            SERVLET_ROOT_CONTEXT_SERVICE_NAME, DEFAULT_SERVLET_ROOT_CONTEXT_SERVICE_NAME);
-
-    traceEnabled = configProvider.getBoolean(TRACE_ENABLED, DEFAULT_TRACE_ENABLED);
-    integrationsEnabled =
-        configProvider.getBoolean(INTEGRATIONS_ENABLED, DEFAULT_INTEGRATIONS_ENABLED);
-    integrationSynapseLegacyOperationName =
-        configProvider.getBoolean(INTEGRATION_SYNAPSE_LEGACY_OPERATION_NAME, false);
-    writerType = configProvider.getString(WRITER_TYPE, DEFAULT_AGENT_WRITER_TYPE);
-
-    idGenerationStrategy =
-        configProvider.getEnum(ID_GENERATION_STRATEGY, IdGenerationStrategy.class, RANDOM);
-    if (idGenerationStrategy != RANDOM) {
-      log.warn(
-          "*** you are using an unsupported id generation strategy {} - this can impact correctness of traces",
-          idGenerationStrategy);
-    }
-
-    String agentHostFromEnvironment = null;
-    int agentPortFromEnvironment = -1;
-    String unixSocketFromEnvironment = null;
-    boolean rebuildAgentUrl = false;
-
-    final String agentUrlFromEnvironment = configProvider.getString(TRACE_AGENT_URL);
-    if (agentUrlFromEnvironment != null) {
-      try {
-        final URI parsedAgentUrl = new URI(agentUrlFromEnvironment);
-        agentHostFromEnvironment = parsedAgentUrl.getHost();
-        agentPortFromEnvironment = parsedAgentUrl.getPort();
-        if ("unix".equals(parsedAgentUrl.getScheme())) {
-          unixSocketFromEnvironment = parsedAgentUrl.getPath();
-        }
-      } catch (URISyntaxException e) {
-        log.warn("{} not configured correctly: {}. Ignoring", TRACE_AGENT_URL, e.getMessage());
-      }
-    }
-
-    if (agentHostFromEnvironment == null) {
-      agentHostFromEnvironment = configProvider.getString(AGENT_HOST);
-      rebuildAgentUrl = true;
-    }
-
-    if (agentPortFromEnvironment < 0) {
-      agentPortFromEnvironment = configProvider.getInteger(TRACE_AGENT_PORT, -1, AGENT_PORT_LEGACY);
-      rebuildAgentUrl = true;
-    }
-
-    if (agentHostFromEnvironment == null) {
-      agentHost = DEFAULT_AGENT_HOST;
-    } else {
-      agentHost = agentHostFromEnvironment;
-    }
-
-    if (agentPortFromEnvironment < 0) {
-      agentPort = DEFAULT_TRACE_AGENT_PORT;
-    } else {
-      agentPort = agentPortFromEnvironment;
-    }
-
-    if (rebuildAgentUrl) {
-      agentUrl = "http://" + agentHost + ":" + agentPort;
-    } else {
-      agentUrl = agentUrlFromEnvironment;
-    }
-
-    if (unixSocketFromEnvironment == null) {
-      unixSocketFromEnvironment = configProvider.getString(AGENT_UNIX_DOMAIN_SOCKET);
-      String unixPrefix = "unix://";
-      // handle situation where someone passes us a unix:// URL instead of a socket path
-      if (unixSocketFromEnvironment != null && unixSocketFromEnvironment.startsWith(unixPrefix)) {
-        unixSocketFromEnvironment = unixSocketFromEnvironment.substring(unixPrefix.length());
-      }
-    }
-
-    agentUnixDomainSocket = unixSocketFromEnvironment;
-
-    agentNamedPipe = configProvider.getString(AGENT_NAMED_PIPE);
-
-    agentConfiguredUsingDefault =
-        agentHostFromEnvironment == null
-            && agentPortFromEnvironment < 0
-            && unixSocketFromEnvironment == null
-            && agentNamedPipe == null;
-
-    agentTimeout = configProvider.getInteger(AGENT_TIMEOUT, DEFAULT_AGENT_TIMEOUT);
-
-    // DD_PROXY_NO_PROXY is specified as a space-separated list of hosts
-    noProxyHosts = tryMakeImmutableSet(configProvider.getSpacedList(PROXY_NO_PROXY));
-
-    prioritySamplingEnabled =
-        configProvider.getBoolean(PRIORITY_SAMPLING, DEFAULT_PRIORITY_SAMPLING_ENABLED);
-    prioritySamplingForce =
-        configProvider.getString(PRIORITY_SAMPLING_FORCE, DEFAULT_PRIORITY_SAMPLING_FORCE);
-
-    traceResolverEnabled =
-        configProvider.getBoolean(TRACE_RESOLVER_ENABLED, DEFAULT_TRACE_RESOLVER_ENABLED);
-    serviceMapping = configProvider.getMergedMap(SERVICE_MAPPING);
-
-    {
-      final Map<String, String> tags = new HashMap<>(configProvider.getMergedMap(GLOBAL_TAGS));
-      tags.putAll(configProvider.getMergedMap(TAGS));
-      this.tags = getMapWithPropertiesDefinedByEnvironment(tags, ENV, VERSION);
-    }
-
-    spanTags = configProvider.getMergedMap(SPAN_TAGS);
-    jmxTags = configProvider.getMergedMap(JMX_TAGS);
-
-    primaryTag = configProvider.getString(PRIMARY_TAG);
-
-    excludedClasses = tryMakeImmutableList(configProvider.getList(TRACE_CLASSES_EXCLUDE));
-    excludedClassesFile = configProvider.getString(TRACE_CLASSES_EXCLUDE_FILE);
-    excludedClassLoaders = tryMakeImmutableSet(configProvider.getList(TRACE_CLASSLOADERS_EXCLUDE));
-    excludedCodeSources = tryMakeImmutableList(configProvider.getList(TRACE_CODESOURCES_EXCLUDE));
-
-    if (isEnabled(false, HEADER_TAGS, ".legacy.parsing.enabled")) {
-      requestHeaderTags = configProvider.getMergedMap(HEADER_TAGS);
-      responseHeaderTags = Collections.emptyMap();
-      if (configProvider.isSet(REQUEST_HEADER_TAGS)) {
-        logIngoredSettingWarning(REQUEST_HEADER_TAGS, HEADER_TAGS, ".legacy.parsing.enabled");
-      }
-      if (configProvider.isSet(RESPONSE_HEADER_TAGS)) {
-        logIngoredSettingWarning(RESPONSE_HEADER_TAGS, HEADER_TAGS, ".legacy.parsing.enabled");
-      }
-    } else {
-      requestHeaderTags =
-          configProvider.getMergedMapWithOptionalMappings(
-              "http.request.headers.", true, HEADER_TAGS, REQUEST_HEADER_TAGS);
-      responseHeaderTags =
-          configProvider.getMergedMapWithOptionalMappings(
-              "http.response.headers.", true, HEADER_TAGS, RESPONSE_HEADER_TAGS);
-    }
-
-    httpServerPathResourceNameMapping =
-        configProvider.getOrderedMap(TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING);
-
-    httpServerErrorStatuses =
-        configProvider.getIntegerRange(
-            HTTP_SERVER_ERROR_STATUSES, DEFAULT_HTTP_SERVER_ERROR_STATUSES);
-
-    httpClientErrorStatuses =
-        configProvider.getIntegerRange(
-            HTTP_CLIENT_ERROR_STATUSES, DEFAULT_HTTP_CLIENT_ERROR_STATUSES);
-
-    httpServerTagQueryString =
-        configProvider.getBoolean(
-            HTTP_SERVER_TAG_QUERY_STRING, DEFAULT_HTTP_SERVER_TAG_QUERY_STRING);
-
-    httpServerRawQueryString = configProvider.getBoolean(HTTP_SERVER_RAW_QUERY_STRING, true);
-
-    httpServerRawResource = configProvider.getBoolean(HTTP_SERVER_RAW_RESOURCE, false);
-
-    httpServerRouteBasedNaming =
-        configProvider.getBoolean(
-            HTTP_SERVER_ROUTE_BASED_NAMING, DEFAULT_HTTP_SERVER_ROUTE_BASED_NAMING);
-
-    httpClientTagQueryString =
-        configProvider.getBoolean(
-            HTTP_CLIENT_TAG_QUERY_STRING, DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING);
-
-    httpClientSplitByDomain =
-        configProvider.getBoolean(
-            HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN);
-
-    dbClientSplitByInstance =
-        configProvider.getBoolean(
-            DB_CLIENT_HOST_SPLIT_BY_INSTANCE, DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE);
-
-    dbClientSplitByInstanceTypeSuffix =
-        configProvider.getBoolean(
-            DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX,
-            DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX);
-
-    splitByTags = tryMakeImmutableSet(configProvider.getList(SPLIT_BY_TAGS));
-
-    scopeDepthLimit = configProvider.getInteger(SCOPE_DEPTH_LIMIT, DEFAULT_SCOPE_DEPTH_LIMIT);
-
-    scopeStrictMode = configProvider.getBoolean(SCOPE_STRICT_MODE, false);
-
-    scopeInheritAsyncPropagation = configProvider.getBoolean(SCOPE_INHERIT_ASYNC_PROPAGATION, true);
-
-    scopeIterationKeepAlive =
-        configProvider.getInteger(SCOPE_ITERATION_KEEP_ALIVE, DEFAULT_SCOPE_ITERATION_KEEP_ALIVE);
-
-    partialFlushMinSpans =
-        configProvider.getInteger(PARTIAL_FLUSH_MIN_SPANS, DEFAULT_PARTIAL_FLUSH_MIN_SPANS);
-
-    traceStrictWritesEnabled = configProvider.getBoolean(TRACE_STRICT_WRITES_ENABLED, false);
-
-    runtimeContextFieldInjection =
-        configProvider.getBoolean(
-            RUNTIME_CONTEXT_FIELD_INJECTION, DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION);
-    serialVersionUIDFieldInjection =
-        configProvider.getBoolean(
-            SERIALVERSIONUID_FIELD_INJECTION, DEFAULT_SERIALVERSIONUID_FIELD_INJECTION);
-
-    logExtractHeaderNames =
-        configProvider.getBoolean(
-            PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED,
-            DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED);
-
-    propagationStylesToExtract =
-        getPropagationStyleSetSettingFromEnvironmentOrDefault(
-            PROPAGATION_STYLE_EXTRACT, DEFAULT_PROPAGATION_STYLE_EXTRACT);
-    propagationStylesToInject =
-        getPropagationStyleSetSettingFromEnvironmentOrDefault(
-            PROPAGATION_STYLE_INJECT, DEFAULT_PROPAGATION_STYLE_INJECT);
-
-    clockSyncPeriod = configProvider.getInteger(CLOCK_SYNC_PERIOD, DEFAULT_CLOCK_SYNC_PERIOD);
-
-    dogStatsDNamedPipe = configProvider.getString(DOGSTATSD_NAMED_PIPE);
-
-    dogStatsDStartDelay =
-        configProvider.getInteger(
-            DOGSTATSD_START_DELAY, DEFAULT_DOGSTATSD_START_DELAY, JMX_FETCH_START_DELAY);
-
-    boolean runtimeMetricsEnabled = configProvider.getBoolean(RUNTIME_METRICS_ENABLED, true);
-
-    jmxFetchEnabled =
-        runtimeMetricsEnabled
-            && configProvider.getBoolean(JMX_FETCH_ENABLED, DEFAULT_JMX_FETCH_ENABLED);
-    jmxFetchConfigDir = configProvider.getString(JMX_FETCH_CONFIG_DIR);
-    jmxFetchConfigs = tryMakeImmutableList(configProvider.getList(JMX_FETCH_CONFIG));
-    jmxFetchMetricsConfigs =
-        tryMakeImmutableList(configProvider.getList(JMX_FETCH_METRICS_CONFIGS));
-    jmxFetchCheckPeriod = configProvider.getInteger(JMX_FETCH_CHECK_PERIOD);
-    jmxFetchInitialRefreshBeansPeriod =
-        configProvider.getInteger(JMX_FETCH_INITIAL_REFRESH_BEANS_PERIOD);
-    jmxFetchRefreshBeansPeriod = configProvider.getInteger(JMX_FETCH_REFRESH_BEANS_PERIOD);
-
-    jmxFetchStatsdPort = configProvider.getInteger(JMX_FETCH_STATSD_PORT, DOGSTATSD_PORT);
-    jmxFetchStatsdHost =
-        configProvider.getString(
-            JMX_FETCH_STATSD_HOST,
-            // default to agent host if an explicit port has been set
-            null != jmxFetchStatsdPort && jmxFetchStatsdPort > 0 ? agentHost : null,
-            DOGSTATSD_HOST);
-
-    jmxFetchMultipleRuntimeServicesEnabled =
-        configProvider.getBoolean(
-            JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_ENABLED,
-            DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_ENABLED);
-    jmxFetchMultipleRuntimeServicesLimit =
-        configProvider.getInteger(
-            JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_LIMIT,
-            DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_LIMIT);
-
-    // Writer.Builder createMonitor will use the values of the JMX fetch & agent to fill-in defaults
-    healthMetricsEnabled =
-        runtimeMetricsEnabled
-            && configProvider.getBoolean(HEALTH_METRICS_ENABLED, DEFAULT_HEALTH_METRICS_ENABLED);
-    healthMetricsStatsdHost = configProvider.getString(HEALTH_METRICS_STATSD_HOST);
-    healthMetricsStatsdPort = configProvider.getInteger(HEALTH_METRICS_STATSD_PORT);
-    perfMetricsEnabled =
-        runtimeMetricsEnabled
-            && isJavaVersionAtLeast(8)
-            && configProvider.getBoolean(PERF_METRICS_ENABLED, DEFAULT_PERF_METRICS_ENABLED);
-
-    tracerMetricsEnabled =
-        isJavaVersionAtLeast(8) && configProvider.getBoolean(TRACER_METRICS_ENABLED, false);
-    tracerMetricsBufferingEnabled =
-        configProvider.getBoolean(TRACER_METRICS_BUFFERING_ENABLED, false);
-    tracerMetricsMaxAggregates = configProvider.getInteger(TRACER_METRICS_MAX_AGGREGATES, 2048);
-    tracerMetricsMaxPending = configProvider.getInteger(TRACER_METRICS_MAX_PENDING, 2048);
-
-    logsInjectionEnabled =
-        configProvider.getBoolean(LOGS_INJECTION_ENABLED, DEFAULT_LOGS_INJECTION_ENABLED);
-    logsMDCTagsInjectionEnabled = configProvider.getBoolean(LOGS_MDC_TAGS_INJECTION_ENABLED, true);
-    reportHostName =
-        configProvider.getBoolean(TRACE_REPORT_HOSTNAME, DEFAULT_TRACE_REPORT_HOSTNAME);
-
-    traceAgentV05Enabled =
-        configProvider.getBoolean(ENABLE_TRACE_AGENT_V05, DEFAULT_TRACE_AGENT_V05_ENABLED);
-
-    traceAnnotations = configProvider.getString(TRACE_ANNOTATIONS, DEFAULT_TRACE_ANNOTATIONS);
-
-    traceMethods = configProvider.getString(TRACE_METHODS, DEFAULT_TRACE_METHODS);
-
-    traceExecutorsAll = configProvider.getBoolean(TRACE_EXECUTORS_ALL, DEFAULT_TRACE_EXECUTORS_ALL);
-    traceExecutors = tryMakeImmutableList(configProvider.getList(TRACE_EXECUTORS));
-
-    traceThreadPoolExecutorsExclude =
-        tryMakeImmutableSet(configProvider.getList(TRACE_THREAD_POOL_EXECUTORS_EXCLUDE));
-
-    traceAnalyticsEnabled =
-        configProvider.getBoolean(TRACE_ANALYTICS_ENABLED, DEFAULT_TRACE_ANALYTICS_ENABLED);
-
-    String traceClientIpHeader = configProvider.getString(TRACE_CLIENT_IP_HEADER);
-    if (traceClientIpHeader == null) {
-      traceClientIpHeader = configProvider.getString(APPSEC_IP_ADDR_HEADER);
-    }
-    if (traceClientIpHeader != null) {
-      traceClientIpHeader = traceClientIpHeader.toLowerCase(Locale.ROOT);
-    }
-    this.traceClientIpHeader = traceClientIpHeader;
-
-    this.traceClientIpResolverEnabled =
-        configProvider.getBoolean(TRACE_CLIENT_IP_RESOLVER_ENABLED, true);
-
-    traceSamplingServiceRules = configProvider.getMergedMap(TRACE_SAMPLING_SERVICE_RULES);
-    traceSamplingOperationRules = configProvider.getMergedMap(TRACE_SAMPLING_OPERATION_RULES);
-    traceSamplingRules = configProvider.getString(TRACE_SAMPLING_RULES);
-    traceSampleRate = configProvider.getDouble(TRACE_SAMPLE_RATE);
-    traceRateLimit = configProvider.getInteger(TRACE_RATE_LIMIT, DEFAULT_TRACE_RATE_LIMIT);
-
-    profilingEnabled = configProvider.getBoolean(PROFILING_ENABLED, PROFILING_ENABLED_DEFAULT);
-    profilingAgentless =
-        configProvider.getBoolean(PROFILING_AGENTLESS, PROFILING_AGENTLESS_DEFAULT);
-    profilingLegacyTracingIntegrationEnabled =
-        configProvider.getBoolean(
-            PROFILING_LEGACY_TRACING_INTEGRATION, PROFILING_LEGACY_TRACING_INTEGRATION_DEFAULT);
-    isAsyncProfilerEnabled =
-        configProvider.getBoolean(PROFILING_ASYNC_ENABLED, PROFILING_ASYNC_ALLOC_ENABLED_DEFAULT);
-    profilingUrl = configProvider.getString(PROFILING_URL);
-
-    if (tmpApiKey == null) {
-      final String oldProfilingApiKeyFile = configProvider.getString(PROFILING_API_KEY_FILE_OLD);
-      tmpApiKey = getEnv(propertyNameToEnvironmentVariableName(PROFILING_API_KEY_OLD));
-      if (oldProfilingApiKeyFile != null) {
-        try {
-          tmpApiKey =
-              new String(
-                      Files.readAllBytes(Paths.get(oldProfilingApiKeyFile)), StandardCharsets.UTF_8)
-                  .trim();
-        } catch (final IOException e) {
-          log.error("Cannot read API key from file {}, skipping", oldProfilingApiKeyFile, e);
-        }
-      }
-    }
-    if (tmpApiKey == null) {
-      final String veryOldProfilingApiKeyFile =
-          configProvider.getString(PROFILING_API_KEY_FILE_VERY_OLD);
-      tmpApiKey = getEnv(propertyNameToEnvironmentVariableName(PROFILING_API_KEY_VERY_OLD));
-      if (veryOldProfilingApiKeyFile != null) {
-        try {
-          tmpApiKey =
-              new String(
-                      Files.readAllBytes(Paths.get(veryOldProfilingApiKeyFile)),
-                      StandardCharsets.UTF_8)
-                  .trim();
-        } catch (final IOException e) {
-          log.error("Cannot read API key from file {}, skipping", veryOldProfilingApiKeyFile, e);
-        }
-      }
-    }
-
-    profilingTags = configProvider.getMergedMap(PROFILING_TAGS);
-    profilingStartDelay =
-        configProvider.getInteger(PROFILING_START_DELAY, PROFILING_START_DELAY_DEFAULT);
-    profilingStartForceFirst =
-        configProvider.getBoolean(PROFILING_START_FORCE_FIRST, PROFILING_START_FORCE_FIRST_DEFAULT);
-    profilingUploadPeriod =
-        configProvider.getInteger(PROFILING_UPLOAD_PERIOD, PROFILING_UPLOAD_PERIOD_DEFAULT);
-    profilingTemplateOverrideFile = configProvider.getString(PROFILING_TEMPLATE_OVERRIDE_FILE);
-    profilingUploadTimeout =
-        configProvider.getInteger(PROFILING_UPLOAD_TIMEOUT, PROFILING_UPLOAD_TIMEOUT_DEFAULT);
-    profilingUploadCompression =
-        configProvider.getString(
-            PROFILING_UPLOAD_COMPRESSION, PROFILING_UPLOAD_COMPRESSION_DEFAULT);
-    profilingProxyHost = configProvider.getString(PROFILING_PROXY_HOST);
-    profilingProxyPort =
-        configProvider.getInteger(PROFILING_PROXY_PORT, PROFILING_PROXY_PORT_DEFAULT);
-    profilingProxyUsername = configProvider.getString(PROFILING_PROXY_USERNAME);
-    profilingProxyPassword = configProvider.getString(PROFILING_PROXY_PASSWORD);
-
-    profilingExceptionSampleLimit =
-        configProvider.getInteger(
-            PROFILING_EXCEPTION_SAMPLE_LIMIT, PROFILING_EXCEPTION_SAMPLE_LIMIT_DEFAULT);
-    profilingExceptionHistogramTopItems =
-        configProvider.getInteger(
-            PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS,
-            PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS_DEFAULT);
-    profilingExceptionHistogramMaxCollectionSize =
-        configProvider.getInteger(
-            PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE,
-            PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE_DEFAULT);
-
-    profilingExcludeAgentThreads = configProvider.getBoolean(PROFILING_EXCLUDE_AGENT_THREADS, true);
-
-    // code hotspots are disabled by default because of potential perf overhead they can incur
-    profilingHotspotsEnabled = configProvider.getBoolean(PROFILING_HOTSPOTS_ENABLED, false);
-
-    profilingUploadSummaryOn413Enabled =
-        configProvider.getBoolean(
-            PROFILING_UPLOAD_SUMMARY_ON_413, PROFILING_UPLOAD_SUMMARY_ON_413_DEFAULT);
-
-    crashTrackingAgentless =
-        configProvider.getBoolean(CRASH_TRACKING_AGENTLESS, CRASH_TRACKING_AGENTLESS_DEFAULT);
-    crashTrackingTags = configProvider.getMergedMap(CRASH_TRACKING_TAGS);
-
-    telemetryEnabled = configProvider.getBoolean(TELEMETRY_ENABLED, DEFAULT_TELEMETRY_ENABLED);
-    int telemetryInterval =
-        configProvider.getInteger(
-            TELEMETRY_HEARTBEAT_INTERVAL, DEFAULT_TELEMETRY_HEARTBEAT_INTERVAL);
-    if (telemetryInterval < 1 || telemetryInterval > 3600) {
-      log.warn(
-          "Wrong Telemetry heartbeat interval: {}. The value must be in range 1-3600",
-          telemetryInterval);
-      telemetryInterval = DEFAULT_TELEMETRY_HEARTBEAT_INTERVAL;
-    }
-    telemetryHeartbeatInterval = telemetryInterval;
-
-    this.clientIpEnabled = configProvider.getBoolean(CLIENT_IP_ENABLED, DEFAULT_CLIENT_IP_ENABLED);
-
-    // ConfigProvider.getString currently doesn't fallback to default for empty strings. So we have
-    // special handling here until we have a general solution for empty string value fallback.
-    String appSecEnabled = configProvider.getString(APPSEC_ENABLED);
-    if (appSecEnabled == null || appSecEnabled.isEmpty()) {
-      appSecEnabled =
-          configProvider.getStringExcludingSource(
-              APPSEC_ENABLED, DEFAULT_APPSEC_ENABLED, SystemPropertiesConfigSource.class);
-      if (appSecEnabled.isEmpty()) {
-        appSecEnabled = DEFAULT_APPSEC_ENABLED;
-      }
-    }
-    this.appSecEnabled = ProductActivationConfig.fromString(appSecEnabled);
-    appSecReportingInband =
-        configProvider.getBoolean(APPSEC_REPORTING_INBAND, DEFAULT_APPSEC_REPORTING_INBAND);
-    appSecRulesFile = configProvider.getString(APPSEC_RULES_FILE, null);
-
-    // Default AppSec report timeout min=5, max=60
-    appSecReportMaxTimeout = configProvider.getInteger(APPSEC_REPORT_TIMEOUT_SEC, 60);
-    appSecReportMinTimeout = Math.min(appSecReportMaxTimeout, 5);
-
-    appSecTraceRateLimit =
-        configProvider.getInteger(APPSEC_TRACE_RATE_LIMIT, DEFAULT_APPSEC_TRACE_RATE_LIMIT);
-
-    appSecWafMetrics = configProvider.getBoolean(APPSEC_WAF_METRICS, DEFAULT_APPSEC_WAF_METRICS);
-
-    appSecObfuscationParameterKeyRegexp =
-        configProvider.getString(APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP, null);
-    appSecObfuscationParameterValueRegexp =
-        configProvider.getString(APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP, null);
-
-    appSecHttpBlockedTemplateHtml =
-        configProvider.getString(APPSEC_HTTP_BLOCKED_TEMPLATE_HTML, null);
-    appSecHttpBlockedTemplateJson =
-        configProvider.getString(APPSEC_HTTP_BLOCKED_TEMPLATE_JSON, null);
-
-    iastEnabled = configProvider.getBoolean(IAST_ENABLED, DEFAULT_IAST_ENABLED);
-    iastMaxConcurrentRequests =
-        configProvider.getInteger(
-            IAST_MAX_CONCURRENT_REQUESTS, DEFAULT_IAST_MAX_CONCURRENT_REQUESTS);
-    iastVulnerabilitiesPerRequest =
-        configProvider.getInteger(
-            IAST_VULNERABILITIES_PER_REQUEST, DEFAULT_IAST_VULNERABILITIES_PER_REQUEST);
-    iastRequestSampling =
-        configProvider.getFloat(IAST_REQUEST_SAMPLING, DEFAULT_IAST_REQUEST_SAMPLING);
-    iastWeakHashAlgorithms =
-        tryMakeImmutableSet(
-            configProvider.getSet(IAST_WEAK_HASH_ALGORITHMS, DEFAULT_IAST_WEAK_HASH_ALGORITHMS));
-    iastWeakCipherAlgorithms =
-        getPattern(
-            DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS,
-            configProvider.getString(IAST_WEAK_CIPHER_ALGORITHMS));
-    iastDeduplicationEnabled =
-        configProvider.getBoolean(IAST_DEDUPLICATION_ENABLED, DEFAULT_IAST_DEDUPLICATION_ENABLED);
-
-    ciVisibilityEnabled =
-        configProvider.getBoolean(CIVISIBILITY_ENABLED, DEFAULT_CIVISIBILITY_ENABLED);
-    ciVisibilityAgentlessEnabled =
-        configProvider.getBoolean(
-            CIVISIBILITY_AGENTLESS_ENABLED, DEFAULT_CIVISIBILITY_AGENTLESS_ENABLED);
-
-    final String ciVisibilityAgentlessUrlStr = configProvider.getString(CIVISIBILITY_AGENTLESS_URL);
-    URI parsedCiVisibilityUri = null;
-    if (ciVisibilityAgentlessUrlStr != null && !ciVisibilityAgentlessUrlStr.isEmpty()) {
-      try {
-        parsedCiVisibilityUri = new URL(ciVisibilityAgentlessUrlStr).toURI();
-      } catch (MalformedURLException | URISyntaxException ex) {
-        log.error(
-            "Cannot parse CI Visibility agentless URL '{}', skipping", ciVisibilityAgentlessUrlStr);
-      }
-    }
-    if (parsedCiVisibilityUri != null) {
-      ciVisibilityAgentlessUrl = ciVisibilityAgentlessUrlStr;
-    } else {
-      ciVisibilityAgentlessUrl = null;
-    }
-
-    remoteConfigEnabled =
-        configProvider.getBoolean(REMOTE_CONFIG_ENABLED, DEFAULT_REMOTE_CONFIG_ENABLED);
-    remoteConfigIntegrityCheckEnabled =
-        configProvider.getBoolean(
-            REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED, DEFAULT_REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED);
-    remoteConfigUrl = configProvider.getString(REMOTE_CONFIG_URL);
-    remoteConfigInitialPollInterval =
-        configProvider.getInteger(
-            REMOTE_CONFIG_INITIAL_POLL_INTERVAL, DEFAULT_REMOTE_CONFIG_INITIAL_POLL_INTERVAL);
-    remoteConfigMaxPayloadSize =
-        configProvider.getInteger(
-                REMOTE_CONFIG_MAX_PAYLOAD_SIZE, DEFAULT_REMOTE_CONFIG_MAX_PAYLOAD_SIZE)
-            * 1024;
-    remoteConfigTargetsKeyId =
-        configProvider.getString(
-            REMOTE_CONFIG_TARGETS_KEY_ID, DEFAULT_REMOTE_CONFIG_TARGETS_KEY_ID);
-    remoteConfigTargetsKey =
-        configProvider.getString(REMOTE_CONFIG_TARGETS_KEY, DEFAULT_REMOTE_CONFIG_TARGETS_KEY);
-
-    debuggerEnabled = configProvider.getBoolean(DEBUGGER_ENABLED, DEFAULT_DEBUGGER_ENABLED);
-    debuggerUploadTimeout =
-        configProvider.getInteger(DEBUGGER_UPLOAD_TIMEOUT, DEFAULT_DEBUGGER_UPLOAD_TIMEOUT);
-    debuggerUploadFlushInterval =
-        configProvider.getInteger(
-            DEBUGGER_UPLOAD_FLUSH_INTERVAL, DEFAULT_DEBUGGER_UPLOAD_FLUSH_INTERVAL);
-    debuggerClassFileDumpEnabled =
-        configProvider.getBoolean(
-            DEBUGGER_CLASSFILE_DUMP_ENABLED, DEFAULT_DEBUGGER_CLASSFILE_DUMP_ENABLED);
-    debuggerPollInterval =
-        configProvider.getInteger(DEBUGGER_POLL_INTERVAL, DEFAULT_DEBUGGER_POLL_INTERVAL);
-    debuggerDiagnosticsInterval =
-        configProvider.getInteger(
-            DEBUGGER_DIAGNOSTICS_INTERVAL, DEFAULT_DEBUGGER_DIAGNOSTICS_INTERVAL);
-    debuggerMetricEnabled =
-        runtimeMetricsEnabled
-            && configProvider.getBoolean(
-                DEBUGGER_METRICS_ENABLED, DEFAULT_DEBUGGER_METRICS_ENABLED);
-    debuggerProbeFileLocation = configProvider.getString(DEBUGGER_PROBE_FILE_LOCATION);
-    debuggerUploadBatchSize =
-        configProvider.getInteger(DEBUGGER_UPLOAD_BATCH_SIZE, DEFAULT_DEBUGGER_UPLOAD_BATCH_SIZE);
-    debuggerMaxPayloadSize =
-        configProvider.getInteger(DEBUGGER_MAX_PAYLOAD_SIZE, DEFAULT_DEBUGGER_MAX_PAYLOAD_SIZE)
-            * 1024;
-    debuggerVerifyByteCode =
-        configProvider.getBoolean(DEBUGGER_VERIFY_BYTECODE, DEFAULT_DEBUGGER_VERIFY_BYTECODE);
-    debuggerInstrumentTheWorld =
-        configProvider.getBoolean(
-            DEBUGGER_INSTRUMENT_THE_WORLD, DEFAULT_DEBUGGER_INSTRUMENT_THE_WORLD);
-    debuggerExcludeFile = configProvider.getString(DEBUGGER_EXCLUDE_FILE);
-
-    jdbcPreparedStatementClassName =
-        configProvider.getString(JDBC_PREPARED_STATEMENT_CLASS_NAME, "");
-
-    jdbcConnectionClassName = configProvider.getString(JDBC_CONNECTION_CLASS_NAME, "");
-
-    awsPropagationEnabled = isPropagationEnabled(true, "aws");
-    sqsPropagationEnabled = awsPropagationEnabled && isPropagationEnabled(true, "sqs");
-
-    kafkaClientPropagationEnabled = isPropagationEnabled(true, "kafka", "kafka.client");
-    kafkaClientPropagationDisabledTopics =
-        tryMakeImmutableSet(configProvider.getList(KAFKA_CLIENT_PROPAGATION_DISABLED_TOPICS));
-    kafkaClientBase64DecodingEnabled =
-        configProvider.getBoolean(KAFKA_CLIENT_BASE64_DECODING_ENABLED, false);
-
-    jmsPropagationEnabled = isPropagationEnabled(true, "jms");
-    jmsPropagationDisabledTopics =
-        tryMakeImmutableSet(configProvider.getList(JMS_PROPAGATION_DISABLED_TOPICS));
-    jmsPropagationDisabledQueues =
-        tryMakeImmutableSet(configProvider.getList(JMS_PROPAGATION_DISABLED_QUEUES));
-
-    rabbitPropagationEnabled = isPropagationEnabled(true, "rabbit", "rabbitmq");
-    rabbitPropagationDisabledQueues =
-        tryMakeImmutableSet(configProvider.getList(RABBIT_PROPAGATION_DISABLED_QUEUES));
-    rabbitPropagationDisabledExchanges =
-        tryMakeImmutableSet(configProvider.getList(RABBIT_PROPAGATION_DISABLED_EXCHANGES));
-
-    messageBrokerSplitByDestination =
-        configProvider.getBoolean(MESSAGE_BROKER_SPLIT_BY_DESTINATION, false);
-
-    grpcIgnoredInboundMethods =
-        tryMakeImmutableSet(configProvider.getList(GRPC_IGNORED_INBOUND_METHODS));
-    grpcIgnoredOutboundMethods =
-        tryMakeImmutableSet(configProvider.getList(GRPC_IGNORED_OUTBOUND_METHODS));
-    grpcServerTrimPackageResource =
-        configProvider.getBoolean(GRPC_SERVER_TRIM_PACKAGE_RESOURCE, false);
-    grpcServerErrorStatuses =
-        configProvider.getIntegerRange(
-            GRPC_SERVER_ERROR_STATUSES, DEFAULT_GRPC_SERVER_ERROR_STATUSES);
-    grpcClientErrorStatuses =
-        configProvider.getIntegerRange(
-            GRPC_CLIENT_ERROR_STATUSES, DEFAULT_GRPC_CLIENT_ERROR_STATUSES);
-
-    hystrixTagsEnabled = configProvider.getBoolean(HYSTRIX_TAGS_ENABLED, false);
-    hystrixMeasuredEnabled = configProvider.getBoolean(HYSTRIX_MEASURED_ENABLED, false);
-
-    igniteCacheIncludeKeys = configProvider.getBoolean(IGNITE_CACHE_INCLUDE_KEYS, false);
-
-    obfuscationQueryRegexp = configProvider.getString(OBFUSCATION_QUERY_STRING_REGEXP);
-
-    playReportHttpStatus = configProvider.getBoolean(PLAY_REPORT_HTTP_STATUS, false);
-
-    servletPrincipalEnabled = configProvider.getBoolean(SERVLET_PRINCIPAL_ENABLED, false);
-
-    xDatadogTagsMaxLength =
-        configProvider.getInteger(
-            TRACE_X_DATADOG_TAGS_MAX_LENGTH, DEFAULT_TRACE_X_DATADOG_TAGS_MAX_LENGTH);
-
-    servletAsyncTimeoutError = configProvider.getBoolean(SERVLET_ASYNC_TIMEOUT_ERROR, true);
-
-    debugEnabled = isDebugMode();
-
-    internalExitOnFailure = configProvider.getBoolean(INTERNAL_EXIT_ON_FAILURE, false);
-
-    resolverOutlinePoolEnabled = configProvider.getBoolean(RESOLVER_OUTLINE_POOL_ENABLED, true);
-    resolverOutlinePoolSize =
-        configProvider.getInteger(RESOLVER_OUTLINE_POOL_SIZE, DEFAULT_RESOLVER_OUTLINE_POOL_SIZE);
-    resolverTypePoolSize =
-        configProvider.getInteger(RESOLVER_TYPE_POOL_SIZE, DEFAULT_RESOLVER_TYPE_POOL_SIZE);
-    resolverUseLoadClassEnabled = configProvider.getBoolean(RESOLVER_USE_LOADCLASS, true);
-
-    cwsEnabled = configProvider.getBoolean(CWS_ENABLED, DEFAULT_CWS_ENABLED);
-    cwsTlsRefresh = configProvider.getInteger(CWS_TLS_REFRESH, DEFAULT_CWS_TLS_REFRESH);
-
-    dataStreamsEnabled =
-        configProvider.getBoolean(DATA_STREAMS_ENABLED, DEFAULT_DATA_STREAMS_ENABLED);
-
-    azureAppServices = configProvider.getBoolean(AZURE_APP_SERVICES, false);
-    traceAgentPath = configProvider.getString(TRACE_AGENT_PATH);
-    String traceAgentArgsString = configProvider.getString(TRACE_AGENT_ARGS);
-    if (traceAgentArgsString == null) {
-      traceAgentArgs = Collections.emptyList();
-    } else {
-      traceAgentArgs =
-          Collections.unmodifiableList(
-              new ArrayList<>(parseStringIntoSetOfNonEmptyStrings(traceAgentArgsString)));
-    }
-
-    dogStatsDPath = configProvider.getString(DOGSTATSD_PATH);
-    String dogStatsDArgsString = configProvider.getString(DOGSTATSD_ARGS);
-    if (dogStatsDArgsString == null) {
-      dogStatsDArgs = Collections.emptyList();
-    } else {
-      dogStatsDArgs =
-          Collections.unmodifiableList(
-              new ArrayList<>(parseStringIntoSetOfNonEmptyStrings(dogStatsDArgsString)));
-    }
-
-    // Setting this last because we have a few places where this can come from
-    apiKey = tmpApiKey;
-
-    if (profilingAgentless && apiKey == null) {
-      log.warn(
+    this.generalConfig = new GeneralFeatureConfig(configProvider);
+    this.tracerConfig = new TracerFeatureConfig(configProvider);
+    this.iastConfig = new IastFeatureConfig(configProvider);
+    this.jmxFetchConfig =
+        new JmxFetchFeatureConfig(configProvider, this.generalConfig, this.tracerConfig);
+    this.traceInstrumentationConfig = new TraceInstrumentationFeatureConfig(configProvider);
+    this.profilingConfig =
+        new ProfilingFeatureConfig(configProvider, this.generalConfig, this.tracerConfig);
+    this.crashTrackingConfig =
+        new CrashTrackingFeatureConfig(configProvider, this.generalConfig, this.tracerConfig);
+    this.appSecConfig = new AppSecFeatureConfig(configProvider);
+    this.ciVisibilityConfig = new CiVisibilityFeatureConfig(configProvider);
+    this.remoteConfig = new RemoteFeatureConfig(configProvider);
+    this.debuggerConfig = new DebuggerFeatureConfig(configProvider, this.tracerConfig);
+    this.cwsConfig = new CwsFeatureConfig(configProvider);
+    this.configFileStatus = configProvider.getConfigFileStatus();
+
+    if (this.profilingConfig.isProfilingAgentless() && this.generalConfig.getApiKey() == null) {
+      LOGGER.warn(
           "Agentless profiling activated but no api key provided. Profile uploading will likely fail");
     }
 
-    log.debug("New instance: {}", this);
+    LOGGER.debug("New instance: {}", this);
+  }
+
+  public GeneralFeatureConfig getGeneralConfig() {
+    return this.generalConfig;
+  }
+
+  public TracerFeatureConfig getTracerConfig() {
+    return this.tracerConfig;
+  }
+
+  public IastFeatureConfig getIastConfig() {
+    return this.iastConfig;
+  }
+
+  public JmxFetchFeatureConfig getJmxFetchConfig() {
+    return this.jmxFetchConfig;
+  }
+
+  public TraceInstrumentationFeatureConfig getTraceInstrumentationConfig() {
+    return this.traceInstrumentationConfig;
+  }
+
+  public ProfilingFeatureConfig getProfilingConfig() {
+    return this.profilingConfig;
+  }
+
+  public CrashTrackingFeatureConfig getCrashTrackingConfig() {
+    return this.crashTrackingConfig;
+  }
+
+  public AppSecFeatureConfig getAppSecConfig() {
+    return this.appSecConfig;
+  }
+
+  public CiVisibilityFeatureConfig getCiVisibilityConfig() {
+    return this.ciVisibilityConfig;
+  }
+
+  public RemoteFeatureConfig getRemoteConfig() {
+    return this.remoteConfig;
+  }
+
+  public DebuggerFeatureConfig getDebuggerConfig() {
+    return this.debuggerConfig;
+  }
+
+  public CwsFeatureConfig getCwsConfig() {
+    return this.cwsConfig;
   }
 
   public long getStartTimeMillis() {
-    return startTimeMillis;
+    return this.generalConfig.getStartTimeMillis();
   }
 
   public String getRuntimeId() {
-    return runtimeId;
+    return this.generalConfig.getRuntimeId();
   }
 
   public String getRuntimeVersion() {
-    return runtimeVersion;
+    return this.generalConfig.getRuntimeVersion();
   }
 
   public String getApiKey() {
-    return apiKey;
+    return this.generalConfig.getApiKey();
   }
 
   public String getSite() {
-    return site;
+    return this.generalConfig.getSite();
   }
 
   public String getHostName() {
-    return hostName;
+    return this.generalConfig.getHostName();
   }
 
   public String getServiceName() {
-    return serviceName;
+    return this.generalConfig.getServiceName();
   }
 
   public boolean isServiceNameSetByUser() {
-    return serviceNameSetByUser;
+    return this.generalConfig.isServiceNameSetByUser();
   }
 
   public String getRootContextServiceName() {
-    return rootContextServiceName;
+    return this.traceInstrumentationConfig.getRootContextServiceName();
   }
 
   public boolean isTraceEnabled() {
-    return traceEnabled;
+    return this.traceInstrumentationConfig.isTraceEnabled();
   }
 
   public boolean isIntegrationsEnabled() {
-    return integrationsEnabled;
+    return this.traceInstrumentationConfig.isIntegrationsEnabled();
   }
 
   public boolean isIntegrationSynapseLegacyOperationName() {
-    return integrationSynapseLegacyOperationName;
+    return this.traceInstrumentationConfig.isIntegrationSynapseLegacyOperationName();
   }
 
   public String getWriterType() {
-    return writerType;
+    return this.tracerConfig.getWriterType();
   }
 
   public boolean isAgentConfiguredUsingDefault() {
-    return agentConfiguredUsingDefault;
+    return this.tracerConfig.isAgentConfiguredUsingDefault();
   }
 
   public String getAgentUrl() {
-    return agentUrl;
+    return this.tracerConfig.getAgentUrl();
   }
 
   public String getAgentHost() {
-    return agentHost;
+    return this.tracerConfig.getAgentHost();
   }
 
   public int getAgentPort() {
-    return agentPort;
+    return this.tracerConfig.getAgentPort();
   }
 
   public String getAgentUnixDomainSocket() {
-    return agentUnixDomainSocket;
+    return this.tracerConfig.getAgentUnixDomainSocket();
   }
 
   public String getAgentNamedPipe() {
-    return agentNamedPipe;
+    return this.tracerConfig.getAgentNamedPipe();
   }
 
   public int getAgentTimeout() {
-    return agentTimeout;
+    return this.tracerConfig.getAgentTimeout();
   }
 
   public Set<String> getNoProxyHosts() {
-    return noProxyHosts;
+    return this.tracerConfig.getNoProxyHosts();
   }
 
   public boolean isPrioritySamplingEnabled() {
-    return prioritySamplingEnabled;
+    return this.tracerConfig.isPrioritySamplingEnabled();
   }
 
   public String getPrioritySamplingForce() {
-    return prioritySamplingForce;
+    return this.tracerConfig.getPrioritySamplingForce();
   }
 
   public boolean isTraceResolverEnabled() {
-    return traceResolverEnabled;
+    return this.tracerConfig.isTraceResolverEnabled();
   }
 
   public Set<String> getIastWeakHashAlgorithms() {
-    return iastWeakHashAlgorithms;
+    return this.iastConfig.getIastWeakHashAlgorithms();
   }
 
   public Pattern getIastWeakCipherAlgorithms() {
-    return iastWeakCipherAlgorithms;
+    return this.iastConfig.getIastWeakCipherAlgorithms();
   }
 
   public boolean isIastDeduplicationEnabled() {
-    return iastDeduplicationEnabled;
+    return this.iastConfig.isIastDeduplicationEnabled();
   }
 
   public Map<String, String> getServiceMapping() {
-    return serviceMapping;
+    return this.tracerConfig.getServiceMapping();
   }
 
   public List<String> getExcludedClasses() {
-    return excludedClasses;
+    return this.traceInstrumentationConfig.getExcludedClasses();
   }
 
   public String getExcludedClassesFile() {
-    return excludedClassesFile;
+    return this.traceInstrumentationConfig.getExcludedClassesFile();
   }
 
   public Set<String> getExcludedClassLoaders() {
-    return excludedClassLoaders;
+    return this.traceInstrumentationConfig.getExcludedClassLoaders();
   }
 
   public List<String> getExcludedCodeSources() {
-    return excludedCodeSources;
+    return this.traceInstrumentationConfig.getExcludedCodeSources();
   }
 
   public Map<String, String> getRequestHeaderTags() {
-    return requestHeaderTags;
+    return this.tracerConfig.getRequestHeaderTags();
   }
 
   public Map<String, String> getResponseHeaderTags() {
-    return responseHeaderTags;
+    return this.tracerConfig.getResponseHeaderTags();
   }
 
   public Map<String, String> getHttpServerPathResourceNameMapping() {
-    return httpServerPathResourceNameMapping;
+    return this.tracerConfig.getHttpServerPathResourceNameMapping();
   }
 
   public BitSet getHttpServerErrorStatuses() {
-    return httpServerErrorStatuses;
+    return this.tracerConfig.getHttpServerErrorStatuses();
   }
 
   public BitSet getHttpClientErrorStatuses() {
-    return httpClientErrorStatuses;
+    return this.tracerConfig.getHttpClientErrorStatuses();
   }
 
   public boolean isHttpServerTagQueryString() {
-    return httpServerTagQueryString;
+    return this.traceInstrumentationConfig.isHttpServerTagQueryString();
   }
 
   public boolean isHttpServerRawQueryString() {
-    return httpServerRawQueryString;
+    return this.traceInstrumentationConfig.isHttpServerRawQueryString();
   }
 
   public boolean isHttpServerRawResource() {
-    return httpServerRawResource;
+    return this.traceInstrumentationConfig.isHttpServerRawResource();
   }
 
   public boolean isHttpServerRouteBasedNaming() {
-    return httpServerRouteBasedNaming;
+    return this.traceInstrumentationConfig.isHttpServerRouteBasedNaming();
   }
 
   public boolean isHttpClientTagQueryString() {
-    return httpClientTagQueryString;
+    return this.traceInstrumentationConfig.isHttpClientTagQueryString();
   }
 
   public boolean isHttpClientSplitByDomain() {
-    return httpClientSplitByDomain;
+    return this.traceInstrumentationConfig.isHttpClientSplitByDomain();
   }
 
   public boolean isDbClientSplitByInstance() {
-    return dbClientSplitByInstance;
+    return this.traceInstrumentationConfig.isDbClientSplitByInstance();
   }
 
   public boolean isDbClientSplitByInstanceTypeSuffix() {
-    return dbClientSplitByInstanceTypeSuffix;
+    return this.traceInstrumentationConfig.isDbClientSplitByInstanceTypeSuffix();
   }
 
   public Set<String> getSplitByTags() {
-    return splitByTags;
+    return this.tracerConfig.getSplitByTags();
   }
 
   public int getScopeDepthLimit() {
-    return scopeDepthLimit;
+    return this.tracerConfig.getScopeDepthLimit();
   }
 
   public boolean isScopeStrictMode() {
-    return scopeStrictMode;
+    return this.tracerConfig.isScopeStrictMode();
   }
 
   public boolean isScopeInheritAsyncPropagation() {
-    return scopeInheritAsyncPropagation;
+    return this.tracerConfig.isScopeInheritAsyncPropagation();
   }
 
   public int getScopeIterationKeepAlive() {
-    return scopeIterationKeepAlive;
+    return this.tracerConfig.getScopeIterationKeepAlive();
   }
 
   public int getPartialFlushMinSpans() {
-    return partialFlushMinSpans;
+    return this.tracerConfig.getPartialFlushMinSpans();
   }
 
   public boolean isTraceStrictWritesEnabled() {
-    return traceStrictWritesEnabled;
+    return this.tracerConfig.isTraceStrictWritesEnabled();
   }
 
   public boolean isRuntimeContextFieldInjection() {
-    return runtimeContextFieldInjection;
+    return this.traceInstrumentationConfig.isRuntimeContextFieldInjection();
   }
 
   public boolean isSerialVersionUIDFieldInjection() {
-    return serialVersionUIDFieldInjection;
+    return this.traceInstrumentationConfig.isSerialVersionUIDFieldInjection();
   }
 
   public boolean isLogExtractHeaderNames() {
-    return logExtractHeaderNames;
+    return this.tracerConfig.isLogExtractHeaderNames();
   }
 
   public Set<PropagationStyle> getPropagationStylesToExtract() {
-    return propagationStylesToExtract;
+    return this.tracerConfig.getPropagationStylesToExtract();
   }
 
   public Set<PropagationStyle> getPropagationStylesToInject() {
-    return propagationStylesToInject;
+    return this.tracerConfig.getPropagationStylesToInject();
   }
 
   public int getClockSyncPeriod() {
-    return clockSyncPeriod;
+    return this.tracerConfig.getClockSyncPeriod();
   }
 
   public String getDogStatsDNamedPipe() {
-    return dogStatsDNamedPipe;
+    return this.generalConfig.getDogStatsDNamedPipe();
   }
 
   public int getDogStatsDStartDelay() {
-    return dogStatsDStartDelay;
+    return this.generalConfig.getDogStatsDStartDelay();
   }
 
   public boolean isJmxFetchEnabled() {
-    return jmxFetchEnabled;
+    return this.jmxFetchConfig.isJmxFetchEnabled();
   }
 
   public String getJmxFetchConfigDir() {
-    return jmxFetchConfigDir;
+    return this.jmxFetchConfig.getJmxFetchConfigDir();
   }
 
   public List<String> getJmxFetchConfigs() {
-    return jmxFetchConfigs;
+    return this.jmxFetchConfig.getJmxFetchConfigs();
   }
 
   public List<String> getJmxFetchMetricsConfigs() {
-    return jmxFetchMetricsConfigs;
+    return this.jmxFetchConfig.getJmxFetchMetricsConfigs();
   }
 
   public Integer getJmxFetchCheckPeriod() {
-    return jmxFetchCheckPeriod;
+    return this.jmxFetchConfig.getJmxFetchCheckPeriod();
   }
 
   public Integer getJmxFetchRefreshBeansPeriod() {
-    return jmxFetchRefreshBeansPeriod;
+    return this.jmxFetchConfig.getJmxFetchRefreshBeansPeriod();
   }
 
   public Integer getJmxFetchInitialRefreshBeansPeriod() {
-    return jmxFetchInitialRefreshBeansPeriod;
+    return this.jmxFetchConfig.getJmxFetchInitialRefreshBeansPeriod();
   }
 
   public String getJmxFetchStatsdHost() {
-    return jmxFetchStatsdHost;
+    return this.jmxFetchConfig.getJmxFetchStatsdHost();
   }
 
   public Integer getJmxFetchStatsdPort() {
-    return jmxFetchStatsdPort;
+    return this.jmxFetchConfig.getJmxFetchStatsdPort();
   }
 
   public boolean isJmxFetchMultipleRuntimeServicesEnabled() {
-    return jmxFetchMultipleRuntimeServicesEnabled;
+    return this.jmxFetchConfig.isJmxFetchMultipleRuntimeServicesEnabled();
   }
 
   public int getJmxFetchMultipleRuntimeServicesLimit() {
-    return jmxFetchMultipleRuntimeServicesLimit;
+    return this.jmxFetchConfig.getJmxFetchMultipleRuntimeServicesLimit();
   }
 
   public boolean isHealthMetricsEnabled() {
-    return healthMetricsEnabled;
+    return this.generalConfig.isHealthMetricsEnabled();
   }
 
   public String getHealthMetricsStatsdHost() {
-    return healthMetricsStatsdHost;
+    return this.generalConfig.getHealthMetricsStatsdHost();
   }
 
   public Integer getHealthMetricsStatsdPort() {
-    return healthMetricsStatsdPort;
+    return this.generalConfig.getHealthMetricsStatsdPort();
   }
 
   public boolean isPerfMetricsEnabled() {
-    return perfMetricsEnabled;
+    return this.generalConfig.isPerfMetricsEnabled();
   }
 
   public boolean isTracerMetricsEnabled() {
-    return tracerMetricsEnabled;
+    return this.generalConfig.isTracerMetricsEnabled();
   }
 
   public boolean isTracerMetricsBufferingEnabled() {
-    return tracerMetricsBufferingEnabled;
+    return this.generalConfig.isTracerMetricsBufferingEnabled();
   }
 
   public int getTracerMetricsMaxAggregates() {
-    return tracerMetricsMaxAggregates;
+    return this.generalConfig.getTracerMetricsMaxAggregates();
   }
 
   public int getTracerMetricsMaxPending() {
-    return tracerMetricsMaxPending;
+    return this.generalConfig.getTracerMetricsMaxPending();
   }
 
   public boolean isLogsInjectionEnabled() {
-    return logsInjectionEnabled;
+    return this.traceInstrumentationConfig.isLogsInjectionEnabled();
   }
 
   public boolean isLogsMDCTagsInjectionEnabled() {
-    return logsMDCTagsInjectionEnabled;
+    return this.traceInstrumentationConfig.isLogsMDCTagsInjectionEnabled();
   }
 
   public boolean isReportHostName() {
-    return reportHostName;
+    return this.generalConfig.isReportHostName();
   }
 
   public String getTraceAnnotations() {
-    return traceAnnotations;
+    return this.traceInstrumentationConfig.getTraceAnnotations();
   }
 
   public String getTraceMethods() {
-    return traceMethods;
+    return this.traceInstrumentationConfig.getTraceMethods();
   }
 
   public boolean isTraceExecutorsAll() {
-    return traceExecutorsAll;
+    return this.traceInstrumentationConfig.isTraceExecutorsAll();
   }
 
   public List<String> getTraceExecutors() {
-    return traceExecutors;
+    return this.traceInstrumentationConfig.getTraceExecutors();
   }
 
   public Set<String> getTraceThreadPoolExecutorsExclude() {
-    return traceThreadPoolExecutorsExclude;
+    return this.traceInstrumentationConfig.getTraceThreadPoolExecutorsExclude();
   }
 
   public boolean isTraceAnalyticsEnabled() {
-    return traceAnalyticsEnabled;
+    return this.tracerConfig.isTraceAnalyticsEnabled();
   }
 
   public String getTraceClientIpHeader() {
-    return traceClientIpHeader;
+    return this.tracerConfig.getTraceClientIpHeader();
   }
 
-  // whether to collect headers and run the client ip resolution (also requires appsec to be enabled
-  // or clientIpEnabled)
   public boolean isTraceClientIpResolverEnabled() {
-    return traceClientIpResolverEnabled;
-  }
-
-  public Map<String, String> getTraceSamplingServiceRules() {
-    return traceSamplingServiceRules;
-  }
-
-  public Map<String, String> getTraceSamplingOperationRules() {
-    return traceSamplingOperationRules;
-  }
-
-  public String getTraceSamplingRules() {
-    return traceSamplingRules;
-  }
-
-  public Double getTraceSampleRate() {
-    return traceSampleRate;
-  }
-
-  public int getTraceRateLimit() {
-    return traceRateLimit;
-  }
-
-  public boolean isProfilingEnabled() {
-    return profilingEnabled;
-  }
-
-  public boolean isProfilingAgentless() {
-    return profilingAgentless;
-  }
-
-  public int getProfilingStartDelay() {
-    return profilingStartDelay;
-  }
-
-  public boolean isProfilingStartForceFirst() {
-    return profilingStartForceFirst;
-  }
-
-  public int getProfilingUploadPeriod() {
-    return profilingUploadPeriod;
-  }
-
-  public String getProfilingTemplateOverrideFile() {
-    return profilingTemplateOverrideFile;
-  }
-
-  public int getProfilingUploadTimeout() {
-    return profilingUploadTimeout;
-  }
-
-  public String getProfilingUploadCompression() {
-    return profilingUploadCompression;
-  }
-
-  public String getProfilingProxyHost() {
-    return profilingProxyHost;
-  }
-
-  public int getProfilingProxyPort() {
-    return profilingProxyPort;
-  }
-
-  public String getProfilingProxyUsername() {
-    return profilingProxyUsername;
-  }
-
-  public String getProfilingProxyPassword() {
-    return profilingProxyPassword;
-  }
-
-  public int getProfilingExceptionSampleLimit() {
-    return profilingExceptionSampleLimit;
-  }
-
-  public int getProfilingExceptionHistogramTopItems() {
-    return profilingExceptionHistogramTopItems;
-  }
-
-  public int getProfilingExceptionHistogramMaxCollectionSize() {
-    return profilingExceptionHistogramMaxCollectionSize;
-  }
-
-  public boolean isProfilingExcludeAgentThreads() {
-    return profilingExcludeAgentThreads;
-  }
-
-  public boolean isProfilingHotspotsEnabled() {
-    return profilingHotspotsEnabled;
-  }
-
-  public boolean isProfilingUploadSummaryOn413Enabled() {
-    return profilingUploadSummaryOn413Enabled;
-  }
-
-  public boolean isProfilingLegacyTracingIntegrationEnabled() {
-    return profilingLegacyTracingIntegrationEnabled;
-  }
-
-  public boolean isAsyncProfilerEnabled() {
-    return isAsyncProfilerEnabled;
-  }
-
-  public boolean isCrashTrackingAgentless() {
-    return crashTrackingAgentless;
-  }
-
-  public boolean isTelemetryEnabled() {
-    return telemetryEnabled;
-  }
-
-  public int getTelemetryHeartbeatInterval() {
-    return telemetryHeartbeatInterval;
+    return this.tracerConfig.isTraceClientIpResolverEnabled();
   }
 
   public boolean isClientIpEnabled() {
-    return clientIpEnabled;
+    return this.tracerConfig.isClientIpEnabled();
+  }
+
+  public Map<String, String> getTraceSamplingServiceRules() {
+    return this.tracerConfig.getTraceSamplingServiceRules();
+  }
+
+  public Map<String, String> getTraceSamplingOperationRules() {
+    return this.tracerConfig.getTraceSamplingOperationRules();
+  }
+
+  public String getTraceSamplingRules() {
+    return this.tracerConfig.getTraceSamplingRules();
+  }
+
+  public Double getTraceSampleRate() {
+    return this.tracerConfig.getTraceSampleRate();
+  }
+
+  public int getTraceRateLimit() {
+    return this.tracerConfig.getTraceRateLimit();
+  }
+
+  public boolean isProfilingEnabled() {
+    return this.profilingConfig.isProfilingEnabled();
+  }
+
+  public boolean isProfilingAgentless() {
+    return this.profilingConfig.isProfilingAgentless();
+  }
+
+  public int getProfilingStartDelay() {
+    return this.profilingConfig.getProfilingStartDelay();
+  }
+
+  public boolean isProfilingStartForceFirst() {
+    return this.profilingConfig.isProfilingStartForceFirst();
+  }
+
+  public int getProfilingUploadPeriod() {
+    return this.profilingConfig.getProfilingUploadPeriod();
+  }
+
+  public String getProfilingTemplateOverrideFile() {
+    return this.profilingConfig.getProfilingTemplateOverrideFile();
+  }
+
+  public int getProfilingUploadTimeout() {
+    return this.profilingConfig.getProfilingUploadTimeout();
+  }
+
+  public String getProfilingUploadCompression() {
+    return this.profilingConfig.getProfilingUploadCompression();
+  }
+
+  public String getProfilingProxyHost() {
+    return this.profilingConfig.getProfilingProxyHost();
+  }
+
+  public int getProfilingProxyPort() {
+    return this.profilingConfig.getProfilingProxyPort();
+  }
+
+  public String getProfilingProxyUsername() {
+    return this.profilingConfig.getProfilingProxyUsername();
+  }
+
+  public String getProfilingProxyPassword() {
+    return this.profilingConfig.getProfilingProxyPassword();
+  }
+
+  public int getProfilingExceptionSampleLimit() {
+    return this.profilingConfig.getProfilingExceptionSampleLimit();
+  }
+
+  public int getProfilingExceptionHistogramTopItems() {
+    return this.profilingConfig.getProfilingExceptionHistogramTopItems();
+  }
+
+  public int getProfilingExceptionHistogramMaxCollectionSize() {
+    return this.profilingConfig.getProfilingExceptionHistogramMaxCollectionSize();
+  }
+
+  public boolean isProfilingExcludeAgentThreads() {
+    return this.profilingConfig.isProfilingExcludeAgentThreads();
+  }
+
+  public boolean isProfilingHotspotsEnabled() {
+    return this.profilingConfig.isProfilingHotspotsEnabled();
+  }
+
+  public boolean isProfilingUploadSummaryOn413Enabled() {
+    return this.profilingConfig.isProfilingUploadSummaryOn413Enabled();
+  }
+
+  public boolean isProfilingLegacyTracingIntegrationEnabled() {
+    return this.profilingConfig.isProfilingLegacyTracingIntegrationEnabled();
+  }
+
+  public boolean isAsyncProfilerEnabled() {
+    return this.profilingConfig.isAsyncProfilerEnabled();
+  }
+
+  public boolean isCrashTrackingAgentless() {
+    return this.crashTrackingConfig.isCrashTrackingAgentless();
+  }
+
+  public boolean isTelemetryEnabled() {
+    return this.generalConfig.isTelemetryEnabled();
+  }
+
+  public int getTelemetryHeartbeatInterval() {
+    return this.generalConfig.getTelemetryHeartbeatInterval();
   }
 
   public ProductActivationConfig getAppSecEnabledConfig() {
-    return appSecEnabled;
+    return this.appSecConfig.getAppSecEnabledConfig();
   }
 
   public boolean isAppSecReportingInband() {
-    return appSecReportingInband;
+    return this.appSecConfig.isAppSecReportingInband();
   }
 
   public int getAppSecReportMinTimeout() {
-    return appSecReportMinTimeout;
+    return this.appSecConfig.getAppSecReportMinTimeout();
   }
 
   public int getAppSecReportMaxTimeout() {
-    return appSecReportMaxTimeout;
+    return this.appSecConfig.getAppSecReportMaxTimeout();
   }
 
   public int getAppSecTraceRateLimit() {
-    return appSecTraceRateLimit;
+    return this.appSecConfig.getAppSecTraceRateLimit();
   }
 
   public boolean isAppSecWafMetrics() {
-    return appSecWafMetrics;
+    return this.appSecConfig.isAppSecWafMetrics();
   }
 
   public String getAppSecObfuscationParameterKeyRegexp() {
-    return appSecObfuscationParameterKeyRegexp;
+    return this.appSecConfig.getAppSecObfuscationParameterKeyRegexp();
   }
 
   public String getAppSecObfuscationParameterValueRegexp() {
-    return appSecObfuscationParameterValueRegexp;
+    return this.appSecConfig.getAppSecObfuscationParameterValueRegexp();
   }
 
   public String getAppSecHttpBlockedTemplateHtml() {
-    return appSecHttpBlockedTemplateHtml;
+    return this.appSecConfig.getAppSecHttpBlockedTemplateHtml();
   }
 
   public String getAppSecHttpBlockedTemplateJson() {
-    return appSecHttpBlockedTemplateJson;
+    return this.appSecConfig.getAppSecHttpBlockedTemplateJson();
   }
 
   public boolean isIastEnabled() {
-    return iastEnabled;
+    return this.iastConfig.isIastEnabled();
   }
 
   public int getIastMaxConcurrentRequests() {
-    return iastMaxConcurrentRequests;
+    return this.iastConfig.getIastMaxConcurrentRequests();
   }
 
   public int getIastVulnerabilitiesPerRequest() {
-    return iastVulnerabilitiesPerRequest;
+    return this.iastConfig.getIastVulnerabilitiesPerRequest();
   }
 
   public float getIastRequestSampling() {
-    return iastRequestSampling;
+    return this.iastConfig.getIastRequestSampling();
   }
 
   public boolean isCiVisibilityEnabled() {
-    return ciVisibilityEnabled;
+    return this.ciVisibilityConfig.isCiVisibilityEnabled();
   }
 
   public boolean isCiVisibilityAgentlessEnabled() {
-    return ciVisibilityAgentlessEnabled;
+    return this.ciVisibilityConfig.isCiVisibilityAgentlessEnabled();
   }
 
   public String getCiVisibilityAgentlessUrl() {
-    return ciVisibilityAgentlessUrl;
+    return this.ciVisibilityConfig.getCiVisibilityAgentlessUrl();
   }
 
   public String getAppSecRulesFile() {
-    return appSecRulesFile;
+    return this.appSecConfig.getAppSecRulesFile();
   }
 
   public long getRemoteConfigMaxPayloadSizeBytes() {
-    return remoteConfigMaxPayloadSize;
+    return this.remoteConfig.getRemoteConfigMaxPayloadSizeBytes();
   }
 
   public boolean isRemoteConfigEnabled() {
-    return remoteConfigEnabled;
+    return this.remoteConfig.isRemoteConfigEnabled();
   }
 
   public boolean isRemoteConfigIntegrityCheckEnabled() {
-    return remoteConfigIntegrityCheckEnabled;
+    return this.remoteConfig.isRemoteConfigIntegrityCheckEnabled();
   }
 
   public String getFinalRemoteConfigUrl() {
-    return remoteConfigUrl;
+    return this.remoteConfig.getFinalRemoteConfigUrl();
   }
 
   public int getRemoteConfigInitialPollInterval() {
-    return remoteConfigInitialPollInterval;
+    return this.remoteConfig.getRemoteConfigInitialPollInterval();
   }
 
   public String getRemoteConfigTargetsKeyId() {
-    return remoteConfigTargetsKeyId;
+    return this.remoteConfig.getRemoteConfigTargetsKeyId();
   }
 
   public String getRemoteConfigTargetsKey() {
-    return remoteConfigTargetsKey;
+    return this.remoteConfig.getRemoteConfigTargetsKey();
   }
 
   public boolean isDebuggerEnabled() {
-    return debuggerEnabled;
+    return this.debuggerConfig.isDebuggerEnabled();
   }
 
   public int getDebuggerUploadTimeout() {
-    return debuggerUploadTimeout;
+    return this.debuggerConfig.getDebuggerUploadTimeout();
   }
 
   public int getDebuggerUploadFlushInterval() {
-    return debuggerUploadFlushInterval;
+    return this.debuggerConfig.getDebuggerUploadFlushInterval();
   }
 
   public boolean isDebuggerClassFileDumpEnabled() {
-    return debuggerClassFileDumpEnabled;
+    return this.debuggerConfig.isDebuggerClassFileDumpEnabled();
   }
 
   public int getDebuggerPollInterval() {
-    return debuggerPollInterval;
+    return this.debuggerConfig.getDebuggerPollInterval();
   }
 
   public int getDebuggerDiagnosticsInterval() {
-    return debuggerDiagnosticsInterval;
+    return this.debuggerConfig.getDebuggerDiagnosticsInterval();
   }
 
   public boolean isDebuggerMetricsEnabled() {
-    return debuggerMetricEnabled;
+    return this.debuggerConfig.isDebuggerMetricsEnabled();
   }
 
   public int getDebuggerUploadBatchSize() {
-    return debuggerUploadBatchSize;
+    return this.debuggerConfig.getDebuggerUploadBatchSize();
   }
 
   public long getDebuggerMaxPayloadSize() {
-    return debuggerMaxPayloadSize;
+    return this.debuggerConfig.getDebuggerMaxPayloadSize();
   }
 
   public boolean isDebuggerVerifyByteCode() {
-    return debuggerVerifyByteCode;
+    return this.debuggerConfig.isDebuggerVerifyByteCode();
   }
 
   public boolean isDebuggerInstrumentTheWorld() {
-    return debuggerInstrumentTheWorld;
+    return this.debuggerConfig.isDebuggerInstrumentTheWorld();
   }
 
   public String getDebuggerExcludeFile() {
-    return debuggerExcludeFile;
-  }
-
-  public String getFinalDebuggerProbeUrl() {
-    // by default poll from datadog agent
-    return "http://" + agentHost + ":" + agentPort;
-  }
-
-  public String getFinalDebuggerSnapshotUrl() {
-    // by default send to datadog agent
-    return agentUrl + "/debugger/v1/input";
+    return this.debuggerConfig.getDebuggerExcludeFile();
   }
 
   public String getDebuggerProbeFileLocation() {
-    return debuggerProbeFileLocation;
+    return this.debuggerConfig.getDebuggerProbeFileLocation();
+  }
+
+  public String getFinalDebuggerSnapshotUrl() {
+    return this.debuggerConfig.getFinalDebuggerSnapshotUrl();
   }
 
   public boolean isAwsPropagationEnabled() {
-    return awsPropagationEnabled;
+    return this.traceInstrumentationConfig.isAwsPropagationEnabled();
   }
 
   public boolean isSqsPropagationEnabled() {
-    return sqsPropagationEnabled;
+    return this.traceInstrumentationConfig.isSqsPropagationEnabled();
   }
 
   public boolean isKafkaClientPropagationEnabled() {
-    return kafkaClientPropagationEnabled;
+    return this.traceInstrumentationConfig.isKafkaClientPropagationEnabled();
   }
 
   public boolean isKafkaClientPropagationDisabledForTopic(String topic) {
-    return null != topic && kafkaClientPropagationDisabledTopics.contains(topic);
+    return this.traceInstrumentationConfig.isKafkaClientPropagationDisabledForTopic(topic);
   }
 
   public boolean isJmsPropagationEnabled() {
-    return jmsPropagationEnabled;
+    return this.traceInstrumentationConfig.isJmsPropagationEnabled();
   }
 
   public boolean isJmsPropagationDisabledForDestination(final String queueOrTopic) {
-    return null != queueOrTopic
-        && (jmsPropagationDisabledQueues.contains(queueOrTopic)
-            || jmsPropagationDisabledTopics.contains(queueOrTopic));
+    return this.traceInstrumentationConfig.isJmsPropagationDisabledForDestination(queueOrTopic);
   }
 
   public boolean isKafkaClientBase64DecodingEnabled() {
-    return kafkaClientBase64DecodingEnabled;
+    return this.traceInstrumentationConfig.isKafkaClientBase64DecodingEnabled();
   }
 
   public boolean isRabbitPropagationEnabled() {
-    return rabbitPropagationEnabled;
+    return this.traceInstrumentationConfig.isRabbitPropagationEnabled();
   }
 
   public boolean isRabbitPropagationDisabledForDestination(final String queueOrExchange) {
-    return null != queueOrExchange
-        && (rabbitPropagationDisabledQueues.contains(queueOrExchange)
-            || rabbitPropagationDisabledExchanges.contains(queueOrExchange));
+    return this.traceInstrumentationConfig.isRabbitPropagationDisabledForDestination(
+        queueOrExchange);
   }
 
   public boolean isMessageBrokerSplitByDestination() {
-    return messageBrokerSplitByDestination;
+    return this.traceInstrumentationConfig.isMessageBrokerSplitByDestination();
   }
 
   public boolean isHystrixTagsEnabled() {
-    return hystrixTagsEnabled;
+    return this.traceInstrumentationConfig.isHystrixTagsEnabled();
   }
 
   public boolean isHystrixMeasuredEnabled() {
-    return hystrixMeasuredEnabled;
+    return this.traceInstrumentationConfig.isHystrixMeasuredEnabled();
   }
 
   public boolean isIgniteCacheIncludeKeys() {
-    return igniteCacheIncludeKeys;
+    return this.traceInstrumentationConfig.isIgniteCacheIncludeKeys();
   }
 
   public String getObfuscationQueryRegexp() {
-    return obfuscationQueryRegexp;
+    return this.traceInstrumentationConfig.getObfuscationQueryRegexp();
   }
 
   public boolean getPlayReportHttpStatus() {
-    return playReportHttpStatus;
+    return this.traceInstrumentationConfig.getPlayReportHttpStatus();
   }
 
   public boolean isServletPrincipalEnabled() {
-    return servletPrincipalEnabled;
+    return this.traceInstrumentationConfig.isServletPrincipalEnabled();
   }
 
   public int getxDatadogTagsMaxLength() {
-    return xDatadogTagsMaxLength;
+    return this.tracerConfig.getxDatadogTagsMaxLength();
   }
 
   public boolean isServletAsyncTimeoutError() {
-    return servletAsyncTimeoutError;
+    return this.traceInstrumentationConfig.isServletAsyncTimeoutError();
   }
 
   public boolean isTraceAgentV05Enabled() {
-    return traceAgentV05Enabled;
+    return this.tracerConfig.isTraceAgentV05Enabled();
   }
 
   public boolean isDebugEnabled() {
-    return debugEnabled;
+    return this.generalConfig.isDebugEnabled();
   }
 
   public boolean isCwsEnabled() {
-    return cwsEnabled;
+    return this.cwsConfig.isCwsEnabled();
   }
 
   public int getCwsTlsRefresh() {
-    return cwsTlsRefresh;
+    return this.cwsConfig.getCwsTlsRefresh();
   }
 
   public boolean isAzureAppServices() {
-    return azureAppServices;
+    return this.generalConfig.isAzureAppServices();
   }
 
   public boolean isDataStreamsEnabled() {
-    return dataStreamsEnabled;
+    return this.generalConfig.isDataStreamsEnabled();
   }
 
   public String getTraceAgentPath() {
-    return traceAgentPath;
+    return this.tracerConfig.getTraceAgentPath();
   }
 
   public List<String> getTraceAgentArgs() {
-    return traceAgentArgs;
+    return this.tracerConfig.getTraceAgentArgs();
   }
 
   public String getDogStatsDPath() {
-    return dogStatsDPath;
+    return this.generalConfig.getDogStatsDPath();
   }
 
   public List<String> getDogStatsDArgs() {
-    return dogStatsDArgs;
+    return this.generalConfig.getDogStatsDArgs();
   }
 
   public String getConfigFileStatus() {
@@ -2100,182 +884,99 @@ public class Config {
   }
 
   public IdGenerationStrategy getIdGenerationStrategy() {
-    return idGenerationStrategy;
+    return this.tracerConfig.getIdGenerationStrategy();
   }
 
   public boolean isInternalExitOnFailure() {
-    return internalExitOnFailure;
+    return this.generalConfig.isInternalExitOnFailure();
   }
 
   public boolean isResolverOutlinePoolEnabled() {
-    return resolverOutlinePoolEnabled;
+    return this.traceInstrumentationConfig.isResolverOutlinePoolEnabled();
   }
 
   public int getResolverOutlinePoolSize() {
-    return resolverOutlinePoolSize;
+    return this.traceInstrumentationConfig.getResolverOutlinePoolSize();
   }
 
   public int getResolverTypePoolSize() {
-    return resolverTypePoolSize;
+    return this.traceInstrumentationConfig.getResolverTypePoolSize();
   }
 
   public boolean isResolverUseLoadClassEnabled() {
-    return resolverUseLoadClassEnabled;
+    return this.traceInstrumentationConfig.isResolverUseLoadClassEnabled();
   }
 
   public String getJdbcPreparedStatementClassName() {
-    return jdbcPreparedStatementClassName;
+    return this.traceInstrumentationConfig.getJdbcPreparedStatementClassName();
   }
 
   public String getJdbcConnectionClassName() {
-    return jdbcConnectionClassName;
+    return this.traceInstrumentationConfig.getJdbcConnectionClassName();
   }
 
   public Set<String> getGrpcIgnoredInboundMethods() {
-    return grpcIgnoredInboundMethods;
+    return this.traceInstrumentationConfig.getGrpcIgnoredInboundMethods();
   }
 
   public Set<String> getGrpcIgnoredOutboundMethods() {
-    return grpcIgnoredOutboundMethods;
+    return this.traceInstrumentationConfig.getGrpcIgnoredOutboundMethods();
   }
 
   public boolean isGrpcServerTrimPackageResource() {
-    return grpcServerTrimPackageResource;
+    return this.traceInstrumentationConfig.isGrpcServerTrimPackageResource();
   }
 
   public BitSet getGrpcServerErrorStatuses() {
-    return grpcServerErrorStatuses;
+    return this.traceInstrumentationConfig.getGrpcServerErrorStatuses();
   }
 
   public BitSet getGrpcClientErrorStatuses() {
-    return grpcClientErrorStatuses;
+    return this.traceInstrumentationConfig.getGrpcClientErrorStatuses();
   }
 
-  /** @return A map of tags to be applied only to the local application root span. */
   public Map<String, Object> getLocalRootSpanTags() {
-    final Map<String, String> runtimeTags = getRuntimeTags();
-    final Map<String, Object> result = new HashMap<>(runtimeTags.size() + 1);
-    result.putAll(runtimeTags);
-    result.put(LANGUAGE_TAG_KEY, LANGUAGE_TAG_VALUE);
-
-    if (reportHostName) {
-      final String hostName = getHostName();
-      if (null != hostName && !hostName.isEmpty()) {
-        result.put(INTERNAL_HOST_NAME, hostName);
-      }
-    }
-
-    if (azureAppServices) {
-      result.putAll(getAzureAppServicesTags());
-    }
-
-    return Collections.unmodifiableMap(result);
+    return this.generalConfig.getLocalRootSpanTags();
   }
 
   public WellKnownTags getWellKnownTags() {
-    return new WellKnownTags(
-        getRuntimeId(),
-        reportHostName ? getHostName() : "",
-        getEnv(),
-        serviceName,
-        getVersion(),
-        LANGUAGE_TAG_VALUE);
+    return this.generalConfig.getWellKnownTags();
   }
 
   public String getPrimaryTag() {
-    return primaryTag;
+    return this.generalConfig.getPrimaryTag();
+  }
+
+  public Map<String, String> getGlobalTags() {
+    return this.generalConfig.getGlobalTags();
   }
 
   public Set<String> getMetricsIgnoredResources() {
-    return tryMakeImmutableSet(configProvider.getList(TRACER_METRICS_IGNORED_RESOURCES));
+    return tryMakeImmutableSet(this.configProvider.getList(TRACER_METRICS_IGNORED_RESOURCES));
   }
 
   public String getEnv() {
-    // intentionally not thread safe
-    if (env == null) {
-      env = getMergedSpanTags().get("env");
-      if (env == null) {
-        env = "";
-      }
-    }
-
-    return env;
+    return this.generalConfig.getEnv();
   }
 
   public String getVersion() {
-    // intentionally not thread safe
-    if (version == null) {
-      version = getMergedSpanTags().get("version");
-      if (version == null) {
-        version = "";
-      }
-    }
-
-    return version;
+    return this.generalConfig.getVersion();
   }
 
   public Map<String, String> getMergedSpanTags() {
-    // Do not include runtimeId into span tags: we only want that added to the root span
-    final Map<String, String> result = newHashMap(getGlobalTags().size() + spanTags.size());
-    result.putAll(getGlobalTags());
-    result.putAll(spanTags);
-    return Collections.unmodifiableMap(result);
+    return this.generalConfig.getMergedSpanTags();
   }
 
   public Map<String, String> getMergedJmxTags() {
-    final Map<String, String> runtimeTags = getRuntimeTags();
-    final Map<String, String> result =
-        newHashMap(
-            getGlobalTags().size() + jmxTags.size() + runtimeTags.size() + 1 /* for serviceName */);
-    result.putAll(getGlobalTags());
-    result.putAll(jmxTags);
-    result.putAll(runtimeTags);
-    // service name set here instead of getRuntimeTags because apm already manages the service tag
-    // and may chose to override it.
-    // Additionally, infra/JMX metrics require `service` rather than APM's `service.name` tag
-    result.put(SERVICE_TAG, serviceName);
-    return Collections.unmodifiableMap(result);
+    return this.jmxFetchConfig.getMergedJmxTags();
   }
 
   public Map<String, String> getMergedProfilingTags() {
-    final Map<String, String> runtimeTags = getRuntimeTags();
-    final String host = getHostName();
-    final Map<String, String> result =
-        newHashMap(
-            getGlobalTags().size()
-                + profilingTags.size()
-                + runtimeTags.size()
-                + 4 /* for serviceName and host and language and runtime_version */);
-    result.put(HOST_TAG, host); // Host goes first to allow to override it
-    result.putAll(getGlobalTags());
-    result.putAll(profilingTags);
-    result.putAll(runtimeTags);
-    // service name set here instead of getRuntimeTags because apm already manages the service tag
-    // and may chose to override it.
-    result.put(SERVICE_TAG, serviceName);
-    result.put(LANGUAGE_TAG_KEY, LANGUAGE_TAG_VALUE);
-    result.put(RUNTIME_VERSION_TAG, runtimeVersion);
-    return Collections.unmodifiableMap(result);
+    return this.profilingConfig.getMergedProfilingTags();
   }
 
   public Map<String, String> getMergedCrashTrackingTags() {
-    final Map<String, String> runtimeTags = getRuntimeTags();
-    final String host = getHostName();
-    final Map<String, String> result =
-        newHashMap(
-            getGlobalTags().size()
-                + crashTrackingTags.size()
-                + runtimeTags.size()
-                + 3 /* for serviceName and host and language */);
-    result.put(HOST_TAG, host); // Host goes first to allow to override it
-    result.putAll(getGlobalTags());
-    result.putAll(crashTrackingTags);
-    result.putAll(runtimeTags);
-    // service name set here instead of getRuntimeTags because apm already manages the service tag
-    // and may chose to override it.
-    result.put(SERVICE_TAG, serviceName);
-    result.put(LANGUAGE_TAG_KEY, LANGUAGE_TAG_VALUE);
-    return Collections.unmodifiableMap(result);
+    return this.crashTrackingConfig.getMergedCrashTrackingTags();
   }
 
   /**
@@ -2293,166 +994,37 @@ public class Config {
     return DEFAULT_ANALYTICS_SAMPLE_RATE;
   }
 
-  /**
-   * Provide 'global' tags, i.e. tags set everywhere. We have to support old (dd.trace.global.tags)
-   * version of this setting if new (dd.tags) version has not been specified.
-   */
-  public Map<String, String> getGlobalTags() {
-    return tags;
-  }
-
-  /**
-   * Return a map of tags required by the datadog backend to link runtime metrics (i.e. jmx) and
-   * traces.
-   *
-   * <p>These tags must be applied to every runtime metrics and placed on the root span of every
-   * trace.
-   *
-   * @return A map of tag-name -> tag-value
-   */
-  private Map<String, String> getRuntimeTags() {
-    return Collections.singletonMap(RUNTIME_ID_TAG, runtimeId);
-  }
-
-  private Map<String, String> getAzureAppServicesTags() {
-    // These variable names and derivations are copied from the dotnet tracer
-    // See
-    // https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/src/Datadog.Trace/PlatformHelpers/AzureAppServices.cs
-    // and
-    // https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/src/Datadog.Trace/TraceContext.cs#L207
-    Map<String, String> aasTags = new HashMap<>();
-
-    /// The site name of the site instance in Azure where the traced application is running.
-    String siteName = getEnv("WEBSITE_SITE_NAME");
-    if (siteName != null) {
-      aasTags.put("aas.site.name", siteName);
-    }
-
-    // The kind of application instance running in Azure.
-    // Possible values: app, api, mobileapp, app_linux, app_linux_container, functionapp,
-    // functionapp_linux, functionapp_linux_container
-
-    // The type of application instance running in Azure.
-    // Possible values: app, function
-    if (getEnv("FUNCTIONS_WORKER_RUNTIME") != null
-        || getEnv("FUNCTIONS_EXTENSIONS_VERSION") != null) {
-      aasTags.put("aas.site.kind", "functionapp");
-      aasTags.put("aas.site.type", "function");
-    } else {
-      aasTags.put("aas.site.kind", "app");
-      aasTags.put("aas.site.type", "app");
-    }
-
-    //  The resource group of the site instance in Azure App Services
-    String resourceGroup = getEnv("WEBSITE_RESOURCE_GROUP");
-    if (resourceGroup != null) {
-      aasTags.put("aas.resource.group", resourceGroup);
-    }
-
-    // Example: 8c500027-5f00-400e-8f00-60000000000f+apm-dotnet-EastUSwebspace
-    // Format: {subscriptionId}+{planResourceGroup}-{hostedInRegion}
-    String websiteOwner = getEnv("WEBSITE_OWNER_NAME");
-    int plusIndex = websiteOwner == null ? -1 : websiteOwner.indexOf("+");
-
-    // The subscription ID of the site instance in Azure App Services
-    String subscriptionId = null;
-    if (plusIndex > 0) {
-      subscriptionId = websiteOwner.substring(0, plusIndex);
-      aasTags.put("aas.subscription.id", subscriptionId);
-    }
-
-    if (subscriptionId != null && siteName != null && resourceGroup != null) {
-      // The resource ID of the site instance in Azure App Services
-      String resourceId =
-          "/subscriptions/"
-              + subscriptionId
-              + "/resourcegroups/"
-              + resourceGroup
-              + "/providers/microsoft.web/sites/"
-              + siteName;
-      resourceId = resourceId.toLowerCase();
-      aasTags.put("aas.resource.id", resourceId);
-    } else {
-      log.warn(
-          "Unable to generate resource id subscription id: {}, site name: {}, resource group {}",
-          subscriptionId,
-          siteName,
-          resourceGroup);
-    }
-
-    // The instance ID in Azure
-    String instanceId = getEnv("WEBSITE_INSTANCE_ID");
-    instanceId = instanceId == null ? "unknown" : instanceId;
-    aasTags.put("aas.environment.instance_id", instanceId);
-
-    // The instance name in Azure
-    String instanceName = getEnv("COMPUTERNAME");
-    instanceName = instanceName == null ? "unknown" : instanceName;
-    aasTags.put("aas.environment.instance_name", instanceName);
-
-    // The operating system in Azure
-    String operatingSystem = getEnv("WEBSITE_OS");
-    operatingSystem = operatingSystem == null ? "unknown" : operatingSystem;
-    aasTags.put("aas.environment.os", operatingSystem);
-
-    // The version of the extension installed
-    String siteExtensionVersion = getEnv("DD_AAS_JAVA_EXTENSION_VERSION");
-    siteExtensionVersion = siteExtensionVersion == null ? "unknown" : siteExtensionVersion;
-    aasTags.put("aas.environment.extension_version", siteExtensionVersion);
-
-    aasTags.put("aas.environment.runtime", getProp("java.vm.name", "unknown"));
-
-    return aasTags;
-  }
-
   public String getFinalProfilingUrl() {
-    if (profilingUrl != null) {
-      // when profilingUrl is set we use it regardless of apiKey/agentless config
-      return profilingUrl;
-    } else if (profilingAgentless) {
-      // when agentless profiling is turned on we send directly to our intake
-      return "https://intake.profile." + site + "/api/v2/profile";
-    } else {
-      // when profilingUrl and agentless are not set we send to the dd trace agent running locally
-      return "http://" + agentHost + ":" + agentPort + "/profiling/v1/input";
-    }
+    return this.profilingConfig.getFinalProfilingUrl();
   }
 
   public String getFinalCrashTrackingTelemetryUrl() {
-    if (crashTrackingAgentless) {
-      // when agentless crashTracking is turned on we send directly to our intake
-      return "https://all-http-intake.logs." + site + "/api/v2/apmtelemetry";
-    } else {
-      // when agentless are not set we send to the dd trace agent running locally
-      return "http://" + agentHost + ":" + agentPort + "/telemetry/proxy/api/v2/apmtelemetry";
-    }
+    return this.crashTrackingConfig.getFinalCrashTrackingTelemetryUrl();
   }
 
   public boolean isIntegrationEnabled(
       final Iterable<String> integrationNames, final boolean defaultEnabled) {
-    return isEnabled(integrationNames, "integration.", ".enabled", defaultEnabled);
+    return this.traceInstrumentationConfig.isIntegrationEnabled(integrationNames, defaultEnabled);
   }
 
   public boolean isIntegrationShortcutMatchingEnabled(
       final Iterable<String> integrationNames, final boolean defaultEnabled) {
-    return isEnabled(
-        integrationNames, "integration.", ".matching.shortcut.enabled", defaultEnabled);
+    return this.traceInstrumentationConfig.isIntegrationShortcutMatchingEnabled(
+        integrationNames, defaultEnabled);
   }
 
   public boolean isJmxFetchIntegrationEnabled(
       final Iterable<String> integrationNames, final boolean defaultEnabled) {
-    return isEnabled(integrationNames, "jmxfetch.", ".enabled", defaultEnabled);
+    return this.traceInstrumentationConfig.isJmxFetchIntegrationEnabled(
+        integrationNames, defaultEnabled);
   }
 
   public boolean isRuleEnabled(final String name) {
-    return isRuleEnabled(name, true);
+    return this.traceInstrumentationConfig.isRuleEnabled(name);
   }
 
   public boolean isRuleEnabled(final String name, boolean defaultEnabled) {
-    boolean enabled = configProvider.getBoolean("trace." + name + ".enabled", defaultEnabled);
-    boolean lowerEnabled =
-        configProvider.getBoolean("trace." + name.toLowerCase() + ".enabled", defaultEnabled);
-    return defaultEnabled ? enabled && lowerEnabled : enabled || lowerEnabled;
+    return this.traceInstrumentationConfig.isRuleEnabled(name, defaultEnabled);
   }
 
   /**
@@ -2469,67 +1041,34 @@ public class Config {
 
   public boolean isEndToEndDurationEnabled(
       final boolean defaultEnabled, final String... integrationNames) {
-    return isEnabled(Arrays.asList(integrationNames), "", ".e2e.duration.enabled", defaultEnabled);
-  }
-
-  public boolean isPropagationEnabled(
-      final boolean defaultEnabled, final String... integrationNames) {
-    return isEnabled(Arrays.asList(integrationNames), "", ".propagation.enabled", defaultEnabled);
+    return this.traceInstrumentationConfig.isEndToEndDurationEnabled(
+        defaultEnabled, integrationNames);
   }
 
   public boolean isLegacyTracingEnabled(
       final boolean defaultEnabled, final String... integrationNames) {
-    return isEnabled(
-        Arrays.asList(integrationNames), "", ".legacy.tracing.enabled", defaultEnabled);
-  }
-
-  public boolean isEnabled(
-      final boolean defaultEnabled, final String settingName, String settingSuffix) {
-    return isEnabled(Collections.singletonList(settingName), "", settingSuffix, defaultEnabled);
-  }
-
-  private void logIngoredSettingWarning(
-      String setting, String overridingSetting, String overridingSuffix) {
-    log.warn(
-        "Setting {} ignored since {}{} is enabled.",
-        propertyNameToSystemPropertyName(setting),
-        propertyNameToSystemPropertyName(overridingSetting),
-        overridingSuffix);
+    return this.traceInstrumentationConfig.isLegacyTracingEnabled(defaultEnabled, integrationNames);
   }
 
   public boolean isTraceAnalyticsIntegrationEnabled(
       final SortedSet<String> integrationNames, final boolean defaultEnabled) {
-    return isEnabled(integrationNames, "", ".analytics.enabled", defaultEnabled);
+    return this.traceInstrumentationConfig.isTraceAnalyticsIntegrationEnabled(
+        integrationNames, defaultEnabled);
   }
 
   public boolean isTraceAnalyticsIntegrationEnabled(
       final boolean defaultEnabled, final String... integrationNames) {
-    return isEnabled(Arrays.asList(integrationNames), "", ".analytics.enabled", defaultEnabled);
+    return this.traceInstrumentationConfig.isTraceAnalyticsIntegrationEnabled(
+        defaultEnabled, integrationNames);
   }
 
   public boolean isSamplingMechanismValidationDisabled() {
-    return configProvider.getBoolean(TracerConfig.SAMPLING_MECHANISM_VALIDATION_DISABLED, false);
+    return this.tracerConfig.isSamplingMechanismValidationDisabled();
   }
 
   public <T extends Enum<T>> T getEnumValue(
       final String name, final Class<T> type, final T defaultValue) {
-    return configProvider.getEnum(name, type, defaultValue);
-  }
-
-  private static boolean isDebugMode() {
-    final String tracerDebugLevelSysprop = "dd.trace.debug";
-    final String tracerDebugLevelProp = getProp(tracerDebugLevelSysprop);
-
-    if (tracerDebugLevelProp != null) {
-      return Boolean.parseBoolean(tracerDebugLevelProp);
-    }
-
-    final String tracerDebugLevelEnv = getEnv(toEnvVar(tracerDebugLevelSysprop));
-
-    if (tracerDebugLevelEnv != null) {
-      return Boolean.parseBoolean(tracerDebugLevelEnv);
-    }
-    return false;
+    return this.configProvider.getEnum(name, type, defaultValue);
   }
 
   /**
@@ -2542,196 +1081,6 @@ public class Config {
   public static boolean traceAnalyticsIntegrationEnabled(
       final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     return Config.get().isTraceAnalyticsIntegrationEnabled(integrationNames, defaultEnabled);
-  }
-
-  private boolean isEnabled(
-      final Iterable<String> integrationNames,
-      final String settingPrefix,
-      final String settingSuffix,
-      final boolean defaultEnabled) {
-    // If default is enabled, we want to disable individually.
-    // If default is disabled, we want to enable individually.
-    boolean anyEnabled = defaultEnabled;
-    for (final String name : integrationNames) {
-      final String configKey = settingPrefix + name + settingSuffix;
-      final String fullKey = configKey.startsWith("trace.") ? configKey : "trace." + configKey;
-      final boolean configEnabled = configProvider.getBoolean(fullKey, defaultEnabled, configKey);
-      if (defaultEnabled) {
-        anyEnabled &= configEnabled;
-      } else {
-        anyEnabled |= configEnabled;
-      }
-    }
-    return anyEnabled;
-  }
-
-  /**
-   * Calls configProvider.getString(String, String) and converts the result to a set of strings
-   * splitting by space or comma.
-   */
-  private Set<PropagationStyle> getPropagationStyleSetSettingFromEnvironmentOrDefault(
-      final String name, final String defaultValue) {
-    final String value = configProvider.getString(name, defaultValue);
-    Set<PropagationStyle> result =
-        convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(value));
-
-    if (result.isEmpty()) {
-      // Treat empty parsing result as no value and use default instead
-      result =
-          convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(defaultValue));
-    }
-
-    return result;
-  }
-
-  private static final String PREFIX = "dd.";
-
-  /**
-   * Converts the property name, e.g. 'service.name' into a public system property name, e.g.
-   * `dd.service.name`.
-   *
-   * @param setting The setting name, e.g. `service.name`
-   * @return The public facing system property name
-   */
-  @Nonnull
-  private static String propertyNameToSystemPropertyName(final String setting) {
-    return PREFIX + setting;
-  }
-
-  @Nonnull
-  private static Map<String, String> newHashMap(final int size) {
-    return new HashMap<>(size + 1, 1f);
-  }
-
-  /**
-   * @param map
-   * @param propNames
-   * @return new unmodifiable copy of {@param map} where properties are overwritten from environment
-   */
-  @Nonnull
-  private Map<String, String> getMapWithPropertiesDefinedByEnvironment(
-      @Nonnull final Map<String, String> map, @Nonnull final String... propNames) {
-    final Map<String, String> res = new HashMap<>(map);
-    for (final String propName : propNames) {
-      final String val = configProvider.getString(propName);
-      if (val != null) {
-        res.put(propName, val);
-      }
-    }
-    return Collections.unmodifiableMap(res);
-  }
-
-  @Nonnull
-  private static Set<String> parseStringIntoSetOfNonEmptyStrings(final String str) {
-    // Using LinkedHashSet to preserve original string order
-    final Set<String> result = new LinkedHashSet<>();
-    // Java returns single value when splitting an empty string. We do not need that value, so
-    // we need to throw it out.
-    int start = 0;
-    int i = 0;
-    for (; i < str.length(); ++i) {
-      char c = str.charAt(i);
-      if (Character.isWhitespace(c) || c == ',') {
-        if (i - start - 1 > 0) {
-          result.add(str.substring(start, i));
-        }
-        start = i + 1;
-      }
-    }
-    if (i - start - 1 > 0) {
-      result.add(str.substring(start));
-    }
-    return Collections.unmodifiableSet(result);
-  }
-
-  @Nonnull
-  private static Set<PropagationStyle> convertStringSetToPropagationStyleSet(
-      final Set<String> input) {
-    // Using LinkedHashSet to preserve original string order
-    final Set<PropagationStyle> result = new LinkedHashSet<>();
-    for (final String value : input) {
-      try {
-        result.add(PropagationStyle.valueOf(value.toUpperCase()));
-      } catch (final IllegalArgumentException e) {
-        log.debug("Cannot recognize config string value: {}, {}", value, PropagationStyle.class);
-      }
-    }
-    return Collections.unmodifiableSet(result);
-  }
-
-  /** Returns the detected hostname. First tries locally, then using DNS */
-  private static String initHostName() {
-    String possibleHostname;
-
-    // Try environment variable.  This works in almost all environments
-    if (isWindowsOS()) {
-      possibleHostname = getEnv("COMPUTERNAME");
-    } else {
-      possibleHostname = getEnv("HOSTNAME");
-    }
-
-    if (possibleHostname != null && !possibleHostname.isEmpty()) {
-      log.debug("Determined hostname from environment variable");
-      return possibleHostname.trim();
-    }
-
-    // Try hostname command
-    try (final BufferedReader reader =
-        new BufferedReader(
-            new InputStreamReader(Runtime.getRuntime().exec("hostname").getInputStream()))) {
-      possibleHostname = reader.readLine();
-    } catch (final Throwable ignore) {
-      // Ignore.  Hostname command is not always available
-    }
-
-    if (possibleHostname != null && !possibleHostname.isEmpty()) {
-      log.debug("Determined hostname from hostname command");
-      return possibleHostname.trim();
-    }
-
-    // From DNS
-    try {
-      return InetAddress.getLocalHost().getHostName();
-    } catch (final UnknownHostException e) {
-      // If we are not able to detect the hostname we do not throw an exception.
-    }
-
-    return null;
-  }
-
-  private static boolean isWindowsOS() {
-    return getProp("os.name").startsWith("Windows");
-  }
-
-  private static String getEnv(String name) {
-    String value = System.getenv(name);
-    if (value != null) {
-      ConfigCollector.get().put(name, value);
-    }
-    return value;
-  }
-
-  private static Pattern getPattern(String defaultValue, String userValue) {
-    try {
-      if (userValue != null) {
-        return Pattern.compile(userValue);
-      }
-    } catch (Exception e) {
-      log.debug("Cannot create pattern from user value {}", userValue);
-    }
-    return Pattern.compile(defaultValue);
-  }
-
-  private static String getProp(String name) {
-    return getProp(name, null);
-  }
-
-  private static String getProp(String name, String def) {
-    String value = System.getProperty(name, def);
-    if (value != null) {
-      ConfigCollector.get().put(name, value);
-    }
-    return value;
   }
 
   // This has to be placed after all other static fields to give them a chance to initialize
@@ -2750,9 +1099,6 @@ public class Config {
    *   DDTracer.builder().withProperties(new Properties()).build()
    * </pre>
    *
-   * <p>Config keys for use in Properties instance construction can be found in {@link
-   * GeneralConfig} and {@link TracerConfig}.
-   *
    * @deprecated
    */
   @Deprecated
@@ -2767,365 +1113,35 @@ public class Config {
   @Override
   public String toString() {
     return "Config{"
-        + "runtimeId='"
-        + runtimeId
+        + "generalConfig="
+        + this.generalConfig
+        + ", tracerConfig="
+        + this.tracerConfig
+        + ", iastConfig="
+        + this.iastConfig
+        + ", jmxFetchConfig="
+        + this.jmxFetchConfig
+        + ", traceInstrumentationConfig="
+        + this.traceInstrumentationConfig
+        + ", profilingConfig="
+        + this.profilingConfig
+        + ", crashTrackingConfig="
+        + this.crashTrackingConfig
+        + ", appSecConfig="
+        + this.appSecConfig
+        + ", ciVisibilityConfig="
+        + this.ciVisibilityConfig
+        + ", remoteConfig="
+        + this.remoteConfig
+        + ", debuggerConfig="
+        + this.debuggerConfig
+        + ", cwsConfig="
+        + this.cwsConfig
+        + ", configFileStatus='"
+        + this.configFileStatus
         + '\''
-        + ", runtimeVersion='"
-        + runtimeVersion
-        + ", apiKey="
-        + (apiKey == null ? "null" : "****")
-        + ", site='"
-        + site
-        + '\''
-        + ", hostName='"
-        + hostName
-        + '\''
-        + ", serviceName='"
-        + serviceName
-        + '\''
-        + ", serviceNameSetByUser="
-        + serviceNameSetByUser
-        + ", rootContextServiceName="
-        + rootContextServiceName
-        + ", traceEnabled="
-        + traceEnabled
-        + ", integrationsEnabled="
-        + integrationsEnabled
-        + ", integrationSynapseLegacyOperationName="
-        + integrationSynapseLegacyOperationName
-        + ", writerType='"
-        + writerType
-        + '\''
-        + ", agentConfiguredUsingDefault="
-        + agentConfiguredUsingDefault
-        + ", agentUrl='"
-        + agentUrl
-        + '\''
-        + ", agentHost='"
-        + agentHost
-        + '\''
-        + ", agentPort="
-        + agentPort
-        + ", agentUnixDomainSocket='"
-        + agentUnixDomainSocket
-        + '\''
-        + ", agentTimeout="
-        + agentTimeout
-        + ", noProxyHosts="
-        + noProxyHosts
-        + ", prioritySamplingEnabled="
-        + prioritySamplingEnabled
-        + ", prioritySamplingForce='"
-        + prioritySamplingForce
-        + '\''
-        + ", traceResolverEnabled="
-        + traceResolverEnabled
-        + ", serviceMapping="
-        + serviceMapping
-        + ", tags="
-        + tags
-        + ", spanTags="
-        + spanTags
-        + ", jmxTags="
-        + jmxTags
-        + ", excludedClasses="
-        + excludedClasses
-        + ", excludedClassesFile="
-        + excludedClassesFile
-        + ", excludedClassLoaders="
-        + excludedClassLoaders
-        + ", excludedCodeSources="
-        + excludedCodeSources
-        + ", requestHeaderTags="
-        + requestHeaderTags
-        + ", responseHeaderTags="
-        + responseHeaderTags
-        + ", httpServerErrorStatuses="
-        + httpServerErrorStatuses
-        + ", httpClientErrorStatuses="
-        + httpClientErrorStatuses
-        + ", httpServerTagQueryString="
-        + httpServerTagQueryString
-        + ", httpServerRawQueryString="
-        + httpServerRawQueryString
-        + ", httpServerRawResource="
-        + httpServerRawResource
-        + ", httpServerRouteBasedNaming="
-        + httpServerRouteBasedNaming
-        + ", httpServerPathResourceNameMapping="
-        + httpServerPathResourceNameMapping
-        + ", httpClientTagQueryString="
-        + httpClientTagQueryString
-        + ", httpClientSplitByDomain="
-        + httpClientSplitByDomain
-        + ", dbClientSplitByInstance="
-        + dbClientSplitByInstance
-        + ", dbClientSplitByInstanceTypeSuffix="
-        + dbClientSplitByInstanceTypeSuffix
-        + ", splitByTags="
-        + splitByTags
-        + ", scopeDepthLimit="
-        + scopeDepthLimit
-        + ", scopeStrictMode="
-        + scopeStrictMode
-        + ", scopeInheritAsyncPropagation="
-        + scopeInheritAsyncPropagation
-        + ", scopeIterationKeepAlive="
-        + scopeIterationKeepAlive
-        + ", partialFlushMinSpans="
-        + partialFlushMinSpans
-        + ", traceStrictWritesEnabled="
-        + traceStrictWritesEnabled
-        + ", runtimeContextFieldInjection="
-        + runtimeContextFieldInjection
-        + ", serialVersionUIDFieldInjection="
-        + serialVersionUIDFieldInjection
-        + ", propagationStylesToExtract="
-        + propagationStylesToExtract
-        + ", propagationStylesToInject="
-        + propagationStylesToInject
-        + ", clockSyncPeriod="
-        + clockSyncPeriod
-        + ", jmxFetchEnabled="
-        + jmxFetchEnabled
-        + ", dogStatsDStartDelay="
-        + dogStatsDStartDelay
-        + ", jmxFetchConfigDir='"
-        + jmxFetchConfigDir
-        + '\''
-        + ", jmxFetchConfigs="
-        + jmxFetchConfigs
-        + ", jmxFetchMetricsConfigs="
-        + jmxFetchMetricsConfigs
-        + ", jmxFetchCheckPeriod="
-        + jmxFetchCheckPeriod
-        + ", jmxFetchInitialRefreshBeansPeriod="
-        + jmxFetchInitialRefreshBeansPeriod
-        + ", jmxFetchRefreshBeansPeriod="
-        + jmxFetchRefreshBeansPeriod
-        + ", jmxFetchStatsdHost='"
-        + jmxFetchStatsdHost
-        + '\''
-        + ", jmxFetchStatsdPort="
-        + jmxFetchStatsdPort
-        + ", jmxFetchMultipleRuntimeServicesEnabled="
-        + jmxFetchMultipleRuntimeServicesEnabled
-        + ", jmxFetchMultipleRuntimeServicesLimit="
-        + jmxFetchMultipleRuntimeServicesLimit
-        + ", healthMetricsEnabled="
-        + healthMetricsEnabled
-        + ", healthMetricsStatsdHost='"
-        + healthMetricsStatsdHost
-        + '\''
-        + ", healthMetricsStatsdPort="
-        + healthMetricsStatsdPort
-        + ", perfMetricsEnabled="
-        + perfMetricsEnabled
-        + ", tracerMetricsEnabled="
-        + tracerMetricsEnabled
-        + ", tracerMetricsBufferingEnabled="
-        + tracerMetricsBufferingEnabled
-        + ", tracerMetricsMaxAggregates="
-        + tracerMetricsMaxAggregates
-        + ", tracerMetricsMaxPending="
-        + tracerMetricsMaxPending
-        + ", logsInjectionEnabled="
-        + logsInjectionEnabled
-        + ", logsMDCTagsInjectionEnabled="
-        + logsMDCTagsInjectionEnabled
-        + ", reportHostName="
-        + reportHostName
-        + ", traceAnnotations='"
-        + traceAnnotations
-        + '\''
-        + ", traceMethods='"
-        + traceMethods
-        + '\''
-        + ", traceExecutorsAll="
-        + traceExecutorsAll
-        + ", traceExecutors="
-        + traceExecutors
-        + ", traceAnalyticsEnabled="
-        + traceAnalyticsEnabled
-        + ", traceSamplingServiceRules="
-        + traceSamplingServiceRules
-        + ", traceSamplingOperationRules="
-        + traceSamplingOperationRules
-        + ", traceSamplingJsonRules="
-        + traceSamplingRules
-        + ", traceSampleRate="
-        + traceSampleRate
-        + ", traceRateLimit="
-        + traceRateLimit
-        + ", profilingEnabled="
-        + profilingEnabled
-        + ", profilingAgentless="
-        + profilingAgentless
-        + ", profilingUrl='"
-        + profilingUrl
-        + '\''
-        + ", profilingTags="
-        + profilingTags
-        + ", profilingStartDelay="
-        + profilingStartDelay
-        + ", profilingStartForceFirst="
-        + profilingStartForceFirst
-        + ", profilingUploadPeriod="
-        + profilingUploadPeriod
-        + ", profilingTemplateOverrideFile='"
-        + profilingTemplateOverrideFile
-        + '\''
-        + ", profilingUploadTimeout="
-        + profilingUploadTimeout
-        + ", profilingUploadCompression='"
-        + profilingUploadCompression
-        + '\''
-        + ", profilingProxyHost='"
-        + profilingProxyHost
-        + '\''
-        + ", profilingProxyPort="
-        + profilingProxyPort
-        + ", profilingProxyUsername='"
-        + profilingProxyUsername
-        + '\''
-        + ", profilingProxyPassword="
-        + (profilingProxyPassword == null ? "null" : "****")
-        + ", profilingExceptionSampleLimit="
-        + profilingExceptionSampleLimit
-        + ", profilingExceptionHistogramTopItems="
-        + profilingExceptionHistogramTopItems
-        + ", profilingExceptionHistogramMaxCollectionSize="
-        + profilingExceptionHistogramMaxCollectionSize
-        + ", profilingExcludeAgentThreads="
-        + profilingExcludeAgentThreads
-        + ", crashTrackingTags="
-        + crashTrackingTags
-        + ", crashTrackingAgentless="
-        + crashTrackingAgentless
-        + ", remoteConfigEnabled="
-        + remoteConfigEnabled
-        + ", remoteConfigUrl="
-        + remoteConfigUrl
-        + ", remoteConfigInitialPollInterval="
-        + remoteConfigInitialPollInterval
-        + ", remoteConfigMaxPayloadSize="
-        + remoteConfigMaxPayloadSize
-        + ", remoteConfigIntegrityCheckEnabled="
-        + remoteConfigIntegrityCheckEnabled
-        + ", debuggerEnabled="
-        + debuggerEnabled
-        + ", debuggerUploadTimeout="
-        + debuggerUploadTimeout
-        + ", debuggerUploadFlushInterval="
-        + debuggerUploadFlushInterval
-        + ", debuggerClassFileDumpEnabled="
-        + debuggerClassFileDumpEnabled
-        + ", debuggerPollInterval="
-        + debuggerPollInterval
-        + ", debuggerDiagnosticsInterval="
-        + debuggerDiagnosticsInterval
-        + ", debuggerMetricEnabled="
-        + debuggerMetricEnabled
-        + ", debuggerProbeFileLocation="
-        + debuggerProbeFileLocation
-        + ", debuggerUploadBatchSize="
-        + debuggerUploadBatchSize
-        + ", debuggerMaxPayloadSize="
-        + debuggerMaxPayloadSize
-        + ", debuggerVerifyByteCode="
-        + debuggerVerifyByteCode
-        + ", debuggerInstrumentTheWorld="
-        + debuggerInstrumentTheWorld
-        + ", debuggerExcludeFile="
-        + debuggerExcludeFile
-        + ", awsPropagationEnabled="
-        + awsPropagationEnabled
-        + ", sqsPropagationEnabled="
-        + sqsPropagationEnabled
-        + ", kafkaClientPropagationEnabled="
-        + kafkaClientPropagationEnabled
-        + ", kafkaClientPropagationDisabledTopics="
-        + kafkaClientPropagationDisabledTopics
-        + ", kafkaClientBase64DecodingEnabled="
-        + kafkaClientBase64DecodingEnabled
-        + ", jmsPropagationEnabled="
-        + jmsPropagationEnabled
-        + ", jmsPropagationDisabledTopics="
-        + jmsPropagationDisabledTopics
-        + ", jmsPropagationDisabledQueues="
-        + jmsPropagationDisabledQueues
-        + ", rabbitPropagationEnabled="
-        + rabbitPropagationEnabled
-        + ", rabbitPropagationDisabledQueues="
-        + rabbitPropagationDisabledQueues
-        + ", rabbitPropagationDisabledExchanges="
-        + rabbitPropagationDisabledExchanges
-        + ", messageBrokerSplitByDestination="
-        + messageBrokerSplitByDestination
-        + ", hystrixTagsEnabled="
-        + hystrixTagsEnabled
-        + ", hystrixMeasuredEnabled="
-        + hystrixMeasuredEnabled
-        + ", igniteCacheIncludeKeys="
-        + igniteCacheIncludeKeys
-        + ", servletPrincipalEnabled="
-        + servletPrincipalEnabled
-        + ", servletAsyncTimeoutError="
-        + servletAsyncTimeoutError
-        + ", datadogTagsLimit="
-        + xDatadogTagsMaxLength
-        + ", traceAgentV05Enabled="
-        + traceAgentV05Enabled
-        + ", debugEnabled="
-        + debugEnabled
-        + ", configFile='"
-        + configFileStatus
-        + '\''
-        + ", idGenerationStrategy="
-        + idGenerationStrategy
-        + ", internalExitOnFailure="
-        + internalExitOnFailure
-        + ", resolverOutlinePoolEnabled="
-        + resolverOutlinePoolEnabled
-        + ", resolverOutlinePoolSize="
-        + resolverOutlinePoolSize
-        + ", resolverTypePoolSize="
-        + resolverTypePoolSize
-        + ", resolverUseLoadClassEnabled="
-        + resolverUseLoadClassEnabled
-        + ", jdbcPreparedStatementClassName='"
-        + jdbcPreparedStatementClassName
-        + '\''
-        + ", jdbcConnectionClassName='"
-        + jdbcConnectionClassName
-        + '\''
-        + ", grpcIgnoredInboundMethods="
-        + grpcIgnoredInboundMethods
-        + ", grpcIgnoredOutboundMethods="
-        + grpcIgnoredOutboundMethods
-        + ", grpcServerErrorStatuses="
-        + grpcServerErrorStatuses
-        + ", grpcClientErrorStatuses="
-        + grpcClientErrorStatuses
         + ", configProvider="
-        + configProvider
-        + ", clientIpEnabled="
-        + clientIpEnabled
-        + ", appSecEnabled="
-        + appSecEnabled
-        + ", appSecReportingInband="
-        + appSecReportingInband
-        + ", appSecRulesFile='"
-        + appSecRulesFile
-        + "'"
-        + ", appSecHttpBlockedTemplateHtml="
-        + appSecHttpBlockedTemplateHtml
-        + ", appSecHttpBlockedTemplateJson="
-        + appSecHttpBlockedTemplateJson
-        + ", cwsEnabled="
-        + cwsEnabled
-        + ", cwsTlsRefresh="
-        + cwsTlsRefresh
+        + this.configProvider
         + '}';
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/config/AbstractFeatureConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/config/AbstractFeatureConfig.java
@@ -1,0 +1,65 @@
+package datadog.trace.api.config;
+
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.annotation.Nonnull;
+
+public class AbstractFeatureConfig {
+  protected final ConfigProvider configProvider;
+
+  public AbstractFeatureConfig(ConfigProvider configProvider) {
+    this.configProvider = configProvider;
+  }
+
+  protected boolean isEnabled(
+      final boolean defaultEnabled, final String settingName, String settingSuffix) {
+    return isEnabled(Collections.singletonList(settingName), "", settingSuffix, defaultEnabled);
+  }
+
+  protected boolean isEnabled(
+      final Iterable<String> integrationNames,
+      final String settingPrefix,
+      final String settingSuffix,
+      final boolean defaultEnabled) {
+    // If default is enabled, we want to disable individually.
+    // If default is disabled, we want to enable individually.
+    boolean anyEnabled = defaultEnabled;
+    for (final String name : integrationNames) {
+      final String configKey = settingPrefix + name + settingSuffix;
+      final String fullKey = configKey.startsWith("trace.") ? configKey : "trace." + configKey;
+      final boolean configEnabled =
+          this.configProvider.getBoolean(fullKey, defaultEnabled, configKey);
+      if (defaultEnabled) {
+        anyEnabled &= configEnabled;
+      } else {
+        anyEnabled |= configEnabled;
+      }
+    }
+    return anyEnabled;
+  }
+
+  @Nonnull
+  public static Set<String> parseStringIntoSetOfNonEmptyStrings(final String str) {
+    // Using LinkedHashSet to preserve original string order
+    final Set<String> result = new LinkedHashSet<>();
+    // Java returns single value when splitting an empty string. We do not need that value, so
+    // we need to throw it out.
+    int start = 0;
+    int i = 0;
+    for (; i < str.length(); ++i) {
+      char c = str.charAt(i);
+      if (Character.isWhitespace(c) || c == ',') {
+        if (i - start - 1 > 0) {
+          result.add(str.substring(start, i));
+        }
+        start = i + 1;
+      }
+    }
+    if (i - start - 1 > 0) {
+      result.add(str.substring(start));
+    }
+    return Collections.unmodifiableSet(result);
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/config/AppSecFeatureConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/config/AppSecFeatureConfig.java
@@ -1,0 +1,150 @@
+package datadog.trace.api.config;
+
+import static datadog.trace.api.config.AppSecConfig.APPSEC_ENABLED;
+import static datadog.trace.api.config.AppSecConfig.APPSEC_HTTP_BLOCKED_TEMPLATE_HTML;
+import static datadog.trace.api.config.AppSecConfig.APPSEC_HTTP_BLOCKED_TEMPLATE_JSON;
+import static datadog.trace.api.config.AppSecConfig.APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP;
+import static datadog.trace.api.config.AppSecConfig.APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP;
+import static datadog.trace.api.config.AppSecConfig.APPSEC_REPORTING_INBAND;
+import static datadog.trace.api.config.AppSecConfig.APPSEC_REPORT_TIMEOUT_SEC;
+import static datadog.trace.api.config.AppSecConfig.APPSEC_RULES_FILE;
+import static datadog.trace.api.config.AppSecConfig.APPSEC_TRACE_RATE_LIMIT;
+import static datadog.trace.api.config.AppSecConfig.APPSEC_WAF_METRICS;
+import static datadog.trace.api.config.AppSecConfig.DEFAULT_APPSEC_ENABLED;
+import static datadog.trace.api.config.AppSecConfig.DEFAULT_APPSEC_REPORTING_INBAND;
+import static datadog.trace.api.config.AppSecConfig.DEFAULT_APPSEC_TRACE_RATE_LIMIT;
+import static datadog.trace.api.config.AppSecConfig.DEFAULT_APPSEC_WAF_METRICS;
+
+import datadog.trace.api.ProductActivationConfig;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import datadog.trace.bootstrap.config.provider.SystemPropertiesConfigSource;
+
+public class AppSecFeatureConfig extends AbstractFeatureConfig {
+  private final ProductActivationConfig appSecEnabled;
+  private final boolean appSecReportingInband;
+  private final String appSecRulesFile;
+  private final int appSecReportMinTimeout;
+  private final int appSecReportMaxTimeout;
+  private final int appSecTraceRateLimit;
+  private final boolean appSecWafMetrics;
+  private final String appSecObfuscationParameterKeyRegexp;
+  private final String appSecObfuscationParameterValueRegexp;
+  private final String appSecHttpBlockedTemplateHtml;
+  private final String appSecHttpBlockedTemplateJson;
+
+  public AppSecFeatureConfig(ConfigProvider configProvider) {
+    super(configProvider);
+    // ConfigProvider.getString currently doesn't fallback to default for empty strings. So we have
+    // special handling here until we have a general solution for empty string value fallback.
+    String appSecEnabled = configProvider.getString(APPSEC_ENABLED);
+    if (appSecEnabled == null || appSecEnabled.isEmpty()) {
+      appSecEnabled =
+          configProvider.getStringExcludingSource(
+              APPSEC_ENABLED, DEFAULT_APPSEC_ENABLED, SystemPropertiesConfigSource.class);
+      if (appSecEnabled.isEmpty()) {
+        appSecEnabled = DEFAULT_APPSEC_ENABLED;
+      }
+    }
+    this.appSecEnabled = ProductActivationConfig.fromString(appSecEnabled);
+    this.appSecReportingInband =
+        configProvider.getBoolean(APPSEC_REPORTING_INBAND, DEFAULT_APPSEC_REPORTING_INBAND);
+    this.appSecRulesFile = configProvider.getString(APPSEC_RULES_FILE, null);
+
+    // Default AppSec report timeout min=5, max=60
+    this.appSecReportMaxTimeout = configProvider.getInteger(APPSEC_REPORT_TIMEOUT_SEC, 60);
+    this.appSecReportMinTimeout = Math.min(this.appSecReportMaxTimeout, 5);
+
+    this.appSecTraceRateLimit =
+        configProvider.getInteger(APPSEC_TRACE_RATE_LIMIT, DEFAULT_APPSEC_TRACE_RATE_LIMIT);
+
+    this.appSecWafMetrics =
+        configProvider.getBoolean(APPSEC_WAF_METRICS, DEFAULT_APPSEC_WAF_METRICS);
+
+    this.appSecObfuscationParameterKeyRegexp =
+        configProvider.getString(APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP, null);
+    this.appSecObfuscationParameterValueRegexp =
+        configProvider.getString(APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP, null);
+
+    this.appSecHttpBlockedTemplateHtml =
+        configProvider.getString(APPSEC_HTTP_BLOCKED_TEMPLATE_HTML, null);
+    this.appSecHttpBlockedTemplateJson =
+        configProvider.getString(APPSEC_HTTP_BLOCKED_TEMPLATE_JSON, null);
+  }
+
+  public ProductActivationConfig getAppSecEnabledConfig() {
+    return this.appSecEnabled;
+  }
+
+  public boolean isAppSecReportingInband() {
+    return this.appSecReportingInband;
+  }
+
+  public String getAppSecRulesFile() {
+    return this.appSecRulesFile;
+  }
+
+  public int getAppSecReportMinTimeout() {
+    return this.appSecReportMinTimeout;
+  }
+
+  public int getAppSecReportMaxTimeout() {
+    return this.appSecReportMaxTimeout;
+  }
+
+  public int getAppSecTraceRateLimit() {
+    return this.appSecTraceRateLimit;
+  }
+
+  public boolean isAppSecWafMetrics() {
+    return this.appSecWafMetrics;
+  }
+
+  public String getAppSecObfuscationParameterKeyRegexp() {
+    return this.appSecObfuscationParameterKeyRegexp;
+  }
+
+  public String getAppSecObfuscationParameterValueRegexp() {
+    return this.appSecObfuscationParameterValueRegexp;
+  }
+
+  public String getAppSecHttpBlockedTemplateHtml() {
+    return this.appSecHttpBlockedTemplateHtml;
+  }
+
+  public String getAppSecHttpBlockedTemplateJson() {
+    return this.appSecHttpBlockedTemplateJson;
+  }
+
+  @Override
+  public String toString() {
+    return "AppSecFeatureConfig{"
+        + "appSecEnabled="
+        + this.appSecEnabled
+        + ", appSecReportingInband="
+        + this.appSecReportingInband
+        + ", appSecRulesFile='"
+        + this.appSecRulesFile
+        + '\''
+        + ", appSecReportMinTimeout="
+        + this.appSecReportMinTimeout
+        + ", appSecReportMaxTimeout="
+        + this.appSecReportMaxTimeout
+        + ", appSecTraceRateLimit="
+        + this.appSecTraceRateLimit
+        + ", appSecWafMetrics="
+        + this.appSecWafMetrics
+        + ", appSecObfuscationParameterKeyRegexp='"
+        + this.appSecObfuscationParameterKeyRegexp
+        + '\''
+        + ", appSecObfuscationParameterValueRegexp='"
+        + this.appSecObfuscationParameterValueRegexp
+        + '\''
+        + ", appSecHttpBlockedTemplateHtml='"
+        + this.appSecHttpBlockedTemplateHtml
+        + '\''
+        + ", appSecHttpBlockedTemplateJson='"
+        + this.appSecHttpBlockedTemplateJson
+        + '\''
+        + '}';
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/config/CiVisibilityFeatureConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/config/CiVisibilityFeatureConfig.java
@@ -1,0 +1,75 @@
+package datadog.trace.api.config;
+
+import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_AGENTLESS_ENABLED;
+import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_AGENTLESS_URL;
+import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_ENABLED;
+import static datadog.trace.api.config.CiVisibilityConfig.DEFAULT_CIVISIBILITY_AGENTLESS_ENABLED;
+import static datadog.trace.api.config.CiVisibilityConfig.DEFAULT_CIVISIBILITY_ENABLED;
+
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CiVisibilityFeatureConfig extends AbstractFeatureConfig {
+  private static final Logger LOGGER = LoggerFactory.getLogger(CiVisibilityConfig.class);
+  private final boolean ciVisibilityEnabled;
+  private final boolean ciVisibilityAgentlessEnabled;
+  private final String ciVisibilityAgentlessUrl;
+
+  public CiVisibilityFeatureConfig(ConfigProvider configProvider) {
+    super(configProvider);
+    this.ciVisibilityEnabled =
+        configProvider.getBoolean(CIVISIBILITY_ENABLED, DEFAULT_CIVISIBILITY_ENABLED);
+    this.ciVisibilityAgentlessEnabled =
+        configProvider.getBoolean(
+            CIVISIBILITY_AGENTLESS_ENABLED, DEFAULT_CIVISIBILITY_AGENTLESS_ENABLED);
+    this.ciVisibilityAgentlessUrl = parseAgentlessUrl(configProvider);
+  }
+
+  private String parseAgentlessUrl(ConfigProvider configProvider) {
+    final String ciVisibilityAgentlessUrlStr = configProvider.getString(CIVISIBILITY_AGENTLESS_URL);
+    URI parsedCiVisibilityUri = null;
+    if (ciVisibilityAgentlessUrlStr != null && !ciVisibilityAgentlessUrlStr.isEmpty()) {
+      try {
+        parsedCiVisibilityUri = new URL(ciVisibilityAgentlessUrlStr).toURI();
+      } catch (MalformedURLException | URISyntaxException ex) {
+        LOGGER.error(
+            "Cannot parse CI Visibility agentless URL '{}', skipping", ciVisibilityAgentlessUrlStr);
+      }
+    }
+    if (parsedCiVisibilityUri != null) {
+      return ciVisibilityAgentlessUrlStr;
+    } else {
+      return null;
+    }
+  }
+
+  public boolean isCiVisibilityEnabled() {
+    return this.ciVisibilityEnabled;
+  }
+
+  public boolean isCiVisibilityAgentlessEnabled() {
+    return this.ciVisibilityAgentlessEnabled;
+  }
+
+  public String getCiVisibilityAgentlessUrl() {
+    return this.ciVisibilityAgentlessUrl;
+  }
+
+  @Override
+  public String toString() {
+    return "CiVisibilityFeatureConfig{"
+        + "ciVisibilityEnabled="
+        + this.ciVisibilityEnabled
+        + ", ciVisibilityAgentlessEnabled="
+        + this.ciVisibilityAgentlessEnabled
+        + ", ciVisibilityAgentlessUrl='"
+        + this.ciVisibilityAgentlessUrl
+        + '\''
+        + '}';
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/config/CrashTrackingFeatureConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/config/CrashTrackingFeatureConfig.java
@@ -1,0 +1,88 @@
+package datadog.trace.api.config;
+
+import static datadog.trace.api.DDTags.HOST_TAG;
+import static datadog.trace.api.DDTags.LANGUAGE_TAG_KEY;
+import static datadog.trace.api.DDTags.LANGUAGE_TAG_VALUE;
+import static datadog.trace.api.DDTags.SERVICE_TAG;
+import static datadog.trace.api.config.CrashTrackingConfig.CRASH_TRACKING_AGENTLESS;
+import static datadog.trace.api.config.CrashTrackingConfig.CRASH_TRACKING_AGENTLESS_DEFAULT;
+import static datadog.trace.api.config.CrashTrackingConfig.CRASH_TRACKING_TAGS;
+import static datadog.trace.api.config.GeneralFeatureConfig.newHashMap;
+
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import java.util.Collections;
+import java.util.Map;
+
+public class CrashTrackingFeatureConfig extends AbstractFeatureConfig {
+  private final GeneralFeatureConfig generalConfig;
+  private final TracerFeatureConfig tracerConfig;
+  private final boolean crashTrackingAgentless;
+  private final Map<String, String> crashTrackingTags;
+
+  public CrashTrackingFeatureConfig(
+      ConfigProvider configProvider,
+      GeneralFeatureConfig generalConfig,
+      TracerFeatureConfig tracerConfig) {
+    super(configProvider);
+    this.generalConfig = generalConfig;
+    this.tracerConfig = tracerConfig;
+    this.crashTrackingAgentless =
+        configProvider.getBoolean(CRASH_TRACKING_AGENTLESS, CRASH_TRACKING_AGENTLESS_DEFAULT);
+    this.crashTrackingTags = configProvider.getMergedMap(CRASH_TRACKING_TAGS);
+  }
+
+  public boolean isCrashTrackingAgentless() {
+    return this.crashTrackingAgentless;
+  }
+
+  public String getFinalCrashTrackingTelemetryUrl() {
+    if (this.crashTrackingAgentless) {
+      // when agentless crashTracking is turned on we send directly to our intake
+      return "https://all-http-intake.logs."
+          + this.generalConfig.getSite()
+          + "/api/v2/apmtelemetry";
+    } else {
+      // when agentless are not set we send to the dd trace agent running locally
+      return "http://"
+          + this.tracerConfig.getAgentHost()
+          + ":"
+          + this.tracerConfig.getAgentPort()
+          + "/telemetry/proxy/api/v2/apmtelemetry";
+    }
+  }
+
+  public Map<String, String> getMergedCrashTrackingTags() {
+    final Map<String, String> runtimeTags = this.generalConfig.getRuntimeTags();
+    final Map<String, String> globalTags = this.generalConfig.getGlobalTags();
+    final String host = this.generalConfig.getHostName();
+    final Map<String, String> result =
+        newHashMap(
+            globalTags.size()
+                + this.crashTrackingTags.size()
+                + runtimeTags.size()
+                + 3 /* for serviceName and host and language */);
+    result.put(HOST_TAG, host); // Host goes first to allow to override it
+    result.putAll(globalTags);
+    result.putAll(this.crashTrackingTags);
+    result.putAll(runtimeTags);
+    // service name set here instead of getRuntimeTags because apm already manages the service tag
+    // and may choose to override it.
+    result.put(SERVICE_TAG, this.generalConfig.getServiceName());
+    result.put(LANGUAGE_TAG_KEY, LANGUAGE_TAG_VALUE);
+    return Collections.unmodifiableMap(result);
+  }
+
+  @Override
+  public String toString() {
+    return "CrashTrackingFeatureConfig{"
+        + "generalConfig="
+        + this.generalConfig
+        + ", tracerConfig="
+        + this.tracerConfig
+        + ", crashTrackingAgentless="
+        + this.crashTrackingAgentless
+        + ", crashTrackingTags="
+        + this.crashTrackingTags
+        + '}';
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/config/CwsFeatureConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/config/CwsFeatureConfig.java
@@ -1,0 +1,37 @@
+package datadog.trace.api.config;
+
+import static datadog.trace.api.config.CwsConfig.CWS_ENABLED;
+import static datadog.trace.api.config.CwsConfig.CWS_TLS_REFRESH;
+import static datadog.trace.api.config.CwsConfig.DEFAULT_CWS_ENABLED;
+import static datadog.trace.api.config.CwsConfig.DEFAULT_CWS_TLS_REFRESH;
+
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+
+public class CwsFeatureConfig extends AbstractFeatureConfig {
+  private final boolean cwsEnabled;
+  private final int cwsTlsRefresh;
+
+  public CwsFeatureConfig(ConfigProvider configProvider) {
+    super(configProvider);
+    this.cwsEnabled = configProvider.getBoolean(CWS_ENABLED, DEFAULT_CWS_ENABLED);
+    this.cwsTlsRefresh = configProvider.getInteger(CWS_TLS_REFRESH, DEFAULT_CWS_TLS_REFRESH);
+  }
+
+  public boolean isCwsEnabled() {
+    return this.cwsEnabled;
+  }
+
+  public int getCwsTlsRefresh() {
+    return this.cwsTlsRefresh;
+  }
+
+  @Override
+  public String toString() {
+    return "CwsFeatureConfig{"
+        + "cwsEnabled="
+        + this.cwsEnabled
+        + ", cwsTlsRefresh="
+        + this.cwsTlsRefresh
+        + '}';
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/config/DebuggerFeatureConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/config/DebuggerFeatureConfig.java
@@ -1,0 +1,180 @@
+package datadog.trace.api.config;
+
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_CLASSFILE_DUMP_ENABLED;
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_DIAGNOSTICS_INTERVAL;
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_ENABLED;
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_EXCLUDE_FILE;
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_INSTRUMENT_THE_WORLD;
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_MAX_PAYLOAD_SIZE;
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_METRICS_ENABLED;
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_POLL_INTERVAL;
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_PROBE_FILE_LOCATION;
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_UPLOAD_BATCH_SIZE;
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_UPLOAD_FLUSH_INTERVAL;
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_UPLOAD_TIMEOUT;
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_VERIFY_BYTECODE;
+import static datadog.trace.api.config.DebuggerConfig.DEFAULT_DEBUGGER_CLASSFILE_DUMP_ENABLED;
+import static datadog.trace.api.config.DebuggerConfig.DEFAULT_DEBUGGER_DIAGNOSTICS_INTERVAL;
+import static datadog.trace.api.config.DebuggerConfig.DEFAULT_DEBUGGER_ENABLED;
+import static datadog.trace.api.config.DebuggerConfig.DEFAULT_DEBUGGER_INSTRUMENT_THE_WORLD;
+import static datadog.trace.api.config.DebuggerConfig.DEFAULT_DEBUGGER_MAX_PAYLOAD_SIZE;
+import static datadog.trace.api.config.DebuggerConfig.DEFAULT_DEBUGGER_METRICS_ENABLED;
+import static datadog.trace.api.config.DebuggerConfig.DEFAULT_DEBUGGER_POLL_INTERVAL;
+import static datadog.trace.api.config.DebuggerConfig.DEFAULT_DEBUGGER_UPLOAD_BATCH_SIZE;
+import static datadog.trace.api.config.DebuggerConfig.DEFAULT_DEBUGGER_UPLOAD_FLUSH_INTERVAL;
+import static datadog.trace.api.config.DebuggerConfig.DEFAULT_DEBUGGER_UPLOAD_TIMEOUT;
+import static datadog.trace.api.config.DebuggerConfig.DEFAULT_DEBUGGER_VERIFY_BYTECODE;
+import static datadog.trace.api.config.GeneralConfig.RUNTIME_METRICS_ENABLED;
+
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+
+public class DebuggerFeatureConfig extends AbstractFeatureConfig {
+  private final TracerFeatureConfig tracerConfig;
+  private final boolean debuggerEnabled;
+  private final int debuggerUploadTimeout;
+  private final int debuggerUploadFlushInterval;
+  private final boolean debuggerClassFileDumpEnabled;
+  private final int debuggerPollInterval;
+  private final int debuggerDiagnosticsInterval;
+  private final boolean debuggerMetricEnabled;
+  private final String debuggerProbeFileLocation;
+  private final int debuggerUploadBatchSize;
+  private final long debuggerMaxPayloadSize;
+  private final boolean debuggerVerifyByteCode;
+  private final boolean debuggerInstrumentTheWorld;
+  private final String debuggerExcludeFile;
+
+  public DebuggerFeatureConfig(ConfigProvider configProvider, TracerFeatureConfig tracerConfig) {
+    super(configProvider);
+    this.tracerConfig = tracerConfig;
+    this.debuggerEnabled = configProvider.getBoolean(DEBUGGER_ENABLED, DEFAULT_DEBUGGER_ENABLED);
+    this.debuggerUploadTimeout =
+        configProvider.getInteger(DEBUGGER_UPLOAD_TIMEOUT, DEFAULT_DEBUGGER_UPLOAD_TIMEOUT);
+    this.debuggerUploadFlushInterval =
+        configProvider.getInteger(
+            DEBUGGER_UPLOAD_FLUSH_INTERVAL, DEFAULT_DEBUGGER_UPLOAD_FLUSH_INTERVAL);
+    this.debuggerClassFileDumpEnabled =
+        configProvider.getBoolean(
+            DEBUGGER_CLASSFILE_DUMP_ENABLED, DEFAULT_DEBUGGER_CLASSFILE_DUMP_ENABLED);
+    this.debuggerPollInterval =
+        configProvider.getInteger(DEBUGGER_POLL_INTERVAL, DEFAULT_DEBUGGER_POLL_INTERVAL);
+    this.debuggerDiagnosticsInterval =
+        configProvider.getInteger(
+            DEBUGGER_DIAGNOSTICS_INTERVAL, DEFAULT_DEBUGGER_DIAGNOSTICS_INTERVAL);
+    boolean runtimeMetricsEnabled = configProvider.getBoolean(RUNTIME_METRICS_ENABLED, true);
+    this.debuggerMetricEnabled =
+        runtimeMetricsEnabled
+            && configProvider.getBoolean(
+                DEBUGGER_METRICS_ENABLED, DEFAULT_DEBUGGER_METRICS_ENABLED);
+    this.debuggerProbeFileLocation = configProvider.getString(DEBUGGER_PROBE_FILE_LOCATION);
+    this.debuggerUploadBatchSize =
+        configProvider.getInteger(DEBUGGER_UPLOAD_BATCH_SIZE, DEFAULT_DEBUGGER_UPLOAD_BATCH_SIZE);
+    this.debuggerMaxPayloadSize =
+        configProvider.getInteger(DEBUGGER_MAX_PAYLOAD_SIZE, DEFAULT_DEBUGGER_MAX_PAYLOAD_SIZE)
+            * 1024L;
+    this.debuggerVerifyByteCode =
+        configProvider.getBoolean(DEBUGGER_VERIFY_BYTECODE, DEFAULT_DEBUGGER_VERIFY_BYTECODE);
+    this.debuggerInstrumentTheWorld =
+        configProvider.getBoolean(
+            DEBUGGER_INSTRUMENT_THE_WORLD, DEFAULT_DEBUGGER_INSTRUMENT_THE_WORLD);
+    this.debuggerExcludeFile = configProvider.getString(DEBUGGER_EXCLUDE_FILE);
+  }
+
+  public boolean isDebuggerEnabled() {
+    return this.debuggerEnabled;
+  }
+
+  public int getDebuggerUploadTimeout() {
+    return this.debuggerUploadTimeout;
+  }
+
+  public int getDebuggerUploadFlushInterval() {
+    return this.debuggerUploadFlushInterval;
+  }
+
+  public boolean isDebuggerClassFileDumpEnabled() {
+    return this.debuggerClassFileDumpEnabled;
+  }
+
+  public int getDebuggerPollInterval() {
+    return this.debuggerPollInterval;
+  }
+
+  public int getDebuggerDiagnosticsInterval() {
+    return this.debuggerDiagnosticsInterval;
+  }
+
+  public boolean isDebuggerMetricsEnabled() {
+    return this.debuggerMetricEnabled;
+  }
+
+  public int getDebuggerUploadBatchSize() {
+    return this.debuggerUploadBatchSize;
+  }
+
+  public long getDebuggerMaxPayloadSize() {
+    return this.debuggerMaxPayloadSize;
+  }
+
+  public boolean isDebuggerVerifyByteCode() {
+    return this.debuggerVerifyByteCode;
+  }
+
+  public boolean isDebuggerInstrumentTheWorld() {
+    return this.debuggerInstrumentTheWorld;
+  }
+
+  public String getDebuggerExcludeFile() {
+    return this.debuggerExcludeFile;
+  }
+
+  public String getDebuggerProbeFileLocation() {
+    return this.debuggerProbeFileLocation;
+  }
+
+  public String getFinalDebuggerProbeUrl() {
+    // by default poll from datadog agent
+    return "http://" + this.tracerConfig.getAgentHost() + ":" + this.tracerConfig.getAgentPort();
+  }
+
+  public String getFinalDebuggerSnapshotUrl() {
+    // by default send to datadog agent
+    return this.tracerConfig.getAgentUrl() + "/debugger/v1/input";
+  }
+
+  @Override
+  public String toString() {
+    return "DebuggerFeatureConfig{"
+        + "tracerConfig="
+        + this.tracerConfig
+        + ", debuggerEnabled="
+        + this.debuggerEnabled
+        + ", debuggerUploadTimeout="
+        + this.debuggerUploadTimeout
+        + ", debuggerUploadFlushInterval="
+        + this.debuggerUploadFlushInterval
+        + ", debuggerClassFileDumpEnabled="
+        + this.debuggerClassFileDumpEnabled
+        + ", debuggerPollInterval="
+        + this.debuggerPollInterval
+        + ", debuggerDiagnosticsInterval="
+        + this.debuggerDiagnosticsInterval
+        + ", debuggerMetricEnabled="
+        + this.debuggerMetricEnabled
+        + ", debuggerProbeFileLocation='"
+        + this.debuggerProbeFileLocation
+        + '\''
+        + ", debuggerUploadBatchSize="
+        + this.debuggerUploadBatchSize
+        + ", debuggerMaxPayloadSize="
+        + this.debuggerMaxPayloadSize
+        + ", debuggerVerifyByteCode="
+        + this.debuggerVerifyByteCode
+        + ", debuggerInstrumentTheWorld="
+        + this.debuggerInstrumentTheWorld
+        + ", debuggerExcludeFile='"
+        + this.debuggerExcludeFile
+        + '\''
+        + '}';
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/config/GeneralFeatureConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/config/GeneralFeatureConfig.java
@@ -1,0 +1,771 @@
+package datadog.trace.api.config;
+
+import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME;
+import static datadog.trace.api.DDTags.INTERNAL_HOST_NAME;
+import static datadog.trace.api.DDTags.LANGUAGE_TAG_KEY;
+import static datadog.trace.api.DDTags.LANGUAGE_TAG_VALUE;
+import static datadog.trace.api.DDTags.RUNTIME_ID_TAG;
+import static datadog.trace.api.DDTags.SERVICE;
+import static datadog.trace.api.Platform.isJavaVersionAtLeast;
+import static datadog.trace.api.config.AbstractFeatureConfig.parseStringIntoSetOfNonEmptyStrings;
+import static datadog.trace.api.config.GeneralConfig.API_KEY;
+import static datadog.trace.api.config.GeneralConfig.API_KEY_FILE;
+import static datadog.trace.api.config.GeneralConfig.AZURE_APP_SERVICES;
+import static datadog.trace.api.config.GeneralConfig.DATA_STREAMS_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.DEFAULT_DATA_STREAMS_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.DEFAULT_DOGSTATSD_START_DELAY;
+import static datadog.trace.api.config.GeneralConfig.DEFAULT_HEALTH_METRICS_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.DEFAULT_PERF_METRICS_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.DEFAULT_SITE;
+import static datadog.trace.api.config.GeneralConfig.DEFAULT_TELEMETRY_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.DEFAULT_TELEMETRY_HEARTBEAT_INTERVAL;
+import static datadog.trace.api.config.GeneralConfig.DEFAULT_TRACE_REPORT_HOSTNAME;
+import static datadog.trace.api.config.GeneralConfig.DOGSTATSD_ARGS;
+import static datadog.trace.api.config.GeneralConfig.DOGSTATSD_NAMED_PIPE;
+import static datadog.trace.api.config.GeneralConfig.DOGSTATSD_PATH;
+import static datadog.trace.api.config.GeneralConfig.DOGSTATSD_START_DELAY;
+import static datadog.trace.api.config.GeneralConfig.ENV;
+import static datadog.trace.api.config.GeneralConfig.GLOBAL_TAGS;
+import static datadog.trace.api.config.GeneralConfig.HEALTH_METRICS_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.HEALTH_METRICS_STATSD_HOST;
+import static datadog.trace.api.config.GeneralConfig.HEALTH_METRICS_STATSD_PORT;
+import static datadog.trace.api.config.GeneralConfig.INTERNAL_EXIT_ON_FAILURE;
+import static datadog.trace.api.config.GeneralConfig.PERF_METRICS_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.PRIMARY_TAG;
+import static datadog.trace.api.config.GeneralConfig.RUNTIME_ID_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.RUNTIME_METRICS_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.SERVICE_NAME;
+import static datadog.trace.api.config.GeneralConfig.SITE;
+import static datadog.trace.api.config.GeneralConfig.TAGS;
+import static datadog.trace.api.config.GeneralConfig.TELEMETRY_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.TELEMETRY_HEARTBEAT_INTERVAL;
+import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_BUFFERING_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_AGGREGATES;
+import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_PENDING;
+import static datadog.trace.api.config.GeneralConfig.VERSION;
+import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_START_DELAY;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_API_KEY_FILE_OLD;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_API_KEY_FILE_VERY_OLD;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_API_KEY_OLD;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_API_KEY_VERY_OLD;
+import static datadog.trace.api.config.TracerConfig.SPAN_TAGS;
+import static datadog.trace.api.config.TracerConfig.TRACE_REPORT_HOSTNAME;
+import static datadog.trace.util.Strings.propertyNameToEnvironmentVariableName;
+import static datadog.trace.util.Strings.toEnvVar;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.ConfigCollector;
+import datadog.trace.api.WellKnownTags;
+import datadog.trace.bootstrap.config.provider.CapturedEnvironmentConfigSource;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import datadog.trace.bootstrap.config.provider.SystemPropertiesConfigSource;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GeneralFeatureConfig {
+  private static final Logger LOGGER = LoggerFactory.getLogger(GeneralFeatureConfig.class);
+
+  private final long startTimeMillis;
+  /**
+   * this is a random UUID that gets generated on JVM start up and is attached to every root span
+   * and every JMX metric that is sent out.
+   */
+  private final String runtimeId;
+  /** This is the version of the runtime, ex: 1.8.0_332, 11.0.15, 17.0.3 */
+  private final String runtimeVersion;
+
+  /**
+   * Note: this has effect only on profiling site. Traces are sent to Datadog agent and are not
+   * affected by this setting.
+   */
+  private final String apiKey;
+  /**
+   * Note: this has effect only on profiling site. Traces are sent to Datadog agent and are not
+   * affected by this setting.
+   */
+  private final String site;
+
+  private final String hostName;
+  private final String serviceName;
+  private final boolean serviceNameSetByUser;
+  private final Map<String, String> tags;
+  private final Map<String, String> spanTags;
+  private final String primaryTag;
+
+  private final boolean debugEnabled;
+  private final boolean reportHostName;
+  private final boolean azureAppServices;
+  private String env;
+  private String version;
+  private DogStatsDConfig dogStatsDConfig;
+  private final boolean healthMetricsEnabled;
+  private final String healthMetricsStatsdHost;
+  private final Integer healthMetricsStatsdPort;
+  private final boolean perfMetricsEnabled;
+  private final boolean tracerMetricsEnabled;
+  private final boolean tracerMetricsBufferingEnabled;
+  private final int tracerMetricsMaxAggregates;
+  private final int tracerMetricsMaxPending;
+  private final boolean internalExitOnFailure;
+  private final boolean dataStreamsEnabled;
+  private final boolean telemetryEnabled;
+  private final int telemetryHeartbeatInterval;
+
+  public GeneralFeatureConfig(ConfigProvider configProvider) {
+    this.startTimeMillis = System.currentTimeMillis();
+    this.runtimeId = generateRuntimeId(configProvider);
+    this.runtimeVersion = System.getProperty("java.version", "unknown");
+
+    String tmpApiKey = readApiKey(configProvider);
+    this.site = configProvider.getString(SITE, DEFAULT_SITE);
+
+    this.hostName = initHostName();
+
+    String userProvidedServiceName =
+        configProvider.getStringExcludingSource(
+            SERVICE, null, CapturedEnvironmentConfigSource.class, SERVICE_NAME);
+
+    if (userProvidedServiceName == null) {
+      this.serviceNameSetByUser = false;
+      this.serviceName = configProvider.getString(SERVICE, DEFAULT_SERVICE_NAME, SERVICE_NAME);
+    } else {
+      this.serviceNameSetByUser = true;
+      this.serviceName = userProvidedServiceName;
+    }
+
+    {
+      final Map<String, String> tags = new HashMap<>(configProvider.getMergedMap(GLOBAL_TAGS));
+      tags.putAll(configProvider.getMergedMap(TAGS));
+      this.tags = getMapWithPropertiesDefinedByEnvironment(configProvider, tags, ENV, VERSION);
+    }
+
+    this.spanTags = configProvider.getMergedMap(SPAN_TAGS);
+    this.primaryTag = configProvider.getString(PRIMARY_TAG);
+
+    this.debugEnabled = isDebugMode();
+    this.reportHostName =
+        configProvider.getBoolean(TRACE_REPORT_HOSTNAME, DEFAULT_TRACE_REPORT_HOSTNAME);
+    this.azureAppServices = configProvider.getBoolean(AZURE_APP_SERVICES, false);
+
+    this.dogStatsDConfig = new DogStatsDConfig(configProvider);
+
+    boolean runtimeMetricsEnabled = configProvider.getBoolean(RUNTIME_METRICS_ENABLED, true);
+
+    // Writer.Builder createMonitor will use the values of the JMX fetch & agent to fill-in defaults
+    this.healthMetricsEnabled =
+        runtimeMetricsEnabled
+            && configProvider.getBoolean(HEALTH_METRICS_ENABLED, DEFAULT_HEALTH_METRICS_ENABLED);
+    this.healthMetricsStatsdHost = configProvider.getString(HEALTH_METRICS_STATSD_HOST);
+    this.healthMetricsStatsdPort = configProvider.getInteger(HEALTH_METRICS_STATSD_PORT);
+    this.perfMetricsEnabled =
+        runtimeMetricsEnabled
+            && isJavaVersionAtLeast(8)
+            && configProvider.getBoolean(PERF_METRICS_ENABLED, DEFAULT_PERF_METRICS_ENABLED);
+
+    this.tracerMetricsEnabled =
+        isJavaVersionAtLeast(8) && configProvider.getBoolean(TRACER_METRICS_ENABLED, false);
+    this.tracerMetricsBufferingEnabled =
+        configProvider.getBoolean(TRACER_METRICS_BUFFERING_ENABLED, false);
+    this.tracerMetricsMaxAggregates =
+        configProvider.getInteger(TRACER_METRICS_MAX_AGGREGATES, 2048);
+    this.tracerMetricsMaxPending = configProvider.getInteger(TRACER_METRICS_MAX_PENDING, 2048);
+
+    telemetryEnabled = configProvider.getBoolean(TELEMETRY_ENABLED, DEFAULT_TELEMETRY_ENABLED);
+    int telemetryInterval =
+        configProvider.getInteger(
+            TELEMETRY_HEARTBEAT_INTERVAL, DEFAULT_TELEMETRY_HEARTBEAT_INTERVAL);
+    if (telemetryInterval < 1 || telemetryInterval > 3600) {
+      LOGGER.warn(
+          "Wrong Telemetry heartbeat interval: {}. The value must be in range 1-3600",
+          telemetryInterval);
+      telemetryInterval = DEFAULT_TELEMETRY_HEARTBEAT_INTERVAL;
+    }
+    telemetryHeartbeatInterval = telemetryInterval;
+
+    internalExitOnFailure = configProvider.getBoolean(INTERNAL_EXIT_ON_FAILURE, false);
+
+    dataStreamsEnabled =
+        configProvider.getBoolean(DATA_STREAMS_ENABLED, DEFAULT_DATA_STREAMS_ENABLED);
+
+    // Setting this last because we have a few places where this can come from
+    this.apiKey = tmpApiKey;
+  }
+
+  private static String generateRuntimeId(ConfigProvider configProvider) {
+    Config currentInstance = Config.get();
+    if (currentInstance != null) {
+      return currentInstance.getRuntimeId();
+    } else if (configProvider.getBoolean(RUNTIME_ID_ENABLED, true)) {
+      return UUID.randomUUID().toString();
+    } else {
+      return "";
+    }
+  }
+
+  private static String readApiKey(ConfigProvider configProvider) {
+    // Note: We do not want APiKey to be loaded from property for security reasons
+    // Note: we do not use defined default here
+    // FIXME: We should use better authentication mechanism
+    final String apiKeyFile = configProvider.getString(API_KEY_FILE);
+    String tmpApiKey =
+        configProvider.getStringExcludingSource(API_KEY, null, SystemPropertiesConfigSource.class);
+    if (apiKeyFile != null) {
+      try {
+        tmpApiKey =
+            new String(Files.readAllBytes(Paths.get(apiKeyFile)), StandardCharsets.UTF_8).trim();
+      } catch (final IOException e) {
+        LOGGER.error("Cannot read API key from file {}, skipping", apiKeyFile, e);
+      }
+    }
+    if (tmpApiKey == null) {
+      final String oldProfilingApiKeyFile = configProvider.getString(PROFILING_API_KEY_FILE_OLD);
+      tmpApiKey = getEnv(propertyNameToEnvironmentVariableName(PROFILING_API_KEY_OLD));
+      if (oldProfilingApiKeyFile != null) {
+        try {
+          tmpApiKey =
+              new String(
+                      Files.readAllBytes(Paths.get(oldProfilingApiKeyFile)), StandardCharsets.UTF_8)
+                  .trim();
+        } catch (final IOException e) {
+          LOGGER.error("Cannot read API key from file {}, skipping", oldProfilingApiKeyFile, e);
+        }
+      }
+    }
+    if (tmpApiKey == null) {
+      final String veryOldProfilingApiKeyFile =
+          configProvider.getString(PROFILING_API_KEY_FILE_VERY_OLD);
+      tmpApiKey = getEnv(propertyNameToEnvironmentVariableName(PROFILING_API_KEY_VERY_OLD));
+      if (veryOldProfilingApiKeyFile != null) {
+        try {
+          tmpApiKey =
+              new String(
+                      Files.readAllBytes(Paths.get(veryOldProfilingApiKeyFile)),
+                      StandardCharsets.UTF_8)
+                  .trim();
+        } catch (final IOException e) {
+          LOGGER.error("Cannot read API key from file {}, skipping", veryOldProfilingApiKeyFile, e);
+        }
+      }
+    }
+    return tmpApiKey;
+  }
+
+  /** Returns the detected hostname. First tries locally, then using DNS */
+  private static String initHostName() {
+    String possibleHostname;
+
+    // Try environment variable.  This works in almost all environments
+    if (isWindowsOS()) {
+      possibleHostname = getEnv("COMPUTERNAME");
+    } else {
+      possibleHostname = getEnv("HOSTNAME");
+    }
+
+    if (possibleHostname != null && !possibleHostname.isEmpty()) {
+      LOGGER.debug("Determined hostname from environment variable");
+      return possibleHostname.trim();
+    }
+
+    // Try hostname command
+    try (final BufferedReader reader =
+        new BufferedReader(
+            new InputStreamReader(Runtime.getRuntime().exec("hostname").getInputStream()))) {
+      possibleHostname = reader.readLine();
+    } catch (final Throwable ignore) {
+      // Ignore.  Hostname command is not always available
+    }
+
+    if (possibleHostname != null && !possibleHostname.isEmpty()) {
+      LOGGER.debug("Determined hostname from hostname command");
+      return possibleHostname.trim();
+    }
+
+    // From DNS
+    try {
+      return InetAddress.getLocalHost().getHostName();
+    } catch (final UnknownHostException e) {
+      // If we are not able to detect the hostname we do not throw an exception.
+    }
+
+    return null;
+  }
+
+  private static boolean isWindowsOS() {
+    return getProp("os.name").startsWith("Windows");
+  }
+
+  private static boolean isDebugMode() {
+    final String tracerDebugLevelSysprop = "dd.trace.debug";
+    final String tracerDebugLevelProp = getProp(tracerDebugLevelSysprop);
+
+    if (tracerDebugLevelProp != null) {
+      return Boolean.parseBoolean(tracerDebugLevelProp);
+    }
+
+    final String tracerDebugLevelEnv = getEnv(toEnvVar(tracerDebugLevelSysprop));
+
+    if (tracerDebugLevelEnv != null) {
+      return Boolean.parseBoolean(tracerDebugLevelEnv);
+    }
+    return false;
+  }
+
+  private static String getEnv(String name) {
+    String value = System.getenv(name);
+    if (value != null) {
+      ConfigCollector.get().put(name, value);
+    }
+    return value;
+  }
+
+  private static String getProp(String name) {
+    return getProp(name, null);
+  }
+
+  private static String getProp(String name, String def) {
+    String value = System.getProperty(name, def);
+    if (value != null) {
+      ConfigCollector.get().put(name, value);
+    }
+    return value;
+  }
+
+  @Nonnull
+  public static Map<String, String> newHashMap(final int size) {
+    return new HashMap<>(size + 1, 1f);
+  }
+
+  /**
+   * @param map
+   * @param propNames
+   * @return new unmodifiable copy of {@param map} where properties are overwritten from environment
+   */
+  @Nonnull
+  private Map<String, String> getMapWithPropertiesDefinedByEnvironment(
+      @Nonnull ConfigProvider configProvider,
+      @Nonnull final Map<String, String> map,
+      @Nonnull final String... propNames) {
+    final Map<String, String> res = new HashMap<>(map);
+    for (final String propName : propNames) {
+      final String val = configProvider.getString(propName);
+      if (val != null) {
+        res.put(propName, val);
+      }
+    }
+    return Collections.unmodifiableMap(res);
+  }
+
+  public long getStartTimeMillis() {
+    return this.startTimeMillis;
+  }
+
+  public String getRuntimeId() {
+    return this.runtimeId;
+  }
+
+  public String getRuntimeVersion() {
+    return this.runtimeVersion;
+  }
+
+  /**
+   * Return a map of tags required by the datadog backend to link runtime metrics (i.e. jmx) and
+   * traces.
+   *
+   * <p>These tags must be applied to every runtime metrics and placed on the root span of every
+   * trace.
+   *
+   * @return A map of tag-name -> tag-value
+   */
+  public Map<String, String> getRuntimeTags() {
+    return Collections.singletonMap(RUNTIME_ID_TAG, getRuntimeId());
+  }
+
+  public String getApiKey() {
+    return this.apiKey;
+  }
+
+  public String getSite() {
+    return this.site;
+  }
+
+  public String getHostName() {
+    return this.hostName;
+  }
+
+  public String getServiceName() {
+    return this.serviceName;
+  }
+
+  public boolean isServiceNameSetByUser() {
+    return this.serviceNameSetByUser;
+  }
+
+  /** @return A map of tags to be applied only to the local application root span. */
+  public Map<String, Object> getLocalRootSpanTags() {
+    final Map<String, String> runtimeTags = getRuntimeTags();
+    final Map<String, Object> result = new HashMap<>(runtimeTags.size() + 1);
+    result.putAll(runtimeTags);
+    result.put(LANGUAGE_TAG_KEY, LANGUAGE_TAG_VALUE);
+
+    if (reportHostName) {
+      final String hostName = getHostName();
+      if (null != hostName && !hostName.isEmpty()) {
+        result.put(INTERNAL_HOST_NAME, hostName);
+      }
+    }
+
+    if (azureAppServices) {
+      result.putAll(getAzureAppServicesTags());
+    }
+
+    return Collections.unmodifiableMap(result);
+  }
+
+  private Map<String, String> getAzureAppServicesTags() {
+    // These variable names and derivations are copied from the dotnet tracer
+    // See
+    // https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/src/Datadog.Trace/PlatformHelpers/AzureAppServices.cs
+    // and
+    // https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/src/Datadog.Trace/TraceContext.cs#L207
+    Map<String, String> aasTags = new HashMap<>();
+
+    /// The site name of the site instance in Azure where the traced application is running.
+    String siteName = getEnv("WEBSITE_SITE_NAME");
+    if (siteName != null) {
+      aasTags.put("aas.site.name", siteName);
+    }
+
+    // The kind of application instance running in Azure.
+    // Possible values: app, api, mobileapp, app_linux, app_linux_container, functionapp,
+    // functionapp_linux, functionapp_linux_container
+
+    // The type of application instance running in Azure.
+    // Possible values: app, function
+    if (getEnv("FUNCTIONS_WORKER_RUNTIME") != null
+        || getEnv("FUNCTIONS_EXTENSIONS_VERSION") != null) {
+      aasTags.put("aas.site.kind", "functionapp");
+      aasTags.put("aas.site.type", "function");
+    } else {
+      aasTags.put("aas.site.kind", "app");
+      aasTags.put("aas.site.type", "app");
+    }
+
+    //  The resource group of the site instance in Azure App Services
+    String resourceGroup = getEnv("WEBSITE_RESOURCE_GROUP");
+    if (resourceGroup != null) {
+      aasTags.put("aas.resource.group", resourceGroup);
+    }
+
+    // Example: 8c500027-5f00-400e-8f00-60000000000f+apm-dotnet-EastUSwebspace
+    // Format: {subscriptionId}+{planResourceGroup}-{hostedInRegion}
+    String websiteOwner = getEnv("WEBSITE_OWNER_NAME");
+    int plusIndex = websiteOwner == null ? -1 : websiteOwner.indexOf("+");
+
+    // The subscription ID of the site instance in Azure App Services
+    String subscriptionId = null;
+    if (plusIndex > 0) {
+      subscriptionId = websiteOwner.substring(0, plusIndex);
+      aasTags.put("aas.subscription.id", subscriptionId);
+    }
+
+    if (subscriptionId != null && siteName != null && resourceGroup != null) {
+      // The resource ID of the site instance in Azure App Services
+      String resourceId =
+          "/subscriptions/"
+              + subscriptionId
+              + "/resourcegroups/"
+              + resourceGroup
+              + "/providers/microsoft.web/sites/"
+              + siteName;
+      resourceId = resourceId.toLowerCase();
+      aasTags.put("aas.resource.id", resourceId);
+    } else {
+      LOGGER.warn(
+          "Unable to generate resource id subscription id: {}, site name: {}, resource group {}",
+          subscriptionId,
+          siteName,
+          resourceGroup);
+    }
+
+    // The instance ID in Azure
+    String instanceId = getEnv("WEBSITE_INSTANCE_ID");
+    instanceId = instanceId == null ? "unknown" : instanceId;
+    aasTags.put("aas.environment.instance_id", instanceId);
+
+    // The instance name in Azure
+    String instanceName = getEnv("COMPUTERNAME");
+    instanceName = instanceName == null ? "unknown" : instanceName;
+    aasTags.put("aas.environment.instance_name", instanceName);
+
+    // The operating system in Azure
+    String operatingSystem = getEnv("WEBSITE_OS");
+    operatingSystem = operatingSystem == null ? "unknown" : operatingSystem;
+    aasTags.put("aas.environment.os", operatingSystem);
+
+    // The version of the extension installed
+    String siteExtensionVersion = getEnv("DD_AAS_JAVA_EXTENSION_VERSION");
+    siteExtensionVersion = siteExtensionVersion == null ? "unknown" : siteExtensionVersion;
+    aasTags.put("aas.environment.extension_version", siteExtensionVersion);
+
+    aasTags.put("aas.environment.runtime", getProp("java.vm.name", "unknown"));
+
+    return aasTags;
+  }
+
+  public WellKnownTags getWellKnownTags() {
+    return new WellKnownTags(
+        getRuntimeId(),
+        this.reportHostName ? getHostName() : "",
+        getEnv(),
+        this.serviceName,
+        getVersion(),
+        LANGUAGE_TAG_VALUE);
+  }
+
+  public String getPrimaryTag() {
+    return this.primaryTag;
+  }
+
+  /**
+   * Provide 'global' tags, i.e. tags set everywhere. We have to support old (dd.trace.global.tags)
+   * version of this setting if new (dd.tags) version has not been specified.
+   */
+  public Map<String, String> getGlobalTags() {
+    return this.tags;
+  }
+
+  public boolean isDebugEnabled() {
+    return this.debugEnabled;
+  }
+
+  public boolean isReportHostName() {
+    return this.reportHostName;
+  }
+
+  public String getEnv() {
+    // intentionally not thread safe
+    if (this.env == null) {
+      this.env = getMergedSpanTags().get("env");
+      if (this.env == null) {
+        this.env = "";
+      }
+    }
+
+    return this.env;
+  }
+
+  public String getVersion() {
+    // intentionally not thread safe
+    if (this.version == null) {
+      this.version = getMergedSpanTags().get("version");
+      if (this.version == null) {
+        this.version = "";
+      }
+    }
+    return this.version;
+  }
+
+  public boolean isAzureAppServices() {
+    return this.azureAppServices;
+  }
+
+  public String getDogStatsDNamedPipe() {
+    return this.dogStatsDConfig.namedPipe;
+  }
+
+  public int getDogStatsDStartDelay() {
+    return this.dogStatsDConfig.startDelay;
+  }
+
+  public String getDogStatsDPath() {
+    return this.dogStatsDConfig.path;
+  }
+
+  public List<String> getDogStatsDArgs() {
+    return this.dogStatsDConfig.args;
+  }
+
+  public boolean isHealthMetricsEnabled() {
+    return this.healthMetricsEnabled;
+  }
+
+  public String getHealthMetricsStatsdHost() {
+    return this.healthMetricsStatsdHost;
+  }
+
+  public Integer getHealthMetricsStatsdPort() {
+    return this.healthMetricsStatsdPort;
+  }
+
+  public boolean isPerfMetricsEnabled() {
+    return this.perfMetricsEnabled;
+  }
+
+  public boolean isTracerMetricsEnabled() {
+    return this.tracerMetricsEnabled;
+  }
+
+  public boolean isTracerMetricsBufferingEnabled() {
+    return this.tracerMetricsBufferingEnabled;
+  }
+
+  public int getTracerMetricsMaxAggregates() {
+    return this.tracerMetricsMaxAggregates;
+  }
+
+  public int getTracerMetricsMaxPending() {
+    return this.tracerMetricsMaxPending;
+  }
+
+  public boolean isTelemetryEnabled() {
+    return this.telemetryEnabled;
+  }
+
+  public int getTelemetryHeartbeatInterval() {
+    return this.telemetryHeartbeatInterval;
+  }
+
+  public boolean isDataStreamsEnabled() {
+    return this.dataStreamsEnabled;
+  }
+
+  public boolean isInternalExitOnFailure() {
+    return this.internalExitOnFailure;
+  }
+
+  public Map<String, String> getMergedSpanTags() {
+    // Do not include runtimeId into span tags: we only want that added to the root span
+    final Map<String, String> result = newHashMap(getGlobalTags().size() + this.spanTags.size());
+    result.putAll(getGlobalTags());
+    result.putAll(this.spanTags);
+    return Collections.unmodifiableMap(result);
+  }
+
+  private static class DogStatsDConfig {
+    private final String namedPipe;
+    private final int startDelay;
+    private final String path;
+    private final List<String> args;
+
+    public DogStatsDConfig(ConfigProvider configProvider) {
+      this.namedPipe = configProvider.getString(DOGSTATSD_NAMED_PIPE);
+      this.startDelay =
+          configProvider.getInteger(
+              DOGSTATSD_START_DELAY, DEFAULT_DOGSTATSD_START_DELAY, JMX_FETCH_START_DELAY);
+      this.path = configProvider.getString(DOGSTATSD_PATH);
+      String dogStatsDArgsString = configProvider.getString(DOGSTATSD_ARGS);
+      if (dogStatsDArgsString == null) {
+        this.args = Collections.emptyList();
+      } else {
+        this.args =
+            Collections.unmodifiableList(
+                new ArrayList<>(parseStringIntoSetOfNonEmptyStrings(dogStatsDArgsString)));
+      }
+    }
+
+    @Override
+    public String toString() {
+      return "DogStatsDConfig{"
+          + "namedPipe='"
+          + this.namedPipe
+          + '\''
+          + ", startDelay="
+          + this.startDelay
+          + ", path='"
+          + this.path
+          + '\''
+          + ", args="
+          + this.args
+          + '}';
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "GeneralFeatureConfig{"
+        + "startTimeMillis="
+        + this.startTimeMillis
+        + ", runtimeId='"
+        + this.runtimeId
+        + '\''
+        + ", runtimeVersion='"
+        + this.runtimeVersion
+        + '\''
+        + ", apiKey="
+        + (this.apiKey == null ? "null" : "****")
+        + ", site='"
+        + this.site
+        + '\''
+        + ", hostName='"
+        + this.hostName
+        + '\''
+        + ", serviceName='"
+        + this.serviceName
+        + '\''
+        + ", serviceNameSetByUser="
+        + this.serviceNameSetByUser
+        + ", tags="
+        + this.tags
+        + ", spanTags="
+        + this.spanTags
+        + ", primaryTag='"
+        + this.primaryTag
+        + '\''
+        + ", debugEnabled="
+        + this.debugEnabled
+        + ", reportHostName="
+        + this.reportHostName
+        + ", azureAppServices="
+        + this.azureAppServices
+        + ", env='"
+        + this.env
+        + '\''
+        + ", version='"
+        + this.version
+        + '\''
+        + ", dogStatsDConfig="
+        + this.dogStatsDConfig
+        + ", healthMetricsEnabled="
+        + this.healthMetricsEnabled
+        + ", healthMetricsStatsdHost='"
+        + this.healthMetricsStatsdHost
+        + '\''
+        + ", healthMetricsStatsdPort="
+        + this.healthMetricsStatsdPort
+        + ", perfMetricsEnabled="
+        + this.perfMetricsEnabled
+        + ", tracerMetricsEnabled="
+        + this.tracerMetricsEnabled
+        + ", tracerMetricsBufferingEnabled="
+        + this.tracerMetricsBufferingEnabled
+        + ", tracerMetricsMaxAggregates="
+        + this.tracerMetricsMaxAggregates
+        + ", tracerMetricsMaxPending="
+        + this.tracerMetricsMaxPending
+        + ", internalExitOnFailure="
+        + this.internalExitOnFailure
+        + ", dataStreamsEnabled="
+        + this.dataStreamsEnabled
+        + ", telemetryEnabled="
+        + this.telemetryEnabled
+        + ", telemetryHeartbeatInterval="
+        + this.telemetryHeartbeatInterval
+        + '}';
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/config/GeneralFeatureConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/config/GeneralFeatureConfig.java
@@ -78,7 +78,7 @@ import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class GeneralFeatureConfig {
+public class GeneralFeatureConfig extends AbstractFeatureConfig {
   private static final Logger LOGGER = LoggerFactory.getLogger(GeneralFeatureConfig.class);
 
   private final long startTimeMillis;
@@ -128,6 +128,7 @@ public class GeneralFeatureConfig {
   private final int telemetryHeartbeatInterval;
 
   public GeneralFeatureConfig(ConfigProvider configProvider) {
+    super(configProvider);
     this.startTimeMillis = System.currentTimeMillis();
     this.runtimeId = generateRuntimeId(configProvider);
     this.runtimeVersion = System.getProperty("java.version", "unknown");
@@ -651,8 +652,9 @@ public class GeneralFeatureConfig {
 
   public Map<String, String> getMergedSpanTags() {
     // Do not include runtimeId into span tags: we only want that added to the root span
-    final Map<String, String> result = newHashMap(getGlobalTags().size() + this.spanTags.size());
-    result.putAll(getGlobalTags());
+    Map<String, String> globalTags = getGlobalTags();
+    final Map<String, String> result = newHashMap(globalTags.size() + this.spanTags.size());
+    result.putAll(globalTags);
     result.putAll(this.spanTags);
     return Collections.unmodifiableMap(result);
   }

--- a/internal-api/src/main/java/datadog/trace/api/config/IastFeatureConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/config/IastFeatureConfig.java
@@ -1,0 +1,95 @@
+package datadog.trace.api.config;
+
+import static datadog.trace.api.config.IastConfig.DEFAULT_IAST_DEDUPLICATION_ENABLED;
+import static datadog.trace.api.config.IastConfig.DEFAULT_IAST_ENABLED;
+import static datadog.trace.api.config.IastConfig.DEFAULT_IAST_MAX_CONCURRENT_REQUESTS;
+import static datadog.trace.api.config.IastConfig.DEFAULT_IAST_REQUEST_SAMPLING;
+import static datadog.trace.api.config.IastConfig.DEFAULT_IAST_VULNERABILITIES_PER_REQUEST;
+import static datadog.trace.api.config.IastConfig.DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS;
+import static datadog.trace.api.config.IastConfig.DEFAULT_IAST_WEAK_HASH_ALGORITHMS;
+import static datadog.trace.api.config.IastConfig.IAST_DEDUPLICATION_ENABLED;
+import static datadog.trace.api.config.IastConfig.IAST_ENABLED;
+import static datadog.trace.api.config.IastConfig.IAST_MAX_CONCURRENT_REQUESTS;
+import static datadog.trace.api.config.IastConfig.IAST_REQUEST_SAMPLING;
+import static datadog.trace.api.config.IastConfig.IAST_VULNERABILITIES_PER_REQUEST;
+import static datadog.trace.api.config.IastConfig.IAST_WEAK_CIPHER_ALGORITHMS;
+import static datadog.trace.api.config.IastConfig.IAST_WEAK_HASH_ALGORITHMS;
+import static datadog.trace.util.CollectionUtils.tryMakeImmutableSet;
+
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class IastFeatureConfig extends AbstractFeatureConfig {
+  private static final Logger LOGGER = LoggerFactory.getLogger(IastFeatureConfig.class);
+  private final Set<String> iastWeakHashAlgorithms;
+  private final Pattern iastWeakCipherAlgorithms;
+  private final boolean iastDeduplicationEnabled;
+  private final boolean iastEnabled;
+  private final int iastMaxConcurrentRequests;
+  private final int iastVulnerabilitiesPerRequest;
+  private final float iastRequestSampling;
+
+  public IastFeatureConfig(ConfigProvider configProvider) {
+    super(configProvider);
+    this.iastWeakHashAlgorithms =
+        tryMakeImmutableSet(
+            configProvider.getSet(IAST_WEAK_HASH_ALGORITHMS, DEFAULT_IAST_WEAK_HASH_ALGORITHMS));
+    this.iastWeakCipherAlgorithms =
+        getPattern(
+            DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS,
+            configProvider.getString(IAST_WEAK_CIPHER_ALGORITHMS));
+    this.iastDeduplicationEnabled =
+        configProvider.getBoolean(IAST_DEDUPLICATION_ENABLED, DEFAULT_IAST_DEDUPLICATION_ENABLED);
+    this.iastEnabled = configProvider.getBoolean(IAST_ENABLED, DEFAULT_IAST_ENABLED);
+    this.iastMaxConcurrentRequests =
+        configProvider.getInteger(
+            IAST_MAX_CONCURRENT_REQUESTS, DEFAULT_IAST_MAX_CONCURRENT_REQUESTS);
+    this.iastVulnerabilitiesPerRequest =
+        configProvider.getInteger(
+            IAST_VULNERABILITIES_PER_REQUEST, DEFAULT_IAST_VULNERABILITIES_PER_REQUEST);
+    this.iastRequestSampling =
+        configProvider.getFloat(IAST_REQUEST_SAMPLING, DEFAULT_IAST_REQUEST_SAMPLING);
+  }
+
+  private static Pattern getPattern(String defaultValue, String userValue) {
+    try {
+      if (userValue != null) {
+        return Pattern.compile(userValue);
+      }
+    } catch (Exception e) {
+      LOGGER.debug("Cannot create pattern from user value {}", userValue);
+    }
+    return Pattern.compile(defaultValue);
+  }
+
+  public Set<String> getIastWeakHashAlgorithms() {
+    return this.iastWeakHashAlgorithms;
+  }
+
+  public Pattern getIastWeakCipherAlgorithms() {
+    return this.iastWeakCipherAlgorithms;
+  }
+
+  public boolean isIastDeduplicationEnabled() {
+    return this.iastDeduplicationEnabled;
+  }
+
+  public boolean isIastEnabled() {
+    return this.iastEnabled;
+  }
+
+  public int getIastMaxConcurrentRequests() {
+    return this.iastMaxConcurrentRequests;
+  }
+
+  public int getIastVulnerabilitiesPerRequest() {
+    return this.iastVulnerabilitiesPerRequest;
+  }
+
+  public float getIastRequestSampling() {
+    return this.iastRequestSampling;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/config/JmxFetchFeatureConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/config/JmxFetchFeatureConfig.java
@@ -1,0 +1,180 @@
+package datadog.trace.api.config;
+
+import static datadog.trace.api.DDTags.SERVICE_TAG;
+import static datadog.trace.api.config.GeneralConfig.DOGSTATSD_HOST;
+import static datadog.trace.api.config.GeneralConfig.DOGSTATSD_PORT;
+import static datadog.trace.api.config.GeneralConfig.RUNTIME_METRICS_ENABLED;
+import static datadog.trace.api.config.GeneralFeatureConfig.newHashMap;
+import static datadog.trace.api.config.JmxFetchConfig.DEFAULT_JMX_FETCH_ENABLED;
+import static datadog.trace.api.config.JmxFetchConfig.DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_ENABLED;
+import static datadog.trace.api.config.JmxFetchConfig.DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_LIMIT;
+import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_CHECK_PERIOD;
+import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_CONFIG;
+import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_CONFIG_DIR;
+import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_ENABLED;
+import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_INITIAL_REFRESH_BEANS_PERIOD;
+import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_METRICS_CONFIGS;
+import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_ENABLED;
+import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_LIMIT;
+import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_REFRESH_BEANS_PERIOD;
+import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_STATSD_HOST;
+import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_STATSD_PORT;
+import static datadog.trace.api.config.JmxFetchConfig.JMX_TAGS;
+import static datadog.trace.util.CollectionUtils.tryMakeImmutableList;
+
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class JmxFetchFeatureConfig extends AbstractFeatureConfig {
+  private final GeneralFeatureConfig generalConfig;
+  private final boolean jmxFetchEnabled;
+  private final String jmxFetchConfigDir;
+  private final List<String> jmxFetchConfigs;
+  @Deprecated private final List<String> jmxFetchMetricsConfigs;
+  private final Integer jmxFetchCheckPeriod;
+  private final Integer jmxFetchInitialRefreshBeansPeriod;
+  private final Integer jmxFetchRefreshBeansPeriod;
+  private final String jmxFetchStatsdHost;
+  private final Integer jmxFetchStatsdPort;
+  private final boolean jmxFetchMultipleRuntimeServicesEnabled;
+  private final int jmxFetchMultipleRuntimeServicesLimit;
+  private final Map<String, String> jmxTags;
+
+  public JmxFetchFeatureConfig(
+      ConfigProvider configProvider,
+      GeneralFeatureConfig generalConfig,
+      TracerFeatureConfig tracerConfig) {
+    super(configProvider);
+    this.generalConfig = generalConfig;
+
+    boolean runtimeMetricsEnabled = configProvider.getBoolean(RUNTIME_METRICS_ENABLED, true);
+    this.jmxFetchEnabled =
+        runtimeMetricsEnabled
+            && configProvider.getBoolean(JMX_FETCH_ENABLED, DEFAULT_JMX_FETCH_ENABLED);
+    this.jmxFetchConfigDir = configProvider.getString(JMX_FETCH_CONFIG_DIR);
+    this.jmxFetchConfigs = tryMakeImmutableList(configProvider.getList(JMX_FETCH_CONFIG));
+    this.jmxFetchMetricsConfigs =
+        tryMakeImmutableList(configProvider.getList(JMX_FETCH_METRICS_CONFIGS));
+    this.jmxFetchCheckPeriod = configProvider.getInteger(JMX_FETCH_CHECK_PERIOD);
+    this.jmxFetchInitialRefreshBeansPeriod =
+        configProvider.getInteger(JMX_FETCH_INITIAL_REFRESH_BEANS_PERIOD);
+    this.jmxFetchRefreshBeansPeriod = configProvider.getInteger(JMX_FETCH_REFRESH_BEANS_PERIOD);
+
+    this.jmxFetchStatsdPort = configProvider.getInteger(JMX_FETCH_STATSD_PORT, DOGSTATSD_PORT);
+    this.jmxFetchStatsdHost =
+        configProvider.getString(
+            JMX_FETCH_STATSD_HOST,
+            // default to agent host if an explicit port has been set
+            null != this.jmxFetchStatsdPort && this.jmxFetchStatsdPort > 0
+                ? tracerConfig.getAgentHost()
+                : null,
+            DOGSTATSD_HOST);
+
+    this.jmxFetchMultipleRuntimeServicesEnabled =
+        configProvider.getBoolean(
+            JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_ENABLED,
+            DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_ENABLED);
+    this.jmxFetchMultipleRuntimeServicesLimit =
+        configProvider.getInteger(
+            JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_LIMIT,
+            DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_LIMIT);
+
+    this.jmxTags = configProvider.getMergedMap(JMX_TAGS);
+  }
+
+  public boolean isJmxFetchEnabled() {
+    return this.jmxFetchEnabled;
+  }
+
+  public String getJmxFetchConfigDir() {
+    return this.jmxFetchConfigDir;
+  }
+
+  public List<String> getJmxFetchConfigs() {
+    return this.jmxFetchConfigs;
+  }
+
+  public List<String> getJmxFetchMetricsConfigs() {
+    return this.jmxFetchMetricsConfigs;
+  }
+
+  public Integer getJmxFetchCheckPeriod() {
+    return this.jmxFetchCheckPeriod;
+  }
+
+  public Integer getJmxFetchRefreshBeansPeriod() {
+    return this.jmxFetchRefreshBeansPeriod;
+  }
+
+  public Integer getJmxFetchInitialRefreshBeansPeriod() {
+    return this.jmxFetchInitialRefreshBeansPeriod;
+  }
+
+  public String getJmxFetchStatsdHost() {
+    return this.jmxFetchStatsdHost;
+  }
+
+  public Integer getJmxFetchStatsdPort() {
+    return this.jmxFetchStatsdPort;
+  }
+
+  public boolean isJmxFetchMultipleRuntimeServicesEnabled() {
+    return this.jmxFetchMultipleRuntimeServicesEnabled;
+  }
+
+  public int getJmxFetchMultipleRuntimeServicesLimit() {
+    return this.jmxFetchMultipleRuntimeServicesLimit;
+  }
+
+  public Map<String, String> getMergedJmxTags() {
+    final Map<String, String> runtimeTags = this.generalConfig.getRuntimeTags();
+    final Map<String, String> globalTags = this.generalConfig.getGlobalTags();
+    final Map<String, String> result =
+        newHashMap(
+            globalTags.size() + this.jmxTags.size() + runtimeTags.size() + 1 /* for serviceName */);
+    result.putAll(globalTags);
+    result.putAll(this.jmxTags);
+    result.putAll(runtimeTags);
+    // service name set here instead of getRuntimeTags because apm already manages the service tag
+    // and may choose to override it.
+    // Additionally, infra/JMX metrics require `service` rather than APM's `service.name` tag
+    result.put(SERVICE_TAG, this.generalConfig.getServiceName());
+    return Collections.unmodifiableMap(result);
+  }
+
+  @Override
+  public String toString() {
+    return "JmxFetchFeatureConfig{"
+        + "generalConfig="
+        + this.generalConfig
+        + ", jmxFetchEnabled="
+        + this.jmxFetchEnabled
+        + ", jmxFetchConfigDir='"
+        + this.jmxFetchConfigDir
+        + '\''
+        + ", jmxFetchConfigs="
+        + this.jmxFetchConfigs
+        + ", jmxFetchMetricsConfigs="
+        + this.jmxFetchMetricsConfigs
+        + ", jmxFetchCheckPeriod="
+        + this.jmxFetchCheckPeriod
+        + ", jmxFetchInitialRefreshBeansPeriod="
+        + this.jmxFetchInitialRefreshBeansPeriod
+        + ", jmxFetchRefreshBeansPeriod="
+        + this.jmxFetchRefreshBeansPeriod
+        + ", jmxFetchStatsdHost='"
+        + this.jmxFetchStatsdHost
+        + '\''
+        + ", jmxFetchStatsdPort="
+        + this.jmxFetchStatsdPort
+        + ", jmxFetchMultipleRuntimeServicesEnabled="
+        + this.jmxFetchMultipleRuntimeServicesEnabled
+        + ", jmxFetchMultipleRuntimeServicesLimit="
+        + this.jmxFetchMultipleRuntimeServicesLimit
+        + ", jmxTags="
+        + this.jmxTags
+        + '}';
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/config/ProfilingFeatureConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/config/ProfilingFeatureConfig.java
@@ -1,0 +1,312 @@
+package datadog.trace.api.config;
+
+import static datadog.trace.api.DDTags.HOST_TAG;
+import static datadog.trace.api.DDTags.LANGUAGE_TAG_KEY;
+import static datadog.trace.api.DDTags.LANGUAGE_TAG_VALUE;
+import static datadog.trace.api.DDTags.RUNTIME_VERSION_TAG;
+import static datadog.trace.api.DDTags.SERVICE_TAG;
+import static datadog.trace.api.config.GeneralFeatureConfig.newHashMap;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_AGENTLESS;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_AGENTLESS_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_ASYNC_ALLOC_ENABLED_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_ASYNC_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_ENABLED_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCLUDE_AGENT_THREADS;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_HOTSPOTS_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_LEGACY_TRACING_INTEGRATION;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_LEGACY_TRACING_INTEGRATION_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_HOST;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_PASSWORD;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_PORT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_PORT_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_USERNAME;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_START_DELAY;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_START_DELAY_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_START_FORCE_FIRST;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_START_FORCE_FIRST_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_TAGS;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_TEMPLATE_OVERRIDE_FILE;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_COMPRESSION;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_COMPRESSION_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_PERIOD;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_PERIOD_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_SUMMARY_ON_413;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_SUMMARY_ON_413_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_TIMEOUT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_TIMEOUT_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_URL;
+
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import java.util.Collections;
+import java.util.Map;
+
+public class ProfilingFeatureConfig extends AbstractFeatureConfig {
+  private final GeneralFeatureConfig generalConfig;
+  private final TracerFeatureConfig tracerConfig;
+  private final boolean profilingEnabled;
+  private final boolean profilingAgentless;
+  private final boolean profilingLegacyTracingIntegrationEnabled;
+  private final boolean asyncProfilerEnabled;
+  @Deprecated private final String profilingUrl;
+  private final Map<String, String> profilingTags;
+  private final int profilingStartDelay;
+  private final boolean profilingStartForceFirst;
+  private final int profilingUploadPeriod;
+  private final String profilingTemplateOverrideFile;
+  private final int profilingUploadTimeout;
+  private final String profilingUploadCompression;
+  private final String profilingProxyHost;
+  private final int profilingProxyPort;
+  private final String profilingProxyUsername;
+  private final String profilingProxyPassword;
+  private final int profilingExceptionSampleLimit;
+  private final int profilingExceptionHistogramTopItems;
+  private final int profilingExceptionHistogramMaxCollectionSize;
+  private final boolean profilingExcludeAgentThreads;
+  private final boolean profilingHotspotsEnabled;
+  private final boolean profilingUploadSummaryOn413Enabled;
+
+  public ProfilingFeatureConfig(
+      ConfigProvider configProvider,
+      GeneralFeatureConfig generalConfig,
+      TracerFeatureConfig tracerConfig) {
+    super(configProvider);
+    this.generalConfig = generalConfig;
+    this.tracerConfig = tracerConfig;
+    this.profilingEnabled = configProvider.getBoolean(PROFILING_ENABLED, PROFILING_ENABLED_DEFAULT);
+    this.profilingAgentless =
+        configProvider.getBoolean(PROFILING_AGENTLESS, PROFILING_AGENTLESS_DEFAULT);
+    this.profilingLegacyTracingIntegrationEnabled =
+        configProvider.getBoolean(
+            PROFILING_LEGACY_TRACING_INTEGRATION, PROFILING_LEGACY_TRACING_INTEGRATION_DEFAULT);
+    this.asyncProfilerEnabled =
+        configProvider.getBoolean(PROFILING_ASYNC_ENABLED, PROFILING_ASYNC_ALLOC_ENABLED_DEFAULT);
+    this.profilingUrl = configProvider.getString(PROFILING_URL);
+
+    this.profilingTags = configProvider.getMergedMap(PROFILING_TAGS);
+    this.profilingStartDelay =
+        configProvider.getInteger(PROFILING_START_DELAY, PROFILING_START_DELAY_DEFAULT);
+    this.profilingStartForceFirst =
+        configProvider.getBoolean(PROFILING_START_FORCE_FIRST, PROFILING_START_FORCE_FIRST_DEFAULT);
+    this.profilingUploadPeriod =
+        configProvider.getInteger(PROFILING_UPLOAD_PERIOD, PROFILING_UPLOAD_PERIOD_DEFAULT);
+    this.profilingTemplateOverrideFile = configProvider.getString(PROFILING_TEMPLATE_OVERRIDE_FILE);
+    this.profilingUploadTimeout =
+        configProvider.getInteger(PROFILING_UPLOAD_TIMEOUT, PROFILING_UPLOAD_TIMEOUT_DEFAULT);
+    this.profilingUploadCompression =
+        configProvider.getString(
+            PROFILING_UPLOAD_COMPRESSION, PROFILING_UPLOAD_COMPRESSION_DEFAULT);
+    this.profilingProxyHost = configProvider.getString(PROFILING_PROXY_HOST);
+    this.profilingProxyPort =
+        configProvider.getInteger(PROFILING_PROXY_PORT, PROFILING_PROXY_PORT_DEFAULT);
+    this.profilingProxyUsername = configProvider.getString(PROFILING_PROXY_USERNAME);
+    this.profilingProxyPassword = configProvider.getString(PROFILING_PROXY_PASSWORD);
+
+    this.profilingExceptionSampleLimit =
+        configProvider.getInteger(
+            PROFILING_EXCEPTION_SAMPLE_LIMIT, PROFILING_EXCEPTION_SAMPLE_LIMIT_DEFAULT);
+    this.profilingExceptionHistogramTopItems =
+        configProvider.getInteger(
+            PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS,
+            PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS_DEFAULT);
+    this.profilingExceptionHistogramMaxCollectionSize =
+        configProvider.getInteger(
+            PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE,
+            PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE_DEFAULT);
+
+    this.profilingExcludeAgentThreads =
+        configProvider.getBoolean(PROFILING_EXCLUDE_AGENT_THREADS, true);
+
+    // code hotspots are disabled by default because of potential perf overhead they can incur
+    this.profilingHotspotsEnabled = configProvider.getBoolean(PROFILING_HOTSPOTS_ENABLED, false);
+
+    this.profilingUploadSummaryOn413Enabled =
+        configProvider.getBoolean(
+            PROFILING_UPLOAD_SUMMARY_ON_413, PROFILING_UPLOAD_SUMMARY_ON_413_DEFAULT);
+  }
+
+  public boolean isProfilingEnabled() {
+    return this.profilingEnabled;
+  }
+
+  public boolean isProfilingAgentless() {
+    return this.profilingAgentless;
+  }
+
+  public int getProfilingStartDelay() {
+    return this.profilingStartDelay;
+  }
+
+  public boolean isProfilingStartForceFirst() {
+    return this.profilingStartForceFirst;
+  }
+
+  public int getProfilingUploadPeriod() {
+    return this.profilingUploadPeriod;
+  }
+
+  public String getProfilingTemplateOverrideFile() {
+    return this.profilingTemplateOverrideFile;
+  }
+
+  public int getProfilingUploadTimeout() {
+    return this.profilingUploadTimeout;
+  }
+
+  public String getProfilingUploadCompression() {
+    return this.profilingUploadCompression;
+  }
+
+  public String getProfilingProxyHost() {
+    return this.profilingProxyHost;
+  }
+
+  public int getProfilingProxyPort() {
+    return this.profilingProxyPort;
+  }
+
+  public String getProfilingProxyUsername() {
+    return this.profilingProxyUsername;
+  }
+
+  public String getProfilingProxyPassword() {
+    return this.profilingProxyPassword;
+  }
+
+  public int getProfilingExceptionSampleLimit() {
+    return this.profilingExceptionSampleLimit;
+  }
+
+  public int getProfilingExceptionHistogramTopItems() {
+    return this.profilingExceptionHistogramTopItems;
+  }
+
+  public int getProfilingExceptionHistogramMaxCollectionSize() {
+    return this.profilingExceptionHistogramMaxCollectionSize;
+  }
+
+  public boolean isProfilingExcludeAgentThreads() {
+    return this.profilingExcludeAgentThreads;
+  }
+
+  public boolean isProfilingHotspotsEnabled() {
+    return this.profilingHotspotsEnabled;
+  }
+
+  public boolean isProfilingUploadSummaryOn413Enabled() {
+    return this.profilingUploadSummaryOn413Enabled;
+  }
+
+  public boolean isProfilingLegacyTracingIntegrationEnabled() {
+    return this.profilingLegacyTracingIntegrationEnabled;
+  }
+
+  public boolean isAsyncProfilerEnabled() {
+    return this.asyncProfilerEnabled;
+  }
+
+  public String getFinalProfilingUrl() {
+    if (this.profilingUrl != null) {
+      // when profilingUrl is set we use it regardless of apiKey/agentless config
+      return this.profilingUrl;
+    } else if (this.profilingAgentless) {
+      // when agentless profiling is turned on we send directly to our intake
+      return "https://intake.profile." + this.generalConfig.getSite() + "/api/v2/profile";
+    } else {
+      // when profilingUrl and agentless are not set we send to the dd trace agent running locally
+      return "http://"
+          + this.tracerConfig.getAgentHost()
+          + ":"
+          + this.tracerConfig.getAgentPort()
+          + "/profiling/v1/input";
+    }
+  }
+
+  public Map<String, String> getMergedProfilingTags() {
+    final Map<String, String> runtimeTags = this.generalConfig.getRuntimeTags();
+    final Map<String, String> globalTags = this.generalConfig.getGlobalTags();
+    final String host = this.generalConfig.getHostName();
+    final Map<String, String> result =
+        newHashMap(
+            globalTags.size()
+                + this.profilingTags.size()
+                + runtimeTags.size()
+                + 4 /* for serviceName and host and language and runtime_version */);
+    result.put(HOST_TAG, host); // Host goes first to allow to override it
+    result.putAll(globalTags);
+    result.putAll(this.profilingTags);
+    result.putAll(runtimeTags);
+    // service name set here instead of getRuntimeTags because apm already manages the service tag
+    // and may choose to override it.
+    result.put(SERVICE_TAG, this.generalConfig.getServiceName());
+    result.put(LANGUAGE_TAG_KEY, LANGUAGE_TAG_VALUE);
+    result.put(RUNTIME_VERSION_TAG, this.generalConfig.getRuntimeVersion());
+    return Collections.unmodifiableMap(result);
+  }
+
+  @Override
+  public String toString() {
+    return "ProfilingFeatureConfig{"
+        + "generalConfig="
+        + this.generalConfig
+        + ", tracerConfig="
+        + this.tracerConfig
+        + ", profilingEnabled="
+        + this.profilingEnabled
+        + ", profilingAgentless="
+        + this.profilingAgentless
+        + ", profilingLegacyTracingIntegrationEnabled="
+        + this.profilingLegacyTracingIntegrationEnabled
+        + ", asyncProfilerEnabled="
+        + this.asyncProfilerEnabled
+        + ", profilingUrl='"
+        + this.profilingUrl
+        + '\''
+        + ", profilingTags="
+        + this.profilingTags
+        + ", profilingStartDelay="
+        + this.profilingStartDelay
+        + ", profilingStartForceFirst="
+        + this.profilingStartForceFirst
+        + ", profilingUploadPeriod="
+        + this.profilingUploadPeriod
+        + ", profilingTemplateOverrideFile='"
+        + this.profilingTemplateOverrideFile
+        + '\''
+        + ", profilingUploadTimeout="
+        + this.profilingUploadTimeout
+        + ", profilingUploadCompression='"
+        + this.profilingUploadCompression
+        + '\''
+        + ", profilingProxyHost='"
+        + this.profilingProxyHost
+        + '\''
+        + ", profilingProxyPort="
+        + this.profilingProxyPort
+        + ", profilingProxyUsername='"
+        + this.profilingProxyUsername
+        + '\''
+        + ", profilingProxyPassword="
+        + (this.profilingProxyPassword == null ? "null" : "****")
+        + ", profilingExceptionSampleLimit="
+        + this.profilingExceptionSampleLimit
+        + ", profilingExceptionHistogramTopItems="
+        + this.profilingExceptionHistogramTopItems
+        + ", profilingExceptionHistogramMaxCollectionSize="
+        + this.profilingExceptionHistogramMaxCollectionSize
+        + ", profilingExcludeAgentThreads="
+        + this.profilingExcludeAgentThreads
+        + ", profilingHotspotsEnabled="
+        + this.profilingHotspotsEnabled
+        + ", profilingUploadSummaryOn413Enabled="
+        + this.profilingUploadSummaryOn413Enabled
+        + '}';
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/config/RemoteFeatureConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/config/RemoteFeatureConfig.java
@@ -1,0 +1,100 @@
+package datadog.trace.api.config;
+
+import static datadog.trace.api.config.RemoteConfigConfig.DEFAULT_REMOTE_CONFIG_ENABLED;
+import static datadog.trace.api.config.RemoteConfigConfig.DEFAULT_REMOTE_CONFIG_INITIAL_POLL_INTERVAL;
+import static datadog.trace.api.config.RemoteConfigConfig.DEFAULT_REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED;
+import static datadog.trace.api.config.RemoteConfigConfig.DEFAULT_REMOTE_CONFIG_MAX_PAYLOAD_SIZE;
+import static datadog.trace.api.config.RemoteConfigConfig.DEFAULT_REMOTE_CONFIG_TARGETS_KEY;
+import static datadog.trace.api.config.RemoteConfigConfig.DEFAULT_REMOTE_CONFIG_TARGETS_KEY_ID;
+import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_ENABLED;
+import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_INITIAL_POLL_INTERVAL;
+import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED;
+import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_MAX_PAYLOAD_SIZE;
+import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_TARGETS_KEY;
+import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_TARGETS_KEY_ID;
+import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_URL;
+
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+
+public class RemoteFeatureConfig extends AbstractFeatureConfig {
+  private final boolean remoteConfigEnabled;
+  private final boolean remoteConfigIntegrityCheckEnabled;
+  private final String remoteConfigUrl;
+  private final int remoteConfigInitialPollInterval;
+  private final long remoteConfigMaxPayloadSize;
+  private final String remoteConfigTargetsKeyId;
+  private final String remoteConfigTargetsKey;
+
+  public RemoteFeatureConfig(ConfigProvider configProvider) {
+    super(configProvider);
+    this.remoteConfigEnabled =
+        configProvider.getBoolean(REMOTE_CONFIG_ENABLED, DEFAULT_REMOTE_CONFIG_ENABLED);
+    this.remoteConfigIntegrityCheckEnabled =
+        configProvider.getBoolean(
+            REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED, DEFAULT_REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED);
+    this.remoteConfigUrl = configProvider.getString(REMOTE_CONFIG_URL);
+    this.remoteConfigInitialPollInterval =
+        configProvider.getInteger(
+            REMOTE_CONFIG_INITIAL_POLL_INTERVAL, DEFAULT_REMOTE_CONFIG_INITIAL_POLL_INTERVAL);
+    this.remoteConfigMaxPayloadSize =
+        configProvider.getInteger(
+                REMOTE_CONFIG_MAX_PAYLOAD_SIZE, DEFAULT_REMOTE_CONFIG_MAX_PAYLOAD_SIZE)
+            * 1024L;
+    this.remoteConfigTargetsKeyId =
+        configProvider.getString(
+            REMOTE_CONFIG_TARGETS_KEY_ID, DEFAULT_REMOTE_CONFIG_TARGETS_KEY_ID);
+    this.remoteConfigTargetsKey =
+        configProvider.getString(REMOTE_CONFIG_TARGETS_KEY, DEFAULT_REMOTE_CONFIG_TARGETS_KEY);
+  }
+
+  public long getRemoteConfigMaxPayloadSizeBytes() {
+    return this.remoteConfigMaxPayloadSize;
+  }
+
+  public boolean isRemoteConfigEnabled() {
+    return this.remoteConfigEnabled;
+  }
+
+  public boolean isRemoteConfigIntegrityCheckEnabled() {
+    return this.remoteConfigIntegrityCheckEnabled;
+  }
+
+  public String getFinalRemoteConfigUrl() {
+    return this.remoteConfigUrl;
+  }
+
+  public int getRemoteConfigInitialPollInterval() {
+    return this.remoteConfigInitialPollInterval;
+  }
+
+  public String getRemoteConfigTargetsKeyId() {
+    return this.remoteConfigTargetsKeyId;
+  }
+
+  public String getRemoteConfigTargetsKey() {
+    return this.remoteConfigTargetsKey;
+  }
+
+  @Override
+  public String toString() {
+    return "RemoteFeatureConfig{"
+        + "remoteConfigEnabled="
+        + this.remoteConfigEnabled
+        + ", remoteConfigIntegrityCheckEnabled="
+        + this.remoteConfigIntegrityCheckEnabled
+        + ", remoteConfigUrl='"
+        + this.remoteConfigUrl
+        + '\''
+        + ", remoteConfigInitialPollInterval="
+        + this.remoteConfigInitialPollInterval
+        + ", remoteConfigMaxPayloadSize="
+        + this.remoteConfigMaxPayloadSize
+        + ", remoteConfigTargetsKeyId='"
+        + this.remoteConfigTargetsKeyId
+        + '\''
+        + ", remoteConfigTargetsKey='"
+        + this.remoteConfigTargetsKey
+        + '\''
+        + '}';
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/config/TraceInstrumentationFeatureConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/config/TraceInstrumentationFeatureConfig.java
@@ -1,0 +1,747 @@
+package datadog.trace.api.config;
+
+import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVLET_ROOT_CONTEXT_SERVICE_NAME;
+import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX;
+import static datadog.trace.api.config.TraceInstrumentationConfig.DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX;
+import static datadog.trace.api.config.TraceInstrumentationConfig.DEFAULT_GRPC_CLIENT_ERROR_STATUSES;
+import static datadog.trace.api.config.TraceInstrumentationConfig.DEFAULT_GRPC_SERVER_ERROR_STATUSES;
+import static datadog.trace.api.config.TraceInstrumentationConfig.DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN;
+import static datadog.trace.api.config.TraceInstrumentationConfig.DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING;
+import static datadog.trace.api.config.TraceInstrumentationConfig.DEFAULT_HTTP_SERVER_ROUTE_BASED_NAMING;
+import static datadog.trace.api.config.TraceInstrumentationConfig.DEFAULT_HTTP_SERVER_TAG_QUERY_STRING;
+import static datadog.trace.api.config.TraceInstrumentationConfig.DEFAULT_INTEGRATIONS_ENABLED;
+import static datadog.trace.api.config.TraceInstrumentationConfig.DEFAULT_LOGS_INJECTION_ENABLED;
+import static datadog.trace.api.config.TraceInstrumentationConfig.DEFAULT_RESOLVER_OUTLINE_POOL_SIZE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.DEFAULT_RESOLVER_TYPE_POOL_SIZE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION;
+import static datadog.trace.api.config.TraceInstrumentationConfig.DEFAULT_SERIALVERSIONUID_FIELD_INJECTION;
+import static datadog.trace.api.config.TraceInstrumentationConfig.DEFAULT_TRACE_ANNOTATIONS;
+import static datadog.trace.api.config.TraceInstrumentationConfig.DEFAULT_TRACE_EXECUTORS_ALL;
+import static datadog.trace.api.config.TraceInstrumentationConfig.DEFAULT_TRACE_METHODS;
+import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_CLIENT_ERROR_STATUSES;
+import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_IGNORED_INBOUND_METHODS;
+import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_IGNORED_OUTBOUND_METHODS;
+import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_SERVER_ERROR_STATUSES;
+import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_SERVER_TRIM_PACKAGE_RESOURCE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN;
+import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_CLIENT_TAG_QUERY_STRING;
+import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_RAW_QUERY_STRING;
+import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_RAW_RESOURCE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_ROUTE_BASED_NAMING;
+import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_TAG_QUERY_STRING;
+import static datadog.trace.api.config.TraceInstrumentationConfig.HYSTRIX_MEASURED_ENABLED;
+import static datadog.trace.api.config.TraceInstrumentationConfig.HYSTRIX_TAGS_ENABLED;
+import static datadog.trace.api.config.TraceInstrumentationConfig.IGNITE_CACHE_INCLUDE_KEYS;
+import static datadog.trace.api.config.TraceInstrumentationConfig.INTEGRATIONS_ENABLED;
+import static datadog.trace.api.config.TraceInstrumentationConfig.INTEGRATION_SYNAPSE_LEGACY_OPERATION_NAME;
+import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_CONNECTION_CLASS_NAME;
+import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_PREPARED_STATEMENT_CLASS_NAME;
+import static datadog.trace.api.config.TraceInstrumentationConfig.JMS_PROPAGATION_DISABLED_QUEUES;
+import static datadog.trace.api.config.TraceInstrumentationConfig.JMS_PROPAGATION_DISABLED_TOPICS;
+import static datadog.trace.api.config.TraceInstrumentationConfig.KAFKA_CLIENT_BASE64_DECODING_ENABLED;
+import static datadog.trace.api.config.TraceInstrumentationConfig.KAFKA_CLIENT_PROPAGATION_DISABLED_TOPICS;
+import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_INJECTION_ENABLED;
+import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_MDC_TAGS_INJECTION_ENABLED;
+import static datadog.trace.api.config.TraceInstrumentationConfig.MESSAGE_BROKER_SPLIT_BY_DESTINATION;
+import static datadog.trace.api.config.TraceInstrumentationConfig.OBFUSCATION_QUERY_STRING_REGEXP;
+import static datadog.trace.api.config.TraceInstrumentationConfig.PLAY_REPORT_HTTP_STATUS;
+import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGATION_DISABLED_EXCHANGES;
+import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGATION_DISABLED_QUEUES;
+import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_OUTLINE_POOL_ENABLED;
+import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_OUTLINE_POOL_SIZE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_TYPE_POOL_SIZE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_USE_LOADCLASS;
+import static datadog.trace.api.config.TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
+import static datadog.trace.api.config.TraceInstrumentationConfig.SERIALVERSIONUID_FIELD_INJECTION;
+import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ASYNC_TIMEOUT_ERROR;
+import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_PRINCIPAL_ENABLED;
+import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ROOT_CONTEXT_SERVICE_NAME;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ANNOTATIONS;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE_FILE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSLOADERS_EXCLUDE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CODESOURCES_EXCLUDE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ENABLED;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_EXECUTORS;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_EXECUTORS_ALL;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_METHODS;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_THREAD_POOL_EXECUTORS_EXCLUDE;
+import static datadog.trace.api.config.TracerConfig.DEFAULT_TRACE_ENABLED;
+import static datadog.trace.util.CollectionUtils.tryMakeImmutableList;
+import static datadog.trace.util.CollectionUtils.tryMakeImmutableSet;
+
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+
+public class TraceInstrumentationFeatureConfig extends AbstractFeatureConfig {
+  private final StaticConfig staticConfig;
+  private final boolean traceEnabled;
+  private final boolean integrationSynapseLegacyOperationName;
+  private final String traceAnnotations;
+  private final boolean logsInjectionEnabled;
+  private final boolean logsMDCTagsInjectionEnabled;
+  private final String traceMethods;
+  private final boolean traceExecutorsAll;
+  private final List<String> traceExecutors;
+  private final Set<String> traceThreadPoolExecutorsExclude;
+  private final boolean httpServerTagQueryString;
+  private final boolean httpServerRawQueryString;
+  private final boolean httpServerRawResource;
+  private final boolean httpServerRouteBasedNaming;
+  private final boolean httpClientTagQueryString;
+  private final boolean httpClientSplitByDomain;
+  private final boolean dbClientSplitByInstance;
+  private final boolean dbClientSplitByInstanceTypeSuffix;
+  private final boolean awsPropagationEnabled;
+  private final boolean sqsPropagationEnabled;
+
+  private final boolean kafkaClientPropagationEnabled;
+  private final Set<String> kafkaClientPropagationDisabledTopics;
+  private final boolean kafkaClientBase64DecodingEnabled;
+
+  private final boolean jmsPropagationEnabled;
+  private final Set<String> jmsPropagationDisabledTopics;
+  private final Set<String> jmsPropagationDisabledQueues;
+
+  private final boolean rabbitPropagationEnabled;
+  private final Set<String> rabbitPropagationDisabledQueues;
+  private final Set<String> rabbitPropagationDisabledExchanges;
+  private final boolean messageBrokerSplitByDestination;
+  private final boolean hystrixTagsEnabled;
+  private final boolean hystrixMeasuredEnabled;
+  private final boolean igniteCacheIncludeKeys;
+  private final String obfuscationQueryRegexp;
+  // TODO: remove at a future point.
+  private final boolean playReportHttpStatus;
+  private final boolean servletPrincipalEnabled;
+  private final boolean servletAsyncTimeoutError;
+  private final String jdbcPreparedStatementClassName;
+  private final String jdbcConnectionClassName;
+  private final String rootContextServiceName;
+  private final Set<String> grpcIgnoredInboundMethods;
+  private final Set<String> grpcIgnoredOutboundMethods;
+  private final boolean grpcServerTrimPackageResource;
+  private final BitSet grpcServerErrorStatuses;
+  private final BitSet grpcClientErrorStatuses;
+
+  public TraceInstrumentationFeatureConfig(ConfigProvider configProvider) {
+    super(configProvider);
+    this.staticConfig = new StaticConfig(configProvider);
+
+    this.traceEnabled = configProvider.getBoolean(TRACE_ENABLED, DEFAULT_TRACE_ENABLED);
+
+    this.integrationSynapseLegacyOperationName =
+        configProvider.getBoolean(INTEGRATION_SYNAPSE_LEGACY_OPERATION_NAME, false);
+
+    this.traceAnnotations = configProvider.getString(TRACE_ANNOTATIONS, DEFAULT_TRACE_ANNOTATIONS);
+
+    this.logsInjectionEnabled =
+        configProvider.getBoolean(LOGS_INJECTION_ENABLED, DEFAULT_LOGS_INJECTION_ENABLED);
+    this.logsMDCTagsInjectionEnabled =
+        configProvider.getBoolean(LOGS_MDC_TAGS_INJECTION_ENABLED, true);
+
+    this.traceMethods = configProvider.getString(TRACE_METHODS, DEFAULT_TRACE_METHODS);
+
+    this.traceExecutorsAll =
+        configProvider.getBoolean(TRACE_EXECUTORS_ALL, DEFAULT_TRACE_EXECUTORS_ALL);
+    this.traceExecutors = tryMakeImmutableList(configProvider.getList(TRACE_EXECUTORS));
+    this.traceThreadPoolExecutorsExclude =
+        tryMakeImmutableSet(configProvider.getList(TRACE_THREAD_POOL_EXECUTORS_EXCLUDE));
+
+    this.httpServerTagQueryString =
+        configProvider.getBoolean(
+            HTTP_SERVER_TAG_QUERY_STRING, DEFAULT_HTTP_SERVER_TAG_QUERY_STRING);
+    this.httpServerRawQueryString = configProvider.getBoolean(HTTP_SERVER_RAW_QUERY_STRING, true);
+    this.httpServerRawResource = configProvider.getBoolean(HTTP_SERVER_RAW_RESOURCE, false);
+    this.httpServerRouteBasedNaming =
+        configProvider.getBoolean(
+            HTTP_SERVER_ROUTE_BASED_NAMING, DEFAULT_HTTP_SERVER_ROUTE_BASED_NAMING);
+    this.httpClientTagQueryString =
+        configProvider.getBoolean(
+            HTTP_CLIENT_TAG_QUERY_STRING, DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING);
+    this.httpClientSplitByDomain =
+        configProvider.getBoolean(
+            HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN);
+
+    this.dbClientSplitByInstance =
+        configProvider.getBoolean(
+            DB_CLIENT_HOST_SPLIT_BY_INSTANCE, DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE);
+    this.dbClientSplitByInstanceTypeSuffix =
+        configProvider.getBoolean(
+            DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX,
+            DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX);
+
+    this.awsPropagationEnabled = isPropagationEnabled(true, "aws");
+    this.sqsPropagationEnabled = awsPropagationEnabled && isPropagationEnabled(true, "sqs");
+
+    this.kafkaClientPropagationEnabled = isPropagationEnabled(true, "kafka", "kafka.client");
+    this.kafkaClientPropagationDisabledTopics =
+        tryMakeImmutableSet(configProvider.getList(KAFKA_CLIENT_PROPAGATION_DISABLED_TOPICS));
+    this.kafkaClientBase64DecodingEnabled =
+        configProvider.getBoolean(KAFKA_CLIENT_BASE64_DECODING_ENABLED, false);
+
+    this.jmsPropagationEnabled = isPropagationEnabled(true, "jms");
+    this.jmsPropagationDisabledTopics =
+        tryMakeImmutableSet(configProvider.getList(JMS_PROPAGATION_DISABLED_TOPICS));
+    this.jmsPropagationDisabledQueues =
+        tryMakeImmutableSet(configProvider.getList(JMS_PROPAGATION_DISABLED_QUEUES));
+
+    this.rabbitPropagationEnabled = isPropagationEnabled(true, "rabbit", "rabbitmq");
+    this.rabbitPropagationDisabledQueues =
+        tryMakeImmutableSet(configProvider.getList(RABBIT_PROPAGATION_DISABLED_QUEUES));
+    this.rabbitPropagationDisabledExchanges =
+        tryMakeImmutableSet(configProvider.getList(RABBIT_PROPAGATION_DISABLED_EXCHANGES));
+
+    this.messageBrokerSplitByDestination =
+        configProvider.getBoolean(MESSAGE_BROKER_SPLIT_BY_DESTINATION, false);
+    this.hystrixTagsEnabled = configProvider.getBoolean(HYSTRIX_TAGS_ENABLED, false);
+    this.hystrixMeasuredEnabled = configProvider.getBoolean(HYSTRIX_MEASURED_ENABLED, false);
+    this.igniteCacheIncludeKeys = configProvider.getBoolean(IGNITE_CACHE_INCLUDE_KEYS, false);
+    this.obfuscationQueryRegexp = configProvider.getString(OBFUSCATION_QUERY_STRING_REGEXP);
+    this.playReportHttpStatus = configProvider.getBoolean(PLAY_REPORT_HTTP_STATUS, false);
+
+    this.servletPrincipalEnabled = configProvider.getBoolean(SERVLET_PRINCIPAL_ENABLED, false);
+    this.servletAsyncTimeoutError = configProvider.getBoolean(SERVLET_ASYNC_TIMEOUT_ERROR, true);
+    this.jdbcPreparedStatementClassName =
+        configProvider.getString(JDBC_PREPARED_STATEMENT_CLASS_NAME, "");
+    this.jdbcConnectionClassName = configProvider.getString(JDBC_CONNECTION_CLASS_NAME, "");
+
+    this.rootContextServiceName =
+        configProvider.getString(
+            SERVLET_ROOT_CONTEXT_SERVICE_NAME, DEFAULT_SERVLET_ROOT_CONTEXT_SERVICE_NAME);
+
+    this.grpcIgnoredInboundMethods =
+        tryMakeImmutableSet(configProvider.getList(GRPC_IGNORED_INBOUND_METHODS));
+    this.grpcIgnoredOutboundMethods =
+        tryMakeImmutableSet(configProvider.getList(GRPC_IGNORED_OUTBOUND_METHODS));
+    this.grpcServerTrimPackageResource =
+        configProvider.getBoolean(GRPC_SERVER_TRIM_PACKAGE_RESOURCE, false);
+    this.grpcServerErrorStatuses =
+        configProvider.getIntegerRange(
+            GRPC_SERVER_ERROR_STATUSES, DEFAULT_GRPC_SERVER_ERROR_STATUSES);
+    this.grpcClientErrorStatuses =
+        configProvider.getIntegerRange(
+            GRPC_CLIENT_ERROR_STATUSES, DEFAULT_GRPC_CLIENT_ERROR_STATUSES);
+  }
+
+  public boolean isTraceEnabled() {
+    return this.traceEnabled;
+  }
+
+  public boolean isIntegrationsEnabled() {
+    return this.staticConfig.isIntegrationsEnabled();
+  }
+
+  public boolean isIntegrationSynapseLegacyOperationName() {
+    return this.integrationSynapseLegacyOperationName;
+  }
+
+  public String getTraceAnnotations() {
+    return this.traceAnnotations;
+  }
+
+  public boolean isLogsInjectionEnabled() {
+    return this.logsInjectionEnabled;
+  }
+
+  public boolean isLogsMDCTagsInjectionEnabled() {
+    return this.logsMDCTagsInjectionEnabled;
+  }
+
+  public String getTraceMethods() {
+    return this.traceMethods;
+  }
+
+  public boolean isTraceExecutorsAll() {
+    return this.traceExecutorsAll;
+  }
+
+  public List<String> getTraceExecutors() {
+    return this.traceExecutors;
+  }
+
+  public Set<String> getTraceThreadPoolExecutorsExclude() {
+    return this.traceThreadPoolExecutorsExclude;
+  }
+
+  public List<String> getExcludedClasses() {
+    return this.staticConfig.getExcludedClasses();
+  }
+
+  public String getExcludedClassesFile() {
+    return this.staticConfig.getExcludedClassesFile();
+  }
+
+  public Set<String> getExcludedClassLoaders() {
+    return this.staticConfig.getExcludedClassLoaders();
+  }
+
+  public List<String> getExcludedCodeSources() {
+    return this.staticConfig.getExcludedCodeSources();
+  }
+
+  public boolean isHttpServerTagQueryString() {
+    return this.httpServerTagQueryString;
+  }
+
+  public boolean isHttpServerRawQueryString() {
+    return this.httpServerRawQueryString;
+  }
+
+  public boolean isHttpServerRawResource() {
+    return this.httpServerRawResource;
+  }
+
+  public boolean isHttpServerRouteBasedNaming() {
+    return this.httpServerRouteBasedNaming;
+  }
+
+  public boolean isHttpClientTagQueryString() {
+    return this.httpClientTagQueryString;
+  }
+
+  public boolean isHttpClientSplitByDomain() {
+    return this.httpClientSplitByDomain;
+  }
+
+  public boolean isDbClientSplitByInstance() {
+    return this.dbClientSplitByInstance;
+  }
+
+  public boolean isDbClientSplitByInstanceTypeSuffix() {
+    return this.dbClientSplitByInstanceTypeSuffix;
+  }
+
+  public boolean isAwsPropagationEnabled() {
+    return this.awsPropagationEnabled;
+  }
+
+  public boolean isSqsPropagationEnabled() {
+    return this.sqsPropagationEnabled;
+  }
+
+  public boolean isKafkaClientPropagationEnabled() {
+    return this.kafkaClientPropagationEnabled;
+  }
+
+  public boolean isKafkaClientPropagationDisabledForTopic(String topic) {
+    return null != topic && this.kafkaClientPropagationDisabledTopics.contains(topic);
+  }
+
+  public boolean isJmsPropagationEnabled() {
+    return this.jmsPropagationEnabled;
+  }
+
+  public boolean isJmsPropagationDisabledForDestination(final String queueOrTopic) {
+    return null != queueOrTopic
+        && (this.jmsPropagationDisabledQueues.contains(queueOrTopic)
+            || this.jmsPropagationDisabledTopics.contains(queueOrTopic));
+  }
+
+  public boolean isKafkaClientBase64DecodingEnabled() {
+    return this.kafkaClientBase64DecodingEnabled;
+  }
+
+  public boolean isRabbitPropagationEnabled() {
+    return this.rabbitPropagationEnabled;
+  }
+
+  public boolean isRabbitPropagationDisabledForDestination(final String queueOrExchange) {
+    return null != queueOrExchange
+        && (this.rabbitPropagationDisabledQueues.contains(queueOrExchange)
+            || this.rabbitPropagationDisabledExchanges.contains(queueOrExchange));
+  }
+
+  public boolean isMessageBrokerSplitByDestination() {
+    return this.messageBrokerSplitByDestination;
+  }
+
+  public boolean isHystrixTagsEnabled() {
+    return this.hystrixTagsEnabled;
+  }
+
+  public boolean isHystrixMeasuredEnabled() {
+    return this.hystrixMeasuredEnabled;
+  }
+
+  public boolean isIgniteCacheIncludeKeys() {
+    return this.igniteCacheIncludeKeys;
+  }
+
+  public String getObfuscationQueryRegexp() {
+    return this.obfuscationQueryRegexp;
+  }
+
+  public boolean getPlayReportHttpStatus() {
+    return this.playReportHttpStatus;
+  }
+
+  public boolean isServletPrincipalEnabled() {
+    return this.servletPrincipalEnabled;
+  }
+
+  public boolean isServletAsyncTimeoutError() {
+    return this.servletAsyncTimeoutError;
+  }
+
+  public String getJdbcPreparedStatementClassName() {
+    return this.jdbcPreparedStatementClassName;
+  }
+
+  public String getJdbcConnectionClassName() {
+    return this.jdbcConnectionClassName;
+  }
+
+  public String getRootContextServiceName() {
+    return this.rootContextServiceName;
+  }
+
+  public boolean isRuntimeContextFieldInjection() {
+    return this.staticConfig.isRuntimeContextFieldInjection();
+  }
+
+  public boolean isSerialVersionUIDFieldInjection() {
+    return this.staticConfig.isSerialVersionUIDFieldInjection();
+  }
+
+  public Set<String> getGrpcIgnoredInboundMethods() {
+    return this.grpcIgnoredInboundMethods;
+  }
+
+  public Set<String> getGrpcIgnoredOutboundMethods() {
+    return this.grpcIgnoredOutboundMethods;
+  }
+
+  public boolean isGrpcServerTrimPackageResource() {
+    return this.grpcServerTrimPackageResource;
+  }
+
+  public BitSet getGrpcServerErrorStatuses() {
+    return this.grpcServerErrorStatuses;
+  }
+
+  public BitSet getGrpcClientErrorStatuses() {
+    return this.grpcClientErrorStatuses;
+  }
+
+  public boolean isResolverOutlinePoolEnabled() {
+    return this.staticConfig.isResolverOutlinePoolEnabled();
+  }
+
+  public int getResolverOutlinePoolSize() {
+    return this.staticConfig.getResolverOutlinePoolSize();
+  }
+
+  public int getResolverTypePoolSize() {
+    return this.staticConfig.getResolverTypePoolSize();
+  }
+
+  public boolean isResolverUseLoadClassEnabled() {
+    return this.staticConfig.isResolverUseLoadClassEnabled();
+  }
+
+  public boolean isPropagationEnabled(
+      final boolean defaultEnabled, final String... integrationNames) {
+    return isEnabled(Arrays.asList(integrationNames), "", ".propagation.enabled", defaultEnabled);
+  }
+
+  public boolean isIntegrationEnabled(
+      final Iterable<String> integrationNames, final boolean defaultEnabled) {
+    return this.staticConfig.isIntegrationEnabled(integrationNames, defaultEnabled);
+  }
+
+  public boolean isIntegrationShortcutMatchingEnabled(
+      final Iterable<String> integrationNames, final boolean defaultEnabled) {
+    return this.staticConfig.isIntegrationShortcutMatchingEnabled(integrationNames, defaultEnabled);
+  }
+
+  public boolean isJmxFetchIntegrationEnabled(
+      final Iterable<String> integrationNames, final boolean defaultEnabled) {
+    return this.staticConfig.isJmxFetchIntegrationEnabled(integrationNames, defaultEnabled);
+  }
+
+  public boolean isRuleEnabled(final String name) {
+    return isRuleEnabled(name, true);
+  }
+
+  public boolean isRuleEnabled(final String name, boolean defaultEnabled) {
+    boolean enabled = configProvider.getBoolean("trace." + name + ".enabled", defaultEnabled);
+    boolean lowerEnabled =
+        configProvider.getBoolean("trace." + name.toLowerCase() + ".enabled", defaultEnabled);
+    return defaultEnabled ? enabled && lowerEnabled : enabled || lowerEnabled;
+  }
+
+  public boolean isEndToEndDurationEnabled(
+      final boolean defaultEnabled, final String... integrationNames) {
+    return isEnabled(Arrays.asList(integrationNames), "", ".e2e.duration.enabled", defaultEnabled);
+  }
+
+  public boolean isLegacyTracingEnabled(
+      final boolean defaultEnabled, final String... integrationNames) {
+    return isEnabled(
+        Arrays.asList(integrationNames), "", ".legacy.tracing.enabled", defaultEnabled);
+  }
+
+  public boolean isTraceAnalyticsIntegrationEnabled(
+      final SortedSet<String> integrationNames, final boolean defaultEnabled) {
+    return isEnabled(integrationNames, "", ".analytics.enabled", defaultEnabled);
+  }
+
+  public boolean isTraceAnalyticsIntegrationEnabled(
+      final boolean defaultEnabled, final String... integrationNames) {
+    return isEnabled(Arrays.asList(integrationNames), "", ".analytics.enabled", defaultEnabled);
+  }
+
+  @Override
+  public String toString() {
+    return "TraceInstrumentationFeatureConfig{"
+        + "staticConfig="
+        + this.staticConfig
+        + ", traceEnabled="
+        + this.traceEnabled
+        + ", integrationSynapseLegacyOperationName="
+        + this.integrationSynapseLegacyOperationName
+        + ", traceAnnotations='"
+        + this.traceAnnotations
+        + '\''
+        + ", logsInjectionEnabled="
+        + this.logsInjectionEnabled
+        + ", logsMDCTagsInjectionEnabled="
+        + this.logsMDCTagsInjectionEnabled
+        + ", traceMethods='"
+        + this.traceMethods
+        + '\''
+        + ", traceExecutorsAll="
+        + this.traceExecutorsAll
+        + ", traceExecutors="
+        + this.traceExecutors
+        + ", traceThreadPoolExecutorsExclude="
+        + this.traceThreadPoolExecutorsExclude
+        + ", httpServerTagQueryString="
+        + this.httpServerTagQueryString
+        + ", httpServerRawQueryString="
+        + this.httpServerRawQueryString
+        + ", httpServerRawResource="
+        + this.httpServerRawResource
+        + ", httpServerRouteBasedNaming="
+        + this.httpServerRouteBasedNaming
+        + ", httpClientTagQueryString="
+        + this.httpClientTagQueryString
+        + ", httpClientSplitByDomain="
+        + this.httpClientSplitByDomain
+        + ", dbClientSplitByInstance="
+        + this.dbClientSplitByInstance
+        + ", dbClientSplitByInstanceTypeSuffix="
+        + this.dbClientSplitByInstanceTypeSuffix
+        + ", awsPropagationEnabled="
+        + this.awsPropagationEnabled
+        + ", sqsPropagationEnabled="
+        + this.sqsPropagationEnabled
+        + ", kafkaClientPropagationEnabled="
+        + this.kafkaClientPropagationEnabled
+        + ", kafkaClientPropagationDisabledTopics="
+        + this.kafkaClientPropagationDisabledTopics
+        + ", kafkaClientBase64DecodingEnabled="
+        + this.kafkaClientBase64DecodingEnabled
+        + ", jmsPropagationEnabled="
+        + this.jmsPropagationEnabled
+        + ", jmsPropagationDisabledTopics="
+        + this.jmsPropagationDisabledTopics
+        + ", jmsPropagationDisabledQueues="
+        + this.jmsPropagationDisabledQueues
+        + ", rabbitPropagationEnabled="
+        + this.rabbitPropagationEnabled
+        + ", rabbitPropagationDisabledQueues="
+        + this.rabbitPropagationDisabledQueues
+        + ", rabbitPropagationDisabledExchanges="
+        + this.rabbitPropagationDisabledExchanges
+        + ", messageBrokerSplitByDestination="
+        + this.messageBrokerSplitByDestination
+        + ", hystrixTagsEnabled="
+        + this.hystrixTagsEnabled
+        + ", hystrixMeasuredEnabled="
+        + this.hystrixMeasuredEnabled
+        + ", igniteCacheIncludeKeys="
+        + this.igniteCacheIncludeKeys
+        + ", obfuscationQueryRegexp='"
+        + this.obfuscationQueryRegexp
+        + '\''
+        + ", playReportHttpStatus="
+        + this.playReportHttpStatus
+        + ", servletPrincipalEnabled="
+        + this.servletPrincipalEnabled
+        + ", servletAsyncTimeoutError="
+        + this.servletAsyncTimeoutError
+        + ", jdbcPreparedStatementClassName='"
+        + this.jdbcPreparedStatementClassName
+        + '\''
+        + ", jdbcConnectionClassName='"
+        + this.jdbcConnectionClassName
+        + '\''
+        + ", rootContextServiceName='"
+        + this.rootContextServiceName
+        + '\''
+        + ", grpcIgnoredInboundMethods="
+        + this.grpcIgnoredInboundMethods
+        + ", grpcIgnoredOutboundMethods="
+        + this.grpcIgnoredOutboundMethods
+        + ", grpcServerTrimPackageResource="
+        + this.grpcServerTrimPackageResource
+        + ", grpcServerErrorStatuses="
+        + this.grpcServerErrorStatuses
+        + ", grpcClientErrorStatuses="
+        + this.grpcClientErrorStatuses
+        + '}';
+  }
+
+  public static class StaticConfig extends AbstractFeatureConfig {
+    private final boolean integrationsEnabled;
+    private final List<String> excludedClasses;
+    private final String excludedClassesFile;
+    private final Set<String> excludedClassLoaders;
+    private final List<String> excludedCodeSources;
+    private final boolean runtimeContextFieldInjection;
+    private final boolean serialVersionUIDFieldInjection;
+    private final boolean resolverOutlinePoolEnabled;
+    private final int resolverOutlinePoolSize;
+    private final int resolverTypePoolSize;
+    private final boolean resolverUseLoadClassEnabled;
+
+    /**
+     * This configuration is frozen at application initialization and cannot be updated at a later
+     * time by user configuration.
+     *
+     * @param configProvider The configuration provider to get configuration value from.
+     */
+    public StaticConfig(ConfigProvider configProvider) {
+      super(configProvider);
+      this.integrationsEnabled =
+          configProvider.getBoolean(INTEGRATIONS_ENABLED, DEFAULT_INTEGRATIONS_ENABLED);
+
+      this.excludedClasses = tryMakeImmutableList(configProvider.getList(TRACE_CLASSES_EXCLUDE));
+      this.excludedClassesFile = configProvider.getString(TRACE_CLASSES_EXCLUDE_FILE);
+      this.excludedClassLoaders =
+          tryMakeImmutableSet(configProvider.getList(TRACE_CLASSLOADERS_EXCLUDE));
+      this.excludedCodeSources =
+          tryMakeImmutableList(configProvider.getList(TRACE_CODESOURCES_EXCLUDE));
+
+      this.runtimeContextFieldInjection =
+          configProvider.getBoolean(
+              RUNTIME_CONTEXT_FIELD_INJECTION, DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION);
+      this.serialVersionUIDFieldInjection =
+          configProvider.getBoolean(
+              SERIALVERSIONUID_FIELD_INJECTION, DEFAULT_SERIALVERSIONUID_FIELD_INJECTION);
+
+      this.resolverOutlinePoolEnabled =
+          configProvider.getBoolean(RESOLVER_OUTLINE_POOL_ENABLED, true);
+      this.resolverOutlinePoolSize =
+          configProvider.getInteger(RESOLVER_OUTLINE_POOL_SIZE, DEFAULT_RESOLVER_OUTLINE_POOL_SIZE);
+      this.resolverTypePoolSize =
+          configProvider.getInteger(RESOLVER_TYPE_POOL_SIZE, DEFAULT_RESOLVER_TYPE_POOL_SIZE);
+      this.resolverUseLoadClassEnabled = configProvider.getBoolean(RESOLVER_USE_LOADCLASS, true);
+    }
+
+    public static StaticConfig getInstance() {
+      return Singleton.INSTANCE;
+    }
+
+    public boolean isIntegrationsEnabled() {
+      return this.integrationsEnabled;
+    }
+
+    public List<String> getExcludedClasses() {
+      return this.excludedClasses;
+    }
+
+    public String getExcludedClassesFile() {
+      return this.excludedClassesFile;
+    }
+
+    public Set<String> getExcludedClassLoaders() {
+      return this.excludedClassLoaders;
+    }
+
+    public List<String> getExcludedCodeSources() {
+      return this.excludedCodeSources;
+    }
+
+    public boolean isRuntimeContextFieldInjection() {
+      return this.runtimeContextFieldInjection;
+    }
+
+    public boolean isSerialVersionUIDFieldInjection() {
+      return this.serialVersionUIDFieldInjection;
+    }
+
+    public boolean isResolverOutlinePoolEnabled() {
+      return this.resolverOutlinePoolEnabled;
+    }
+
+    public int getResolverOutlinePoolSize() {
+      return this.resolverOutlinePoolSize;
+    }
+
+    public int getResolverTypePoolSize() {
+      return this.resolverTypePoolSize;
+    }
+
+    public boolean isResolverUseLoadClassEnabled() {
+      return this.resolverUseLoadClassEnabled;
+    }
+
+    public boolean isIntegrationEnabled(
+        final Iterable<String> integrationNames, final boolean defaultEnabled) {
+      return isEnabled(integrationNames, "integration.", ".enabled", defaultEnabled);
+    }
+
+    public boolean isIntegrationShortcutMatchingEnabled(
+        final Iterable<String> integrationNames, final boolean defaultEnabled) {
+      return isEnabled(
+          integrationNames, "integration.", ".matching.shortcut.enabled", defaultEnabled);
+    }
+
+    public boolean isJmxFetchIntegrationEnabled(
+        final Iterable<String> integrationNames, final boolean defaultEnabled) {
+      return isEnabled(integrationNames, "jmxfetch.", ".enabled", defaultEnabled);
+    }
+
+    @Override
+    public String toString() {
+      return "StaticConfig{"
+          + "integrationsEnabled="
+          + this.integrationsEnabled
+          + ", excludedClasses="
+          + this.excludedClasses
+          + ", excludedClassesFile='"
+          + this.excludedClassesFile
+          + '\''
+          + ", excludedClassLoaders="
+          + this.excludedClassLoaders
+          + ", excludedCodeSources="
+          + this.excludedCodeSources
+          + ", runtimeContextFieldInjection="
+          + this.runtimeContextFieldInjection
+          + ", serialVersionUIDFieldInjection="
+          + this.serialVersionUIDFieldInjection
+          + ", resolverOutlinePoolEnabled="
+          + this.resolverOutlinePoolEnabled
+          + ", resolverOutlinePoolSize="
+          + this.resolverOutlinePoolSize
+          + ", resolverTypePoolSize="
+          + this.resolverTypePoolSize
+          + ", resolverUseLoadClassEnabled="
+          + this.resolverUseLoadClassEnabled
+          + '}';
+    }
+
+    private static class Singleton {
+      private static final StaticConfig INSTANCE = new StaticConfig(ConfigProvider.getInstance());
+    }
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/config/TraceInstrumentationFeatureConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/config/TraceInstrumentationFeatureConfig.java
@@ -334,6 +334,10 @@ public class TraceInstrumentationFeatureConfig extends AbstractFeatureConfig {
     return null != topic && this.kafkaClientPropagationDisabledTopics.contains(topic);
   }
 
+  public boolean isKafkaClientBase64DecodingEnabled() {
+    return this.kafkaClientBase64DecodingEnabled;
+  }
+
   public boolean isJmsPropagationEnabled() {
     return this.jmsPropagationEnabled;
   }
@@ -342,10 +346,6 @@ public class TraceInstrumentationFeatureConfig extends AbstractFeatureConfig {
     return null != queueOrTopic
         && (this.jmsPropagationDisabledQueues.contains(queueOrTopic)
             || this.jmsPropagationDisabledTopics.contains(queueOrTopic));
-  }
-
-  public boolean isKafkaClientBase64DecodingEnabled() {
-    return this.kafkaClientBase64DecodingEnabled;
   }
 
   public boolean isRabbitPropagationEnabled() {

--- a/internal-api/src/main/java/datadog/trace/api/config/TracerFeatureConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/config/TracerFeatureConfig.java
@@ -14,6 +14,7 @@ import static datadog.trace.api.config.TracerConfig.AGENT_UNIX_DOMAIN_SOCKET;
 import static datadog.trace.api.config.TracerConfig.CLIENT_IP_ENABLED;
 import static datadog.trace.api.config.TracerConfig.CLOCK_SYNC_PERIOD;
 import static datadog.trace.api.config.TracerConfig.DEFAULT_AGENT_WRITER_TYPE;
+import static datadog.trace.api.config.TracerConfig.DEFAULT_ANALYTICS_SAMPLE_RATE;
 import static datadog.trace.api.config.TracerConfig.DEFAULT_CLIENT_IP_ENABLED;
 import static datadog.trace.api.config.TracerConfig.DEFAULT_CLOCK_SYNC_PERIOD;
 import static datadog.trace.api.config.TracerConfig.DEFAULT_HTTP_CLIENT_ERROR_STATUSES;
@@ -464,6 +465,21 @@ public class TracerFeatureConfig extends AbstractFeatureConfig {
   public boolean isSamplingMechanismValidationDisabled() {
     return this.configProvider.getBoolean(
         TracerConfig.SAMPLING_MECHANISM_VALIDATION_DISABLED, false);
+  }
+
+  /**
+   * Returns the sample rate for the specified instrumentation or {@link
+   * TracerConfig#DEFAULT_ANALYTICS_SAMPLE_RATE} if none specified.
+   */
+  public float getInstrumentationAnalyticsSampleRate(final String... aliases) {
+    for (final String alias : aliases) {
+      final String configKey = alias + ".analytics.sample-rate";
+      final Float rate = configProvider.getFloat("trace." + configKey, configKey);
+      if (null != rate) {
+        return rate;
+      }
+    }
+    return DEFAULT_ANALYTICS_SAMPLE_RATE;
   }
 
   public boolean isTraceAgentV05Enabled() {

--- a/internal-api/src/main/java/datadog/trace/api/config/TracerFeatureConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/config/TracerFeatureConfig.java
@@ -1,0 +1,671 @@
+package datadog.trace.api.config;
+
+import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_HOST;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_TIMEOUT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_PORT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_X_DATADOG_TAGS_MAX_LENGTH;
+import static datadog.trace.api.IdGenerationStrategy.RANDOM;
+import static datadog.trace.api.config.AppSecConfig.APPSEC_IP_ADDR_HEADER;
+import static datadog.trace.api.config.TracerConfig.AGENT_HOST;
+import static datadog.trace.api.config.TracerConfig.AGENT_NAMED_PIPE;
+import static datadog.trace.api.config.TracerConfig.AGENT_PORT_LEGACY;
+import static datadog.trace.api.config.TracerConfig.AGENT_TIMEOUT;
+import static datadog.trace.api.config.TracerConfig.AGENT_UNIX_DOMAIN_SOCKET;
+import static datadog.trace.api.config.TracerConfig.CLIENT_IP_ENABLED;
+import static datadog.trace.api.config.TracerConfig.CLOCK_SYNC_PERIOD;
+import static datadog.trace.api.config.TracerConfig.DEFAULT_AGENT_WRITER_TYPE;
+import static datadog.trace.api.config.TracerConfig.DEFAULT_CLIENT_IP_ENABLED;
+import static datadog.trace.api.config.TracerConfig.DEFAULT_CLOCK_SYNC_PERIOD;
+import static datadog.trace.api.config.TracerConfig.DEFAULT_HTTP_CLIENT_ERROR_STATUSES;
+import static datadog.trace.api.config.TracerConfig.DEFAULT_HTTP_SERVER_ERROR_STATUSES;
+import static datadog.trace.api.config.TracerConfig.DEFAULT_PARTIAL_FLUSH_MIN_SPANS;
+import static datadog.trace.api.config.TracerConfig.DEFAULT_PRIORITY_SAMPLING_ENABLED;
+import static datadog.trace.api.config.TracerConfig.DEFAULT_PRIORITY_SAMPLING_FORCE;
+import static datadog.trace.api.config.TracerConfig.DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED;
+import static datadog.trace.api.config.TracerConfig.DEFAULT_PROPAGATION_STYLE_EXTRACT;
+import static datadog.trace.api.config.TracerConfig.DEFAULT_PROPAGATION_STYLE_INJECT;
+import static datadog.trace.api.config.TracerConfig.DEFAULT_SCOPE_DEPTH_LIMIT;
+import static datadog.trace.api.config.TracerConfig.DEFAULT_SCOPE_ITERATION_KEEP_ALIVE;
+import static datadog.trace.api.config.TracerConfig.DEFAULT_TRACE_AGENT_V05_ENABLED;
+import static datadog.trace.api.config.TracerConfig.DEFAULT_TRACE_ANALYTICS_ENABLED;
+import static datadog.trace.api.config.TracerConfig.DEFAULT_TRACE_RATE_LIMIT;
+import static datadog.trace.api.config.TracerConfig.DEFAULT_TRACE_RESOLVER_ENABLED;
+import static datadog.trace.api.config.TracerConfig.ENABLE_TRACE_AGENT_V05;
+import static datadog.trace.api.config.TracerConfig.HEADER_TAGS;
+import static datadog.trace.api.config.TracerConfig.HTTP_CLIENT_ERROR_STATUSES;
+import static datadog.trace.api.config.TracerConfig.HTTP_SERVER_ERROR_STATUSES;
+import static datadog.trace.api.config.TracerConfig.ID_GENERATION_STRATEGY;
+import static datadog.trace.api.config.TracerConfig.PARTIAL_FLUSH_MIN_SPANS;
+import static datadog.trace.api.config.TracerConfig.PRIORITY_SAMPLING;
+import static datadog.trace.api.config.TracerConfig.PRIORITY_SAMPLING_FORCE;
+import static datadog.trace.api.config.TracerConfig.PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED;
+import static datadog.trace.api.config.TracerConfig.PROPAGATION_STYLE_EXTRACT;
+import static datadog.trace.api.config.TracerConfig.PROPAGATION_STYLE_INJECT;
+import static datadog.trace.api.config.TracerConfig.PROXY_NO_PROXY;
+import static datadog.trace.api.config.TracerConfig.REQUEST_HEADER_TAGS;
+import static datadog.trace.api.config.TracerConfig.RESPONSE_HEADER_TAGS;
+import static datadog.trace.api.config.TracerConfig.SCOPE_DEPTH_LIMIT;
+import static datadog.trace.api.config.TracerConfig.SCOPE_INHERIT_ASYNC_PROPAGATION;
+import static datadog.trace.api.config.TracerConfig.SCOPE_ITERATION_KEEP_ALIVE;
+import static datadog.trace.api.config.TracerConfig.SCOPE_STRICT_MODE;
+import static datadog.trace.api.config.TracerConfig.SERVICE_MAPPING;
+import static datadog.trace.api.config.TracerConfig.SPLIT_BY_TAGS;
+import static datadog.trace.api.config.TracerConfig.TRACE_AGENT_ARGS;
+import static datadog.trace.api.config.TracerConfig.TRACE_AGENT_PATH;
+import static datadog.trace.api.config.TracerConfig.TRACE_AGENT_PORT;
+import static datadog.trace.api.config.TracerConfig.TRACE_AGENT_URL;
+import static datadog.trace.api.config.TracerConfig.TRACE_ANALYTICS_ENABLED;
+import static datadog.trace.api.config.TracerConfig.TRACE_CLIENT_IP_HEADER;
+import static datadog.trace.api.config.TracerConfig.TRACE_CLIENT_IP_RESOLVER_ENABLED;
+import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING;
+import static datadog.trace.api.config.TracerConfig.TRACE_RATE_LIMIT;
+import static datadog.trace.api.config.TracerConfig.TRACE_RESOLVER_ENABLED;
+import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLE_RATE;
+import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLING_OPERATION_RULES;
+import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLING_RULES;
+import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLING_SERVICE_RULES;
+import static datadog.trace.api.config.TracerConfig.TRACE_STRICT_WRITES_ENABLED;
+import static datadog.trace.api.config.TracerConfig.TRACE_X_DATADOG_TAGS_MAX_LENGTH;
+import static datadog.trace.api.config.TracerConfig.WRITER_TYPE;
+import static datadog.trace.util.CollectionUtils.tryMakeImmutableSet;
+
+import datadog.trace.api.IdGenerationStrategy;
+import datadog.trace.api.PropagationStyle;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * System properties are {@link TracerFeatureConfig#PREFIX}'ed. Environment variables are the same
+ * as the system property, but uppercased and '.' is replaced with '_'.
+ */
+public class TracerFeatureConfig extends AbstractFeatureConfig {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TracerFeatureConfig.class);
+  private static final String PREFIX = "dd.";
+
+  private final IdGenerationStrategy idGenerationStrategy;
+  private final String writerType;
+  private final AgentConfig agentConfig;
+  private final Set<String> noProxyHosts;
+  private final String traceAgentPath;
+  private final List<String> traceAgentArgs;
+
+  private final boolean prioritySamplingEnabled;
+  private final String prioritySamplingForce;
+
+  private final boolean traceResolverEnabled;
+  private final Map<String, String> serviceMapping;
+  private final boolean traceAnalyticsEnabled;
+  private final String traceClientIpHeader;
+  private final boolean traceClientIpResolverEnabled;
+  private final boolean clientIpEnabled;
+  private final Map<String, String> traceSamplingServiceRules;
+  private final Map<String, String> traceSamplingOperationRules;
+  private final String traceSamplingRules;
+  private final Double traceSampleRate;
+  private final int traceRateLimit;
+  private final Map<String, String> requestHeaderTags;
+  private final Map<String, String> responseHeaderTags;
+  private final BitSet httpServerErrorStatuses;
+  private final BitSet httpClientErrorStatuses;
+  private final Map<String, String> httpServerPathResourceNameMapping;
+  private final Set<String> splitByTags;
+  private final int scopeDepthLimit;
+  private final boolean scopeStrictMode;
+  private final boolean scopeInheritAsyncPropagation;
+  private final int scopeIterationKeepAlive;
+  private final int partialFlushMinSpans;
+  private final boolean traceStrictWritesEnabled;
+  private final boolean logExtractHeaderNames;
+  private final Set<PropagationStyle> propagationStylesToExtract;
+  private final Set<PropagationStyle> propagationStylesToInject;
+  private final boolean traceAgentV05Enabled;
+  private final int clockSyncPeriod;
+  private final int xDatadogTagsMaxLength;
+
+  public TracerFeatureConfig(ConfigProvider configProvider) {
+    super(configProvider);
+    this.idGenerationStrategy =
+        configProvider.getEnum(ID_GENERATION_STRATEGY, IdGenerationStrategy.class, RANDOM);
+    if (idGenerationStrategy != RANDOM) {
+      LOGGER.warn(
+          "*** you are using an unsupported id generation strategy {} - this can impact correctness of traces",
+          idGenerationStrategy);
+    }
+    this.writerType = configProvider.getString(WRITER_TYPE, DEFAULT_AGENT_WRITER_TYPE);
+    this.agentConfig = new AgentConfig(configProvider);
+
+    // DD_PROXY_NO_PROXY is specified as a space-separated list of hosts
+    this.noProxyHosts = tryMakeImmutableSet(configProvider.getSpacedList(PROXY_NO_PROXY));
+
+    this.traceAgentPath = configProvider.getString(TRACE_AGENT_PATH);
+    String traceAgentArgsString = configProvider.getString(TRACE_AGENT_ARGS);
+    if (traceAgentArgsString == null) {
+      this.traceAgentArgs = Collections.emptyList();
+    } else {
+      this.traceAgentArgs =
+          Collections.unmodifiableList(
+              new ArrayList<>(parseStringIntoSetOfNonEmptyStrings(traceAgentArgsString)));
+    }
+
+    this.prioritySamplingEnabled =
+        configProvider.getBoolean(PRIORITY_SAMPLING, DEFAULT_PRIORITY_SAMPLING_ENABLED);
+    this.prioritySamplingForce =
+        configProvider.getString(PRIORITY_SAMPLING_FORCE, DEFAULT_PRIORITY_SAMPLING_FORCE);
+
+    this.traceResolverEnabled =
+        configProvider.getBoolean(TRACE_RESOLVER_ENABLED, DEFAULT_TRACE_RESOLVER_ENABLED);
+    this.serviceMapping = configProvider.getMergedMap(SERVICE_MAPPING);
+
+    this.traceAnalyticsEnabled =
+        configProvider.getBoolean(TRACE_ANALYTICS_ENABLED, DEFAULT_TRACE_ANALYTICS_ENABLED);
+    String traceClientIpHeader = configProvider.getString(TRACE_CLIENT_IP_HEADER);
+    if (traceClientIpHeader == null) {
+      traceClientIpHeader = configProvider.getString(APPSEC_IP_ADDR_HEADER);
+    }
+    if (traceClientIpHeader != null) {
+      traceClientIpHeader = traceClientIpHeader.toLowerCase(Locale.ROOT);
+    }
+    this.traceClientIpHeader = traceClientIpHeader;
+    this.traceClientIpResolverEnabled =
+        configProvider.getBoolean(TRACE_CLIENT_IP_RESOLVER_ENABLED, true);
+    this.clientIpEnabled = configProvider.getBoolean(CLIENT_IP_ENABLED, DEFAULT_CLIENT_IP_ENABLED);
+
+    this.traceSamplingServiceRules = configProvider.getMergedMap(TRACE_SAMPLING_SERVICE_RULES);
+    this.traceSamplingOperationRules = configProvider.getMergedMap(TRACE_SAMPLING_OPERATION_RULES);
+    this.traceSamplingRules = configProvider.getString(TRACE_SAMPLING_RULES);
+    this.traceSampleRate = configProvider.getDouble(TRACE_SAMPLE_RATE);
+    this.traceRateLimit = configProvider.getInteger(TRACE_RATE_LIMIT, DEFAULT_TRACE_RATE_LIMIT);
+    if (isEnabled(false, HEADER_TAGS, ".legacy.parsing.enabled")) {
+      this.requestHeaderTags = configProvider.getMergedMap(HEADER_TAGS);
+      this.responseHeaderTags = Collections.emptyMap();
+      if (configProvider.isSet(REQUEST_HEADER_TAGS)) {
+        logIgnoredSettingWarning(REQUEST_HEADER_TAGS, HEADER_TAGS, ".legacy.parsing.enabled");
+      }
+      if (configProvider.isSet(RESPONSE_HEADER_TAGS)) {
+        logIgnoredSettingWarning(RESPONSE_HEADER_TAGS, HEADER_TAGS, ".legacy.parsing.enabled");
+      }
+    } else {
+      this.requestHeaderTags =
+          configProvider.getMergedMapWithOptionalMappings(
+              "http.request.headers.", true, HEADER_TAGS, REQUEST_HEADER_TAGS);
+      this.responseHeaderTags =
+          configProvider.getMergedMapWithOptionalMappings(
+              "http.response.headers.", true, HEADER_TAGS, RESPONSE_HEADER_TAGS);
+    }
+    this.httpServerPathResourceNameMapping =
+        configProvider.getOrderedMap(TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING);
+    this.httpServerErrorStatuses =
+        configProvider.getIntegerRange(
+            HTTP_SERVER_ERROR_STATUSES, DEFAULT_HTTP_SERVER_ERROR_STATUSES);
+    this.httpClientErrorStatuses =
+        configProvider.getIntegerRange(
+            HTTP_CLIENT_ERROR_STATUSES, DEFAULT_HTTP_CLIENT_ERROR_STATUSES);
+    this.splitByTags = tryMakeImmutableSet(configProvider.getList(SPLIT_BY_TAGS));
+
+    this.scopeDepthLimit = configProvider.getInteger(SCOPE_DEPTH_LIMIT, DEFAULT_SCOPE_DEPTH_LIMIT);
+    this.scopeStrictMode = configProvider.getBoolean(SCOPE_STRICT_MODE, false);
+    this.scopeInheritAsyncPropagation =
+        configProvider.getBoolean(SCOPE_INHERIT_ASYNC_PROPAGATION, true);
+    this.scopeIterationKeepAlive =
+        configProvider.getInteger(SCOPE_ITERATION_KEEP_ALIVE, DEFAULT_SCOPE_ITERATION_KEEP_ALIVE);
+
+    this.partialFlushMinSpans =
+        configProvider.getInteger(PARTIAL_FLUSH_MIN_SPANS, DEFAULT_PARTIAL_FLUSH_MIN_SPANS);
+    this.traceStrictWritesEnabled = configProvider.getBoolean(TRACE_STRICT_WRITES_ENABLED, false);
+
+    this.logExtractHeaderNames =
+        configProvider.getBoolean(
+            PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED,
+            DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED);
+    this.propagationStylesToExtract =
+        getPropagationStyleSetSettingFromEnvironmentOrDefault(
+            PROPAGATION_STYLE_EXTRACT, DEFAULT_PROPAGATION_STYLE_EXTRACT);
+    this.propagationStylesToInject =
+        getPropagationStyleSetSettingFromEnvironmentOrDefault(
+            PROPAGATION_STYLE_INJECT, DEFAULT_PROPAGATION_STYLE_INJECT);
+    this.traceAgentV05Enabled =
+        configProvider.getBoolean(ENABLE_TRACE_AGENT_V05, DEFAULT_TRACE_AGENT_V05_ENABLED);
+    this.clockSyncPeriod = configProvider.getInteger(CLOCK_SYNC_PERIOD, DEFAULT_CLOCK_SYNC_PERIOD);
+    this.xDatadogTagsMaxLength =
+        configProvider.getInteger(
+            TRACE_X_DATADOG_TAGS_MAX_LENGTH, DEFAULT_TRACE_X_DATADOG_TAGS_MAX_LENGTH);
+  }
+
+  /**
+   * Converts the property name, e.g. 'service.name' into a public system property name, e.g.
+   * `dd.service.name`.
+   *
+   * @param setting The setting name, e.g. `service.name`
+   * @return The public facing system property name
+   */
+  @Nonnull
+  private static String propertyNameToSystemPropertyName(final String setting) {
+    return PREFIX + setting;
+  }
+
+  @Nonnull
+  private static Set<PropagationStyle> convertStringSetToPropagationStyleSet(
+      final Set<String> input) {
+    // Using LinkedHashSet to preserve original string order
+    final Set<PropagationStyle> result = new LinkedHashSet<>();
+    for (final String value : input) {
+      try {
+        result.add(PropagationStyle.valueOf(value.toUpperCase()));
+      } catch (final IllegalArgumentException e) {
+        LOGGER.debug("Cannot recognize config string value: {}, {}", value, PropagationStyle.class);
+      }
+    }
+    return Collections.unmodifiableSet(result);
+  }
+
+  private void logIgnoredSettingWarning(
+      String setting, String overridingSetting, String overridingSuffix) {
+    LOGGER.warn(
+        "Setting {} ignored since {}{} is enabled.",
+        propertyNameToSystemPropertyName(setting),
+        propertyNameToSystemPropertyName(overridingSetting),
+        overridingSuffix);
+  }
+
+  /**
+   * Calls configProvider.getString(String, String) and converts the result to a set of strings
+   * splitting by space or comma.
+   */
+  private Set<PropagationStyle> getPropagationStyleSetSettingFromEnvironmentOrDefault(
+      final String name, final String defaultValue) {
+    final String value = configProvider.getString(name, defaultValue);
+    Set<PropagationStyle> result =
+        convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(value));
+    if (result.isEmpty()) {
+      // Treat empty parsing result as no value and use default instead
+      result =
+          convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(defaultValue));
+    }
+    return result;
+  }
+
+  public IdGenerationStrategy getIdGenerationStrategy() {
+    return this.idGenerationStrategy;
+  }
+
+  public String getWriterType() {
+    return this.writerType;
+  }
+
+  public boolean isAgentConfiguredUsingDefault() {
+    return this.agentConfig.configuredUsingDefault;
+  }
+
+  public String getAgentUrl() {
+    return this.agentConfig.url;
+  }
+
+  public String getAgentHost() {
+    return this.agentConfig.host;
+  }
+
+  public int getAgentPort() {
+    return this.agentConfig.port;
+  }
+
+  public String getAgentUnixDomainSocket() {
+    return this.agentConfig.unixDomainSocket;
+  }
+
+  public String getAgentNamedPipe() {
+    return this.agentConfig.namedPipe;
+  }
+
+  /**
+   * Get the agent timeout.
+   *
+   * @return The agent timeout (in seconds).
+   */
+  public int getAgentTimeout() {
+    return this.agentConfig.timeout;
+  }
+
+  public Set<String> getNoProxyHosts() {
+    return this.noProxyHosts;
+  }
+
+  public String getTraceAgentPath() {
+    return this.traceAgentPath;
+  }
+
+  public List<String> getTraceAgentArgs() {
+    return this.traceAgentArgs;
+  }
+
+  public boolean isPrioritySamplingEnabled() {
+    return this.prioritySamplingEnabled;
+  }
+
+  public String getPrioritySamplingForce() {
+    return this.prioritySamplingForce;
+  }
+
+  public boolean isTraceResolverEnabled() {
+    return this.traceResolverEnabled;
+  }
+
+  public Map<String, String> getServiceMapping() {
+    return this.serviceMapping;
+  }
+
+  public boolean isTraceAnalyticsEnabled() {
+    return this.traceAnalyticsEnabled;
+  }
+
+  public String getTraceClientIpHeader() {
+    return this.traceClientIpHeader;
+  }
+
+  public boolean isTraceClientIpResolverEnabled() {
+    return this.traceClientIpResolverEnabled;
+  }
+
+  public boolean isClientIpEnabled() {
+    return this.clientIpEnabled;
+  }
+
+  public Map<String, String> getTraceSamplingServiceRules() {
+    return this.traceSamplingServiceRules;
+  }
+
+  public Map<String, String> getTraceSamplingOperationRules() {
+    return this.traceSamplingOperationRules;
+  }
+
+  public String getTraceSamplingRules() {
+    return this.traceSamplingRules;
+  }
+
+  public Double getTraceSampleRate() {
+    return this.traceSampleRate;
+  }
+
+  public int getTraceRateLimit() {
+    return this.traceRateLimit;
+  }
+
+  public Map<String, String> getRequestHeaderTags() {
+    return this.requestHeaderTags;
+  }
+
+  public Map<String, String> getResponseHeaderTags() {
+    return this.responseHeaderTags;
+  }
+
+  public Map<String, String> getHttpServerPathResourceNameMapping() {
+    return this.httpServerPathResourceNameMapping;
+  }
+
+  public BitSet getHttpServerErrorStatuses() {
+    return this.httpServerErrorStatuses;
+  }
+
+  public BitSet getHttpClientErrorStatuses() {
+    return this.httpClientErrorStatuses;
+  }
+
+  public Set<String> getSplitByTags() {
+    return this.splitByTags;
+  }
+
+  public int getScopeDepthLimit() {
+    return this.scopeDepthLimit;
+  }
+
+  public boolean isScopeStrictMode() {
+    return this.scopeStrictMode;
+  }
+
+  public boolean isScopeInheritAsyncPropagation() {
+    return this.scopeInheritAsyncPropagation;
+  }
+
+  public int getScopeIterationKeepAlive() {
+    return this.scopeIterationKeepAlive;
+  }
+
+  public int getPartialFlushMinSpans() {
+    return this.partialFlushMinSpans;
+  }
+
+  public boolean isTraceStrictWritesEnabled() {
+    return this.traceStrictWritesEnabled;
+  }
+
+  public boolean isLogExtractHeaderNames() {
+    return this.logExtractHeaderNames;
+  }
+
+  public Set<PropagationStyle> getPropagationStylesToExtract() {
+    return this.propagationStylesToExtract;
+  }
+
+  public Set<PropagationStyle> getPropagationStylesToInject() {
+    return this.propagationStylesToInject;
+  }
+
+  public boolean isSamplingMechanismValidationDisabled() {
+    return this.configProvider.getBoolean(
+        TracerConfig.SAMPLING_MECHANISM_VALIDATION_DISABLED, false);
+  }
+
+  public boolean isTraceAgentV05Enabled() {
+    return this.traceAgentV05Enabled;
+  }
+
+  public int getClockSyncPeriod() {
+    return this.clockSyncPeriod;
+  }
+
+  public int getxDatadogTagsMaxLength() {
+    return this.xDatadogTagsMaxLength;
+  }
+
+  private static class AgentConfig {
+    private final boolean configuredUsingDefault;
+    private final String url;
+    private final String host;
+    private final int port;
+    private final String unixDomainSocket;
+    private final String namedPipe;
+    /** The agent timeout (in seconds). */
+    private final int timeout;
+
+    private AgentConfig(ConfigProvider configProvider) {
+      String agentHostFromEnvironment = null;
+      int agentPortFromEnvironment = -1;
+      String unixSocketFromEnvironment = null;
+      boolean rebuildAgentUrl = false;
+
+      final String agentUrlFromEnvironment = configProvider.getString(TRACE_AGENT_URL);
+      if (agentUrlFromEnvironment != null) {
+        try {
+          final URI parsedAgentUrl = new URI(agentUrlFromEnvironment);
+          agentHostFromEnvironment = parsedAgentUrl.getHost();
+          agentPortFromEnvironment = parsedAgentUrl.getPort();
+          if ("unix".equals(parsedAgentUrl.getScheme())) {
+            unixSocketFromEnvironment = parsedAgentUrl.getPath();
+          }
+        } catch (URISyntaxException e) {
+          LOGGER.warn("{} not configured correctly: {}. Ignoring", TRACE_AGENT_URL, e.getMessage());
+        }
+      }
+
+      if (agentHostFromEnvironment == null) {
+        agentHostFromEnvironment = configProvider.getString(AGENT_HOST);
+        rebuildAgentUrl = true;
+      }
+
+      if (agentPortFromEnvironment < 0) {
+        agentPortFromEnvironment =
+            configProvider.getInteger(TRACE_AGENT_PORT, -1, AGENT_PORT_LEGACY);
+        rebuildAgentUrl = true;
+      }
+
+      if (agentHostFromEnvironment == null) {
+        this.host = DEFAULT_AGENT_HOST;
+      } else {
+        this.host = agentHostFromEnvironment;
+      }
+
+      if (agentPortFromEnvironment < 0) {
+        this.port = DEFAULT_TRACE_AGENT_PORT;
+      } else {
+        this.port = agentPortFromEnvironment;
+      }
+
+      if (rebuildAgentUrl) {
+        this.url = "http://" + this.host + ":" + this.port;
+      } else {
+        this.url = agentUrlFromEnvironment;
+      }
+
+      if (unixSocketFromEnvironment == null) {
+        unixSocketFromEnvironment = configProvider.getString(AGENT_UNIX_DOMAIN_SOCKET);
+        String unixPrefix = "unix://";
+        // handle situation where someone passes us a unix:// URL instead of a socket path
+        if (unixSocketFromEnvironment != null && unixSocketFromEnvironment.startsWith(unixPrefix)) {
+          unixSocketFromEnvironment = unixSocketFromEnvironment.substring(unixPrefix.length());
+        }
+      }
+
+      this.unixDomainSocket = unixSocketFromEnvironment;
+
+      this.namedPipe = configProvider.getString(AGENT_NAMED_PIPE);
+
+      this.configuredUsingDefault =
+          agentHostFromEnvironment == null
+              && agentPortFromEnvironment < 0
+              && unixSocketFromEnvironment == null
+              && this.namedPipe == null;
+
+      this.timeout = configProvider.getInteger(AGENT_TIMEOUT, DEFAULT_AGENT_TIMEOUT);
+    }
+
+    @Override
+    public String toString() {
+      return "AgentConfig{"
+          + "configuredUsingDefault="
+          + this.configuredUsingDefault
+          + ", url='"
+          + this.url
+          + '\''
+          + ", host='"
+          + this.host
+          + '\''
+          + ", port="
+          + this.port
+          + ", unixDomainSocket='"
+          + this.unixDomainSocket
+          + '\''
+          + ", namedPipe='"
+          + this.namedPipe
+          + '\''
+          + ", timeout="
+          + this.timeout
+          + '}';
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "TracerFeatureConfig{"
+        + "idGenerationStrategy="
+        + this.idGenerationStrategy
+        + ", writerType='"
+        + this.writerType
+        + '\''
+        + ", agentConfig="
+        + this.agentConfig
+        + ", noProxyHosts="
+        + this.noProxyHosts
+        + ", traceAgentPath='"
+        + this.traceAgentPath
+        + '\''
+        + ", traceAgentArgs="
+        + this.traceAgentArgs
+        + ", prioritySamplingEnabled="
+        + this.prioritySamplingEnabled
+        + ", prioritySamplingForce='"
+        + this.prioritySamplingForce
+        + '\''
+        + ", traceResolverEnabled="
+        + this.traceResolverEnabled
+        + ", serviceMapping="
+        + this.serviceMapping
+        + ", traceAnalyticsEnabled="
+        + this.traceAnalyticsEnabled
+        + ", traceClientIpHeader='"
+        + this.traceClientIpHeader
+        + '\''
+        + ", traceClientIpResolverEnabled="
+        + this.traceClientIpResolverEnabled
+        + ", clientIpEnabled="
+        + this.clientIpEnabled
+        + ", traceSamplingServiceRules="
+        + this.traceSamplingServiceRules
+        + ", traceSamplingOperationRules="
+        + this.traceSamplingOperationRules
+        + ", traceSamplingRules='"
+        + this.traceSamplingRules
+        + '\''
+        + ", traceSampleRate="
+        + this.traceSampleRate
+        + ", traceRateLimit="
+        + this.traceRateLimit
+        + ", requestHeaderTags="
+        + this.requestHeaderTags
+        + ", responseHeaderTags="
+        + this.responseHeaderTags
+        + ", httpServerErrorStatuses="
+        + this.httpServerErrorStatuses
+        + ", httpClientErrorStatuses="
+        + this.httpClientErrorStatuses
+        + ", httpServerPathResourceNameMapping="
+        + this.httpServerPathResourceNameMapping
+        + ", splitByTags="
+        + this.splitByTags
+        + ", scopeDepthLimit="
+        + this.scopeDepthLimit
+        + ", scopeStrictMode="
+        + this.scopeStrictMode
+        + ", scopeInheritAsyncPropagation="
+        + this.scopeInheritAsyncPropagation
+        + ", scopeIterationKeepAlive="
+        + this.scopeIterationKeepAlive
+        + ", partialFlushMinSpans="
+        + this.partialFlushMinSpans
+        + ", traceStrictWritesEnabled="
+        + this.traceStrictWritesEnabled
+        + ", logExtractHeaderNames="
+        + this.logExtractHeaderNames
+        + ", propagationStylesToExtract="
+        + this.propagationStylesToExtract
+        + ", propagationStylesToInject="
+        + this.propagationStylesToInject
+        + ", traceAgentV05Enabled="
+        + this.traceAgentV05Enabled
+        + ", clockSyncPeriod="
+        + this.clockSyncPeriod
+        + ", xDatadogTagsMaxLength="
+        + this.xDatadogTagsMaxLength
+        + '}';
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -1,5 +1,6 @@
 package datadog.trace.api
 
+import datadog.trace.api.config.TracerConfig
 import datadog.trace.api.env.FixedCapturedEnvironment
 import datadog.trace.bootstrap.config.provider.ConfigConverter
 import datadog.trace.bootstrap.config.provider.ConfigProvider
@@ -7,8 +8,6 @@ import datadog.trace.test.util.DDSpecification
 import org.junit.Rule
 import spock.lang.Unroll
 
-import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_CLIENT_ERROR_STATUSES
-import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_ERROR_STATUSES
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME
 import static datadog.trace.api.DDTags.HOST_TAG
 import static datadog.trace.api.DDTags.LANGUAGE_TAG_KEY
@@ -273,7 +272,7 @@ class ConfigTest extends DDSpecification {
     config.traceRateLimit == 200
 
     config.profilingEnabled == true
-    config.profilingUrl == "new url"
+    config.finalProfilingUrl == "new url"
     config.mergedProfilingTags == [b: "2", f: "6", (HOST_TAG): "test-host", (RUNTIME_ID_TAG): config.getRuntimeId(),  (RUNTIME_VERSION_TAG): config.getRuntimeVersion(), (SERVICE_TAG): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
     config.profilingStartDelay == 1111
     config.profilingStartForceFirst == true
@@ -441,7 +440,7 @@ class ConfigTest extends DDSpecification {
     config.traceRateLimit == 200
 
     config.profilingEnabled == true
-    config.profilingUrl == "new url"
+    config.finalProfilingUrl == "new url"
     config.mergedProfilingTags == [b: "2", f: "6", (HOST_TAG): "test-host", (RUNTIME_ID_TAG): config.getRuntimeId(), (RUNTIME_VERSION_TAG): config.getRuntimeVersion(), (SERVICE_TAG): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
     config.profilingStartDelay == 1111
     config.profilingStartForceFirst == true
@@ -1012,11 +1011,11 @@ class ConfigTest extends DDSpecification {
 
     then:
     config.serviceMapping == map
-    config.spanTags == map
+    config.mergedSpanTags == map
     config.requestHeaderTags == map
     config.responseHeaderTags == [:]
     propConfig.serviceMapping == map
-    propConfig.spanTags == map
+    propConfig.mergedSpanTags == map
     propConfig.requestHeaderTags == map
     propConfig.responseHeaderTags == [:]
 
@@ -1143,10 +1142,10 @@ class ConfigTest extends DDSpecification {
       assert propConfig.httpServerErrorStatuses == toBitSet(expected)
       assert propConfig.httpClientErrorStatuses == toBitSet(expected)
     } else {
-      assert config.httpServerErrorStatuses == DEFAULT_HTTP_SERVER_ERROR_STATUSES
-      assert config.httpClientErrorStatuses == DEFAULT_HTTP_CLIENT_ERROR_STATUSES
-      assert propConfig.httpServerErrorStatuses == DEFAULT_HTTP_SERVER_ERROR_STATUSES
-      assert propConfig.httpClientErrorStatuses == DEFAULT_HTTP_CLIENT_ERROR_STATUSES
+      assert config.httpServerErrorStatuses == TracerConfig.DEFAULT_HTTP_SERVER_ERROR_STATUSES
+      assert config.httpClientErrorStatuses == TracerConfig.DEFAULT_HTTP_CLIENT_ERROR_STATUSES
+      assert propConfig.httpServerErrorStatuses == TracerConfig.DEFAULT_HTTP_SERVER_ERROR_STATUSES
+      assert propConfig.httpClientErrorStatuses == TracerConfig.DEFAULT_HTTP_CLIENT_ERROR_STATUSES
     }
 
     where:
@@ -1176,7 +1175,7 @@ class ConfigTest extends DDSpecification {
 
     then:
     config.serviceMapping == map
-    config.spanTags == map
+    config.mergedSpanTags == map
     config.requestHeaderTags == map
 
     where:

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -90,8 +90,6 @@ import static datadog.trace.api.config.TracerConfig.PRIORITIZATION_TYPE
 import static datadog.trace.api.config.TracerConfig.PRIORITY_SAMPLING
 import static datadog.trace.api.config.TracerConfig.PROPAGATION_STYLE_EXTRACT
 import static datadog.trace.api.config.TracerConfig.PROPAGATION_STYLE_INJECT
-import static datadog.trace.api.config.TracerConfig.REQUEST_HEADER_TAGS
-import static datadog.trace.api.config.TracerConfig.RESPONSE_HEADER_TAGS
 import static datadog.trace.api.config.TracerConfig.SERVICE_MAPPING
 import static datadog.trace.api.config.TracerConfig.SPAN_TAGS
 import static datadog.trace.api.config.TracerConfig.SPLIT_BY_TAGS

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -1,12 +1,10 @@
 package datadog.trace.api
 
-import datadog.trace.api.config.TracerConfig
 import datadog.trace.api.env.FixedCapturedEnvironment
 import datadog.trace.bootstrap.config.provider.ConfigConverter
 import datadog.trace.bootstrap.config.provider.ConfigProvider
 import datadog.trace.test.util.DDSpecification
 import org.junit.Rule
-import spock.lang.Unroll
 
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME
 import static datadog.trace.api.DDTags.HOST_TAG
@@ -110,7 +108,7 @@ import static datadog.trace.api.config.TracerConfig.TRACE_X_DATADOG_TAGS_MAX_LEN
 
 class ConfigTest extends DDSpecification {
 
-  static final String PREFIX = "dd."
+  public static final String PREFIX = "dd."
 
   @Rule
   public final FixedCapturedEnvironment fixedCapturedEnvironment = new FixedCapturedEnvironment()
@@ -120,7 +118,6 @@ class ConfigTest extends DDSpecification {
   private static final DD_TRACE_ENABLED_ENV = "DD_TRACE_ENABLED"
   private static final DD_WRITER_TYPE_ENV = "DD_WRITER_TYPE"
   private static final DD_PRIORITIZATION_TYPE_ENV = "DD_PRIORITIZATION_TYPE"
-  private static final DD_SERVICE_MAPPING_ENV = "DD_SERVICE_MAPPING"
   private static final DD_TAGS_ENV = "DD_TAGS"
   private static final DD_ENV_ENV = "DD_ENV"
   private static final DD_VERSION_ENV = "DD_VERSION"
@@ -778,155 +775,6 @@ class ConfigTest extends DDSpecification {
     config.serviceName == "what actually wants"
   }
 
-  def "verify integration config"() {
-    setup:
-    environmentVariables.set("DD_INTEGRATION_ORDER_ENABLED", "false")
-    environmentVariables.set("DD_INTEGRATION_TEST_ENV_ENABLED", "true")
-    environmentVariables.set("DD_INTEGRATION_DISABLED_ENV_ENABLED", "false")
-
-    System.setProperty("dd.integration.order.enabled", "true")
-    System.setProperty("dd.integration.test-prop.enabled", "true")
-    System.setProperty("dd.integration.disabled-prop.enabled", "false")
-
-    expect:
-    Config.get().isIntegrationEnabled(integrationNames, defaultEnabled) == expected
-
-    where:
-    // spotless:off
-    names                          | defaultEnabled | expected
-    []                             | true           | true
-    []                             | false          | false
-    ["invalid"]                    | true           | true
-    ["invalid"]                    | false          | false
-    ["test-prop"]                  | false          | true
-    ["test-env"]                   | false          | true
-    ["disabled-prop"]              | true           | false
-    ["disabled-env"]               | true           | false
-    ["other", "test-prop"]         | false          | true
-    ["other", "test-env"]          | false          | true
-    ["order"]                      | false          | true
-    ["test-prop", "disabled-prop"] | false          | true
-    ["disabled-env", "test-env"]   | false          | true
-    ["test-prop", "disabled-prop"] | true           | false
-    ["disabled-env", "test-env"]   | true           | false
-    // spotless:on
-
-    integrationNames = new TreeSet<>(names)
-  }
-
-  def "verify rule config #name"() {
-    setup:
-    environmentVariables.set("DD_TRACE_TEST_ENABLED", "true")
-    environmentVariables.set("DD_TRACE_TEST_ENV_ENABLED", "true")
-    environmentVariables.set("DD_TRACE_DISABLED_ENV_ENABLED", "false")
-
-    System.setProperty("dd.trace.test.enabled", "false")
-    System.setProperty("dd.trace.test-prop.enabled", "true")
-    System.setProperty("dd.trace.disabled-prop.enabled", "false")
-
-    expect:
-    Config.get().isRuleEnabled(name) == enabled
-
-    where:
-    // spotless:off
-    name            | enabled
-    ""              | true
-    "invalid"       | true
-    "test-prop"     | true
-    "Test-Prop"     | true
-    "test-env"      | true
-    "Test-Env"      | true
-    "test"          | false
-    "TEST"          | false
-    "disabled-prop" | false
-    "Disabled-Prop" | false
-    "disabled-env"  | false
-    "Disabled-Env"  | false
-    // spotless:on
-  }
-
-  def "verify integration jmxfetch config"() {
-    setup:
-    environmentVariables.set("DD_JMXFETCH_ORDER_ENABLED", "false")
-    environmentVariables.set("DD_JMXFETCH_TEST_ENV_ENABLED", "true")
-    environmentVariables.set("DD_JMXFETCH_DISABLED_ENV_ENABLED", "false")
-
-    System.setProperty("dd.jmxfetch.order.enabled", "true")
-    System.setProperty("dd.jmxfetch.test-prop.enabled", "true")
-    System.setProperty("dd.jmxfetch.disabled-prop.enabled", "false")
-
-    expect:
-    Config.get().isJmxFetchIntegrationEnabled(integrationNames, defaultEnabled) == expected
-
-    where:
-    // spotless:off
-    names                          | defaultEnabled | expected
-    []                             | true           | true
-    []                             | false          | false
-    ["invalid"]                    | true           | true
-    ["invalid"]                    | false          | false
-    ["test-prop"]                  | false          | true
-    ["test-env"]                   | false          | true
-    ["disabled-prop"]              | true           | false
-    ["disabled-env"]               | true           | false
-    ["other", "test-prop"]         | false          | true
-    ["other", "test-env"]          | false          | true
-    ["order"]                      | false          | true
-    ["test-prop", "disabled-prop"] | false          | true
-    ["disabled-env", "test-env"]   | false          | true
-    ["test-prop", "disabled-prop"] | true           | false
-    ["disabled-env", "test-env"]   | true           | false
-    // spotless:on
-
-    integrationNames = new TreeSet<>(names)
-  }
-
-  def "verify integration trace analytics config"() {
-    setup:
-    environmentVariables.set("DD_ORDER_ANALYTICS_ENABLED", "false")
-    environmentVariables.set("DD_TEST_ENV_ANALYTICS_ENABLED", "true")
-    environmentVariables.set("DD_DISABLED_ENV_ANALYTICS_ENABLED", "false")
-    // trace prefix form should take precedence over the old non-prefix form
-    environmentVariables.set("DD_ALIAS_ENV_ANALYTICS_ENABLED", "false")
-    environmentVariables.set("DD_TRACE_ALIAS_ENV_ANALYTICS_ENABLED", "true")
-
-    System.setProperty("dd.order.analytics.enabled", "true")
-    System.setProperty("dd.test-prop.analytics.enabled", "true")
-    System.setProperty("dd.disabled-prop.analytics.enabled", "false")
-    // trace prefix form should take precedence over the old non-prefix form
-    System.setProperty("dd.alias-prop.analytics.enabled", "false")
-    System.setProperty("dd.trace.alias-prop.analytics.enabled", "true")
-
-    expect:
-    Config.get().isTraceAnalyticsIntegrationEnabled(integrationNames, defaultEnabled) == expected
-
-    where:
-    // spotless:off
-    names                           | defaultEnabled | expected
-    []                              | true           | true
-    []                              | false          | false
-    ["invalid"]                     | true           | true
-    ["invalid"]                     | false          | false
-    ["test-prop"]                   | false          | true
-    ["test-env"]                    | false          | true
-    ["disabled-prop"]               | true           | false
-    ["disabled-env"]                | true           | false
-    ["other", "test-prop"]          | false          | true
-    ["other", "test-env"]           | false          | true
-    ["order"]                       | false          | true
-    ["test-prop", "disabled-prop"]  | false          | true
-    ["disabled-env", "test-env"]    | false          | true
-    ["test-prop", "disabled-prop"]  | true           | false
-    ["disabled-env", "test-env"]    | true           | false
-    ["alias-prop", "disabled-prop"] | false          | true
-    ["disabled-env", "alias-env"]   | false          | true
-    ["alias-prop", "disabled-prop"] | true           | false
-    ["disabled-env", "alias-env"]   | true           | false
-    // spotless:on
-
-    integrationNames = new TreeSet<>(names)
-  }
-
   def "test getFloatSettingFromEnvironment(#name)"() {
     setup:
     environmentVariables.set("DD_ENV_ZERO_TEST", "0.0")
@@ -989,243 +837,6 @@ class ConfigTest extends DDSpecification {
     defaultValue = 10.0
   }
 
-  def "verify mapping configs on tracer for #mapString"() {
-    setup:
-    System.setProperty(PREFIX + HEADER_TAGS + ".legacy.parsing.enabled", "true")
-    System.setProperty(PREFIX + SERVICE_MAPPING, mapString)
-    System.setProperty(PREFIX + SPAN_TAGS, mapString)
-    System.setProperty(PREFIX + HEADER_TAGS, mapString)
-    System.setProperty(PREFIX + REQUEST_HEADER_TAGS, "rqh1")
-    System.setProperty(PREFIX + RESPONSE_HEADER_TAGS, "rsh1")
-    def props = new Properties()
-    props.setProperty(HEADER_TAGS + ".legacy.parsing.enabled", "true")
-    props.setProperty(SERVICE_MAPPING, mapString)
-    props.setProperty(SPAN_TAGS, mapString)
-    props.setProperty(HEADER_TAGS, mapString)
-    props.setProperty(PREFIX + REQUEST_HEADER_TAGS, "rqh1")
-    props.setProperty(PREFIX + RESPONSE_HEADER_TAGS, "rsh1")
-
-    when:
-    def config = new Config()
-    def propConfig = Config.get(props)
-
-    then:
-    config.serviceMapping == map
-    config.mergedSpanTags == map
-    config.requestHeaderTags == map
-    config.responseHeaderTags == [:]
-    propConfig.serviceMapping == map
-    propConfig.mergedSpanTags == map
-    propConfig.requestHeaderTags == map
-    propConfig.responseHeaderTags == [:]
-
-    where:
-    // spotless:off
-    mapString                                                     | map
-    "a:1, a:2, a:3"                                               | [a: "3"]
-    "a:b,c:d,e:"                                                  | [a: "b", c: "d"]
-    // space separated
-    "a:1  a:2  a:3"                                               | [a: "3"]
-    "a:b c:d e:"                                                  | [a: "b", c: "d"]
-    // More different string variants:
-    "a:"                                                          | [:]
-    "a:a;"                                                        | [a: "a;"]
-    "a:1, a:2, a:3"                                               | [a: "3"]
-    "a:1  a:2  a:3"                                               | [a: "3"]
-    "a:b,c:d,e:"                                                  | [a: "b", c: "d"]
-    "a:b c:d e:"                                                  | [a: "b", c: "d"]
-    "key 1!:va|ue_1,"                                             | ["key 1!": "va|ue_1"]
-    "key 1!:va|ue_1 "                                             | ["key 1!": "va|ue_1"]
-    " key1 :value1 ,\t key2:  value2"                             | [key1: "value1", key2: "value2"]
-    "a:b,c,d"                                                     | [:]
-    "a:b,c,d,k:v"                                                 | [:]
-    "key1 :value1  \t key2:  value2"                              | [key1: "value1", key2: "value2"]
-    "dyno:web.1 dynotype:web buildpackversion:dev appname:******" | ["dyno": "web.1", "dynotype": "web", "buildpackversion": "dev", "appname": "******"]
-    "is:val:id"                                                   | [is: "val:id"]
-    "a:b,is:val:id,x:y"                                           | [a: "b", is: "val:id", x: "y"]
-    "a:b:c:d"                                                     | [a: "b:c:d"]
-    // Invalid strings:
-    ""                                                            | [:]
-    "1"                                                           | [:]
-    "a"                                                           | [:]
-    "a,1"                                                         | [:]
-    "!a"                                                          | [:]
-    "    "                                                        | [:]
-    ",,,,"                                                        | [:]
-    ":,:,:,:,"                                                    | [:]
-    ": : : : "                                                    | [:]
-    "::::"                                                        | [:]
-    // spotless:on
-  }
-
-  def "verify mapping header tags on tracer for #mapString"() {
-    setup:
-    Map<String, String> rqMap = map.clone()
-    rqMap.put("rqh1", "http.request.headers.rqh1")
-    System.setProperty(PREFIX + HEADER_TAGS, mapString)
-    System.setProperty(PREFIX + REQUEST_HEADER_TAGS, "rqh1")
-    System.setProperty(PREFIX + RESPONSE_HEADER_TAGS, "rsh1")
-    Map<String, String> rsMap = map.collectEntries { k, v -> [k, v.replace("http.request.headers", "http.response.headers")] }
-    rsMap.put("rsh1", "http.response.headers.rsh1")
-    def props = new Properties()
-    props.setProperty(HEADER_TAGS, mapString)
-    props.setProperty(PREFIX + REQUEST_HEADER_TAGS, "rQh1")
-    props.setProperty(PREFIX + RESPONSE_HEADER_TAGS, "rsH1")
-
-    when:
-    def config = new Config()
-    def propConfig = Config.get(props)
-
-    then:
-    config.requestHeaderTags == rqMap
-    propConfig.requestHeaderTags == rqMap
-    config.responseHeaderTags == rsMap
-    propConfig.responseHeaderTags == rsMap
-
-    where:
-    // spotless:off
-    mapString                                                     | map
-    "a:one, a:two, a:three"                                       | [a: "three"]
-    "a:b,c:d,e:"                                                  | [a: "b", c: "d"]
-    // space separated
-    "a:one  a:two  a:three"                                       | [a: "three"]
-    "a:b c:d e:"                                                  | [a: "b", c: "d"]
-    // More different string variants:
-    "a:"                                                          | [:]
-    "a:a;"                                                        | [a: "a;"]
-    "a:one, a:two, a:three"                                       | [a: "three"]
-    "a:one  a:two  a:three"                                       | [a: "three"]
-    "a:b,c:d,e:"                                                  | [a: "b", c: "d"]
-    "a:b c:d e:"                                                  | [a: "b", c: "d"]
-    "key=1!:va|ue_1,"                                             | ["key=1!": "va|ue_1"]
-    "key=1!:va|ue_1 "                                             | ["key=1!": "va|ue_1"]
-    " kEy1 :vaLue1 ,\t keY2:  valUe2"                             | [key1: "vaLue1", key2: "valUe2"]
-    "a:b,c,D"                                                     | [a: "b", c: "http.request.headers.c", d: "http.request.headers.d"]
-    "a:b,C,d,k:v"                                                 | [a: "b", c: "http.request.headers.c", d: "http.request.headers.d", k: "v"]
-    "a b c:d "                                                    | [a: "http.request.headers.a", b: "http.request.headers.b", c: "d"]
-    "dyno:web.1 dynotype:web buildpackversion:dev appname:n*****" | ["dyno": "web.1", "dynotype": "web", "buildpackversion": "dev", "appname": "n*****"]
-    "A.1,B.1"                                                     | ["a.1": "http.request.headers.a_1", "b.1": "http.request.headers.b_1"]
-    "is:val:id"                                                   | [is: "val:id"]
-    "a:b,is:val:id,x:y"                                           | [a: "b", is: "val:id", x: "y"]
-    "a:b:c:d"                                                     | [a: "b:c:d"]
-    // Invalid strings:
-    ""                                                            | [:]
-    "1"                                                           | [:]
-    "a:1"                                                         | [:]
-    "a,1"                                                         | [:]
-    "!a"                                                          | [:]
-    "    "                                                        | [:]
-    ",,,,"                                                        | [:]
-    ":,:,:,:,"                                                    | [:]
-    ": : : : "                                                    | [:]
-    "::::"                                                        | [:]
-    "kEy1 :value1  \t keY2:  value2"                              | [:]
-    // spotless:on
-  }
-
-  def "verify integer range configs on tracer"() {
-    setup:
-    System.setProperty(PREFIX + HTTP_SERVER_ERROR_STATUSES, value)
-    System.setProperty(PREFIX + HTTP_CLIENT_ERROR_STATUSES, value)
-    def props = new Properties()
-    props.setProperty(HTTP_CLIENT_ERROR_STATUSES, value)
-    props.setProperty(HTTP_SERVER_ERROR_STATUSES, value)
-
-    when:
-    def config = new Config()
-    def propConfig = Config.get(props)
-
-    then:
-    if (expected) {
-      assert config.httpServerErrorStatuses == toBitSet(expected)
-      assert config.httpClientErrorStatuses == toBitSet(expected)
-      assert propConfig.httpServerErrorStatuses == toBitSet(expected)
-      assert propConfig.httpClientErrorStatuses == toBitSet(expected)
-    } else {
-      assert config.httpServerErrorStatuses == TracerConfig.DEFAULT_HTTP_SERVER_ERROR_STATUSES
-      assert config.httpClientErrorStatuses == TracerConfig.DEFAULT_HTTP_CLIENT_ERROR_STATUSES
-      assert propConfig.httpServerErrorStatuses == TracerConfig.DEFAULT_HTTP_SERVER_ERROR_STATUSES
-      assert propConfig.httpClientErrorStatuses == TracerConfig.DEFAULT_HTTP_CLIENT_ERROR_STATUSES
-    }
-
-    where:
-    value               | expected // null means default value
-    // spotless:off
-    "1"                 | null
-    "a"                 | null
-    ""                  | null
-    "1000"              | null
-    "100-200-300"       | null
-    "500"               | [500]
-    "100,999"           | [100, 999]
-    "999-888"           | 888..999
-    "400-403,405-407"   | [400, 401, 402, 403, 405, 406, 407]
-    " 400 - 403 , 405 " | [400, 401, 402, 403, 405]
-    // spotless:on
-  }
-
-  def "verify null value mapping configs on tracer"() {
-    setup:
-    environmentVariables.set(DD_SERVICE_MAPPING_ENV, mapString)
-    environmentVariables.set(DD_SPAN_TAGS_ENV, mapString)
-    environmentVariables.set(DD_HEADER_TAGS_ENV, mapString)
-
-    when:
-    def config = new Config()
-
-    then:
-    config.serviceMapping == map
-    config.mergedSpanTags == map
-    config.requestHeaderTags == map
-
-    where:
-    mapString | map
-    // spotless:off
-    null      | [:]
-    ""        | [:]
-    // spotless:on
-  }
-
-  def "verify empty value list configs on tracer"() {
-    setup:
-    System.setProperty(PREFIX + JMX_FETCH_METRICS_CONFIGS, listString)
-
-    when:
-    def config = new Config()
-
-    then:
-    config.jmxFetchMetricsConfigs == list
-
-    where:
-    // spotless:off
-    listString | list
-    ""         | []
-    // spotless:on
-  }
-
-  def "verify hostname not added to root span tags by default"() {
-    setup:
-    Properties properties = new Properties()
-
-    when:
-    def config = Config.get(properties)
-
-    then:
-    !config.localRootSpanTags.containsKey('_dd.hostname')
-  }
-
-  def "verify configuration to add hostname to root span tags"() {
-    setup:
-    Properties properties = new Properties()
-    properties.setProperty(TRACE_REPORT_HOSTNAME, 'true')
-
-    when:
-    def config = Config.get(properties)
-
-    then:
-    config.localRootSpanTags.containsKey('_dd.hostname')
-  }
-
   def "verify fallback to properties file"() {
     setup:
     System.setProperty(PREFIX + CONFIGURATION_FILE, "src/test/resources/dd-java-tracer.properties")
@@ -1284,46 +895,6 @@ class ConfigTest extends DDSpecification {
 
     then:
     config.serviceName == 'unnamed-java-app'
-  }
-
-  def "get analytics sample rate"() {
-    setup:
-    environmentVariables.set("DD_FOO_ANALYTICS_SAMPLE_RATE", "0.5")
-    environmentVariables.set("DD_BAR_ANALYTICS_SAMPLE_RATE", "0.9")
-    // trace prefix form should take precedence over the old non-prefix form
-    environmentVariables.set("DD_ALIAS_ENV_ANALYTICS_SAMPLE_RATE", "0.8")
-    environmentVariables.set("DD_TRACE_ALIAS_ENV_ANALYTICS_SAMPLE_RATE", "0.4")
-
-    System.setProperty("dd.baz.analytics.sample-rate", "0.7")
-    System.setProperty("dd.buzz.analytics.sample-rate", "0.3")
-    // trace prefix form should take precedence over the old non-prefix form
-    System.setProperty("dd.alias-prop.analytics.sample-rate", "0.1")
-    System.setProperty("dd.trace.alias-prop.analytics.sample-rate", "0.2")
-
-    when:
-    String[] array = services.toArray(new String[0])
-    def value = Config.get().getInstrumentationAnalyticsSampleRate(array)
-
-    then:
-    value == expected
-
-    where:
-    // spotless:off
-    services                | expected
-    ["foo"]                 | 0.5f
-    ["baz"]                 | 0.7f
-    ["doesnotexist"]        | 1.0f
-    ["doesnotexist", "foo"] | 0.5f
-    ["doesnotexist", "baz"] | 0.7f
-    ["foo", "bar"]          | 0.5f
-    ["bar", "foo"]          | 0.9f
-    ["baz", "buzz"]         | 0.7f
-    ["buzz", "baz"]         | 0.3f
-    ["foo", "baz"]          | 0.5f
-    ["baz", "foo"]          | 0.7f
-    ["alias-env", "baz"]    | 0.4f
-    ["alias-prop", "foo"]   | 0.2f
-    // spotless:on
   }
 
   def "verify api key loaded from file: #path"() {
@@ -1591,8 +1162,8 @@ class ConfigTest extends DDSpecification {
 
     then:
     config.mergedSpanTags == ["env": "test_env", "version": "1.2.3"]
-    config.getWellKnownTags().getEnv() as String == "test_env"
-    config.getWellKnownTags().getVersion() as String == "1.2.3"
+    config.wellKnownTags.getEnv() as String == "test_env"
+    config.wellKnownTags.getVersion() as String == "1.2.3"
   }
 
   def "explicit DD_ENV and DD_VERSION overwrites dd.trace.global.tags"() {
@@ -1607,8 +1178,8 @@ class ConfigTest extends DDSpecification {
 
     then:
     config.mergedSpanTags == ["version": "1.2.3", "env": "production-us", "other_tag": "test"]
-    config.getWellKnownTags().getEnv() as String == "production-us"
-    config.getWellKnownTags().getVersion() as String == "1.2.3"
+    config.wellKnownTags.getEnv() as String == "production-us"
+    config.wellKnownTags.getVersion() as String == "1.2.3"
   }
 
   def "merge env from dd.trace.global.tags and DD_VERSION"() {
@@ -1780,7 +1351,7 @@ class ConfigTest extends DDSpecification {
       'service.version': 'my-svc-vers']
   }
 
-  def "set servicenaem by DD_SERVICE"() {
+  def "set service name by DD_SERVICE"() {
     setup:
     environmentVariables.set("DD_SERVICE", "dd-service-env-var")
     System.setProperty(PREFIX + GLOBAL_TAGS, "service:service-tag-in-dd-trace-global-tags-java-property,service.version:my-svc-vers")
@@ -1809,61 +1380,6 @@ class ConfigTest extends DDSpecification {
 
     where:
     [serviceProperty, serviceName] << [[SERVICE, SERVICE_NAME], [DEFAULT_SERVICE_NAME, "my-service"]].combinations()
-  }
-
-  def "detect if agent is configured using default values"() {
-    setup:
-    if (host != null) {
-      System.setProperty(PREFIX + AGENT_HOST, host)
-    }
-    if (socket != null) {
-      System.setProperty(PREFIX + AGENT_UNIX_DOMAIN_SOCKET, socket)
-    }
-    if (port != null) {
-      System.setProperty(PREFIX + TRACE_AGENT_PORT, port)
-    }
-    if (legacyPort != null) {
-      System.setProperty(PREFIX + AGENT_PORT_LEGACY, legacyPort)
-    }
-
-    when:
-    def config = new Config()
-
-    then:
-    config.isAgentConfiguredUsingDefault() == configuredUsingDefault
-
-    when:
-    Properties properties = new Properties()
-    if (propertyHost != null) {
-      properties.setProperty(AGENT_HOST, propertyHost)
-    }
-    if (propertySocket != null) {
-      properties.setProperty(AGENT_UNIX_DOMAIN_SOCKET, propertySocket)
-    }
-    if (propertyPort != null) {
-      properties.setProperty(TRACE_AGENT_PORT, propertyPort)
-    }
-
-    def childConfig = new Config(ConfigProvider.withPropertiesOverride(properties))
-
-    then:
-    childConfig.isAgentConfiguredUsingDefault() == childConfiguredUsingDefault
-
-    where:
-    // spotless:off
-    host                              | socket    | port | legacyPort | propertyHost | propertySocket | propertyPort | configuredUsingDefault | childConfiguredUsingDefault
-    null                              | null      | null | null       | null         | null           | null         | true                   | true
-    "example"                         | null      | null | null       | null         | null           | null         | false                  | false
-    ConfigDefaults.DEFAULT_AGENT_HOST | null      | null | null       | null         | null           | null         | false                  | false
-    null                              | "example" | null | null       | null         | null           | null         | false                  | false
-    null                              | null      | "1"  | null       | null         | null           | null         | false                  | false
-    null                              | null      | null | "1"        | null         | null           | null         | false                  | false
-    "example"                         | "example" | null | null       | null         | null           | null         | false                  | false
-    null                              | null      | null | null       | "example"    | null           | null         | true                   | false
-    null                              | null      | null | null       | null         | "example"      | null         | true                   | false
-    null                              | null      | null | null       | null         | null           | "1"          | true                   | false
-    "example"                         | "example" | null | null       | "example"    | null           | null         | false                  | false
-    // spotless:on
   }
 
   // Static methods test:
@@ -2033,68 +1549,6 @@ class ConfigTest extends DDSpecification {
     def config = new Config()
     then:
     config.getMetricsIgnoredResources() == ["GET /healthcheck", "SELECT foo from bar"].toSet()
-  }
-
-  @Unroll
-  def "appsec state with sys = #sys env = #env"() {
-    setup:
-    if (sys != null) {
-      System.setProperty("dd.appsec.enabled", sys)
-    }
-    if (env != null) {
-      environmentVariables.set("DD_APPSEC_ENABLED", env)
-    }
-
-    when:
-    def config = new Config()
-
-    then:
-    config.getAppSecEnabledConfig() == res
-
-    where:
-    sys        | env        | res
-    null       | null       | ProductActivationConfig.ENABLED_INACTIVE
-    null       | ""         | ProductActivationConfig.ENABLED_INACTIVE
-    null       | "inactive" | ProductActivationConfig.ENABLED_INACTIVE
-    null       | "false"    | ProductActivationConfig.FULLY_DISABLED
-    null       | "0"        | ProductActivationConfig.FULLY_DISABLED
-    null       | "invalid"  | ProductActivationConfig.FULLY_DISABLED
-    null       | "true"     | ProductActivationConfig.FULLY_ENABLED
-    null       | "1"        | ProductActivationConfig.FULLY_ENABLED
-    ""         | null       | ProductActivationConfig.ENABLED_INACTIVE
-    ""         | ""         | ProductActivationConfig.ENABLED_INACTIVE
-    ""         | "inactive" | ProductActivationConfig.ENABLED_INACTIVE
-    ""         | "false"    | ProductActivationConfig.FULLY_DISABLED
-    ""         | "0"        | ProductActivationConfig.FULLY_DISABLED
-    ""         | "invalid"  | ProductActivationConfig.FULLY_DISABLED
-    ""         | "true"     | ProductActivationConfig.FULLY_ENABLED
-    ""         | "1"        | ProductActivationConfig.FULLY_ENABLED
-    "inactive" | null       | ProductActivationConfig.ENABLED_INACTIVE
-    "inactive" | ""         | ProductActivationConfig.ENABLED_INACTIVE
-    "inactive" | "inactive" | ProductActivationConfig.ENABLED_INACTIVE
-    "inactive" | "false"    | ProductActivationConfig.ENABLED_INACTIVE
-    "inactive" | "0"        | ProductActivationConfig.ENABLED_INACTIVE
-    "inactive" | "invalid"  | ProductActivationConfig.ENABLED_INACTIVE
-    "inactive" | "true"     | ProductActivationConfig.ENABLED_INACTIVE
-    "inactive" | "1"        | ProductActivationConfig.ENABLED_INACTIVE
-    "false"    | null       | ProductActivationConfig.FULLY_DISABLED
-    "false"    | ""         | ProductActivationConfig.FULLY_DISABLED
-    "false"    | "inactive" | ProductActivationConfig.FULLY_DISABLED
-    "false"    | "false"    | ProductActivationConfig.FULLY_DISABLED
-    "false"    | "0"        | ProductActivationConfig.FULLY_DISABLED
-    "false"    | "invalid"  | ProductActivationConfig.FULLY_DISABLED
-    "false"    | "true"     | ProductActivationConfig.FULLY_DISABLED
-    "false"    | "1"        | ProductActivationConfig.FULLY_DISABLED
-    "0"        | null       | ProductActivationConfig.FULLY_DISABLED
-    "true"     | null       | ProductActivationConfig.FULLY_ENABLED
-    "true"     | ""         | ProductActivationConfig.FULLY_ENABLED
-    "true"     | "inactive" | ProductActivationConfig.FULLY_ENABLED
-    "true"     | "false"    | ProductActivationConfig.FULLY_ENABLED
-    "true"     | "0"        | ProductActivationConfig.FULLY_ENABLED
-    "true"     | "invalid"  | ProductActivationConfig.FULLY_ENABLED
-    "true"     | "true"     | ProductActivationConfig.FULLY_ENABLED
-    "true"     | "1"        | ProductActivationConfig.FULLY_ENABLED
-    "1"        | null       | ProductActivationConfig.FULLY_ENABLED
   }
 
   static class ClassThrowsExceptionForValueOfMethod {

--- a/internal-api/src/test/groovy/datadog/trace/api/config/AppSecConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/config/AppSecConfigTest.groovy
@@ -1,0 +1,71 @@
+package datadog.trace.api.config
+
+import datadog.trace.api.Config
+import datadog.trace.api.ProductActivationConfig
+import datadog.trace.test.util.DDSpecification
+import spock.lang.Unroll
+
+class AppSecConfigTest extends DDSpecification {
+
+  @Unroll
+  def "appsec state with sys = #sys env = #env"() {
+    setup:
+    if (sys != null) {
+      System.setProperty("dd.appsec.enabled", sys)
+    }
+    if (env != null) {
+      environmentVariables.set("DD_APPSEC_ENABLED", env)
+    }
+
+    when:
+    def config = new Config()
+
+    then:
+    config.getAppSecEnabledConfig() == res
+
+    where:
+    sys        | env        | res
+    null       | null       | ProductActivationConfig.ENABLED_INACTIVE
+    null       | ""         | ProductActivationConfig.ENABLED_INACTIVE
+    null       | "inactive" | ProductActivationConfig.ENABLED_INACTIVE
+    null       | "false"    | ProductActivationConfig.FULLY_DISABLED
+    null       | "0"        | ProductActivationConfig.FULLY_DISABLED
+    null       | "invalid"  | ProductActivationConfig.FULLY_DISABLED
+    null       | "true"     | ProductActivationConfig.FULLY_ENABLED
+    null       | "1"        | ProductActivationConfig.FULLY_ENABLED
+    ""         | null       | ProductActivationConfig.ENABLED_INACTIVE
+    ""         | ""         | ProductActivationConfig.ENABLED_INACTIVE
+    ""         | "inactive" | ProductActivationConfig.ENABLED_INACTIVE
+    ""         | "false"    | ProductActivationConfig.FULLY_DISABLED
+    ""         | "0"        | ProductActivationConfig.FULLY_DISABLED
+    ""         | "invalid"  | ProductActivationConfig.FULLY_DISABLED
+    ""         | "true"     | ProductActivationConfig.FULLY_ENABLED
+    ""         | "1"        | ProductActivationConfig.FULLY_ENABLED
+    "inactive" | null       | ProductActivationConfig.ENABLED_INACTIVE
+    "inactive" | ""         | ProductActivationConfig.ENABLED_INACTIVE
+    "inactive" | "inactive" | ProductActivationConfig.ENABLED_INACTIVE
+    "inactive" | "false"    | ProductActivationConfig.ENABLED_INACTIVE
+    "inactive" | "0"        | ProductActivationConfig.ENABLED_INACTIVE
+    "inactive" | "invalid"  | ProductActivationConfig.ENABLED_INACTIVE
+    "inactive" | "true"     | ProductActivationConfig.ENABLED_INACTIVE
+    "inactive" | "1"        | ProductActivationConfig.ENABLED_INACTIVE
+    "false"    | null       | ProductActivationConfig.FULLY_DISABLED
+    "false"    | ""         | ProductActivationConfig.FULLY_DISABLED
+    "false"    | "inactive" | ProductActivationConfig.FULLY_DISABLED
+    "false"    | "false"    | ProductActivationConfig.FULLY_DISABLED
+    "false"    | "0"        | ProductActivationConfig.FULLY_DISABLED
+    "false"    | "invalid"  | ProductActivationConfig.FULLY_DISABLED
+    "false"    | "true"     | ProductActivationConfig.FULLY_DISABLED
+    "false"    | "1"        | ProductActivationConfig.FULLY_DISABLED
+    "0"        | null       | ProductActivationConfig.FULLY_DISABLED
+    "true"     | null       | ProductActivationConfig.FULLY_ENABLED
+    "true"     | ""         | ProductActivationConfig.FULLY_ENABLED
+    "true"     | "inactive" | ProductActivationConfig.FULLY_ENABLED
+    "true"     | "false"    | ProductActivationConfig.FULLY_ENABLED
+    "true"     | "0"        | ProductActivationConfig.FULLY_ENABLED
+    "true"     | "invalid"  | ProductActivationConfig.FULLY_ENABLED
+    "true"     | "true"     | ProductActivationConfig.FULLY_ENABLED
+    "true"     | "1"        | ProductActivationConfig.FULLY_ENABLED
+    "1"        | null       | ProductActivationConfig.FULLY_ENABLED
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/config/AppSecConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/config/AppSecConfigTest.groovy
@@ -1,11 +1,76 @@
 package datadog.trace.api.config
 
 import datadog.trace.api.Config
-import datadog.trace.api.ProductActivationConfig
 import datadog.trace.test.util.DDSpecification
 import spock.lang.Unroll
 
+import static datadog.trace.api.ConfigTest.PREFIX
+import static datadog.trace.api.ProductActivationConfig.ENABLED_INACTIVE
+import static datadog.trace.api.ProductActivationConfig.FULLY_DISABLED
+import static datadog.trace.api.ProductActivationConfig.FULLY_ENABLED
+import static datadog.trace.api.config.AppSecConfig.APPSEC_ENABLED
+import static datadog.trace.api.config.AppSecConfig.APPSEC_HTTP_BLOCKED_TEMPLATE_HTML
+import static datadog.trace.api.config.AppSecConfig.APPSEC_HTTP_BLOCKED_TEMPLATE_JSON
+import static datadog.trace.api.config.AppSecConfig.APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP
+import static datadog.trace.api.config.AppSecConfig.APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP
+import static datadog.trace.api.config.AppSecConfig.APPSEC_REPORTING_INBAND
+import static datadog.trace.api.config.AppSecConfig.APPSEC_REPORT_TIMEOUT_SEC
+import static datadog.trace.api.config.AppSecConfig.APPSEC_RULES_FILE
+import static datadog.trace.api.config.AppSecConfig.APPSEC_TRACE_RATE_LIMIT
+import static datadog.trace.api.config.AppSecConfig.APPSEC_WAF_METRICS
+import static datadog.trace.api.config.AppSecConfig.DEFAULT_APPSEC_REPORTING_INBAND
+import static datadog.trace.api.config.AppSecConfig.DEFAULT_APPSEC_TRACE_RATE_LIMIT
+import static datadog.trace.api.config.AppSecConfig.DEFAULT_APPSEC_WAF_METRICS
+
 class AppSecConfigTest extends DDSpecification {
+  def "check default config values"() {
+    when:
+    def config = new Config()
+
+    then:
+    config.appSecEnabledConfig == ENABLED_INACTIVE
+    config.appSecReportingInband == DEFAULT_APPSEC_REPORTING_INBAND
+    config.appSecRulesFile == null
+    config.appSecReportMinTimeout == 5
+    config.appSecReportMaxTimeout == 60
+    config.appSecTraceRateLimit == DEFAULT_APPSEC_TRACE_RATE_LIMIT
+    config.appSecWafMetrics == DEFAULT_APPSEC_WAF_METRICS
+    config.appSecObfuscationParameterKeyRegexp == null
+    config.appSecObfuscationParameterValueRegexp == null
+    config.appSecHttpBlockedTemplateHtml == null
+    config.appSecHttpBlockedTemplateJson == null
+  }
+
+  def "check overridden config values"() {
+    setup:
+    def ruleFile = "/var/file"
+    System.setProperty(PREFIX + APPSEC_ENABLED, "true")
+    System.setProperty(PREFIX + APPSEC_REPORTING_INBAND, "true")
+    System.setProperty(PREFIX + APPSEC_RULES_FILE, ruleFile)
+    System.setProperty(PREFIX + APPSEC_REPORT_TIMEOUT_SEC, "80")
+    System.setProperty(PREFIX + APPSEC_TRACE_RATE_LIMIT, "120")
+    System.setProperty(PREFIX + APPSEC_WAF_METRICS, "false")
+    System.setProperty(PREFIX + APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP, "obfuscation-key-regexp")
+    System.setProperty(PREFIX + APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP, "obfuscation-value-regexp")
+    System.setProperty(PREFIX + APPSEC_HTTP_BLOCKED_TEMPLATE_HTML, "template-html")
+    System.setProperty(PREFIX + APPSEC_HTTP_BLOCKED_TEMPLATE_JSON, "template-json")
+
+    when:
+    def config = new Config()
+
+    then:
+    config.appSecEnabledConfig == FULLY_ENABLED
+    config.appSecReportingInband
+    config.appSecRulesFile == ruleFile
+    config.appSecReportMinTimeout == 5
+    config.appSecReportMaxTimeout == 80
+    config.appSecTraceRateLimit == 120
+    !config.appSecWafMetrics
+    config.appSecObfuscationParameterKeyRegexp == "obfuscation-key-regexp"
+    config.appSecObfuscationParameterValueRegexp == "obfuscation-value-regexp"
+    config.appSecHttpBlockedTemplateHtml == "template-html"
+    config.appSecHttpBlockedTemplateJson == "template-json"
+  }
 
   @Unroll
   def "appsec state with sys = #sys env = #env"() {
@@ -25,47 +90,47 @@ class AppSecConfigTest extends DDSpecification {
 
     where:
     sys        | env        | res
-    null       | null       | ProductActivationConfig.ENABLED_INACTIVE
-    null       | ""         | ProductActivationConfig.ENABLED_INACTIVE
-    null       | "inactive" | ProductActivationConfig.ENABLED_INACTIVE
-    null       | "false"    | ProductActivationConfig.FULLY_DISABLED
-    null       | "0"        | ProductActivationConfig.FULLY_DISABLED
-    null       | "invalid"  | ProductActivationConfig.FULLY_DISABLED
-    null       | "true"     | ProductActivationConfig.FULLY_ENABLED
-    null       | "1"        | ProductActivationConfig.FULLY_ENABLED
-    ""         | null       | ProductActivationConfig.ENABLED_INACTIVE
-    ""         | ""         | ProductActivationConfig.ENABLED_INACTIVE
-    ""         | "inactive" | ProductActivationConfig.ENABLED_INACTIVE
-    ""         | "false"    | ProductActivationConfig.FULLY_DISABLED
-    ""         | "0"        | ProductActivationConfig.FULLY_DISABLED
-    ""         | "invalid"  | ProductActivationConfig.FULLY_DISABLED
-    ""         | "true"     | ProductActivationConfig.FULLY_ENABLED
-    ""         | "1"        | ProductActivationConfig.FULLY_ENABLED
-    "inactive" | null       | ProductActivationConfig.ENABLED_INACTIVE
-    "inactive" | ""         | ProductActivationConfig.ENABLED_INACTIVE
-    "inactive" | "inactive" | ProductActivationConfig.ENABLED_INACTIVE
-    "inactive" | "false"    | ProductActivationConfig.ENABLED_INACTIVE
-    "inactive" | "0"        | ProductActivationConfig.ENABLED_INACTIVE
-    "inactive" | "invalid"  | ProductActivationConfig.ENABLED_INACTIVE
-    "inactive" | "true"     | ProductActivationConfig.ENABLED_INACTIVE
-    "inactive" | "1"        | ProductActivationConfig.ENABLED_INACTIVE
-    "false"    | null       | ProductActivationConfig.FULLY_DISABLED
-    "false"    | ""         | ProductActivationConfig.FULLY_DISABLED
-    "false"    | "inactive" | ProductActivationConfig.FULLY_DISABLED
-    "false"    | "false"    | ProductActivationConfig.FULLY_DISABLED
-    "false"    | "0"        | ProductActivationConfig.FULLY_DISABLED
-    "false"    | "invalid"  | ProductActivationConfig.FULLY_DISABLED
-    "false"    | "true"     | ProductActivationConfig.FULLY_DISABLED
-    "false"    | "1"        | ProductActivationConfig.FULLY_DISABLED
-    "0"        | null       | ProductActivationConfig.FULLY_DISABLED
-    "true"     | null       | ProductActivationConfig.FULLY_ENABLED
-    "true"     | ""         | ProductActivationConfig.FULLY_ENABLED
-    "true"     | "inactive" | ProductActivationConfig.FULLY_ENABLED
-    "true"     | "false"    | ProductActivationConfig.FULLY_ENABLED
-    "true"     | "0"        | ProductActivationConfig.FULLY_ENABLED
-    "true"     | "invalid"  | ProductActivationConfig.FULLY_ENABLED
-    "true"     | "true"     | ProductActivationConfig.FULLY_ENABLED
-    "true"     | "1"        | ProductActivationConfig.FULLY_ENABLED
-    "1"        | null       | ProductActivationConfig.FULLY_ENABLED
+    null       | null       | ENABLED_INACTIVE
+    null       | ""         | ENABLED_INACTIVE
+    null       | "inactive" | ENABLED_INACTIVE
+    null       | "false"    | FULLY_DISABLED
+    null       | "0"        | FULLY_DISABLED
+    null       | "invalid"  | FULLY_DISABLED
+    null       | "true"     | FULLY_ENABLED
+    null       | "1"        | FULLY_ENABLED
+    ""         | null       | ENABLED_INACTIVE
+    ""         | ""         | ENABLED_INACTIVE
+    ""         | "inactive" | ENABLED_INACTIVE
+    ""         | "false"    | FULLY_DISABLED
+    ""         | "0"        | FULLY_DISABLED
+    ""         | "invalid"  | FULLY_DISABLED
+    ""         | "true"     | FULLY_ENABLED
+    ""         | "1"        | FULLY_ENABLED
+    "inactive" | null       | ENABLED_INACTIVE
+    "inactive" | ""         | ENABLED_INACTIVE
+    "inactive" | "inactive" | ENABLED_INACTIVE
+    "inactive" | "false"    | ENABLED_INACTIVE
+    "inactive" | "0"        | ENABLED_INACTIVE
+    "inactive" | "invalid"  | ENABLED_INACTIVE
+    "inactive" | "true"     | ENABLED_INACTIVE
+    "inactive" | "1"        | ENABLED_INACTIVE
+    "false"    | null       | FULLY_DISABLED
+    "false"    | ""         | FULLY_DISABLED
+    "false"    | "inactive" | FULLY_DISABLED
+    "false"    | "false"    | FULLY_DISABLED
+    "false"    | "0"        | FULLY_DISABLED
+    "false"    | "invalid"  | FULLY_DISABLED
+    "false"    | "true"     | FULLY_DISABLED
+    "false"    | "1"        | FULLY_DISABLED
+    "0"        | null       | FULLY_DISABLED
+    "true"     | null       | FULLY_ENABLED
+    "true"     | ""         | FULLY_ENABLED
+    "true"     | "inactive" | FULLY_ENABLED
+    "true"     | "false"    | FULLY_ENABLED
+    "true"     | "0"        | FULLY_ENABLED
+    "true"     | "invalid"  | FULLY_ENABLED
+    "true"     | "true"     | FULLY_ENABLED
+    "true"     | "1"        | FULLY_ENABLED
+    "1"        | null       | FULLY_ENABLED
   }
 }

--- a/internal-api/src/test/groovy/datadog/trace/api/config/CiVisibilityConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/config/CiVisibilityConfigTest.groovy
@@ -1,0 +1,51 @@
+package datadog.trace.api.config
+
+import datadog.trace.api.Config
+import datadog.trace.test.util.DDSpecification
+
+import static datadog.trace.api.ConfigTest.PREFIX
+import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_AGENTLESS_ENABLED
+import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_AGENTLESS_URL
+import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_ENABLED
+import static datadog.trace.api.config.CiVisibilityConfig.DEFAULT_CIVISIBILITY_AGENTLESS_ENABLED
+import static datadog.trace.api.config.CiVisibilityConfig.DEFAULT_CIVISIBILITY_ENABLED
+
+class CiVisibilityConfigTest extends DDSpecification {
+  def "check default config values"() {
+    when:
+    def config = new Config()
+
+    then:
+    config.ciVisibilityEnabled == DEFAULT_CIVISIBILITY_ENABLED
+    config.ciVisibilityAgentlessEnabled == DEFAULT_CIVISIBILITY_AGENTLESS_ENABLED
+    config.ciVisibilityAgentlessUrl == null
+  }
+
+  def "check overridden config values"() {
+    setup:
+    def url = "http://localhost/route"
+    System.setProperty(PREFIX + CIVISIBILITY_ENABLED, "true")
+    System.setProperty(PREFIX + CIVISIBILITY_AGENTLESS_ENABLED, "true")
+    System.setProperty(PREFIX + CIVISIBILITY_AGENTLESS_URL, url)
+
+    when:
+    def config = new Config()
+
+    then:
+    config.ciVisibilityEnabled
+    config.ciVisibilityAgentlessEnabled
+    config.ciVisibilityAgentlessUrl == url
+  }
+
+  def "check invalid URL parsing"() {
+    setup:
+    def url = "not-an-url"
+    System.setProperty(PREFIX + CIVISIBILITY_AGENTLESS_URL, url)
+
+    when:
+    def config = new Config()
+
+    then:
+    config.ciVisibilityAgentlessUrl == null
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/config/CrashTrackingConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/config/CrashTrackingConfigTest.groovy
@@ -1,0 +1,46 @@
+package datadog.trace.api.config
+
+import datadog.trace.api.Config
+import datadog.trace.test.util.DDSpecification
+
+import static datadog.trace.api.ConfigTest.PREFIX
+import static datadog.trace.api.config.CrashTrackingConfig.CRASH_TRACKING_AGENTLESS
+import static datadog.trace.api.config.CrashTrackingConfig.CRASH_TRACKING_AGENTLESS_DEFAULT
+
+class CrashTrackingConfigTest extends DDSpecification {
+  def "check default config values"() {
+    when:
+    def config = new Config()
+
+    then:
+    config.crashTrackingAgentless == CRASH_TRACKING_AGENTLESS_DEFAULT
+    config.finalCrashTrackingTelemetryUrl == "http://localhost:8126/telemetry/proxy/api/v2/apmtelemetry"
+  }
+
+
+  def "check overridden config values"() {
+    setup:
+    System.setProperty(PREFIX + CRASH_TRACKING_AGENTLESS, "true")
+
+    when:
+    def config = new Config()
+
+    then:
+    config.crashTrackingAgentless
+    config.finalCrashTrackingTelemetryUrl == "https://all-http-intake.logs.datadoghq.com/api/v2/apmtelemetry"
+  }
+
+  def "check merged tags"() {
+    when:
+    def config = new Config()
+
+    then:
+    with(config.mergedCrashTrackingTags) {
+      size() == config.generalConfig.runtimeTags.size() +
+        config.generalConfig.globalTags.size() + 3
+      containsKey(datadog.trace.api.DDTags.HOST_TAG)
+      containsKey(datadog.trace.api.DDTags.SERVICE_TAG)
+      containsKey(datadog.trace.api.DDTags.LANGUAGE_TAG_KEY)
+    }
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/config/GeneralConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/config/GeneralConfigTest.groovy
@@ -44,7 +44,7 @@ class GeneralConfigTest extends DDSpecification {
     config.dogStatsDNamedPipe == null
     config.dogStatsDStartDelay == DEFAULT_DOGSTATSD_START_DELAY
     config.dogStatsDPath == null
-    config.dogStatsDArgs == Collections.emptyList()
+    config.dogStatsDArgs == []
   }
 
   def "check overridden config values for DogStatsD"() {
@@ -61,6 +61,6 @@ class GeneralConfigTest extends DDSpecification {
     config.dogStatsDNamedPipe == "/var/pipe"
     config.dogStatsDStartDelay == 30
     config.dogStatsDPath == "/usr/lib/dogstatd"
-    config.dogStatsDArgs == List.of("start")
+    config.dogStatsDArgs == ["start"]
   }
 }

--- a/internal-api/src/test/groovy/datadog/trace/api/config/GeneralConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/config/GeneralConfigTest.groovy
@@ -1,0 +1,31 @@
+package datadog.trace.api.config
+
+import datadog.trace.api.Config
+import datadog.trace.test.util.DDSpecification
+
+import static datadog.trace.api.config.TracerConfig.TRACE_REPORT_HOSTNAME
+
+class GeneralConfigTest extends DDSpecification {
+  def "verify hostname not added to root span tags by default"() {
+    setup:
+    Properties properties = new Properties()
+
+    when:
+    def config = Config.get(properties)
+
+    then:
+    !config.localRootSpanTags.containsKey('_dd.hostname')
+  }
+
+  def "verify configuration to add hostname to root span tags"() {
+    setup:
+    Properties properties = new Properties()
+    properties.setProperty(TRACE_REPORT_HOSTNAME, 'true')
+
+    when:
+    def config = Config.get(properties)
+
+    then:
+    config.localRootSpanTags.containsKey('_dd.hostname')
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/config/GeneralConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/config/GeneralConfigTest.groovy
@@ -3,6 +3,12 @@ package datadog.trace.api.config
 import datadog.trace.api.Config
 import datadog.trace.test.util.DDSpecification
 
+import static datadog.trace.api.ConfigTest.PREFIX
+import static datadog.trace.api.config.GeneralConfig.DEFAULT_DOGSTATSD_START_DELAY
+import static datadog.trace.api.config.GeneralConfig.DOGSTATSD_ARGS
+import static datadog.trace.api.config.GeneralConfig.DOGSTATSD_NAMED_PIPE
+import static datadog.trace.api.config.GeneralConfig.DOGSTATSD_PATH
+import static datadog.trace.api.config.GeneralConfig.DOGSTATSD_START_DELAY
 import static datadog.trace.api.config.TracerConfig.TRACE_REPORT_HOSTNAME
 
 class GeneralConfigTest extends DDSpecification {
@@ -27,5 +33,34 @@ class GeneralConfigTest extends DDSpecification {
 
     then:
     config.localRootSpanTags.containsKey('_dd.hostname')
+  }
+
+  def "check default config values for DogStatsD"() {
+
+    when:
+    def config = Config.get()
+
+    then:
+    config.dogStatsDNamedPipe == null
+    config.dogStatsDStartDelay == DEFAULT_DOGSTATSD_START_DELAY
+    config.dogStatsDPath == null
+    config.dogStatsDArgs == Collections.emptyList()
+  }
+
+  def "check overridden config values for DogStatsD"() {
+    setup:
+    System.setProperty(PREFIX + DOGSTATSD_NAMED_PIPE, "/var/pipe")
+    System.setProperty(PREFIX + DOGSTATSD_START_DELAY, "30")
+    System.setProperty(PREFIX + DOGSTATSD_PATH, "/usr/lib/dogstatd")
+    System.setProperty(PREFIX + DOGSTATSD_ARGS, "start")
+
+    when:
+    def config = new Config()
+
+    then:
+    config.dogStatsDNamedPipe == "/var/pipe"
+    config.dogStatsDStartDelay == 30
+    config.dogStatsDPath == "/usr/lib/dogstatd"
+    config.dogStatsDArgs == List.of("start")
   }
 }

--- a/internal-api/src/test/groovy/datadog/trace/api/config/IastConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/config/IastConfigTest.groovy
@@ -1,0 +1,70 @@
+package datadog.trace.api.config
+
+import datadog.trace.api.Config
+import datadog.trace.test.util.DDSpecification
+
+import static datadog.trace.api.ConfigTest.PREFIX
+import static datadog.trace.api.config.IastConfig.DEFAULT_IAST_DEDUPLICATION_ENABLED
+import static datadog.trace.api.config.IastConfig.DEFAULT_IAST_ENABLED
+import static datadog.trace.api.config.IastConfig.DEFAULT_IAST_MAX_CONCURRENT_REQUESTS
+import static datadog.trace.api.config.IastConfig.DEFAULT_IAST_REQUEST_SAMPLING
+import static datadog.trace.api.config.IastConfig.DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS
+import static datadog.trace.api.config.IastConfig.DEFAULT_IAST_WEAK_HASH_ALGORITHMS
+import static datadog.trace.api.config.IastConfig.IAST_DEDUPLICATION_ENABLED
+import static datadog.trace.api.config.IastConfig.IAST_ENABLED
+import static datadog.trace.api.config.IastConfig.IAST_MAX_CONCURRENT_REQUESTS
+import static datadog.trace.api.config.IastConfig.IAST_REQUEST_SAMPLING
+import static datadog.trace.api.config.IastConfig.IAST_VULNERABILITIES_PER_REQUEST
+import static datadog.trace.api.config.IastConfig.IAST_WEAK_CIPHER_ALGORITHMS
+import static datadog.trace.api.config.IastConfig.IAST_WEAK_HASH_ALGORITHMS
+
+class IastConfigTest extends DDSpecification {
+  def "check default config values"() {
+    when:
+    def config = new Config()
+
+    then:
+    config.iastWeakHashAlgorithms == DEFAULT_IAST_WEAK_HASH_ALGORITHMS
+    config.iastWeakCipherAlgorithms.pattern() == DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS
+    config.iastDeduplicationEnabled == DEFAULT_IAST_DEDUPLICATION_ENABLED
+    config.iastEnabled == DEFAULT_IAST_ENABLED
+    config.iastMaxConcurrentRequests == DEFAULT_IAST_MAX_CONCURRENT_REQUESTS
+    config.iastVulnerabilitiesPerRequest == DEFAULT_IAST_MAX_CONCURRENT_REQUESTS
+    config.iastRequestSampling == DEFAULT_IAST_REQUEST_SAMPLING
+  }
+
+  def "check overridden config values"() {
+    setup:
+    System.setProperty(PREFIX + IAST_WEAK_HASH_ALGORITHMS, "MD2,MD4,MD2")
+    def weekCypherAlgorithms = "(BLOWFISH|ARCFOUR|RC2).*"
+    System.setProperty(PREFIX + IAST_WEAK_CIPHER_ALGORITHMS, weekCypherAlgorithms)
+    System.setProperty(PREFIX + IAST_DEDUPLICATION_ENABLED, "false")
+    System.setProperty(PREFIX + IAST_ENABLED, "true")
+    System.setProperty(PREFIX + IAST_MAX_CONCURRENT_REQUESTS, "5")
+    System.setProperty(PREFIX + IAST_VULNERABILITIES_PER_REQUEST, "6")
+    System.setProperty(PREFIX + IAST_REQUEST_SAMPLING, "50")
+
+    when:
+    def config = new Config()
+
+    then:
+    config.iastWeakHashAlgorithms == Set.of("MD2", "MD4")
+    config.iastWeakCipherAlgorithms.pattern() == weekCypherAlgorithms
+    !config.iastDeduplicationEnabled
+    config.iastEnabled
+    config.iastMaxConcurrentRequests == 5
+    config.iastVulnerabilitiesPerRequest == 6
+    config.iastRequestSampling == 50
+  }
+
+  def "check invalid algorithms pattern"() {
+    setup:
+    System.setProperty(PREFIX + IAST_WEAK_CIPHER_ALGORITHMS, "[*")
+
+    when:
+    def config = new Config()
+
+    then:
+    config.iastWeakCipherAlgorithms.pattern() == DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/config/IastConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/config/IastConfigTest.groovy
@@ -48,7 +48,7 @@ class IastConfigTest extends DDSpecification {
     def config = new Config()
 
     then:
-    config.iastWeakHashAlgorithms == Set.of("MD2", "MD4")
+    config.iastWeakHashAlgorithms == ["MD2", "MD4"] as Set
     config.iastWeakCipherAlgorithms.pattern() == weekCypherAlgorithms
     !config.iastDeduplicationEnabled
     config.iastEnabled

--- a/internal-api/src/test/groovy/datadog/trace/api/config/JmxFetchConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/config/JmxFetchConfigTest.groovy
@@ -7,8 +7,6 @@ import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_METRICS_CONFIGS
 import static datadog.trace.api.ConfigTest.PREFIX
 
 class JmxFetchConfigTest extends DDSpecification {
-
-
   def "verify empty value list configs on tracer"() {
     setup:
     System.setProperty(PREFIX + JMX_FETCH_METRICS_CONFIGS, listString)

--- a/internal-api/src/test/groovy/datadog/trace/api/config/JmxFetchConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/config/JmxFetchConfigTest.groovy
@@ -1,0 +1,28 @@
+package datadog.trace.api.config
+
+import datadog.trace.api.Config
+import datadog.trace.test.util.DDSpecification
+
+import static datadog.trace.api.config.JmxFetchConfig.JMX_FETCH_METRICS_CONFIGS
+import static datadog.trace.api.ConfigTest.PREFIX
+
+class JmxFetchConfigTest extends DDSpecification {
+
+
+  def "verify empty value list configs on tracer"() {
+    setup:
+    System.setProperty(PREFIX + JMX_FETCH_METRICS_CONFIGS, listString)
+
+    when:
+    def config = new Config()
+
+    then:
+    config.jmxFetchMetricsConfigs == list
+
+    where:
+    // spotless:off
+    listString | list
+    ""         | []
+    // spotless:on
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/config/TraceInstrumentationConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/config/TraceInstrumentationConfigTest.groovy
@@ -27,7 +27,6 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.KAFKA_CLIENT_P
 import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGATION_DISABLED_EXCHANGES
 import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGATION_DISABLED_QUEUES
 import static datadog.trace.api.config.TracerConfig.DEFAULT_TRACE_ENABLED
-import static java.util.Collections.emptyList
 
 class TraceInstrumentationConfigTest extends DDSpecification {
   def "check default config values"() {
@@ -43,12 +42,12 @@ class TraceInstrumentationConfigTest extends DDSpecification {
     config.logsMDCTagsInjectionEnabled
     config.traceMethods == DEFAULT_TRACE_METHODS
     config.traceExecutorsAll == DEFAULT_TRACE_EXECUTORS_ALL
-    config.traceExecutors == emptyList()
-    config.traceThreadPoolExecutorsExclude == Set.<String>of()
-    config.excludedClasses == emptyList()
+    config.traceExecutors == []
+    config.traceThreadPoolExecutorsExclude == [] as Set
+    config.excludedClasses == []
     config.excludedClassesFile == null
-    config.excludedClassLoaders == Set.<String>of()
-    config.excludedCodeSources == emptyList()
+    config.excludedClassLoaders == [] as Set
+    config.excludedCodeSources == []
     config.httpServerTagQueryString == DEFAULT_HTTP_SERVER_TAG_QUERY_STRING
     config.httpServerRawQueryString
     !config.httpServerRawResource
@@ -76,8 +75,8 @@ class TraceInstrumentationConfigTest extends DDSpecification {
     config.rootContextServiceName == DEFAULT_SERVLET_ROOT_CONTEXT_SERVICE_NAME
     config.runtimeContextFieldInjection == DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION
     config.serialVersionUIDFieldInjection == DEFAULT_SERIALVERSIONUID_FIELD_INJECTION
-    config.grpcIgnoredInboundMethods == Set.<String>of()
-    config.grpcIgnoredOutboundMethods == Set.<String>of()
+    config.grpcIgnoredInboundMethods == [] as Set
+    config.grpcIgnoredOutboundMethods == [] as Set
     !config.grpcServerTrimPackageResource
     config.grpcServerErrorStatuses == DEFAULT_GRPC_SERVER_ERROR_STATUSES
     config.grpcClientErrorStatuses == DEFAULT_GRPC_CLIENT_ERROR_STATUSES

--- a/internal-api/src/test/groovy/datadog/trace/api/config/TraceInstrumentationConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/config/TraceInstrumentationConfigTest.groovy
@@ -1,0 +1,155 @@
+package datadog.trace.api.config
+
+import datadog.trace.api.Config
+import datadog.trace.test.util.DDSpecification
+
+class TraceInstrumentationConfigTest extends DDSpecification {
+
+  def "verify integration config"() {
+    setup:
+    environmentVariables.set("DD_INTEGRATION_ORDER_ENABLED", "false")
+    environmentVariables.set("DD_INTEGRATION_TEST_ENV_ENABLED", "true")
+    environmentVariables.set("DD_INTEGRATION_DISABLED_ENV_ENABLED", "false")
+
+    System.setProperty("dd.integration.order.enabled", "true")
+    System.setProperty("dd.integration.test-prop.enabled", "true")
+    System.setProperty("dd.integration.disabled-prop.enabled", "false")
+
+    expect:
+    Config.get().isIntegrationEnabled(integrationNames, defaultEnabled) == expected
+
+    where:
+    // spotless:off
+    names                          | defaultEnabled | expected
+    []                             | true           | true
+    []                             | false          | false
+    ["invalid"]                    | true           | true
+    ["invalid"]                    | false          | false
+    ["test-prop"]                  | false          | true
+    ["test-env"]                   | false          | true
+    ["disabled-prop"]              | true           | false
+    ["disabled-env"]               | true           | false
+    ["other", "test-prop"]         | false          | true
+    ["other", "test-env"]          | false          | true
+    ["order"]                      | false          | true
+    ["test-prop", "disabled-prop"] | false          | true
+    ["disabled-env", "test-env"]   | false          | true
+    ["test-prop", "disabled-prop"] | true           | false
+    ["disabled-env", "test-env"]   | true           | false
+    // spotless:on
+
+    integrationNames = new TreeSet<>(names)
+  }
+
+  def "verify rule config #name"() {
+    setup:
+    environmentVariables.set("DD_TRACE_TEST_ENABLED", "true")
+    environmentVariables.set("DD_TRACE_TEST_ENV_ENABLED", "true")
+    environmentVariables.set("DD_TRACE_DISABLED_ENV_ENABLED", "false")
+
+    System.setProperty("dd.trace.test.enabled", "false")
+    System.setProperty("dd.trace.test-prop.enabled", "true")
+    System.setProperty("dd.trace.disabled-prop.enabled", "false")
+
+    expect:
+    Config.get().isRuleEnabled(name) == enabled
+
+    where:
+    // spotless:off
+    name            | enabled
+    ""              | true
+    "invalid"       | true
+    "test-prop"     | true
+    "Test-Prop"     | true
+    "test-env"      | true
+    "Test-Env"      | true
+    "test"          | false
+    "TEST"          | false
+    "disabled-prop" | false
+    "Disabled-Prop" | false
+    "disabled-env"  | false
+    "Disabled-Env"  | false
+    // spotless:on
+  }
+  def "verify integration jmxfetch config"() {
+    setup:
+    environmentVariables.set("DD_JMXFETCH_ORDER_ENABLED", "false")
+    environmentVariables.set("DD_JMXFETCH_TEST_ENV_ENABLED", "true")
+    environmentVariables.set("DD_JMXFETCH_DISABLED_ENV_ENABLED", "false")
+
+    System.setProperty("dd.jmxfetch.order.enabled", "true")
+    System.setProperty("dd.jmxfetch.test-prop.enabled", "true")
+    System.setProperty("dd.jmxfetch.disabled-prop.enabled", "false")
+
+    expect:
+    Config.get().isJmxFetchIntegrationEnabled(integrationNames, defaultEnabled) == expected
+
+    where:
+    // spotless:off
+    names                          | defaultEnabled | expected
+    []                             | true           | true
+    []                             | false          | false
+    ["invalid"]                    | true           | true
+    ["invalid"]                    | false          | false
+    ["test-prop"]                  | false          | true
+    ["test-env"]                   | false          | true
+    ["disabled-prop"]              | true           | false
+    ["disabled-env"]               | true           | false
+    ["other", "test-prop"]         | false          | true
+    ["other", "test-env"]          | false          | true
+    ["order"]                      | false          | true
+    ["test-prop", "disabled-prop"] | false          | true
+    ["disabled-env", "test-env"]   | false          | true
+    ["test-prop", "disabled-prop"] | true           | false
+    ["disabled-env", "test-env"]   | true           | false
+    // spotless:on
+
+    integrationNames = new TreeSet<>(names)
+  }
+
+  def "verify integration trace analytics config"() {
+    setup:
+    environmentVariables.set("DD_ORDER_ANALYTICS_ENABLED", "false")
+    environmentVariables.set("DD_TEST_ENV_ANALYTICS_ENABLED", "true")
+    environmentVariables.set("DD_DISABLED_ENV_ANALYTICS_ENABLED", "false")
+    // trace prefix form should take precedence over the old non-prefix form
+    environmentVariables.set("DD_ALIAS_ENV_ANALYTICS_ENABLED", "false")
+    environmentVariables.set("DD_TRACE_ALIAS_ENV_ANALYTICS_ENABLED", "true")
+
+    System.setProperty("dd.order.analytics.enabled", "true")
+    System.setProperty("dd.test-prop.analytics.enabled", "true")
+    System.setProperty("dd.disabled-prop.analytics.enabled", "false")
+    // trace prefix form should take precedence over the old non-prefix form
+    System.setProperty("dd.alias-prop.analytics.enabled", "false")
+    System.setProperty("dd.trace.alias-prop.analytics.enabled", "true")
+
+    expect:
+    Config.get().isTraceAnalyticsIntegrationEnabled(integrationNames, defaultEnabled) == expected
+
+    where:
+    // spotless:off
+    names                           | defaultEnabled | expected
+    []                              | true           | true
+    []                              | false          | false
+    ["invalid"]                     | true           | true
+    ["invalid"]                     | false          | false
+    ["test-prop"]                   | false          | true
+    ["test-env"]                    | false          | true
+    ["disabled-prop"]               | true           | false
+    ["disabled-env"]                | true           | false
+    ["other", "test-prop"]          | false          | true
+    ["other", "test-env"]           | false          | true
+    ["order"]                       | false          | true
+    ["test-prop", "disabled-prop"]  | false          | true
+    ["disabled-env", "test-env"]    | false          | true
+    ["test-prop", "disabled-prop"]  | true           | false
+    ["disabled-env", "test-env"]    | true           | false
+    ["alias-prop", "disabled-prop"] | false          | true
+    ["disabled-env", "alias-env"]   | false          | true
+    ["alias-prop", "disabled-prop"] | true           | false
+    ["disabled-env", "alias-env"]   | true           | false
+    // spotless:on
+
+    integrationNames = new TreeSet<>(names)
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/config/TracerConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/config/TracerConfigTest.groovy
@@ -36,9 +36,9 @@ class TracerConfigTest extends DDSpecification {
     def config = new Config()
 
     then:
-    config.noProxyHosts == Set.<String>of()
+    config.noProxyHosts == [] as Set
     config.traceAgentPath == null
-    config.traceAgentArgs == List.of()
+    config.traceAgentArgs == []
     config.prioritySamplingForce == DEFAULT_PRIORITY_SAMPLING_FORCE
     config.traceAnalyticsEnabled == DEFAULT_TRACE_ANALYTICS_ENABLED
     config.traceClientIpHeader == null

--- a/internal-api/src/test/groovy/datadog/trace/api/config/TracerConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/config/TracerConfigTest.groovy
@@ -5,9 +5,19 @@ import datadog.trace.api.ConfigDefaults
 import datadog.trace.bootstrap.config.provider.ConfigProvider
 import datadog.trace.test.util.DDSpecification
 
+import static datadog.trace.api.ConfigTest.DD_HEADER_TAGS_ENV
+import static datadog.trace.api.ConfigTest.DD_SPAN_TAGS_ENV
+import static datadog.trace.api.ConfigTest.PREFIX
+import static datadog.trace.api.ConfigTest.toBitSet
 import static datadog.trace.api.config.TracerConfig.AGENT_HOST
 import static datadog.trace.api.config.TracerConfig.AGENT_PORT_LEGACY
 import static datadog.trace.api.config.TracerConfig.AGENT_UNIX_DOMAIN_SOCKET
+import static datadog.trace.api.config.TracerConfig.DEFAULT_CLIENT_IP_ENABLED
+import static datadog.trace.api.config.TracerConfig.DEFAULT_PRIORITY_SAMPLING_FORCE
+import static datadog.trace.api.config.TracerConfig.DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED
+import static datadog.trace.api.config.TracerConfig.DEFAULT_SCOPE_DEPTH_LIMIT
+import static datadog.trace.api.config.TracerConfig.DEFAULT_SCOPE_ITERATION_KEEP_ALIVE
+import static datadog.trace.api.config.TracerConfig.DEFAULT_TRACE_ANALYTICS_ENABLED
 import static datadog.trace.api.config.TracerConfig.HEADER_TAGS
 import static datadog.trace.api.config.TracerConfig.HTTP_CLIENT_ERROR_STATUSES
 import static datadog.trace.api.config.TracerConfig.HTTP_SERVER_ERROR_STATUSES
@@ -15,16 +25,33 @@ import static datadog.trace.api.config.TracerConfig.REQUEST_HEADER_TAGS
 import static datadog.trace.api.config.TracerConfig.RESPONSE_HEADER_TAGS
 import static datadog.trace.api.config.TracerConfig.SERVICE_MAPPING
 import static datadog.trace.api.config.TracerConfig.SPAN_TAGS
-import static datadog.trace.api.ConfigTest.PREFIX
-import static datadog.trace.api.ConfigTest.DD_SPAN_TAGS_ENV
-import static datadog.trace.api.ConfigTest.DD_HEADER_TAGS_ENV
-import static datadog.trace.api.ConfigTest.toBitSet
 import static datadog.trace.api.config.TracerConfig.TRACE_AGENT_PORT
-
 
 class TracerConfigTest extends DDSpecification {
 
   private static final DD_SERVICE_MAPPING_ENV = "DD_SERVICE_MAPPING"
+
+  def "check default config values"() {
+    when:
+    def config = new Config()
+
+    then:
+    config.noProxyHosts == Set.<String>of()
+    config.traceAgentPath == null
+    config.traceAgentArgs == List.of()
+    config.prioritySamplingForce == DEFAULT_PRIORITY_SAMPLING_FORCE
+    config.traceAnalyticsEnabled == DEFAULT_TRACE_ANALYTICS_ENABLED
+    config.traceClientIpHeader == null
+    config.traceClientIpResolverEnabled
+    config.clientIpEnabled == DEFAULT_CLIENT_IP_ENABLED
+    config.traceSamplingRules == null
+    config.scopeDepthLimit == DEFAULT_SCOPE_DEPTH_LIMIT
+    !config.scopeStrictMode
+    config.scopeInheritAsyncPropagation
+    config.scopeIterationKeepAlive == DEFAULT_SCOPE_ITERATION_KEEP_ALIVE
+    !config.traceStrictWritesEnabled
+    config.logExtractHeaderNames == DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED
+  }
 
   def "verify mapping configs on tracer for #mapString"() {
     setup:

--- a/internal-api/src/test/groovy/datadog/trace/api/config/TracerConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/config/TracerConfigTest.groovy
@@ -1,0 +1,320 @@
+package datadog.trace.api.config
+
+import datadog.trace.api.Config
+import datadog.trace.api.ConfigDefaults
+import datadog.trace.bootstrap.config.provider.ConfigProvider
+import datadog.trace.test.util.DDSpecification
+
+import static datadog.trace.api.config.TracerConfig.AGENT_HOST
+import static datadog.trace.api.config.TracerConfig.AGENT_PORT_LEGACY
+import static datadog.trace.api.config.TracerConfig.AGENT_UNIX_DOMAIN_SOCKET
+import static datadog.trace.api.config.TracerConfig.HEADER_TAGS
+import static datadog.trace.api.config.TracerConfig.HTTP_CLIENT_ERROR_STATUSES
+import static datadog.trace.api.config.TracerConfig.HTTP_SERVER_ERROR_STATUSES
+import static datadog.trace.api.config.TracerConfig.REQUEST_HEADER_TAGS
+import static datadog.trace.api.config.TracerConfig.RESPONSE_HEADER_TAGS
+import static datadog.trace.api.config.TracerConfig.SERVICE_MAPPING
+import static datadog.trace.api.config.TracerConfig.SPAN_TAGS
+import static datadog.trace.api.ConfigTest.PREFIX
+import static datadog.trace.api.ConfigTest.DD_SPAN_TAGS_ENV
+import static datadog.trace.api.ConfigTest.DD_HEADER_TAGS_ENV
+import static datadog.trace.api.ConfigTest.toBitSet
+import static datadog.trace.api.config.TracerConfig.TRACE_AGENT_PORT
+
+
+class TracerConfigTest extends DDSpecification {
+
+  private static final DD_SERVICE_MAPPING_ENV = "DD_SERVICE_MAPPING"
+
+  def "verify mapping configs on tracer for #mapString"() {
+    setup:
+    System.setProperty(PREFIX + HEADER_TAGS + ".legacy.parsing.enabled", "true")
+    System.setProperty(PREFIX + SERVICE_MAPPING, mapString)
+    System.setProperty(PREFIX + SPAN_TAGS, mapString)
+    System.setProperty(PREFIX + HEADER_TAGS, mapString)
+    System.setProperty(PREFIX + REQUEST_HEADER_TAGS, "rqh1")
+    System.setProperty(PREFIX + RESPONSE_HEADER_TAGS, "rsh1")
+    def props = new Properties()
+    props.setProperty(HEADER_TAGS + ".legacy.parsing.enabled", "true")
+    props.setProperty(SERVICE_MAPPING, mapString)
+    props.setProperty(SPAN_TAGS, mapString)
+    props.setProperty(HEADER_TAGS, mapString)
+    props.setProperty(PREFIX + REQUEST_HEADER_TAGS, "rqh1")
+    props.setProperty(PREFIX + RESPONSE_HEADER_TAGS, "rsh1")
+
+    when:
+    def config = new Config()
+    def propConfig = Config.get(props)
+
+    then:
+    config.serviceMapping == map
+    config.mergedSpanTags == map
+    config.requestHeaderTags == map
+    config.responseHeaderTags == [:]
+    propConfig.serviceMapping == map
+    propConfig.mergedSpanTags == map
+    propConfig.requestHeaderTags == map
+    propConfig.responseHeaderTags == [:]
+
+    where:
+    // spotless:off
+    mapString                                                     | map
+    "a:1, a:2, a:3"                                               | [a: "3"]
+    "a:b,c:d,e:"                                                  | [a: "b", c: "d"]
+    // space separated
+    "a:1  a:2  a:3"                                               | [a: "3"]
+    "a:b c:d e:"                                                  | [a: "b", c: "d"]
+    // More different string variants:
+    "a:"                                                          | [:]
+    "a:a;"                                                        | [a: "a;"]
+    "a:1, a:2, a:3"                                               | [a: "3"]
+    "a:1  a:2  a:3"                                               | [a: "3"]
+    "a:b,c:d,e:"                                                  | [a: "b", c: "d"]
+    "a:b c:d e:"                                                  | [a: "b", c: "d"]
+    "key 1!:va|ue_1,"                                             | ["key 1!": "va|ue_1"]
+    "key 1!:va|ue_1 "                                             | ["key 1!": "va|ue_1"]
+    " key1 :value1 ,\t key2:  value2"                             | [key1: "value1", key2: "value2"]
+    "a:b,c,d"                                                     | [:]
+    "a:b,c,d,k:v"                                                 | [:]
+    "key1 :value1  \t key2:  value2"                              | [key1: "value1", key2: "value2"]
+    "dyno:web.1 dynotype:web buildpackversion:dev appname:******" | ["dyno": "web.1", "dynotype": "web", "buildpackversion": "dev", "appname": "******"]
+    "is:val:id"                                                   | [is: "val:id"]
+    "a:b,is:val:id,x:y"                                           | [a: "b", is: "val:id", x: "y"]
+    "a:b:c:d"                                                     | [a: "b:c:d"]
+    // Invalid strings:
+    ""                                                            | [:]
+    "1"                                                           | [:]
+    "a"                                                           | [:]
+    "a,1"                                                         | [:]
+    "!a"                                                          | [:]
+    "    "                                                        | [:]
+    ",,,,"                                                        | [:]
+    ":,:,:,:,"                                                    | [:]
+    ": : : : "                                                    | [:]
+    "::::"                                                        | [:]
+    // spotless:on
+  }
+
+  def "verify mapping header tags on tracer for #mapString"() {
+    setup:
+    Map<String, String> rqMap = map.clone()
+    rqMap.put("rqh1", "http.request.headers.rqh1")
+    System.setProperty(PREFIX + HEADER_TAGS, mapString)
+    System.setProperty(PREFIX + REQUEST_HEADER_TAGS, "rqh1")
+    System.setProperty(PREFIX + RESPONSE_HEADER_TAGS, "rsh1")
+    Map<String, String> rsMap = map.collectEntries { k, v -> [k, v.replace("http.request.headers", "http.response.headers")] }
+    rsMap.put("rsh1", "http.response.headers.rsh1")
+    def props = new Properties()
+    props.setProperty(HEADER_TAGS, mapString)
+    props.setProperty(PREFIX + REQUEST_HEADER_TAGS, "rQh1")
+    props.setProperty(PREFIX + RESPONSE_HEADER_TAGS, "rsH1")
+
+    when:
+    def config = new Config()
+    def propConfig = Config.get(props)
+
+    then:
+    config.requestHeaderTags == rqMap
+    propConfig.requestHeaderTags == rqMap
+    config.responseHeaderTags == rsMap
+    propConfig.responseHeaderTags == rsMap
+
+    where:
+    // spotless:off
+    mapString                                                     | map
+    "a:one, a:two, a:three"                                       | [a: "three"]
+    "a:b,c:d,e:"                                                  | [a: "b", c: "d"]
+    // space separated
+    "a:one  a:two  a:three"                                       | [a: "three"]
+    "a:b c:d e:"                                                  | [a: "b", c: "d"]
+    // More different string variants:
+    "a:"                                                          | [:]
+    "a:a;"                                                        | [a: "a;"]
+    "a:one, a:two, a:three"                                       | [a: "three"]
+    "a:one  a:two  a:three"                                       | [a: "three"]
+    "a:b,c:d,e:"                                                  | [a: "b", c: "d"]
+    "a:b c:d e:"                                                  | [a: "b", c: "d"]
+    "key=1!:va|ue_1,"                                             | ["key=1!": "va|ue_1"]
+    "key=1!:va|ue_1 "                                             | ["key=1!": "va|ue_1"]
+    " kEy1 :vaLue1 ,\t keY2:  valUe2"                             | [key1: "vaLue1", key2: "valUe2"]
+    "a:b,c,D"                                                     | [a: "b", c: "http.request.headers.c", d: "http.request.headers.d"]
+    "a:b,C,d,k:v"                                                 | [a: "b", c: "http.request.headers.c", d: "http.request.headers.d", k: "v"]
+    "a b c:d "                                                    | [a: "http.request.headers.a", b: "http.request.headers.b", c: "d"]
+    "dyno:web.1 dynotype:web buildpackversion:dev appname:n*****" | ["dyno": "web.1", "dynotype": "web", "buildpackversion": "dev", "appname": "n*****"]
+    "A.1,B.1"                                                     | ["a.1": "http.request.headers.a_1", "b.1": "http.request.headers.b_1"]
+    "is:val:id"                                                   | [is: "val:id"]
+    "a:b,is:val:id,x:y"                                           | [a: "b", is: "val:id", x: "y"]
+    "a:b:c:d"                                                     | [a: "b:c:d"]
+    // Invalid strings:
+    ""                                                            | [:]
+    "1"                                                           | [:]
+    "a:1"                                                         | [:]
+    "a,1"                                                         | [:]
+    "!a"                                                          | [:]
+    "    "                                                        | [:]
+    ",,,,"                                                        | [:]
+    ":,:,:,:,"                                                    | [:]
+    ": : : : "                                                    | [:]
+    "::::"                                                        | [:]
+    "kEy1 :value1  \t keY2:  value2"                              | [:]
+    // spotless:on
+  }
+
+  def "verify integer range configs on tracer"() {
+    setup:
+    System.setProperty(PREFIX + HTTP_SERVER_ERROR_STATUSES, value)
+    System.setProperty(PREFIX + HTTP_CLIENT_ERROR_STATUSES, value)
+    def props = new Properties()
+    props.setProperty(HTTP_CLIENT_ERROR_STATUSES, value)
+    props.setProperty(HTTP_SERVER_ERROR_STATUSES, value)
+
+    when:
+    def config = new Config()
+    def propConfig = Config.get(props)
+
+    then:
+    if (expected) {
+      assert config.httpServerErrorStatuses == toBitSet(expected)
+      assert config.httpClientErrorStatuses == toBitSet(expected)
+      assert propConfig.httpServerErrorStatuses == toBitSet(expected)
+      assert propConfig.httpClientErrorStatuses == toBitSet(expected)
+    } else {
+      assert config.httpServerErrorStatuses == TracerConfig.DEFAULT_HTTP_SERVER_ERROR_STATUSES
+      assert config.httpClientErrorStatuses == TracerConfig.DEFAULT_HTTP_CLIENT_ERROR_STATUSES
+      assert propConfig.httpServerErrorStatuses == TracerConfig.DEFAULT_HTTP_SERVER_ERROR_STATUSES
+      assert propConfig.httpClientErrorStatuses == TracerConfig.DEFAULT_HTTP_CLIENT_ERROR_STATUSES
+    }
+
+    where:
+    value               | expected // null means default value
+    // spotless:off
+    "1"                 | null
+    "a"                 | null
+    ""                  | null
+    "1000"              | null
+    "100-200-300"       | null
+    "500"               | [500]
+    "100,999"           | [100, 999]
+    "999-888"           | 888..999
+    "400-403,405-407"   | [400, 401, 402, 403, 405, 406, 407]
+    " 400 - 403 , 405 " | [400, 401, 402, 403, 405]
+    // spotless:on
+  }
+
+  def "verify null value mapping configs on tracer"() {
+    setup:
+    environmentVariables.set(DD_SERVICE_MAPPING_ENV, mapString)
+    environmentVariables.set(DD_SPAN_TAGS_ENV, mapString)
+    environmentVariables.set(DD_HEADER_TAGS_ENV, mapString)
+
+    when:
+    def config = new Config()
+
+    then:
+    config.serviceMapping == map
+    config.mergedSpanTags == map
+    config.requestHeaderTags == map
+
+    where:
+    mapString | map
+    // spotless:off
+    null      | [:]
+    ""        | [:]
+    // spotless:on
+  }
+
+  def "get analytics sample rate"() {
+    setup:
+    environmentVariables.set("DD_FOO_ANALYTICS_SAMPLE_RATE", "0.5")
+    environmentVariables.set("DD_BAR_ANALYTICS_SAMPLE_RATE", "0.9")
+    // trace prefix form should take precedence over the old non-prefix form
+    environmentVariables.set("DD_ALIAS_ENV_ANALYTICS_SAMPLE_RATE", "0.8")
+    environmentVariables.set("DD_TRACE_ALIAS_ENV_ANALYTICS_SAMPLE_RATE", "0.4")
+
+    System.setProperty("dd.baz.analytics.sample-rate", "0.7")
+    System.setProperty("dd.buzz.analytics.sample-rate", "0.3")
+    // trace prefix form should take precedence over the old non-prefix form
+    System.setProperty("dd.alias-prop.analytics.sample-rate", "0.1")
+    System.setProperty("dd.trace.alias-prop.analytics.sample-rate", "0.2")
+
+    when:
+    String[] array = services.toArray(new String[0])
+    def value = Config.get().getInstrumentationAnalyticsSampleRate(array)
+
+    then:
+    value == expected
+
+    where:
+    // spotless:off
+    services                | expected
+    ["foo"]                 | 0.5f
+    ["baz"]                 | 0.7f
+    ["doesnotexist"]        | 1.0f
+    ["doesnotexist", "foo"] | 0.5f
+    ["doesnotexist", "baz"] | 0.7f
+    ["foo", "bar"]          | 0.5f
+    ["bar", "foo"]          | 0.9f
+    ["baz", "buzz"]         | 0.7f
+    ["buzz", "baz"]         | 0.3f
+    ["foo", "baz"]          | 0.5f
+    ["baz", "foo"]          | 0.7f
+    ["alias-env", "baz"]    | 0.4f
+    ["alias-prop", "foo"]   | 0.2f
+    // spotless:on
+  }
+
+  def "detect if agent is configured using default values"() {
+    setup:
+    if (host != null) {
+      System.setProperty(PREFIX + AGENT_HOST, host)
+    }
+    if (socket != null) {
+      System.setProperty(PREFIX + AGENT_UNIX_DOMAIN_SOCKET, socket)
+    }
+    if (port != null) {
+      System.setProperty(PREFIX + TRACE_AGENT_PORT, port)
+    }
+    if (legacyPort != null) {
+      System.setProperty(PREFIX + AGENT_PORT_LEGACY, legacyPort)
+    }
+
+    when:
+    def config = new Config()
+
+    then:
+    config.isAgentConfiguredUsingDefault() == configuredUsingDefault
+
+    when:
+    Properties properties = new Properties()
+    if (propertyHost != null) {
+      properties.setProperty(AGENT_HOST, propertyHost)
+    }
+    if (propertySocket != null) {
+      properties.setProperty(AGENT_UNIX_DOMAIN_SOCKET, propertySocket)
+    }
+    if (propertyPort != null) {
+      properties.setProperty(TRACE_AGENT_PORT, propertyPort)
+    }
+
+    def childConfig = new Config(ConfigProvider.withPropertiesOverride(properties))
+
+    then:
+    childConfig.isAgentConfiguredUsingDefault() == childConfiguredUsingDefault
+
+    where:
+    // spotless:off
+    host                              | socket    | port | legacyPort | propertyHost | propertySocket | propertyPort | configuredUsingDefault | childConfiguredUsingDefault
+    null                              | null      | null | null       | null         | null           | null         | true                   | true
+    "example"                         | null      | null | null       | null         | null           | null         | false                  | false
+    ConfigDefaults.DEFAULT_AGENT_HOST | null | null | null | null | null | null | false | false
+    null                              | "example" | null | null       | null         | null           | null         | false                  | false
+    null                              | null      | "1"  | null       | null         | null           | null         | false                  | false
+    null                              | null      | null | "1"        | null         | null           | null         | false                  | false
+    "example"                         | "example" | null | null       | null         | null           | null         | false                  | false
+    null                              | null      | null | null       | "example"    | null           | null         | true                   | false
+    null                              | null      | null | null       | null         | "example"      | null         | true                   | false
+    null                              | null      | null | null       | null         | null           | "1"          | true                   | false
+    "example"                         | "example" | null | null       | "example"    | null           | null         | false                  | false
+    // spotless:on
+  }
+}


### PR DESCRIPTION
# What Does This Do

This PR splits the `Config` class to dedicated feature config classes.

# Motivation

Having multiple configuration class will help to have different initialization stages for GraalVM `native-image`.
It should also help to maintain configuration and have a clearer idea of how is defined config values and where they are used.

# Additional Notes

The `Config` API was maintained by delegating calls to the new config classes.