### PR TITLE
Fix NullPointerException in OpenLiberty with AppSec

### DIFF
--- a/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/HttpServletExtractAdapter.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/HttpServletExtractAdapter.java
@@ -41,12 +41,22 @@ public abstract class HttpServletExtractAdapter<T> implements AgentPropagation.C
 
     @Override
     Enumeration<String> getHeaderNames(HttpServletResponse request) {
-      return Collections.enumeration(request.getHeaderNames());
+      try {
+        return Collections.enumeration(request.getHeaderNames());
+      } catch (NullPointerException e) {
+        // SRTServletResponse#getHeaderNames() will throw NPE if called after response close.
+        return Collections.emptyEnumeration();
+      }
     }
 
     @Override
     String getHeader(HttpServletResponse request, String name) {
-      return request.getHeader(name);
+      try {
+        return request.getHeader(name);
+      } catch (NullPointerException e) {
+        // SRTServletResponse#getHeader(name) will throw NPE if called after response close.
+        return null;
+      }
     }
   }
 }

--- a/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySmokeTest.groovy
+++ b/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySmokeTest.groovy
@@ -25,6 +25,9 @@ class SpringBootOpenLibertySmokeTest extends AbstractServerSmokeTest {
     command.addAll((String[]) [
       "-Ddd.writer.type=MultiWriter:TraceStructureWriter:${output.getAbsolutePath()},DDAgentWriter",
       "-Ddd.jmxfetch.enabled=false",
+      "-Ddd.appsec.enabled=true",
+      "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug",
+      "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug",
       "-jar",
       openLibertyShadowJar,
       "--server.port=${httpPort}"


### PR DESCRIPTION
# What Does This Do
* `SRTServletResponse#getHeaderNames()` and `#getHeader(name)` will throw NullPointerException if called after the response has been closed. This was happening in the OpenLiberty smoke tests with AppSec enabled.
* Enable AppSec in OpenLiberty smoke tests.

# Motivation

# Additional Notes
I'm not sure this is the best solution, and I wonder if we can go further and avoid these callbacks if the response is closed.
