### PR TITLE
Log telemetry request success

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
@@ -126,6 +126,8 @@ public class TelemetryRunnable implements Runnable {
           "Telemetry Intake Service responded with: " + response.code() + " " + response.message());
       return false;
     }
+
+    log.info("Telemetry message sent successfully");
     return true;
   }
 


### PR DESCRIPTION
# What Does This Do

Log telemetry request success.

# Motivation

There can be occasional errors submitting telemetry, which will be logged to warning, while there were no logs for success, giving the impression that telemetry was broken. Seeing success messages helps assessing the status.

# Additional Notes

We'll probably need to improve these logs to be more informative. This PR is just the bare minimum to see in the tracer that telemetry works.
