### PR TITLE
Ensure that remote config activation test runs on CI

### DIFF
--- a/dd-smoke-tests/appsec/springboot/springboot.gradle
+++ b/dd-smoke-tests/appsec/springboot/springboot.gradle
@@ -34,4 +34,4 @@ task testRuntimeActivation(type: Test) {
   jvmArgs '-Dsmoke_test.appsec.enabled=inactive',
     "-Ddatadog.smoketest.appsec.springboot.shadowJar.path=${tasks.shadowJar.archivePath}"
 }
-tasks['check'].dependsOn(testRuntimeActivation)
+tasks['test'].dependsOn(testRuntimeActivation)


### PR DESCRIPTION
# What Does This Do

Ensure that remote config activation test runs on CI. It was currently tied to the `check` phase, and not `test`.

# Motivation

# Additional Notes
