### PR TITLE
Update jnr-ffi and jnr-unixsocket

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -24,8 +24,8 @@ final class CachedData {
     kotlin        : "1.3.72",
     coroutines    : "1.3.0",
     dogstatsd     : "4.1.0",
-    jnr_unixsocket: "0.28",
-    jnr_ffi       : '2.1.12', // dependency of jnr_unixsocket: update in tandem
+    jnr_unixsocket: "0.36",
+    jnr_ffi       : '2.1.16', // dependency of jnr_unixsocket: update in tandem
     commons       : "3.2",
     mockito       : '4.4.0',
     jctools       : '3.3.0',


### PR DESCRIPTION
# What Does This Do
Update jnr-ffi and jnr-unixsocket to the latest version supporting Java 7.

# Motivation

# Additional Notes
