### PR TITLE
make SPAN_ATTRIBUTE public to avoid IllegalAccessError in AWS-SDK instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AsyncAfterTransmissionInterceptorCallingResponseHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AsyncAfterTransmissionInterceptorCallingResponseHandlerInstrumentation.java
@@ -25,13 +25,6 @@ public final class AsyncAfterTransmissionInterceptorCallingResponseHandlerInstru
         isMethod().and(named("onHeaders")), getClass().getName() + "$OnHeadersAdvice");
   }
 
-  @Override
-  public String[] helperClassNames() {
-    return new String[] {
-      packageName + ".TracingExecutionInterceptor", packageName + ".AwsSdkClientDecorator"
-    };
-  }
-
   public static class OnHeadersAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentSpan methodEnter(

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
@@ -15,7 +15,7 @@ import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 /** AWS request execution interceptor */
 public class TracingExecutionInterceptor implements ExecutionInterceptor {
 
-  static final ExecutionAttribute<AgentSpan> SPAN_ATTRIBUTE =
+  public static final ExecutionAttribute<AgentSpan> SPAN_ATTRIBUTE =
       new ExecutionAttribute<>("DatadogSpan");
 
   @Override


### PR DESCRIPTION
# What Does This Do

#4084 was the wrong fix for the problem, it was actually enough to just make the `SPAN_ATTRIBUTE` public (the helper classes were already added by the base class)

# Motivation

# Additional Notes
