### PR TITLE
Profiler context smoke tests

### DIFF
--- a/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
+++ b/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
@@ -10,13 +10,21 @@ import com.datadog.profiling.controller.ConfigurationException;
 import com.datadog.profiling.controller.Controller;
 import com.datadog.profiling.controller.ControllerFactory;
 import com.datadog.profiling.controller.ProfilingSystem;
+import com.datadog.profiling.controller.RecordingData;
+import com.datadog.profiling.controller.RecordingDataListener;
+import com.datadog.profiling.controller.RecordingType;
 import com.datadog.profiling.controller.UnsupportedEnvironmentException;
 import com.datadog.profiling.uploader.ProfileUploader;
 import datadog.trace.api.Config;
 import datadog.trace.api.Platform;
+import datadog.trace.api.config.ProfilingConfig;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
@@ -34,6 +42,42 @@ public class ProfilingAgent {
 
   private static volatile ProfilingSystem profiler;
   private static volatile ProfileUploader uploader;
+
+  private static class DataDumper implements RecordingDataListener {
+    private final Path path;
+
+    DataDumper(Path path) {
+      if (Files.notExists(path)) {
+        try {
+          Files.createDirectories(path);
+        } catch (IOException e) {
+          log.warn("Unable to crate the debug profile dump directory", e);
+          this.path = null;
+          return;
+        }
+      }
+      if (!Files.isDirectory(path)) {
+        log.warn("Profiler debug dump path must be an existing directory");
+        this.path = null;
+      } else {
+        this.path = path;
+      }
+    }
+
+    @Override
+    public void onNewData(RecordingType type, RecordingData data, boolean handleSynchronously) {
+      if (path == null) {
+        return;
+      }
+      try {
+        Path tmp = Files.createTempFile(path, "dd-profiler-debug-", ".jfr");
+        Files.copy(data.getStream(), tmp, StandardCopyOption.REPLACE_EXISTING);
+        log.debug("Debug profile stored as {}", tmp);
+      } catch (IOException e) {
+        log.debug("Unable to write debug profile dump", e);
+      }
+    }
+  }
 
   /**
    * Main entry point into profiling Note: this must be reentrant because we may want to start
@@ -81,6 +125,9 @@ public class ProfilingAgent {
           PerSpanTracingContextTrackerFactory.register(configProvider);
         }
 
+        String dumpPath = configProvider.getString(ProfilingConfig.PROFILING_DEBUG_DUMP_PATH);
+        DataDumper dumper = dumpPath != null ? new DataDumper(Paths.get(dumpPath)) : null;
+
         uploader = new ProfileUploader(config, configProvider);
 
         final Duration startupDelay = Duration.ofSeconds(config.getProfilingStartDelay());
@@ -94,7 +141,12 @@ public class ProfilingAgent {
             new ProfilingSystem(
                 configProvider,
                 controller,
-                uploader::upload,
+                dumper == null
+                    ? uploader::upload
+                    : (type, data, sync) -> {
+                      dumper.onNewData(type, data, sync);
+                      uploader.upload(type, data, sync);
+                    },
                 startupDelay,
                 startupDelayRandomRange,
                 uploadPeriod,

--- a/dd-smoke-tests/profiling-integration-tests/profiling-integration-tests.gradle
+++ b/dd-smoke-tests/profiling-integration-tests/profiling-integration-tests.gradle
@@ -23,6 +23,9 @@ jar {
 
 dependencies {
   implementation project(':dd-trace-api')
+  api project(':dd-trace-ot')
+  // https://mvnrepository.com/artifact/org.apache.commons/commons-math3
+  implementation 'org.apache.commons:commons-math3:3.6.1'
 
   testImplementation project(':dd-smoke-tests')
   testImplementation project(':dd-java-agent:agent-profiling:profiling-testing')
@@ -35,4 +38,13 @@ dependencies {
 tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
   jvmArgs "-Ddatadog.smoketest.profiling.shadowJar.path=${tasks.shadowJar.archivePath}"
+}
+
+shadowJar {
+  include {
+    return it.directory || it.path.endsWith('.jar') ||
+      it.path.startsWith('io/opentracing') ||
+      it.path.startsWith('datadog/smoketest') ||
+      it.path.startsWith("org/apache/commons")
+  }
 }

--- a/dd-smoke-tests/profiling-integration-tests/src/main/java/datadog/smoketest/profiling/CodeHotspotsApplication.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/main/java/datadog/smoketest/profiling/CodeHotspotsApplication.java
@@ -1,0 +1,102 @@
+package datadog.smoketest.profiling;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+import org.apache.commons.math3.distribution.ExponentialDistribution;
+
+public final class CodeHotspotsApplication {
+  public static void main(String[] args) {
+    CodeHotspotsApplication application = new CodeHotspotsApplication(GlobalTracer.get());
+    String kind = args[0];
+
+    switch (kind) {
+      case "reactive":
+        application.queueing(
+            Integer.parseInt(args[1]),
+            Long.parseLong(args[2]),
+            Long.parseLong(args[3]),
+            Integer.parseInt(args[4]));
+        break;
+      case "batch":
+        application.batch(Long.parseLong(args[1]), Integer.parseInt(args[2]));
+        break;
+      case "fanout":
+        application.fanout(
+            Integer.parseInt(args[1]), Long.parseLong(args[2]), Integer.parseInt(args[3]));
+        break;
+      default:
+        throw new RuntimeException("Invalid application kind: " + kind);
+    }
+  }
+
+  private final Tracer tracer;
+
+  private CodeHotspotsApplication(Tracer tracer) {
+    this.tracer = tracer;
+  }
+
+  private void batch(long meanServiceTimeNs, int runtimeSecs) {
+    ParallelProcessing processor = new ParallelProcessing();
+    Span topSpan = tracer.buildSpan("top").start();
+
+    try (Scope scope = tracer.activateSpan(topSpan)) {
+      processor.run(1, meanServiceTimeNs, runtimeSecs, this::process);
+    }
+  }
+
+  private void fanout(int workers, long meanServiceTimeNs, int runtimeSecs) {
+    ParallelProcessing processor = new ParallelProcessing();
+    Span topSpan = tracer.buildSpan("top").start();
+
+    try (Scope scope = tracer.activateSpan(topSpan)) {
+      processor.run(workers, meanServiceTimeNs, runtimeSecs, this::process);
+    }
+  }
+
+  private void queueing(int workers, long meanServiceTimeNs, long arrivalRate, int runtimeSecs) {
+    long finalTs = System.nanoTime() + TimeUnit.SECONDS.toNanos(runtimeSecs);
+
+    ExponentialDistribution arrivalDistribution =
+        new ExponentialDistribution(1_000_000_000d / arrivalRate);
+    QueueProcessing processing = new QueueProcessing(workers, workers, meanServiceTimeNs);
+
+    Span topSpan = tracer.buildSpan("top").start();
+
+    try {
+      while (!Thread.currentThread().isInterrupted() && System.nanoTime() < finalTs) {
+        long sample = (long) arrivalDistribution.sample();
+        long nextArrivalTs = System.nanoTime() + sample;
+        while (System.nanoTime() < nextArrivalTs) {
+          LockSupport.parkNanos(nextArrivalTs - System.nanoTime());
+          if (Thread.currentThread().isInterrupted()) {
+            return;
+          }
+        }
+        try (Scope scope = tracer.activateSpan(topSpan)) {
+          processing.enqueue(this::process);
+        }
+      }
+    } finally {
+      processing.shutdown();
+      topSpan.finish();
+    }
+  }
+
+  private long process(long serviceTime) {
+    long cntr = 0;
+    long endTs = System.nanoTime() + serviceTime;
+    Span span = tracer.buildSpan("work_item").start();
+    try (Scope scope = tracer.activateSpan(span)) {
+      while (!Thread.currentThread().isInterrupted() && System.nanoTime() < endTs) {
+        cntr++;
+      }
+    } finally {
+      span.finish();
+    }
+    return cntr;
+  }
+}

--- a/dd-smoke-tests/profiling-integration-tests/src/main/java/datadog/smoketest/profiling/ParallelProcessing.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/main/java/datadog/smoketest/profiling/ParallelProcessing.java
@@ -1,0 +1,33 @@
+package datadog.smoketest.profiling;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.commons.math3.distribution.NormalDistribution;
+
+final class ParallelProcessing {
+  void run(int workers, long meanServiceTimeNs, int runTimeSecs, Consumer<Long> workTask) {
+    Thread[] threads = new Thread[workers];
+    for (int i = 0; i < workers; i++) {
+      threads[i] =
+          new Thread(
+              () -> {
+                long endTs = System.nanoTime() + TimeUnit.SECONDS.toNanos(runTimeSecs);
+
+                NormalDistribution distribution =
+                    new NormalDistribution(meanServiceTimeNs, meanServiceTimeNs / 1000d);
+                while (!Thread.currentThread().isInterrupted() && System.nanoTime() < endTs) {
+                  workTask.accept((long) distribution.sample());
+                }
+              },
+              "Worker " + i);
+      threads[i].setDaemon(true);
+      threads[i].start();
+    }
+    for (Thread thread : threads) {
+      try {
+        thread.join();
+      } catch (InterruptedException ignored) {
+      }
+    }
+  }
+}

--- a/dd-smoke-tests/profiling-integration-tests/src/main/java/datadog/smoketest/profiling/QueueProcessing.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/main/java/datadog/smoketest/profiling/QueueProcessing.java
@@ -1,0 +1,50 @@
+package datadog.smoketest.profiling;
+
+import datadog.trace.api.function.Consumer;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.commons.math3.distribution.ExponentialDistribution;
+
+final class QueueProcessing {
+  private final BlockingQueue<Consumer<Long>> workQueue;
+  private final ExecutorService executor;
+
+  QueueProcessing(int queueCapacity, int workers, long meanServiceTimeNs) {
+    workQueue = new ArrayBlockingQueue<>(queueCapacity);
+    executor =
+        Executors.newFixedThreadPool(
+            workers,
+            r -> {
+              Thread t = new Thread(r, "Worker");
+              t.setDaemon(true);
+              return t;
+            });
+    for (int i = 0; i < workers; i++) {
+      executor.submit(
+          () -> {
+            ExponentialDistribution distribution = new ExponentialDistribution(meanServiceTimeNs);
+            while (!Thread.currentThread().isInterrupted()) {
+              try {
+                Consumer<Long> item = workQueue.take();
+                long sample = (long) distribution.sample();
+                System.out.println("=== service time: " + sample + "ns");
+                item.accept(sample);
+                System.out.println("=== submitted");
+              } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+              }
+            }
+          });
+    }
+  }
+
+  boolean enqueue(Consumer<Long> workItem) {
+    return workQueue.offer(workItem);
+  }
+
+  void shutdown() {
+    executor.shutdownNow();
+  }
+}

--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/CodeHotspotsTest.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/CodeHotspotsTest.java
@@ -1,0 +1,284 @@
+package datadog.smoketest;
+
+import static datadog.smoketest.SmokeTestUtils.buildDirectory;
+import static datadog.smoketest.SmokeTestUtils.createProcessBuilder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.openjdk.jmc.common.item.Attribute.attr;
+import static org.openjdk.jmc.common.unit.UnitLookup.NUMBER;
+
+import datadog.smoketest.profiling.CodeHotspotsApplication;
+import datadog.trace.api.Platform;
+import java.io.File;
+import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
+import org.apache.commons.math3.stat.descriptive.rank.PSquarePercentile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.openjdk.jmc.common.item.IAttribute;
+import org.openjdk.jmc.common.item.IItem;
+import org.openjdk.jmc.common.item.IItemCollection;
+import org.openjdk.jmc.common.item.IItemIterable;
+import org.openjdk.jmc.common.item.IMemberAccessor;
+import org.openjdk.jmc.common.item.ItemFilters;
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.flightrecorder.JfrLoaderToolkit;
+import org.openjdk.jmc.flightrecorder.jdk.JdkAttributes;
+
+@DisabledOnJ9
+public final class CodeHotspotsTest {
+  private static final int TEST_CASE_TIMEOUT = 5; // seconds
+  private static final IAttribute<IQuantity> SPAN_ID = attr("spanId", "spanId", "spanId", NUMBER);
+
+  private static final Path LOG_FILE_BASE =
+      Paths.get(buildDirectory(), "reports", "testProcess." + CodeHotspotsTest.class.getName());
+
+  @BeforeAll
+  static void setupAll() throws Exception {
+    if (Platform.isMac() && System.getenv("TEST_LIBASYNC") == null) {
+      throw new UnsupportedOperationException(
+          "Set TEST_ASYNCLIB env variable to point to MacOS version of libasynProfiler.so and rerun");
+    }
+    Files.createDirectories(LOG_FILE_BASE);
+  }
+
+  private Path logFilePath = null;
+  private Path dumpDir = null;
+
+  private int timeout;
+
+  @BeforeEach
+  void setup(final TestInfo testInfo) throws Exception {
+    logFilePath = LOG_FILE_BASE.resolve(testInfo.getTestMethod().orElse(null).getName() + ".log");
+    dumpDir = Files.createTempDirectory("dd-profiler-");
+
+    double load = ManagementFactory.getOperatingSystemMXBean().getSystemLoadAverage();
+    int cores = Runtime.getRuntime().availableProcessors();
+    // if the system is busy the timeout needs to be extended in order for the profiler to run
+    double timeoutQuotient = Math.ceil(Math.max(1d, load / cores));
+
+    timeout = (int) (TEST_CASE_TIMEOUT * timeoutQuotient);
+    if (timeoutQuotient > 1) {
+      System.out.println(
+          "===> Timeout scaled by "
+              + timeoutQuotient
+              + " to "
+              + timeout
+              + "s (load = "
+              + load
+              + ", cores = "
+              + cores
+              + ")");
+    }
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    Files.walk(dumpDir).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+    Files.deleteIfExists(dumpDir);
+    System.out.println("===\n");
+  }
+
+  @ParameterizedTest(
+      name = "Test reactive app (mean service time = {0}, arrival rate = {1} tasks/s)")
+  @MethodSource("reactiveTestParams")
+  void testReactive(Duration meanServiceTime, int arrivalRate, double minCoverage)
+      throws Exception {
+    System.out.println(
+        "=== Test reactive app (mean service time = "
+            + meanServiceTime
+            + ", arrival rate = "
+            + arrivalRate
+            + " tasks/s)");
+    int interval = 10; // milliseconds
+    int workers = 2;
+    Process targetProcess =
+        createProcessBuilder(
+                CodeHotspotsApplication.class.getName(),
+                0,
+                timeout * 2,
+                interval,
+                interval,
+                dumpDir,
+                logFilePath,
+                "reactive",
+                Integer.toString(workers),
+                Long.toString(meanServiceTime.toNanos()),
+                Long.toString(arrivalRate),
+                Integer.toString(timeout))
+            .start();
+
+    int ret = targetProcess.waitFor();
+    assertEquals(0, ret);
+
+    long serviceRate = (long) (workers * 1_000_000_000d) / meanServiceTime.toNanos();
+    double idleness = Math.max(0d, (serviceRate - arrivalRate) / (double) serviceRate);
+
+    Files.walk(dumpDir)
+        .filter(Files::isRegularFile)
+        .map(Path::toFile)
+        .forEach(f -> validateJfr(f, idleness, minCoverage));
+  }
+
+  private static Stream<Arguments> reactiveTestParams() {
+    return Stream.of(
+        Arguments.of(Duration.ofMillis(100), 5000, 0.9d),
+        Arguments.of(Duration.ofMillis(1), 5000, 0.5d),
+        Arguments.of(Duration.of(100, ChronoUnit.MICROS), 5000, 0.2d),
+        Arguments.of(Duration.ofMillis(100), 50, 0.8d),
+        Arguments.of(Duration.ofMillis(1), 50, 0.3d),
+        Arguments.of(Duration.of(100, ChronoUnit.MICROS), 50, 0.15d));
+  }
+
+  @Test
+  @DisplayName("Test batch app")
+  void testBatch() throws Exception {
+    System.out.println("Test batch app");
+    int meanServiceTimeSecs = 1; // seconds
+    long meanServiceTimeNs = TimeUnit.SECONDS.toNanos(meanServiceTimeSecs);
+    int interval = 10; // milliseconds
+    Process targetProcess =
+        createProcessBuilder(
+                CodeHotspotsApplication.class.getName(),
+                0,
+                timeout * 2,
+                interval,
+                interval,
+                dumpDir,
+                logFilePath,
+                "batch",
+                Long.toString(meanServiceTimeNs),
+                Integer.toString(timeout))
+            .start();
+
+    int ret = targetProcess.waitFor();
+    assertEquals(0, ret);
+
+    Files.walk(dumpDir)
+        .filter(Files::isRegularFile)
+        .map(Path::toFile)
+        .forEach(f -> validateJfr(f, 0, 0.9));
+  }
+
+  @Test
+  @DisplayName("Test saturated parallel processing")
+  void testSaturatedFanout() throws Exception {
+    System.out.println("Test saturated parallel processing");
+    int meanServiceTimeSecs = 1; // seconds
+    long meanServiceTimeNs = TimeUnit.SECONDS.toNanos(meanServiceTimeSecs);
+    int interval = 10; // milliseconds
+    int workers =
+        Runtime.getRuntime().availableProcessors() * 2; // more workers than available cores
+    Process targetProcess =
+        createProcessBuilder(
+                CodeHotspotsApplication.class.getName(),
+                0,
+                timeout * 2,
+                interval,
+                interval,
+                dumpDir,
+                logFilePath,
+                "fanout",
+                Integer.toString(workers),
+                Long.toString(meanServiceTimeNs),
+                Integer.toString(timeout))
+            .start();
+
+    int ret = targetProcess.waitFor();
+    assertEquals(0, ret);
+
+    Files.walk(dumpDir)
+        .filter(Files::isRegularFile)
+        .map(Path::toFile)
+        .forEach(f -> validateJfr(f, 0, 0.8));
+  }
+
+  private static void validateJfr(File f, double idleness, double minCoverage) {
+    try {
+      IItemCollection events = JfrLoaderToolkit.loadEvents(f);
+      IItemCollection wallclock = events.apply(ItemFilters.type("datadog.MethodSample"));
+      //      IItemCollection cpu = events.apply(ItemFilters.type("datadog.ExecutionSample"));
+      assertTrue(wallclock.hasItems());
+      //      assertTrue(cpu.hasItems());
+
+      validateStats(wallclock, idleness, minCoverage);
+    } catch (Exception e) {
+      fail(e);
+    }
+  }
+
+  private static void validateStats(IItemCollection events, double idleness, double minCoverage) {
+    SummaryStatistics summaryStats = new SummaryStatistics();
+    PSquarePercentile p50 = new PSquarePercentile(50d);
+    PSquarePercentile p99 = new PSquarePercentile(1d);
+    long qualifiedSamples = 0;
+    long nonQualifiedSamples = 0;
+
+    Map<String, AtomicLong> spanSampleCnt = new HashMap<>();
+    for (IItemIterable items : events) {
+      IMemberAccessor<IQuantity, IItem> spanIdAccessor = SPAN_ID.getAccessor(items.getType());
+      IMemberAccessor<String, IItem> threadNameAccessor =
+          JdkAttributes.EVENT_THREAD_NAME.getAccessor(items.getType());
+      for (IItem item : items) {
+        String threadName = threadNameAccessor.getMember(item);
+        if (!threadName.contains("Worker")) {
+          continue;
+        }
+        long spanId = spanIdAccessor.getMember(item).longValue();
+        if (spanId == 0) {
+          nonQualifiedSamples++;
+        } else {
+          qualifiedSamples++;
+          spanSampleCnt
+              .computeIfAbsent(Long.toString(spanId), k -> new AtomicLong(0))
+              .incrementAndGet();
+        }
+      }
+    }
+    spanSampleCnt.values().stream()
+        .map(AtomicLong::get)
+        .forEach(
+            v -> {
+              summaryStats.addValue(v);
+              p99.increment(v);
+              p50.increment(v);
+            });
+
+    /*
+     Qualified samples are scaled according to 'idleness' -
+     If the system is idle the workers will be waiting for input (preferably, outside any context) and as such
+     the ratio of samples without context will be inflated.
+     Re-scaling using the idleness metric brings the coverage back to the level as if the system is fully
+     utilized.
+    */
+    double scaledQualifiedSamples = (qualifiedSamples / (1 - idleness));
+    double coverage = (scaledQualifiedSamples / (scaledQualifiedSamples + nonQualifiedSamples));
+    System.out.println("Spans     : " + summaryStats.getN());
+    System.out.println("  Coverage: " + coverage);
+    System.out.println("Samples   :");
+    System.out.println("  Mean    : " + summaryStats.getMean());
+    System.out.println("  Median  : " + p50.getResult());
+    System.out.println("  P99     : " + p99.getResult());
+
+    assertTrue(coverage >= minCoverage, "Expected coverage: " + coverage + " >= " + minCoverage);
+  }
+}

--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/DisableOnJ9Condition.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/DisableOnJ9Condition.java
@@ -1,0 +1,15 @@
+package datadog.smoketest;
+
+import datadog.trace.api.Platform;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public final class DisableOnJ9Condition implements ExecutionCondition {
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+    return Platform.isJ9()
+        ? ConditionEvaluationResult.disabled("Profiling context is not supported for J9")
+        : ConditionEvaluationResult.enabled("");
+  }
+}

--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/DisabledOnJ9.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/DisabledOnJ9.java
@@ -1,0 +1,12 @@
+package datadog.smoketest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DisableOnJ9Condition.class)
+public @interface DisabledOnJ9 {}

--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/JFRBasedProfilingIntegrationTest.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/JFRBasedProfilingIntegrationTest.java
@@ -227,8 +227,6 @@ class JFRBasedProfilingIntegrationTest {
       assertNotNull(requestTags.get("runtime-id"));
       assertEquals(InetAddress.getLocalHost().getHostName(), requestTags.get("host"));
 
-      dumpJfrRecording(rawJfr.get());
-
       assertFalse(logHasErrors(logFilePath));
       IItemCollection events = JfrLoaderToolkit.loadEvents(new ByteArrayInputStream(rawJfr.get()));
       assertTrue(events.hasItems());
@@ -276,8 +274,6 @@ class JFRBasedProfilingIntegrationTest {
       assertTrue(
           period > 0 && period <= upperLimit,
           () -> "Upload period = " + period + "ms, expected (0, " + upperLimit + "]ms");
-
-      dumpJfrRecording(rawJfr.get());
 
       events = JfrLoaderToolkit.loadEvents(new ByteArrayInputStream(rawJfr.get()));
       assertTrue(events.hasItems());
@@ -342,15 +338,6 @@ class JFRBasedProfilingIntegrationTest {
           assertTrue(spanId >= 0, "spanId must not be negative");
         }
       }
-    }
-  }
-
-  private void dumpJfrRecording(final byte[] byteData) {
-    try {
-      final Path dumpPath = Files.createTempFile("dd-dump-", ".jfr");
-      Files.write(dumpPath, byteData);
-      log.debug("Received profile stored at: {}", dumpPath.toAbsolutePath());
-    } catch (final IOException ignored) {
     }
   }
 
@@ -679,6 +666,7 @@ class JFRBasedProfilingIntegrationTest {
             "-Ddd.profiling.legacy.tracing.integration=" + legacyTracingIntegration,
             "-Ddd.profiling.endpoint.collection.enabled=" + endpointCollectionEnabled,
             "-Ddd.profiling.upload.timeout=" + PROFILING_UPLOAD_TIMEOUT_SECONDS,
+            "-Ddd.profiling.debug.dump_path=/tmp/dd-profiler",
             "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug",
             "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug",
             "-XX:+IgnoreUnrecognizedVMOptions",

--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/SmokeTestUtils.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/SmokeTestUtils.java
@@ -1,0 +1,99 @@
+package datadog.smoketest;
+
+import datadog.trace.api.config.ProfilingConfig;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+final class SmokeTestUtils {
+  static ProcessBuilder createProcessBuilder(
+      String targetClass,
+      final int profilingStartDelaySecs,
+      final int profilingUploadPeriodSecs,
+      int cpuSamplerIntervalMs,
+      int wallSamplerIntervalMs,
+      final Path dumpPath,
+      final Path logFilePath,
+      String... args) {
+    final String templateOverride =
+        SmokeTestUtils.class.getClassLoader().getResource("overrides.jfp").getFile();
+
+    final List<String> command =
+        new ArrayList<>(
+            Arrays.asList(
+                javaPath(),
+                "-Xmx" + System.getProperty("datadog.forkedMaxHeapSize", "512M"),
+                "-Xms" + System.getProperty("datadog.forkedMinHeapSize", "64M"),
+                "-javaagent:" + agentShadowJar(),
+                "-XX:ErrorFile=/tmp/hs_err_pid%p.log",
+                "-Ddd.service.name=smoke-test-code_hotspots-java-app",
+                "-Ddd.env=smoketest",
+                "-Ddd.version=99",
+                "-Ddd.profiling.enabled=true",
+                "-Ddd.profiling.async.enabled=true",
+                "-Ddd." + ProfilingConfig.PROFILING_AUXILIARY_TYPE + "=async",
+                "-Ddd."
+                    + ProfilingConfig.PROFILING_ASYNC_LIBPATH
+                    + "="
+                    + System.getenv("TEST_LIBASYNC"),
+                "-Ddd."
+                    + ProfilingConfig.PROFILING_ASYNC_CPU_INTERVAL
+                    + "="
+                    + cpuSamplerIntervalMs
+                    + "ms",
+                "-Ddd." + ProfilingConfig.PROFILING_ASYNC_WALL_ENABLED + "=true",
+                "-Ddd." + ProfilingConfig.PROFILING_ASYNC_WALL_THREAD_FILTER_ENABLED + "=true",
+                "-Ddd."
+                    + ProfilingConfig.PROFILING_ASYNC_WALL_INTERVAL
+                    + "="
+                    + wallSamplerIntervalMs
+                    + "ms",
+                "-Ddd." + ProfilingConfig.PROFILING_ASYNC_WALL_COLLAPSE_SAMPLES + "=false",
+                "-Ddd." + ProfilingConfig.PROFILING_ASYNC_LOG_LEVEL + "=debug",
+                "-Ddd.profiling.agentless=false",
+                "-Ddd.profiling.start-delay=" + profilingStartDelaySecs,
+                "-Ddd." + ProfilingConfig.PROFILING_START_FORCE_FIRST + "=true",
+                "-Ddd.profiling.upload.period=" + profilingUploadPeriodSecs,
+                "-Ddd.profiling.hotspots.enabled=true",
+                "-Ddd.profiling.legacy.tracing.integration=false",
+                "-Ddd.profiling.endpoint.collection.enabled=true",
+                "-Ddd.profiling.debug.dump_path=" + dumpPath,
+                "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug",
+                "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug",
+                "-XX:+IgnoreUnrecognizedVMOptions",
+                "-XX:+UnlockCommercialFeatures",
+                "-XX:+FlightRecorder",
+                "-Ddd." + ProfilingConfig.PROFILING_TEMPLATE_OVERRIDE_FILE + "=" + templateOverride,
+                "-cp",
+                profilingShadowJar(),
+                targetClass));
+    command.addAll(Arrays.asList(args));
+    final ProcessBuilder processBuilder = new ProcessBuilder(command);
+    processBuilder.directory(new File(buildDirectory()));
+
+    processBuilder.environment().put("JAVA_HOME", System.getProperty("java.home"));
+
+    processBuilder.redirectErrorStream(true);
+    processBuilder.redirectOutput(ProcessBuilder.Redirect.to(logFilePath.toFile()));
+    return processBuilder;
+  }
+
+  static String javaPath() {
+    final String separator = System.getProperty("file.separator");
+    return System.getProperty("java.home") + separator + "bin" + separator + "java";
+  }
+
+  static String profilingShadowJar() {
+    return System.getProperty("datadog.smoketest.profiling.shadowJar.path");
+  }
+
+  static String agentShadowJar() {
+    return System.getProperty("datadog.smoketest.agent.shadowJar.path");
+  }
+
+  static String buildDirectory() {
+    return System.getProperty("datadog.smoketest.builddir");
+  }
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -81,7 +81,7 @@ public final class ProfilingConfig {
 
   public static final String PROFILING_ASYNC_WALL_COLLAPSE_SAMPLES =
       "profiling.async.wall.collapse.samples";
-  public static final boolean PROFILING_ASYNC_WALL_COLLAPSE_SAMPLES_DEFAULT = true;
+  public static final boolean PROFILING_ASYNC_WALL_COLLAPSE_SAMPLES_DEFAULT = false;
 
   public static final String PROFILING_ASYNC_STACKDEPTH = "profiling.async.stackdepth";
   public static final int PROFILING_ASYNC_STACKDEPTH_DEFAULT = 512;
@@ -154,6 +154,8 @@ public final class ProfilingConfig {
 
   public static final String PROFILING_DISABLED_EVENTS = "profiling.disabled.events";
   public static final String PROFILING_ENABLED_EVENTS = "profiling.disabled.events";
+
+  public static final String PROFILING_DEBUG_DUMP_PATH = "profiling.debug.dump_path";
 
   private ProfilingConfig() {}
 }


### PR DESCRIPTION
# What Does This Do
This PR is adding smoke tests for the accepted coverage percentage for various types of applications.
For this there are several simulations - a batch application, a concurrent application and reactive/async application. Each of these types of applications has a different expected minimal coverage, due to the nature of the workload, and the smoke tests are asserting it.

# Motivation
The idea is to have a 'no-dependency' tests allowing to verify the basic assertions about the code hotspots coverage.
This is not supposed to exhaustively cover the problem space but rather give us specific numbers we can use when talking about how precisely and how extensively code hotspots are describing the profiled app.

# Additional Notes
The test may turn out to be flaky although the limits were set based on the values we are getting from CI. 
In case of unexpected failures the lower limits will have to be readjusted.
