### PR TITLE
Less verbose error on missing statsd_port

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
+++ b/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
@@ -228,7 +228,12 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
   private static void discoverStatsDPort(final Map<String, Object> info) {
     try {
       Map<String, ?> config = (Map<String, ?>) info.get("config");
-      int statsdPort = ((Number) config.get("statsd_port")).intValue();
+      final Object statsdPortObj = config.get("statsd_port");
+      if (statsdPortObj == null) {
+        log.debug("statsd_port missing from trace agent /info response");
+        return;
+      }
+      int statsdPort = ((Number) statsdPortObj).intValue();
       DDAgentStatsDClientManager.setDefaultStatsDPort(statsdPort);
     } catch (Throwable ignore) {
       log.debug("statsd_port missing from trace agent /info response", ignore);


### PR DESCRIPTION
# What Does This Do
Found during testing. If a feature discovery call got no `statsd_port` in the response, we logged a long NullPointerException.

This PR makes the handling of missing port gentler on logging.

# Motivation

Exception with enabled telemetry and disabled tracer:

# Additional Notes
