### PR TITLE
add IAST started debug log

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastSystem.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastSystem.java
@@ -35,6 +35,7 @@ public class IastSystem {
     InstrumentationBridge.registerIastModule(iastModule);
     registerRequestStartedCallback(ss, overheadController);
     registerRequestEndedCallback(ss, overheadController);
+    log.debug("IAST started");
   }
 
   private static void registerRequestStartedCallback(


### PR DESCRIPTION
# What Does This Do

Add debug log message when IAST is started 

# Motivation

When something goes wrong in dd.trace start up we need to know if IAST was started successfully 

# Additional Notes
