### PR TITLE
Tune TaintedMapTest thresholds

### DIFF
--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedMapTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedMapTest.groovy
@@ -260,7 +260,7 @@ class TaintedMapTest extends DDSpecification {
 
   def 'multi-threaded put-intensive workflow with garbage collection interaction and under max size'() {
     given:
-    float maxAcceptableLoss = 0.999
+    float maxAcceptableLoss = 0.99
     float maxAcceptableLossPerThread = 0.9
     int nThreads = 16
     int nObjectsPerThread = (int) Math.floor(DefaultTaintedMap.DEFAULT_FLAT_MODE_THRESHOLD / nThreads) * 2
@@ -334,7 +334,7 @@ class TaintedMapTest extends DDSpecification {
     map.toList().size() <= nThreads * nRetainedObjectsPerThread * 2
 
     and: 'map does not contain extra objects'
-    map.toList().findAll { it.get() != null }.size() <= nThreads * nRetainedObjectsPerThread
+    map.toList().findAll { it.get() != null }.size() <= nThreads * nRetainedObjectsPerThread + nBeforeWaitGC
 
     and: 'map did not lose too many objects'
     map.toList().findAll { it.get() != null }.size() >= nThreads * nRetainedObjectsPerThread * maxAcceptableLoss


### PR DESCRIPTION
# What Does This Do
These are flaky, especially under high load, and in OpenJ9.

# Motivation

# Additional Notes
The approach to test this class needs to change significantly. This is a temporary measure.