### PR TITLE
"Automagically" create dd_crash_uploader script for crash tracking.

### DIFF
--- a/dd-java-agent/agent-crashtracking/agent-crashtracking.gradle
+++ b/dd-java-agent/agent-crashtracking/agent-crashtracking.gradle
@@ -10,6 +10,12 @@ apply from: "$rootDir/gradle/java.gradle"
 minimumBranchCoverage = 0.6
 minimumInstructionCoverage = 0.9
 
+evaluationDependsOn ':dd-java-agent'
+
+tasks.withType(Test).configureEach { subTask ->
+  dependsOn project(':dd-java-agent').tasks.named("shadowJar")
+}
+
 dependencies {
   implementation deps.slf4j
   implementation project(':communication')

--- a/dd-java-agent/agent-crashtracking/agent-crashtracking.gradle
+++ b/dd-java-agent/agent-crashtracking/agent-crashtracking.gradle
@@ -8,7 +8,10 @@ apply from: "$rootDir/gradle/java.gradle"
 
 // FIXME: Improve test coverage.
 minimumBranchCoverage = 0.6
-minimumInstructionCoverage = 0.9
+// runtime dependent parts (eg. looking up values from the JVM args) are not easy to exercise in unit tests
+// the minimum coverage is reduced to reflect that
+// minimumInstructionCoverage = 0.9
+minimumInstructionCoverage = 0.7
 
 evaluationDependsOn ':dd-java-agent'
 

--- a/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/ScriptInitializer.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/ScriptInitializer.java
@@ -1,0 +1,137 @@
+package com.datadog.crashtracking;
+
+import com.sun.management.HotSpotDiagnosticMXBean;
+import datadog.common.process.PidHelper;
+import datadog.trace.api.Platform;
+import datadog.trace.util.Strings;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.management.ManagementFactory;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Comparator;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class ScriptInitializer {
+  private static final Logger log = LoggerFactory.getLogger(ScriptInitializer.class);
+
+  /**
+   * If the value of `-XX:OnError` JVM argument is referring to `dd_crash_uploader.sh` or
+   * `dd_crash_uploader.bat` and the script does not exist it will be created and prefilled with
+   * code ensuring the error log upload will be triggered on JVM crash.
+   */
+  public static void initialize() {
+    try {
+      // this is HotSpot specific implementation (eg. will not work for IBM J9)
+      HotSpotDiagnosticMXBean diagBean =
+          ManagementFactory.getPlatformMXBean(HotSpotDiagnosticMXBean.class);
+      String onErrorVal = diagBean.getVMOption("OnError").getValue();
+      String onErrorFile =
+          Strings.replace(
+              diagBean.getVMOption("ErrorFile").getValue(), "%p", Long.toString(PidHelper.PID));
+      initialize(onErrorVal, onErrorFile);
+    } catch (Throwable t) {
+      log.warn(
+          "Failed creating custom crash upload script. Crash tracking will not work properly.", t);
+    }
+  }
+
+  // @VisibleForTests
+  static void initialize(String onErrorVal, String onErrorFile) throws IOException {
+    if (onErrorVal == null || onErrorVal.isEmpty()) {
+      log.debug("'-XX:OnError' argument was not provided. Crash tracking is disabled.");
+      return;
+    }
+    if (onErrorFile == null || onErrorFile.isEmpty()) {
+      log.debug("'-XX:ErrorFile' argument was not provided. Crash tracking is disabled.");
+      return;
+    }
+    Path scriptPath = Paths.get(onErrorVal);
+    if (scriptPath.getFileName().toString().toLowerCase().contains("dd_crash_uploader")
+        && Files.notExists(scriptPath)) {
+      try {
+        Files.createDirectories(scriptPath.getParent());
+      } catch (FileAlreadyExistsException ignored) {
+        // can be safely ignored; if the folder exists we will just reuse it
+      }
+      String agentJar = findAgentJar();
+      if (agentJar == null) {
+        log.warn("Unable to locate the agent jar. Crash tracking will not work properly.");
+        return;
+      }
+      writeScript(onErrorFile, agentJar, scriptPath);
+    }
+  }
+
+  private static void writeScript(String crashFile, String execClass, Path scriptPath)
+      throws IOException {
+    log.debug("Writing crash uploader script: {}", scriptPath);
+    try (BufferedReader br = new BufferedReader(new InputStreamReader(getScriptData()))) {
+      try (BufferedWriter bw = Files.newBufferedWriter(scriptPath)) {
+        br.lines()
+            .map(
+                line ->
+                    Strings.replace(
+                        Strings.replace(line, "!AGENT_JAR!", execClass),
+                        "!JAVA_ERROR_FILE!",
+                        crashFile))
+            .forEach(line -> writeLine(bw, line));
+      }
+    }
+    Files.setPosixFilePermissions(scriptPath, PosixFilePermissions.fromString("r-xr-x---"));
+  }
+
+  private static void writeLine(BufferedWriter bw, String line) {
+    try {
+      bw.write(line);
+      bw.newLine();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static InputStream getScriptData() {
+    String name = Platform.isWindows() ? "upload_crash.bat" : "upload_crash.sh";
+    return CrashUploader.class.getResourceAsStream(name);
+  }
+
+  private static String findAgentJar() throws IOException {
+    String agentPath = null;
+    String selfClass =
+        CrashUploader.class
+            .getClassLoader()
+            .getResource(CrashUploader.class.getName().replace('.', '/') + ".class")
+            .toString();
+    if (selfClass.startsWith("jar:file:")) {
+      int idx = selfClass.lastIndexOf(".jar");
+      if (idx > -1) {
+        agentPath = selfClass.substring(9, idx + 4);
+      }
+    } else {
+      // test harness env is different; use the known project structure to locate the agent jar
+      if (selfClass.startsWith("file:")) {
+        int idx = selfClass.lastIndexOf("dd-java-agent");
+        if (idx > -1) {
+          Path libsPath = Paths.get(selfClass.substring(5, idx + 13), "build", "libs");
+          try (Stream<Path> files = Files.walk(libsPath)) {
+            agentPath =
+                files
+                    .sorted(Comparator.reverseOrder())
+                    .filter(p -> p.getFileName().toString().toLowerCase().endsWith(".jar"))
+                    .findFirst()
+                    .toString();
+          }
+        }
+      }
+    }
+    return agentPath;
+  }
+}

--- a/dd-java-agent/agent-crashtracking/src/main/resources/com/datadog/crashtracking/upload_crash.bat
+++ b/dd-java-agent/agent-crashtracking/src/main/resources/com/datadog/crashtracking/upload_crash.bat
@@ -1,0 +1,4 @@
+@echo off
+
+java -jar "!AGENT_JAR!" uploadCrash "!JAVA_ERROR_FILE!"
+if %ERRORLEVEL% EQU 0 echo "Uploaded error file \"!JAVA_ERROR_FILE!\""

--- a/dd-java-agent/agent-crashtracking/src/main/resources/com/datadog/crashtracking/upload_crash.sh
+++ b/dd-java-agent/agent-crashtracking/src/main/resources/com/datadog/crashtracking/upload_crash.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+
+java -jar "!AGENT_JAR!" uploadCrash "!JAVA_ERROR_FILE!"
+if [ $? -eq 0 ]; then
+  echo "Uploaded error file \"!JAVA_ERROR_FILE!\""
+fi

--- a/dd-java-agent/agent-crashtracking/src/test/java/com/datadog/crashtracking/ScriptInitializerTest.java
+++ b/dd-java-agent/agent-crashtracking/src/test/java/com/datadog/crashtracking/ScriptInitializerTest.java
@@ -1,0 +1,83 @@
+package com.datadog.crashtracking;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Comparator;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class ScriptInitializerTest {
+  private Path tempDir;
+
+  @BeforeEach
+  void setup() throws Exception {
+    tempDir = Files.createTempDirectory("dd-test-");
+  }
+
+  @AfterEach
+  void teardown() throws Exception {
+    Files.walk(tempDir).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+    Files.deleteIfExists(tempDir);
+  }
+
+  @Test
+  void testSanity() {
+    assertDoesNotThrow(() -> ScriptInitializer.initialize(null, null));
+    assertDoesNotThrow(
+        () -> ScriptInitializer.initialize(tempDir.resolve("dummy.sh").toString(), null));
+    assertDoesNotThrow(() -> ScriptInitializer.initialize(null, "hs_err.log"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"dd_crash_uploader.sh", "dd_crash_uploader.bat"})
+  void testInitializationSuccess(String target) throws IOException {
+    Path file = tempDir.resolve(target);
+    String hsErrFile = "/tmp/hs_err.log";
+    ScriptInitializer.initialize(file.toString(), hsErrFile);
+    assertTrue(Files.exists(file), "File " + file + " should have been created");
+    List<String> lines = Files.readAllLines(file);
+    assertFalse(lines.isEmpty(), "File " + file + " is expected to be non-empty");
+    // sanity to check the crash log file was properly replaced in the script
+    assertTrue(lines.stream().anyMatch(l -> l.contains(hsErrFile)));
+  }
+
+  @Test
+  void testNoInitialization() throws IOException {
+    // the initializer needs a particular script name to kick-in
+    Path file = tempDir.resolve("some_other_script.sh");
+    String hsErrFile = "/tmp/hs_err.log";
+    ScriptInitializer.initialize(file.toString(), hsErrFile);
+    assertFalse(Files.exists(file), "File " + file + " should not have been created");
+  }
+
+  @Test
+  void testInitializationExisting() throws IOException {
+    Path file = tempDir.resolve("dd_crash_uploader.sh");
+    Files.createFile(file);
+    ScriptInitializer.initialize(file.toString(), "/tmp/hs_err.log");
+    assertTrue(Files.exists(file), "File " + file + " should not have been removed");
+    assertTrue(
+        Files.readAllLines(file).isEmpty(),
+        "File " + file + " content should not have been modified");
+  }
+
+  @Test
+  void testInvalidFolder() throws IOException {
+    Files.setPosixFilePermissions(tempDir, PosixFilePermissions.fromString("r-x------"));
+    Path file = tempDir.resolve("dd_crash_uploader.sh");
+    assertThrows(
+        IOException.class, () -> ScriptInitializer.initialize(file.toString(), "/tmp/hs_err.log"));
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentCLI.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentCLI.java
@@ -70,11 +70,11 @@ public final class AgentCLI {
     for (String arg : args) {
       try {
         files.add(new FileInputStream(arg));
+        new CrashUploader().upload(files);
       } catch (FileNotFoundException | SecurityException e) {
         log.error("Failed to open {}", arg, e);
+        System.exit(1);
       }
     }
-
-    new CrashUploader().upload(files);
   }
 }


### PR DESCRIPTION
# What Does This Do
When `-XX:OnError=<action>` JVM arg is specified and `<action>` is a script file named `dd_crash_uploader.sh` or `dd_crash_uploader.bat` (for windows), regardless of in which directory that script should be located, the action script will be 'automagically' generated at the agent startup.
In case of a failure to generate the script (non-accessible location, already existing etc.) this step will be just skipped without affecting the rest of the agent startup.

# Motivation
Although we are able to pick up the crash log file and upload it to our intake, the configuration itself is pretty involved. One needs to create a script to redirect the on-crash action to our `AgentCLI` action, set it up to pick up the crash log file (which can be located in some other place using `-XX:ErrorLogFile` JVM argument) and then wire it back using the `-XX:OnError` JVM argument.
All of this requires a lot of typing or copy-pasting when errors can be introduced. Therefore, having an automated script setup based only on the `-XX:OnError` (and optionally `-XX:ErrorLogFile`) JVM arguments sounds as a good way to improve onboarding, at least until we have full auto-injection support.

# Additional Notes
