### PR TITLE
Refine stacktrace filtering

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastModuleImpl.java
@@ -52,6 +52,7 @@ public final class IastModuleImpl implements IastModule {
     this.overheadController = overheadController;
   }
 
+  @Override
   public void onCipherAlgorithm(@Nullable final String algorithm) {
     if (algorithm == null) {
       return;
@@ -76,6 +77,7 @@ public final class IastModuleImpl implements IastModule {
     reporter.report(span, vulnerability);
   }
 
+  @Override
   public void onHashingAlgorithm(@Nullable final String algorithm) {
     if (algorithm == null) {
       return;
@@ -452,8 +454,7 @@ public final class IastModuleImpl implements IastModule {
             new Evidence(evidence.toString(), targetRanges)));
   }
 
-  private static StackTraceElement findValidPackageForVulnerability(
-      Stream<StackTraceElement> stream) {
+  static StackTraceElement findValidPackageForVulnerability(Stream<StackTraceElement> stream) {
     final StackTraceElement[] first = new StackTraceElement[1];
     return stream
         .filter(
@@ -461,7 +462,7 @@ public final class IastModuleImpl implements IastModule {
               if (first[0] == null) {
                 first[0] = stack;
               }
-              return IastExclusionTrie.apply(stack.getClassName()) != 1;
+              return IastExclusionTrie.apply(stack.getClassName()) < 1;
             })
         .findFirst()
         .orElse(first[0]);

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastModuleImpl.java
@@ -468,10 +468,6 @@ public final class IastModuleImpl implements IastModule {
         .orElse(first[0]);
   }
 
-  private static Range[] getRanges(final TaintedObject taintedObject) {
-    return taintedObject == null ? Ranges.EMPTY : taintedObject.getRanges();
-  }
-
   private static TaintedObject getTainted(final TaintedObjects to, final Object value) {
     return value == null ? null : to.get(value);
   }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastModuleFindValidPackageForVulnerability.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastModuleFindValidPackageForVulnerability.groovy
@@ -1,0 +1,48 @@
+package com.datadog.iast
+
+
+class IastModuleFindValidPackageForVulnerability extends IastModuleImplTestBase {
+
+  final StackTraceElement ignoredPackageClassElement = element("org.springframework.Ignored")
+  final StackTraceElement notIgnoredPackageClassElement = element("datadog.smoketest.NotIgnored")
+  final StackTraceElement notInIastExclusionTrie = element("not.in.iast.exclusion.Class")
+
+
+  void 'filter ignored package element from stack'() {
+
+    given:
+    final StackTraceElement expected = notInIastExclusionTrie
+    final list = Arrays.asList(ignoredPackageClassElement, expected, notIgnoredPackageClassElement)
+    when:
+    final StackTraceElement result = IastModuleImpl.findValidPackageForVulnerability(list.stream())
+    then:
+    result == expected
+  }
+
+  void 'not filter not ignored package element from stack'() {
+
+    given:
+    final StackTraceElement expected = notIgnoredPackageClassElement
+    final list = Arrays.asList(ignoredPackageClassElement, expected, notInIastExclusionTrie)
+    when:
+    final StackTraceElement result = IastModuleImpl.findValidPackageForVulnerability(list.stream())
+    then:
+    result == expected
+  }
+
+  void 'If all elements are filtered returns the first one'() {
+
+    given:
+    final StackTraceElement expected = ignoredPackageClassElement
+    final ignoredPackageClassElement2 = element("java.Ignored")
+    final list = Arrays.asList(expected, ignoredPackageClassElement2)
+    when:
+    final StackTraceElement result = IastModuleImpl.findValidPackageForVulnerability(list.stream())
+    then:
+    result == expected
+  }
+
+  private StackTraceElement element(final String declaringClass) {
+    return new StackTraceElement(declaringClass, "method", "fileName", 1)
+  }
+}

--- a/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog.trace.instrumentation.iastinstrumenter/iast_exclusion.trie
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog.trace.instrumentation.iastinstrumenter/iast_exclusion.trie
@@ -4,8 +4,9 @@
 # Use 0 to allow transformation of packages or classes beneath ignored packages
 # End lines with '.*' to match any sub-package or '$*' to match nested-classes
 
-# 0 = global allows
-# 1 = Iast Instrumenter ignores
+# 0 = global allows and not filter stacktrace
+# 1 = Iast Instrumenter ignores and filter stacktrace
+# 2 = Iast Instrumenter allows and filter stacktrace
 
 # -------- JDK --------
 1 com.sun.*

--- a/dd-java-agent/instrumentation/iast-instrumenter/src/test/groovy/IastExclusionTrieTest.groovy
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/test/groovy/IastExclusionTrieTest.groovy
@@ -1,5 +1,4 @@
-package datadog.trace.instrumentation.iastinstrumenter
-
+import datadog.trace.instrumentation.iastinstrumenter.IastExclusionTrie
 import datadog.trace.test.util.DDSpecification
 import spock.lang.Unroll
 


### PR DESCRIPTION
# What Does This Do
Filter out from stack classes that matches the IAST exclusion trie

# Motivation
Filter out frameworks (e.g. Spring) from vulnerability stack

# Additional Notes
Add a new value to IAST exclusion trie to manage all combinations
Keep a last resort fallback (e.g. if all frames are filtered, keep the first non-DD frame
