### PR TITLE
larger smoke tests image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,6 +446,10 @@ jobs:
     <<: *tests
     resource_class: xlarge
 
+  huge_tests:
+    <<: *tests
+    resource_class: 2xlarge
+
   # The only way to do fan-in in CircleCI seems to have a proper job, so let's have one that
   # doesn't consume so many resources. The execution time for this including spin up seems to
   # be around 6 seconds.
@@ -711,7 +715,7 @@ build_test_jobs: &build_test_jobs
       matrix:
         <<: *profiling_test_matrix
 
-  - xlarge_tests:
+  - huge_tests:
       requires:
         - build
       name: z_test_<< matrix.testJvm >>_smoke
@@ -720,7 +724,7 @@ build_test_jobs: &build_test_jobs
       matrix:
         <<: *test_matrix
 
-  - xlarge_tests:
+  - huge_tests:
       requires:
         - build
       name: test_IBM11_smoke
@@ -728,7 +732,7 @@ build_test_jobs: &build_test_jobs
       stage: smoke
       testJvm: "IBM11"
 
-  - xlarge_tests:
+  - huge_tests:
       requires:
         - build
       name: test_IBM17_smoke

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -721,6 +721,7 @@ build_test_jobs: &build_test_jobs
       name: z_test_<< matrix.testJvm >>_smoke
       gradleTarget: "stageMainDist :dd-smoke-test"
       stage: smoke
+      maxWorkers: 8
       matrix:
         <<: *test_matrix
 
@@ -730,6 +731,7 @@ build_test_jobs: &build_test_jobs
       name: test_IBM11_smoke
       gradleTarget: "stageMainDist :dd-smoke-test"
       stage: smoke
+      maxWorkers: 8
       testJvm: "IBM11"
 
   - huge_tests:
@@ -738,15 +740,17 @@ build_test_jobs: &build_test_jobs
       name: test_IBM17_smoke
       gradleTarget: "stageMainDist :dd-smoke-test"
       stage: smoke
+      maxWorkers: 8
       testJvm: "IBM17"
 
 
-  - tests:
+  - huge_tests:
       requires:
         - build
       name: z_test_8_smoke
       gradleTarget: "stageMainDist :dd-smoke-test"
       stage: smoke
+      maxWorkers: 8
       testJvm: "8"
 
   - fan_in:

--- a/dd-smoke-tests/dd-smoke-tests.gradle
+++ b/dd-smoke-tests/dd-smoke-tests.gradle
@@ -10,10 +10,6 @@ dependencies {
   api project(':utils:test-agent-utils:decoder')
 }
 
-def smokeTestLimit = gradle.sharedServices.registerIfAbsent("smokeTestLimit", BuildService) {
-  maxParallelUsages = 2
-}
-
 Project parent_project = project
 subprojects { Project subProj ->
   // Don't need javadoc task run for internal projects.
@@ -31,9 +27,6 @@ subprojects { Project subProj ->
 
     // The jar path for the test agent (taken from https://github.com/DataDog/dd-trace-test-agent )
     jvmArgs "-Ddatadog.smoketest.test.agent.dir=${project.getRootDir()}/dd-smoke-tests/src/main/resources/datadog.smoketest.test.agent.jar"
-
-    // Only one smoke test at a time
-    usesService(smokeTestLimit)
 
     // Make it so all smoke tests can be run with a single command.
     if (parent_project.hasProperty(subTask.name)) {


### PR DESCRIPTION
# What Does This Do

The smoke tests are currently CPU bound despite having a lot of RAM headroom, and circleci doesn't offer a way to trade RAM for vCPUs https://circleci.com/docs/configuration-reference/#docker-execution-environment so the only option is to double the size of the image for now.

# Motivation

# Additional Notes
