### PR TITLE
WAF lazy loading

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
@@ -65,10 +65,14 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
           }
           Map<String, Object> configMap = Collections.singletonMap("waf", newConfig);
           this.lastConfig.put("waf", newConfig);
-          distributeSubConfigurations(configMap, reconfiguration);
-          log.info(
-              "New AppSec configuration has been applied. AppSec status: {}",
-              AppSecSystem.ACTIVE ? "active" : "inactive");
+          if (AppSecSystem.ACTIVE) {
+            distributeSubConfigurations(configMap, reconfiguration);
+            log.info(
+                "New AppSec configuration {} has been applied. Loaded {} rules. AppSec status: {}",
+                newConfig.getVersion(),
+                newConfig.getRules().size(),
+                AppSecSystem.ACTIVE ? "active" : "inactive");
+          }
         });
     this.configurationPoller.addListener(
         Product.ASM_DATA,
@@ -108,6 +112,17 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
           final boolean newState =
               newConfig != null && newConfig.asm != null && newConfig.asm.enabled;
           if (AppSecSystem.ACTIVE != newState) {
+            if (newState) {
+              // Enforce applying waf rules if wasn't done before (lazy loading)
+              AppSecConfig conf = (AppSecConfig) this.lastConfig.get("waf");
+              Map<String, Object> configMap = Collections.singletonMap("waf", conf);
+              distributeSubConfigurations(configMap, reconfiguration);
+              log.info(
+                  "New AppSec configuration {} has been applied. Loaded {} rules.",
+                  conf.getVersion(),
+                  conf.getRules().size());
+            }
+
             log.warn("AppSec {} (runtime)", newState ? "enabled" : "disabled");
             AppSecSystem.ACTIVE = newState;
           }


### PR DESCRIPTION
# What Does This Do
WAF loads lazily to reduce startup time.

# Benchmark (startup time till first request handled)
<img width="938" alt="image" src="https://user-images.githubusercontent.com/7569471/197286156-3e0eb0b9-97a8-4126-92ab-d7be7a674ce6.png">

Based on numbers the `telemetry`, `remote-config`, `appsec` gives **+2.14% of overhead**.
