### PR TITLE
add missing helper class names to avoid IllegalAccessErrors

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AsyncAfterTransmissionInterceptorCallingResponseHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AsyncAfterTransmissionInterceptorCallingResponseHandlerInstrumentation.java
@@ -25,6 +25,13 @@ public final class AsyncAfterTransmissionInterceptorCallingResponseHandlerInstru
         isMethod().and(named("onHeaders")), getClass().getName() + "$OnHeadersAdvice");
   }
 
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".TracingExecutionInterceptor", packageName + ".AwsSdkClientDecorator"
+    };
+  }
+
   public static class OnHeadersAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentSpan methodEnter(


### PR DESCRIPTION
# What Does This Do

Adds missing helper classes to an instrumentation, this was noticed because of a large number of `IllegalAccessError`s picked up by exception profiling:
<img width="965" alt="Screenshot 2022-10-24 at 21 24 41" src="https://user-images.githubusercontent.com/16439049/197621920-0ae30cd7-4fea-4a14-9762-4aa61146e8b2.png">

Modifying the `ThrowableInstrumentation` to print the stack trace was the only way to get the error message (should this be made available as setting?):

```
java.lang.IllegalAccessError: class software.amazon.awssdk.core.internal.http.async.AsyncAfterTransmissionInterceptorCallingResponseHandler tried to access field datadog.trace.instrumentation.aws.v2.TracingExecutionInterceptor.SPAN_ATTRIBUTE (software.amazon.awssdk.core.internal.http.async.AsyncAfterTransmissionInterceptorCallingResponseHandler and datadog.trace.instrumentation.aws.v2.TracingExecutionInterceptor are in unnamed module of loader 'app')
	at software.amazon.awssdk.core.internal.http.async.AsyncAfterTransmissionInterceptorCallingResponseHandler.onHeaders(AsyncAfterTransmissionInterceptorCallingResponseHandler.java:67)
	at software.amazon.awssdk.http.nio.netty.internal.ResponseHandler.channelRead0(ResponseHandler.java:98)
	at software.amazon.awssdk.http.nio.netty.internal.ResponseHandler.channelRead0(ResponseHandler.java:73)
```

# Motivation

# Additional Notes
