### PR TITLE
Do not log exceptions when remote config returns 404

### DIFF
--- a/remote-config/src/main/java/datadog/remoteconfig/ConfigurationPoller.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/ConfigurationPoller.java
@@ -210,6 +210,10 @@ public class ConfigurationPoller
 
   void sendRequest(Consumer<ResponseBody> responseBodyConsumer) throws IOException {
     try (Response response = fetchConfiguration()) {
+      if (response.code() == 404) {
+        log.debug("Remote configuration endpoint is disabled");
+        return;
+      }
       ResponseBody body = response.body();
       if (response.isSuccessful()) {
         if (body == null) {


### PR DESCRIPTION
# What Does This Do

If the agent has remote config enabled, the library discovers the endpoint, and then the agent is restarted with remote config disabled, we want to keep the logs quiet. We keep a debug-level message, but no warning or exception.

# Motivation

# Additional Notes
