### PR TITLE
Add DD_TAGS tags into snapshot/probe status tags

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/JsonSnapshotSerializer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/JsonSnapshotSerializer.java
@@ -145,15 +145,6 @@ public class JsonSnapshotSerializer implements DebuggerContext.SnapshotSerialize
       this.timestamp = debugger.snapshot.getTimestamp();
     }
 
-    public static String concatTags(String... tags) {
-      StringBuilder sb = new StringBuilder();
-      for (String tag : tags) {
-        sb.append(tag);
-        sb.append(",");
-      }
-      return sb.substring(0, sb.length() - 1); // Remove last comma
-    }
-
     public String getService() {
       return service;
     }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
@@ -1,7 +1,6 @@
 package com.datadog.debugger.sink;
 
 import com.datadog.debugger.agent.DebuggerAgent;
-import com.datadog.debugger.agent.JsonSnapshotSerializer;
 import com.datadog.debugger.uploader.BatchUploader;
 import com.datadog.debugger.util.DebuggerMetrics;
 import datadog.trace.api.Config;
@@ -10,6 +9,7 @@ import datadog.trace.bootstrap.debugger.DiagnosticMessage;
 import datadog.trace.bootstrap.debugger.Snapshot;
 import datadog.trace.core.DDTraceCoreInfo;
 import datadog.trace.util.AgentTaskScheduler;
+import datadog.trace.util.TagsHelper;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -82,16 +82,16 @@ public class DebuggerSink implements DebuggerContext.Sink {
       ProbeStatusSink probeStatusSink,
       SnapshotSink snapshotSink) {
     this.batchUploader = batchUploader;
-    tags = buildTags(config);
+    tags = getDefaultTagsMergedWithGlobalTags(config);
     this.debuggerMetrics = debuggerMetrics;
     this.probeStatusSink = probeStatusSink;
     this.snapshotSink = snapshotSink;
     this.uploadFlushInterval = config.getDebuggerUploadFlushInterval();
   }
 
-  private static String buildTags(Config config) {
+  private static String getDefaultTagsMergedWithGlobalTags(Config config) {
     String debuggerTags =
-        JsonSnapshotSerializer.IntakeRequest.concatTags(
+        TagsHelper.concatTags(
             "env:" + config.getEnv(),
             "version:" + config.getVersion(),
             "debugger_version:" + DDTraceCoreInfo.VERSION,

--- a/internal-api/src/main/java/datadog/trace/util/TagsHelper.java
+++ b/internal-api/src/main/java/datadog/trace/util/TagsHelper.java
@@ -66,4 +66,13 @@ public final class TagsHelper {
         || c == '/'
         || c == ':';
   }
+
+  public static String concatTags(String... tags) {
+    StringBuilder sb = new StringBuilder();
+    for (String tag : tags) {
+      sb.append(tag);
+      sb.append(",");
+    }
+    return sb.substring(0, sb.length() - 1); // Remove last comma
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/util/TagsHelper.java
+++ b/internal-api/src/main/java/datadog/trace/util/TagsHelper.java
@@ -68,6 +68,9 @@ public final class TagsHelper {
   }
 
   public static String concatTags(String... tags) {
+    if (tags == null || tags.length == 0) {
+      return "";
+    }
     StringBuilder sb = new StringBuilder();
     for (String tag : tags) {
       sb.append(tag);

--- a/internal-api/src/test/java/datadog/trace/util/TagsHelperTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/TagsHelperTest.java
@@ -56,4 +56,12 @@ public class TagsHelperTest {
     assertEquals(200, TagsHelper.sanitize(tag.toString()).length());
     assertEquals(200, TagsHelper.sanitize(tag.toString()).getBytes(StandardCharsets.UTF_8).length);
   }
+
+  @Test
+  public void concat() {
+    assertEquals("", TagsHelper.concatTags());
+    assertEquals("", TagsHelper.concatTags(""));
+    assertEquals("foo:bar", TagsHelper.concatTags("foo:bar"));
+    assertEquals("foo0:bar0,foo1:bar1", TagsHelper.concatTags("foo0:bar0", "foo1:bar1"));
+  }
 }


### PR DESCRIPTION
# What Does This Do
using the tracer global tags that includes DD_TAGS we can add custom tags to the snapshot or probe statuses.

# Motivation
This is useful for Source Code Integration which requires tags for commit sha and repository

# Additional Notes
