### PR TITLE
User blocking support in the WAF

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -958,7 +958,7 @@ public class Agent {
     }
   }
 
-  /** @see datadog.trace.api.ProductActivation#fromString(String) */
+  /** @see datadog.trace.api.ProductActivationConfig#fromString(String) */
   private static boolean isAppSecFullyDisabled() {
     // must be kept in sync with logic from Config!
     final String featureEnabledSysprop = AgentFeature.APPSEC.systemProp;

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Constants.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Constants.java
@@ -15,6 +15,7 @@ public final class Constants {
    */
   public static final String[] BOOTSTRAP_PACKAGE_PREFIXES = {
     "datadog.slf4j",
+    "datadog.appsec.api",
     "datadog.trace.api",
     "datadog.trace.bootstrap",
     "datadog.trace.context",

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/blocking/BlockingActionHelper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/blocking/BlockingActionHelper.java
@@ -4,8 +4,8 @@ import static datadog.trace.api.config.AppSecConfig.APPSEC_HTTP_BLOCKED_TEMPLATE
 import static datadog.trace.api.config.AppSecConfig.APPSEC_HTTP_BLOCKED_TEMPLATE_JSON;
 import static java.lang.ClassLoader.getSystemClassLoader;
 
+import datadog.appsec.api.blocking.BlockingContentType;
 import datadog.trace.api.Config;
-import datadog.trace.api.gateway.Flow;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -57,11 +57,11 @@ public class BlockingActionHelper {
   }
 
   public static TemplateType determineTemplateType(
-      Flow.Action.BlockingContentType blockingContentType, String acceptHeader) {
-    if (blockingContentType == Flow.Action.BlockingContentType.HTML) {
+      BlockingContentType blockingContentType, String acceptHeader) {
+    if (blockingContentType == BlockingContentType.HTML) {
       return TemplateType.HTML;
     }
-    if (blockingContentType == Flow.Action.BlockingContentType.JSON) {
+    if (blockingContentType == BlockingContentType.JSON) {
       return TemplateType.JSON;
     }
 

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/blocking/BlockingActionHelperSpecification.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/blocking/BlockingActionHelperSpecification.groovy
@@ -1,7 +1,7 @@
 package datadog.trace.bootstrap.blocking
 
+import datadog.appsec.api.blocking.BlockingContentType
 import datadog.trace.api.Config
-import datadog.trace.api.gateway.Flow
 import datadog.trace.test.util.DDSpecification
 
 import java.nio.charset.StandardCharsets
@@ -13,7 +13,7 @@ class BlockingActionHelperSpecification extends DDSpecification {
 
   void 'determineTemplate with auto returns #templateType for "#accept"'() {
     expect:
-    BlockingActionHelper.determineTemplateType(Flow.Action.BlockingContentType.AUTO, accept) == templateType
+    BlockingActionHelper.determineTemplateType(BlockingContentType.AUTO, accept) == templateType
 
     where:
     accept   | templateType
@@ -35,12 +35,12 @@ class BlockingActionHelperSpecification extends DDSpecification {
 
   void 'determineTemplate with json'() {
     expect:
-    BlockingActionHelper.determineTemplateType(Flow.Action.BlockingContentType.JSON, 'text/html') == JSON
+    BlockingActionHelper.determineTemplateType(BlockingContentType.JSON, 'text/html') == JSON
   }
 
   void 'determineTemplate with html'() {
     expect:
-    BlockingActionHelper.determineTemplateType(Flow.Action.BlockingContentType.HTML, 'application/json') == HTML
+    BlockingActionHelper.determineTemplateType(BlockingContentType.HTML, 'application/json') == HTML
   }
 
   void 'getHttpCode return #result for #input'() {

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
@@ -55,8 +55,10 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
       1 * this.span.setTag(DDTags.HTTP_FRAGMENT, _)
       1 * this.span.setTag(Tags.HTTP_URL, url)
       1 * this.span.setTag(Tags.HTTP_HOSTNAME, req.url.host)
-      1 * this.span.getRequestContext()
+      2 * this.span.getRequestContext()
       1 * this.span.setResourceName({ it as String == req.method.toUpperCase() + " " + req.path }, ResourceNamePriorities.HTTP_PATH_NORMALIZER)
+    } else {
+      1 * this.span.getRequestContext()
     }
     0 * _
 
@@ -81,7 +83,7 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
     then:
     if (expectedUrl) {
       1 * this.span.setTag(Tags.HTTP_URL, expectedUrl)
-      1 * this.span.getRequestContext()
+      2 * this.span.getRequestContext()
     }
     if (expectedUrl && tagQueryString) {
       1 * this.span.setTag(DDTags.HTTP_QUERY, expectedQuery)
@@ -93,6 +95,7 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
         1 * this.span.setTag(Tags.HTTP_HOSTNAME, req.url.host)
       }
     } else {
+      1 * this.span.getRequestContext()
       1 * this.span.setResourceName({ it as String == expectedPath })
     }
     1 * this.span.setTag(Tags.HTTP_METHOD, null)
@@ -132,7 +135,7 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
     1 * this.span.setTag(Tags.HTTP_HOSTNAME, req.url.host)
     1 * this.span.setTag(DDTags.HTTP_QUERY, expectedQuery)
     1 * this.span.setTag(DDTags.HTTP_FRAGMENT, null)
-    1 * this.span.getRequestContext()
+    2 * this.span.getRequestContext()
     1 * this.span.setResourceName({ it as String == expectedResource }, ResourceNamePriorities.HTTP_PATH_NORMALIZER)
     1 * this.span.setTag(Tags.HTTP_METHOD, null)
     0 * _

--- a/dd-java-agent/appsec/src/jmh/java/datadog/appsec/benchmark/AppSecBenchmark.java
+++ b/dd-java-agent/appsec/src/jmh/java/datadog/appsec/benchmark/AppSecBenchmark.java
@@ -8,6 +8,7 @@ import com.datadog.appsec.AppSecSystem;
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery;
 import datadog.communication.ddagent.SharedCommunicationObjects;
 import datadog.communication.monitor.Monitoring;
+import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.InstrumentationGateway;
@@ -236,6 +237,14 @@ public class AppSecBenchmark {
     @Override
     public TraceSegment getTraceSegment() {
       return TraceSegment.NoOp.INSTANCE;
+    }
+
+    @Override
+    public void setBlockResponseFunction(BlockResponseFunction blockResponseFunction) {}
+
+    @Override
+    public BlockResponseFunction getBlockResponseFunction() {
+      return null;
     }
 
     @Override

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/AppSecSystem.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/AppSecSystem.java
@@ -1,5 +1,6 @@
 package com.datadog.appsec;
 
+import com.datadog.appsec.blocking.BlockingServiceImpl;
 import com.datadog.appsec.config.AppSecConfigService;
 import com.datadog.appsec.config.AppSecConfigServiceImpl;
 import com.datadog.appsec.event.EventDispatcher;
@@ -8,6 +9,7 @@ import com.datadog.appsec.gateway.GatewayBridge;
 import com.datadog.appsec.gateway.RateLimiter;
 import com.datadog.appsec.util.AbortStartupException;
 import com.datadog.appsec.util.StandardizedLogging;
+import datadog.appsec.api.blocking.Blocking;
 import datadog.communication.ddagent.SharedCommunicationObjects;
 import datadog.communication.monitor.Counter;
 import datadog.communication.monitor.Monitoring;
@@ -84,6 +86,8 @@ public class AppSecSystem {
     setActive(appSecEnabledConfig == ProductActivation.FULLY_ENABLED);
 
     APP_SEC_CONFIG_SERVICE.maybeSubscribeConfigPolling();
+
+    Blocking.setBlockingService(new BlockingServiceImpl(REPLACEABLE_EVENT_PRODUCER));
 
     STARTED.set(true);
 

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/blocking/BlockingServiceImpl.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/blocking/BlockingServiceImpl.java
@@ -1,0 +1,115 @@
+package com.datadog.appsec.blocking;
+
+import com.datadog.appsec.event.EventProducerService;
+import com.datadog.appsec.event.ExpiredSubscriberInfoException;
+import com.datadog.appsec.event.data.KnownAddresses;
+import com.datadog.appsec.event.data.SingletonDataBundle;
+import com.datadog.appsec.gateway.AppSecRequestContext;
+import datadog.appsec.api.blocking.BlockingContentType;
+import datadog.appsec.api.blocking.BlockingDetails;
+import datadog.appsec.api.blocking.BlockingService;
+import datadog.trace.api.gateway.BlockResponseFunction;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.internal.TraceSegment;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BlockingServiceImpl implements BlockingService {
+  private static final Logger log = LoggerFactory.getLogger(BlockingServiceImpl.class);
+
+  private final EventProducerService eventProducer;
+  private volatile EventProducerService.DataSubscriberInfo subInfo;
+
+  public BlockingServiceImpl(EventProducerService eventProducer) {
+    this.eventProducer = eventProducer;
+  }
+
+  @Override
+  public BlockingDetails shouldBlockUser(@Nonnull String userId) {
+    AppSecRequestContext reqCtx = getAppSecRequestContext();
+    if (reqCtx == null) {
+      log.debug("No request context to determine if user should be blocked");
+      return null;
+    }
+
+    Flow<Void> flow;
+    while (true) {
+      if (subInfo == null) {
+        subInfo = eventProducer.getDataSubscribers(KnownAddresses.USER_ID);
+      }
+      SingletonDataBundle<String> db = new SingletonDataBundle<>(KnownAddresses.USER_ID, userId);
+      try {
+        flow = eventProducer.publishDataEvent(subInfo, reqCtx, db, true);
+        break;
+      } catch (ExpiredSubscriberInfoException e) {
+        subInfo = null;
+      }
+    }
+
+    Flow.Action action = flow.getAction();
+    log.debug("Result of checking if user should be blocked: action={}", action);
+
+    if (action instanceof Flow.Action.RequestBlockingAction) {
+      Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+      return new BlockingDetails(rba.getStatusCode(), rba.getBlockingContentType());
+    }
+    return null;
+  }
+
+  @Override
+  public boolean tryCommitBlockingResponse(int statusCode, BlockingContentType templateType) {
+    log.info(
+        "Will try to commit blocking response statusCode={} templateType={}",
+        statusCode,
+        templateType);
+    RequestContext reqCtx = getRequestContext();
+    if (reqCtx == null) {
+      return false;
+    }
+
+    BlockResponseFunction blockResponseFunction = reqCtx.getBlockResponseFunction();
+    if (blockResponseFunction == null) {
+      log.warn("Do not know how to commit blocking response for this server");
+      return false;
+    }
+
+    log.debug("About to call block response function: {}", blockResponseFunction);
+    boolean res = blockResponseFunction.tryCommitBlockingResponse(statusCode, templateType);
+    if (res) {
+      TraceSegment traceSegment = reqCtx.getTraceSegment();
+      if (traceSegment != null) {
+        traceSegment.setTagTop("appsec.blocked", "true");
+      }
+    }
+    return res;
+  }
+
+  private static RequestContext getRequestContext() {
+    AgentSpan agentSpan = AgentTracer.get().activeSpan();
+    if (agentSpan == null) {
+      log.warn("Cannot block (no active span)");
+      return null;
+    }
+
+    return agentSpan.getRequestContext();
+  }
+
+  private AppSecRequestContext getAppSecRequestContext() {
+    AppSecRequestContext ctx = null;
+    RequestContext reqCtx = getRequestContext();
+    if (reqCtx != null) {
+      ctx = reqCtx.getData(RequestContextSlot.APPSEC);
+    }
+
+    if (ctx == null) {
+      log.warn("No AppSec request context. Not an http request or AppSec inactive?");
+      return null;
+    }
+    return ctx;
+  }
+}

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
@@ -93,6 +93,8 @@ public interface KnownAddresses {
 
   Address<Object> GRPC_SERVER_REQUEST_MESSAGE = new Address<>("grpc.server.request.message");
 
+  Address<String> USER_ID = new Address<>("usr.id");
+
   static Address<?> forName(String name) {
     switch (name) {
       case "server.request.body":
@@ -135,6 +137,8 @@ public interface KnownAddresses {
         return HEADERS_NO_COOKIES;
       case "grpc.server.request.message":
         return GRPC_SERVER_REQUEST_MESSAGE;
+      case "usr.id":
+        return USER_ID;
       default:
         return null;
     }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -5,6 +5,7 @@ import com.datadog.appsec.event.data.DataBundle;
 import com.datadog.appsec.event.data.KnownAddresses;
 import com.datadog.appsec.report.raw.events.AppSecEvent100;
 import com.datadog.appsec.util.StandardizedLogging;
+import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.api.http.StoredBodySupplier;
 import datadog.trace.api.internal.TraceSegment;
 import io.sqreen.powerwaf.Additive;
@@ -70,6 +71,7 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   private boolean rawReqBodyPublished;
   private boolean convertedReqBodyPublished;
   private boolean respDataPublished;
+  private BlockResponseFunction blockResponseFunction;
 
   // should be guarded by this
   private Additive additive;
@@ -326,6 +328,10 @@ public class AppSecRequestContext implements DataBundle, Closeable {
 
   public void setRespDataPublished(boolean respDataPublished) {
     this.respDataPublished = respDataPublished;
+  }
+
+  public void setBlockResponseFunction(BlockResponseFunction blockResponseFunction) {
+    this.blockResponseFunction = blockResponseFunction;
   }
 
   @Override

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -18,6 +18,7 @@ import com.datadog.appsec.report.raw.events.*;
 import com.datadog.appsec.util.StandardizedLogging;
 import com.google.auto.service.AutoService;
 import com.squareup.moshi.*;
+import datadog.appsec.api.blocking.BlockingContentType;
 import datadog.trace.api.Config;
 import datadog.trace.api.ProductActivation;
 import datadog.trace.api.gateway.Flow;
@@ -454,10 +455,9 @@ public class PowerWAFModule implements AppSecModule {
         int statusCode =
             ((Number) actionInfo.parameters.getOrDefault("status_code", 403)).intValue();
         String contentType = (String) actionInfo.parameters.getOrDefault("type", "auto");
-        Flow.Action.BlockingContentType blockingContentType = Flow.Action.BlockingContentType.AUTO;
+        BlockingContentType blockingContentType = BlockingContentType.AUTO;
         try {
-          blockingContentType =
-              Flow.Action.BlockingContentType.valueOf(contentType.toUpperCase(Locale.ROOT));
+          blockingContentType = BlockingContentType.valueOf(contentType.toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException iae) {
           log.warn("Unknown content type: {}; using auto", contentType);
         }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/blocking/BlockingServiceImplSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/blocking/BlockingServiceImplSpecification.groovy
@@ -1,0 +1,146 @@
+package com.datadog.appsec.blocking
+
+import com.datadog.appsec.event.ChangeableFlow
+import com.datadog.appsec.event.DataListener
+import com.datadog.appsec.event.EventDispatcher
+import com.datadog.appsec.event.EventProducerService
+import com.datadog.appsec.event.OrderedCallback
+import com.datadog.appsec.event.data.DataBundle
+import com.datadog.appsec.event.data.KnownAddresses
+import com.datadog.appsec.gateway.AppSecRequestContext
+import datadog.appsec.api.blocking.BlockingContentType
+import datadog.appsec.api.blocking.BlockingDetails
+import datadog.trace.api.gateway.BlockResponseFunction
+import datadog.trace.api.gateway.Flow
+import datadog.trace.api.gateway.RequestContext
+import datadog.trace.api.gateway.RequestContextSlot
+import datadog.trace.api.internal.TraceSegment
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import datadog.trace.test.util.DDSpecification
+
+class BlockingServiceImplSpecification extends DDSpecification {
+  EventProducerService eps = new EventDispatcher()
+  def bs = new BlockingServiceImpl(eps)
+  def origTracer
+  AgentTracer.TracerAPI tracer = Mock()
+
+  void setup() {
+    origTracer = AgentTracer.get()
+  }
+
+  void cleanup() {
+    AgentTracer.forceRegister origTracer
+  }
+
+
+  void shouldBlockUser() {
+    setup:
+    BlockingDetails result
+    EventDispatcher.DataSubscriptionSet set = new EventDispatcher.DataSubscriptionSet()
+    set.addSubscription([KnownAddresses.USER_ID], new DataListener() {
+      final OrderedCallback.Priority priority = OrderedCallback.Priority.DEFAULT
+
+      @Override
+      void onDataAvailable(ChangeableFlow flow, AppSecRequestContext context, DataBundle dataBundle, boolean isTransient) {
+        if (dataBundle.get(KnownAddresses.USER_ID) == 'blocked.user') {
+          flow.action = new Flow.Action.RequestBlockingAction(405, BlockingContentType.HTML)
+        }
+      }
+    })
+    eps.subscribeDataAvailable set
+
+    AppSecRequestContext appSecRequestContext = Mock()
+    AgentTracer.forceRegister(Stub(AgentTracer.TracerAPI) {
+      activeSpan() >> Stub(AgentSpan) {
+        getRequestContext() >> Stub(RequestContext) {
+          getData(RequestContextSlot.APPSEC) >> appSecRequestContext
+        }
+      }
+    })
+
+    when:
+    result = bs.shouldBlockUser('blocked.user')
+
+    then:
+    0 * _
+    result != null
+    result.blockingContentType == BlockingContentType.HTML
+    result.statusCode == 405
+
+    when:
+    result = bs.shouldBlockUser('not.blocked.user')
+
+    then:
+    0 * _
+    result == null
+  }
+
+  void 'shouldBlockUser with no active span'() {
+    setup:
+    AgentTracer.TracerAPI tracerApi = Mock(AgentTracer.TracerAPI)
+    AgentTracer.forceRegister(tracerApi)
+    def result
+
+    when:
+    result = bs.shouldBlockUser('foo.bar')
+
+    then:
+    result == null
+    1 * tracerApi.activeSpan() >> null
+  }
+
+  void tryCommitBlockingResponse() {
+    setup:
+    BlockResponseFunction brf = Mock()
+    TraceSegment mts = Mock()
+    AgentTracer.forceRegister(Mock(AgentTracer.TracerAPI) {
+      activeSpan() >> Mock(AgentSpan) {
+        getRequestContext() >> Mock(RequestContext) {
+          getBlockResponseFunction() >> brf
+          getTraceSegment() >> mts
+        }
+      }
+    })
+
+    when:
+    boolean res = bs.tryCommitBlockingResponse(405, BlockingContentType.HTML)
+
+    then:
+    res == true
+    1 * brf.tryCommitBlockingResponse(405, BlockingContentType.HTML) >> true
+    1 * mts.setTagTop('appsec.blocked', 'true')
+  }
+
+  void 'tryCommitBlockingResponse without active span'() {
+    setup:
+    RequestContext reqCtx = Mock(RequestContext)
+    AgentTracer.forceRegister(Mock(AgentTracer.TracerAPI) {
+      activeSpan() >> Mock(AgentSpan) {
+        getRequestContext() >> reqCtx
+      }
+    })
+
+    when:
+    boolean res = bs.tryCommitBlockingResponse(405, BlockingContentType.HTML)
+
+    then:
+    res == false
+    1 * reqCtx.getBlockResponseFunction() >> null
+    noExceptionThrown()
+  }
+
+  void 'tryCommitBlockingResponse without blocking response function'() {
+    setup:
+    AgentTracer.TracerAPI tracerApi = Mock(AgentTracer.TracerAPI)
+    AgentTracer.forceRegister(tracerApi)
+
+    when:
+    boolean res = bs.tryCommitBlockingResponse(405, BlockingContentType.HTML)
+
+    then:
+    res == false
+    1 * tracerApi.activeSpan() >> null
+    noExceptionThrown()
+  }
+}

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/EventDispatcherSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/EventDispatcherSpecification.groovy
@@ -5,6 +5,7 @@ import com.datadog.appsec.event.data.DataBundle
 import com.datadog.appsec.event.data.KnownAddresses
 import com.datadog.appsec.event.data.MapDataBundle
 import com.datadog.appsec.gateway.AppSecRequestContext
+import datadog.appsec.api.blocking.BlockingContentType
 import datadog.trace.api.gateway.Flow
 import datadog.trace.test.util.DDSpecification
 
@@ -125,12 +126,12 @@ class EventDispatcherSpecification extends DDSpecification {
     then:
     1 * dataListener1.onDataAvailable(_ as Flow, ctx, _ as DataBundle, true) >> {
       ChangeableFlow flow = it.first()
-      flow.action = new Flow.Action.RequestBlockingAction(404, Flow.Action.BlockingContentType.AUTO)
+      flow.action = new Flow.Action.RequestBlockingAction(404, BlockingContentType.AUTO)
     }
     0 * dataListener2.onDataAvailable(_ as Flow, ctx, _ as DataBundle, _ as boolean)
     assert resultFlow.blocking
     assert resultFlow.action.statusCode == 404
-    assert resultFlow.action.blockingContentType == Flow.Action.BlockingContentType.AUTO
+    assert resultFlow.action.blockingContentType == BlockingContentType.AUTO
   }
 
   void 'non transient data publishing saves the bundle in the context'() {

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecification.groovy
@@ -9,32 +9,33 @@ class KnownAddressesSpecification extends Specification {
 
     where:
     name << [
-      "server.request.body",
-      "server.request.body.raw",
-      "_server.request.scheme",
-      "server.request.uri.raw",
-      "server.request.client_ip",
-      "_server.request.client_port",
-      "http.client_ip",
-      "server.request.method",
-      "server.request.path_params",
-      "server.request.cookies",
-      "server.request.transport",
-      "server.response.status",
-      "server.response.body.raw",
-      "server.response.headers.no_cookies",
-      "server.request.body.files_field_names",
-      "server.request.body.filenames",
-      "server.request.body.combined_file_size",
-      "server.request.query",
-      "server.request.headers.no_cookies",
-      "grpc.server.request.message"
+      'server.request.body',
+      'server.request.body.raw',
+      '_server.request.scheme',
+      'server.request.uri.raw',
+      'server.request.client_ip',
+      '_server.request.client_port',
+      'http.client_ip',
+      'server.request.method',
+      'server.request.path_params',
+      'server.request.cookies',
+      'server.request.transport',
+      'server.response.status',
+      'server.response.body.raw',
+      'server.response.headers.no_cookies',
+      'server.request.body.files_field_names',
+      'server.request.body.filenames',
+      'server.request.body.combined_file_size',
+      'server.request.query',
+      'server.request.headers.no_cookies',
+      'grpc.server.request.message',
+      'usr.id',
     ]
   }
 
   void 'number of known addresses is expected number'() {
     expect:
-    Address.instanceCount() == 20
-    KnownAddresses.GRPC_SERVER_REQUEST_MESSAGE.serial == Address.instanceCount() - 1
+    Address.instanceCount() == 21
+    KnownAddresses.USER_ID.serial == Address.instanceCount() - 1
   }
 }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
@@ -13,6 +13,7 @@ import com.datadog.appsec.report.raw.events.AppSecEvent100
 import datadog.trace.api.internal.TraceSegment
 import datadog.trace.api.function.TriConsumer
 import datadog.trace.api.function.TriFunction
+import datadog.trace.api.gateway.BlockResponseFunction
 import datadog.trace.api.gateway.Flow
 import datadog.trace.api.gateway.IGSpanInfo
 import datadog.trace.api.gateway.RequestContext
@@ -38,6 +39,7 @@ class GatewayBridgeSpecification extends DDSpecification {
   TraceSegment traceSegment = Mock()
   RequestContext ctx = new RequestContext() {
     final AppSecRequestContext data = arCtx
+    BlockResponseFunction blockResponseFunction
 
     @Override
     Object getData(RequestContextSlot slot) {
@@ -715,6 +717,7 @@ class GatewayBridgeSpecification extends DDSpecification {
   void 'no appsec events if was not created request context in request_start event'() {
     RequestContext emptyCtx = new RequestContext() {
         final Object data = null
+        BlockResponseFunction blockResponseFunction
 
         @Override
         Object getData(RequestContextSlot slot) {

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
@@ -21,6 +21,7 @@ import com.datadog.appsec.report.raw.events.Tags
 import com.datadog.appsec.test.StubAppSecConfigService
 import datadog.trace.api.ConfigDefaults
 import datadog.trace.api.internal.TraceSegment
+import datadog.appsec.api.blocking.BlockingContentType
 import datadog.trace.api.gateway.Flow
 import datadog.trace.test.util.DDSpecification
 import io.sqreen.powerwaf.Powerwaf
@@ -183,8 +184,8 @@ class PowerWAFModuleSpecification extends DDSpecification {
     then:
     1 * reconf.reloadSubscriptions()
     1 * flow.setAction({ Flow.Action.RequestBlockingAction rba ->
-      rba.statusCode == 501
-      rba.blockingContentType == Flow.Action.BlockingContentType.JSON
+      rba.statusCode == 501 &&
+        rba.blockingContentType == BlockingContentType.JSON
     })
     1 * ctx.getOrCreateAdditive(_, true) >> { it[0].openAdditive() }
     1 * ctx.reportEvents(_ as Collection<AppSecEvent100>, _)
@@ -410,7 +411,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     0 * ctx._(*_)
     flow.blocking == true
     flow.action.statusCode == 418
-    flow.action.blockingContentType == Flow.Action.BlockingContentType.HTML
+    flow.action.blockingContentType == BlockingContentType.HTML
   }
 
   void 'no metrics are set if waf metrics are off'() {

--- a/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyDecorator.java
+++ b/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyDecorator.java
@@ -1,11 +1,17 @@
 package datadog.trace.instrumentation.grizzly;
 
+import datadog.appsec.api.blocking.BlockingContentType;
+import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import org.glassfish.grizzly.http.server.Request;
 import org.glassfish.grizzly.http.server.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class GrizzlyDecorator extends HttpServerDecorator<Request, Request, Response, Request> {
   public static final CharSequence GRIZZLY = UTF8BytesString.create("grizzly");
@@ -60,5 +66,32 @@ public class GrizzlyDecorator extends HttpServerDecorator<Request, Request, Resp
   @Override
   protected CharSequence component() {
     return GRIZZLY;
+  }
+
+  @Override
+  protected BlockResponseFunction createBlockResponseFunction(Request request, Request request2) {
+    return new GrizzlyBlockResponseFunction(request);
+  }
+
+  public static class GrizzlyBlockResponseFunction implements BlockResponseFunction {
+    private static final Logger log = LoggerFactory.getLogger(GrizzlyBlockResponseFunction.class);
+
+    private final Request request;
+
+    public GrizzlyBlockResponseFunction(Request request) {
+      this.request = request;
+    }
+
+    @Override
+    public boolean tryCommitBlockingResponse(int statusCode, BlockingContentType templateType) {
+      AgentScope agentScope = AgentTracer.get().activeScope();
+      if (agentScope == null) {
+        log.warn("Can't block: no active scope");
+        return false;
+      }
+
+      return GrizzlyBlockingHelper.block(
+          this.request, this.request.getResponse(), statusCode, templateType, agentScope);
+    }
   }
 }

--- a/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
@@ -44,6 +44,7 @@ public class GrizzlyHttpHandlerInstrumentation extends Instrumenter.Tracing
       packageName + ".ExtractAdapter$Request",
       packageName + ".ExtractAdapter$Response",
       packageName + ".GrizzlyDecorator",
+      packageName + ".GrizzlyDecorator$GrizzlyBlockResponseFunction",
       packageName + ".RequestURIDataAdapter",
       packageName + ".SpanClosingListener",
       packageName + ".GrizzlyBlockingHelper",

--- a/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyAsyncTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyAsyncTest.groovy
@@ -1,3 +1,5 @@
+import datadog.appsec.api.blocking.Blocking
+
 import javax.ws.rs.GET
 import javax.ws.rs.HeaderParam
 import javax.ws.rs.Path
@@ -9,6 +11,7 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_BOTH
@@ -88,6 +91,17 @@ class GrizzlyAsyncTest extends GrizzlyTest {
       executor.execute {
         controller(ERROR) {
           ar.resume(Response.status(ERROR.status).entity(ERROR.body).build())
+        }
+      }
+    }
+
+    @GET
+    @Path("user-block")
+    Response userBlock(@Suspended AsyncResponse ar) {
+      executor.execute {
+        controller(USER_BLOCK) {
+          Blocking.forUser('user-to-block').blockIfMatch()
+          ar.resume(Response.status(200).entity('should not be reached').build())
         }
       }
     }

--- a/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyTest.groovy
@@ -1,3 +1,4 @@
+import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.instrumentation.grizzly.GrizzlyDecorator
 import org.glassfish.grizzly.http.server.HttpServer
@@ -25,6 +26,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 
 class GrizzlyTest extends HttpServerTest<HttpServer> {
 
@@ -155,6 +157,15 @@ class GrizzlyTest extends HttpServerTest<HttpServer> {
     Response error() {
       controller(ERROR) {
         Response.status(ERROR.status).entity(ERROR.body).build()
+      }
+    }
+
+    @GET
+    @Path("user-block")
+    Response userBlock() {
+      controller(USER_BLOCK) {
+        Blocking.forUser('user-to-block').blockIfMatch()
+        Response.status(200).entity('should not be reached').build()
       }
     }
 

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/DefaultFilterChainInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/DefaultFilterChainInstrumentation.java
@@ -25,8 +25,10 @@ public class DefaultFilterChainInstrumentation extends Instrumenter.Tracing
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".GrizzlyDecorator",
+      packageName + ".GrizzlyDecorator$GrizzlyHttpBlockResponseFunction",
       packageName + ".GrizzlyHttpBlockingHelper",
       packageName + ".GrizzlyHttpBlockingHelper$CloseCompletionHandler",
+      packageName + ".GrizzlyHttpBlockingHelper$JustCompleteProcessor",
       packageName + ".HTTPRequestPacketURIDataAdapter",
       packageName + ".ExtractAdapter"
     };

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/GrizzlyDecorator.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/GrizzlyDecorator.java
@@ -2,7 +2,11 @@ package datadog.trace.instrumentation.grizzlyhttp232;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 
+import datadog.appsec.api.blocking.BlockingContentType;
+import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.bootstrap.ActiveSubsystems;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -122,6 +126,15 @@ public class GrizzlyDecorator
           GrizzlyHttpBlockingHelper.block(
               ctx, (HttpServerFilter) thiz, httpRequest, httpResponse, rba, nextAction);
     }
+    if (ActiveSubsystems.APPSEC_ACTIVE) {
+      RequestContext requestContext = span.getRequestContext();
+      if (requestContext != null) {
+        BlockResponseFunction brf = requestContext.getBlockResponseFunction();
+        if (brf instanceof GrizzlyHttpBlockResponseFunction) {
+          ((GrizzlyHttpBlockResponseFunction) brf).ctx = ctx;
+        }
+      }
+    }
     scope.close();
 
     return nextAction;
@@ -136,5 +149,28 @@ public class GrizzlyDecorator
     }
     ctx.getAttributes().removeAttribute(DD_SPAN_ATTRIBUTE);
     ctx.getAttributes().removeAttribute(DD_RESPONSE_ATTRIBUTE);
+  }
+
+  @Override
+  protected BlockResponseFunction createBlockResponseFunction(
+      HttpRequestPacket httpRequestPacket, HttpRequestPacket httpRequestPacket2) {
+    return new GrizzlyHttpBlockResponseFunction(httpRequestPacket.getHeader("Accept"));
+  }
+
+  public static class GrizzlyHttpBlockResponseFunction implements BlockResponseFunction {
+    private final String acceptHeader;
+    public volatile FilterChainContext ctx;
+
+    public GrizzlyHttpBlockResponseFunction(String acceptHeader) {
+      this.acceptHeader = acceptHeader;
+    }
+
+    @Override
+    public boolean tryCommitBlockingResponse(int statusCode, BlockingContentType templateType) {
+      if (ctx == null) {
+        return false;
+      }
+      return GrizzlyHttpBlockingHelper.block(ctx, acceptHeader, statusCode, templateType);
+    }
   }
 }

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/GrizzlyHttpBlockingHelper.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/GrizzlyHttpBlockingHelper.java
@@ -1,5 +1,8 @@
 package datadog.trace.instrumentation.grizzlyhttp232;
 
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_RESPONSE_ATTRIBUTE;
+
+import datadog.appsec.api.blocking.BlockingContentType;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.bootstrap.blocking.BlockingActionHelper;
 import java.lang.invoke.MethodHandle;
@@ -7,8 +10,15 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import org.glassfish.grizzly.Buffer;
 import org.glassfish.grizzly.CompletionHandler;
+import org.glassfish.grizzly.Connection;
+import org.glassfish.grizzly.Context;
 import org.glassfish.grizzly.EmptyCompletionHandler;
+import org.glassfish.grizzly.IOEvent;
+import org.glassfish.grizzly.Processor;
+import org.glassfish.grizzly.ProcessorResult;
 import org.glassfish.grizzly.WriteResult;
+import org.glassfish.grizzly.asyncqueue.MessageCloner;
+import org.glassfish.grizzly.asyncqueue.PushBackHandler;
 import org.glassfish.grizzly.filterchain.FilterChainContext;
 import org.glassfish.grizzly.filterchain.NextAction;
 import org.glassfish.grizzly.http.HttpContent;
@@ -109,6 +119,56 @@ public class GrizzlyHttpBlockingHelper {
     return nextAction;
   }
 
+  public static boolean block(
+      FilterChainContext ctx,
+      String acceptHeader,
+      int statusCode,
+      BlockingContentType templateType) {
+    if (ENCODE_HTTP_PACKET == null) {
+      return false;
+    }
+    int filterIdx = ctx.getFilterChain().indexOfType(HttpServerFilter.class);
+    if (filterIdx == -1) {
+      log.warn("Can't block: can't find filter of type HttpServerFilter");
+      return false;
+    }
+    HttpServerFilter httpServerFilter = (HttpServerFilter) ctx.getFilterChain().get(filterIdx);
+
+    HttpStatus status =
+        HttpStatus.newHttpStatus(BlockingActionHelper.getHttpCode(statusCode), "Request Blocked");
+    HttpResponsePacket httpResponse =
+        (HttpResponsePacket) ctx.getAttributes().getAttribute(DD_RESPONSE_ATTRIBUTE);
+    status.setValues(httpResponse);
+
+    BlockingActionHelper.TemplateType type =
+        BlockingActionHelper.determineTemplateType(templateType, acceptHeader);
+
+    httpResponse.setHeader("Content-type", BlockingActionHelper.getContentType(type));
+    byte[] template = BlockingActionHelper.getTemplate(type);
+    httpResponse.setContentLength(template.length);
+    HttpContent httpContent =
+        HttpContent.builder(httpResponse).content(HeapBuffer.wrap(template)).last(true).build();
+
+    Buffer buff;
+    try {
+      buff = (Buffer) ENCODE_HTTP_PACKET.invoke(httpServerFilter, ctx, httpContent);
+    } catch (Throwable e) {
+      log.error("Failure serializing http response for blocking", e);
+      // in normal circumstances, recycle is called by encodeHttPacket
+      httpContent.recycle();
+      return true;
+    }
+
+    ctx.write(buff);
+    ctx.flush(CLOSE_COMPLETION_HANDLER);
+
+    Context ictx = ctx.getInternalContext();
+    // see ProcessorExecutor::execute
+    ictx.setProcessor(JustCompleteProcessor.INSTANCE);
+
+    return true;
+  }
+
   public static class CloseCompletionHandler extends EmptyCompletionHandler {
     @Override
     public void completed(Object result) {
@@ -119,6 +179,64 @@ public class GrizzlyHttpBlockingHelper {
       } finally {
         wr.recycle();
       }
+    }
+  }
+
+  public static class JustCompleteProcessor implements Processor {
+    public static final Processor INSTANCE = new JustCompleteProcessor();
+
+    @Override
+    public Context obtainContext(Connection connection) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ProcessorResult process(Context context) {
+      return ProcessorResult.createComplete();
+    }
+
+    @Override
+    public void read(Connection connection, CompletionHandler completionHandler) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void write(
+        Connection connection,
+        Object dstAddress,
+        Object message,
+        CompletionHandler completionHandler) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void write(
+        Connection connection,
+        Object dstAddress,
+        Object message,
+        CompletionHandler completionHandler,
+        MessageCloner messageCloner) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void write(
+        Connection connection,
+        Object dstAddress,
+        Object message,
+        CompletionHandler completionHandler,
+        PushBackHandler pushBackHandler) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isInterested(IOEvent ioEvent) {
+      return false;
+    }
+
+    @Override
+    public void setInterested(IOEvent ioEvent, boolean isInterested) {
+      throw new UnsupportedOperationException();
     }
   }
 }

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/HttpCodecFilterInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/HttpCodecFilterInstrumentation.java
@@ -29,8 +29,10 @@ public final class HttpCodecFilterInstrumentation extends Instrumenter.Tracing
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".GrizzlyDecorator",
+      packageName + ".GrizzlyDecorator$GrizzlyHttpBlockResponseFunction",
       packageName + ".GrizzlyHttpBlockingHelper",
       packageName + ".GrizzlyHttpBlockingHelper$CloseCompletionHandler",
+      packageName + ".GrizzlyHttpBlockingHelper$JustCompleteProcessor",
       packageName + ".HTTPRequestPacketURIDataAdapter",
       packageName + ".ExtractAdapter"
     };

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/HttpServerFilterInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/HttpServerFilterInstrumentation.java
@@ -29,8 +29,10 @@ public class HttpServerFilterInstrumentation extends Instrumenter.Tracing
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".GrizzlyDecorator",
+      packageName + ".GrizzlyDecorator$GrizzlyHttpBlockResponseFunction",
       packageName + ".GrizzlyHttpBlockingHelper",
       packageName + ".GrizzlyHttpBlockingHelper$CloseCompletionHandler",
+      packageName + ".GrizzlyHttpBlockingHelper$JustCompleteProcessor",
       packageName + ".HTTPRequestPacketURIDataAdapter",
       packageName + ".ExtractAdapter"
     };

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyAsyncTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyAsyncTest.groovy
@@ -1,3 +1,5 @@
+import datadog.appsec.api.blocking.Blocking
+
 import javax.ws.rs.Consumes
 import javax.ws.rs.FormParam
 import javax.ws.rs.GET
@@ -23,6 +25,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 
 class GrizzlyAsyncTest extends GrizzlyTest {
 
@@ -128,6 +131,17 @@ class GrizzlyAsyncTest extends GrizzlyTest {
       executor.execute {
         controller(ERROR) {
           ar.resume(Response.status(ERROR.status).entity(ERROR.body).build())
+        }
+      }
+    }
+
+    @GET
+    @Path("user-block")
+    Response userBlock(@Suspended AsyncResponse ar) {
+      executor.execute {
+        controller(USER_BLOCK) {
+          Blocking.forUser('user-to-block').blockIfMatch()
+          ar.resume(Response.status(200).entity('should not be reached').build())
         }
       }
     }

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyTest.groovy
@@ -1,3 +1,4 @@
+import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.instrumentation.grizzlyhttp232.GrizzlyDecorator
 import org.glassfish.grizzly.http.server.HttpServer
@@ -32,6 +33,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 
 class GrizzlyTest extends HttpServerTest<HttpServer> {
 
@@ -204,6 +206,15 @@ class GrizzlyTest extends HttpServerTest<HttpServer> {
     Response error() {
       controller(ERROR) {
         Response.status(ERROR.status).entity(ERROR.body).build()
+      }
+    }
+
+    @GET
+    @Path("user-block")
+    Response userBlock() {
+      controller(USER_BLOCK) {
+        Blocking.forUser('user-to-block').blockIfMatch()
+        Response.status(200).entity('should not be reached').build()
       }
     }
 

--- a/dd-java-agent/instrumentation/jetty-11/src/main/java/datadog/trace/instrumentation/jetty11/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-11/src/main/java/datadog/trace/instrumentation/jetty11/JettyServerInstrumentation.java
@@ -53,6 +53,8 @@ public final class JettyServerInstrumentation extends Instrumenter.Tracing
       packageName + ".JettyServerAdvice",
       packageName + ".JettyServerAdvice$HandleAdvice",
       packageName + ".JettyServerAdvice$ResetAdvice",
+      "datadog.trace.instrumentation.jetty.JettyBlockResponseFunction",
+      "datadog.trace.instrumentation.jetty.JettyBlockingHelper",
     };
   }
 

--- a/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/JettyDecorator.java
@@ -2,11 +2,13 @@ package datadog.trace.instrumentation.jetty11;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
+import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
+import datadog.trace.instrumentation.jetty.JettyBlockResponseFunction;
 import jakarta.servlet.ServletException;
 import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.Request;
@@ -84,5 +86,10 @@ public class JettyDecorator extends HttpServerDecorator<Request, Request, Respon
       onError(span, throwable);
     }
     return super.onResponse(span, response);
+  }
+
+  @Override
+  protected BlockResponseFunction createBlockResponseFunction(Request request, Request request1) {
+    return new JettyBlockResponseFunction(request);
   }
 }

--- a/dd-java-agent/instrumentation/jetty-11/src/test/groovy/Jetty11Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-11/src/test/groovy/Jetty11Test.groovy
@@ -1,3 +1,4 @@
+import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
 import jakarta.servlet.http.HttpServlet
@@ -143,6 +144,9 @@ class Jetty11Test extends HttpServerTest<Server> {
           case QUERY_PARAM:
             response.status = endpoint.status
             response.writer.print(endpoint.bodyForQuery(request.queryString))
+            break
+          case USER_BLOCK:
+            Blocking.forUser('user-to-block').blockIfMatch()
             break
           case REDIRECT:
             response.sendRedirect(endpoint.body)

--- a/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyDecorator.java
@@ -2,11 +2,13 @@ package datadog.trace.instrumentation.jetty70;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
+import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
+import datadog.trace.instrumentation.jetty.JettyBlockResponseFunction;
 import javax.servlet.ServletException;
 import org.eclipse.jetty.server.HttpConnection;
 import org.eclipse.jetty.server.Request;
@@ -84,5 +86,10 @@ public class JettyDecorator extends HttpServerDecorator<Request, Request, Respon
       onError(span, throwable);
     }
     return super.onResponse(span, response);
+  }
+
+  @Override
+  protected BlockResponseFunction createBlockResponseFunction(Request request, Request connection) {
+    return new JettyBlockResponseFunction(request);
   }
 }

--- a/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyServerInstrumentation.java
@@ -57,6 +57,7 @@ public final class JettyServerInstrumentation extends Instrumenter.Tracing
       packageName + ".ExtractAdapter$Response",
       packageName + ".JettyDecorator",
       packageName + ".RequestURIDataAdapter",
+      "datadog.trace.instrumentation.jetty.JettyBlockResponseFunction",
       "datadog.trace.instrumentation.jetty.JettyBlockingHelper",
     };
   }

--- a/dd-java-agent/instrumentation/jetty-7.0/src/test/groovy/Jetty70Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/test/groovy/Jetty70Test.groovy
@@ -1,3 +1,4 @@
+import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
 import org.eclipse.jetty.server.Request
@@ -19,6 +20,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 
 class Jetty70Test extends HttpServerTest<Server> {
 
@@ -142,6 +144,9 @@ class Jetty70Test extends HttpServerTest<Server> {
           break
         case EXCEPTION:
           throw new Exception(endpoint.body)
+        case USER_BLOCK:
+          Blocking.forUser('user-to-block').blockIfMatch()
+          break
         default:
           response.status = NOT_FOUND.status
           response.writer.print(NOT_FOUND.body)

--- a/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyDecorator.java
@@ -2,11 +2,13 @@ package datadog.trace.instrumentation.jetty76;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
+import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
+import datadog.trace.instrumentation.jetty.JettyBlockResponseFunction;
 import javax.servlet.ServletException;
 import org.eclipse.jetty.server.AbstractHttpConnection;
 import org.eclipse.jetty.server.Request;
@@ -84,5 +86,10 @@ public class JettyDecorator extends HttpServerDecorator<Request, Request, Respon
       onError(span, throwable);
     }
     return super.onResponse(span, response);
+  }
+
+  @Override
+  protected BlockResponseFunction createBlockResponseFunction(Request request, Request connection) {
+    return new JettyBlockResponseFunction(request);
   }
 }

--- a/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyServerInstrumentation.java
@@ -56,6 +56,7 @@ public final class JettyServerInstrumentation extends Instrumenter.Tracing
       packageName + ".ExtractAdapter$Response",
       packageName + ".JettyDecorator",
       packageName + ".RequestURIDataAdapter",
+      "datadog.trace.instrumentation.jetty.JettyBlockResponseFunction",
       "datadog.trace.instrumentation.jetty.JettyBlockingHelper",
     };
   }

--- a/dd-java-agent/instrumentation/jetty-7.6/src/test/groovy/Jetty76Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-7.6/src/test/groovy/Jetty76Test.groovy
@@ -1,3 +1,4 @@
+import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
 import org.eclipse.jetty.server.Request
@@ -18,6 +19,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 
 class Jetty76Test extends HttpServerTest<Server> {
 
@@ -126,6 +128,10 @@ class Jetty76Test extends HttpServerTest<Server> {
           break
         case EXCEPTION:
           throw new Exception(endpoint.body)
+        case USER_BLOCK:
+          Blocking.forUser('user-to-block').blockIfMatch()
+          response.writer.print('should not be reached')
+          break
         default:
           response.status = NOT_FOUND.status
           response.writer.print(NOT_FOUND.body)

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyDecorator.java
@@ -2,11 +2,13 @@ package datadog.trace.instrumentation.jetty9;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
+import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
+import datadog.trace.instrumentation.jetty.JettyBlockResponseFunction;
 import javax.servlet.ServletException;
 import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.Request;
@@ -84,5 +86,10 @@ public class JettyDecorator extends HttpServerDecorator<Request, Request, Respon
       onError(span, throwable);
     }
     return super.onResponse(span, response);
+  }
+
+  @Override
+  protected BlockResponseFunction createBlockResponseFunction(Request request, Request connection) {
+    return new JettyBlockResponseFunction(request);
   }
 }

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyServerInstrumentation.java
@@ -60,6 +60,7 @@ public final class JettyServerInstrumentation extends Instrumenter.Tracing
       packageName + ".ExtractAdapter$Response",
       packageName + ".JettyDecorator",
       packageName + ".RequestURIDataAdapter",
+      "datadog.trace.instrumentation.jetty.JettyBlockResponseFunction",
       "datadog.trace.instrumentation.jetty.JettyBlockingHelper",
     };
   }

--- a/dd-java-agent/instrumentation/jetty-9/src/test/groovy/Jetty9Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-9/src/test/groovy/Jetty9Test.groovy
@@ -1,3 +1,4 @@
+import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
 import org.eclipse.jetty.server.Request
@@ -20,6 +21,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 
 class Jetty9Test extends HttpServerTest<Server> {
 
@@ -140,6 +142,9 @@ class Jetty9Test extends HttpServerTest<Server> {
           break
         case EXCEPTION:
           throw new Exception(endpoint.body)
+        case USER_BLOCK:
+          Blocking.forUser('user-to-block').blockIfMatch()
+          break
         default:
           response.status = NOT_FOUND.status
           response.writer.print(NOT_FOUND.body)

--- a/dd-java-agent/instrumentation/jetty-common/src/main/java/datadog/trace/instrumentation/jetty/JettyBlockResponseFunction.java
+++ b/dd-java-agent/instrumentation/jetty-common/src/main/java/datadog/trace/instrumentation/jetty/JettyBlockResponseFunction.java
@@ -1,0 +1,20 @@
+package datadog.trace.instrumentation.jetty;
+
+import datadog.appsec.api.blocking.BlockingContentType;
+import datadog.trace.api.gateway.BlockResponseFunction;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+
+public class JettyBlockResponseFunction implements BlockResponseFunction {
+  private final Request request;
+
+  public JettyBlockResponseFunction(Request request) {
+    this.request = request;
+  }
+
+  @Override
+  public boolean tryCommitBlockingResponse(int statusCode, BlockingContentType templateType) {
+    Response response = request.getResponse();
+    return JettyBlockingHelper.block(request, response, statusCode, templateType);
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-common/src/test/groovy/datadog/trace/instrumentation/jetty/JettyBlockingHelperSpecification.groovy
+++ b/dd-java-agent/instrumentation/jetty-common/src/test/groovy/datadog/trace/instrumentation/jetty/JettyBlockingHelperSpecification.groovy
@@ -7,7 +7,7 @@ import org.eclipse.jetty.server.Response
 
 import javax.servlet.ServletOutputStream
 
-import static datadog.trace.api.gateway.Flow.Action.BlockingContentType.AUTO
+import static datadog.appsec.api.blocking.BlockingContentType.AUTO
 
 class JettyBlockingHelperSpecification extends DDSpecification {
   void 'block completes successfully'() {

--- a/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/LibertyDecorator.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/LibertyDecorator.java
@@ -3,18 +3,25 @@ package datadog.trace.instrumentation.liberty20;
 import static datadog.trace.instrumentation.liberty20.HttpServletExtractAdapter.Request;
 import static datadog.trace.instrumentation.liberty20.HttpServletExtractAdapter.Response;
 
+import com.ibm.ws.webcontainer.srt.SRTServletRequest;
 import com.ibm.ws.webcontainer.srt.SRTServletResponse;
 import com.ibm.ws.webcontainer.webapp.WebAppErrorReport;
+import com.ibm.wsspi.webcontainer.servlet.IExtendedResponse;
+import datadog.appsec.api.blocking.BlockingContentType;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
+import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
+import datadog.trace.instrumentation.servlet.ServletBlockingHelper;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LibertyDecorator
     extends HttpServerDecorator<
@@ -131,5 +138,37 @@ public class LibertyDecorator
     }
     span.setTag(DDTags.ERROR_MSG, report.getMessage());
     return span;
+  }
+
+  public static class LibertyBlockResponseFunction implements BlockResponseFunction {
+    private static final Logger log = LoggerFactory.getLogger(LibertyBlockResponseFunction.class);
+    private final HttpServletRequest request;
+
+    public LibertyBlockResponseFunction(HttpServletRequest request) {
+      this.request = request;
+    }
+
+    @Override
+    public boolean tryCommitBlockingResponse(int statusCode, BlockingContentType bct) {
+      if (!(request instanceof SRTServletRequest)) {
+        log.warn("Can't block; request not of type SRTServletRequest");
+        return false;
+      }
+      IExtendedResponse response = ((SRTServletRequest) request).getResponse();
+      if (!(response instanceof HttpServletResponse)) {
+        log.warn("Can't block; response not of type HttpServletResponse");
+        return false;
+      }
+      ServletBlockingHelper.commitBlockingResponse(
+          request, (HttpServletResponse) response, statusCode, bct);
+
+      return true;
+    }
+  }
+
+  @Override
+  protected BlockResponseFunction createBlockResponseFunction(
+      HttpServletRequest httpServletRequest, HttpServletRequest connection) {
+    return new LibertyBlockResponseFunction(httpServletRequest);
   }
 }

--- a/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/LibertyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/LibertyServerInstrumentation.java
@@ -43,6 +43,7 @@ public final class LibertyServerInstrumentation extends Instrumenter.Tracing
       packageName + ".HttpServletExtractAdapter$Request",
       packageName + ".HttpServletExtractAdapter$Response",
       packageName + ".LibertyDecorator",
+      packageName + ".LibertyDecorator$LibertyBlockResponseFunction",
       packageName + ".RequestURIDataAdapter",
       "datadog.trace.instrumentation.servlet.ServletBlockingHelper",
     };

--- a/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/RequestFinishInstrumentation.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/RequestFinishInstrumentation.java
@@ -28,6 +28,7 @@ public class RequestFinishInstrumentation extends Instrumenter.Tracing
       packageName + ".HttpServletExtractAdapter$Request",
       packageName + ".HttpServletExtractAdapter$Response",
       packageName + ".LibertyDecorator",
+      packageName + ".LibertyDecorator$LibertyBlockResponseFunction",
       packageName + ".RequestURIDataAdapter",
     };
   }

--- a/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/ResponseFinishInstrumentation.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/ResponseFinishInstrumentation.java
@@ -27,6 +27,7 @@ public class ResponseFinishInstrumentation extends Instrumenter.Tracing
       packageName + ".HttpServletExtractAdapter$Request",
       packageName + ".HttpServletExtractAdapter$Response",
       packageName + ".LibertyDecorator",
+      packageName + ".LibertyDecorator$LibertyBlockResponseFunction",
       packageName + ".RequestURIDataAdapter",
     };
   }

--- a/dd-java-agent/instrumentation/liberty-20/src/webapp/java/datadog/trace/instrumentation/liberty20/PassthruSyncServlet3.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/webapp/java/datadog/trace/instrumentation/liberty20/PassthruSyncServlet3.java
@@ -28,6 +28,7 @@ import javax.servlet.http.HttpServlet;
       "/query",
       "/encoded path query",
       "/encoded_query",
+      "/user-block",
     })
 public class PassthruSyncServlet3 extends HttpServlet {
   HttpServlet delegate;

--- a/dd-java-agent/instrumentation/netty-3.8/src/latestDepTest/groovy/datadog/trace/instrumentation/netty38/latestdep/Netty38ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-3.8/src/latestDepTest/groovy/datadog/trace/instrumentation/netty38/latestdep/Netty38ClientTest.groovy
@@ -1,3 +1,5 @@
+package datadog.trace.instrumentation.netty38.latestdep
+
 import com.ning.http.client.AsyncCompletionHandler
 import com.ning.http.client.AsyncHttpClient
 import com.ning.http.client.AsyncHttpClientConfig

--- a/dd-java-agent/instrumentation/netty-3.8/src/latestDepTest/groovy/datadog/trace/instrumentation/netty38/latestdep/Netty38ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-3.8/src/latestDepTest/groovy/datadog/trace/instrumentation/netty38/latestdep/Netty38ServerTest.groovy
@@ -1,3 +1,5 @@
+package datadog.trace.instrumentation.netty38.latestdep
+
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.instrumentation.netty38.server.NettyHttpServerDecorator
@@ -95,7 +97,7 @@ class Netty38ServerTest extends HttpServerTest<ServerBootstrap> {
                   response.setContent(responseContent)
                   break
               }
-              response.headers().set(CONTENT_TYPE, "text/plain").set(IG_RESPONSE_HEADER, IG_RESPONSE_HEADER_VALUE)
+              response.headers().set(CONTENT_TYPE, "text/plain").set(HttpServerTest.IG_RESPONSE_HEADER, HttpServerTest.IG_RESPONSE_HEADER_VALUE)
               if (responseContent) {
                 response.headers().set(CONTENT_LENGTH, responseContent.readableBytes())
               }

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/ChannelFutureListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/ChannelFutureListenerInstrumentation.java
@@ -47,11 +47,18 @@ public class ChannelFutureListenerInstrumentation extends Instrumenter.Tracing
   @Override
   public String[] helperClassNames() {
     return new String[] {
+      packageName + ".util.CombinedSimpleChannelHandler",
       packageName + ".AbstractNettyAdvice",
       packageName + ".ChannelTraceContext",
       packageName + ".ChannelTraceContext$Factory",
       packageName + ".server.ResponseExtractAdapter",
-      packageName + ".server.NettyHttpServerDecorator"
+      packageName + ".server.NettyHttpServerDecorator",
+      packageName + ".server.NettyHttpServerDecorator$NettyBlockResponseFunction",
+      packageName + ".server.NettyHttpServerDecorator$IgnoreBlockingExceptionHandler",
+      packageName + ".server.BlockingResponseHandler",
+      packageName + ".server.HttpServerRequestTracingHandler",
+      packageName + ".server.HttpServerResponseTracingHandler",
+      packageName + ".server.HttpServerTracingHandler"
     };
   }
 

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/NettyChannelPipelineInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/NettyChannelPipelineInstrumentation.java
@@ -59,8 +59,10 @@ public class NettyChannelPipelineInstrumentation extends Instrumenter.Tracing
       // server helpers
       packageName + ".server.ResponseExtractAdapter",
       packageName + ".server.NettyHttpServerDecorator",
-      packageName + ".server.HttpServerRequestTracingHandler",
+      packageName + ".server.NettyHttpServerDecorator$NettyBlockResponseFunction",
+      packageName + ".server.NettyHttpServerDecorator$IgnoreBlockingExceptionHandler",
       packageName + ".server.BlockingResponseHandler",
+      packageName + ".server.HttpServerRequestTracingHandler",
       packageName + ".server.HttpServerResponseTracingHandler",
       packageName + ".server.HttpServerTracingHandler"
     };

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/NettyHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/NettyHttpServerDecorator.java
@@ -2,6 +2,9 @@ package datadog.trace.instrumentation.netty38.server;
 
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.HOST;
 
+import datadog.appsec.api.blocking.BlockingContentType;
+import datadog.appsec.api.blocking.BlockingException;
+import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.ContextVisitors;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
@@ -12,9 +15,18 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
 import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelHandler;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.ChannelPipeline;
+import org.jboss.netty.channel.ChannelUpstreamHandler;
+import org.jboss.netty.channel.ExceptionEvent;
+import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
+import org.jboss.netty.channel.UpstreamMessageEvent;
 import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class NettyHttpServerDecorator
     extends HttpServerDecorator<HttpRequest, Channel, HttpResponse, HttpHeaders> {
@@ -85,5 +97,70 @@ public class NettyHttpServerDecorator
   @Override
   protected int status(final HttpResponse httpResponse) {
     return httpResponse.getStatus().getCode();
+  }
+
+  @Override
+  protected BlockResponseFunction createBlockResponseFunction(
+      HttpRequest httpRequest, Channel channel) {
+    return new NettyBlockResponseFunction(channel.getPipeline(), httpRequest);
+  }
+
+  public static class NettyBlockResponseFunction implements BlockResponseFunction {
+    private final ChannelPipeline pipeline;
+    public static final Logger log = LoggerFactory.getLogger(NettyBlockResponseFunction.class);
+    private final HttpRequest httpRequestMessage;
+
+    public NettyBlockResponseFunction(ChannelPipeline pipeline, HttpRequest httpRequestMessage) {
+      this.pipeline = pipeline;
+      this.httpRequestMessage = httpRequestMessage;
+    }
+
+    @Override
+    public boolean tryCommitBlockingResponse(int statusCode, BlockingContentType templateType) {
+      ChannelHandler handlerBefore = pipeline.get(HttpServerTracingHandler.class);
+      if (handlerBefore == null) {
+        handlerBefore = pipeline.get(HttpServerRequestTracingHandler.class);
+        if (handlerBefore == null) {
+          log.warn(
+              "Can't block without an HttpServerTracingHandler or HttpServerRequestTracingHandler in the pipeline");
+          return false;
+        }
+      }
+
+      try {
+        pipeline.addAfter(
+            handlerBefore.getClass().getName(),
+            "blocking_handler",
+            new BlockingResponseHandler(statusCode, templateType));
+        pipeline.addBefore(
+            "blocking_handler", "before_blocking_handler", new SimpleChannelUpstreamHandler());
+      } catch (RuntimeException rte) {
+        log.warn("Failed adding blocking handler");
+      }
+
+      // prevent BlockingException from being handled, in order to avoid the existing
+      // handlers trying to write an error response
+      pipeline.addFirst(
+          "ignore_blocking_exception_handler", IgnoreBlockingExceptionHandler.INSTANCE);
+
+      ChannelHandlerContext context = pipeline.getContext("before_blocking_handler");
+      context.sendUpstream(
+          new UpstreamMessageEvent(pipeline.getChannel(), httpRequestMessage, null));
+
+      return true;
+    }
+  }
+
+  public static class IgnoreBlockingExceptionHandler extends SimpleChannelUpstreamHandler {
+    public static ChannelUpstreamHandler INSTANCE = new IgnoreBlockingExceptionHandler();
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, ExceptionEvent e) throws Exception {
+      if ((e.getCause() instanceof BlockingException)) {
+        NettyBlockResponseFunction.log.info("Suppressing handling of BlockingException");
+      } else {
+        super.exceptionCaught(ctx, e);
+      }
+    }
   }
 }

--- a/dd-java-agent/instrumentation/netty-3.8/src/test/groovy/datadog/trace/instrumentation/netty38/Netty38ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-3.8/src/test/groovy/datadog/trace/instrumentation/netty38/Netty38ClientTest.groovy
@@ -1,3 +1,5 @@
+package datadog.trace.instrumentation.netty38
+
 import com.ning.http.client.AsyncCompletionHandler
 import com.ning.http.client.AsyncHttpClient
 import com.ning.http.client.AsyncHttpClientConfig

--- a/dd-java-agent/instrumentation/netty-3.8/src/test/groovy/datadog/trace/instrumentation/netty38/Netty38ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-3.8/src/test/groovy/datadog/trace/instrumentation/netty38/Netty38ServerTest.groovy
@@ -1,3 +1,6 @@
+package datadog.trace.instrumentation.netty38
+
+import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.instrumentation.netty38.server.NettyHttpServerDecorator
@@ -35,6 +38,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.forPath
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE
@@ -89,13 +93,19 @@ class Netty38ServerTest extends HttpServerTest<ServerBootstrap> {
                   break
                 case EXCEPTION:
                   throw new Exception(endpoint.body)
+                case USER_BLOCK:
+                  Blocking.forUser('user-to-block').blockIfMatch()
+                // should never be output:
+                  response = new DefaultHttpResponse(HTTP_1_1, HttpResponseStatus.valueOf(200))
+                  response.content = 'should never be reached'
+                  break
                 default:
                   responseContent = ChannelBuffers.copiedBuffer(NOT_FOUND.body, CharsetUtil.UTF_8)
                   response = new DefaultHttpResponse(HTTP_1_1, HttpResponseStatus.valueOf(endpoint.status))
                   response.setContent(responseContent)
                   break
               }
-              response.headers().set(CONTENT_TYPE, "text/plain").set(IG_RESPONSE_HEADER, IG_RESPONSE_HEADER_VALUE)
+              response.headers().set(CONTENT_TYPE, "text/plain").set(HttpServerTest.IG_RESPONSE_HEADER, HttpServerTest.IG_RESPONSE_HEADER_VALUE)
               if (responseContent) {
                 response.headers().set(CONTENT_LENGTH, responseContent.readableBytes())
               }

--- a/dd-java-agent/instrumentation/netty-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/netty-4.0/build.gradle
@@ -1,4 +1,5 @@
 // Set properties before any plugins get loaded
+// asynchttpclient is not compatible with Java 11
 ext {
   maxJavaVersionForTests = JavaVersion.VERSION_1_8
 }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/ChannelFutureListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/ChannelFutureListenerInstrumentation.java
@@ -53,6 +53,9 @@ public class ChannelFutureListenerInstrumentation extends Instrumenter.Tracing
       // server helpers
       packageName + ".server.ResponseExtractAdapter",
       packageName + ".server.NettyHttpServerDecorator",
+      packageName + ".server.NettyHttpServerDecorator$NettyBlockResponseFunction",
+      packageName + ".server.BlockingResponseHandler",
+      packageName + ".server.BlockingResponseHandler$IgnoreAllWritesHandler",
       packageName + ".server.HttpServerRequestTracingHandler",
       packageName + ".server.HttpServerResponseTracingHandler",
       packageName + ".server.HttpServerTracingHandler"

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/NettyChannelHandlerContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/NettyChannelHandlerContextInstrumentation.java
@@ -48,6 +48,12 @@ public class NettyChannelHandlerContextInstrumentation extends Instrumenter.Trac
       packageName + ".client.NettyHttpClientDecorator",
       packageName + ".server.ResponseExtractAdapter",
       packageName + ".server.NettyHttpServerDecorator",
+      packageName + ".server.NettyHttpServerDecorator$NettyBlockResponseFunction",
+      packageName + ".server.BlockingResponseHandler",
+      packageName + ".server.BlockingResponseHandler$IgnoreAllWritesHandler",
+      packageName + ".server.HttpServerRequestTracingHandler",
+      packageName + ".server.HttpServerResponseTracingHandler",
+      packageName + ".server.HttpServerTracingHandler"
     };
   }
 

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/NettyChannelPipelineInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/NettyChannelPipelineInstrumentation.java
@@ -65,9 +65,11 @@ public class NettyChannelPipelineInstrumentation extends Instrumenter.Tracing
       packageName + ".client.HttpClientResponseTracingHandler",
       packageName + ".client.HttpClientTracingHandler",
       // server helpers
-      packageName + ".server.BlockingResponseHandler",
       packageName + ".server.ResponseExtractAdapter",
       packageName + ".server.NettyHttpServerDecorator",
+      packageName + ".server.NettyHttpServerDecorator$NettyBlockResponseFunction",
+      packageName + ".server.BlockingResponseHandler",
+      packageName + ".server.BlockingResponseHandler$IgnoreAllWritesHandler",
       packageName + ".server.HttpServerRequestTracingHandler",
       packageName + ".server.HttpServerResponseTracingHandler",
       packageName + ".server.HttpServerTracingHandler"

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/NettyHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/NettyHttpServerDecorator.java
@@ -2,6 +2,8 @@ package datadog.trace.instrumentation.netty40.server;
 
 import static io.netty.handler.codec.http.HttpHeaders.Names.HOST;
 
+import datadog.appsec.api.blocking.BlockingContentType;
+import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.ContextVisitors;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
@@ -9,12 +11,18 @@ import datadog.trace.bootstrap.instrumentation.api.URIDefaultDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class NettyHttpServerDecorator
     extends HttpServerDecorator<HttpRequest, Channel, HttpResponse, HttpHeaders> {
@@ -85,5 +93,53 @@ public class NettyHttpServerDecorator
   @Override
   protected int status(final HttpResponse httpResponse) {
     return httpResponse.getStatus().code();
+  }
+
+  @Override
+  protected BlockResponseFunction createBlockResponseFunction(
+      HttpRequest httpRequest, Channel channel) {
+    return new NettyBlockResponseFunction(channel.pipeline(), httpRequest);
+  }
+
+  public static class NettyBlockResponseFunction implements BlockResponseFunction {
+    private final ChannelPipeline pipeline;
+    public static final Logger log = LoggerFactory.getLogger(NettyBlockResponseFunction.class);
+    private final HttpRequest httpRequestMessage;
+
+    public NettyBlockResponseFunction(ChannelPipeline pipeline, HttpRequest httpRequestMessage) {
+      this.pipeline = pipeline;
+      this.httpRequestMessage = httpRequestMessage;
+    }
+
+    @Override
+    public boolean tryCommitBlockingResponse(int statusCode, BlockingContentType templateType) {
+      ChannelHandler handlerBefore = pipeline.get(HttpServerTracingHandler.class);
+      if (handlerBefore == null) {
+        handlerBefore = pipeline.get(HttpServerRequestTracingHandler.class);
+        if (handlerBefore == null) {
+          log.warn(
+              "Can't block without an HttpServerTracingHandler or HttpServerRequestTracingHandler in the pipeline");
+          return false;
+        }
+      }
+
+      try {
+        pipeline
+            .addAfter(
+                handlerBefore.getClass().getName(),
+                "blocking_handler",
+                new BlockingResponseHandler(statusCode, templateType))
+            .addBefore(
+                "blocking_handler", "before_blocking_handler", new ChannelInboundHandlerAdapter());
+      } catch (RuntimeException rte) {
+        log.warn("Failed adding blocking handler", rte);
+        return false;
+      }
+
+      ChannelHandlerContext context = pipeline.context("before_blocking_handler");
+      context.fireChannelRead(httpRequestMessage);
+
+      return true;
+    }
   }
 }

--- a/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
@@ -1,3 +1,4 @@
+import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.instrumentation.netty40.server.NettyHttpServerDecorator
@@ -24,6 +25,7 @@ import io.netty.util.CharsetUtil
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_BOTH
@@ -87,6 +89,12 @@ class Netty40ServerTest extends HttpServerTest<EventLoopGroup> {
                         break
                       case EXCEPTION:
                         throw new Exception(endpoint.body)
+                      case USER_BLOCK:
+                        Blocking.forUser('user-to-block').blockIfMatch()
+                      // should never be output:
+                        response = new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.valueOf(200))
+                        response.content = 'should never be reached'
+                        break
                       default:
                         content = Unpooled.copiedBuffer(NOT_FOUND.body, CharsetUtil.UTF_8)
                         response = new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.valueOf(NOT_FOUND.status), content)

--- a/dd-java-agent/instrumentation/netty-4.1/build.gradle
+++ b/dd-java-agent/instrumentation/netty-4.1/build.gradle
@@ -1,4 +1,3 @@
-
 apply from: "$rootDir/gradle/java.gradle"
 
 muzzle {

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/ChannelFutureListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/ChannelFutureListenerInstrumentation.java
@@ -53,6 +53,9 @@ public class ChannelFutureListenerInstrumentation extends Instrumenter.Tracing
       // server helpers
       packageName + ".server.ResponseExtractAdapter",
       packageName + ".server.NettyHttpServerDecorator",
+      packageName + ".server.NettyHttpServerDecorator$NettyBlockResponseFunction",
+      packageName + ".server.BlockingResponseHandler",
+      packageName + ".server.BlockingResponseHandler$IgnoreAllWritesHandler",
       packageName + ".server.HttpServerRequestTracingHandler",
       packageName + ".server.HttpServerResponseTracingHandler",
       packageName + ".server.HttpServerTracingHandler"

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyChannelHandlerContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyChannelHandlerContextInstrumentation.java
@@ -48,6 +48,12 @@ public class NettyChannelHandlerContextInstrumentation extends Instrumenter.Trac
       packageName + ".client.NettyHttpClientDecorator",
       packageName + ".server.ResponseExtractAdapter",
       packageName + ".server.NettyHttpServerDecorator",
+      packageName + ".server.NettyHttpServerDecorator$NettyBlockResponseFunction",
+      packageName + ".server.BlockingResponseHandler",
+      packageName + ".server.BlockingResponseHandler$IgnoreAllWritesHandler",
+      packageName + ".server.HttpServerRequestTracingHandler",
+      packageName + ".server.HttpServerResponseTracingHandler",
+      packageName + ".server.HttpServerTracingHandler"
     };
   }
 

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyChannelPipelineInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/NettyChannelPipelineInstrumentation.java
@@ -65,9 +65,11 @@ public class NettyChannelPipelineInstrumentation extends Instrumenter.Tracing
       packageName + ".client.HttpClientResponseTracingHandler",
       packageName + ".client.HttpClientTracingHandler",
       // server helpers
-      packageName + ".server.BlockingResponseHandler",
       packageName + ".server.ResponseExtractAdapter",
       packageName + ".server.NettyHttpServerDecorator",
+      packageName + ".server.NettyHttpServerDecorator$NettyBlockResponseFunction",
+      packageName + ".server.BlockingResponseHandler",
+      packageName + ".server.BlockingResponseHandler$IgnoreAllWritesHandler",
       packageName + ".server.HttpServerRequestTracingHandler",
       packageName + ".server.HttpServerResponseTracingHandler",
       packageName + ".server.HttpServerTracingHandler"

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/BlockingResponseHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/BlockingResponseHandler.java
@@ -1,10 +1,13 @@
 package datadog.trace.instrumentation.netty41.server;
 
+import datadog.appsec.api.blocking.BlockingContentType;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.bootstrap.blocking.BlockingActionHelper;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpRequest;
@@ -15,15 +18,22 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class BlockingResponseHandler extends ChannelInboundHandlerAdapter {
-  private final Flow.Action.RequestBlockingAction rba;
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(BlockingResponseHandler.class);
+  public static final Logger log = LoggerFactory.getLogger(BlockingResponseHandler.class);
   private static volatile boolean HAS_WARNED;
+
+  private final int statusCode;
+  private final BlockingContentType bct;
 
   private boolean hasBlockedAlready;
 
+  public BlockingResponseHandler(int statusCode, BlockingContentType bct) {
+    this.statusCode = statusCode;
+    this.bct = bct;
+  }
+
   public BlockingResponseHandler(Flow.Action.RequestBlockingAction rba) {
-    this.rba = rba;
+    this.statusCode = rba.getStatusCode();
+    this.bct = rba.getBlockingContentType();
   }
 
   @Override
@@ -46,10 +56,10 @@ public class BlockingResponseHandler extends ChannelInboundHandlerAdapter {
 
     if (ctxForDownstream == null) {
       if (HAS_WARNED) {
-        LOGGER.debug(
+        log.debug(
             "Unable to block because HttpServerResponseTracingHandler was not found on the pipeline");
       } else {
-        LOGGER.warn(
+        log.warn(
             "Unable to block because HttpServerResponseTracingHandler was not found on the pipeline");
         HAS_WARNED = true;
       }
@@ -59,14 +69,14 @@ public class BlockingResponseHandler extends ChannelInboundHandlerAdapter {
 
     HttpRequest request = (HttpRequest) msg;
 
-    int httpCode = BlockingActionHelper.getHttpCode(rba.getStatusCode());
+    int httpCode = BlockingActionHelper.getHttpCode(statusCode);
     HttpResponseStatus httpResponseStatus = HttpResponseStatus.valueOf(httpCode);
     FullHttpResponse response =
         new DefaultFullHttpResponse(request.protocolVersion(), httpResponseStatus);
 
     String acceptHeader = request.headers().get("accept");
     BlockingActionHelper.TemplateType type =
-        BlockingActionHelper.determineTemplateType(rba.getBlockingContentType(), acceptHeader);
+        BlockingActionHelper.determineTemplateType(bct, acceptHeader);
     response
         .headers()
         .set("Content-type", BlockingActionHelper.getContentType(type))
@@ -80,23 +90,41 @@ public class BlockingResponseHandler extends ChannelInboundHandlerAdapter {
 
     ReferenceCountUtil.release(msg);
 
-    // unlike in netty 3.8, write starts in the handler before the one associated with ctx
-    // so add a dummy one that will be skipped. We do not want to start from the end of the
+    // write starts in the handler before the one associated with ctx
+    // so add one that will be skipped (but that will prevent any writes later coming from later
+    // handlers).
+    // We do not want to start from the end of the
     // pipeline because there is an increased risk of hitting duplex handlers that
     // expect to have seen a request before processing the response
     ctxForDownstream =
         ctxForDownstream
             .pipeline()
-            .addAfter(ctxForDownstream.name(), "noop", new ChannelOutboundHandlerAdapter())
-            .context("noop");
+            .addAfter(
+                ctxForDownstream.name(),
+                "ignore_all_writes_handler",
+                IgnoreAllWritesHandler.INSTANCE)
+            .context("ignore_all_writes_handler");
+
     ctxForDownstream
         .writeAndFlush(response)
         .addListener(
             fut -> {
               if (!fut.isSuccess()) {
-                LOGGER.warn("Write of blocking response failed", fut.cause());
+                log.warn("Write of blocking response failed", fut.cause());
               }
               ctx.channel().close();
             });
+  }
+
+  @ChannelHandler.Sharable
+  public static class IgnoreAllWritesHandler extends ChannelOutboundHandlerAdapter {
+    public static final IgnoreAllWritesHandler INSTANCE = new IgnoreAllWritesHandler();
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise)
+        throws Exception {
+      log.info("Ignored write of object {}", msg);
+      ReferenceCountUtil.release(msg);
+    }
   }
 }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/server/RatpackForkedHttpServerTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/server/RatpackForkedHttpServerTest.groovy
@@ -1,5 +1,6 @@
 package server
 
+import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
 import ratpack.exec.Promise
@@ -21,6 +22,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 
 class RatpackForkedHttpServerTest extends RatpackHttpServerTest {
 
@@ -138,6 +140,18 @@ class RatpackForkedHttpServerTest extends RatpackHttpServerTest {
             }.fork().then { HttpServerTest.ServerEndpoint endpoint ->
               controller(endpoint) {
                 context.response.status(endpoint.status).send(endpoint.bodyForQuery(request.query))
+              }
+            }
+          }
+        }
+        prefix(USER_BLOCK.relativeRawPath()) {
+          all {
+            Promise.sync {
+              USER_BLOCK
+            }.fork().then { HttpServerTest.ServerEndpoint endpoint ->
+              controller(endpoint) {
+                Blocking.forUser('user-to-block').blockIfMatch()
+                context.response.status(200).send('should never be reached')
               }
             }
           }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/server/RatpackHttpServerTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/server/RatpackHttpServerTest.groovy
@@ -1,6 +1,6 @@
 package server
 
-
+import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
@@ -18,6 +18,7 @@ import ratpack.test.embed.EmbeddedApp
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_JSON
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_URLENCODED
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.CREATED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
@@ -124,6 +125,14 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> {
           all {
             controller(ERROR) {
               context.response.status(ERROR.status).send(ERROR.body)
+            }
+          }
+        }
+        prefix(USER_BLOCK.relativeRawPath()) {
+          all {
+            controller(USER_BLOCK) {
+              Blocking.forUser('user-to-block').blockIfMatch()
+              context.response.status(SUCCESS.status).send('should never be reached')
             }
           }
         }

--- a/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/TestServlet2.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/TestServlet2.groovy
@@ -1,3 +1,4 @@
+import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServerTest
 import groovy.servlet.AbstractHttpServlet
 
@@ -13,6 +14,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 
 class TestServlet2 {
 
@@ -48,6 +50,9 @@ class TestServlet2 {
             break
           case ERROR:
             resp.sendError(endpoint.status, endpoint.body)
+            break
+          case USER_BLOCK:
+            Blocking.forUser('user-to-block').blockIfMatch()
             break
           case EXCEPTION:
             throw new Exception(endpoint.body)

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
@@ -278,6 +278,11 @@ class JettyServlet3TestInclude extends JettyServlet3Test {
   }
 
   @Override
+  boolean testUserBlocking() {
+    false
+  }
+
+  @Override
   void handlerSpan(TraceAssert trace, ServerEndpoint endpoint = SUCCESS) {
     includeSpan(trace, endpoint)
   }
@@ -338,6 +343,12 @@ class JettyServlet3TestDispatchAsync extends JettyServlet3Test {
   @Override
   boolean testTimeout() {
     return true
+  }
+
+  @Override
+  boolean testUserBlocking() {
+    // XXX bug: the dispatch span is not finished
+    false
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
@@ -80,6 +80,7 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
 
     @Override
     void stop() {
+      //      sleep 10_000
       server.stop()
       server.destroy()
     }

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/latestDepTest/groovy/TestServlet.groovy
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/latestDepTest/groovy/TestServlet.groovy
@@ -1,3 +1,4 @@
+import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServerTest
 import jakarta.servlet.http.HttpServlet
 import jakarta.servlet.http.HttpServletRequest
@@ -15,6 +16,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 
 class TestServlet extends HttpServlet {
 
@@ -74,6 +76,9 @@ class TestServlet extends HttpServlet {
           throw new Exception(endpoint.body)
         case CUSTOM_EXCEPTION:
           throw new InputMismatchException(endpoint.body)
+        case USER_BLOCK:
+          Blocking.forUser('user-to-block').blockIfMatch()
+          break
       }
     }
   }

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/RequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/RequestInstrumentation.java
@@ -33,6 +33,8 @@ public final class RequestInstrumentation extends Instrumenter.Tracing
       packageName + ".ExtractAdapter$Request",
       packageName + ".ExtractAdapter$Response",
       packageName + ".TomcatDecorator",
+      packageName + ".TomcatDecorator$TomcatBlockResponseFunction",
+      packageName + ".TomcatBlockingHelper",
       packageName + ".RequestURIDataAdapter",
     };
   }

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/ResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/ResponseInstrumentation.java
@@ -33,6 +33,8 @@ public final class ResponseInstrumentation extends Instrumenter.Tracing
       packageName + ".ExtractAdapter$Request",
       packageName + ".ExtractAdapter$Response",
       packageName + ".TomcatDecorator",
+      packageName + ".TomcatDecorator$TomcatBlockResponseFunction",
+      packageName + ".TomcatBlockingHelper",
       packageName + ".RequestURIDataAdapter",
     };
   }

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/TomcatServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/TomcatServerInstrumentation.java
@@ -49,6 +49,7 @@ public final class TomcatServerInstrumentation extends Instrumenter.Tracing
       packageName + ".ExtractAdapter$Request",
       packageName + ".ExtractAdapter$Response",
       packageName + ".TomcatDecorator",
+      packageName + ".TomcatDecorator$TomcatBlockResponseFunction",
       packageName + ".RequestURIDataAdapter",
       packageName + ".TomcatBlockingHelper",
     };

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/test/groovy/TestServlet.groovy
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/test/groovy/TestServlet.groovy
@@ -1,3 +1,4 @@
+import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServerTest
 
 import javax.servlet.http.HttpServlet
@@ -16,6 +17,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 
 class TestServlet extends HttpServlet {
 
@@ -76,6 +78,9 @@ class TestServlet extends HttpServlet {
           throw new Exception(endpoint.body)
         case CUSTOM_EXCEPTION:
           throw new InputMismatchException(endpoint.body)
+        case USER_BLOCK:
+          Blocking.forUser('user-to-block').blockIfMatch()
+          break
       }
     }
   }

--- a/dd-java-agent/instrumentation/undertow/src/main/java/datadog/trace/instrumentation/undertow/UndertowBlockResponseFunction.java
+++ b/dd-java-agent/instrumentation/undertow/src/main/java/datadog/trace/instrumentation/undertow/UndertowBlockResponseFunction.java
@@ -1,0 +1,27 @@
+package datadog.trace.instrumentation.undertow;
+
+import datadog.appsec.api.blocking.BlockingContentType;
+import datadog.trace.api.gateway.BlockResponseFunction;
+import datadog.trace.api.gateway.Flow;
+import io.undertow.server.HttpServerExchange;
+
+public class UndertowBlockResponseFunction implements BlockResponseFunction {
+  private final HttpServerExchange exchange;
+
+  public UndertowBlockResponseFunction(HttpServerExchange exchange) {
+    this.exchange = exchange;
+  }
+
+  @Override
+  public boolean tryCommitBlockingResponse(int statusCode, BlockingContentType templateType) {
+    Flow.Action.RequestBlockingAction rab =
+        new Flow.Action.RequestBlockingAction(statusCode, templateType);
+    exchange.putAttachment(UndertowBlockingHandler.REQUEST_BLOCKING_DATA, rab);
+    if (exchange.isInIoThread()) {
+      exchange.dispatch(UndertowBlockingHandler.INSTANCE);
+    } else {
+      UndertowBlockingHandler.INSTANCE.handleRequest(exchange);
+    }
+    return true;
+  }
+}

--- a/dd-java-agent/instrumentation/undertow/src/main/java/datadog/trace/instrumentation/undertow/UndertowBlockingHandler.java
+++ b/dd-java-agent/instrumentation/undertow/src/main/java/datadog/trace/instrumentation/undertow/UndertowBlockingHandler.java
@@ -2,7 +2,6 @@ package datadog.trace.instrumentation.undertow;
 
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.bootstrap.blocking.BlockingActionHelper;
-import datadog.trace.bootstrap.blocking.BlockingActionHelper.TemplateType;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.AttachmentKey;
@@ -41,7 +40,7 @@ public class UndertowBlockingHandler implements HttpHandler {
       HeaderMap headers = xchg.getResponseHeaders();
       HeaderValues acceptHeaderValues = xchg.getRequestHeaders().get(Headers.ACCEPT);
       String acceptHeader = acceptHeaderValues != null ? acceptHeaderValues.peekLast() : null;
-      TemplateType type =
+      BlockingActionHelper.TemplateType type =
           BlockingActionHelper.determineTemplateType(rba.getBlockingContentType(), acceptHeader);
       byte[] template = BlockingActionHelper.getTemplate(type);
 

--- a/dd-java-agent/instrumentation/undertow/src/main/java/datadog/trace/instrumentation/undertow/UndertowDecorator.java
+++ b/dd-java-agent/instrumentation/undertow/src/main/java/datadog/trace/instrumentation/undertow/UndertowDecorator.java
@@ -4,7 +4,7 @@ import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstanceStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
@@ -25,13 +25,9 @@ public class UndertowDecorator
       InstanceStore.of(AttachmentKey.class);
 
   @SuppressWarnings("unchecked")
-  public static final AttachmentKey<Boolean> DD_HTTPSERVEREXCHANGE_DISPATCH =
+  public static final AttachmentKey<AgentScope.Continuation> DD_UNDERTOW_CONTINUATION =
       attachmentStore.putIfAbsent(
-          "DD_HTTPSERVEREXCHANGE_DISPATCH", AttachmentKey.create(Boolean.class));
-
-  @SuppressWarnings("unchecked")
-  public static final AttachmentKey<AgentSpan> DD_UNDERTOW_SPAN =
-      attachmentStore.putIfAbsent("DD_UNDERTOW_SPAN", AttachmentKey.create(AgentSpan.class));
+          "DD_UNDERTOW_CONTINUATION", AttachmentKey.create(AgentScope.Continuation.class));
 
   public static final UndertowDecorator DECORATE = new UndertowDecorator();
 

--- a/dd-java-agent/instrumentation/undertow/src/main/java/datadog/trace/instrumentation/undertow/UndertowDecorator.java
+++ b/dd-java-agent/instrumentation/undertow/src/main/java/datadog/trace/instrumentation/undertow/UndertowDecorator.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.undertow;
 
+import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstanceStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
@@ -82,5 +83,11 @@ public class UndertowDecorator
   @Override
   protected int status(final HttpServerExchange exchange) {
     return exchange.getResponseCode();
+  }
+
+  @Override
+  protected BlockResponseFunction createBlockResponseFunction(
+      HttpServerExchange httpServerExchange, HttpServerExchange httpServerExchange1) {
+    return new UndertowBlockResponseFunction(httpServerExchange);
   }
 }

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/ExchangeEndSpanListener.java
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/ExchangeEndSpanListener.java
@@ -1,22 +1,36 @@
 package datadog.trace.instrumentation.undertow;
 
+import static datadog.trace.instrumentation.undertow.UndertowDecorator.DD_UNDERTOW_CONTINUATION;
 import static datadog.trace.instrumentation.undertow.UndertowDecorator.DECORATE;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import io.undertow.server.DefaultResponseListener;
 import io.undertow.server.ExchangeCompletionListener;
 import io.undertow.server.HttpServerExchange;
 
 public class ExchangeEndSpanListener implements ExchangeCompletionListener {
-  private final AgentSpan span;
+  public static final ExchangeEndSpanListener INSTANCE = new ExchangeEndSpanListener();
 
-  public ExchangeEndSpanListener(AgentSpan span) {
-    this.span = span;
-  }
+  private ExchangeEndSpanListener() {}
 
   @Override
   public void exchangeEvent(HttpServerExchange exchange, NextListener nextListener) {
+    AgentScope.Continuation continuation = exchange.getAttachment(DD_UNDERTOW_CONTINUATION);
+    if (continuation == null) {
+      return;
+    }
+
+    AgentSpan span = continuation.getSpan();
+
+    Throwable throwable = exchange.getAttachment(DefaultResponseListener.EXCEPTION);
+    if (throwable != null) {
+      DECORATE.onError(span, throwable);
+    }
+
     DECORATE.onResponse(span, exchange);
     DECORATE.beforeFinish(span);
+    continuation.cancel();
     span.finish();
     nextListener.proceed();
   }

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/HandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/HandlerInstrumentation.java
@@ -59,13 +59,14 @@ public final class HandlerInstrumentation extends Instrumenter.Tracing
       packageName + ".UndertowExtractAdapter$Request",
       packageName + ".UndertowExtractAdapter$Response",
       packageName + ".UndertowBlockingHandler",
+      packageName + ".UndertowBlockResponseFunction",
     };
   }
 
   public static class HandlerAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class, skipOn = Advice.OnNonDefaultValue.class)
     public static boolean onEnter(
-        @Advice.Argument(value = 0) HttpServerExchange exchange,
+        @Advice.Argument(value = 0) final HttpServerExchange exchange,
         @Advice.Local("agentScope") AgentScope scope) {
       // HttpHandler subclasses are chained so only the first one should create a span
       if (null != exchange.getAttachment(DD_HTTPSERVEREXCHANGE_DISPATCH)) {

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/HandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/HandlerInstrumentation.java
@@ -1,52 +1,50 @@
 package datadog.trace.instrumentation.undertow;
 
-import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.instrumentation.undertow.UndertowBlockingHandler.REQUEST_BLOCKING_DATA;
-import static datadog.trace.instrumentation.undertow.UndertowDecorator.DD_HTTPSERVEREXCHANGE_DISPATCH;
-import static datadog.trace.instrumentation.undertow.UndertowDecorator.DD_UNDERTOW_SPAN;
+import static datadog.trace.instrumentation.undertow.UndertowDecorator.DD_UNDERTOW_CONTINUATION;
 import static datadog.trace.instrumentation.undertow.UndertowDecorator.DECORATE;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.isStatic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.gateway.Flow.Action.RequestBlockingAction;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import net.bytebuddy.asm.Advice;
-import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(Instrumenter.class)
 public final class HandlerInstrumentation extends Instrumenter.Tracing
-    implements Instrumenter.ForTypeHierarchy {
+    implements Instrumenter.ForSingleType {
 
   public HandlerInstrumentation() {
     super("undertow", "undertow-2.0");
   }
 
   @Override
-  public String hierarchyMarkerType() {
-    return "io.undertow.server.HttpHandler";
-  }
-
-  @Override
-  public ElementMatcher<TypeDescription> hierarchyMatcher() {
-    return implementsInterface(named(hierarchyMarkerType()));
+  public String instrumentedType() {
+    return "io.undertow.server.Connectors";
   }
 
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(
         isMethod()
-            .and(named("handleRequest"))
-            .and(takesArgument(0, named("io.undertow.server.HttpServerExchange")))
+            .and(named("executeRootHandler"))
+            .and(takesArguments(2))
+            .and(takesArgument(0, named("io.undertow.server.HttpHandler")))
+            .and(takesArgument(1, named("io.undertow.server.HttpServerExchange")))
+            .and(isStatic())
             .and(isPublic()),
-        getClass().getName() + "$HandlerAdvice");
+        getClass().getName() + "$ExecuteRootHandlerAdvice");
   }
 
   @Override
@@ -63,14 +61,31 @@ public final class HandlerInstrumentation extends Instrumenter.Tracing
     };
   }
 
-  public static class HandlerAdvice {
-    @Advice.OnMethodEnter(suppress = Throwable.class, skipOn = Advice.OnNonDefaultValue.class)
-    public static boolean onEnter(
-        @Advice.Argument(value = 0) final HttpServerExchange exchange,
+  public static class ExecuteRootHandlerAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter(
+        @Advice.Argument(value = 0, readOnly = false) HttpHandler handler,
+        @Advice.Argument(1) final HttpServerExchange exchange,
         @Advice.Local("agentScope") AgentScope scope) {
-      // HttpHandler subclasses are chained so only the first one should create a span
-      if (null != exchange.getAttachment(DD_HTTPSERVEREXCHANGE_DISPATCH)) {
-        return false;
+      AgentScope currentScope = AgentTracer.activeScope();
+      if (currentScope != null) {
+        AgentSpan localRootSpan = currentScope.span().getLocalRootSpan();
+        if (DECORATE.spanName().equals(localRootSpan.getSpanName())) {
+          // if we can here through the dispatch of an HttpHandler, rather than that of a
+          // plain Runnable, then Connects.executeRootHandler() will still have been called,
+          // and this advice executed.
+          // However, a scope may have already been continued through UndertowRunnableWrapper.
+          // This scope may refer to a child span of the original undertow root span, whereas
+          // here we would only be able to activate the scope for the original undertow span.
+          return;
+        }
+      }
+
+      AgentScope.Continuation continuation = exchange.getAttachment(DD_UNDERTOW_CONTINUATION);
+      if (continuation != null) {
+        scope = continuation.activate();
+        exchange.putAttachment(DD_UNDERTOW_CONTINUATION, scope.capture());
+        return;
       }
 
       final AgentSpan.Context.Extracted extractedContext = DECORATE.extract(exchange);
@@ -81,9 +96,9 @@ public final class HandlerInstrumentation extends Instrumenter.Tracing
       scope = activateSpan(span);
       scope.setAsyncPropagation(true);
 
-      // For use by servlet instrumentation
-      exchange.putAttachment(DD_UNDERTOW_SPAN, span);
-      exchange.putAttachment(DD_HTTPSERVEREXCHANGE_DISPATCH, false);
+      exchange.putAttachment(DD_UNDERTOW_CONTINUATION, scope.capture());
+
+      exchange.addExchangeCompleteListener(ExchangeEndSpanListener.INSTANCE);
 
       // TODO is this required?
       // exchange.getRequestHeaders().add(
@@ -94,36 +109,16 @@ public final class HandlerInstrumentation extends Instrumenter.Tracing
       RequestBlockingAction rab = span.getRequestBlockingAction();
       if (rab != null) {
         exchange.putAttachment(REQUEST_BLOCKING_DATA, rab);
-        if (exchange.isInIoThread()) {
-          exchange.dispatch(UndertowBlockingHandler.INSTANCE);
-        } else {
-          UndertowBlockingHandler.INSTANCE.handleRequest(exchange);
-        }
-        return true; /* skip */
+        handler = UndertowBlockingHandler.INSTANCE;
       }
-
-      return false;
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-    public static void closeScope(
-        @Advice.Local("agentScope") final AgentScope scope,
-        @Advice.Argument(value = 0) HttpServerExchange exchange,
-        @Advice.Thrown final Throwable throwable) {
-      if (null != scope) {
-        if (null != throwable) {
-          DECORATE.onError(scope.span(), throwable);
-          exchange.addExchangeCompleteListener(new ExchangeEndSpanListener(scope.span()));
-        } else {
-          boolean dispatched = exchange.getAttachment(DD_HTTPSERVEREXCHANGE_DISPATCH);
-          if (!dispatched) {
-            DECORATE.onResponse(scope.span(), exchange);
-            DECORATE.beforeFinish(scope.span());
-            scope.span().finish();
-          }
-        }
-        scope.close();
+    public static void closeScope(@Advice.Local("agentScope") final AgentScope scope) {
+      if (scope == null) {
+        return;
       }
+      scope.close();
     }
   }
 }

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/ServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/ServletInstrumentation.java
@@ -40,6 +40,8 @@ public final class ServletInstrumentation extends Instrumenter.Tracing
     return new String[] {
       packageName + ".HttpServerExchangeURIDataAdapter",
       packageName + ".UndertowDecorator",
+      packageName + ".UndertowBlockingHandler",
+      packageName + ".UndertowBlockResponseFunction",
       packageName + ".UndertowExtractAdapter",
       packageName + ".UndertowExtractAdapter$Request",
       packageName + ".UndertowExtractAdapter$Response"

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/ServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/ServletInstrumentation.java
@@ -4,12 +4,13 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.SERVLET_CONTEXT;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.SERVLET_PATH;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
-import static datadog.trace.instrumentation.undertow.UndertowDecorator.DD_UNDERTOW_SPAN;
+import static datadog.trace.instrumentation.undertow.UndertowDecorator.DD_UNDERTOW_CONTINUATION;
 import static datadog.trace.instrumentation.undertow.UndertowDecorator.SERVLET_REQUEST;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.servlet.handlers.ServletRequestContext;
@@ -53,8 +54,9 @@ public final class ServletInstrumentation extends Instrumenter.Tracing
     public static void enter(
         @Advice.Argument(0) final HttpServerExchange exchange,
         @Advice.Argument(1) final ServletRequestContext servletRequestContext) {
-      AgentSpan undertowSpan = exchange.getAttachment(DD_UNDERTOW_SPAN);
-      if (null != undertowSpan) {
+      AgentScope.Continuation continuation = exchange.getAttachment(DD_UNDERTOW_CONTINUATION);
+      if (continuation != null) {
+        AgentSpan undertowSpan = continuation.getSpan();
         ServletRequest request = servletRequestContext.getServletRequest();
         request.setAttribute(DD_SPAN_ATTRIBUTE, undertowSpan);
         undertowSpan.setSpanName(SERVLET_REQUEST);

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/UndertowInstrumentation.java
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/UndertowInstrumentation.java
@@ -1,7 +1,6 @@
 package datadog.trace.instrumentation.undertow;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static datadog.trace.instrumentation.undertow.UndertowDecorator.DD_HTTPSERVEREXCHANGE_DISPATCH;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
@@ -54,9 +53,6 @@ public final class UndertowInstrumentation extends Instrumenter.Tracing
         @Advice.Argument(value = 1, readOnly = false) Runnable task,
         @Advice.This final HttpServerExchange current) {
       task = UndertowRunnableWrapper.wrapIfNeeded(task, current);
-      // Tell the rest of the instrumentation this exchange has been dispatched
-      // so it will not be completed synchronously
-      current.putAttachment(DD_HTTPSERVEREXCHANGE_DISPATCH, true);
     }
   }
 }

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/UndertowInstrumentation.java
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/UndertowInstrumentation.java
@@ -39,6 +39,8 @@ public final class UndertowInstrumentation extends Instrumenter.Tracing
       packageName + ".ExchangeEndSpanListener",
       packageName + ".HttpServerExchangeURIDataAdapter",
       packageName + ".UndertowDecorator",
+      packageName + ".UndertowBlockingHandler",
+      packageName + ".UndertowBlockResponseFunction",
       packageName + ".UndertowExtractAdapter",
       packageName + ".UndertowExtractAdapter$Request",
       packageName + ".UndertowExtractAdapter$Response",

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/UndertowRunnableWrapper.java
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/UndertowRunnableWrapper.java
@@ -3,10 +3,8 @@ package datadog.trace.instrumentation.undertow;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.exclude;
-import static datadog.trace.instrumentation.undertow.UndertowDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import io.undertow.server.HttpServerExchange;
 
 public class UndertowRunnableWrapper implements Runnable {
@@ -24,16 +22,8 @@ public class UndertowRunnableWrapper implements Runnable {
 
   @Override
   public void run() {
-    AgentSpan span = continuation.getSpan();
     try (AgentScope scope = continuation.activate()) {
       runnable.run();
-    } catch (Throwable throwable) {
-      DECORATE.onError(span, throwable);
-      throw throwable;
-    } finally {
-      DECORATE.onResponse(span, exchange);
-      DECORATE.beforeFinish(span);
-      span.finish();
     }
   }
 

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowDispatcherTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowDispatcherTest.groovy
@@ -1,3 +1,5 @@
+import datadog.appsec.api.blocking.Blocking
+import datadog.appsec.api.blocking.BlockingException
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
 import io.undertow.Handlers
@@ -103,6 +105,16 @@ class UndertowDispatcherTest extends HttpServerTest<Undertow> {
         .addExactPath(EXCEPTION.getPath()) { exchange ->
           controller(EXCEPTION) {
             throw new Exception(EXCEPTION.body)
+          }
+        }
+        .addExactPath(USER_BLOCK.path) { exchange ->
+          controller(USER_BLOCK) {
+            try {
+              Blocking.forUser('user-to-block').blockIfMatch()
+              exchange.statusCode = 200
+              exchange.responseSender.send('user not blocked')
+              exchange.endExchange()
+            } catch (BlockingException) {}
           }
         }
         ).build()

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowDispatcherTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowDispatcherTest.groovy
@@ -5,6 +5,7 @@ import datadog.trace.agent.test.base.HttpServerTest
 import io.undertow.Handlers
 import io.undertow.Undertow
 import io.undertow.UndertowOptions
+import io.undertow.server.DefaultResponseListener
 import io.undertow.util.Headers
 import io.undertow.util.HttpString
 import io.undertow.util.StatusCodes
@@ -114,7 +115,9 @@ class UndertowDispatcherTest extends HttpServerTest<Undertow> {
               exchange.statusCode = 200
               exchange.responseSender.send('user not blocked')
               exchange.endExchange()
-            } catch (BlockingException) {}
+            } catch (BlockingException be) {
+              exchange.putAttachment(DefaultResponseListener.EXCEPTION, be)
+            }
           }
         }
         ).build()

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowServletTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowServletTest.groovy
@@ -18,6 +18,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 
 class UndertowServletTest extends HttpServerTest<Undertow> {
   private static final CONTEXT = "ctx"
@@ -42,6 +43,7 @@ class UndertowServletTest extends HttpServerTest<Undertow> {
         .addServlet(new ServletInfo("RedirectServlet", RedirectServlet).addMapping(REDIRECT.getPath()))
         .addServlet(new ServletInfo("ErrorServlet", ErrorServlet).addMapping(ERROR.getPath()))
         .addServlet(new ServletInfo("ExceptionServlet", ExceptionServlet).addMapping(EXCEPTION.getPath()))
+        .addServlet(new ServletInfo("UserBlockServlet", UserBlockServlet).addMapping(USER_BLOCK.path))
 
       DeploymentManager manager = container.addDeployment(builder)
       manager.deploy()

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowTest.groovy
@@ -1,3 +1,5 @@
+import datadog.appsec.api.blocking.Blocking
+import datadog.appsec.api.blocking.BlockingException
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
 import io.undertow.Handlers
@@ -104,6 +106,14 @@ class UndertowTest extends HttpServerTest<Undertow> {
         .addExactPath(EXCEPTION.getPath()) { exchange ->
           controller(EXCEPTION) {
             throw new Exception(EXCEPTION.body)
+          }
+        }
+        .addExactPath(USER_BLOCK.getPath()) { exchange ->
+          controller(USER_BLOCK) {
+            try {
+              Blocking.forUser('user-to-block').blockIfMatch()
+              exchange.getResponseSender().send('user not blocked')
+            } catch (BlockingException be) {}
           }
         }
         ).build()

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowTest.groovy
@@ -5,6 +5,7 @@ import datadog.trace.agent.test.base.HttpServerTest
 import io.undertow.Handlers
 import io.undertow.Undertow
 import io.undertow.UndertowOptions
+import io.undertow.server.DefaultResponseListener
 import io.undertow.server.HttpHandler
 import io.undertow.server.HttpServerExchange
 import io.undertow.server.handlers.form.FormData
@@ -110,10 +111,18 @@ class UndertowTest extends HttpServerTest<Undertow> {
         }
         .addExactPath(USER_BLOCK.getPath()) { exchange ->
           controller(USER_BLOCK) {
+            // We need to fudge things here a little.
+            // If we throw, the dispatch to the blocking handler will not even
+            // be called. Also, set the error attachment to make the test pass.
+            // We could maybe explore adding extra instrumentation to catch
+            // the exception and make sure that our UndertowBlockingHandler
+            // (and only that handler) is called afterwards.
             try {
               Blocking.forUser('user-to-block').blockIfMatch()
               exchange.getResponseSender().send('user not blocked')
-            } catch (BlockingException be) {}
+            } catch (BlockingException be) {
+              exchange.putAttachment(DefaultResponseListener.EXCEPTION, be)
+            }
           }
         }
         ).build()

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UserBlockServlet.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UserBlockServlet.groovy
@@ -1,0 +1,19 @@
+import datadog.appsec.api.blocking.Blocking
+
+import javax.servlet.ServletException
+import javax.servlet.http.HttpServlet
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
+import static datadog.trace.agent.test.base.HttpServerTest.controller
+
+class UserBlockServlet extends HttpServlet {
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+    controller(USER_BLOCK) {
+      Blocking.forUser('user-to-block').blockIfMatch()
+      resp.writer.print('user not blocked')
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/undertow/undertow-2.2/src/main/java/datadog/trace/instrumentation/undertow/JakartaServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.2/src/main/java/datadog/trace/instrumentation/undertow/JakartaServletInstrumentation.java
@@ -4,12 +4,13 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.SERVLET_CONTEXT;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.SERVLET_PATH;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
-import static datadog.trace.instrumentation.undertow.UndertowDecorator.DD_UNDERTOW_SPAN;
+import static datadog.trace.instrumentation.undertow.UndertowDecorator.DD_UNDERTOW_CONTINUATION;
 import static datadog.trace.instrumentation.undertow.UndertowDecorator.SERVLET_REQUEST;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.servlet.handlers.ServletRequestContext;
@@ -53,8 +54,9 @@ public final class JakartaServletInstrumentation extends Instrumenter.Tracing
     public static void enter(
         @Advice.Argument(0) final HttpServerExchange exchange,
         @Advice.Argument(1) final ServletRequestContext servletRequestContext) {
-      AgentSpan undertowSpan = exchange.getAttachment(DD_UNDERTOW_SPAN);
-      if (null != undertowSpan) {
+      AgentScope.Continuation continuation = exchange.getAttachment(DD_UNDERTOW_CONTINUATION);
+      if (continuation != null) {
+        AgentSpan undertowSpan = continuation.getSpan();
         ServletRequest request = servletRequestContext.getServletRequest();
         request.setAttribute(DD_SPAN_ATTRIBUTE, undertowSpan);
         undertowSpan.setSpanName(SERVLET_REQUEST);

--- a/dd-java-agent/instrumentation/undertow/undertow-2.2/src/main/java/datadog/trace/instrumentation/undertow/JakartaServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.2/src/main/java/datadog/trace/instrumentation/undertow/JakartaServletInstrumentation.java
@@ -40,6 +40,8 @@ public final class JakartaServletInstrumentation extends Instrumenter.Tracing
     return new String[] {
       packageName + ".HttpServerExchangeURIDataAdapter",
       packageName + ".UndertowDecorator",
+      packageName + ".UndertowBlockingHandler",
+      packageName + ".UndertowBlockResponseFunction",
       packageName + ".UndertowExtractAdapter",
       packageName + ".UndertowExtractAdapter$Request",
       packageName + ".UndertowExtractAdapter$Response"

--- a/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowDispatcherTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowDispatcherTest.groovy
@@ -1,9 +1,11 @@
 import datadog.appsec.api.blocking.Blocking
+import datadog.appsec.api.blocking.BlockingException
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
 import io.undertow.Handlers
 import io.undertow.Undertow
 import io.undertow.UndertowOptions
+import io.undertow.server.DefaultResponseListener
 import io.undertow.util.Headers
 import io.undertow.util.HttpString
 import io.undertow.util.StatusCodes
@@ -113,7 +115,10 @@ class UndertowDispatcherTest extends HttpServerTest<Undertow> {
               exchange.statusCode = 200
               exchange.responseSender.send('user not blocked')
               exchange.endExchange()
-            } catch (BlockingException) {}
+            } catch (BlockingException be) {
+              exchange.putAttachment(DefaultResponseListener.EXCEPTION,
+                new BlockingException("Blocking user with id 'user-to-block'"))
+            }
           }
         }
         ).build()

--- a/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowDispatcherTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowDispatcherTest.groovy
@@ -1,3 +1,4 @@
+import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
 import io.undertow.Handlers
@@ -103,6 +104,16 @@ class UndertowDispatcherTest extends HttpServerTest<Undertow> {
         .addExactPath(EXCEPTION.getPath()) { exchange ->
           controller(EXCEPTION) {
             throw new Exception(EXCEPTION.body)
+          }
+        }
+        .addExactPath(USER_BLOCK.path) { exchange ->
+          controller(USER_BLOCK) {
+            try {
+              Blocking.forUser('user-to-block').blockIfMatch()
+              exchange.statusCode = 200
+              exchange.responseSender.send('user not blocked')
+              exchange.endExchange()
+            } catch (BlockingException) {}
           }
         }
         ).build()

--- a/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowServletTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowServletTest.groovy
@@ -18,6 +18,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 
 class UndertowServletTest extends HttpServerTest<Undertow> {
   private static final CONTEXT = "ctx"
@@ -42,6 +43,7 @@ class UndertowServletTest extends HttpServerTest<Undertow> {
         .addServlet(new ServletInfo("RedirectServlet", RedirectServlet).addMapping(REDIRECT.getPath()))
         .addServlet(new ServletInfo("ErrorServlet", ErrorServlet).addMapping(ERROR.getPath()))
         .addServlet(new ServletInfo("ExceptionServlet", ExceptionServlet).addMapping(EXCEPTION.getPath()))
+        .addServlet(new ServletInfo("UserBlockServlet", UserBlockServlet).addMapping(USER_BLOCK.path))
 
       DeploymentManager manager = container.addDeployment(builder)
       manager.deploy()

--- a/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowTest.groovy
@@ -1,3 +1,5 @@
+import datadog.appsec.api.blocking.Blocking
+import datadog.appsec.api.blocking.BlockingException
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
 import io.undertow.Handlers
@@ -104,6 +106,14 @@ class UndertowTest extends HttpServerTest<Undertow> {
         .addExactPath(EXCEPTION.getPath()) { exchange ->
           controller(EXCEPTION) {
             throw new Exception(EXCEPTION.body)
+          }
+        }
+        .addExactPath(USER_BLOCK.getPath()) { exchange ->
+          controller(USER_BLOCK) {
+            try {
+              Blocking.forUser('user-to-block').blockIfMatch()
+              exchange.getResponseSender().send('user not blocked')
+            } catch (BlockingException be) {}
           }
         }
         ).build()

--- a/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowTest.groovy
@@ -5,6 +5,7 @@ import datadog.trace.agent.test.base.HttpServerTest
 import io.undertow.Handlers
 import io.undertow.Undertow
 import io.undertow.UndertowOptions
+import io.undertow.server.DefaultResponseListener
 import io.undertow.server.HttpHandler
 import io.undertow.server.HttpServerExchange
 import io.undertow.server.handlers.form.FormData
@@ -113,7 +114,9 @@ class UndertowTest extends HttpServerTest<Undertow> {
             try {
               Blocking.forUser('user-to-block').blockIfMatch()
               exchange.getResponseSender().send('user not blocked')
-            } catch (BlockingException be) {}
+            } catch (BlockingException be) {
+              exchange.putAttachment(DefaultResponseListener.EXCEPTION, be)
+            }
           }
         }
         ).build()

--- a/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UserBlockServlet.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UserBlockServlet.groovy
@@ -1,0 +1,19 @@
+import datadog.appsec.api.blocking.Blocking
+
+import jakarta.servlet.ServletException
+import jakarta.servlet.http.HttpServlet
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
+import static datadog.trace.agent.test.base.HttpServerTest.controller
+
+class UserBlockServlet extends HttpServlet {
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+    controller(USER_BLOCK) {
+      Blocking.forUser('user-to-block').blockIfMatch()
+      resp.writer.print('user not blocked')
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/java/server/VertxTestServer.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/java/server/VertxTestServer.java
@@ -14,10 +14,12 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT;
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS;
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.UNKNOWN;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK;
 import static datadog.trace.agent.test.utils.TraceUtils.runnableUnderTraceAsync;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 
+import datadog.appsec.api.blocking.Blocking;
 import datadog.trace.agent.test.base.HttpServerTest;
 import datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint;
 import io.vertx.core.AbstractVerticle;
@@ -149,6 +151,17 @@ public class VertxTestServer extends AbstractVerticle {
                         ctx.response()
                             .setStatusCode(QUERY_PARAM.getStatus())
                             .end(ctx.request().query())));
+    router
+        .route(USER_BLOCK.getPath())
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    USER_BLOCK,
+                    () -> {
+                      Blocking.forUser("user-to-block").blockIfMatch();
+                      ctx.response().end("Should not be reached");
+                    }));
     router
         .route("/path/:id/param")
         .handler(

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/java/server/VertxTestServer.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/java/server/VertxTestServer.java
@@ -14,10 +14,12 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT;
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS;
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.UNKNOWN;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK;
 import static datadog.trace.agent.test.utils.TraceUtils.runnableUnderTraceAsync;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 
+import datadog.appsec.api.blocking.Blocking;
 import datadog.trace.agent.test.base.HttpServerTest;
 import datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint;
 import io.vertx.core.AbstractVerticle;
@@ -150,6 +152,19 @@ public class VertxTestServer extends AbstractVerticle {
                         ctx.response()
                             .setStatusCode(QUERY_PARAM.getStatus())
                             .end(ctx.request().query())));
+
+    router
+        .route(USER_BLOCK.getPath())
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    USER_BLOCK,
+                    () -> {
+                      Blocking.forUser("user-to-block").blockIfMatch();
+                      ctx.response().end("Should not be reached");
+                    }));
+
     router
         .route("/path/:id/param")
         .handler(

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/SpockRunner.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/SpockRunner.java
@@ -34,6 +34,7 @@ public class SpockRunner extends Sputnik {
    */
   public static final String[] BOOTSTRAP_PACKAGE_PREFIXES_COPY = {
     "datadog.slf4j",
+    "datadog.appsec.api",
     "datadog.trace.api",
     "datadog.trace.bootstrap",
     "datadog.trace.context",

--- a/dd-trace-api/build.gradle
+++ b/dd-trace-api/build.gradle
@@ -20,6 +20,7 @@ excludedClassesCoverage += [
   'datadog.trace.api.interceptor.MutableSpan',
   'datadog.trace.api.experimental.ProfilingContext',
   'datadog.trace.api.experimental.ProfilingContext.NoOp',
+  'datadog.appsec.api.blocking.*',
 ]
 
 description = 'dd-trace-api'

--- a/dd-trace-api/src/main/java/datadog/appsec/api/blocking/Blocking.java
+++ b/dd-trace-api/src/main/java/datadog/appsec/api/blocking/Blocking.java
@@ -1,0 +1,105 @@
+package datadog.appsec.api.blocking;
+
+/**
+ * Functionality related to blocking requests. This functionality is available if and only if the
+ * AppSec subsystem is enabled.
+ */
+public class Blocking {
+  private static volatile BlockingService SERVICE = BlockingService.NOOP;
+
+  private Blocking() {}
+
+  /**
+   * Starts a user-blocking action.
+   *
+   * @param userId a non-null unique identifier for the currently identified user
+   * @return an object through which the action in case of a match can be controlled
+   */
+  public static UserBlockingSpec forUser(String userId) {
+    if (userId == null) {
+      throw new NullPointerException("userId cannot be null");
+    }
+    if (SERVICE == null) {
+      throw new IllegalStateException("Blocking service is not available. Is AppSec disabled?");
+    }
+    return new UserBlockingSpec(userId);
+  }
+
+  /**
+   * Tries to commit an HTTP response with the specified status code and content type. No exception
+   * should escape if this fails.
+   *
+   * <p>This method returns <code>false</code> if blocking cannot be attempted because of the
+   * following conditions:
+   *
+   * <ul>
+   *   <li>there is no span available,
+   *   <li>blocking is not supported for the server being used, or
+   *   <li>the blocking service is otherwise incapable, in principle, of blocking (e.g. it's a no-op
+   *       implementation).
+   * </ul>
+   *
+   * <p>This method does not return false if a blocking response has already been committed, or if
+   * there is an error when trying to write the response. This is because the writing may happen
+   * asynchronously, after the caller has returned.
+   *
+   * @param statusCode the status code of the response
+   * @param contentType the content-type of the response.
+   * @return whether blocking was/will be attempted
+   */
+  public static boolean tryCommitBlockingResponse(int statusCode, BlockingContentType contentType) {
+    try {
+      return SERVICE.tryCommitBlockingResponse(statusCode, contentType);
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  /**
+   * Controls the implementation for blocking. The AppSec subsystem calls this method on startup.
+   * This can be called explicitly for e.g. testing purposes.
+   *
+   * @param service the implementation for blocking.
+   */
+  public static void setBlockingService(BlockingService service) {
+    Blocking.SERVICE = service;
+  }
+
+  public static class UserBlockingSpec {
+    private final String userId;
+
+    private UserBlockingSpec(String userId) {
+      this.userId = userId;
+    }
+
+    /**
+     * Whether the user in question should be blocked, and, if so, the details of the blocking
+     * response
+     *
+     * @return the details of the blocking response, or null if the user is not to be blocked
+     */
+    public BlockingDetails shouldBlock() {
+      return SERVICE.shouldBlockUser(userId);
+    }
+
+    /**
+     * Convenience method that:
+     *
+     * <ul>
+     *   <li>calls {@link #shouldBlock()}, and, if the result is non-null
+     *   <li>calls {@link #tryCommitBlockingResponse(int, BlockingContentType)}, and
+     *   <li>throws an exception of the type {@link BlockingException}
+     * </ul>
+     */
+    public void blockIfMatch() {
+      BlockingDetails blockingDetails = shouldBlock();
+      if (blockingDetails == null) {
+        return;
+      }
+
+      SERVICE.tryCommitBlockingResponse(
+          blockingDetails.statusCode, blockingDetails.blockingContentType);
+      throw new BlockingException("Blocking user with id '" + userId + "'");
+    }
+  }
+}

--- a/dd-trace-api/src/main/java/datadog/appsec/api/blocking/BlockingContentType.java
+++ b/dd-trace-api/src/main/java/datadog/appsec/api/blocking/BlockingContentType.java
@@ -1,0 +1,13 @@
+package datadog.appsec.api.blocking;
+
+public enum BlockingContentType {
+  /**
+   * Automatically choose between HTML and JSON, depending on the value of the <code>Accept</code>
+   * header. If the preference value is the same, {@link #JSON} will be preferred.
+   */
+  AUTO,
+  /** An HTTP response. */
+  HTML,
+  /** A JSON response. */
+  JSON,
+}

--- a/dd-trace-api/src/main/java/datadog/appsec/api/blocking/BlockingDetails.java
+++ b/dd-trace-api/src/main/java/datadog/appsec/api/blocking/BlockingDetails.java
@@ -1,0 +1,11 @@
+package datadog.appsec.api.blocking;
+
+public class BlockingDetails {
+  public final int statusCode;
+  public final BlockingContentType blockingContentType;
+
+  public BlockingDetails(int statusCode, BlockingContentType blockingContentType) {
+    this.statusCode = statusCode;
+    this.blockingContentType = blockingContentType;
+  }
+}

--- a/dd-trace-api/src/main/java/datadog/appsec/api/blocking/BlockingException.java
+++ b/dd-trace-api/src/main/java/datadog/appsec/api/blocking/BlockingException.java
@@ -1,0 +1,17 @@
+package datadog.appsec.api.blocking;
+
+public class BlockingException extends RuntimeException {
+  public BlockingException() {}
+
+  public BlockingException(String message) {
+    super(message);
+  }
+
+  public BlockingException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public BlockingException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/dd-trace-api/src/main/java/datadog/appsec/api/blocking/BlockingService.java
+++ b/dd-trace-api/src/main/java/datadog/appsec/api/blocking/BlockingService.java
@@ -1,0 +1,25 @@
+package datadog.appsec.api.blocking;
+
+import javax.annotation.Nonnull;
+
+public interface BlockingService {
+  BlockingService NOOP = new BlockingServiceNoop();
+
+  BlockingDetails shouldBlockUser(@Nonnull String userId);
+
+  boolean tryCommitBlockingResponse(int statusCode, @Nonnull BlockingContentType type);
+
+  class BlockingServiceNoop implements BlockingService {
+    private BlockingServiceNoop() {}
+
+    @Override
+    public BlockingDetails shouldBlockUser(@Nonnull String userId) {
+      return null;
+    }
+
+    @Override
+    public boolean tryCommitBlockingResponse(int statusCode, @Nonnull BlockingContentType type) {
+      return false;
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -9,6 +9,7 @@ import datadog.trace.api.Functions;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
 import datadog.trace.api.config.TracerConfig;
+import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.internal.TraceSegment;
@@ -134,6 +135,8 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext, TraceSe
   private final PropagationTags propagationTags;
 
   private volatile PathwayContext pathwayContext;
+
+  private volatile BlockResponseFunction blockResponseFunction;
 
   public DDSpanContext(
       final DDTraceId traceId,
@@ -694,6 +697,16 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext, TraceSe
   @Override
   public TraceSegment getTraceSegment() {
     return this;
+  }
+
+  @Override
+  public void setBlockResponseFunction(BlockResponseFunction blockResponseFunction) {
+    getTopContext().blockResponseFunction = blockResponseFunction;
+  }
+
+  @Override
+  public BlockResponseFunction getBlockResponseFunction() {
+    return getTopContext().blockResponseFunction;
   }
 
   public PropagationTags getPropagationTags() {

--- a/internal-api/src/main/java/datadog/trace/api/gateway/BlockResponseFunction.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/BlockResponseFunction.java
@@ -1,0 +1,7 @@
+package datadog.trace.api.gateway;
+
+import datadog.appsec.api.blocking.BlockingContentType;
+
+public interface BlockResponseFunction {
+  boolean tryCommitBlockingResponse(int statusCode, BlockingContentType templateType);
+}

--- a/internal-api/src/main/java/datadog/trace/api/gateway/Flow.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/Flow.java
@@ -1,5 +1,7 @@
 package datadog.trace.api.gateway;
 
+import datadog.appsec.api.blocking.BlockingContentType;
+
 /**
  * The result of sending an event to a callback.
  *
@@ -21,12 +23,6 @@ public interface Flow<T> {
       public boolean isBlocking() {
         return false;
       }
-    }
-
-    enum BlockingContentType {
-      AUTO,
-      HTML,
-      JSON,
     }
 
     class RequestBlockingAction implements Action {

--- a/internal-api/src/main/java/datadog/trace/api/gateway/RequestContext.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/RequestContext.java
@@ -11,4 +11,8 @@ public interface RequestContext extends Closeable {
   <T> T getData(RequestContextSlot slot);
 
   TraceSegment getTraceSegment();
+
+  void setBlockResponseFunction(BlockResponseFunction blockResponseFunction);
+
+  BlockResponseFunction getBlockResponseFunction();
 }

--- a/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
@@ -3,6 +3,7 @@ package datadog.trace.api.gateway;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import datadog.appsec.api.blocking.BlockingContentType;
 import datadog.trace.api.function.TriConsumer;
 import datadog.trace.api.function.TriFunction;
 import datadog.trace.api.http.StoredBodySupplier;
@@ -45,6 +46,14 @@ public class InstrumentationGatewayTest {
           @Override
           public TraceSegment getTraceSegment() {
             return TraceSegment.NoOp.INSTANCE;
+          }
+
+          @Override
+          public void setBlockResponseFunction(BlockResponseFunction blockResponseFunction) {}
+
+          @Override
+          public BlockResponseFunction getBlockResponseFunction() {
+            return null;
           }
         };
     flow = new Flow.ResultFlow<>(null);
@@ -123,10 +132,10 @@ public class InstrumentationGatewayTest {
   @Test
   public void testRequestBlockingAction() {
     Flow.Action.RequestBlockingAction rba =
-        new Flow.Action.RequestBlockingAction(400, Flow.Action.BlockingContentType.HTML);
+        new Flow.Action.RequestBlockingAction(400, BlockingContentType.HTML);
     assertThat(rba.isBlocking()).isTrue();
     assertThat(rba.getStatusCode()).isEqualTo(400);
-    assertThat(rba.getBlockingContentType()).isEqualTo(Flow.Action.BlockingContentType.HTML);
+    assertThat(rba.getBlockingContentType()).isEqualTo(BlockingContentType.HTML);
   }
 
   @Test
@@ -322,7 +331,7 @@ public class InstrumentationGatewayTest {
         new Flow.ResultFlow<Void>(null) {
           @Override
           public Action getAction() {
-            return new Action.RequestBlockingAction(410, Action.BlockingContentType.AUTO);
+            return new Action.RequestBlockingAction(410, BlockingContentType.AUTO);
           }
         };
 


### PR DESCRIPTION
Add support for the WAF (part of Application Security Management) to block requests based on user. This currently relies on a new public API required to use this functionality.