### PR TITLE
Go back to actions/github-script@v6

### DIFF
--- a/.github/workflows/add-assets-to-release.yaml
+++ b/.github/workflows/add-assets-to-release.yaml
@@ -27,7 +27,7 @@ jobs:
           echo "Failing job. Release name is invalid for this tag. Clear the contents of the Release Name field and retry."
           exit 1
       - name: Update release name
-        uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # 6.3.3
         with:
           script: |
             const VERSION = process.env.VERSION


### PR DESCRIPTION
# What Does This Do
Go back to actions/github-script@v6.

# Motivation
Current version is incompatible with the script.

# Additional Notes
* This is a follow up to #4048, which reverted the action to an incompatible version.
* We'll need to add `actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0` to the repository allowlist.
* **Not tested.**