### PR TITLE
Extract relevant info from Connection object

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DriverInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DriverInstrumentation.java
@@ -13,6 +13,7 @@ import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.jdbc.DBInfo;
 import datadog.trace.bootstrap.instrumentation.jdbc.JDBCConnectionUrlParser;
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.Map;
 import java.util.Properties;
 import net.bytebuddy.asm.Advice;
@@ -69,7 +70,20 @@ public final class DriverInstrumentation extends Instrumenter.Tracing
         // Exception was probably thrown.
         return;
       }
-      final DBInfo dbInfo = JDBCConnectionUrlParser.extractDBInfo(url, props);
+      String urlToUse = url;
+      try {
+        urlToUse = connection.getMetaData().getURL();
+      } catch (final SQLException se) {
+        // ignore
+      }
+
+      try {
+        props.setProperty("user", connection.getMetaData().getUserName());
+      } catch (final SQLException se) {
+        // ignore
+      }
+
+      final DBInfo dbInfo = JDBCConnectionUrlParser.extractDBInfo(urlToUse, props);
       InstrumentationContext.get(Connection.class, DBInfo.class).put(connection, dbInfo);
     }
   }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DriverInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DriverInstrumentation.java
@@ -71,17 +71,17 @@ public final class DriverInstrumentation extends Instrumenter.Tracing
         return;
       }
       String urlToUse = url;
-      try {
-        urlToUse = connection.getMetaData().getURL();
-      } catch (final SQLException se) {
-        // ignore
-      }
+      // try {
+      //   urlToUse = connection.getMetaData().getURL();
+      // } catch (final SQLException se) {
+      //   // ignore
+      // }
 
-      try {
-        props.setProperty("user", connection.getMetaData().getUserName());
-      } catch (final SQLException se) {
-        // ignore
-      }
+      // try {
+      //   props.setProperty("user", connection.getMetaData().getUserName());
+      // } catch (final SQLException se) {
+      //   // ignore
+      // }
 
       final DBInfo dbInfo = JDBCConnectionUrlParser.extractDBInfo(urlToUse, props);
       InstrumentationContext.get(Connection.class, DBInfo.class).put(connection, dbInfo);

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DriverInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DriverInstrumentation.java
@@ -13,7 +13,6 @@ import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.jdbc.DBInfo;
 import datadog.trace.bootstrap.instrumentation.jdbc.JDBCConnectionUrlParser;
 import java.sql.Connection;
-// import java.sql.SQLException;
 import java.util.Map;
 import java.util.Properties;
 import net.bytebuddy.asm.Advice;

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DriverInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DriverInstrumentation.java
@@ -13,6 +13,7 @@ import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.jdbc.DBInfo;
 import datadog.trace.bootstrap.instrumentation.jdbc.JDBCConnectionUrlParser;
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.Map;
 import java.util.Properties;
 import net.bytebuddy.asm.Advice;
@@ -70,17 +71,17 @@ public final class DriverInstrumentation extends Instrumenter.Tracing
         return;
       }
       String urlToUse = url;
-      // try {
-      //   urlToUse = connection.getMetaData().getURL();
-      // } catch (final SQLException se) {
-      //   // ignore
-      // }
+      try {
+        urlToUse = connection.getMetaData().getURL();
+      } catch (final SQLException se) {
+        // ignore
+      }
 
-      // try {
-      //   props.setProperty("user", connection.getMetaData().getUserName());
-      // } catch (final SQLException se) {
-      //   // ignore
-      // }
+      try {
+        props.setProperty("user", connection.getMetaData().getUserName());
+      } catch (final SQLException se) {
+        // ignore
+      }
 
       final DBInfo dbInfo = JDBCConnectionUrlParser.extractDBInfo(urlToUse, props);
       InstrumentationContext.get(Connection.class, DBInfo.class).put(connection, dbInfo);

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DriverInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DriverInstrumentation.java
@@ -13,7 +13,7 @@ import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.jdbc.DBInfo;
 import datadog.trace.bootstrap.instrumentation.jdbc.JDBCConnectionUrlParser;
 import java.sql.Connection;
-import java.sql.SQLException;
+// import java.sql.SQLException;
 import java.util.Map;
 import java.util.Properties;
 import net.bytebuddy.asm.Advice;


### PR DESCRIPTION
# What Does This Do

Extract metadata from the Connection object so that it can be leveraged when extracting db i

# Motivation

Context: #3643 

This is important when working with custom JDBC drivers that use custom Connection url strings and delegate the creation of the connection objects to other known JDBC drivers. In such contexts, the metadata found in the resulting Connection object was more relevant than the url/props supplied to the `connect` method as the custom url that is passed would not be parsed by the available parsers.

# Additional Notes
