### PR TITLE
Ignore dependency duplicates while collecting with Telemetry

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
@@ -49,25 +49,15 @@ public class TelemetrySystem {
 
   public static void startTelemetry(
       Instrumentation instrumentation, SharedCommunicationObjects sco) {
-    try {
-      DependencyService dependencyService = createDependencyService(instrumentation);
-      TelemetryService telemetryService =
-          new TelemetryServiceImpl(
-              new RequestBuilderSupplier(sco.agentUrl),
-              SystemTimeSource.INSTANCE,
-              Config.get().getTelemetryHeartbeatInterval());
-      TELEMETRY_THREAD =
-          createTelemetryRunnable(telemetryService, sco.okHttpClient, dependencyService);
-      TELEMETRY_THREAD.start();
-    } catch (UnsatisfiedLinkError e) {
-      // TODO: update jnr_ffi and jnr_unixsocket to version that supports aarch64
-      final String arch = System.getProperty("os.arch").toLowerCase();
-      if (!arch.equals("x86") && !arch.equals("amd64")) {
-        log.error("Can't start telemetry. Unsupported architecture: '{}'", arch);
-      } else {
-        throw e;
-      }
-    }
+    DependencyService dependencyService = createDependencyService(instrumentation);
+    TelemetryService telemetryService =
+        new TelemetryServiceImpl(
+            new RequestBuilderSupplier(sco.agentUrl),
+            SystemTimeSource.INSTANCE,
+            Config.get().getTelemetryHeartbeatInterval());
+    TELEMETRY_THREAD =
+        createTelemetryRunnable(telemetryService, sco.okHttpClient, dependencyService);
+    TELEMETRY_THREAD.start();
   }
 
   public static void stop() {

--- a/telemetry/src/main/java/datadog/telemetry/dependency/Dependency.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/Dependency.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
@@ -258,7 +259,7 @@ public final class Dependency {
   private static String parseGroupId(String bundleSymbolicName, String bundleName) {
     // Usually bundleSymbolicName contains bundleName at the end. Check this
 
-    // Bundle name can contains dash, so normalize it
+    // Bundle name can contain dash, so normalize it
     String normalizedBundleName = Strings.replace(bundleName, "-", ".");
 
     String bundleNameWithPrefix = "." + normalizedBundleName;
@@ -268,5 +269,11 @@ public final class Dependency {
     }
 
     return null;
+  }
+
+  // HashCode uses to determine/suppress duplicates when collecting Dependencies.
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, version);
   }
 }

--- a/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyServiceImplSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyServiceImplSpecification.groovy
@@ -167,4 +167,30 @@ class DependencyServiceImplSpecification extends DepSpecification {
     then:
     depService.drainDeterminedDependencies().isEmpty()
   }
+
+  void 'ignore dependency duplicates'() {
+    setup:
+    File junitJar = getJar('junit-4.12.jar')
+    URL url = new File(junitJar.getAbsolutePath()).toURL()
+
+    when:
+    // First time loaded dependency - collect
+    depService.addURL(url)
+    depService.resolveOneDependency()
+
+    then:
+    def set = depService.drainDeterminedDependencies()
+    assertThat(set.size(), is(1))
+    assertThat(set.first().name, is('junit'))
+    assertThat(set.first().version, is('4.12'))
+
+    when:
+    // Second time loaded same dependency (should be ignored)
+    depService.addURL(url)
+    depService.resolveOneDependency()
+
+    then:
+    def dependencies = depService.drainDeterminedDependencies()
+    dependencies.isEmpty()
+  }
 }


### PR DESCRIPTION
# What Does This Do
Added the set of hashes to keep all collected dependencies, to ignore duplicates. Assumed the set of hashes will exist during the whole application life time, because we don't know when exactly new dependency will be loaded.

# Motivation
The same dependency could be loaded twice or more by different class loaders - we can have duplications, that we need to ignore. 

# Additional Notes
