### PR TITLE
Avoid Config mock in PollerRequestFactoryTest

### DIFF
--- a/remote-config/src/test/groovy/datadog/remoteconfig/PollerRequestFactoryTest.groovy
+++ b/remote-config/src/test/groovy/datadog/remoteconfig/PollerRequestFactoryTest.groovy
@@ -6,18 +6,16 @@ import datadog.trace.api.Config
 
 class PollerRequestFactoryTest extends DDSpecification {
 
-  Config config = Mock()
   static final String TRACER_VERSION = "v1.2.3"
   static final String CONTAINER_ID = "456"
 
   void 'remote config request fields been sanitized'() {
-    when:
-    PollerRequestFactory factory = new PollerRequestFactory(config, TRACER_VERSION, CONTAINER_ID, null, null )
-
-    then:
-    1 * config.getServiceName() >> "Service Name"
-    1 * config.getEnv() >> "PROD"
-    1 * config.getVersion() >> "1.0.0-SNAPSHOT"
+    given:
+    System.setProperty("dd.service", "Service Name")
+    System.setProperty("dd.env", "PROD")
+    System.setProperty("dd.tags", "version:1.0.0-SNAPSHOT")
+    rebuildConfig()
+    PollerRequestFactory factory = new PollerRequestFactory(Config.get(), TRACER_VERSION, CONTAINER_ID, null, null )
 
     when:
     RemoteConfigRequest request = factory.buildRemoteConfigRequest( Collections.singletonList("ASM"), null, null, 0)


### PR DESCRIPTION
# What Does This Do

Avoid Config mock in PollerRequestFactoryTest.

# Motivation

Mocking Config here was producing some instrumentation failures in DDSpecification.

# Additional Notes
This test was introducing in https://github.com/DataDog/dd-trace-java/pull/4025 and apparently it works in CI (no failure in master for CI, and I get local failures).

The error I'm seeing:

```
Config will not be modifiable
java.lang.IllegalStateException: Could not install class file transformer
	at net.bytebuddy.agent.builder.AgentBuilder$Default.doInstall(AgentBuilder.java:11142)
	at net.bytebuddy.agent.builder.AgentBuilder$Default.installOn(AgentBuilder.java:11044)
	at net.bytebuddy.agent.builder.AgentBuilder$installOn$4.call(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:47)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:115)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:127)
	at datadog.trace.test.util.DDSpecification.makeConfigInstanceModifiable(DDSpecification.groovy:74)
	at datadog.trace.test.util.DDSpecification.<clinit>(DDSpecification.groovy:33)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at java.base/java.lang.Class.newInstance(Class.java:584)
	at org.spockframework.runtime.BaseSpecRunner.createSpecInstance(BaseSpecRunner.java:104)
	at org.spockframework.runtime.BaseSpecRunner.run(BaseSpecRunner.java:62)
	at org.spockframework.runtime.Sputnik.run(Sputnik.java:63)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:110)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:38)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:62)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at com.sun.proxy.$Proxy5.processTestClass(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$2.run(TestWorker.java:176)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:133)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:71)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
Caused by: java.lang.IllegalStateException: Could not transform any of [class datadog.trace.api.Config]
	at net.bytebuddy.agent.builder.AgentBuilder$RedefinitionStrategy$Listener$ErrorEscalating$1.onError(AgentBuilder.java:6249)
	at net.bytebuddy.agent.builder.AgentBuilder$RedefinitionStrategy$Listener$Compound.onError(AgentBuilder.java:6522)
	at net.bytebuddy.agent.builder.AgentBuilder$RedefinitionStrategy$Collector.apply(AgentBuilder.java:7994)
	at net.bytebuddy.agent.builder.AgentBuilder$RedefinitionStrategy.apply(AgentBuilder.java:5689)
	at net.bytebuddy.agent.builder.AgentBuilder$Default.doInstall(AgentBuilder.java:11126)
	... 38 more
Caused by: java.lang.UnsupportedOperationException: class redefinition failed: attempted to change the schema (add/remove fields)
	at java.instrument/sun.instrument.InstrumentationImpl.retransformClasses0(Native Method)
	at java.instrument/sun.instrument.InstrumentationImpl.retransformClasses(InstrumentationImpl.java:167)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at net.bytebuddy.utility.Invoker$Dispatcher.invoke(Unknown Source)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$Dispatcher$ForNonStaticMethod.invoke(JavaDispatcher.java:1032)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$ProxiedInvocationHandler.invoke(JavaDispatcher.java:1162)
	at net.bytebuddy.agent.builder.$Proxy42.retransformClasses(Unknown Source)
	at net.bytebuddy.agent.builder.AgentBuilder$RedefinitionStrategy$Collector$ForRetransformation.doApply(AgentBuilder.java:8177)
	at net.bytebuddy.agent.builder.AgentBuilder$RedefinitionStrategy$Collector.apply(AgentBuilder.java:7992)
	... 40 more

Condition not satisfied:

!configModificationFailed
||
|true
false

Config class modification failed.  Ensure all test classes extend DDSpecification

Condition not satisfied:

!configModificationFailed
||
|true
false

Config class modification failed.  Ensure all test classes extend DDSpecification

	at app//datadog.trace.test.util.DDSpecification.setupSpec(DDSpecification.groovy:113)
```