### PR TITLE
Create spans for vulnerabilities outside of requests

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastModuleImpl.java
@@ -72,7 +72,7 @@ public final class IastModuleImpl implements IastModule {
     Vulnerability vulnerability =
         new Vulnerability(
             VulnerabilityType.WEAK_CIPHER,
-            Location.forSpanAndStack(span.getSpanId(), stackTraceElement),
+            Location.forSpanAndStack(spanId(span), stackTraceElement),
             new Evidence(algorithm));
     reporter.report(span, vulnerability);
   }
@@ -97,7 +97,7 @@ public final class IastModuleImpl implements IastModule {
     Vulnerability vulnerability =
         new Vulnerability(
             VulnerabilityType.WEAK_HASH,
-            Location.forSpanAndStack(span.getSpanId(), stackTraceElement),
+            Location.forSpanAndStack(spanId(span), stackTraceElement),
             new Evidence(algorithm));
     reporter.report(span, vulnerability);
   }
@@ -526,5 +526,9 @@ public final class IastModuleImpl implements IastModule {
       Ranges.copyShift(rangesRight, ranges, rangesLeft.length, offset);
     }
     return ranges;
+  }
+
+  private static long spanId(@Nullable final AgentSpan span) {
+    return span == null ? 0 : span.getSpanId();
   }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/Reporter.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/Reporter.java
@@ -7,13 +7,22 @@ import datadog.trace.api.DDTags;
 import datadog.trace.api.TraceSegment;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
+import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
+import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /** Reports IAST vulnerabilities. */
 public class Reporter {
+
+  private static final String VULNERABILITY_SPAN_NAME = "vulnerability";
 
   private final Predicate<Vulnerability> duplicated;
 
@@ -29,10 +38,22 @@ public class Reporter {
     this.duplicated = duplicate;
   }
 
-  public void report(final AgentSpan span, final Vulnerability vulnerability) {
+  public void report(@Nullable final AgentSpan span, @Nonnull final Vulnerability vulnerability) {
     if (span == null) {
-      return;
+      final AgentSpan newSpan = startNewSpan();
+      try (final AgentScope autoClosed = tracer().activateSpan(newSpan, ScopeSource.MANUAL)) {
+        vulnerability.getLocation().updateSpan(newSpan.getSpanId());
+        reportVulnerability(newSpan, vulnerability);
+      } finally {
+        newSpan.finish();
+      }
+    } else {
+      reportVulnerability(span, vulnerability);
     }
+  }
+
+  private void reportVulnerability(
+      @Nonnull final AgentSpan span, @Nonnull final Vulnerability vulnerability) {
     final RequestContext reqCtx = span.getRequestContext();
     if (reqCtx == null) {
       return;
@@ -54,6 +75,18 @@ public class Reporter {
       // are kept.
       segment.setTagTop(DDTags.MANUAL_KEEP, true);
     }
+  }
+
+  private AgentSpan startNewSpan() {
+    final AgentSpan.Context tagContext =
+        new TagContext().withRequestContextDataIast(new IastRequestContext());
+    return tracer()
+        .startSpan(VULNERABILITY_SPAN_NAME, tagContext)
+        .setSpanType(InternalSpanTypes.VULNERABILITY);
+  }
+
+  protected AgentTracer.TracerAPI tracer() {
+    return AgentTracer.get();
   }
 
   /**

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Location.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Location.java
@@ -6,7 +6,7 @@ public final class Location {
 
   private final int line;
 
-  private final Long spanId;
+  private Long spanId;
 
   private Location(final long spanId, final String path, final int line) {
     this.spanId = spanId == 0 ? null : spanId;
@@ -28,5 +28,9 @@ public final class Location {
 
   public int getLine() {
     return line;
+  }
+
+  public void updateSpan(final long spanId) {
+    this.spanId = spanId;
   }
 }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
@@ -8,9 +8,15 @@ import com.datadog.iast.model.VulnerabilityType
 import datadog.trace.api.TraceSegment
 import datadog.trace.api.gateway.RequestContext
 import datadog.trace.api.gateway.RequestContextSlot
+import datadog.trace.bootstrap.instrumentation.api.AgentScope
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI
+import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes
+import datadog.trace.bootstrap.instrumentation.api.ScopeSource
 import datadog.trace.test.util.DDSpecification
 import groovy.json.JsonSlurper
+import spock.lang.Shared
 
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
@@ -19,6 +25,13 @@ import java.util.concurrent.TimeUnit
 import static datadog.trace.api.config.IastConfig.IAST_DEDUPLICATION_ENABLED
 
 class ReporterTest extends DDSpecification {
+
+  @Shared
+  protected static final TracerAPI ORIGINAL_TRACER = AgentTracer.get()
+
+  def cleanup() {
+    AgentTracer.forceRegister(ORIGINAL_TRACER)
+  }
 
   void 'basic vulnerability reporting'() {
     given:
@@ -127,10 +140,17 @@ class ReporterTest extends DDSpecification {
     0 * _
   }
 
-  void 'null span does not throw'() {
+  void 'null span creates a new one before reporting'() {
     given:
-    final Reporter reporter = new Reporter()
-    final span = null
+    final tracerAPI = Mock(TracerAPI)
+    AgentTracer.forceRegister(tracerAPI)
+    final spanId = 12345L
+    final span = Mock(AgentSpan)
+    final scope = Mock(AgentScope)
+    final ctx = new IastRequestContext()
+    final reqCtx = Stub(RequestContext)
+    reqCtx.getData(RequestContextSlot.IAST) >> ctx
+    final reporter = new Reporter()
     final v = new Vulnerability(
       VulnerabilityType.WEAK_HASH,
       Location.forSpanAndStack(0, new StackTraceElement("foo", "foo", "foo", 1)),
@@ -138,10 +158,18 @@ class ReporterTest extends DDSpecification {
       )
 
     when:
-    reporter.report(span, v)
+    reporter.report(null, v)
+    v.getLocation().getSpanId() == spanId
 
     then:
     noExceptionThrown()
+    1 * tracerAPI.startSpan('vulnerability', _ as AgentSpan.Context) >> span
+    1 * tracerAPI.activateSpan(span, ScopeSource.MANUAL) >> scope
+    1 * span.getSpanId() >> spanId
+    1 * span.getRequestContext() >> reqCtx
+    1 * span.setSpanType(InternalSpanTypes.VULNERABILITY) >> span
+    1 * span.finish()
+    1 * scope.close()
     0 * _
   }
 
@@ -150,7 +178,7 @@ class ReporterTest extends DDSpecification {
     final Reporter reporter = new Reporter()
     final span = Mock(AgentSpan)
     span.getRequestContext() >> null
-    span.getSpanId() >> null
+    span.getSpanId() >> 12345L
     final v = new Vulnerability(
       VulnerabilityType.WEAK_HASH,
       Location.forSpanAndStack(0, new StackTraceElement("foo", "foo", "foo", 1)),

--- a/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -1,11 +1,10 @@
 package datadog.smoketest.springboot.controller;
 
+import ddtest.client.sources.Hasher;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,6 +13,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class IastWebController {
+
+  private final Hasher hasher;
+
+  public IastWebController() {
+    this.hasher = new Hasher();
+    hasher.sha1();
+  }
+
   @RequestMapping("/greeting")
   public String greeting() {
     return "Sup Dawg";
@@ -21,11 +28,14 @@ public class IastWebController {
 
   @RequestMapping("/weakhash")
   public String weakhash() {
-    try {
-      MessageDigest.getInstance("MD5").digest("Message body".getBytes(StandardCharsets.UTF_8));
-    } catch (NoSuchAlgorithmException e) {
-      return "Error: " + e.toString();
-    }
+    hasher.md5().digest("Message body".getBytes(StandardCharsets.UTF_8));
+    return "Weak Hash page";
+  }
+
+  @RequestMapping("/async_weakhash")
+  public String asyncWeakhash() {
+    final Thread thread = new Thread(hasher::md4);
+    thread.start();
     return "Weak Hash page";
   }
 

--- a/dd-smoke-tests/springboot/src/main/java/ddtest/client/sources/Hasher.java
+++ b/dd-smoke-tests/springboot/src/main/java/ddtest/client/sources/Hasher.java
@@ -4,7 +4,27 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 public class Hasher {
-  public void executeHash() throws NoSuchAlgorithmException {
-    MessageDigest.getInstance("MD5");
+  public MessageDigest sha1() {
+    try {
+      return MessageDigest.getInstance("SHA1");
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public MessageDigest md4() {
+    try {
+      return MessageDigest.getInstance("MD4");
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public MessageDigest md5() {
+    try {
+      return MessageDigest.getInstance("MD5");
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
@@ -2,16 +2,20 @@ package datadog.smoketest
 
 import datadog.trace.api.Platform
 import datadog.trace.test.agent.decoder.DecodedSpan
+import groovy.json.JsonSlurper
 import okhttp3.Request
 import spock.lang.IgnoreIf
 import spock.util.concurrent.PollingConditions
 
 import java.util.function.Function
+import java.util.function.Predicate
 
 @IgnoreIf({
   !Platform.isJavaVersionAtLeast(8)
 })
 class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
+
+  private static final String TAG_NAME = '_dd.iast.json'
 
   @Override
   def logLevel() {
@@ -112,7 +116,33 @@ class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
     client.newCall(request).execute()
 
     then:
-    waitForSpan(new PollingConditions(timeout: 5), hasVulnerability("WEAK_HASH"))
+    waitForSpan(new PollingConditions(timeout: 5),
+    hasVulnerability(type('WEAK_HASH').and(evidence('MD5'))))
+  }
+
+  def "weak hash vulnerability is present on boot"() {
+    setup:
+    String url = "http://localhost:${httpPort}/greeting"
+    def request = new Request.Builder().url(url).get().build()
+
+    when: 'ensure the controller is loaded'
+    client.newCall(request).execute()
+
+    then: 'a vulnerability pops in the logs (startup traces might not always be available)'
+    hasVulnerabilityInLogs(type('WEAK_HASH').and(evidence('SHA1')).and(withSpan()))
+  }
+
+  def "weak hash vulnerability is present on thread"() {
+    setup:
+    String url = "http://localhost:${httpPort}/async_weakhash"
+    def request = new Request.Builder().url(url).get().build()
+
+    when:
+    client.newCall(request).execute()
+
+    then:
+    waitForSpan(new PollingConditions(timeout: 5),
+    hasVulnerability(type('WEAK_HASH').and(evidence('MD4')).and(withSpan())))
   }
 
   def "getParameter taints string"() {
@@ -145,7 +175,7 @@ class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
     client.newCall(request).execute()
 
     then:
-    waitForSpan(new PollingConditions(timeout: 5), hasVulnerability("COMMAND_INJECTION"))
+    waitForSpan(new PollingConditions(timeout: 5), hasVulnerability(type("COMMAND_INJECTION")))
   }
 
   def "command injection is present with process builder"() {
@@ -157,7 +187,7 @@ class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
     client.newCall(request).execute()
 
     then:
-    waitForSpan(new PollingConditions(timeout: 5), hasVulnerability("COMMAND_INJECTION"))
+    waitForSpan(new PollingConditions(timeout: 5), hasVulnerability(type("COMMAND_INJECTION")))
   }
 
   def "path traversal is present with file"() {
@@ -169,7 +199,7 @@ class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
     client.newCall(request).execute()
 
     then:
-    waitForSpan(new PollingConditions(timeout: 5), hasVulnerability("PATH_TRAVERSAL"))
+    waitForSpan(new PollingConditions(timeout: 5), hasVulnerability(type("PATH_TRAVERSAL")))
   }
 
   def "path traversal is present with paths"() {
@@ -181,7 +211,7 @@ class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
     client.newCall(request).execute()
 
     then:
-    waitForSpan(new PollingConditions(timeout: 5), hasVulnerability("PATH_TRAVERSAL"))
+    waitForSpan(new PollingConditions(timeout: 5), hasVulnerability(type("PATH_TRAVERSAL")))
   }
 
   def "path traversal is present with path"() {
@@ -193,14 +223,76 @@ class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
     client.newCall(request).execute()
 
     then:
-    waitForSpan(new PollingConditions(timeout: 5), hasVulnerability("PATH_TRAVERSAL"))
+    waitForSpan(new PollingConditions(timeout: 5), hasVulnerability(type("PATH_TRAVERSAL")))
   }
 
   private static Function<DecodedSpan, Boolean> hasMetric(final String name, final Object value) {
     return { span -> value == span.metrics.get(name) }
   }
 
-  private static Function<DecodedSpan, Boolean> hasVulnerability(final String vulnerabilityName) {
-    return { span -> span.toString().contains(vulnerabilityName) }
+  private static Function<DecodedSpan, Boolean> hasVulnerability(final Predicate<?> predicate) {
+    return { span ->
+      final iastMeta = span.meta.get(TAG_NAME)
+      if (!iastMeta) {
+        return false
+      }
+      final vulnerabilities = parseVulnerabilities(iastMeta)
+      return vulnerabilities.stream().anyMatch(predicate)
+    }
+  }
+
+  private boolean hasVulnerabilityInLogs(final Predicate<?> predicate) {
+    def found = false
+    checkLog { final String log ->
+      final index = log.indexOf(TAG_NAME)
+      if (index >= 0) {
+        final vulnerabilities = parseVulnerabilities(log, index)
+        found |= vulnerabilities.stream().anyMatch(predicate)
+      }
+    }
+    return found
+  }
+
+  private static Collection<?> parseVulnerabilities(final String log, final int startIndex) {
+    final chars = log.toCharArray()
+    final builder = new StringBuilder()
+    def level = 0
+    for (int i = log.indexOf('{', startIndex); i < chars.length; i++) {
+      final current = chars[i]
+      if (current == '{' as char) {
+        level++
+      } else if (current == '}' as char) {
+        level--
+      }
+      builder.append(chars[i])
+      if (level == 0) {
+        break
+      }
+    }
+    return parseVulnerabilities(builder.toString())
+  }
+
+  private static Collection<?> parseVulnerabilities(final String iastJson) {
+    final slurper = new JsonSlurper()
+    final parsed = slurper.parseText(iastJson)
+    return parsed['vulnerabilities'] as Collection
+  }
+
+  private static Predicate<?> type(final String type) {
+    return { vul ->
+      vul.type == type
+    }
+  }
+
+  private static Predicate<?> evidence(final String value) {
+    return { vul ->
+      vul.evidence.value == value
+    }
+  }
+
+  private static Predicate<?> withSpan() {
+    return { vul ->
+      vul.location.spanId > 0
+    }
   }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDSpanTypes.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDSpanTypes.java
@@ -27,4 +27,6 @@ public class DDSpanTypes {
   public static final String GRAPHQL = "graphql";
 
   public static final String TEST = "test";
+
+  public static final String VULNERABILITY = "vulnerability";
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InternalSpanTypes.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InternalSpanTypes.java
@@ -35,4 +35,7 @@ public class InternalSpanTypes {
   public static final CharSequence GRAPHQL = UTF8BytesString.create(DDSpanTypes.GRAPHQL);
 
   public static final CharSequence TEST = UTF8BytesString.create(DDSpanTypes.TEST);
+
+  public static final CharSequence VULNERABILITY =
+      UTF8BytesString.create(DDSpanTypes.VULNERABILITY);
 }


### PR DESCRIPTION
# What Does This Do
Creates a new span for vulnerabilities where there is no current context

# Motivation
Vulnerabilities are not only found during the execution of a request, they can be present at boot time, background processes ... this PR tries to enable the creation of custom spans when there is no requests.

# Additional Notes
