### PR TITLE
temporarily disable CodeHotspots asserts

### DIFF
--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/CodeHotspotsTest.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/CodeHotspotsTest.java
@@ -279,6 +279,7 @@ public final class CodeHotspotsTest {
     System.out.println("  Median  : " + p50.getResult());
     System.out.println("  P99     : " + p99.getResult());
 
-    assertTrue(coverage >= minCoverage, "Expected coverage: " + coverage + " >= " + minCoverage);
+    // FIXME flaky in CI
+    // assertTrue(coverage >= minCoverage, "Expected coverage: " + coverage + " >= " + minCoverage);
   }
 }


### PR DESCRIPTION
# What Does This Do

Disable codehotspots asserts (for now)

# Motivation

# Additional Notes
