### PR TITLE
Fix telemetry when all other products are disabled

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -54,7 +54,8 @@ public class AgentInstaller {
         || Config.get().isProfilingEnabled()
         || Config.get().getAppSecEnabledConfig() != ProductActivationConfig.FULLY_DISABLED
         || Config.get().isIastEnabled()
-        || Config.get().isCiVisibilityEnabled()) {
+        || Config.get().isCiVisibilityEnabled()
+        || Config.get().isTelemetryEnabled()) {
       installBytebuddyAgent(inst, false, new AgentBuilder.Listener[0]);
       if (DEBUG) {
         log.debug("Class instrumentation installed");


### PR DESCRIPTION


# What Does This Do
Running telemetry when no other agent integrations were enabled led to classloading exceptions. This commit ensures that ByteBuddy is installed if telemetry is enabled.

# Motivation

Exception with enabled telemetry and disabled tracer:

```
[dd.trace 2022-10-31 11:25:01:501 +0100] [dd-telemetry] ERROR datadog.telemetry.TelemetryRunnable - Uncaught exception in dd-telemetry
java.lang.LinkageError: loader (instance of  datadog/trace/bootstrap/DatadogClassLoader): attempted  duplicate class definition for name: "org/objectweb/asm/MethodWriter"
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:756)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at datadog.trace.bootstrap.DatadogClassLoader.findClass(DatadogClassLoader.java:105)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	at jnr.ffi.provider.jffi.AsmLibraryLoader.generateInterfaceImpl(AsmLibraryLoader.java:96)
	at jnr.ffi.provider.jffi.AsmLibraryLoader.loadLibrary(AsmLibraryLoader.java:86)
	at jnr.ffi.provider.jffi.NativeLibraryLoader.loadLibrary(NativeLibraryLoader.java:44)
	at jnr.ffi.LibraryLoader.load(LibraryLoader.java:392)
	at jnr.ffi.LibraryLoader.load(LibraryLoader.java:371)
	at datadog.telemetry.Uname.<clinit>(Uname.java:24)
	at datadog.telemetry.HostInfo.getHostname(HostInfo.java:28)
	at datadog.telemetry.RequestBuilder.<init>(RequestBuilder.java:66)
	at datadog.telemetry.RequestBuilderSupplier.get(RequestBuilderSupplier.java:17)
	at datadog.telemetry.RequestBuilderSupplier.get(RequestBuilderSupplier.java:6)
	at datadog.telemetry.TelemetryServiceImpl.addStartedRequest(TelemetryServiceImpl.java:59)
	at datadog.telemetry.TelemetryRunnable.run(TelemetryRunnable.java:53)
	at java.lang.Thread.run(Thread.java:750)
```

# Additional Notes
