### PR TITLE
Command Injection detection

### DIFF
--- a/dd-java-agent/agent-iast/build.gradle
+++ b/dd-java-agent/agent-iast/build.gradle
@@ -54,6 +54,7 @@ ext {
     'com.datadog.iast.model.json.SourceTypeAdapter',
     'com.datadog.iast.model.json.DDSpanIdAdapter',
     'com.datadog.iast.model.json.EvidenceAdapter',
+    'com.datadog.iast.model.json.VulnerabilityTypeAdapter',
   ]
   excludedClassesBranchCoverage = []
   excludedClassesInstructionCoverage = []

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastModuleImpl.java
@@ -1,5 +1,7 @@
 package com.datadog.iast;
 
+import static com.datadog.iast.taint.Ranges.rangesProviderFor;
+
 import com.datadog.iast.model.Evidence;
 import com.datadog.iast.model.Location;
 import com.datadog.iast.model.Range;
@@ -7,9 +9,11 @@ import com.datadog.iast.model.Source;
 import com.datadog.iast.model.SourceType;
 import com.datadog.iast.model.Vulnerability;
 import com.datadog.iast.model.VulnerabilityType;
+import com.datadog.iast.model.VulnerabilityType.InjectionType;
 import com.datadog.iast.overhead.Operations;
 import com.datadog.iast.overhead.OverheadController;
 import com.datadog.iast.taint.Ranges;
+import com.datadog.iast.taint.Ranges.RangesProvider;
 import com.datadog.iast.taint.TaintedObject;
 import com.datadog.iast.taint.TaintedObjects;
 import datadog.trace.api.Config;
@@ -20,6 +24,7 @@ import datadog.trace.instrumentation.iastinstrumenter.IastExclusionTrie;
 import datadog.trace.util.stacktrace.StackWalker;
 import datadog.trace.util.stacktrace.StackWalkerFactory;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -291,6 +296,73 @@ public final class IastModuleImpl implements IastModule {
     reporter.report(span, vulnerability);
   }
 
+  @Override
+  public void onRuntimeExec(@Nonnull final String... cmdArray) {
+    if (!canBeTainted(cmdArray)) {
+      return;
+    }
+    final IastRequestContext ctx = IastRequestContext.get();
+    if (ctx == null) {
+      return;
+    }
+    final TaintedObjects to = ctx.getTaintedObjects();
+    final RangesProvider<String> rangesProvider = rangesProviderFor(to, cmdArray);
+    checkInjection(VulnerabilityType.COMMAND_INJECTION, rangesProvider);
+  }
+
+  @Override
+  public void onProcessBuilderStart(@Nonnull final List<String> command) {
+    if (!canBeTainted(command)) {
+      return;
+    }
+    final IastRequestContext ctx = IastRequestContext.get();
+    if (ctx == null) {
+      return;
+    }
+    final TaintedObjects to = ctx.getTaintedObjects();
+    final RangesProvider<String> rangesProvider = Ranges.rangesProviderFor(to, command);
+    checkInjection(VulnerabilityType.COMMAND_INJECTION, rangesProvider);
+  }
+
+  private <E> void checkInjection(
+      @Nonnull final InjectionType type, @Nonnull final RangesProvider<E> rangeProvider) {
+    final int rangeCount = rangeProvider.rangeCount();
+    if (rangeCount == 0) {
+      return;
+    }
+    final AgentSpan span = AgentTracer.activeSpan();
+    if (!overheadController.consumeQuota(Operations.REPORT_VULNERABILITY, span)) {
+      return;
+    }
+    final StringBuilder evidence = new StringBuilder();
+    final Range[] targetRanges = new Range[rangeCount];
+    int rangeIndex = 0;
+    for (int i = 0; i < rangeProvider.size(); i++) {
+      final E item = rangeProvider.value(i);
+      if (item != null) {
+        if (evidence.length() > 0) {
+          evidence.append(type.evidenceSeparator());
+        }
+        final Range[] taintedRanges = rangeProvider.ranges(item);
+        if (taintedRanges != null) {
+          Ranges.copyShift(taintedRanges, targetRanges, rangeIndex, evidence.length());
+          rangeIndex += taintedRanges.length;
+        }
+        evidence.append(item);
+      }
+    }
+
+    StackTraceElement stackTraceElement =
+        stackWalker.walk(IastModuleImpl::findValidPackageForVulnerability);
+
+    reporter.report(
+        span,
+        new Vulnerability(
+            type,
+            Location.forSpanAndStack(span.getSpanId(), stackTraceElement),
+            new Evidence(evidence.toString(), targetRanges)));
+  }
+
   private static StackTraceElement findValidPackageForVulnerability(
       Stream<StackTraceElement> stream) {
     final StackTraceElement[] first = new StackTraceElement[1];
@@ -323,10 +395,29 @@ public final class IastModuleImpl implements IastModule {
   }
 
   private static boolean canBeTaintedNullSafe(@Nullable final CharSequence[] args) {
-    if (args == null || args.length == 0) {
+    if (args == null) {
+      return false;
+    }
+    return canBeTainted(args);
+  }
+
+  private static boolean canBeTainted(@Nonnull final CharSequence[] args) {
+    if (args.length == 0) {
       return false;
     }
     for (final CharSequence item : args) {
+      if (canBeTaintedNullSafe(item)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean canBeTainted(@Nonnull final List<? extends CharSequence> items) {
+    if (items.size() == 0) {
+      return false;
+    }
+    for (final CharSequence item : items) {
       if (canBeTaintedNullSafe(item)) {
         return true;
       }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
@@ -3,19 +3,57 @@ package com.datadog.iast.model;
 import java.util.zip.CRC32;
 import javax.annotation.Nonnull;
 
-public enum VulnerabilityType {
-  WEAK_CIPHER,
-  WEAK_HASH,
-  SQL_INJECTION;
+public interface VulnerabilityType {
+  VulnerabilityType WEAK_CIPHER = new VulnerabilityTypeImpl("WEAK_CIPHER");
+  VulnerabilityType WEAK_HASH = new VulnerabilityTypeImpl("WEAK_HASH");
+  InjectionType SQL_INJECTION = new InjectionTypeImpl("SQL_INJECTION", ' ');
+  InjectionType COMMAND_INJECTION = new InjectionTypeImpl("COMMAND_INJECTION", ' ');
 
-  public long calculateHash(@Nonnull final Vulnerability vulnerability) {
-    CRC32 crc = new CRC32();
-    crc.update(name().getBytes());
-    final Location location = vulnerability.getLocation();
-    if (location != null) {
-      crc.update(location.getLine());
-      crc.update(location.getPath().getBytes());
+  String name();
+
+  long calculateHash(@Nonnull final Vulnerability vulnerability);
+
+  interface InjectionType extends VulnerabilityType {
+    char evidenceSeparator();
+  }
+
+  class VulnerabilityTypeImpl implements VulnerabilityType {
+
+    private final String name;
+
+    public VulnerabilityTypeImpl(@Nonnull final String name) {
+      this.name = name;
     }
-    return crc.getValue();
+
+    @Override
+    public String name() {
+      return name;
+    }
+
+    @Override
+    public long calculateHash(@Nonnull final Vulnerability vulnerability) {
+      CRC32 crc = new CRC32();
+      crc.update(name().getBytes());
+      final Location location = vulnerability.getLocation();
+      if (location != null) {
+        crc.update(location.getLine());
+        crc.update(location.getPath().getBytes());
+      }
+      return crc.getValue();
+    }
+  }
+
+  class InjectionTypeImpl extends VulnerabilityTypeImpl implements InjectionType {
+    private final char evidenceSeparator;
+
+    public InjectionTypeImpl(@Nonnull final String name, final char evidenceSeparator) {
+      super(name);
+      this.evidenceSeparator = evidenceSeparator;
+    }
+
+    @Override
+    public char evidenceSeparator() {
+      return evidenceSeparator;
+    }
   }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/json/AdapterFactory.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/json/AdapterFactory.java
@@ -4,6 +4,7 @@ import com.datadog.iast.model.Evidence;
 import com.datadog.iast.model.Source;
 import com.datadog.iast.model.Vulnerability;
 import com.datadog.iast.model.VulnerabilityBatch;
+import com.datadog.iast.model.VulnerabilityType;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.JsonWriter;
@@ -57,6 +58,8 @@ class AdapterFactory implements JsonAdapter.Factory {
       return new VulnerabilityBatchAdapter(moshi);
     } else if (Evidence.class.equals(rawType)) {
       return new EvidenceAdapter();
+    } else if (VulnerabilityType.class.equals(rawType)) {
+      return new VulnerabilityTypeAdapter();
     }
     return null;
   }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/json/VulnerabilityTypeAdapter.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/json/VulnerabilityTypeAdapter.java
@@ -1,0 +1,27 @@
+package com.datadog.iast.model.json;
+
+import com.datadog.iast.model.VulnerabilityType;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import java.io.IOException;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class VulnerabilityTypeAdapter extends JsonAdapter<VulnerabilityType> {
+  @Nullable
+  @Override
+  public VulnerabilityType fromJson(@Nonnull final JsonReader reader) throws IOException {
+    throw new UnsupportedOperationException("VulnerabilityType deserialization not supported");
+  }
+
+  @Override
+  public void toJson(@Nonnull final JsonWriter writer, @Nullable final VulnerabilityType value)
+      throws IOException {
+    if (value == null) {
+      writer.nullValue();
+      return;
+    }
+    writer.value(value.name());
+  }
+}

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/Ranges.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/Ranges.java
@@ -2,12 +2,38 @@ package com.datadog.iast.taint;
 
 import com.datadog.iast.model.Range;
 import com.datadog.iast.model.Source;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /** Utilities to work with {@link Range} instances. */
 public final class Ranges {
 
   public static final Range[] EMPTY = new Range[0];
+  public static final RangesProvider<?> EMPTY_PROVIDER =
+      new RangesProvider<Object>() {
+        @Override
+        public int rangeCount() {
+          return 0;
+        }
+
+        @Override
+        public int size() {
+          return 0;
+        }
+
+        @Override
+        public Object value(final int index) {
+          throw new UnsupportedOperationException("empty provider");
+        }
+
+        @Override
+        public Range[] ranges(final Object value) {
+          throw new UnsupportedOperationException("empty provider");
+        }
+      };
 
   private Ranges() {}
 
@@ -23,6 +49,121 @@ public final class Ranges {
       for (int iSrc = 0, iDst = dstPos; iSrc < src.length; iSrc++, iDst++) {
         dst[iDst] = src[iSrc].shift(shift);
       }
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <E> RangesProvider<E> rangesProviderFor(
+      @Nonnull final TaintedObjects to, @Nullable final E[] items) {
+    if (items == null || items.length == 0) {
+      return (RangesProvider<E>) EMPTY_PROVIDER;
+    }
+    return new ArrayProvider<E>(items, to);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <E> RangesProvider<E> rangesProviderFor(
+      @Nonnull final TaintedObjects to, @Nullable final List<E> items) {
+    if (items == null || items.isEmpty()) {
+      return (RangesProvider<E>) EMPTY_PROVIDER;
+    }
+    return new ListProvider<E>(items, to);
+  }
+
+  public interface RangesProvider<E> {
+    int rangeCount();
+
+    int size();
+
+    E value(final int index);
+
+    Range[] ranges(final E value);
+  }
+
+  private abstract static class IterableProvider<E, LIST> implements RangesProvider<E> {
+    private final LIST items;
+    private final Map<E, Range[]> ranges;
+    private final int rangeCount;
+
+    private IterableProvider(@Nonnull final LIST items, @Nonnull final TaintedObjects to) {
+      this.items = items;
+      final int length = size(items);
+      Map<E, Range[]> ranges = null;
+      int rangeCount = 0;
+      for (int i = 0; i < length; i++) {
+        final E item = item(items, i);
+        if (item != null) {
+          final TaintedObject tainted = to.get(item);
+          if (tainted != null) {
+            final Range[] taintedRanges = tainted.getRanges();
+            rangeCount += taintedRanges.length;
+            if (ranges == null) {
+              ranges = new HashMap<>(length);
+            }
+            ranges.put(item, taintedRanges);
+          }
+        }
+      }
+      this.ranges = ranges;
+      this.rangeCount = rangeCount;
+    }
+
+    @Override
+    public int rangeCount() {
+      return rangeCount;
+    }
+
+    @Override
+    public E value(final int index) {
+      return item(items, index);
+    }
+
+    @Override
+    public Range[] ranges(final E value) {
+      return ranges == null ? null : ranges.get(value);
+    }
+
+    @Override
+    public int size() {
+      return size(items);
+    }
+
+    protected abstract int size(@Nonnull final LIST items);
+
+    protected abstract E item(@Nonnull final LIST items, final int index);
+  }
+
+  private static class ArrayProvider<E> extends IterableProvider<E, E[]> {
+
+    private ArrayProvider(@Nonnull final E[] items, @Nonnull final TaintedObjects to) {
+      super(items, to);
+    }
+
+    @Override
+    protected int size(@Nonnull final E[] items) {
+      return items.length;
+    }
+
+    @Override
+    protected E item(@Nonnull final E[] items, final int index) {
+      return items[index];
+    }
+  }
+
+  private static class ListProvider<E> extends IterableProvider<E, List<E>> {
+
+    private ListProvider(@Nonnull final List<E> items, @Nonnull final TaintedObjects to) {
+      super(items, to);
+    }
+
+    @Override
+    protected int size(@Nonnull final List<E> items) {
+      return items.size();
+    }
+
+    @Override
+    protected E item(@Nonnull final List<E> items, final int index) {
+      return items.get(index);
     }
   }
 }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastModuleImplCommandInjectionTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastModuleImplCommandInjectionTest.groovy
@@ -1,0 +1,94 @@
+package com.datadog.iast
+
+import com.datadog.iast.model.Vulnerability
+import com.datadog.iast.model.VulnerabilityType
+import datadog.trace.api.gateway.RequestContext
+import datadog.trace.api.gateway.RequestContextSlot
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import spock.lang.Shared
+
+import static com.datadog.iast.taint.TaintUtils.addFromTaintFormat
+import static com.datadog.iast.taint.TaintUtils.taintFormat
+
+class IastModuleImplCommandInjectionTest extends IastModuleImplTestBase {
+
+  @Shared
+  private List<Object> objectHolder
+
+  @Shared
+  private IastRequestContext ctx
+
+  def setup() {
+    objectHolder = []
+    ctx = new IastRequestContext()
+    final reqCtx = Mock(RequestContext) {
+      getData(RequestContextSlot.IAST) >> ctx
+    }
+    final span = Mock(AgentSpan) {
+      getSpanId() >> 123456
+      getRequestContext() >> reqCtx
+    }
+    tracer.activeSpan() >> span
+    overheadController.consumeQuota(_, _) >> true
+  }
+
+  void 'iast module detect command injection on process builder start (#command)'(final List<String> command, final String expected) {
+    setup:
+    final cmd = mapTaintedCommand(command)
+
+    when:
+    module.onProcessBuilderStart(cmd)
+
+    then:
+    if (expected != null) {
+      1 * reporter.report(_, _) >> { args -> assertVulnerability(args[1] as Vulnerability, expected) }
+    } else {
+      0 * reporter.report(_, _)
+    }
+
+    where:
+    command                    | expected
+    ['ls', '-lah']             | null
+    ['==>ls<==', '-lah']       | '==>ls<== -lah'
+    ['==>ls<==', '==>-lah<=='] | '==>ls<== ==>-lah<=='
+  }
+
+  void 'iast module detect command injection on runtime exec (#command)'(final List<String> command, final String expected) {
+    setup:
+    final cmd = mapTaintedCommand(command).toArray(new String[0]) as String[]
+
+    when:
+    module.onRuntimeExec(cmd)
+
+    then:
+    if (expected != null) {
+      1 * reporter.report(_, _) >> { args -> assertVulnerability(args[1] as Vulnerability, expected) }
+    } else {
+      0 * reporter.report(_, _)
+    }
+
+    where:
+    command                    | expected
+    ['ls', '-lah']             | null
+    ['==>ls<==', '-lah']       | '==>ls<== -lah'
+    ['==>ls<==', '==>-lah<=='] | '==>ls<== ==>-lah<=='
+  }
+
+  private List<String> mapTaintedCommand(final List<String> command) {
+    return command.collect {
+      final item = addFromTaintFormat(ctx.taintedObjects, it)
+      objectHolder.add(item)
+      return item
+    }
+  }
+
+  private static void assertVulnerability(final Vulnerability vuln, final String expected) {
+    assert vuln != null
+    assert vuln.getType() == VulnerabilityType.COMMAND_INJECTION
+    assert vuln.getLocation() != null
+    final evidence = vuln.getEvidence()
+    assert evidence != null
+    final formatted = taintFormat(evidence.getValue(), evidence.getRanges())
+    assert formatted == expected
+  }
+}

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/RangesTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/RangesTest.groovy
@@ -5,6 +5,8 @@ import com.datadog.iast.model.Source
 import com.datadog.iast.model.SourceType
 import datadog.trace.test.util.DDSpecification
 
+import static com.datadog.iast.taint.Ranges.rangesProviderFor
+
 class RangesTest extends DDSpecification {
 
   def 'forString'() {
@@ -59,6 +61,57 @@ class RangesTest extends DDSpecification {
     1      | 2      | -1    | [[1, 1]] | [null, [0, 1]]
   }
 
+  void 'test range provider'(final Object values, final List<TaintedObject> tainted, final int size, final int rangeCount) {
+    setup:
+    final to = Mock(TaintedObjects)
+    values.eachWithIndex { Object entry, int i ->
+      to.get(entry) >> tainted.get(i)
+    }
+
+    when:
+    final provider = rangesProviderFor(to, values)
+
+    then:
+    provider.size() == size
+    provider.rangeCount() == rangeCount
+    values.eachWithIndex { Object entry, int i ->
+      final value = provider.value(i)
+      assert value == entry
+      assert provider.ranges(value) == tainted.get(i)?.getRanges()
+    } == values
+
+    where:
+    values                                | tainted                                                 | size | rangeCount
+    ['a', 'b', 'c', 'd']                  | [null, ranged(2), null, ranged(6), null]                | 4    | 8
+    ['a', 'b', 'c', 'd', 'e'] as String[] | [ranged(1), ranged(1), ranged(1), ranged(1), ranged(1)] | 5    | 5
+  }
+
+  void 'test empty range provider'() {
+    setup:
+    final to = Mock(TaintedObjects)
+    final provider = rangesProviderFor(to, [])
+
+    when:
+    final rangeCount = provider.rangeCount()
+    final size = provider.size()
+
+    then:
+    rangeCount == 0
+    size == 0
+
+    when:
+    provider.value(0)
+
+    then:
+    thrown(UnsupportedOperationException)
+
+    when:
+    provider.ranges('abc')
+
+    then:
+    thrown(UnsupportedOperationException)
+  }
+
   Range[] rangesFromSpec(List<List<Object>> spec) {
     def ranges = new Range[spec.size()]
     int j = 0
@@ -73,5 +126,12 @@ class RangesTest extends DDSpecification {
       j++
     }
     ranges
+  }
+
+  TaintedObject ranged(final int rangeCount) {
+    final Range[] ranges = new Range[rangeCount]
+    return Mock(TaintedObject) {
+      getRanges() >> ranges
+    }
   }
 }

--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/ProcessBuilderCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/ProcessBuilderCallSite.java
@@ -1,0 +1,24 @@
+package datadog.trace.instrumentation.java.lang;
+
+import datadog.trace.agent.tooling.csi.CallSite;
+import datadog.trace.api.iast.IastAdvice;
+import datadog.trace.api.iast.InstrumentationBridge;
+import java.util.List;
+import javax.annotation.Nullable;
+
+// TODO deal with the environment
+@CallSite(spi = IastAdvice.class)
+public class ProcessBuilderCallSite {
+
+  @CallSite.Before("java.lang.Process java.lang.ProcessBuilder.start()")
+  public static void beforeStart(@CallSite.This @Nullable final ProcessBuilder self) {
+    if (self == null) {
+      return;
+    }
+    // be careful when fetching the environment as it does mutate the instance
+    final List<String> cmd = self.command();
+    if (cmd != null && cmd.size() > 0) {
+      InstrumentationBridge.onProcessBuilderStart(cmd);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/RuntimeCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/RuntimeCallSite.java
@@ -1,0 +1,67 @@
+package datadog.trace.instrumentation.java.lang;
+
+import datadog.trace.agent.tooling.csi.CallSite;
+import datadog.trace.api.iast.IastAdvice;
+import datadog.trace.api.iast.InstrumentationBridge;
+import java.io.File;
+import javax.annotation.Nullable;
+
+// TODO deal with the environment
+@CallSite(spi = IastAdvice.class)
+public class RuntimeCallSite {
+
+  @CallSite.Before("java.lang.Process java.lang.Runtime.exec(java.lang.String)")
+  public static void beforeStart(@CallSite.Argument @Nullable final String command) {
+    if (command != null) { // runtime fails if null
+      InstrumentationBridge.onRuntimeExec(command);
+    }
+  }
+
+  @CallSite.Before("java.lang.Process java.lang.Runtime.exec(java.lang.String[])")
+  public static void beforeExec(@CallSite.Argument @Nullable final String[] cmdArray) {
+    if (cmdArray != null && cmdArray.length > 0) { // runtime fails if null or empty
+      InstrumentationBridge.onRuntimeExec(cmdArray);
+    }
+  }
+
+  @CallSite.Before("java.lang.Process java.lang.Runtime.exec(java.lang.String, java.lang.String[])")
+  public static void beforeExec(
+      @CallSite.Argument @Nullable final String command,
+      @CallSite.Argument @Nullable final String[] envp) {
+    if (command != null) { // runtime fails if null
+      InstrumentationBridge.onRuntimeExec(command);
+    }
+  }
+
+  @CallSite.Before(
+      "java.lang.Process java.lang.Runtime.exec(java.lang.String[], java.lang.String[])")
+  public static void beforeExec(
+      @CallSite.Argument @Nullable final String[] cmdArray,
+      @CallSite.Argument @Nullable final String[] envp) {
+    if (cmdArray != null && cmdArray.length > 0) { // runtime fails if null or empty
+      InstrumentationBridge.onRuntimeExec(cmdArray);
+    }
+  }
+
+  @CallSite.Before(
+      "java.lang.Process java.lang.Runtime.exec(java.lang.String, java.lang.String[], java.io.File)")
+  public static void beforeExec(
+      @CallSite.Argument @Nullable final String command,
+      @CallSite.Argument @Nullable final String[] envp,
+      @CallSite.Argument @Nullable final File dir) {
+    if (command != null) { // runtime fails if null
+      InstrumentationBridge.onRuntimeExec(command);
+    }
+  }
+
+  @CallSite.Before(
+      "java.lang.Process java.lang.Runtime.exec(java.lang.String[], java.lang.String[], java.io.File)")
+  public static void beforeExec(
+      @CallSite.Argument @Nullable final String[] cmdArray,
+      @CallSite.Argument @Nullable final String[] envp,
+      @CallSite.Argument @Nullable final File dir) {
+    if (cmdArray != null && cmdArray.length > 0) { // runtime fails if null or empty
+      InstrumentationBridge.onRuntimeExec(cmdArray);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/ProcessBuilderCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/ProcessBuilderCallSiteTest.groovy
@@ -1,0 +1,30 @@
+package datadog.trace.instrumentation.java.lang
+
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.IastModule
+import datadog.trace.api.iast.InstrumentationBridge
+import foo.bar.TestProcessBuilderSuite
+
+class ProcessBuilderCallSiteTest extends AgentTestRunner {
+
+  @Override
+  protected void configurePreAgent() {
+    injectSysConfig("dd.iast.enabled", "true")
+  }
+
+
+  def 'test start'() {
+    setup:
+    final command = ['you_cant_run_me', '-lah']
+    final iastModule = Mock(IastModule)
+    InstrumentationBridge.registerIastModule(iastModule)
+
+    when:
+    TestProcessBuilderSuite.start(command)
+
+    then:
+    thrown(IOException)
+    1 * iastModule.onProcessBuilderStart(command)
+    0 * _
+  }
+}

--- a/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/RuntimeCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/RuntimeCallSiteTest.groovy
@@ -1,0 +1,116 @@
+package datadog.trace.instrumentation.java.lang
+
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.IastModule
+import datadog.trace.api.iast.InstrumentationBridge
+import foo.bar.TestRuntimeSuite
+
+class RuntimeCallSiteTest extends AgentTestRunner {
+
+  @Override
+  protected void configurePreAgent() {
+    injectSysConfig("dd.iast.enabled", "true")
+  }
+
+  def 'test exec with command string'() {
+    setup:
+    final runtime = Mock(Runtime)
+    final iastModule = Mock(IastModule)
+    final command = 'ls'
+    InstrumentationBridge.registerIastModule(iastModule)
+
+    when:
+    new TestRuntimeSuite(runtime).exec(command)
+
+    then:
+    1 * iastModule.onRuntimeExec(command)
+    1 * runtime.exec(command)
+    0 * _
+  }
+
+  def 'test exec with command string and env array'() {
+    setup:
+    final runtime = Mock(Runtime)
+    final iastModule = Mock(IastModule)
+    final command = 'ls'
+    final env = ['DD_TRACE_DEBUG=true'] as String[]
+    InstrumentationBridge.registerIastModule(iastModule)
+
+    when:
+    new TestRuntimeSuite(runtime).exec(command, env)
+
+    then:
+    1 * iastModule.onRuntimeExec(command)
+    1 * runtime.exec(command, env)
+    0 * _
+  }
+
+  def 'test exec with command string array'() {
+    setup:
+    final runtime = Mock(Runtime)
+    final iastModule = Mock(IastModule)
+    final command = ['ls', '-lah'] as String[]
+    InstrumentationBridge.registerIastModule(iastModule)
+
+    when:
+    new TestRuntimeSuite(runtime).exec(command)
+
+    then:
+    1 * iastModule.onRuntimeExec(command)
+    1 * runtime.exec(command)
+    0 * _
+  }
+
+  def 'test exec with command string array and env array'() {
+    setup:
+    final runtime = Mock(Runtime)
+    final iastModule = Mock(IastModule)
+    final command = ['ls', '-lah'] as String[]
+    final env = ['DD_TRACE_DEBUG=true'] as String[]
+    InstrumentationBridge.registerIastModule(iastModule)
+
+    when:
+    new TestRuntimeSuite(runtime).exec(command, env)
+
+    then:
+    1 * iastModule.onRuntimeExec(command)
+    1 * runtime.exec(command, env)
+    0 * _
+  }
+
+  def 'test exec with command string and env array and dir'() {
+    setup:
+    final runtime = Mock(Runtime)
+    final iastModule = Mock(IastModule)
+    final command = 'ls'
+    final env = ['DD_TRACE_DEBUG=true'] as String[]
+    final file = Mock(File)
+    InstrumentationBridge.registerIastModule(iastModule)
+
+    when:
+    new TestRuntimeSuite(runtime).exec(command, env, file)
+
+    then:
+    1 * iastModule.onRuntimeExec(command)
+    1 * runtime.exec(command, env, file)
+    0 * _
+  }
+
+  def 'test exec with command string array and env array and dir'() {
+    setup:
+    final runtime = Mock(Runtime)
+    final iastModule = Mock(IastModule)
+    final command = ['ls', '-lah'] as String[]
+    final env = ['DD_TRACE_DEBUG=true'] as String[]
+    final file = Mock(File)
+    InstrumentationBridge.registerIastModule(iastModule)
+
+    when:
+    new TestRuntimeSuite(runtime).exec(command, env, file)
+
+    then:
+    1 * iastModule.onRuntimeExec(command)
+    1 * runtime.exec(command, env, file)
+    0 * _
+  }
+}

--- a/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestProcessBuilderSuite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestProcessBuilderSuite.java
@@ -1,0 +1,18 @@
+package foo.bar;
+
+import java.io.IOException;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestProcessBuilderSuite {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TestProcessBuilderSuite.class);
+
+  public static Process start(final List<String> command) throws IOException {
+    LOGGER.debug("Before process builder start {}", command);
+    final Process result = new ProcessBuilder(command).start();
+    LOGGER.debug("After process builder init {}", result);
+    return result;
+  }
+}

--- a/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestRuntimeSuite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestRuntimeSuite.java
@@ -1,0 +1,61 @@
+package foo.bar;
+
+import java.io.File;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestRuntimeSuite {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TestRuntimeSuite.class);
+
+  private final Runtime runtime;
+
+  public TestRuntimeSuite(final Runtime runtime) {
+    this.runtime = runtime;
+  }
+
+  public Process exec(final String command) throws IOException {
+    LOGGER.debug("Before runtime exec {}", command);
+    final Process result = runtime.exec(command);
+    LOGGER.debug("After runtime exec {}", result);
+    return result;
+  }
+
+  public Process exec(final String[] command) throws IOException {
+    LOGGER.debug("Before runtime exec {}", (Object) command);
+    final Process result = runtime.exec(command);
+    LOGGER.debug("After runtime exec {}", result);
+    return result;
+  }
+
+  public Process exec(final String command, final String[] envp) throws IOException {
+    LOGGER.debug("Before runtime exec {} {}", command, envp);
+    final Process result = runtime.exec(command, envp);
+    LOGGER.debug("After runtime exec {}", result);
+    return result;
+  }
+
+  public Process exec(final String[] command, final String[] envp) throws IOException {
+    LOGGER.debug("Before runtime exec {} {}", command, envp);
+    final Process result = runtime.exec(command, envp);
+    LOGGER.debug("After runtime exec {}", result);
+    return result;
+  }
+
+  public Process exec(final String command, final String[] envp, final File file)
+      throws IOException {
+    LOGGER.debug("Before runtime exec {} {} {}", command, envp, file);
+    final Process result = runtime.exec(command, envp, file);
+    LOGGER.debug("After runtime exec {}", result);
+    return result;
+  }
+
+  public Process exec(final String[] command, final String[] envp, final File file)
+      throws IOException {
+    LOGGER.debug("Before runtime exec {} {} {}", command, envp, file);
+    final Process result = runtime.exec(command, envp, file);
+    LOGGER.debug("After runtime exec {}", result);
+    return result;
+  }
+}

--- a/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -3,7 +3,8 @@ package datadog.smoketest.springboot.controller;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import org.apache.catalina.servlet4preview.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,5 +35,34 @@ public class IastWebController {
     // TestSuite testSuite = new TestSuite(new HttpServletRequestWrapper(request));
     // testSuite.getParameterMap();
     return "Param is: " + param;
+  }
+
+  @GetMapping("/cmdi/runtime")
+  public String commandInjectionRuntime(final HttpServletRequest request) {
+    withProcess(() -> Runtime.getRuntime().exec(request.getParameter("cmd")));
+    return "Command Injection page";
+  }
+
+  @GetMapping("/cmdi/process_builder")
+  public String commandInjectionProcessBuilder(final HttpServletRequest request) {
+    withProcess(() -> new ProcessBuilder(request.getParameter("cmd")).start());
+    return "Command Injection page";
+  }
+
+  private void withProcess(final Operation<Process> op) {
+    Process process = null;
+    try {
+      process = op.run();
+    } catch (final Throwable e) {
+      // ignore it
+    } finally {
+      if (process != null && process.isAlive()) {
+        process.destroyForcibly();
+      }
+    }
+  }
+
+  private interface Operation<E> {
+    E run() throws Throwable;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/IastModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/IastModule.java
@@ -1,5 +1,6 @@
 package datadog.trace.api.iast;
 
+import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -37,4 +38,8 @@ public interface IastModule {
       @Nullable String recipe,
       @Nullable Object[] dynamicConstants,
       @Nonnull int[] recipeOffsets);
+
+  void onRuntimeExec(@Nonnull String... command);
+
+  void onProcessBuilderStart(@Nonnull List<String> command);
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/InstrumentationBridge.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/InstrumentationBridge.java
@@ -1,5 +1,6 @@
 package datadog.trace.api.iast;
 
+import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
@@ -140,6 +141,26 @@ public abstract class InstrumentationBridge {
       }
     } catch (Throwable t) {
       onUnexpectedException("Callback for onJdbcQuery threw.", t);
+    }
+  }
+
+  public static void onRuntimeExec(@Nonnull final String... command) {
+    try {
+      if (MODULE != null) {
+        MODULE.onRuntimeExec(command);
+      }
+    } catch (final Throwable t) {
+      onUnexpectedException("Callback for onRuntimeExec threw.", t);
+    }
+  }
+
+  public static void onProcessBuilderStart(@Nonnull final List<String> command) {
+    try {
+      if (MODULE != null) {
+        MODULE.onProcessBuilderStart(command);
+      }
+    } catch (final Throwable t) {
+      onUnexpectedException("Callback for onProcessBuilderStart threw.", t);
     }
   }
 

--- a/internal-api/src/test/groovy/datadog/trace/api/iast/InstrumentationBridgeTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/iast/InstrumentationBridgeTest.groovy
@@ -308,4 +308,76 @@ class InstrumentationBridgeTest extends DDSpecification {
     1 * module.onStringConcatFactory(_, _, _, _, _) >> { throw new Error('Boom!!!') }
     noExceptionThrown()
   }
+
+  def "bridge calls module when a when a runtime exec call is detected"() {
+    setup:
+    final module = Mock(IastModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    InstrumentationBridge.onRuntimeExec('ls', '-lah')
+
+    then:
+    1 * module.onRuntimeExec('ls', '-lah')
+  }
+
+  def "bridge calls don't fail with null module when a runtime exec call is detected"() {
+    setup:
+    InstrumentationBridge.registerIastModule(null)
+
+    when:
+    InstrumentationBridge.onRuntimeExec('ls', '-lah')
+
+    then:
+    noExceptionThrown()
+  }
+
+  def "bridge calls don't leak exceptions when a runtime exec call is detected"() {
+    setup:
+    final module = Mock(IastModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    InstrumentationBridge.onRuntimeExec('ls', '-lah')
+
+    then:
+    1 * module.onRuntimeExec(_) >> { throw new Error('Boom!!!') }
+    noExceptionThrown()
+  }
+
+  def "bridge calls module when a when a process builder start call is detected"() {
+    setup:
+    final module = Mock(IastModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    InstrumentationBridge.onProcessBuilderStart(['ls', '-lah'])
+
+    then:
+    1 * module.onProcessBuilderStart(['ls', '-lah'])
+  }
+
+  def "bridge calls don't fail with null module when a process builder start call is detected"() {
+    setup:
+    InstrumentationBridge.registerIastModule(null)
+
+    when:
+    InstrumentationBridge.onProcessBuilderStart(['ls', '-lah'])
+
+    then:
+    noExceptionThrown()
+  }
+
+  def "bridge calls don't leak exceptions when a process builder start call is detected"() {
+    setup:
+    final module = Mock(IastModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    InstrumentationBridge.onProcessBuilderStart(['ls', '-lah'])
+
+    then:
+    1 * module.onProcessBuilderStart(_) >> { throw new Error('Boom!!!') }
+    noExceptionThrown()
+  }
 }


### PR DESCRIPTION
# What Does This Do
Add support for command injection detection by instrumenting calls to `Runtime.exec(...)` and `ProcessBuilder.start()`

# Motivation

# Additional Notes
