### PR TITLE
Kr igor/dsm remove internal

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/Configuration.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/Configuration.java
@@ -1,6 +1,5 @@
 package com.datadog.debugger.agent;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -53,44 +52,6 @@ public class Configuration {
     }
   }
 
-  /** Stores operational configuration */
-  public static class OpsConfiguration {
-    private final long pollInterval;
-
-    public OpsConfiguration(long pollInterval) {
-      this.pollInterval = pollInterval;
-    }
-
-    public long getPollInterval() {
-      return pollInterval;
-    }
-
-    public Duration getPollIntervalDuration() {
-      return Duration.ofSeconds(pollInterval);
-    }
-
-    @Generated
-    @Override
-    public String toString() {
-      return "OperationConfiguration{" + "pollInterval=" + pollInterval + '}';
-    }
-
-    @Generated
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-      OpsConfiguration other = (OpsConfiguration) o;
-      return Objects.equals(pollInterval, other.pollInterval);
-    }
-
-    @Generated
-    @Override
-    public int hashCode() {
-      return Objects.hash(pollInterval);
-    }
-  }
-
   private final String id;
   private final long orgId;
   private final Collection<SnapshotProbe> snapshotProbes;
@@ -98,10 +59,9 @@ public class Configuration {
   private final FilterList allowList;
   private final FilterList denyList;
   private final SnapshotProbe.Sampling sampling;
-  private final OpsConfiguration opsConfig;
 
   public Configuration(String id, long orgId, Collection<SnapshotProbe> snapshotProbes) {
-    this(id, orgId, snapshotProbes, null, null, null, null, null);
+    this(id, orgId, snapshotProbes, null, null, null, null);
   }
 
   public Configuration(
@@ -109,7 +69,7 @@ public class Configuration {
       long orgId,
       Collection<SnapshotProbe> snapshotProbes,
       Collection<MetricProbe> metricProbes) {
-    this(id, orgId, snapshotProbes, metricProbes, null, null, null, null);
+    this(id, orgId, snapshotProbes, metricProbes, null, null, null);
   }
 
   public Configuration(
@@ -119,8 +79,7 @@ public class Configuration {
       Collection<MetricProbe> metricProbes,
       FilterList allowList,
       FilterList denyList,
-      SnapshotProbe.Sampling sampling,
-      OpsConfiguration opsConfig) {
+      SnapshotProbe.Sampling sampling) {
     this.id = id;
     this.orgId = orgId;
     this.snapshotProbes = snapshotProbes;
@@ -128,7 +87,6 @@ public class Configuration {
     this.allowList = allowList;
     this.denyList = denyList;
     this.sampling = sampling;
-    this.opsConfig = opsConfig;
   }
 
   public String getId() {
@@ -157,10 +115,6 @@ public class Configuration {
 
   public SnapshotProbe.Sampling getSampling() {
     return sampling;
-  }
-
-  public OpsConfiguration getOpsConfig() {
-    return opsConfig;
   }
 
   public Collection<ProbeDefinition> getDefinitions() {
@@ -193,8 +147,6 @@ public class Configuration {
         + denyList
         + ", sampling="
         + sampling
-        + ", opsConfig="
-        + opsConfig
         + '}';
   }
 
@@ -210,14 +162,12 @@ public class Configuration {
         && Objects.equals(metricProbes, that.metricProbes)
         && Objects.equals(allowList, that.allowList)
         && Objects.equals(denyList, that.denyList)
-        && Objects.equals(sampling, that.sampling)
-        && Objects.equals(opsConfig, that.opsConfig);
+        && Objects.equals(sampling, that.sampling);
   }
 
   @Generated
   @Override
   public int hashCode() {
-    return Objects.hash(
-        id, orgId, snapshotProbes, metricProbes, allowList, denyList, sampling, opsConfig);
+    return Objects.hash(id, orgId, snapshotProbes, metricProbes, allowList, denyList, sampling);
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -147,8 +147,7 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver {
         metricProbes,
         configuration.getAllowList(),
         configuration.getDenyList(),
-        configuration.getSampling(),
-        configuration.getOpsConfig());
+        configuration.getSampling());
   }
 
   Collection<SnapshotProbe> mergeDuplicatedProbes(Collection<SnapshotProbe> probes) {
@@ -221,10 +220,9 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver {
           null,
           currentConfiguration.getAllowList(),
           currentConfiguration.getDenyList(),
-          currentConfiguration.getSampling(),
-          currentConfiguration.getOpsConfig());
+          currentConfiguration.getSampling());
     }
-    return new Configuration("ID", 0, null, null, null, null, null, null);
+    return new Configuration("ID", 0, null, null, null, null, null);
   }
 
   private void retransformClasses(List<Class<?>> classesToBeTransformed) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -793,8 +793,7 @@ public class CapturedSnapshotTest {
             null,
             null,
             null,
-            new SnapshotProbe.Sampling(1),
-            null);
+            new SnapshotProbe.Sampling(1));
     DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, config);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     for (int i = 0; i < 100; i++) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationComparerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationComparerTest.java
@@ -170,7 +170,6 @@ class ConfigurationComparerTest {
             Collections.emptyList(),
             new Configuration.FilterList(Arrays.asList("com.datadog"), Collections.emptyList()),
             null,
-            null,
             null);
     ConfigurationComparer configurationComparer =
         new ConfigurationComparer(empty, config, Collections.emptyMap());
@@ -197,7 +196,6 @@ class ConfigurationComparerTest {
             Collections.emptyList(),
             new Configuration.FilterList(Arrays.asList("com.datadog"), Collections.emptyList()),
             null,
-            null,
             null);
     ConfigurationComparer configurationComparer =
         new ConfigurationComparer(noFilterConfig, config, instrumentationResults);
@@ -211,7 +209,6 @@ class ConfigurationComparerTest {
             Collections.singletonList(probe),
             Collections.emptyList(),
             new Configuration.FilterList(Arrays.asList("com.datacat"), Collections.emptyList()),
-            null,
             null,
             null);
 
@@ -248,7 +245,6 @@ class ConfigurationComparerTest {
             Collections.emptyList(),
             null,
             new Configuration.FilterList(Arrays.asList("com.datadog"), Collections.emptyList()),
-            null,
             null);
     ConfigurationComparer configurationComparer =
         new ConfigurationComparer(noFilterConfig, config, instrumentationResults);
@@ -281,7 +277,6 @@ class ConfigurationComparerTest {
             Collections.emptyList(),
             null,
             new Configuration.FilterList(Arrays.asList("com.datadog"), Collections.emptyList()),
-            null,
             null);
     ConfigurationComparer configurationComparer =
         new ConfigurationComparer(empty, config, Collections.emptyMap());

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
@@ -95,7 +95,6 @@ public class ConfigurationTest {
         new Configuration.FilterList(
             Arrays.asList("java.security"), Arrays.asList("javax.security.auth.AuthPermission"));
     SnapshotProbe.Sampling globalSampling = new SnapshotProbe.Sampling(10.0);
-    Configuration.OpsConfiguration opsConfiguration = new Configuration.OpsConfiguration(10);
     Configuration config1 =
         new Configuration(
             "service1",
@@ -104,8 +103,7 @@ public class ConfigurationTest {
             Arrays.asList(metric1),
             allowList,
             denyList,
-            globalSampling,
-            opsConfiguration);
+            globalSampling);
     Configuration config2 =
         new Configuration(
             "service2",
@@ -114,8 +112,7 @@ public class ConfigurationTest {
             Arrays.asList(metric2),
             allowList,
             denyList,
-            globalSampling,
-            opsConfiguration);
+            globalSampling);
     List<Configuration> configs = new ArrayList<>(Arrays.asList(config1, config2));
     ParameterizedType type = Types.newParameterizedType(List.class, Configuration.class);
     JsonAdapter<List<Configuration>> adapter = MoshiHelper.createMoshiConfig().adapter(type);

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientDecorator.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientDecorator.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.grpc.client;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_OUT;
+import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TYPE_TAG;
 
 import datadog.trace.api.Config;
@@ -23,7 +25,8 @@ public class GrpcClientDecorator extends ClientDecorator {
 
   private static final LinkedHashMap<String, String> createClientPathwaySortedTags() {
     LinkedHashMap<String, String> result = new LinkedHashMap<>();
-    result.put(TYPE_TAG, "internal");
+    result.put(TYPE_TAG, "grpc");
+    result.put(DIRECTION_TAG, DIRECTION_OUT);
     return result;
   }
 

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerDecorator.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerDecorator.java
@@ -1,5 +1,7 @@
 package datadog.trace.instrumentation.grpc.server;
 
+import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_IN;
+import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TYPE_TAG;
 
 import datadog.trace.api.Config;
@@ -28,6 +30,7 @@ public class GrpcServerDecorator extends ServerDecorator {
   private static final LinkedHashMap<String, String> createServerPathwaySortedTags() {
     LinkedHashMap<String, String> result = new LinkedHashMap<>();
     result.put(TYPE_TAG, "grpc");
+    result.put(DIRECTION_TAG, DIRECTION_IN);
     return result;
   }
 

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -194,14 +194,14 @@ abstract class GrpcTest extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags.containsAll(["type:internal"])
-        edgeTags.size() == 1
+        edgeTags.containsAll(["type:grpc", "direction:out"])
+        edgeTags.size() == 2
       }
 
       StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
       verifyAll(second) {
-        edgeTags.containsAll(["type:grpc"])
-        edgeTags.size() == 1
+        edgeTags.containsAll(["type:grpc", "direction:in"])
+        edgeTags.size() == 2
       }
     }
 

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTest.groovy
@@ -167,14 +167,14 @@ class KafkaClientTest extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8)) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags == ["topic:$SHARED_TOPIC".toString(), "type:internal"]
-        edgeTags.size() == 2
+        edgeTags == ["topic:$SHARED_TOPIC".toString(), "type:kafka", "direction:out"]
+        edgeTags.size() == 3
       }
 
       StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
       verifyAll(second) {
-        edgeTags == ["group:sender", "partition:" + received.partition(), "topic:$SHARED_TOPIC".toString(), "type:kafka"]
-        edgeTags.size() == 4
+        edgeTags == ["group:sender", "partition:" + received.partition(), "topic:$SHARED_TOPIC".toString(), "type:kafka", "direction:in"]
+        edgeTags.size() == 5
       }
     }
 
@@ -288,14 +288,14 @@ class KafkaClientTest extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8)) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags == ["topic:$SHARED_TOPIC".toString(), "type:internal"]
-        edgeTags.size() == 2
+        edgeTags == ["topic:$SHARED_TOPIC".toString(), "type:kafka", "direction:out"]
+        edgeTags.size() == 3
       }
 
       StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
       verifyAll(second) {
-        edgeTags == ["group:sender", "partition:" + received.partition(), "topic:$SHARED_TOPIC".toString(), "type:kafka"]
-        edgeTags.size() == 4
+        edgeTags == ["group:sender", "partition:" + received.partition(), "topic:$SHARED_TOPIC".toString(), "type:kafka", "direction:in"]
+        edgeTags.size() == 5
       }
     }
 
@@ -871,14 +871,14 @@ class KafkaClientTest extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8)) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags == ["topic:$SHARED_TOPIC".toString(), "type:internal"]
-        edgeTags.size() == 2
+        edgeTags == ["topic:$SHARED_TOPIC".toString(), "type:kafka", "direction:out"]
+        edgeTags.size() == 3
       }
 
       StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
       verifyAll(second) {
-        edgeTags == ["group:sender", "partition:" + partition, "topic:$SHARED_TOPIC".toString(), "type:kafka"]
-        edgeTags.size() == 4
+        edgeTags == ["group:sender", "partition:" + partition, "topic:$SHARED_TOPIC".toString(), "type:kafka", "direction:in"]
+        edgeTags.size() == 5
       }
     }
 

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -5,6 +5,8 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_OUT;
+import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.PARTITION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TOPIC_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TYPE_TAG;
@@ -95,7 +97,8 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Tracing
           sortedTags.put(PARTITION_TAG, record.partition().toString());
         }
         sortedTags.put(TOPIC_TAG, record.topic());
-        sortedTags.put(TYPE_TAG, "internal");
+        sortedTags.put(TYPE_TAG, "kafka");
+        sortedTags.put(DIRECTION_TAG, DIRECTION_OUT);
         try {
           propagate().inject(span, record.headers(), SETTER);
           propagate().injectBinaryPathwayContext(span, record.headers(), SETTER, sortedTags);

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
@@ -4,6 +4,8 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateNe
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.closePrevious;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_IN;
+import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.GROUP_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.PARTITION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TOPIC_TAG;
@@ -93,6 +95,7 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
           sortedTags.put(PARTITION_TAG, String.valueOf(val.partition()));
           sortedTags.put(TOPIC_TAG, val.topic());
           sortedTags.put(TYPE_TAG, "kafka");
+          sortedTags.put(DIRECTION_TAG, DIRECTION_IN);
           AgentTracer.get().setDataStreamCheckpoint(span, sortedTags);
         } else {
           span = startSpan(operationName, null);

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
@@ -144,14 +144,14 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags == ["topic:$SHARED_TOPIC".toString(), "type:internal"]
-        edgeTags.size() == 2
+        edgeTags == ["topic:$SHARED_TOPIC".toString(), "type:kafka", "direction:out"]
+        edgeTags.size() == 3
       }
 
       StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
       verifyAll(second) {
-        edgeTags == ["group:sender", "partition:" + received.partition(), "topic:$SHARED_TOPIC".toString(), "type:kafka"]
-        edgeTags.size() == 4
+        edgeTags == ["group:sender", "partition:" + received.partition(), "topic:$SHARED_TOPIC".toString(), "type:kafka", "direction:in"]
+        edgeTags.size() == 5
       }
     }
 
@@ -242,14 +242,14 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags == ["topic:$SHARED_TOPIC".toString(), "type:internal"]
-        edgeTags.size() == 2
+        edgeTags == ["topic:$SHARED_TOPIC".toString(), "type:kafka", "direction:out"]
+        edgeTags.size() == 3
       }
 
       StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
       verifyAll(second) {
-        edgeTags == ["group:sender", "partition:" + received.partition(), "topic:$SHARED_TOPIC".toString(), "type:kafka"]
-        edgeTags.size() == 4
+        edgeTags == ["group:sender", "partition:" + received.partition(), "topic:$SHARED_TOPIC".toString(), "type:kafka", "direction:in"]
+        edgeTags.size() == 5
       }
     }
 

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/latestDepTest/groovy/KafkaStreamsTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/latestDepTest/groovy/KafkaStreamsTest.groovy
@@ -213,26 +213,26 @@ class KafkaStreamsTest extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
       StatsGroup originProducerPoint = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(originProducerPoint) {
-        edgeTags == ["topic:$STREAM_PENDING", "type:internal"]
-        edgeTags.size() == 2
+        edgeTags == ["topic:$STREAM_PENDING", "type:kafka", "direction:out"]
+        edgeTags.size() == 3
       }
 
       StatsGroup kafkaStreamsConsumerPoint = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == originProducerPoint.hash }
       verifyAll(kafkaStreamsConsumerPoint) {
-        edgeTags == ["group:test-application", "partition:0", "topic:$STREAM_PENDING".toString(), "type:kafka"]
-        edgeTags.size() == 4
+        edgeTags == ["group:test-application", "partition:0", "topic:$STREAM_PENDING".toString(), "type:kafka", "direction:in"]
+        edgeTags.size() == 5
       }
 
       StatsGroup kafkaStreamsProducerPoint = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == kafkaStreamsConsumerPoint.hash }
       verifyAll(kafkaStreamsProducerPoint) {
-        edgeTags == ["topic:$STREAM_PROCESSED", "type:internal"]
-        edgeTags.size() == 2
+        edgeTags == ["topic:$STREAM_PROCESSED", "type:kafka", "direction:out"]
+        edgeTags.size() == 3
       }
 
       StatsGroup finalConsumerPoint = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == kafkaStreamsProducerPoint.hash }
       verifyAll(finalConsumerPoint) {
-        edgeTags == ["group:sender", "partition:0", "topic:$STREAM_PROCESSED".toString(), "type:kafka"]
-        edgeTags.size() == 4
+        edgeTags == ["group:sender", "partition:0", "topic:$STREAM_PROCESSED".toString(), "type:kafka", "direction:in"]
+        edgeTags.size() == 5
       }
     }
 

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
@@ -4,6 +4,8 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_IN;
+import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.GROUP_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.PARTITION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TOPIC_TAG;
@@ -245,6 +247,7 @@ public class KafkaStreamTaskInstrumentation extends Instrumenter.Tracing
         sortedTags.put(PARTITION_TAG, String.valueOf(record.partition()));
         sortedTags.put(TOPIC_TAG, record.topic());
         sortedTags.put(TYPE_TAG, "kafka");
+        sortedTags.put(DIRECTION_TAG, DIRECTION_IN);
         AgentTracer.get().setDataStreamCheckpoint(span, sortedTags);
       } else {
         span = startSpan(KAFKA_CONSUME, null);
@@ -311,6 +314,7 @@ public class KafkaStreamTaskInstrumentation extends Instrumenter.Tracing
         sortedTags.put(PARTITION_TAG, String.valueOf(record.partition()));
         sortedTags.put(TOPIC_TAG, record.topic());
         sortedTags.put(TYPE_TAG, "kafka");
+        sortedTags.put(DIRECTION_TAG, DIRECTION_IN);
         AgentTracer.get().setDataStreamCheckpoint(span, sortedTags);
       } else {
         span = startSpan(KAFKA_CONSUME, null);

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -8,6 +8,8 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_OUT;
+import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.EXCHANGE_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.HAS_ROUTING_KEY_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TYPE_TAG;
@@ -187,7 +189,8 @@ public class RabbitChannelInstrumentation extends Instrumenter.Tracing
         sortedTags.put(EXCHANGE_TAG, exchange);
         sortedTags.put(
             HAS_ROUTING_KEY_TAG, routingKey == null || routingKey.equals("") ? "false" : "true");
-        sortedTags.put(TYPE_TAG, "internal");
+        sortedTags.put(TYPE_TAG, "rabbitmq");
+        sortedTags.put(DIRECTION_TAG, DIRECTION_OUT);
         propagate().injectPathwayContext(span, headers, SETTER, sortedTags);
         props =
             new AMQP.BasicProperties(

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
@@ -7,6 +7,8 @@ import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.AM
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.AMQP_QUEUE;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.AMQP_ROUTING_KEY;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.RECORD_QUEUE_TIME_MS;
+import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_IN;
+import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TOPIC_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TYPE_TAG;
 
@@ -196,6 +198,7 @@ public class RabbitDecorator extends MessagingClientDecorator {
       LinkedHashMap<String, String> sortedTags = new LinkedHashMap<>();
       sortedTags.put(TOPIC_TAG, queue);
       sortedTags.put(TYPE_TAG, "rabbitmq");
+      sortedTags.put(DIRECTION_TAG, DIRECTION_IN);
       AgentTracer.get().setDataStreamCheckpoint(span, sortedTags);
     }
 

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -146,14 +146,14 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags == ["exchange:" + exchangeName, "has_routing_key:true", "type:internal"]
-        edgeTags.size() == 3
+        edgeTags == ["exchange:" + exchangeName, "has_routing_key:true", "type:rabbitmq", "direction:out"]
+        edgeTags.size() == 4
       }
 
       StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
       verifyAll(second) {
-        edgeTags == ["topic:" + queueName, "type:rabbitmq"]
-        edgeTags.size() == 2
+        edgeTags == ["topic:" + queueName, "type:rabbitmq", "direction:in"]
+        edgeTags.size() == 3
       }
     }
 
@@ -200,14 +200,14 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags == ["exchange:", "has_routing_key:true", "type:internal"]
-        edgeTags.size() == 3
+        edgeTags == ["exchange:", "has_routing_key:true", "type:rabbitmq", "direction:out"]
+        edgeTags.size() == 4
       }
 
       StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
       verifyAll(second) {
-        edgeTags == ["topic:" + queueName, "type:rabbitmq"]
-        edgeTags.size() == 2
+        edgeTags == ["topic:" + queueName, "type:rabbitmq", "direction:in"]
+        edgeTags.size() == 3
       }
     }
   }
@@ -297,15 +297,15 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
       List<StatsGroup> producerPoints = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == 0 }
       producerPoints.each { producerPoint ->
         verifyAll(producerPoint) {
-          edgeTags == ["exchange:" + exchangeName, "has_routing_key:false", "type:internal"]
-          edgeTags.size() == 3
+          edgeTags == ["exchange:" + exchangeName, "has_routing_key:false", "type:rabbitmq", "direction:out"]
+          edgeTags.size() == 4
         }
       }
 
       StatsGroup consumerPoint = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == producerPoints.get(0).hash }
       verifyAll(consumerPoint) {
-        edgeTags == ["topic:" + queueName, "type:rabbitmq"]
-        edgeTags.size() == 2
+        edgeTags == ["topic:" + queueName, "type:rabbitmq", "direction:in"]
+        edgeTags.size() == 3
       }
     }
 
@@ -389,14 +389,14 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags == ["exchange:" + exchangeName, "has_routing_key:false", "type:internal"]
-        edgeTags.size() == 3
+        edgeTags == ["exchange:" + exchangeName, "has_routing_key:false", "type:rabbitmq", "direction:out"]
+        edgeTags.size() == 4
       }
 
       StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
       verifyAll(second) {
-        edgeTags == ["topic:" + queueName, "type:rabbitmq"]
-        edgeTags.size() == 2
+        edgeTags == ["topic:" + queueName, "type:rabbitmq", "direction:in"]
+        edgeTags.size() == 3
       }
     }
 
@@ -474,14 +474,14 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags.containsAll(["exchange:", "has_routing_key:true", "type:internal"])
-        edgeTags.size() == 3
+        edgeTags.containsAll(["exchange:", "has_routing_key:true", "type:rabbitmq", "direction:out"])
+        edgeTags.size() == 4
       }
 
       StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
       verifyAll(second) {
-        edgeTags == ["topic:some-routing-queue", "type:rabbitmq"]
-        edgeTags.size() == 2
+        edgeTags == ["topic:some-routing-queue", "type:rabbitmq", "direction:in"]
+        edgeTags.size() == 3
       }
     }
   }
@@ -558,14 +558,14 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled() && !noParent) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags == ["exchange:" + exchangeName, "has_routing_key:true", "type:internal"]
-        edgeTags.size() == 3
+        edgeTags == ["exchange:" + exchangeName, "has_routing_key:true", "type:rabbitmq", "direction:out"]
+        edgeTags.size() == 4
       }
 
       StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
       verifyAll(second) {
-        edgeTags == ["topic:" + queueName, "type:rabbitmq"]
-        edgeTags.size() == 2
+        edgeTags == ["topic:" + queueName, "type:rabbitmq", "direction:in"]
+        edgeTags.size() == 3
       }
     }
 
@@ -651,14 +651,14 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled() && !noParent) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
-        edgeTags == ["exchange:" + exchangeName, "has_routing_key:true", "type:internal"]
-        edgeTags.size() == 3
+        edgeTags == ["exchange:" + exchangeName, "has_routing_key:true", "type:rabbitmq", "direction:out"]
+        edgeTags.size() == 4
       }
 
       StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
       verifyAll(second) {
-        edgeTags == ["topic:" + queueName, "type:rabbitmq"]
-        edgeTags.size() == 2
+        edgeTags == ["topic:" + queueName, "type:rabbitmq", "direction:in"]
+        edgeTags.size() == 3
       }
     }
 

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
@@ -216,7 +216,7 @@ public abstract class BaseIntegrationTest {
       Collection<SnapshotProbe> snapshotProbes,
       Configuration.FilterList allowList,
       Configuration.FilterList denyList) {
-    return new Configuration(getAppId(), 2, snapshotProbes, null, allowList, denyList, null, null);
+    return new Configuration(getAppId(), 2, snapshotProbes, null, allowList, denyList, null);
   }
 
   protected void assertCaptureArgs(

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
@@ -14,11 +14,11 @@ import datadog.trace.bootstrap.instrumentation.api.PathwayContext;
 import datadog.trace.bootstrap.instrumentation.api.StatsPoint;
 import datadog.trace.core.Base64Decoder;
 import datadog.trace.core.Base64Encoder;
+import datadog.trace.core.util.LRUCache;
 import datadog.trace.util.FNV64Hash;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -47,7 +47,7 @@ public class DefaultPathwayContext implements PathwayContext {
   private long hash;
   private boolean started;
   // used to detect and prevent loops in case of inaccurate / incomplete instrumentation
-  private final HashMap<Long, Long> history = new HashMap<Long, Long>();
+  private final LRUCache<Long, Long> history = new LRUCache<Long, Long>(10000);
 
   private static final Set<String> hashableTagKeys =
       new HashSet<String>(

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
@@ -18,6 +18,7 @@ import datadog.trace.util.FNV64Hash;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -45,6 +46,8 @@ public class DefaultPathwayContext implements PathwayContext {
   private long edgeStartNanoTicks;
   private long hash;
   private boolean started;
+  // used to detect and prevent loops in case of inaccurate / incomplete instrumentation
+  private final HashMap<Long, Long> history = new HashMap<Long, Long>();
 
   private static final Set<String> hashableTagKeys =
       new HashSet<String>(
@@ -110,7 +113,17 @@ public class DefaultPathwayContext implements PathwayContext {
         allTags.add(tag);
       }
 
-      long newHash = generatePathwayHash(pathwayHashBuilder, hash);
+      long nodeHash = generateNodeHash(pathwayHashBuilder);
+      // loop protection - a node should not be chosen as parent
+      // for an identical node within a single pathway context, as this
+      // will cause a `cardinality explosion` for hash / parentHash tag values
+      if (hash != 0 && history.containsKey(nodeHash)) {
+        hash = history.get(nodeHash);
+      } else {
+        history.put(nodeHash, hash);
+      }
+
+      long newHash = generatePathwayHash(nodeHash, hash);
 
       long pathwayLatencyNano = nanoTicks - pathwayStartNanoTicks;
       long edgeLatencyNano = nanoTicks - edgeStartNanoTicks;
@@ -343,9 +356,7 @@ public class DefaultPathwayContext implements PathwayContext {
     return pathwayHashBuilder.generateHash();
   }
 
-  private long generatePathwayHash(PathwayHashBuilder pathwayHashBuilder, long parentHash) {
-    long nodeHash = generateNodeHash(pathwayHashBuilder);
-
+  private long generatePathwayHash(long nodeHash, long parentHash) {
     lock.lock();
     try {
       outputBuffer.clear();

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
@@ -51,6 +51,7 @@ public class DefaultPathwayContext implements PathwayContext {
           Arrays.asList(
               TagsProcessor.GROUP_TAG,
               TagsProcessor.TYPE_TAG,
+              TagsProcessor.DIRECTION_TAG,
               TagsProcessor.TOPIC_TAG,
               TagsProcessor.EXCHANGE_TAG));
 
@@ -316,7 +317,7 @@ public class DefaultPathwayContext implements PathwayContext {
   }
 
   private static class PathwayHashBuilder {
-    private StringBuilder builder;
+    private final StringBuilder builder;
 
     public PathwayHashBuilder(WellKnownTags wellKnownTags) {
       builder = new StringBuilder();

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/TagsProcessor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/TagsProcessor.java
@@ -24,6 +24,13 @@ public class TagsProcessor {
   private static final DDCache<String, String> TYPE_TAG_CACHE = DDCaches.newFixedSizeCache(32);
   private static final Function<String, String> TYPE_TAG_PREFIX = new StringPrefix("type:");
 
+  public static final String DIRECTION_TAG = "direction";
+  // service centric direction - data flowing into the service
+  public static final String DIRECTION_IN = "in";
+  // service centric direction - data flowing out of the service
+  public static final String DIRECTION_OUT = "out";
+  private static final DDCache<String, String> DIRECTION_TAG_CACHE = DDCaches.newFixedSizeCache(32);
+  private static final Function<String, String> DIRECTION_TAG_PREFIX = new StringPrefix("direction:");
   public static final String TOPIC_TAG = "topic";
   private static final DDCache<String, String> TOPIC_TAG_CACHE = DDCaches.newFixedSizeCache(32);
   private static final Function<String, String> TOPIC_TAG_PREFIX = new StringPrefix("topic:");
@@ -52,6 +59,7 @@ public class TagsProcessor {
   private static Map<String, DDCache<String, String>> createTagToCacheMap() {
     Map<String, DDCache<String, String>> result = new HashMap<String, DDCache<String, String>>();
     result.put(TYPE_TAG, TYPE_TAG_CACHE);
+    result.put(DIRECTION_TAG, DIRECTION_TAG_CACHE);
     result.put(TOPIC_TAG, TOPIC_TAG_CACHE);
     result.put(PARTITION_TAG, PARTITION_TAG_CACHE);
     result.put(GROUP_TAG, GROUP_TAG_CACHE);
@@ -63,6 +71,7 @@ public class TagsProcessor {
   private static Map<String, Function<String, String>> createTagToPrefixMap() {
     Map<String, Function<String, String>> result = new HashMap<String, Function<String, String>>();
     result.put(TYPE_TAG, TYPE_TAG_PREFIX);
+    result.put(DIRECTION_TAG, DIRECTION_TAG_PREFIX);
     result.put(TOPIC_TAG, TOPIC_TAG_PREFIX);
     result.put(PARTITION_TAG, PARTITION_TAG_PREFIX);
     result.put(GROUP_TAG, GROUP_TAG_PREFIX);

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DefaultPathwayContextTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DefaultPathwayContextTest.groovy
@@ -104,7 +104,10 @@ class DefaultPathwayContextTest extends DDCoreSpecification {
     with(pointConsumer.points[2]) {
       edgeTags == ["group:group", "topic:topic", "type:kafka"]
       edgeTags.size() == 3
-      parentHash == pointConsumer.points[1].hash
+      // this point should have the first point as parent,
+      // as the loop protection will reset the parent if two identical
+      // points (same hash for tag values) are about to form a hierarchy
+      parentHash == pointConsumer.points[0].hash
       hash != 0
       pathwayLatencyNano == 55
       edgeLatencyNano == 30

--- a/internal-api/src/main/java/datadog/trace/api/ConfigCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/ConfigCollector.java
@@ -1,11 +1,16 @@
 package datadog.trace.api;
 
 import java.util.Arrays;
-import java.util.LinkedHashMap;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 
-public class ConfigCollector extends LinkedHashMap<String, Object> {
+/**
+ * Collects system properties and environment variables set by the user and used by the tracer. Puts
+ * to this map will happen in Config and ConfigProvider classes, which can run concurrently with
+ * consumers. So this is based on a ConcurrentHashMap to deal with it.
+ */
+public class ConfigCollector extends ConcurrentHashMap<String, Object> {
 
   public static final Set<String> CONFIG_FILTER_LIST =
       new TreeSet<>(

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
@@ -1,5 +1,6 @@
 package datadog.telemetry;
 
+import datadog.trace.api.Config;
 import datadog.trace.api.ConfigCollector;
 import java.io.IOException;
 import java.util.List;
@@ -44,6 +45,9 @@ public class TelemetryRunnable implements Runnable {
 
   @Override
   public void run() {
+    // Ensure that Config has been initialized, so ConfigCollector can collect all settings first.
+    Config.get();
+
     log.debug("Adding APP_STARTED telemetry event");
     this.telemetryService.addConfiguration(ConfigCollector.get());
     for (TelemetryPeriodicAction action : this.actions) {


### PR DESCRIPTION
# What Does This Do
Right now, all of the stats we report for DSM are tagged with `type` tag. It usually contains the dependency type, i.e. Kafka / gRPC / RabbitMq for incoming requests. For outgoing requests, we set `type:internal`, which is confusing and creates ambiguity. This PR switches from a single tag, to the Type / Direction tag pair. 

The direction is instrumentation centric. The incoming gRPC call with have `type:grpc` and `direction:in`, outgoing will have `type:grpc` and `direction:out`. 

Affected instrumentations: Kafka, gRPC, RabbitMQ
