### PR TITLE
Make remote config quiet until endpoint is discovered

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
+++ b/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
@@ -169,10 +169,12 @@ public class SharedCommunicationObjects {
       lastTry = now;
       String configEndpoint = sco.featuresDiscovery.getConfigEndpoint();
       if (configEndpoint == null) {
+        log.debug("Remote config endpoint not found");
         return null;
       }
 
       this.configUrl = sco.featuresDiscovery.buildUrl(configEndpoint).toString();
+      log.info("Found remote config endpoint: {}", this.configUrl);
       return this.configUrl;
     }
   }

--- a/remote-config/src/main/java/datadog/remoteconfig/PollerRequestFactory.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/PollerRequestFactory.java
@@ -5,7 +5,6 @@ import datadog.remoteconfig.tuf.RemoteConfigRequest;
 import datadog.remoteconfig.tuf.RemoteConfigRequest.CachedTargetFile;
 import datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.ClientState;
 import datadog.trace.api.Config;
-import datadog.trace.api.function.Supplier;
 import datadog.trace.util.TagsHelper;
 import java.util.Arrays;
 import java.util.Collection;
@@ -36,15 +35,10 @@ public class PollerRequestFactory {
   private final String tracerVersion;
   private final String containerId;
   private final Moshi moshi;
-  private final Supplier<String> urlSupplier;
-  HttpUrl url;
+  final HttpUrl url;
 
   public PollerRequestFactory(
-      Config config,
-      String tracerVersion,
-      String containerId,
-      Supplier<String> urlProvider,
-      Moshi moshi) {
+      Config config, String tracerVersion, String containerId, String url, Moshi moshi) {
     this.runtimeId = getRuntimeId(config);
     this.serviceName = TagsHelper.sanitize(config.getServiceName());
     this.apiKey = config.getApiKey();
@@ -54,7 +48,7 @@ public class PollerRequestFactory {
     // Semantic Versioning requires build separated with `+`
     this.tracerVersion = tracerVersion.replace('~', '+');
     this.containerId = containerId;
-    this.urlSupplier = urlProvider;
+    this.url = parseUrl(url);
     this.moshi = moshi;
   }
 
@@ -80,13 +74,6 @@ public class PollerRequestFactory {
       ClientState clientState,
       Collection<CachedTargetFile> cachedTargetFiles,
       long capabilities) {
-    if (this.url == null) {
-      String configUrl = this.urlSupplier.get();
-      if (configUrl == null) {
-        return null;
-      }
-      this.url = parseUrl(configUrl);
-    }
     Request.Builder requestBuilder = new Request.Builder().url(this.url).get();
     MediaType applicationJson = MediaType.parse("application/json");
     RequestBody requestBody =

--- a/remote-config/src/test/groovy/datadog/remoteconfig/PollerRequestFactoryTest.groovy
+++ b/remote-config/src/test/groovy/datadog/remoteconfig/PollerRequestFactoryTest.groovy
@@ -8,6 +8,7 @@ class PollerRequestFactoryTest extends DDSpecification {
 
   static final String TRACER_VERSION = "v1.2.3"
   static final String CONTAINER_ID = "456"
+  static final String INVALID_REMOTE_CONFIG_URL = "https://invalid.example.com/"
 
   void 'remote config request fields been sanitized'() {
     given:
@@ -15,7 +16,7 @@ class PollerRequestFactoryTest extends DDSpecification {
     System.setProperty("dd.env", "PROD")
     System.setProperty("dd.tags", "version:1.0.0-SNAPSHOT")
     rebuildConfig()
-    PollerRequestFactory factory = new PollerRequestFactory(Config.get(), TRACER_VERSION, CONTAINER_ID, null, null )
+    PollerRequestFactory factory = new PollerRequestFactory(Config.get(), TRACER_VERSION, CONTAINER_ID, INVALID_REMOTE_CONFIG_URL, null)
 
     when:
     RemoteConfigRequest request = factory.buildRemoteConfigRequest( Collections.singletonList("ASM"), null, null, 0)


### PR DESCRIPTION
# What Does This Do

Make remote config quiet until endpoint is discovered

Also make some more initialization lazy.

# Motivation

Remote config poller has a lower polling interval than feature discovery. In the previous version, remote config polling every 5 seconds got too verbose until a remote config endpoint was discovered (which would never happened if the agent simply had no remote config enabled).

# Additional Notes

Example of log before this PR:

```
web_1    | [dd.trace 2022-10-21 11:18:21:216 +0000] [dd-remote-config] DEBUG datadog.remoteconfig.ConfigurationPoller - Failed to poll remote configuration from (no endpoint discovered yet)
web_1    | java.io.IOException: Endpoint has not been discovered yet
web_1    | 	at datadog.remoteconfig.ConfigurationPoller.fetchConfiguration(ConfigurationPoller.java:201)
web_1    | 	at datadog.remoteconfig.ConfigurationPoller.sendRequest(ConfigurationPoller.java:212)
web_1    | 	at datadog.remoteconfig.ConfigurationPoller.poll(ConfigurationPoller.java:179)
web_1    | 	at datadog.trace.util.AgentTaskScheduler$PeriodicTask.run(AgentTaskScheduler.java:299)
web_1    | 	at datadog.trace.util.AgentTaskScheduler$Worker.run(AgentTaskScheduler.java:254)
web_1    | 	at java.base/java.lang.Thread.run(Thread.java:829)
```
