### PR TITLE
[CI] Add support for Buddy CI and improve other providers

### DIFF
--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/AppVeyorInfo.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/AppVeyorInfo.java
@@ -19,7 +19,9 @@ class AppVeyorInfo extends CIProviderInfo {
   public static final String APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH =
       "APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH";
   public static final String APPVEYOR_REPO_TAG_NAME = "APPVEYOR_REPO_TAG_NAME";
-  public static final String APPVEYOR_REPO_COMMIT_MESSAGE = "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED";
+  public static final String APPVEYOR_REPO_COMMIT_MESSAGE_SUBJECT = "APPVEYOR_REPO_COMMIT_MESSAGE";
+  public static final String APPVEYOR_REPO_COMMIT_MESSAGE_BODY =
+      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED";
   public static final String APPVEYOR_REPO_COMMIT_AUTHOR_NAME = "APPVEYOR_REPO_COMMIT_AUTHOR";
   public static final String APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL =
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL";
@@ -28,6 +30,8 @@ class AppVeyorInfo extends CIProviderInfo {
   protected GitInfo buildCIGitInfo() {
     final String repoProvider = System.getenv(APPVEYOR_REPO_PROVIDER);
     final String tag = buildGitTag(repoProvider);
+    final String messageSubject = System.getenv(APPVEYOR_REPO_COMMIT_MESSAGE_SUBJECT);
+    final String messageBody = System.getenv(APPVEYOR_REPO_COMMIT_MESSAGE_BODY);
     return new GitInfo(
         buildGitRepositoryUrl(repoProvider, System.getenv(APPVEYOR_REPO_NAME)),
         buildGitBranch(repoProvider, tag),
@@ -36,7 +40,7 @@ class AppVeyorInfo extends CIProviderInfo {
             buildGitCommit(),
             buildGitCommitAuthor(),
             PersonInfo.NOOP,
-            System.getenv(APPVEYOR_REPO_COMMIT_MESSAGE)));
+            String.format("%s%n%s", messageSubject, messageBody)));
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/BitriseInfo.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/BitriseInfo.java
@@ -19,6 +19,10 @@ class BitriseInfo extends CIProviderInfo {
   public static final String BITRISE_GIT_BRANCH = "BITRISE_GIT_BRANCH";
   public static final String BITRISE_GIT_TAG = "BITRISE_GIT_TAG";
   public static final String BITRISE_GIT_MESSAGE = "BITRISE_GIT_MESSAGE";
+  public static final String BITRISE_GIT_AUTHOR_NAME = "GIT_CLONE_COMMIT_AUTHOR_NAME";
+  public static final String BITRISE_GIT_AUTHOR_EMAIL = "GIT_CLONE_COMMIT_AUTHOR_EMAIL";
+  public static final String BITRISE_GIT_COMMITER_NAME = "GIT_CLONE_COMMIT_COMMITER_NAME";
+  public static final String BITRISE_GIT_COMMITER_EMAIL = "GIT_CLONE_COMMIT_COMMITER_EMAIL";
 
   @Override
   protected GitInfo buildCIGitInfo() {
@@ -29,8 +33,11 @@ class BitriseInfo extends CIProviderInfo {
         gitTag,
         new CommitInfo(
             buildGitCommit(),
-            PersonInfo.NOOP,
-            PersonInfo.NOOP,
+            new PersonInfo(
+                System.getenv(BITRISE_GIT_AUTHOR_NAME), System.getenv(BITRISE_GIT_AUTHOR_EMAIL)),
+            new PersonInfo(
+                System.getenv(BITRISE_GIT_COMMITER_NAME),
+                System.getenv(BITRISE_GIT_COMMITER_EMAIL)),
             System.getenv(BITRISE_GIT_MESSAGE)));
   }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/BuddyInfo.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/BuddyInfo.java
@@ -1,0 +1,53 @@
+package datadog.trace.bootstrap.instrumentation.ci;
+
+import datadog.trace.bootstrap.instrumentation.ci.git.CommitInfo;
+import datadog.trace.bootstrap.instrumentation.ci.git.GitInfo;
+import datadog.trace.bootstrap.instrumentation.ci.git.PersonInfo;
+
+class BuddyInfo extends CIProviderInfo {
+
+  // https://buddy.works/docs/pipelines/environment-variables
+  public static final String BUDDY = "BUDDY";
+  public static final String BUDDY_PROVIDER_NAME = "buddy";
+  public static final String BUDDY_PIPELINE_ID = "BUDDY_PIPELINE_ID";
+  public static final String BUDDY_PIPELINE_NAME = "BUDDY_PIPELINE_NAME";
+  public static final String BUDDY_PIPELINE_EXECUTION_ID = "BUDDY_EXECUTION_ID";
+  public static final String BUDDY_PIPELINE_EXECUTION_URL = "BUDDY_EXECUTION_URL";
+  public static final String BUDDY_GIT_REPOSITORY_URL = "BUDDY_SCM_URL";
+  public static final String BUDDY_GIT_COMMIT = "BUDDY_EXECUTION_REVISION";
+  public static final String BUDDY_GIT_BRANCH = "BUDDY_EXECUTION_BRANCH";
+  public static final String BUDDY_GIT_TAG = "BUDDY_EXECUTION_TAG";
+  public static final String BUDDY_GIT_COMMIT_MESSAGE = "BUDDY_EXECUTION_REVISION_MESSAGE";
+  public static final String BUDDY_GIT_COMMIT_AUTHOR = "BUDDY_EXECUTION_REVISION_COMMITTER_NAME";
+  public static final String BUDDY_GIT_COMMIT_EMAIL = "BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL";
+
+  @Override
+  protected GitInfo buildCIGitInfo() {
+    return new GitInfo(
+        filterSensitiveInfo(System.getenv(BUDDY_GIT_REPOSITORY_URL)),
+        normalizeRef(System.getenv(BUDDY_GIT_BRANCH)),
+        normalizeRef(System.getenv(BUDDY_GIT_TAG)),
+        new CommitInfo(
+            System.getenv(BUDDY_GIT_COMMIT),
+            PersonInfo.NOOP,
+            buildGitCommiter(),
+            System.getenv(BUDDY_GIT_COMMIT_MESSAGE)));
+  }
+
+  @Override
+  protected CIInfo buildCIInfo() {
+    String pipelineNumber = System.getenv(BUDDY_PIPELINE_EXECUTION_ID);
+    return CIInfo.builder()
+        .ciProviderName(BUDDY_PROVIDER_NAME)
+        .ciPipelineId(String.format("%s/%s", System.getenv(BUDDY_PIPELINE_ID), pipelineNumber))
+        .ciPipelineName(System.getenv(BUDDY_PIPELINE_NAME))
+        .ciPipelineNumber(pipelineNumber)
+        .ciPipelineUrl(System.getenv(BUDDY_PIPELINE_EXECUTION_URL))
+        .build();
+  }
+
+  private PersonInfo buildGitCommiter() {
+    return new PersonInfo(
+        System.getenv(BUDDY_GIT_COMMIT_AUTHOR), System.getenv(BUDDY_GIT_COMMIT_EMAIL));
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/CIProviderInfo.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/CIProviderInfo.java
@@ -4,6 +4,7 @@ import static datadog.trace.bootstrap.instrumentation.ci.AppVeyorInfo.APPVEYOR;
 import static datadog.trace.bootstrap.instrumentation.ci.AzurePipelinesInfo.AZURE;
 import static datadog.trace.bootstrap.instrumentation.ci.BitBucketInfo.BITBUCKET;
 import static datadog.trace.bootstrap.instrumentation.ci.BitriseInfo.BITRISE;
+import static datadog.trace.bootstrap.instrumentation.ci.BuddyInfo.BUDDY;
 import static datadog.trace.bootstrap.instrumentation.ci.BuildkiteInfo.BUILDKITE;
 import static datadog.trace.bootstrap.instrumentation.ci.CircleCIInfo.CIRCLECI;
 import static datadog.trace.bootstrap.instrumentation.ci.GitLabInfo.GITLAB;
@@ -159,6 +160,8 @@ public abstract class CIProviderInfo {
       return new BuildkiteInfo();
     } else if (System.getenv(BITRISE) != null) {
       return new BitriseInfo();
+    } else if (System.getenv(BUDDY) != null) {
+      return new BuddyInfo();
     } else {
       return new UnknownCIInfo();
     }

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/ci/BuddyInfoTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/ci/BuddyInfoTest.groovy
@@ -1,0 +1,34 @@
+package datadog.trace.bootstrap.instrumentation.ci
+
+class BuddyInfoTest extends CIProviderInfoTest {
+
+  @Override
+  CIProviderInfo instanceProvider() {
+    return new BuddyInfo() {
+        @Override
+        protected String getGitFolderName() {
+          return GIT_FOLDER_FOR_TESTS
+        }
+      }
+  }
+
+  @Override
+  String getProviderName() {
+    return BuddyInfo.BUDDY_PROVIDER_NAME
+  }
+
+  @Override
+  Map<String, String> buildRemoteGitInfoEmpty() {
+    final Map<String, String> map = new HashMap<>()
+    map.put(BuddyInfo.BUDDY, "true")
+    return map
+  }
+
+  @Override
+  Map<String, String> buildRemoteGitInfoMismatchLocalGit() {
+    final Map<String, String> map = new HashMap<>()
+    map.put(BuddyInfo.BUDDY, "true")
+    map.put(BuddyInfo.BUDDY_GIT_COMMIT, "0000000000000000000000000000000000000000")
+    return map
+  }
+}

--- a/internal-api/src/test/resources/ci/appveyor.json
+++ b/internal-api/src/test/resources/ci/appveyor.json
@@ -9,7 +9,8 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message-extended",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -24,7 +25,7 @@
       "git.branch": "master",
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
-      "git.commit.message": "appveyor-commit-message",
+      "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
       "git.commit.sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
@@ -39,7 +40,8 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message-extended",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -54,7 +56,7 @@
       "git.branch": "master",
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
-      "git.commit.message": "appveyor-commit-message",
+      "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
       "git.commit.sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
@@ -69,7 +71,8 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message-extended",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -84,7 +87,7 @@
       "git.branch": "master",
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
-      "git.commit.message": "appveyor-commit-message",
+      "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
       "git.commit.sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
@@ -99,7 +102,8 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message-extended",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -114,7 +118,7 @@
       "git.branch": "master",
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
-      "git.commit.message": "appveyor-commit-message",
+      "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
       "git.commit.sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
@@ -129,7 +133,8 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message-extended",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github",
       "HOME": "/not-my-home",
@@ -146,7 +151,7 @@
       "git.branch": "master",
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
-      "git.commit.message": "appveyor-commit-message",
+      "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
       "git.commit.sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
@@ -161,7 +166,8 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message-extended",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -176,7 +182,7 @@
       "git.branch": "master",
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
-      "git.commit.message": "appveyor-commit-message",
+      "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
       "git.commit.sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
@@ -191,7 +197,8 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message-extended",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github",
       "HOME": "/not-my-home",
@@ -208,7 +215,7 @@
       "git.branch": "master",
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
-      "git.commit.message": "appveyor-commit-message",
+      "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
       "git.commit.sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
@@ -223,7 +230,8 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message-extended",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name"
     },
     {
@@ -236,7 +244,7 @@
       "ci.workspace_path": "/foo/bar",
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
-      "git.commit.message": "appveyor-commit-message"
+      "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended"
     }
   ],
   [
@@ -249,7 +257,8 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message-extended",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -264,7 +273,7 @@
       "git.branch": "master",
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
-      "git.commit.message": "appveyor-commit-message",
+      "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
       "git.commit.sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
@@ -279,7 +288,8 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message-extended",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -294,7 +304,7 @@
       "git.branch": "master",
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
-      "git.commit.message": "appveyor-commit-message",
+      "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
       "git.commit.sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
@@ -309,7 +319,8 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message-extended",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -324,7 +335,7 @@
       "git.branch": "feature/one",
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
-      "git.commit.message": "appveyor-commit-message",
+      "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
       "git.commit.sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
@@ -340,7 +351,8 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message-extended",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -355,7 +367,7 @@
       "git.branch": "pr",
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
-      "git.commit.message": "appveyor-commit-message",
+      "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
       "git.commit.sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
@@ -371,7 +383,8 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message-extended",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github"
     },
@@ -386,7 +399,7 @@
       "git.branch": "pr",
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
-      "git.commit.message": "appveyor-commit-message",
+      "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
       "git.commit.sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git"
     }
@@ -401,7 +414,8 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message-extended",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github",
       "APPVEYOR_REPO_TAG_NAME": "origin/tags/0.1.0"
@@ -416,7 +430,7 @@
       "ci.workspace_path": "/foo/bar",
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
-      "git.commit.message": "appveyor-commit-message",
+      "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
       "git.commit.sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git",
       "git.tag": "0.1.0"
@@ -432,7 +446,8 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message-extended",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "APPVEYOR_REPO_PROVIDER": "github",
       "APPVEYOR_REPO_TAG_NAME": "refs/heads/tags/0.1.0"
@@ -447,7 +462,7 @@
       "ci.workspace_path": "/foo/bar",
       "git.commit.author.email": "appveyor-commit-author-email@datadoghq.com",
       "git.commit.author.name": "appveyor-commit-author-name",
-      "git.commit.message": "appveyor-commit-message",
+      "git.commit.message": "appveyor-commit-message\nappveyor-commit-message-extended",
       "git.commit.sha": "appveyor-repo-commit",
       "git.repository_url": "https://github.com/appveyor-repo-name.git",
       "git.tag": "0.1.0"
@@ -461,7 +476,8 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message-extended",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "DD_GIT_BRANCH": "user-supplied-branch",
       "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
@@ -501,7 +517,8 @@
       "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
       "APPVEYOR_REPO_COMMIT_AUTHOR": "appveyor-commit-author-name",
       "APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL": "appveyor-commit-author-email@datadoghq.com",
-      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE": "appveyor-commit-message",
+      "APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED": "appveyor-commit-message-extended",
       "APPVEYOR_REPO_NAME": "appveyor-repo-name",
       "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
       "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",

--- a/internal-api/src/test/resources/ci/bitrise.json
+++ b/internal-api/src/test/resources/ci/bitrise.json
@@ -9,7 +9,11 @@
       "BITRISE_SOURCE_DIR": "/foo/bar",
       "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
       "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
-      "GIT_REPOSITORY_URL": "sample"
+      "GIT_REPOSITORY_URL": "sample",
+      "GIT_CLONE_COMMIT_AUTHOR_NAME": "David Bowie",
+      "GIT_CLONE_COMMIT_AUTHOR_EMAIL": "author@author.com",
+      "GIT_CLONE_COMMIT_COMMITER_NAME": "Akira Toriyama",
+      "GIT_CLONE_COMMIT_COMMITER_EMAIL": "commiter@commiter.com"
     },
     {
       "ci.pipeline.id": "bitrise-pipeline-id",
@@ -20,7 +24,11 @@
       "ci.workspace_path": "/foo/bar",
       "git.commit.message": "bitrise-git-commit-message",
       "git.commit.sha": "gitcommit",
-      "git.repository_url": "sample"
+      "git.repository_url": "sample",
+      "git.commit.author.name": "David Bowie",
+      "git.commit.author.email": "author@author.com",
+      "git.commit.committer.name": "Akira Toriyama",
+      "git.commit.committer.email": "commiter@commiter.com"
     }
   ],
   [

--- a/internal-api/src/test/resources/ci/buddy.json
+++ b/internal-api/src/test/resources/ci/buddy.json
@@ -1,0 +1,32 @@
+[
+  [
+    {
+      "BUDDY": "true",
+      "BUDDY_SCM_URL": "https://github.com/buddyworks/my-project",
+      "BUDDY_PIPELINE_ID": "456",
+      "BUDDY_PIPELINE_NAME": "Deploy to Production",
+      "BUDDY_EXECUTION_URL": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "BUDDY_EXECUTION_ID": "12",
+      "BUDDY_EXECUTION_BRANCH": "master",
+      "BUDDY_EXECUTION_TAG": "v1.0",
+      "BUDDY_EXECUTION_REVISION": "e5e13f8b7f8d5c6096a0501dc09b48eef05fea96",
+      "BUDDY_EXECUTION_REVISION_MESSAGE": "Create buddy.yml",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL": "mikebenson@buddy.works",
+      "BUDDY_EXECUTION_REVISION_COMMITTER_NAME": "Mike Benson"
+    },
+    {
+      "ci.pipeline.id": "456/12",
+      "ci.pipeline.name": "Deploy to Production",
+      "ci.pipeline.number": "12",
+      "ci.pipeline.url": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/456/execution/5d9dc42c422f5a268b389d08",
+      "ci.provider.name": "buddy",
+      "git.commit.message": "Create buddy.yml",
+      "git.commit.sha": "e5e13f8b7f8d5c6096a0501dc09b48eef05fea96",
+      "git.branch": "master",
+      "git.tag": "v1.0",
+      "git.repository_url": "https://github.com/buddyworks/my-project",
+      "git.commit.committer.name": "Mike Benson",
+      "git.commit.committer.email": "mikebenson@buddy.works"
+    }
+  ]
+]


### PR DESCRIPTION
# What Does This Do
* On Bitrise, tag the commit author and commiter by reading the env vars.
* On AppVeyor, read both the body and subject of the commit message, which come in separate env vars.
* Add support for Buddy CI.