### PR TITLE
Replace run-time patching of ServletInputStreamWrapper with build-time equivalent

### DIFF
--- a/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/AbstractServletInputStreamWrapper.java
+++ b/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/AbstractServletInputStreamWrapper.java
@@ -1,14 +1,14 @@
-package datadog.trace.instrumentation.servlet.http;
+package datadog.trace.instrumentation.servlet;
 
 import datadog.trace.api.http.StoredByteBody;
 import java.io.IOException;
 import javax.servlet.ServletInputStream;
 
-public class ServletInputStreamWrapper extends ServletInputStream {
-  public final ServletInputStream is;
-  final StoredByteBody storedByteBody;
+public abstract class AbstractServletInputStreamWrapper extends ServletInputStream {
+  protected final ServletInputStream is;
+  private final StoredByteBody storedByteBody;
 
-  public ServletInputStreamWrapper(ServletInputStream is, StoredByteBody storedByteBody) {
+  public AbstractServletInputStreamWrapper(ServletInputStream is, StoredByteBody storedByteBody) {
     this.is = is;
     this.storedByteBody = storedByteBody;
   }

--- a/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/BufferedReaderWrapper.java
+++ b/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/BufferedReaderWrapper.java
@@ -1,4 +1,4 @@
-package datadog.trace.instrumentation.servlet.http;
+package datadog.trace.instrumentation.servlet;
 
 import datadog.trace.api.http.StoredCharBody;
 import java.io.BufferedReader;

--- a/dd-java-agent/instrumentation/servlet/request-2/build.gradle
+++ b/dd-java-agent/instrumentation/servlet/request-2/build.gradle
@@ -1,15 +1,22 @@
 muzzle {
   pass {
+    name = 'servlet-2.x'
     group = "javax.servlet"
     module = "servlet-api"
     versions = "[2.2, 3.0)"
     assertInverse = true
   }
-
   fail {
     group = "javax.servlet"
     module = 'javax.servlet-api'
     versions = "[3.0,)"
+  }
+  pass {
+    name = 'servlet-2.x-and-3.0.x' // for Servlet2RequestBodyInstrumentation
+    group = "javax.servlet"
+    module = "servlet-api"
+    versions = "[2.2, 3.1)"
+    assertInverse = true
   }
 }
 

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Instrumentation.java
@@ -24,6 +24,11 @@ public final class Servlet2Instrumentation extends Instrumenter.Tracing
     super("servlet", "servlet-2");
   }
 
+  @Override
+  public String muzzleDirective() {
+    return "servlet-2.x";
+  }
+
   // Avoid matching servlet 3 which has its own instrumentation
   static final ElementMatcher<ClassLoader> NOT_SERVLET_3 =
       not(hasClassNamed("javax.servlet.AsyncEvent"));

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2ResponseStatusInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2ResponseStatusInstrumentation.java
@@ -20,6 +20,11 @@ public final class Servlet2ResponseStatusInstrumentation extends Instrumenter.Tr
   }
 
   @Override
+  public String muzzleDirective() {
+    return "servlet-2.x";
+  }
+
+  @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     return Servlet2Instrumentation.NOT_SERVLET_3;
   }

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/ServletInputStreamWrapper.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/ServletInputStreamWrapper.java
@@ -1,0 +1,11 @@
+package datadog.trace.instrumentation.servlet2;
+
+import datadog.trace.api.http.StoredByteBody;
+import datadog.trace.instrumentation.servlet.AbstractServletInputStreamWrapper;
+import javax.servlet.ServletInputStream;
+
+public class ServletInputStreamWrapper extends AbstractServletInputStreamWrapper {
+  public ServletInputStreamWrapper(ServletInputStream is, StoredByteBody storedByteBody) {
+    super(is, storedByteBody);
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/ServletRequestBodyInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/ServletRequestBodyInstrumentation.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.servlet2;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.hasClassNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedNoneOf;
 import static datadog.trace.api.gateway.Events.EVENTS;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -63,7 +64,11 @@ public class ServletRequestBodyInstrumentation extends Instrumenter.AppSec
 
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
-    return implementsInterface(named(hierarchyMarkerType()));
+    return implementsInterface(named(hierarchyMarkerType()))
+        .and(
+            namedNoneOf( // ignore wrappers that ship with servlet-api
+                "javax.servlet.ServletRequestWrapper",
+                "javax.servlet.http.HttpServletRequestWrapper"));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/ServletRequestBodyInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/ServletRequestBodyInstrumentation.java
@@ -1,0 +1,202 @@
+package datadog.trace.instrumentation.servlet2;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.hasClassNamed;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.api.gateway.Events.EVENTS;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
+import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.gateway.CallbackProvider;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.http.StoredBodySupplier;
+import datadog.trace.api.http.StoredByteBody;
+import datadog.trace.api.http.StoredCharBody;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.instrumentation.servlet.BufferedReaderWrapper;
+import java.io.BufferedReader;
+import java.nio.charset.Charset;
+import java.util.function.BiFunction;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+/**
+ * Request bodies after servlet 3.0.x are covered by Servlet3RequestBodyInstrumentation from the
+ * "request-3" module. Any changes to the behaviour here should also be reflected in "request-3".
+ */
+@AutoService(Instrumenter.class)
+public class ServletRequestBodyInstrumentation extends Instrumenter.AppSec
+    implements Instrumenter.ForTypeHierarchy {
+  public ServletRequestBodyInstrumentation() {
+    super("servlet-request-body");
+  }
+
+  @Override
+  public String muzzleDirective() {
+    return "servlet-2.x-and-3.0.x";
+  }
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    // Avoid matching request bodies after 3.0.x which have their own instrumentation
+    return not(hasClassNamed("javax.servlet.ReadListener"));
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "javax.servlet.ServletRequest";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return implementsInterface(named(hierarchyMarkerType()));
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("getInputStream")
+            .and(takesNoArguments())
+            .and(returns(named("javax.servlet.ServletInputStream")))
+            .and(isPublic()),
+        getClass().getName() + "$HttpServletGetInputStreamAdvice");
+    transformation.applyAdvice(
+        named("getReader")
+            .and(takesNoArguments())
+            .and(returns(named("java.io.BufferedReader")))
+            .and(isPublic()),
+        getClass().getName() + "$HttpServletGetReaderAdvice");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      "datadog.trace.instrumentation.servlet.BufferedReaderWrapper",
+      "datadog.trace.instrumentation.servlet.AbstractServletInputStreamWrapper",
+      "datadog.trace.instrumentation.servlet2.ServletInputStreamWrapper"
+    };
+  }
+
+  @SuppressWarnings("Duplicates")
+  @RequiresRequestContext(RequestContextSlot.APPSEC)
+  static class HttpServletGetInputStreamAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    static void after(
+        @Advice.This final ServletRequest thiz,
+        @Advice.Return(readOnly = false) ServletInputStream is,
+        @ActiveRequestContext RequestContext reqCtx) {
+      if (!(thiz instanceof HttpServletRequest) || is == null) {
+        return;
+      }
+
+      HttpServletRequest req = (HttpServletRequest) thiz;
+      Object alreadyWrapped = req.getAttribute("datadog.wrapped_request_body");
+      if (alreadyWrapped != null || is instanceof ServletInputStreamWrapper) {
+        return;
+      }
+
+      CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+      BiFunction<RequestContext, StoredBodySupplier, Void> requestStartCb =
+          cbp.getCallback(EVENTS.requestBodyStart());
+      BiFunction<RequestContext, StoredBodySupplier, Flow<Void>> requestEndedCb =
+          cbp.getCallback(EVENTS.requestBodyDone());
+      if (requestStartCb == null || requestEndedCb == null) {
+        return;
+      }
+
+      req.setAttribute("datadog.wrapped_request_body", Boolean.TRUE);
+
+      int lengthHint = 0;
+      String lengthHeader = req.getHeader("content-length");
+      if (lengthHeader != null) {
+        try {
+          lengthHint = Integer.parseInt(lengthHeader);
+        } catch (NumberFormatException nfe) {
+          // purposefully left blank
+        }
+      }
+
+      String encoding = req.getCharacterEncoding();
+      Charset charset = null;
+      try {
+        if (encoding != null) {
+          charset = Charset.forName(encoding);
+        }
+      } catch (IllegalArgumentException iae) {
+        // purposefully left blank
+      }
+
+      StoredByteBody storedByteBody =
+          new StoredByteBody(reqCtx, requestStartCb, requestEndedCb, charset, lengthHint);
+      ServletInputStreamWrapper servletInputStreamWrapper =
+          new ServletInputStreamWrapper(is, storedByteBody);
+
+      is = servletInputStreamWrapper;
+    }
+  }
+
+  @SuppressWarnings("Duplicates")
+  @RequiresRequestContext(RequestContextSlot.APPSEC)
+  static class HttpServletGetReaderAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    static void after(
+        @Advice.This final ServletRequest thiz,
+        @Advice.Return(readOnly = false) BufferedReader reader) {
+      if (!(thiz instanceof HttpServletRequest) || reader == null) {
+        return;
+      }
+
+      AgentSpan agentSpan = activeSpan();
+      if (agentSpan == null) {
+        return;
+      }
+      HttpServletRequest req = (HttpServletRequest) thiz;
+      Object alreadyWrapped = req.getAttribute("datadog.wrapped_request_body");
+      if (alreadyWrapped != null || reader instanceof BufferedReaderWrapper) {
+        return;
+      }
+      RequestContext requestContext = agentSpan.getRequestContext();
+      if (requestContext == null) {
+        return;
+      }
+      CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+      BiFunction<RequestContext, StoredBodySupplier, Void> requestStartCb =
+          cbp.getCallback(EVENTS.requestBodyStart());
+      BiFunction<RequestContext, StoredBodySupplier, Flow<Void>> requestEndedCb =
+          cbp.getCallback(EVENTS.requestBodyDone());
+      if (requestStartCb == null || requestEndedCb == null) {
+        return;
+      }
+
+      req.setAttribute("datadog.wrapped_request_body", Boolean.TRUE);
+
+      int lengthHint = 0;
+      String lengthHeader = req.getHeader("content-length");
+      if (lengthHeader != null) {
+        try {
+          lengthHint = Integer.parseInt(lengthHeader);
+        } catch (NumberFormatException nfe) {
+          // purposefully left blank
+        }
+      }
+
+      StoredCharBody storedCharBody =
+          new StoredCharBody(requestContext, requestStartCb, requestEndedCb, lengthHint);
+      reader = new BufferedReaderWrapper(reader, storedCharBody);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/WrapperForkedTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/WrapperForkedTest.groovy
@@ -4,8 +4,8 @@ import datadog.trace.api.gateway.RequestContextSlot
 import datadog.trace.api.http.StoredBodySupplier
 import datadog.trace.api.http.StoredByteBody
 import datadog.trace.api.http.StoredCharBody
-import datadog.trace.instrumentation.servlet.http.BufferedReaderWrapper
-import datadog.trace.instrumentation.servlet.http.ServletInputStreamWrapper
+import datadog.trace.instrumentation.servlet.BufferedReaderWrapper
+import datadog.trace.instrumentation.servlet2.ServletInputStreamWrapper
 import spock.lang.Specification
 
 import javax.servlet.ServletInputStream

--- a/dd-java-agent/instrumentation/servlet/request-3/build.gradle
+++ b/dd-java-agent/instrumentation/servlet/request-3/build.gradle
@@ -1,5 +1,6 @@
 muzzle {
   pass {
+    name = 'servlet-3.x'
     group = "javax.servlet"
     module = 'javax.servlet-api'
     versions = "[3.0,)"
@@ -9,6 +10,13 @@ muzzle {
     group = "javax.servlet"
     module = 'servlet-api'
     versions = "[,]"
+  }
+  pass {
+    name = 'servlet-3.1.x' // for Servlet3RequestBodyInstrumentation
+    group = "javax.servlet"
+    module = 'javax.servlet-api'
+    versions = "[3.1,)"
+    assertInverse = true
   }
 }
 
@@ -26,7 +34,9 @@ testSets {
 dependencies {
   testRuntimeOnly project(':dd-java-agent:instrumentation:iast-instrumenter')
 
-  compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
+  // build against 3.1 so we can wrap its additions to ServletInputStream,
+  // but all the other advice in this module is still compatible with 3.0+
+  compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
   implementation project(':dd-java-agent:instrumentation:servlet-common')
 
   testImplementation(project(':dd-java-agent:testing')) {

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/AsyncContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/AsyncContextInstrumentation.java
@@ -33,6 +33,11 @@ public final class AsyncContextInstrumentation extends Instrumenter.Tracing
   }
 
   @Override
+  public String muzzleDirective() {
+    return "servlet-3.x";
+  }
+
+  @Override
   public String hierarchyMarkerType() {
     return "javax.servlet.AsyncContext";
   }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet31InputStreamWrapper.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet31InputStreamWrapper.java
@@ -1,0 +1,28 @@
+package datadog.trace.instrumentation.servlet3;
+
+import datadog.trace.api.http.StoredByteBody;
+import datadog.trace.instrumentation.servlet.AbstractServletInputStreamWrapper;
+import javax.servlet.ReadListener;
+import javax.servlet.ServletInputStream;
+
+/** Provides additional delegation for servlet 3.1 */
+public class Servlet31InputStreamWrapper extends AbstractServletInputStreamWrapper {
+  public Servlet31InputStreamWrapper(ServletInputStream is, StoredByteBody storedByteBody) {
+    super(is, storedByteBody);
+  }
+
+  @Override
+  public boolean isFinished() {
+    return is.isFinished();
+  }
+
+  @Override
+  public boolean isReady() {
+    return is.isReady();
+  }
+
+  @Override
+  public void setReadListener(ReadListener readListener) {
+    is.setReadListener(readListener);
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet31RequestBodyInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet31RequestBodyInstrumentation.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.servlet3;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.hasClassNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedNoneOf;
 import static datadog.trace.api.gateway.Events.EVENTS;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -62,7 +63,11 @@ public class Servlet31RequestBodyInstrumentation extends Instrumenter.AppSec
 
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
-    return implementsInterface(named(hierarchyMarkerType()));
+    return implementsInterface(named(hierarchyMarkerType()))
+        .and(
+            namedNoneOf( // ignore wrappers that ship with servlet-api
+                "javax.servlet.ServletRequestWrapper",
+                "javax.servlet.http.HttpServletRequestWrapper"));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet31RequestBodyInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet31RequestBodyInstrumentation.java
@@ -1,18 +1,17 @@
-package datadog.trace.instrumentation.servlet.http;
+package datadog.trace.instrumentation.servlet3;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.hasClassNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.api.gateway.Events.EVENTS;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
-import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.advice.ActiveRequestContext;
 import datadog.trace.advice.RequiresRequestContext;
-import datadog.trace.agent.tooling.HelperInjector;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
@@ -23,32 +22,37 @@ import datadog.trace.api.http.StoredByteBody;
 import datadog.trace.api.http.StoredCharBody;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.instrumentation.servlet.BufferedReaderWrapper;
 import java.io.BufferedReader;
 import java.nio.charset.Charset;
-import java.security.ProtectionDomain;
-import java.security.SecureClassLoader;
-import java.util.Collections;
-import java.util.Map;
-import java.util.WeakHashMap;
 import java.util.function.BiFunction;
 import javax.servlet.ServletInputStream;
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
-import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.dynamic.ClassFileLocator;
-import net.bytebuddy.dynamic.DynamicType;
-import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.matcher.ElementMatcher;
-import net.bytebuddy.pool.TypePool;
-import net.bytebuddy.utility.JavaModule;
 
+/**
+ * Request bodies before servlet 3.1.x are covered by Servlet2RequestBodyInstrumentation from the
+ * "request-2" module. Any changes to the behaviour here should also be reflected in "request-2".
+ */
 @AutoService(Instrumenter.class)
-public class ServletRequestBodyInstrumentation extends Instrumenter.AppSec
+public class Servlet31RequestBodyInstrumentation extends Instrumenter.AppSec
     implements Instrumenter.ForTypeHierarchy {
-  public ServletRequestBodyInstrumentation() {
+  public Servlet31RequestBodyInstrumentation() {
     super("servlet-request-body");
+  }
+
+  @Override
+  public String muzzleDirective() {
+    return "servlet-3.1.x";
+  }
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    // Avoid matching request bodies before 3.1.x which have their own instrumentation
+    return hasClassNamed("javax.servlet.ReadListener");
   }
 
   @Override
@@ -79,100 +83,11 @@ public class ServletRequestBodyInstrumentation extends Instrumenter.AppSec
 
   @Override
   public String[] helperClassNames() {
-    return new String[] {packageName + ".BufferedReaderWrapper"};
-  }
-
-  @Override
-  public String[] muzzleIgnoredClassNames() {
-    String[] initial = super.muzzleIgnoredClassNames();
-    String[] ret = new String[initial.length + 1];
-    System.arraycopy(initial, 0, ret, 0, initial.length);
-    ret[initial.length] = packageName + ".ServletInputStreamWrapper";
-    return ret;
-  }
-
-  private static final ClassLoader BOOTSTRAP_CLASSLOADER_PLACEHOLDER =
-      new SecureClassLoader(null) {
-        @Override
-        public String toString() {
-          return "<bootstrap>";
-        }
-      };
-
-  @Override
-  public AdviceTransformer transformer() {
-    return new CustomTransformer();
-  }
-
-  // transformer possible adding extra 3 methods to ServletInputStreamWrapper
-  static class CustomTransformer implements AdviceTransformer {
-    private static final String STREAM_WRAPPER_TYPE =
-        "datadog.trace.instrumentation.servlet.http.ServletInputStreamWrapper";
-    private final Map<ClassLoader, Boolean> injectedClassLoaders =
-        Collections.synchronizedMap(new WeakHashMap<ClassLoader, Boolean>());
-
-    @Override
-    public DynamicType.Builder<?> transform(
-        DynamicType.Builder<?> builder,
-        TypeDescription typeDescription,
-        ClassLoader classLoader,
-        JavaModule module,
-        ProtectionDomain pd) {
-      if (classLoader == null) {
-        classLoader = BOOTSTRAP_CLASSLOADER_PLACEHOLDER;
-      }
-
-      if (injectedClassLoaders.containsKey(classLoader)) {
-        return builder;
-      }
-      injectedClassLoaders.put(classLoader, Boolean.TRUE);
-
-      TypePool.Resolution readListenerRes;
-      TypePool typePoolUserCl;
-      if (classLoader != BOOTSTRAP_CLASSLOADER_PLACEHOLDER) {
-        typePoolUserCl = TypePool.Default.of(classLoader);
-      } else {
-        typePoolUserCl = TypePool.Default.ofBootLoader();
-      }
-      readListenerRes = typePoolUserCl.describe("javax.servlet.ReadListener");
-      if (!readListenerRes.isResolved()) {
-        // likely servlet < 3.1
-        // inject original
-        return new HelperInjector("servlet-request-body", STREAM_WRAPPER_TYPE)
-            .transform(builder, typeDescription, classLoader, module, pd);
-      }
-
-      // else at the very least servlet 3.1+ classes are available
-      // modify ServletInputStreamWrapper before injecting it. This should be harmless even if
-      // servlet 3.1 is on the
-      // classpath without the implementation supporting it
-      ClassFileLocator compoundLocator =
-          new ClassFileLocator.Compound(
-              ClassFileLocator.ForClassLoader.of(getClass().getClassLoader()),
-              ClassFileLocator.ForClassLoader.of(classLoader));
-
-      TypePool.Resolution origWrapperRes =
-          TypePool.Default.of(compoundLocator).describe(STREAM_WRAPPER_TYPE);
-      if (!origWrapperRes.isResolved()) {
-        throw new RuntimeException("Could not load original ServletInputStreamWrapper");
-      }
-      TypeDescription origWrapperType = origWrapperRes.resolve();
-
-      DynamicType.Unloaded<?> unloaded =
-          new ByteBuddy()
-              .rebase(origWrapperType, compoundLocator)
-              .method(named("isFinished").and(takesNoArguments()))
-              .intercept(MethodDelegation.toField("is"))
-              .method(named("isReady").and(takesNoArguments()))
-              .intercept(MethodDelegation.toField("is"))
-              .method(named("setReadListener").and(takesArguments(readListenerRes.resolve())))
-              .intercept(MethodDelegation.toField("is"))
-              .make();
-      return new HelperInjector(
-              "servlet-request-body",
-              Collections.singletonMap(origWrapperType.getName(), unloaded.getBytes()))
-          .transform(builder, typeDescription, classLoader, module, pd);
-    }
+    return new String[] {
+      "datadog.trace.instrumentation.servlet.BufferedReaderWrapper",
+      "datadog.trace.instrumentation.servlet.AbstractServletInputStreamWrapper",
+      "datadog.trace.instrumentation.servlet3.Servlet31InputStreamWrapper"
+    };
   }
 
   @SuppressWarnings("Duplicates")
@@ -189,7 +104,7 @@ public class ServletRequestBodyInstrumentation extends Instrumenter.AppSec
 
       HttpServletRequest req = (HttpServletRequest) thiz;
       Object alreadyWrapped = req.getAttribute("datadog.wrapped_request_body");
-      if (alreadyWrapped != null || is instanceof ServletInputStreamWrapper) {
+      if (alreadyWrapped != null || is instanceof Servlet31InputStreamWrapper) {
         return;
       }
 
@@ -226,8 +141,8 @@ public class ServletRequestBodyInstrumentation extends Instrumenter.AppSec
 
       StoredByteBody storedByteBody =
           new StoredByteBody(reqCtx, requestStartCb, requestEndedCb, charset, lengthHint);
-      ServletInputStreamWrapper servletInputStreamWrapper =
-          new ServletInputStreamWrapper(is, storedByteBody);
+      Servlet31InputStreamWrapper servletInputStreamWrapper =
+          new Servlet31InputStreamWrapper(is, storedByteBody);
 
       is = servletInputStreamWrapper;
     }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Instrumentation.java
@@ -21,6 +21,11 @@ public final class Servlet3Instrumentation extends Instrumenter.Tracing
   }
 
   @Override
+  public String muzzleDirective() {
+    return "servlet-3.x";
+  }
+
+  @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Avoid matching servlet 2 which has its own instrumentation
     return hasClassNamed("javax.servlet.AsyncEvent");


### PR DESCRIPTION
# What Does This Do

Takes advantage of recent muzzle changes that let you specify different directives for instrumentations in the same module. 

The `ServletInputStreamWrapper` located under the `request-2` module covers both servlet 2.x and 3.0.x

A new `Servlet31InputStreamWrapper` is located under the `request-3` module and covers the additional methods introduced in servlet 3.1.x. A class-loader check for `javax.servlet.ReadListener`, a new type used in one of the methods added in 3.1, makes sure that at most one of these request-body instrumentations applies to a given class-loader.

Most of the low-level wrapping of `ServletInputStream` has been moved to `servlet-common` to reduce duplication.

This PR also skips the `javax.servlet.ServletRequestWrapper` / `javax.servlet.http.HttpServletRequestWrapper` wrappers - these are part of the servlet-api module and they always delegate to an actual real implementation, so it is safe to skip them. Excluding them should avoid an issue seen in modular environments where we attempt to inject wrappers into the servlet-api module, when really we're only interested in the actual implementations.

# Motivation

The previous run-time approach bypassed various performance improvements - this new approach is more inline with how we handle differences in other instrumentations across versions, sacrificing a bit of duplication at build-time so we don't have to do as much at run-time.