### PR TITLE
Fix logged NullPointerException in OpenLiberty on getAttribute

### DIFF
--- a/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/RequestFinishInstrumentation.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/RequestFinishInstrumentation.java
@@ -53,7 +53,12 @@ public class RequestFinishInstrumentation extends Instrumenter.Tracing
       // this should be a servlet response
       if (resp instanceof SRTServletResponse) {
         SRTServletResponse httpResp = (SRTServletResponse) resp;
-        Object spanObj = req.getAttribute(DD_SPAN_ATTRIBUTE);
+        Object spanObj = null;
+        try {
+          spanObj = req.getAttribute(DD_SPAN_ATTRIBUTE);
+        } catch (NullPointerException e) {
+          // OpenLiberty will throw NPE on getAttribute if the response has already been closed.
+        }
 
         if (spanObj instanceof AgentSpan) {
           req.setAttribute(DD_SPAN_ATTRIBUTE, null);

--- a/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/ResponseFinishInstrumentation.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/ResponseFinishInstrumentation.java
@@ -47,7 +47,12 @@ public class ResponseFinishInstrumentation extends Instrumenter.Tracing
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(@Advice.This SRTServletResponse resp) {
       IExtendedRequest req = resp.getRequest();
-      Object spanObj = req.getAttribute(DD_SPAN_ATTRIBUTE);
+      Object spanObj = null;
+      try {
+        spanObj = req.getAttribute(DD_SPAN_ATTRIBUTE);
+      } catch (NullPointerException e) {
+        // OpenLiberty will throw NPE on getAttribute if the response has already been closed.
+      }
 
       if (spanObj instanceof AgentSpan) {
         req.setAttribute(DD_SPAN_ATTRIBUTE, null);


### PR DESCRIPTION
# What Does This Do

`SRTServletResponse#getAttribute()` will throw NPE if called after response has been closed.

# Motivation

This resulted in a logged exception (at debug logging level):

```
[dd.trace 2022-11-03 22:41:09:340 +0100] [Default Executor-thread-31] DEBUG datadog.trace.bootstrap.ExceptionLogger - Failed to handle exception in instrumentation for com.ibm.ws.webcontainer.srt.SRTServ
letRequest
java.lang.NullPointerException
        at com.ibm.ws.webcontainer.srt.SRTServletRequest$SRTServletRequestHelper.access$300(SRTServletRequest.java:3424)
        at com.ibm.ws.webcontainer.srt.SRTServletRequest.getAttribute(SRTServletRequest.java:402)
        at com.ibm.ws.webcontainer.srt.SRTServletRequest.finish(SRTServletRequest.java:2781)
        at com.ibm.ws.webcontainer31.osgi.srt.SRTConnectionContext31.finishConnection(SRTConnectionContext31.java:216)
        at com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:1166)
        at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:281)
        at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1246)
        at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:468)
        at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:427)
        at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:567)
        at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:501)
        at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:361)
        at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.ready(HttpInboundLink.java:328)
        at com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.sendToDiscriminators(NewConnectionInitialReadCallback.java:167)
        at com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.complete(NewConnectionInitialReadCallback.java:75)
        at com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:514)
        at com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:584)
        at com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:968)
        at com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1057)
        at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:245)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)

```

# Additional Notes
Related to https://github.com/DataDog/dd-trace-java/pull/4095
