### PR TITLE
AppSec default to false on OpenJ9 and non supported archs

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -624,14 +624,15 @@ public class Agent {
   private static boolean isSupportedAppSecArch() {
     final String arch = System.getProperty("os.arch");
     if (Platform.isWindows()) {
-      return "amd64".equals(arch) || "x86_64".equals(arch) || "x86".equals(arch);
+      // TODO: Windows bindings need to be built for x86
+      return "amd64".equals(arch) || "x86_64".equals(arch);
     } else if (Platform.isMac()) {
       return "amd64".equals(arch) || "x86_64".equals(arch) || "aarch64".equals(arch);
     } else if (Platform.isLinux()) {
       return "amd64".equals(arch) || "x86_64".equals(arch) || "aarch64".equals(arch);
     }
-    // Still return true in other if unexpected cases, and we'll handle loading errors during AppSec
-    // startup.
+    // Still return true in other if unexpected cases (e.g. SunOS), and we'll handle loading errors
+    // during AppSec startup.
     return true;
   }
 

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -158,7 +158,7 @@ public class Agent {
       setSystemPropertyDefault(AgentFeature.APPSEC.getSystemProp(), "false");
     } else if (!isSupportedAppSecArch()) {
       log.debug(
-          "OS and architecture (({})/{}) not supported by AppSec, dd.appsec.enabled will default to false",
+          "OS and architecture ({}/{}) not supported by AppSec, dd.appsec.enabled will default to false",
           System.getProperty("os.name"),
           System.getProperty("os.arch"));
       setSystemPropertyDefault(AgentFeature.APPSEC.getSystemProp(), "false");

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -153,6 +153,17 @@ public class Agent {
       }
     }
 
+    if (Platform.isJ9()) {
+      log.debug("OpenJ9 detected, dd.appsec.enabled will default to false");
+      setSystemPropertyDefault(AgentFeature.APPSEC.getSystemProp(), "false");
+    } else if (!isSupportedAppSecArch()) {
+      log.debug(
+          "OS and architecture (({})/{}) not supported by AppSec, dd.appsec.enabled will default to false",
+          System.getProperty("os.name"),
+          System.getProperty("os.arch"));
+      setSystemPropertyDefault(AgentFeature.APPSEC.getSystemProp(), "false");
+    }
+
     jmxFetchEnabled = isFeatureEnabled(AgentFeature.JMXFETCH);
     profilingEnabled = isFeatureEnabled(AgentFeature.PROFILING);
     iastEnabled = isFeatureEnabled(AgentFeature.IAST);
@@ -608,6 +619,20 @@ public class Agent {
     } catch (final Throwable ex) {
       log.warn("Not starting AppSec subsystem: {}", ex.getMessage());
     }
+  }
+
+  private static boolean isSupportedAppSecArch() {
+    final String arch = System.getProperty("os.arch");
+    if (Platform.isWindows()) {
+      return "amd64".equals(arch) || "x86_64".equals(arch) || "x86".equals(arch);
+    } else if (Platform.isMac()) {
+      return "amd64".equals(arch) || "x86_64".equals(arch) || "aarch64".equals(arch);
+    } else if (Platform.isLinux()) {
+      return "amd64".equals(arch) || "x86_64".equals(arch) || "aarch64".equals(arch);
+    }
+    // Still return true in other if unexpected cases, and we'll handle loading errors during AppSec
+    // startup.
+    return true;
   }
 
   private static void maybeStartIast(Class<?> scoClass, Object o) {


### PR DESCRIPTION
# What Does This Do

Some OpenJ9-based JVMs (e.g. old IBM SDK 8.0) have issues with AppSec, so we're disabling it by default. This will prevent issues when enabling remote config by default, and it will also disable 1-click activation of AppSec for OpenJ9.

Also disable on architectures other than x86 and amd64, since PowerWAF is not supported anywhere else yet. So trying to enable it later is pointless.

# Motivation

# Additional Notes
