### PR TITLE
decouple endpoint events from checkpoints

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -762,6 +762,9 @@ public class Agent {
               @Override
               public void withTracer(Tracer tracer) {
                 try {
+                  if (Platform.isOracleJDK8() || Platform.isJ9()) {
+                    return;
+                  }
                   Checkpointer checkpointer =
                       (Checkpointer)
                           AGENT_CLASSLOADER

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -761,6 +761,7 @@ public class Agent {
             new WithGlobalTracer.Callback() {
               @Override
               public void withTracer(Tracer tracer) {
+                log.debug("Initializing profiler tracer integrations");
                 try {
                   if (Platform.isOracleJDK8() || Platform.isJ9()) {
                     return;

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -15,6 +15,7 @@ import static datadog.trace.util.Strings.toEnvVar;
 
 import datadog.trace.api.Checkpointer;
 import datadog.trace.api.Config;
+import datadog.trace.api.EndpointCheckpointer;
 import datadog.trace.api.GlobalTracer;
 import datadog.trace.api.Platform;
 import datadog.trace.api.StatsDClientManager;
@@ -761,20 +762,21 @@ public class Agent {
               @Override
               public void withTracer(Tracer tracer) {
                 try {
+                  Checkpointer checkpointer =
+                      (Checkpointer)
+                          AGENT_CLASSLOADER
+                              .loadClass("datadog.trace.core.jfr.openjdk.JFRCheckpointer")
+                              .getDeclaredConstructor()
+                              .newInstance();
+                  ((AgentTracer.TracerAPI) tracer)
+                      .registerCheckpointer((EndpointCheckpointer) checkpointer);
                   if (Config.get().isProfilingLegacyTracingIntegrationEnabled()) {
                     log.debug("Registering scope event factory");
                     tracer.addScopeListener(
                         createScopeListener("datadog.trace.core.jfr.openjdk.ScopeEventFactory"));
-                  } else if (tracer instanceof AgentTracer.TracerAPI) {
-                    // TODO separate endpoint event tracking from checkpointer so checkpointing can
-                    //  be disabled whenever async-profiler is enabled
+                  } else {
+                    // TODO remove this
                     log.debug("Registering checkpointer");
-                    Checkpointer checkpointer =
-                        (Checkpointer)
-                            AGENT_CLASSLOADER
-                                .loadClass("datadog.trace.core.jfr.openjdk.JFRCheckpointer")
-                                .getDeclaredConstructor()
-                                .newInstance();
                     ((AgentTracer.TracerAPI) tracer).registerCheckpointer(checkpointer);
                     log.debug("Checkpointer {} has been registered", checkpointer);
                   }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/checkpoints/TimelineCheckpointer.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/checkpoints/TimelineCheckpointer.groovy
@@ -28,7 +28,7 @@ class TimelineCheckpointer implements Checkpointer {
   }
 
   @Override
-  void onRootSpanWritten(AgentSpan rootSpan, boolean published, boolean checkpointsSampled) {
+  void onRootSpanFinished(AgentSpan rootSpan, boolean published) {
   }
 
   @Override

--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/JFRBasedProfilingIntegrationTest.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/JFRBasedProfilingIntegrationTest.java
@@ -408,7 +408,7 @@ class JFRBasedProfilingIntegrationTest {
             */
             final long ts = System.nanoTime();
             while (!checkLogLines(
-                logFilePath, line -> line.contains("Registering scope event factory"))) {
+                logFilePath, line -> line.contains("Initializing profiler tracer integrations"))) {
               Thread.sleep(500);
               // Wait at most 30 seconds
               if (System.nanoTime() - ts > 30_000_000_000L) {

--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/JFRCheckpointer.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/JFRCheckpointer.java
@@ -216,10 +216,11 @@ public class JFRCheckpointer implements Checkpointer, ProfilingListener<Profilin
   }
 
   @Override
-  public final void onRootSpanWritten(
-      final AgentSpan rootSpan, final boolean published, final boolean checkpointsSampled) {
+  public final void onRootSpanFinished(final AgentSpan rootSpan, final boolean published) {
     if (isEndpointCollectionEnabled) {
       if (rootSpan instanceof DDSpan) {
+        final Boolean emittingCheckpoints = rootSpan.isEmittingCheckpoints();
+        boolean checkpointsSampled = emittingCheckpoints != null && emittingCheckpoints;
         DDSpan span = (DDSpan) rootSpan;
         EndpointTracker tracker = span.getEndpointTracker();
         if (tracker != null) {

--- a/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
+++ b/dd-trace-core/jfr-openjdk/src/test/groovy/datadog/trace/core/jfr/openjdk/ScopeEventTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.core.jfr.openjdk
 
 import datadog.trace.api.GlobalTracer
+import datadog.trace.api.EndpointCheckpointer
 import datadog.trace.api.config.ProfilingConfig
 import datadog.trace.api.sampling.ConstantSampler
 import datadog.trace.bootstrap.config.provider.ConfigProvider
@@ -322,7 +323,9 @@ class ScopeEventTest extends DDSpecification {
     SystemAccess.enableJmx()
     def recording = JfrHelper.startRecording()
     def configProvider = ConfigProvider.getInstance()
-    tracer.registerCheckpointer(new JFRCheckpointer(new ConstantSampler(true), JFRCheckpointer.getSamplerConfiguration(configProvider), configProvider))
+    def jfrCheckpointer = new JFRCheckpointer(new ConstantSampler(true), JFRCheckpointer.getSamplerConfiguration(configProvider), configProvider)
+    tracer.registerCheckpointer(jfrCheckpointer)
+    tracer.registerCheckpointer((EndpointCheckpointer) jfrCheckpointer)
 
     when: "span goes through lifecycle without activation"
     AgentSpan span = tracer.startSpan("test", true)

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -17,6 +17,7 @@ import datadog.communication.monitor.Recording;
 import datadog.trace.api.Checkpointer;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDId;
+import datadog.trace.api.EndpointCheckpointer;
 import datadog.trace.api.IdGenerationStrategy;
 import datadog.trace.api.Platform;
 import datadog.trace.api.PropagationStyle;
@@ -963,6 +964,11 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
   @Override
   public void registerCheckpointer(Checkpointer checkpointer) {
+    this.spanCheckpointer.register(checkpointer);
+  }
+
+  @Override
+  public void registerCheckpointer(EndpointCheckpointer checkpointer) {
     this.spanCheckpointer.register(checkpointer);
   }
 

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -21,6 +21,8 @@ excludedClassesCoverage += [
   // this one is covered by tests in internal-api-8 together with AdaptiveSampler8
   "datadog.trace.api.sampling.AdaptiveSampler7*",
   "datadog.trace.api.sampling.ConstantSampler",
+  // to be decomissioned
+  "datadog.trace.api.SamplingCheckpointer",
   "datadog.trace.bootstrap.ActiveSubsystems",
   "datadog.trace.bootstrap.config.provider.ConfigProvider.Singleton",
   "datadog.trace.bootstrap.instrumentation.api.Tags",

--- a/internal-api/src/main/java/datadog/trace/api/Checkpointer.java
+++ b/internal-api/src/main/java/datadog/trace/api/Checkpointer.java
@@ -2,7 +2,7 @@ package datadog.trace.api;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 
-public interface Checkpointer {
+public interface Checkpointer extends EndpointCheckpointer {
 
   /**
    * Modifier tag to make an event an end event. The LSB is chosen to allow for good varint
@@ -23,20 +23,4 @@ public interface Checkpointer {
    * @param flags a description of the event
    */
   void checkpoint(AgentSpan span, int flags);
-
-  /**
-   * Callback to be called when a root span is written (together with the trace)
-   *
-   * @param rootSpan the local root span of the trace
-   * @param published {@literal true} the trace and root span published
-   * @param checkpointsSampled {@literal true} the checkpoints were sampled
-   */
-  void onRootSpanWritten(AgentSpan rootSpan, boolean published, boolean checkpointsSampled);
-
-  /**
-   * Callback to be called when a root span is started
-   *
-   * @param rootSpan the local root span of the trace
-   */
-  void onRootSpanStarted(AgentSpan rootSpan);
 }

--- a/internal-api/src/main/java/datadog/trace/api/EndpointCheckpointer.java
+++ b/internal-api/src/main/java/datadog/trace/api/EndpointCheckpointer.java
@@ -1,0 +1,20 @@
+package datadog.trace.api;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+
+public interface EndpointCheckpointer {
+  /**
+   * Callback to be called when a root span is written (together with the trace)
+   *
+   * @param rootSpan the local root span of the trace
+   * @param published {@literal true} the trace and root span published
+   */
+  void onRootSpanFinished(AgentSpan rootSpan, boolean published);
+
+  /**
+   * Callback to be called when a root span is started
+   *
+   * @param rootSpan the local root span of the trace
+   */
+  void onRootSpanStarted(AgentSpan rootSpan);
+}

--- a/internal-api/src/main/java/datadog/trace/api/SpanCheckpointer.java
+++ b/internal-api/src/main/java/datadog/trace/api/SpanCheckpointer.java
@@ -2,14 +2,10 @@ package datadog.trace.api;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 
-public interface SpanCheckpointer {
+public interface SpanCheckpointer extends EndpointCheckpointer {
   void checkpoint(AgentSpan span, int flags);
 
   void onStartWork(AgentSpan span);
 
   void onFinishWork(AgentSpan span);
-
-  void onRootSpanStarted(AgentSpan root);
-
-  void onRootSpanFinished(AgentSpan root, boolean published);
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -4,6 +4,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_ASYNC_PROPAGATING;
 
 import datadog.trace.api.Checkpointer;
 import datadog.trace.api.DDId;
+import datadog.trace.api.EndpointCheckpointer;
 import datadog.trace.api.PropagationStyle;
 import datadog.trace.api.SpanCheckpointer;
 import datadog.trace.api.function.Consumer;
@@ -178,7 +179,15 @@ public class AgentTracer {
      *
      * @param checkpointer
      */
+    @Deprecated(/* forRemoval = true */ )
     void registerCheckpointer(Checkpointer checkpointer);
+
+    /**
+     * Registers the checkpointer
+     *
+     * @param checkpointer
+     */
+    void registerCheckpointer(EndpointCheckpointer checkpointer);
 
     SubscriptionService getSubscriptionService(RequestContextSlot slot);
 
@@ -335,6 +344,9 @@ public class AgentTracer {
 
     @Override
     public void registerCheckpointer(Checkpointer checkpointer) {}
+
+    @Override
+    public void registerCheckpointer(EndpointCheckpointer checkpointer) {}
 
     @Override
     public SubscriptionService getSubscriptionService(RequestContextSlot slot) {

--- a/internal-api/src/test/groovy/datadog/trace/api/SamplingCheckpointerTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/SamplingCheckpointerTest.groovy
@@ -12,9 +12,11 @@ class SamplingCheckpointerTest extends DDSpecification {
   def "test sampling and fallback"() {
     setup:
     Checkpointer checkpointer = Mock()
+    EndpointCheckpointer rootSpanCheckpointer = Mock()
     SamplingCheckpointer sut = SamplingCheckpointer.create()
     if (register) {
       sut.register(checkpointer)
+      sut.register(rootSpanCheckpointer)
     }
     DDId localRootSpanId = DDId.from(1)
     DDId spanId = DDId.from(2)
@@ -52,17 +54,17 @@ class SamplingCheckpointerTest extends DDSpecification {
     when:
     sut.onRootSpanStarted(rootSpan)
     then:
-    rootSpanCount * checkpointer.onRootSpanStarted(rootSpan)
+    rootSpanCount * rootSpanCheckpointer.onRootSpanStarted(rootSpan)
 
     when:
     sut.onRootSpanFinished(rootSpan, true)
     then:
-    rootSpanCount * checkpointer.onRootSpanWritten(rootSpan, true, emitCheckpoints)
+    rootSpanCount * rootSpanCheckpointer.onRootSpanFinished(rootSpan, true)
 
     when:
     sut.onRootSpanFinished(rootSpan, false)
     then:
-    rootSpanCount * checkpointer.onRootSpanWritten(rootSpan, false, emitCheckpoints)
+    rootSpanCount * rootSpanCheckpointer.onRootSpanFinished(rootSpan, false)
 
     where:
     drop  | register | emitCheckpoints


### PR DESCRIPTION
# What Does This Do

* Always emit `EndpointEvent`s, regardless of whether there are any checkpoints, so that it can be used in conjunction with profile events labelled by async-profiler
* Decouple from `Checkpointer` so the latter can be deleted
* Deprecate everything to do with `Checkpointer` for removal

# Motivation

# Additional Notes
