### PR TITLE
Loop protection for PathwayContext

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
@@ -14,11 +14,11 @@ import datadog.trace.bootstrap.instrumentation.api.PathwayContext;
 import datadog.trace.bootstrap.instrumentation.api.StatsPoint;
 import datadog.trace.core.Base64Decoder;
 import datadog.trace.core.Base64Encoder;
+import datadog.trace.core.util.LRUCache;
 import datadog.trace.util.FNV64Hash;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -47,7 +47,7 @@ public class DefaultPathwayContext implements PathwayContext {
   private long hash;
   private boolean started;
   // used to detect and prevent loops in case of inaccurate / incomplete instrumentation
-  private final HashMap<Long, Long> history = new HashMap<Long, Long>();
+  private final LRUCache<Long, Long> history = new LRUCache<Long, Long>(10000);
 
   private static final Set<String> hashableTagKeys =
       new HashSet<String>(

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DefaultPathwayContextTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DefaultPathwayContextTest.groovy
@@ -104,7 +104,10 @@ class DefaultPathwayContextTest extends DDCoreSpecification {
     with(pointConsumer.points[2]) {
       edgeTags == ["group:group", "topic:topic", "type:kafka"]
       edgeTags.size() == 3
-      parentHash == pointConsumer.points[1].hash
+      // this point should have the first point as parent,
+      // as the loop protection will reset the parent if two identical
+      // points (same hash for tag values) are about to form a hierarchy
+      parentHash == pointConsumer.points[0].hash
       hash != 0
       pathwayLatencyNano == 55
       edgeLatencyNano == 30


### PR DESCRIPTION
# What Does This Do
This PR adds a simple loop protection to the PathwayContext, aiming to detect and resolve situations when two identical operations become logically nested. 

A simple example:

You have a Google PubSub listener, which receives a message and then pushes it to two separate gRPC destinations, sequentially. All 3 operations will share the same context, and each time you're calling setCheckpoint, your PathwayContext will get modified. As the result, the second gRPC outgoing call will consider the first one its parent, creating a loop. 
