### PR TITLE
Fix duplicate GraphQL instrumentation bug

### DIFF
--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/main/java8/datadog/trace/instrumentation/graphqljava/GraphQLInstrumentation.java
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/main/java8/datadog/trace/instrumentation/graphqljava/GraphQLInstrumentation.java
@@ -42,8 +42,9 @@ public final class GraphQLInstrumentation extends SimpleInstrumentation {
         return instrumentation;
       }
       instrumentationList.addAll(instrumentations);
+    } else {
+      instrumentationList.add(instrumentation);
     }
-    instrumentationList.add(instrumentation);
     instrumentationList.add(new GraphQLInstrumentation());
     return new ChainedInstrumentation(instrumentationList);
   }

--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLInstallationTest.groovy
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLInstallationTest.groovy
@@ -41,4 +41,26 @@ class GraphQLInstallationTest extends AgentTestRunner {
     then:
     inst2 == inst3
   }
+
+  def "add GraphQL instrumentation to the existing chained instrumentation"() {
+    when:
+    def testInst1 = new TestInst()
+    def testInst2 = new TestInst()
+    def inst3 = GraphQLInstrumentation.install(new ChainedInstrumentation([testInst1, testInst2]))
+
+    then:
+    inst3.class == ChainedInstrumentation
+    def insts = inst3.getInstrumentations()
+    insts.get(0) == testInst1
+    insts.get(1) == testInst2
+    def inst = insts.get(2)
+    inst.class == GraphQLInstrumentation
+
+    when:
+    // do not install if it's already been installed
+    def inst4 = GraphQLInstrumentation.install(inst3)
+
+    then:
+    inst3 == inst4
+  }
 }


### PR DESCRIPTION
# What Does This Do

When GraphQLInstrumentation#install is called with a ChainedInstrumentation object the resulting Instrumentation contains duplicates (the individual Instrumentation objects contained within the ChainedInstrumentation as well as the ChainedInstrumentation itself). This fixes that.

# Motivation

# Additional Notes

Open this PR from the original repository branch to be able run the entire test suit.
Original fix #4088 fails to run system-tests with `DD_API_KEY is missing in env, please add it.` because the PR is open from a fork repository.