### PR TITLE
Fix concurrency issue in telemetry initialization

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/ConfigCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/ConfigCollector.java
@@ -1,11 +1,16 @@
 package datadog.trace.api;
 
 import java.util.Arrays;
-import java.util.LinkedHashMap;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 
-public class ConfigCollector extends LinkedHashMap<String, Object> {
+/**
+ * Collects system properties and environment variables set by the user and used by the tracer. Puts
+ * to this map will happen in Config and ConfigProvider classes, which can run concurrently with
+ * consumers. So this is based on a ConcurrentHashMap to deal with it.
+ */
+public class ConfigCollector extends ConcurrentHashMap<String, Object> {
 
   public static final Set<String> CONFIG_FILTER_LIST =
       new TreeSet<>(

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
@@ -1,5 +1,6 @@
 package datadog.telemetry;
 
+import datadog.trace.api.Config;
 import datadog.trace.api.ConfigCollector;
 import java.io.IOException;
 import java.util.List;
@@ -44,6 +45,9 @@ public class TelemetryRunnable implements Runnable {
 
   @Override
   public void run() {
+    // Ensure that Config has been initialized, so ConfigCollector can collect all settings first.
+    Config.get();
+
     log.debug("Adding APP_STARTED telemetry event");
     this.telemetryService.addConfiguration(ConfigCollector.get());
     for (TelemetryPeriodicAction action : this.actions) {


### PR DESCRIPTION
# What Does This Do

ConfigCollector.put could be called concurrently from Config/ConfigProvider concurrently with Telemetry iterating it. Changed it to a ConcurrentHashMap.

Also call go `Config.get()` before starting telemetry to ensure it is initialized at that point.

# Motivation

Reported exception:

```
Uncaught exception in dd-telemetry [exception:java.util.ConcurrentModificationException. at java.base/java.util.LinkedHashMap$LinkedHashIterator.nextNode(LinkedHashMap.java:756) at java.base/java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:788) at java.base/java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:786) at datadog.telemetry.TelemetryServiceImpl.addConfiguration(TelemetryServiceImpl.java:65) at datadog.telemetry.TelemetryRunnable.run(TelemetryRunnable.java:48) at java.base/java.lang.Thread.run(Thread.java:833)]
```

# Additional Notes
The chances of this issue being triggered probably increased when we made Telemetry initialization asynchronous (https://github.com/DataDog/dd-trace-java/pull/4029) since version [0.113.0](https://github.com/DataDog/dd-trace-java/milestone/150).