### PR TITLE
Fix IastSpringBootSmokeTest flakiness, wait for traces

### DIFF
--- a/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
@@ -87,6 +87,7 @@ class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
     client.newCall(request).execute()
 
     then:
+    waitForTraceCount(1)
     Boolean foundEnabledTag = false
     checkLog {
       if (it.contains("_dd.iast.enabled=1")) {


### PR DESCRIPTION
# What Does This Do

Fix IastSpringBootSmokeTest flakiness, wait for traces

# Motivation

This test occasionally flaked in CI with the following error:

```
Condition not satisfied:

foundEnabledTag
|
false

	at datadog.smoketest.IastSpringBootSmokeTest.iast.enabled tag is present(IastSpringBootSmokeTest.groovy:96)
```

It seems the log is sometimes checked before the traces are written to it.

# Additional Notes
