### PR TITLE
Catch AccessControlException in telemetry HostInfo

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/HostInfo.java
+++ b/telemetry/src/main/java/datadog/telemetry/HostInfo.java
@@ -9,6 +9,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.AccessControlException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -124,7 +125,7 @@ public class HostInfo {
       try {
         byte[] bytes = Files.readAllBytes(file);
         content = new String(bytes, StandardCharsets.ISO_8859_1);
-      } catch (IOException e) {
+      } catch (IOException | AccessControlException e) {
         log.debug("Could not read {}", file, e);
       }
     }
@@ -154,7 +155,8 @@ public class HostInfo {
               version = matcher.group("value");
             }
           }
-        } catch (IOException e) {
+        } catch (IOException | AccessControlException e) {
+          log.debug("Could not read {}", OS_RELEASE_PATH, e);
         }
         if (name != null && version != null) {
           return name + " " + version;


### PR DESCRIPTION
# What Does This Do

# Motivation
Telemetry failing to read a file because of a SecurityManager led to Telemetry thread ending with an uncaught exception.

# Additional Notes

Test case:

```
import javax.xml.parsers.SAXParser;
import javax.xml.parsers.SAXParserFactory;
import org.xml.sax.SAXNotRecognizedException;

public class Bug6359330 {

    public static void main(String[] args) throws Throwable {
        System.setSecurityManager(new SecurityManager());
        try {
            SAXParserFactory spf = SAXParserFactory.newInstance();
            spf.setNamespaceAware(true);
            spf.setValidating(true);
            SAXParser sp = spf.newSAXParser();
            // The following line shouldn't throw a
            // java.security.AccessControlException.
            sp.setProperty("foo", "bar");
        } catch (SAXNotRecognizedException e) {
            // Ignore this expected exception.
        }
    }
}
```

Exception:

```
[dd.trace 2022-11-07 09:19:14:898 +0100] [dd-telemetry] ERROR datadog.telemetry.TelemetryRunnable - Uncaught exception in dd-telemetry
java.security.AccessControlException: access denied ("java.io.FilePermission" "/etc/os-release" "read")
        at java.base/java.security.AccessControlContext.checkPermission(AccessControlContext.java:472)
        at java.base/java.security.AccessController.checkPermission(AccessController.java:897)
        at java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:322)
        at java.base/java.lang.SecurityManager.checkRead(SecurityManager.java:661)
        at java.base/sun.nio.fs.UnixPath.checkRead(UnixPath.java:818)
        at java.base/sun.nio.fs.UnixFileSystemProvider.isRegularFile(UnixFileSystemProvider.java:517)
        at java.base/java.nio.file.Files.isRegularFile(Files.java:2274)
        at datadog.telemetry.HostInfo$Os.getOsVersion(HostInfo.java:141)
	at datadog.telemetry.HostInfo.getOsVersion(HostInfo.java:82)
	at datadog.telemetry.RequestBuilder.<init>(RequestBuilder.java:68)
	at datadog.telemetry.RequestBuilderSupplier.get(RequestBuilderSupplier.java:17)
	at datadog.telemetry.RequestBuilderSupplier.get(RequestBuilderSupplier.java:6)
	at datadog.telemetry.TelemetryServiceImpl.addStartedRequest(TelemetryServiceImpl.java:59)
	at datadog.telemetry.TelemetryRunnable.run(TelemetryRunnable.java:57)
	at java.base/java.lang.Thread.run(Thread.java:829)
```