### PR TITLE
ignore netty resource leak monitoring in exception profiling

### DIFF
--- a/dd-java-agent/instrumentation/exception-profiling/src/main/java11/datadog/exceptions/instrumentation/ThrowableInstanceAdvice.java
+++ b/dd-java-agent/instrumentation/exception-profiling/src/main/java11/datadog/exceptions/instrumentation/ThrowableInstanceAdvice.java
@@ -12,6 +12,9 @@ import net.bytebuddy.asm.Advice;
 public class ThrowableInstanceAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
   public static void onExit(@Advice.This final Throwable t) {
+    if (t.getClass().getName().endsWith(".ResourceLeakDetector$TraceRecord")) {
+      return;
+    }
     /*
      * This instrumentation handler is sensitive to any throwables thrown from its body -
      * it will go into infinite loop of trying to handle the new throwable instance and generating


### PR DESCRIPTION
# What Does This Do

This exception type is an abuse of `Throwable`, don't fill in their stack traces unless a very high level of tracking is configured by `-Dio.netty.leakDetection.level=LEVEL`, and pollute the exception profile. Matches on the suffix of the name because netty is so widely shaded.

# Motivation

# Additional Notes
