### PR TITLE
add option to exclude rabbitmq routingKey from resource name

### DIFF
--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
@@ -95,7 +95,7 @@ public class RabbitDecorator extends MessagingClientDecorator {
         routingKey == null || routingKey.isEmpty()
             ? "<all>"
             : routingKey.startsWith("amq.gen-") ? "<generated>" : routingKey;
-    span.setResourceName("basic.publish " + exchangeName + " -> " + routing);
+    span.setResourceName(buildResourceName("basic.publish", exchangeName, routing));
     span.setTag(AMQP_EXCHANGE, exchange);
     span.setTag(AMQP_ROUTING_KEY, routingKey);
   }
@@ -147,6 +147,15 @@ public class RabbitDecorator extends MessagingClientDecorator {
       return "<generated>";
     }
     return queueName;
+  }
+
+  private String buildResourceName(
+      final String opName, final String exchangeName, final String routingKey) {
+    final String prefix = opName + " " + exchangeName;
+    if (Config.get().isRabbitRoutingKeyExcludedFromResourceName()) {
+      return prefix;
+    }
+    return prefix + " -> " + routingKey;
   }
 
   public TracedDelegatingConsumer wrapConsumer(String queue, Consumer consumer) {

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
@@ -151,11 +151,16 @@ public class RabbitDecorator extends MessagingClientDecorator {
 
   private String buildResourceName(
       final String opName, final String exchangeName, final String routingKey) {
-    final String prefix = opName + " " + exchangeName;
-    if (Config.get().isRabbitRoutingKeyExcludedFromResourceName()) {
-      return prefix;
+    // pre-size to the worst case length
+    final StringBuilder prefix =
+        new StringBuilder(opName.length() + exchangeName.length() + routingKey.length() + 5)
+            .append(opName)
+            .append(" ")
+            .append(exchangeName);
+    if (Config.get().isRabbitIncludeRoutingKeyInResource()) {
+      prefix.append(" -> ").append(routingKey);
     }
-    return prefix + " -> " + routingKey;
+    return prefix.toString();
   }
 
   public TracedDelegatingConsumer wrapConsumer(String queue, Consumer consumer) {

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -952,7 +952,7 @@ class RabbitMQRoutingKeyExcludedForkedTest extends RabbitMQTestBase {
   void configurePreAgent() {
     super.configurePreAgent()
     injectSysConfig("dd.service", "RabbitMQRoutingKeyExcludedForkedTest")
-    injectSysConfig("dd.rabbit.exclude.routingkey.from.resource", "true")
+    injectSysConfig("dd.rabbit.include.routingkey.in.resource", "false")
     injectSysConfig("dd.rabbit.legacy.tracing.enabled", "false")
   }
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -63,8 +63,8 @@ public final class TraceInstrumentationConfig {
   public static final String RABBIT_PROPAGATION_DISABLED_EXCHANGES =
       "rabbit.propagation.disabled.exchanges";
 
-  public static final String RABBIT_EXCLUDE_ROUTINGKEY_FROM_RESOURCE =
-      "rabbit.exclude.routingkey.from.resource";
+  public static final String RABBIT_INCLUDE_ROUTINGKEY_IN_RESOURCE =
+      "rabbit.include.routingkey.in.resource";
 
   public static final String MESSAGE_BROKER_SPLIT_BY_DESTINATION =
       "message.broker.split-by-destination";

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -63,6 +63,9 @@ public final class TraceInstrumentationConfig {
   public static final String RABBIT_PROPAGATION_DISABLED_EXCHANGES =
       "rabbit.propagation.disabled.exchanges";
 
+  public static final String RABBIT_EXCLUDE_ROUTINGKEY_FROM_RESOURCE =
+      "rabbit.exclude.routingkey.from.resource";
+
   public static final String MESSAGE_BROKER_SPLIT_BY_DESTINATION =
       "message.broker.split-by-destination";
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -254,6 +254,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_MDC_TAGS_
 import static datadog.trace.api.config.TraceInstrumentationConfig.MESSAGE_BROKER_SPLIT_BY_DESTINATION;
 import static datadog.trace.api.config.TraceInstrumentationConfig.OBFUSCATION_QUERY_STRING_REGEXP;
 import static datadog.trace.api.config.TraceInstrumentationConfig.PLAY_REPORT_HTTP_STATUS;
+import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_EXCLUDE_ROUTINGKEY_FROM_RESOURCE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGATION_DISABLED_EXCHANGES;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGATION_DISABLED_QUEUES;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_OUTLINE_POOL_ENABLED;
@@ -588,6 +589,8 @@ public class Config {
   private final boolean rabbitPropagationEnabled;
   private final Set<String> rabbitPropagationDisabledQueues;
   private final Set<String> rabbitPropagationDisabledExchanges;
+
+  private final boolean rabbitRoutingKeyExcludedFromResourceName;
 
   private final boolean messageBrokerSplitByDestination;
 
@@ -1256,6 +1259,8 @@ public class Config {
         tryMakeImmutableSet(configProvider.getList(RABBIT_PROPAGATION_DISABLED_QUEUES));
     rabbitPropagationDisabledExchanges =
         tryMakeImmutableSet(configProvider.getList(RABBIT_PROPAGATION_DISABLED_EXCHANGES));
+    rabbitRoutingKeyExcludedFromResourceName =
+        configProvider.getBoolean(RABBIT_EXCLUDE_ROUTINGKEY_FROM_RESOURCE, false);
 
     messageBrokerSplitByDestination =
         configProvider.getBoolean(MESSAGE_BROKER_SPLIT_BY_DESTINATION, false);
@@ -2017,6 +2022,10 @@ public class Config {
     return null != queueOrExchange
         && (rabbitPropagationDisabledQueues.contains(queueOrExchange)
             || rabbitPropagationDisabledExchanges.contains(queueOrExchange));
+  }
+
+  public boolean isRabbitRoutingKeyExcludedFromResourceName() {
+    return rabbitRoutingKeyExcludedFromResourceName;
   }
 
   public boolean isMessageBrokerSplitByDestination() {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -254,7 +254,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_MDC_TAGS_
 import static datadog.trace.api.config.TraceInstrumentationConfig.MESSAGE_BROKER_SPLIT_BY_DESTINATION;
 import static datadog.trace.api.config.TraceInstrumentationConfig.OBFUSCATION_QUERY_STRING_REGEXP;
 import static datadog.trace.api.config.TraceInstrumentationConfig.PLAY_REPORT_HTTP_STATUS;
-import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_EXCLUDE_ROUTINGKEY_FROM_RESOURCE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_INCLUDE_ROUTINGKEY_IN_RESOURCE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGATION_DISABLED_EXCHANGES;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGATION_DISABLED_QUEUES;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_OUTLINE_POOL_ENABLED;
@@ -590,7 +590,7 @@ public class Config {
   private final Set<String> rabbitPropagationDisabledQueues;
   private final Set<String> rabbitPropagationDisabledExchanges;
 
-  private final boolean rabbitRoutingKeyExcludedFromResourceName;
+  private final boolean rabbitIncludeRoutingKeyInResource;
 
   private final boolean messageBrokerSplitByDestination;
 
@@ -1259,8 +1259,8 @@ public class Config {
         tryMakeImmutableSet(configProvider.getList(RABBIT_PROPAGATION_DISABLED_QUEUES));
     rabbitPropagationDisabledExchanges =
         tryMakeImmutableSet(configProvider.getList(RABBIT_PROPAGATION_DISABLED_EXCHANGES));
-    rabbitRoutingKeyExcludedFromResourceName =
-        configProvider.getBoolean(RABBIT_EXCLUDE_ROUTINGKEY_FROM_RESOURCE, false);
+    rabbitIncludeRoutingKeyInResource =
+        configProvider.getBoolean(RABBIT_INCLUDE_ROUTINGKEY_IN_RESOURCE, true);
 
     messageBrokerSplitByDestination =
         configProvider.getBoolean(MESSAGE_BROKER_SPLIT_BY_DESTINATION, false);
@@ -2024,8 +2024,8 @@ public class Config {
             || rabbitPropagationDisabledExchanges.contains(queueOrExchange));
   }
 
-  public boolean isRabbitRoutingKeyExcludedFromResourceName() {
-    return rabbitRoutingKeyExcludedFromResourceName;
+  public boolean isRabbitIncludeRoutingKeyInResource() {
+    return rabbitIncludeRoutingKeyInResource;
   }
 
   public boolean isMessageBrokerSplitByDestination() {


### PR DESCRIPTION
# What Does This Do

Add an option to exclude rabbitMQ routing key from the publisher's resource name. This can be used to reduce the cardinality of generated spans' resources.

The feature is driven by the system property  `dd.trace.rabbit.include.routingkey.in.resource` (or env `DD_TRACE_RABBIT_INCLUDE_ROUTINGKEY_IN_RESOURCE`) which is enabled by default (it's the current behaviour).

Setting it to false will exclude the routingKey to be part of the span resource name

# Motivation

# Additional Notes

Being a breaking change, the option is disabled by default
