### PR TITLE
Remove OpsConfiguration from Configuration

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/Configuration.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/Configuration.java
@@ -1,6 +1,5 @@
 package com.datadog.debugger.agent;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -53,44 +52,6 @@ public class Configuration {
     }
   }
 
-  /** Stores operational configuration */
-  public static class OpsConfiguration {
-    private final long pollInterval;
-
-    public OpsConfiguration(long pollInterval) {
-      this.pollInterval = pollInterval;
-    }
-
-    public long getPollInterval() {
-      return pollInterval;
-    }
-
-    public Duration getPollIntervalDuration() {
-      return Duration.ofSeconds(pollInterval);
-    }
-
-    @Generated
-    @Override
-    public String toString() {
-      return "OperationConfiguration{" + "pollInterval=" + pollInterval + '}';
-    }
-
-    @Generated
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-      OpsConfiguration other = (OpsConfiguration) o;
-      return Objects.equals(pollInterval, other.pollInterval);
-    }
-
-    @Generated
-    @Override
-    public int hashCode() {
-      return Objects.hash(pollInterval);
-    }
-  }
-
   private final String id;
   private final long orgId;
   private final Collection<SnapshotProbe> snapshotProbes;
@@ -98,10 +59,9 @@ public class Configuration {
   private final FilterList allowList;
   private final FilterList denyList;
   private final SnapshotProbe.Sampling sampling;
-  private final OpsConfiguration opsConfig;
 
   public Configuration(String id, long orgId, Collection<SnapshotProbe> snapshotProbes) {
-    this(id, orgId, snapshotProbes, null, null, null, null, null);
+    this(id, orgId, snapshotProbes, null, null, null, null);
   }
 
   public Configuration(
@@ -109,7 +69,7 @@ public class Configuration {
       long orgId,
       Collection<SnapshotProbe> snapshotProbes,
       Collection<MetricProbe> metricProbes) {
-    this(id, orgId, snapshotProbes, metricProbes, null, null, null, null);
+    this(id, orgId, snapshotProbes, metricProbes, null, null, null);
   }
 
   public Configuration(
@@ -119,8 +79,7 @@ public class Configuration {
       Collection<MetricProbe> metricProbes,
       FilterList allowList,
       FilterList denyList,
-      SnapshotProbe.Sampling sampling,
-      OpsConfiguration opsConfig) {
+      SnapshotProbe.Sampling sampling) {
     this.id = id;
     this.orgId = orgId;
     this.snapshotProbes = snapshotProbes;
@@ -128,7 +87,6 @@ public class Configuration {
     this.allowList = allowList;
     this.denyList = denyList;
     this.sampling = sampling;
-    this.opsConfig = opsConfig;
   }
 
   public String getId() {
@@ -157,10 +115,6 @@ public class Configuration {
 
   public SnapshotProbe.Sampling getSampling() {
     return sampling;
-  }
-
-  public OpsConfiguration getOpsConfig() {
-    return opsConfig;
   }
 
   public Collection<ProbeDefinition> getDefinitions() {
@@ -193,8 +147,6 @@ public class Configuration {
         + denyList
         + ", sampling="
         + sampling
-        + ", opsConfig="
-        + opsConfig
         + '}';
   }
 
@@ -210,14 +162,12 @@ public class Configuration {
         && Objects.equals(metricProbes, that.metricProbes)
         && Objects.equals(allowList, that.allowList)
         && Objects.equals(denyList, that.denyList)
-        && Objects.equals(sampling, that.sampling)
-        && Objects.equals(opsConfig, that.opsConfig);
+        && Objects.equals(sampling, that.sampling);
   }
 
   @Generated
   @Override
   public int hashCode() {
-    return Objects.hash(
-        id, orgId, snapshotProbes, metricProbes, allowList, denyList, sampling, opsConfig);
+    return Objects.hash(id, orgId, snapshotProbes, metricProbes, allowList, denyList, sampling);
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -147,8 +147,7 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver {
         metricProbes,
         configuration.getAllowList(),
         configuration.getDenyList(),
-        configuration.getSampling(),
-        configuration.getOpsConfig());
+        configuration.getSampling());
   }
 
   Collection<SnapshotProbe> mergeDuplicatedProbes(Collection<SnapshotProbe> probes) {
@@ -221,10 +220,9 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver {
           null,
           currentConfiguration.getAllowList(),
           currentConfiguration.getDenyList(),
-          currentConfiguration.getSampling(),
-          currentConfiguration.getOpsConfig());
+          currentConfiguration.getSampling());
     }
-    return new Configuration("ID", 0, null, null, null, null, null, null);
+    return new Configuration("ID", 0, null, null, null, null, null);
   }
 
   private void retransformClasses(List<Class<?>> classesToBeTransformed) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -793,8 +793,7 @@ public class CapturedSnapshotTest {
             null,
             null,
             null,
-            new SnapshotProbe.Sampling(1),
-            null);
+            new SnapshotProbe.Sampling(1));
     DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, config);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     for (int i = 0; i < 100; i++) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationComparerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationComparerTest.java
@@ -170,7 +170,6 @@ class ConfigurationComparerTest {
             Collections.emptyList(),
             new Configuration.FilterList(Arrays.asList("com.datadog"), Collections.emptyList()),
             null,
-            null,
             null);
     ConfigurationComparer configurationComparer =
         new ConfigurationComparer(empty, config, Collections.emptyMap());
@@ -197,7 +196,6 @@ class ConfigurationComparerTest {
             Collections.emptyList(),
             new Configuration.FilterList(Arrays.asList("com.datadog"), Collections.emptyList()),
             null,
-            null,
             null);
     ConfigurationComparer configurationComparer =
         new ConfigurationComparer(noFilterConfig, config, instrumentationResults);
@@ -211,7 +209,6 @@ class ConfigurationComparerTest {
             Collections.singletonList(probe),
             Collections.emptyList(),
             new Configuration.FilterList(Arrays.asList("com.datacat"), Collections.emptyList()),
-            null,
             null,
             null);
 
@@ -248,7 +245,6 @@ class ConfigurationComparerTest {
             Collections.emptyList(),
             null,
             new Configuration.FilterList(Arrays.asList("com.datadog"), Collections.emptyList()),
-            null,
             null);
     ConfigurationComparer configurationComparer =
         new ConfigurationComparer(noFilterConfig, config, instrumentationResults);
@@ -281,7 +277,6 @@ class ConfigurationComparerTest {
             Collections.emptyList(),
             null,
             new Configuration.FilterList(Arrays.asList("com.datadog"), Collections.emptyList()),
-            null,
             null);
     ConfigurationComparer configurationComparer =
         new ConfigurationComparer(empty, config, Collections.emptyMap());

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
@@ -95,7 +95,6 @@ public class ConfigurationTest {
         new Configuration.FilterList(
             Arrays.asList("java.security"), Arrays.asList("javax.security.auth.AuthPermission"));
     SnapshotProbe.Sampling globalSampling = new SnapshotProbe.Sampling(10.0);
-    Configuration.OpsConfiguration opsConfiguration = new Configuration.OpsConfiguration(10);
     Configuration config1 =
         new Configuration(
             "service1",
@@ -104,8 +103,7 @@ public class ConfigurationTest {
             Arrays.asList(metric1),
             allowList,
             denyList,
-            globalSampling,
-            opsConfiguration);
+            globalSampling);
     Configuration config2 =
         new Configuration(
             "service2",
@@ -114,8 +112,7 @@ public class ConfigurationTest {
             Arrays.asList(metric2),
             allowList,
             denyList,
-            globalSampling,
-            opsConfiguration);
+            globalSampling);
     List<Configuration> configs = new ArrayList<>(Arrays.asList(config1, config2));
     ParameterizedType type = Types.newParameterizedType(List.class, Configuration.class);
     JsonAdapter<List<Configuration>> adapter = MoshiHelper.createMoshiConfig().adapter(type);

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
@@ -216,7 +216,7 @@ public abstract class BaseIntegrationTest {
       Collection<SnapshotProbe> snapshotProbes,
       Configuration.FilterList allowList,
       Configuration.FilterList denyList) {
-    return new Configuration(getAppId(), 2, snapshotProbes, null, allowList, denyList, null, null);
+    return new Configuration(getAppId(), 2, snapshotProbes, null, allowList, denyList, null);
   }
 
   protected void assertCaptureArgs(


### PR DESCRIPTION
# What Does This Do
Remove OpsConfiguration from Configuration

# Motivation
With RemoveConfig this is no longer used.
It was used for configuring the library behavior from the backend (polling interval)

# Additional Notes
