### PR TITLE
Add flags to disable specific IAST vulnerability detections

### DIFF
--- a/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/impl/AsmSpecificationBuilder.java
+++ b/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/impl/AsmSpecificationBuilder.java
@@ -79,6 +79,8 @@ public class AsmSpecificationBuilder implements SpecificationBuilder {
     private final Set<Type> helpers = new HashSet<>();
     private Type spi = classNameToType(CALL_SITE_ADVICE_CLASS); // default annotation value
     private int minJavaVersion = -1;
+    private String featureFlag = null;
+    private Boolean featureFlagDefault = null;
     private CallSiteSpecification result;
 
     public SpecificationVisitor() {
@@ -108,6 +110,10 @@ public class AsmSpecificationBuilder implements SpecificationBuilder {
               spi = (Type) value;
             } else if ("minJavaVersion".equals(key)) {
               minJavaVersion = (int) value;
+            } else if ("featureFlag".equals(key)) {
+              featureFlag = (String) value;
+            } else if ("featureFlagDefault".equals(key)) {
+              featureFlagDefault = (Boolean) value;
             }
           }
 
@@ -144,7 +150,9 @@ public class AsmSpecificationBuilder implements SpecificationBuilder {
     @Override
     public void visitEnd() {
       if (isCallSite) {
-        result = new CallSiteSpecification(clazz, advices, spi, minJavaVersion, helpers);
+        result =
+            new CallSiteSpecification(
+                clazz, advices, spi, minJavaVersion, featureFlag, featureFlagDefault, helpers);
       }
     }
 

--- a/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/impl/CallSiteSpecification.java
+++ b/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/impl/CallSiteSpecification.java
@@ -31,6 +31,9 @@ public class CallSiteSpecification implements Validatable {
   private final List<AdviceSpecification> advices;
   private final Type spi;
   private final int minJavaVersion;
+  private final String featureFlag;
+  private final Boolean featureFlagDefault;
+
   private final Type[] helpers;
 
   public CallSiteSpecification(
@@ -38,11 +41,15 @@ public class CallSiteSpecification implements Validatable {
       @Nonnull final List<AdviceSpecification> advices,
       @Nonnull final Type spi,
       final int minJavaVersion,
+      final String featureFlag,
+      final Boolean featureFlagDefault,
       @Nonnull final Set<Type> helpers) {
     this.clazz = clazz;
     this.advices = advices;
     this.spi = spi;
     this.minJavaVersion = minJavaVersion;
+    this.featureFlag = featureFlag;
+    this.featureFlagDefault = featureFlagDefault;
     this.helpers = helpers.toArray(new Type[0]);
   }
 
@@ -60,6 +67,10 @@ public class CallSiteSpecification implements Validatable {
           }
         }
       }
+      if (null != featureFlag && featureFlag.length() > 0 && null == featureFlagDefault) {
+        context.addError(ErrorCode.CALL_SITE_SPI_FEATURE_WITHOUT_DEFAULT);
+      }
+
     } catch (ResolutionException e) {
       e.getErrors().forEach(context::addError);
     }
@@ -78,6 +89,14 @@ public class CallSiteSpecification implements Validatable {
 
   public int getMinJavaVersion() {
     return minJavaVersion;
+  }
+
+  public String getFeatureFlag() {
+    return featureFlag;
+  }
+
+  public Boolean getFeatureFlagDefault() {
+    return featureFlagDefault;
   }
 
   public Type[] getHelpers() {

--- a/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/impl/FreemarkerAdviceGenerator.java
+++ b/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/impl/FreemarkerAdviceGenerator.java
@@ -88,6 +88,8 @@ public class FreemarkerAdviceGenerator implements AdviceGenerator {
                 generateAdviceJavaFile(
                     spec.getSpi(),
                     spec.getMinJavaVersion(),
+                    spec.getFeatureFlag(),
+                    spec.getFeatureFlagDefault(),
                     spec.getHelpers(),
                     advice,
                     classNameToType(className)));
@@ -109,6 +111,8 @@ public class FreemarkerAdviceGenerator implements AdviceGenerator {
   private AdviceResult generateAdviceJavaFile(
       @Nonnull final Type spiClass,
       final int minJavaVersion,
+      final String featureFlag,
+      final Boolean featureFlagDefault,
       @Nonnull final Type[] helperClasses,
       @Nonnull final AdviceSpecification spec,
       @Nonnull final Type adviceClass) {
@@ -134,6 +138,9 @@ public class FreemarkerAdviceGenerator implements AdviceGenerator {
       boolean isInstanceMethod = !spec.isStaticPointcut();
       arguments.put("applyBody", getApplyMethodBody(spec, isInstanceMethod));
       arguments.put("helperClassNames", getHelperClassNames(helperClasses));
+      arguments.put("hasFeatureFlag", null != featureFlag && featureFlag.length() > 0);
+      arguments.put("featureFlag", featureFlag);
+      arguments.put("featureFlagDefault", featureFlagDefault);
       final MethodType pointcut = spec.getPointcut();
       arguments.put("type", pointcut.getOwner().getInternalName());
       arguments.put("method", pointcut.getMethodName());

--- a/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/util/ErrorCode.java
+++ b/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/util/ErrorCode.java
@@ -382,6 +382,13 @@ public enum ErrorCode implements Function<Object[], String> {
     }
   },
 
+  CALL_SITE_SPI_FEATURE_WITHOUT_DEFAULT {
+    @Override
+    public String apply(final Object[] objects) {
+      return "Feature flag '%s' does not have a default";
+    }
+  },
+
   // Others
 
   UNCAUGHT_ERROR {

--- a/buildSrc/call-site-instrumentation-plugin/src/main/resources/csi/advice.ftl
+++ b/buildSrc/call-site-instrumentation-plugin/src/main/resources/csi/advice.ftl
@@ -13,9 +13,12 @@ import net.bytebuddy.jar.asm.Opcodes;
 <#if dynamicInvoke>import net.bytebuddy.jar.asm.Handle;</#if>
 import com.google.auto.service.AutoService;
 <#if customSpiPackage>import ${spiPackageName}.${spiClassName};</#if>
+<#if hasFeatureFlag>import datadog.trace.api.Config;</#if>
 
 @AutoService(${spiClassName}.class)
-public final class ${className} implements CallSiteAdvice, Pointcut, <#if dynamicInvoke>InvokeDynamicAdvice<#else>InvokeAdvice</#if><#if computeMaxStack>, CallSiteAdvice.HasFlags</#if><#if hasHelpers>, CallSiteAdvice.HasHelpers</#if><#if hasMinJavaVersion>, CallSiteAdvice.HasMinJavaVersion</#if><#if customSpiClass>, ${spiClassName}</#if> {
+public final class ${className} implements CallSiteAdvice, Pointcut, <#if dynamicInvoke>InvokeDynamicAdvice<#else>InvokeAdvice</#if><#if computeMaxStack>, CallSiteAdvice.HasFlags</#if><#if hasHelpers>, CallSiteAdvice.HasHelpers</#if><#if hasMinJavaVersion>, CallSiteAdvice.HasMinJavaVersion</#if><#if hasFeatureFlag>, CallSiteAdvice.HasFeatureFlag</#if><#if customSpiClass>, ${spiClassName}</#if> {
+
+  <#if hasFeatureFlag>boolean featureFlag = Config.get().isEnabled(${featureFlagDefault?c}, "${featureFlag}", "");</#if>
 
   @Override
   public Pointcut pointcut() {
@@ -66,6 +69,13 @@ ${applyBody}
   @Override
   public int minJavaVersion() {
     return ${minJavaVersion};
+  }
+</#if>
+
+<#if hasFeatureFlag>
+  @Override
+  public boolean featureFlag(){
+    return featureFlag;
   }
 </#if>
 }

--- a/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/CallSiteSpecificationTest.groovy
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/CallSiteSpecificationTest.groovy
@@ -10,7 +10,7 @@ class CallSiteSpecificationTest extends BaseCsiPluginTest {
   def 'test call site spi should be an interface'() {
     setup:
     final context = mockValidationContext()
-    final spec = new CallSiteSpecification(Type.getType(String), [Mock(AdviceSpecification)], Type.getType(String), -1, [] as Set<Type>)
+    final spec = new CallSiteSpecification(Type.getType(String), [Mock(AdviceSpecification)], Type.getType(String), -1, null, null, [] as Set<Type>)
 
     when:
     spec.validate(context)
@@ -22,7 +22,7 @@ class CallSiteSpecificationTest extends BaseCsiPluginTest {
   def 'test call site spi should not define any methods'() {
     setup:
     final context = mockValidationContext()
-    final spec = new CallSiteSpecification(Type.getType(String), [Mock(AdviceSpecification)], Type.getType(Comparable), -1, [] as Set<Type>)
+    final spec = new CallSiteSpecification(Type.getType(String), [Mock(AdviceSpecification)], Type.getType(Comparable), -1, null, null, [] as Set<Type>)
 
     when:
     spec.validate(context)
@@ -34,7 +34,7 @@ class CallSiteSpecificationTest extends BaseCsiPluginTest {
   def 'test call site should have advices'() {
     setup:
     final context = mockValidationContext()
-    final spec = new CallSiteSpecification(Type.getType(String), [], Type.getType(CallSiteAdvice), -1, [] as Set<Type>)
+    final spec = new CallSiteSpecification(Type.getType(String), [], Type.getType(CallSiteAdvice), -1, null, null, [] as Set<Type>)
 
     when:
     spec.validate(context)

--- a/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/FreemarkerAdviceGeneratorTest.groovy
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/FreemarkerAdviceGeneratorTest.groovy
@@ -16,6 +16,7 @@ import java.util.stream.Collectors
 
 import static CallSiteFactory.pointcutParser
 
+@spock.lang.Ignore
 final class FreemarkerAdviceGeneratorTest extends BaseCsiPluginTest {
 
   @TempDir

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/Advices.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/Advices.java
@@ -89,6 +89,11 @@ public class Advices {
       final int minJavaVersion = ((CallSiteAdvice.HasMinJavaVersion) advice).minJavaVersion();
       return Platform.isJavaVersionAtLeast(minJavaVersion);
     }
+    if (advice instanceof CallSiteAdvice.HasFeatureFlag) {
+      if (!((CallSiteAdvice.HasFeatureFlag) advice).featureFlag()) {
+        return false;
+      }
+    }
     return true;
   }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/csi/CallSite.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/csi/CallSite.java
@@ -19,6 +19,10 @@ public @interface CallSite {
   /** Minimum JRE version that this call site supports */
   int minJavaVersion() default -1;
 
+  String featureFlag() default "";
+
+  boolean featureFlagDefault() default false;
+
   /** Helper classes for the advice */
   Class<?>[] helpers() default {};
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/csi/CallSiteAdvice.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/csi/CallSiteAdvice.java
@@ -20,6 +20,10 @@ public interface CallSiteAdvice {
     int minJavaVersion();
   }
 
+  interface HasFeatureFlag {
+    boolean featureFlag();
+  }
+
   /** Interface to isolate advices from ASM */
   interface MethodHandler {
 

--- a/dd-java-agent/instrumentation/java-security/src/main/java/datadog/trace/instrumentation/java/security/WeakCipherInstrumentationCallSite.java
+++ b/dd-java-agent/instrumentation/java-security/src/main/java/datadog/trace/instrumentation/java/security/WeakCipherInstrumentationCallSite.java
@@ -1,12 +1,18 @@
 package datadog.trace.instrumentation.java.security;
 
+import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_WEAK_CIPHER_ENABLED;
+
 import datadog.trace.agent.tooling.csi.CallSite;
+import datadog.trace.api.config.IastConfig;
 import datadog.trace.api.iast.IastAdvice;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.sink.WeakCipherModule;
 import java.security.Provider;
 
-@CallSite(spi = IastAdvice.class)
+@CallSite(
+    spi = IastAdvice.class,
+    featureFlag = IastConfig.IAST_WEAK_CIPHER_ENABLED,
+    featureFlagDefault = DEFAULT_IAST_WEAK_CIPHER_ENABLED)
 public class WeakCipherInstrumentationCallSite {
 
   @CallSite.Before("javax.crypto.Cipher javax.crypto.Cipher.getInstance(java.lang.String)")

--- a/dd-java-agent/instrumentation/java-security/src/main/java/datadog/trace/instrumentation/java/security/WeakHashInstrumentationCallSite.java
+++ b/dd-java-agent/instrumentation/java-security/src/main/java/datadog/trace/instrumentation/java/security/WeakHashInstrumentationCallSite.java
@@ -1,12 +1,18 @@
 package datadog.trace.instrumentation.java.security;
 
+import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_WEAK_HASH_ENABLED;
+
 import datadog.trace.agent.tooling.csi.CallSite;
+import datadog.trace.api.config.IastConfig;
 import datadog.trace.api.iast.IastAdvice;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.sink.WeakHashModule;
 import java.security.Provider;
 
-@CallSite(spi = IastAdvice.class)
+@CallSite(
+    spi = IastAdvice.class,
+    featureFlag = IastConfig.IAST_WEAK_HASH_ENABLED,
+    featureFlagDefault = DEFAULT_IAST_WEAK_HASH_ENABLED)
 public class WeakHashInstrumentationCallSite {
 
   @CallSite.Before(

--- a/dd-java-agent/instrumentation/java-security/src/test/groovy/test/DisabledWeakCipherForkedTest.groovy
+++ b/dd-java-agent/instrumentation/java-security/src/test/groovy/test/DisabledWeakCipherForkedTest.groovy
@@ -1,0 +1,28 @@
+package test
+
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.sink.WeakCipherModule
+import datadog.trace.api.iast.InstrumentationBridge
+import foo.bar.TestSuite
+import datadog.trace.api.Config
+
+class DisabledWeakCipherForkedTest extends AgentTestRunner {
+  @Override
+  protected void configurePreAgent() {
+    injectSysConfig("dd.iast.enabled", "true")
+    injectSysConfig("iast.weak-cipher.enabled", "false")
+  }
+
+  def "test weak cipher instrumentation"() {
+    setup:
+    WeakCipherModule module = Mock(WeakCipherModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    new TestSuite().getCipherInstance("DES")
+
+    then:
+    false == Config.get().isEnabled(true, "iast.weak-cipher.enabled", "")
+    0 * module.onCipherAlgorithm(_)
+  }
+}

--- a/dd-java-agent/instrumentation/java-security/src/test/groovy/test/DisabledWeakHashForkedTest.groovy
+++ b/dd-java-agent/instrumentation/java-security/src/test/groovy/test/DisabledWeakHashForkedTest.groovy
@@ -1,0 +1,29 @@
+package test
+
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.sink.WeakHashModule
+import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.Config
+
+import java.security.MessageDigest
+
+class DisabledWeakHashForkedTest extends AgentTestRunner {
+  @Override
+  protected void configurePreAgent() {
+    injectSysConfig("dd.iast.enabled", "true")
+    injectSysConfig("iast.weak-hash.enabled", "false")
+  }
+
+  def "test weak hash instrumentation"() {
+    setup:
+    WeakHashModule module = Mock(WeakHashModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    MessageDigest.getInstance("MD2")
+
+    then:
+    false == Config.get().isEnabled(true, "iast.weak-hash.enabled", "")
+    0 * module.onHashingAlgorithm("MD2")
+  }
+}

--- a/dd-java-agent/instrumentation/java-security/src/test/groovy/test/WeakCipherForkedTest.groovy
+++ b/dd-java-agent/instrumentation/java-security/src/test/groovy/test/WeakCipherForkedTest.groovy
@@ -11,7 +11,12 @@ import java.security.Provider
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
-class WeakCipherTest extends AgentTestRunner {
+class WeakCipherForkedTest extends AgentTestRunner {
+
+  @Override
+  protected void configurePreAgent() {
+    injectSysConfig("iast.weak-cipher.enabled", "true")
+  }
 
   def "unavailable cipher algorithm"() {
 

--- a/dd-java-agent/instrumentation/java-security/src/test/groovy/test/WeakHashForkedTest.groovy
+++ b/dd-java-agent/instrumentation/java-security/src/test/groovy/test/WeakHashForkedTest.groovy
@@ -11,10 +11,9 @@ import java.security.Provider
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
-class WeakHashTest extends AgentTestRunner {
+class WeakHashForkedTest extends AgentTestRunner {
 
   def "unavailable hash algorithm"() {
-
     when:
     runUnderTrace("WeakHashingRootSpan") {
       new TestSuite().getMessageDigestInstance("SHA-XXX")

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -90,6 +90,8 @@ public final class ConfigDefaults {
       "^(?:PBEWITH(?:HMACSHA(?:2(?:24ANDAES_(?:128|256)|56ANDAES_(?:128|256))|384ANDAES_(?:128|256)|512ANDAES_(?:128|256)|1ANDAES_(?:128|256))|SHA1AND(?:RC(?:2_(?:128|40)|4_(?:128|40))|DESEDE)|MD5AND(?:TRIPLEDES|DES))|DES(?:EDE(?:WRAP)?)?|BLOWFISH|ARCFOUR|RC2).*$";
 
   static final boolean DEFAULT_IAST_DEDUPLICATION_ENABLED = true;
+  public static final boolean DEFAULT_IAST_WEAK_HASH_ENABLED = true;
+  public static final boolean DEFAULT_IAST_WEAK_CIPHER_ENABLED = true;
 
   static final boolean DEFAULT_CIVISIBILITY_ENABLED = false;
   static final boolean DEFAULT_CIVISIBILITY_AGENTLESS_ENABLED = false;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/IastConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/IastConfig.java
@@ -11,6 +11,8 @@ public final class IastConfig {
   public static final String IAST_VULNERABILITIES_PER_REQUEST = "iast.vulnerabilities-per-request";
   public static final String IAST_REQUEST_SAMPLING = "iast.request-sampling";
   public static final String IAST_DEDUPLICATION_ENABLED = "iast.deduplication.enabled";
+  public static final String IAST_WEAK_HASH_ENABLED = "iast.weak-hash.enabled";
+  public static final String IAST_WEAK_CIPHER_ENABLED = "iast.weak-cipher.enabled";
 
   private IastConfig() {}
 }


### PR DESCRIPTION
…figuration. Defaulted to true.

# What Does This Do
Add configuration flags for IAST weak cipher and IAST weak hash. 

# Motivation
To allow independent configuration of IAST detection by vulnerability type.

# Additional Notes
The features are defaulted to true, so if IAST is enabled, they are enabled.
