### PR TITLE
add span context to exception samples

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionSampleEvent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionSampleEvent.java
@@ -27,19 +27,27 @@ public class ExceptionSampleEvent extends Event {
   @Label("First occurrence")
   private final boolean firstOccurrence;
 
+  @Label("Local Root Span Id")
+  private final long localRootSpanId;
+
+  @Label("Span Id")
+  private final long spanId;
+
   public ExceptionSampleEvent(
-      final Throwable e, final boolean sampled, final boolean firstOccurrence) {
+      Throwable e, boolean sampled, boolean firstOccurrence, long localRootSpanId, long spanId) {
     /*
      * TODO: we should have some tests for this class.
      * Unfortunately at the moment this is not easily possible because we cannot build tests with groovy that
      * are compiled against java11 SDK - this seems to be gradle-groovy interaction limitation.
      * Writing these tests in java seems like would introduce more noise.
      */
-    type = e.getClass().getName();
-    message = getMessage(e);
-    stackDepth = getStackDepth(e);
+    this.type = e.getClass().getName();
+    this.message = getMessage(e);
+    this.stackDepth = getStackDepth(e);
     this.sampled = sampled;
     this.firstOccurrence = firstOccurrence;
+    this.localRootSpanId = localRootSpanId;
+    this.spanId = spanId;
   }
 
   private static String getMessage(Throwable t) {


### PR DESCRIPTION
# What Does This Do

This adds the active span and local root span ID to exception sample events so they can be used to explain span latency.

# Motivation

# Additional Notes
