### PR TITLE
Split out instrumentation build-time config

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/TPEHelper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/TPEHelper.java
@@ -3,8 +3,8 @@ package datadog.trace.bootstrap.instrumentation.java.concurrent;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.exclude;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.GenericClassValue;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import java.util.Set;
@@ -37,8 +37,8 @@ public final class TPEHelper {
           });
 
   static {
-    Config config = Config.get();
-    useWrapping = config.isLegacyTracingEnabled(false, "trace.thread-pool-executors");
+    InstrumenterConfig config = InstrumenterConfig.get();
+    useWrapping = config.isLegacyInstrumentationEnabled(false, "trace.thread-pool-executors");
     excludedClasses = config.getTraceThreadPoolExecutorsExclude();
     if (useWrapping) {
       threadLocalScope = null;

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -8,6 +8,7 @@ import datadog.trace.agent.tooling.bytebuddy.DDOutlinePoolStrategy;
 import datadog.trace.agent.tooling.bytebuddy.SharedTypePools;
 import datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers;
 import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.api.IntegrationsCollector;
 import datadog.trace.api.ProductActivationConfig;
 import datadog.trace.bootstrap.FieldBackedContextAccessor;
@@ -76,7 +77,7 @@ public class AgentInstaller {
       final AgentBuilder.Listener... listeners) {
     Utils.setInstrumentation(inst);
 
-    if (Config.get().isResolverOutlinePoolEnabled()) {
+    if (InstrumenterConfig.get().isResolverOutlinePoolEnabled()) {
       DDOutlinePoolStrategy.registerTypePoolFacade();
     } else {
       DDCachingPoolStrategy.registerAsSupplier();

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentStrategies.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentStrategies.java
@@ -6,7 +6,7 @@ import datadog.trace.agent.tooling.bytebuddy.DDLocationStrategy;
 import datadog.trace.agent.tooling.bytebuddy.DDOutlinePoolStrategy;
 import datadog.trace.agent.tooling.bytebuddy.DDOutlineTypeStrategy;
 import datadog.trace.agent.tooling.bytebuddy.DDRediscoveryStrategy;
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.api.Platform;
 import net.bytebuddy.agent.builder.AgentBuilder.ClassFileBufferStrategy;
 import net.bytebuddy.agent.builder.AgentBuilder.LocationStrategy;
@@ -50,7 +50,7 @@ public class AgentStrategies {
   private static final TypeStrategy TYPE_STRATEGY;
 
   static {
-    if (Config.get().isResolverOutlinePoolEnabled()) {
+    if (InstrumenterConfig.get().isResolverOutlinePoolEnabled()) {
       POOL_STRATEGY = DDOutlinePoolStrategy.INSTANCE;
       BUFFER_STRATEGY = DDOutlineTypeStrategy.INSTANCE;
       TYPE_STRATEGY = DDOutlineTypeStrategy.INSTANCE;

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentTransformerBuilder.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentTransformerBuilder.java
@@ -19,7 +19,7 @@ import datadog.trace.agent.tooling.bytebuddy.matcher.ShouldInjectFieldsRawMatche
 import datadog.trace.agent.tooling.bytebuddy.matcher.SingleTypeMatcher;
 import datadog.trace.agent.tooling.context.FieldBackedContextInjector;
 import datadog.trace.agent.tooling.context.FieldBackedContextRequestRewriter;
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import java.lang.instrument.Instrumentation;
 import java.util.HashMap;
 import java.util.Map;
@@ -62,7 +62,7 @@ public class AgentTransformerBuilder
   }
 
   public ResettableClassFileTransformer installOn(Instrumentation instrumentation) {
-    if (Config.get().isRuntimeContextFieldInjection()) {
+    if (InstrumenterConfig.get().isRuntimeContextFieldInjection()) {
       applyContextStoreInjection();
     }
 

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/DDCachingPoolStrategy.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/DDCachingPoolStrategy.java
@@ -5,7 +5,7 @@ import static datadog.trace.bootstrap.AgentClassLoading.LOCATING_CLASS;
 
 import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap;
 import datadog.trace.agent.tooling.WeakCaches;
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.WeakCache;
 import java.lang.ref.WeakReference;
 import java.util.concurrent.ConcurrentMap;
@@ -52,7 +52,7 @@ public final class DDCachingPoolStrategy
 
   static final int CONCURRENCY_LEVEL = 8;
   static final int LOADER_CAPACITY = 64;
-  static final int TYPE_CAPACITY = Config.get().getResolverTypePoolSize();
+  static final int TYPE_CAPACITY = InstrumenterConfig.get().getResolverTypePoolSize();
 
   static final int BOOTSTRAP_HASH = 7236344; // Just a random number
 
@@ -60,7 +60,7 @@ public final class DDCachingPoolStrategy
       WeakReference::new;
 
   public static final DDCachingPoolStrategy INSTANCE =
-      new DDCachingPoolStrategy(Config.get().isResolverUseLoadClassEnabled());
+      new DDCachingPoolStrategy(InstrumenterConfig.get().isResolverUseLoadClassEnabled());
 
   public static void registerAsSupplier() {
     SharedTypePools.registerIfAbsent(INSTANCE);

--- a/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/CrashUploader.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/CrashUploader.java
@@ -62,7 +62,6 @@ public final class CrashUploader {
       MediaType.parse("application/octet-stream");
 
   private final Config config;
-  private final ConfigProvider configProvider;
 
   private final OkHttpClient telemetryClient;
   private final HttpUrl telemetryUrl;
@@ -70,12 +69,11 @@ public final class CrashUploader {
   private final String tags;
 
   public CrashUploader() {
-    this(Config.get(), ConfigProvider.getInstance());
+    this(Config.get());
   }
 
-  CrashUploader(final Config config, final ConfigProvider configProvider) {
+  CrashUploader(final Config config) {
     this.config = config;
-    this.configProvider = configProvider;
 
     telemetryUrl = HttpUrl.get(config.getFinalCrashTrackingTelemetryUrl());
     agentless = config.isCrashTrackingAgentless();
@@ -88,6 +86,8 @@ public final class CrashUploader {
     }
     // Comma separated tags string for V2.4 format
     tags = tagsToString(tagsMap);
+
+    ConfigProvider configProvider = config.configProvider();
 
     telemetryClient =
         OkHttpUtils.buildHttpClient(

--- a/dd-java-agent/agent-crashtracking/src/test/java/com/datadog/crashtracking/CrashUploaderTest.java
+++ b/dd-java-agent/agent-crashtracking/src/test/java/com/datadog/crashtracking/CrashUploaderTest.java
@@ -73,8 +73,6 @@ public class CrashUploaderTest {
 
   @BeforeEach
   public void setup() throws IOException {
-    configProvider = ConfigProvider.getInstance();
-
     server.start();
     url = server.url(URL_PATH);
 
@@ -92,7 +90,7 @@ public class CrashUploaderTest {
     // Given
 
     // When
-    uploader = new CrashUploader(config, configProvider);
+    uploader = new CrashUploader(config);
     List<String> filesContent = new ArrayList<>();
     filesContent.add(CRASH);
     ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -114,7 +112,7 @@ public class CrashUploaderTest {
     // Given
 
     // When
-    uploader = new CrashUploader(config, configProvider);
+    uploader = new CrashUploader(config);
     server.enqueue(new MockResponse().setResponseCode(200));
     List<String> filesContent = new ArrayList<>();
     filesContent.add(CRASH);
@@ -152,7 +150,7 @@ public class CrashUploaderTest {
     when(config.getApiKey()).thenReturn(API_KEY_VALUE);
     when(config.isCrashTrackingAgentless()).thenReturn(true);
 
-    uploader = new CrashUploader(config, configProvider);
+    uploader = new CrashUploader(config);
     server.enqueue(new MockResponse().setResponseCode(200));
     List<InputStream> files = new ArrayList<>();
     files.add(new ByteArrayInputStream(CRASH.getBytes()));
@@ -168,7 +166,7 @@ public class CrashUploaderTest {
     // test added to get the coverage checks to pass since we log conditionally in this case
     when(config.getApiKey()).thenReturn(null);
 
-    uploader = new CrashUploader(config, configProvider);
+    uploader = new CrashUploader(config);
     server.enqueue(new MockResponse().setResponseCode(404));
     List<InputStream> files = new ArrayList<>();
     files.add(new ByteArrayInputStream(CRASH.getBytes()));
@@ -186,7 +184,7 @@ public class CrashUploaderTest {
     when(config.getApiKey()).thenReturn(API_KEY_VALUE);
     when(config.isCrashTrackingAgentless()).thenReturn(true);
 
-    uploader = new CrashUploader(config, configProvider);
+    uploader = new CrashUploader(config);
     server.enqueue(new MockResponse().setResponseCode(404));
     List<InputStream> files = new ArrayList<>();
     files.add(new ByteArrayInputStream(CRASH.getBytes()));

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -9,7 +9,7 @@ import static net.bytebuddy.matcher.ElementMatchers.isSynthetic;
 import datadog.trace.agent.tooling.muzzle.Reference;
 import datadog.trace.agent.tooling.muzzle.ReferenceMatcher;
 import datadog.trace.agent.tooling.muzzle.ReferenceProvider;
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.util.Strings;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.security.ProtectionDomain;
@@ -137,7 +137,8 @@ public interface Instrumenter {
       addAll(instrumentationNames, additionalNames);
       instrumentationPrimaryName = instrumentationName;
 
-      enabled = Config.get().isIntegrationEnabled(instrumentationNames, defaultEnabled());
+      enabled =
+          InstrumenterConfig.get().isIntegrationEnabled(instrumentationNames, defaultEnabled());
     }
 
     public int instrumentationId() {
@@ -281,7 +282,7 @@ public interface Instrumenter {
     }
 
     protected boolean defaultEnabled() {
-      return Config.get().isIntegrationsEnabled();
+      return InstrumenterConfig.get().isIntegrationsEnabled();
     }
 
     public boolean isEnabled() {
@@ -294,7 +295,7 @@ public interface Instrumenter {
     }
 
     protected final boolean isShortcutMatchingEnabled(boolean defaultToShortcut) {
-      return Config.get()
+      return InstrumenterConfig.get()
           .isIntegrationShortcutMatchingEnabled(singletonList(name()), defaultToShortcut);
     }
   }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/ClassFileLocators.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/ClassFileLocators.java
@@ -5,7 +5,7 @@ import static datadog.trace.util.Strings.getResourceName;
 
 import datadog.trace.agent.tooling.Utils;
 import datadog.trace.agent.tooling.WeakCaches;
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.WeakCache;
 import java.io.IOException;
 import java.io.InputStream;
@@ -50,7 +50,7 @@ public final class ClassFileLocators {
       implements ClassFileLocator {
 
     private static final boolean NO_CLASSLOADER_EXCLUDES =
-        Config.get().getExcludedClassLoaders().isEmpty();
+        InstrumenterConfig.get().getExcludedClassLoaders().isEmpty();
 
     public DDClassFileLocator(final ClassLoader classLoader) {
       super(classLoader);
@@ -70,7 +70,9 @@ public final class ClassFileLocators {
         try {
           do {
             if (NO_CLASSLOADER_EXCLUDES
-                || !Config.get().getExcludedClassLoaders().contains(cl.getClass().getName())) {
+                || !InstrumenterConfig.get()
+                    .getExcludedClassLoaders()
+                    .contains(cl.getClass().getName())) {
               resolution = loadClassResource(cl, resourceName);
             }
             cl = cl.getParent();

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/ExceptionHandlers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/ExceptionHandlers.java
@@ -1,6 +1,6 @@
 package datadog.trace.agent.tooling.bytebuddy;
 
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.ExceptionLogger;
 import net.bytebuddy.ClassFileVersion;
 import net.bytebuddy.asm.Advice.ExceptionHandler;
@@ -33,7 +33,7 @@ public class ExceptionHandlers {
             @Override
             public Size apply(final MethodVisitor mv, final Implementation.Context context) {
               final String name = context.getInstrumentedType().getName();
-              final boolean exitOnFailure = Config.get().isInternalExitOnFailure();
+              final boolean exitOnFailure = InstrumenterConfig.get().isInternalExitOnFailure();
               final String logMethod = exitOnFailure ? "error" : "debug";
 
               // Writes the following bytecode if exitOnFailure is false:

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ClassLoaderMatchers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ClassLoaderMatchers.java
@@ -4,7 +4,7 @@ import static datadog.trace.bootstrap.AgentClassLoading.PROBING_CLASSLOADER;
 import static net.bytebuddy.matcher.ElementMatchers.any;
 
 import datadog.trace.agent.tooling.WeakCaches;
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.api.Tracer;
 import datadog.trace.bootstrap.PatchLogger;
 import datadog.trace.bootstrap.WeakCache;
@@ -27,7 +27,7 @@ public final class ClassLoaderMatchers {
   private static final ClassLoader BOOTSTRAP_CLASSLOADER = null;
 
   private static final boolean HAS_CLASSLOADER_EXCLUDES =
-      !Config.get().getExcludedClassLoaders().isEmpty();
+      !InstrumenterConfig.get().getExcludedClassLoaders().isEmpty();
 
   /* Cache of classloader-instance -> (true|false). True = skip instrumentation. False = safe to instrument. */
   private static final WeakCache<ClassLoader, Boolean> skipCache = WeakCaches.newWeakCache(64);
@@ -75,7 +75,7 @@ public final class ClassLoaderMatchers {
         return true;
     }
     if (HAS_CLASSLOADER_EXCLUDES) {
-      return Config.get().getExcludedClassLoaders().contains(classLoaderName);
+      return InstrumenterConfig.get().getExcludedClassLoaders().contains(classLoaderName);
     }
     return false;
   }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/CodeSourceExcludes.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/CodeSourceExcludes.java
@@ -1,6 +1,6 @@
 package datadog.trace.agent.tooling.bytebuddy.matcher;
 
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
 import java.net.URL;
@@ -16,7 +16,7 @@ import java.util.List;
 public class CodeSourceExcludes {
   private CodeSourceExcludes() {}
 
-  private static final List<String> excludes = Config.get().getExcludedCodeSources();
+  static final List<String> excludes = InstrumenterConfig.get().getExcludedCodeSources();
 
   private static final DDCache<String, Boolean> excludedCodeSources;
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/CustomExcludes.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/CustomExcludes.java
@@ -1,6 +1,6 @@
 package datadog.trace.agent.tooling.bytebuddy.matcher;
 
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.util.ClassNameTrie;
 import java.nio.file.Paths;
 import java.util.List;
@@ -16,7 +16,7 @@ public class CustomExcludes {
   private static final ClassNameTrie excludes;
 
   static {
-    List<String> excludedClasses = Config.get().getExcludedClasses();
+    List<String> excludedClasses = InstrumenterConfig.get().getExcludedClasses();
     if (excludedClasses.isEmpty()) {
       excludes = null;
     } else {
@@ -24,7 +24,7 @@ public class CustomExcludes {
       for (String name : excludedClasses) {
         builder.put(name, 1);
       }
-      String excludedClassesFile = Config.get().getExcludedClassesFile();
+      String excludedClassesFile = InstrumenterConfig.get().getExcludedClassesFile();
       if (null != excludedClassesFile) {
         try {
           builder.readClassNameMapping(Paths.get(excludedClassesFile));

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
@@ -8,7 +8,7 @@ import static net.bytebuddy.dynamic.loading.ClassLoadingStrategy.BOOTSTRAP_LOADE
 import datadog.trace.agent.tooling.bytebuddy.ClassFileLocators;
 import datadog.trace.agent.tooling.bytebuddy.TypeInfoCache;
 import datadog.trace.agent.tooling.bytebuddy.TypeInfoCache.SharedTypeInfo;
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
 import java.io.Serializable;
@@ -41,7 +41,8 @@ final class TypeFactory {
   /** Maintain a reusable type factory for each thread involved in class-loading. */
   static final ThreadLocal<TypeFactory> typeFactory = ThreadLocal.withInitial(TypeFactory::new);
 
-  private static final boolean fallBackToLoadClass = Config.get().isResolverUseLoadClassEnabled();
+  private static final boolean fallBackToLoadClass =
+      InstrumenterConfig.get().isResolverUseLoadClassEnabled();
 
   private static final Map<String, TypeDescription> primitiveDescriptorTypes = new HashMap<>();
 
@@ -82,10 +83,10 @@ final class TypeFactory {
   private static final TypeParser fullTypeParser = new FullTypeParser();
 
   private static final TypeInfoCache<TypeDescription> outlineTypes =
-      new TypeInfoCache<>(Config.get().getResolverOutlinePoolSize());
+      new TypeInfoCache<>(InstrumenterConfig.get().getResolverOutlinePoolSize());
 
   private static final TypeInfoCache<TypeDescription> fullTypes =
-      new TypeInfoCache<>(Config.get().getResolverTypePoolSize());
+      new TypeInfoCache<>(InstrumenterConfig.get().getResolverTypePoolSize());
 
   /** Small local cache to help deduplicate lookups when matching/transforming. */
   private final DDCache<String, LazyType> deferredTypes = DDCaches.newFixedSizeCache(16);

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextInjector.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextInjector.java
@@ -4,7 +4,7 @@ import static datadog.trace.agent.tooling.context.ShouldInjectFieldsState.hasInj
 import static datadog.trace.bootstrap.FieldBackedContextStores.getContextStoreId;
 import static datadog.trace.util.Strings.getInternalName;
 
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.FieldBackedContextAccessor;
 import datadog.trace.bootstrap.FieldBackedContextStores;
@@ -67,7 +67,8 @@ public final class FieldBackedContextInjector implements AsmVisitorWrapper {
   /** Keeps track of injection requests for the class being transformed by the current thread. */
   static final ThreadLocal<BitSet> INJECTED_STORE_IDS = new ThreadLocal<>();
 
-  final boolean serialVersionUIDFieldInjection = Config.get().isSerialVersionUIDFieldInjection();
+  final boolean serialVersionUIDFieldInjection =
+      InstrumenterConfig.get().isSerialVersionUIDFieldInjection();
 
   final String keyClassName;
   final String contextClassName;

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsReceiveRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsReceiveRequestInstrumentation.java
@@ -19,11 +19,6 @@ public class SqsReceiveRequestInstrumentation extends Instrumenter.Tracing
   }
 
   @Override
-  protected boolean defaultEnabled() {
-    return super.defaultEnabled() && Config.get().isSqsPropagationEnabled();
-  }
-
-  @Override
   public String instrumentedType() {
     return "com.amazonaws.services.sqs.model.ReceiveMessageRequest";
   }
@@ -38,14 +33,16 @@ public class SqsReceiveRequestInstrumentation extends Instrumenter.Tracing
   public static class ReceiveMessageRequestAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void onExit(@Advice.This ReceiveMessageRequest request) {
-      // ReceiveMessageRequest always returns a mutable list which we can append to
-      List<String> attributeNames = request.getAttributeNames();
-      for (String name : attributeNames) {
-        if ("AWSTraceHeader".equals(name) || "All".equals(name)) {
-          return;
+      if (Config.get().isSqsPropagationEnabled()) {
+        // ReceiveMessageRequest always returns a mutable list which we can append to
+        List<String> attributeNames = request.getAttributeNames();
+        for (String name : attributeNames) {
+          if ("AWSTraceHeader".equals(name) || "All".equals(name)) {
+            return;
+          }
         }
+        attributeNames.add("AWSTraceHeader");
       }
-      attributeNames.add("AWSTraceHeader");
     }
   }
 }

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AbstractExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AbstractExecutorInstrumentation.java
@@ -4,7 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.im
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -21,7 +21,7 @@ public abstract class AbstractExecutorInstrumentation extends Instrumenter.Traci
 
   public static final String EXEC_NAME = "java_concurrent";
 
-  private final boolean TRACE_ALL_EXECUTORS = Config.get().isTraceExecutorsAll();
+  private final boolean TRACE_ALL_EXECUTORS = InstrumenterConfig.get().isTraceExecutorsAll();
 
   /**
    * Only apply executor instrumentation to whitelisted executors. To apply to all executors, use
@@ -43,7 +43,7 @@ public abstract class AbstractExecutorInstrumentation extends Instrumenter.Traci
         "scala.concurrent.impl.ExecutionContextImpl"
       };
 
-      final Set<String> executors = new HashSet<>(Config.get().getTraceExecutors());
+      final Set<String> executors = new HashSet<>(InstrumenterConfig.get().getTraceExecutors());
       executors.addAll(Arrays.asList(whitelist));
 
       PERMITTED_EXECUTORS = executors.toArray(new String[0]);

--- a/dd-java-agent/instrumentation/jboss-logmanager/src/main/java/datadog/trace/instrumentation/jbosslogmanager/ExtLogRecordInstrumentation.java
+++ b/dd-java-agent/instrumentation/jboss-logmanager/src/main/java/datadog/trace/instrumentation/jbosslogmanager/ExtLogRecordInstrumentation.java
@@ -13,6 +13,7 @@ import datadog.trace.agent.tooling.log.UnionMap;
 import datadog.trace.api.Config;
 import datadog.trace.api.CorrelationIdentifier;
 import datadog.trace.api.DDSpanId;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -33,7 +34,7 @@ public class ExtLogRecordInstrumentation extends Instrumenter.Tracing
 
   @Override
   protected boolean defaultEnabled() {
-    return Config.get().isLogsInjectionEnabled();
+    return InstrumenterConfig.get().isLogsInjectionEnabled();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jboss-logmanager/src/main/java/datadog/trace/instrumentation/jbosslogmanager/LoggerNodeInstrumentation.java
+++ b/dd-java-agent/instrumentation/jboss-logmanager/src/main/java/datadog/trace/instrumentation/jbosslogmanager/LoggerNodeInstrumentation.java
@@ -8,7 +8,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -25,7 +25,7 @@ public class LoggerNodeInstrumentation extends Instrumenter.Tracing
 
   @Override
   protected boolean defaultEnabled() {
-    return Config.get().isLogsInjectionEnabled();
+    return InstrumenterConfig.get().isLogsInjectionEnabled();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
@@ -2,7 +2,7 @@ package datadog.trace.instrumentation.jdbc;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 
 @AutoService(Instrumenter.class)
 public class ConnectionInstrumentation extends AbstractConnectionInstrumentation
@@ -79,7 +79,7 @@ public class ConnectionInstrumentation extends AbstractConnectionInstrumentation
   @Override
   public String configuredMatchingType() {
     // this won't match any class unless the property is set
-    return Config.get().getJdbcConnectionClassName();
+    return InstrumenterConfig.get().getJdbcConnectionClassName();
   }
 
   public ConnectionInstrumentation() {

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -2,7 +2,7 @@ package datadog.trace.instrumentation.jdbc;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 
 @AutoService(Instrumenter.class)
 public final class PreparedStatementInstrumentation extends AbstractPreparedStatementInstrumentation
@@ -121,7 +121,7 @@ public final class PreparedStatementInstrumentation extends AbstractPreparedStat
   @Override
   public String configuredMatchingType() {
     // this won't match any class unless the property is set
-    return Config.get().getJdbcPreparedStatementClassName();
+    return InstrumenterConfig.get().getJdbcPreparedStatementClassName();
   }
 
   public PreparedStatementInstrumentation() {

--- a/dd-java-agent/instrumentation/log4j-2.7/src/main/java/datadog/trace/instrumentation/log4j27/ContextDataInjectorFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/log4j-2.7/src/main/java/datadog/trace/instrumentation/log4j27/ContextDataInjectorFactoryInstrumentation.java
@@ -13,7 +13,7 @@ import static net.bytebuddy.matcher.ElementMatchers.returns;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import org.apache.logging.log4j.core.ContextDataInjector;
@@ -27,7 +27,7 @@ public class ContextDataInjectorFactoryInstrumentation extends Instrumenter.Trac
 
   @Override
   protected boolean defaultEnabled() {
-    return Config.get().isLogsInjectionEnabled();
+    return InstrumenterConfig.get().isLogsInjectionEnabled();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/log4j1/src/main/java/datadog/trace/instrumentation/log4j1/CategoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/log4j1/src/main/java/datadog/trace/instrumentation/log4j1/CategoryInstrumentation.java
@@ -15,7 +15,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.util.Map;
@@ -31,7 +31,7 @@ public class CategoryInstrumentation extends Instrumenter.Tracing
 
   @Override
   protected boolean defaultEnabled() {
-    return Config.get().isLogsInjectionEnabled();
+    return InstrumenterConfig.get().isLogsInjectionEnabled();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/log4j1/src/main/java/datadog/trace/instrumentation/log4j1/LoggingEventInstrumentation.java
+++ b/dd-java-agent/instrumentation/log4j1/src/main/java/datadog/trace/instrumentation/log4j1/LoggingEventInstrumentation.java
@@ -11,6 +11,7 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.Config;
 import datadog.trace.api.CorrelationIdentifier;
 import datadog.trace.api.DDSpanId;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -29,7 +30,7 @@ public class LoggingEventInstrumentation extends Instrumenter.Tracing
 
   @Override
   protected boolean defaultEnabled() {
-    return Config.get().isLogsInjectionEnabled();
+    return InstrumenterConfig.get().isLogsInjectionEnabled();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/log4j2/src/main/java/datadog/trace/instrumentation/log4j2/ThreadContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/log4j2/src/main/java/datadog/trace/instrumentation/log4j2/ThreadContextInstrumentation.java
@@ -6,7 +6,7 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.api.WithGlobalTracer;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -22,7 +22,7 @@ public class ThreadContextInstrumentation extends Instrumenter.Tracing
 
   @Override
   protected boolean defaultEnabled() {
-    return Config.get().isLogsInjectionEnabled();
+    return InstrumenterConfig.get().isLogsInjectionEnabled();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/logback-1/src/main/java/datadog/trace/instrumentation/logback/LogbackLoggerInstrumentation.java
+++ b/dd-java-agent/instrumentation/logback-1/src/main/java/datadog/trace/instrumentation/logback/LogbackLoggerInstrumentation.java
@@ -16,7 +16,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.util.Map;
@@ -32,7 +32,7 @@ public class LogbackLoggerInstrumentation extends Instrumenter.Tracing
 
   @Override
   protected boolean defaultEnabled() {
-    return Config.get().isLogsInjectionEnabled();
+    return InstrumenterConfig.get().isLogsInjectionEnabled();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/logback-1/src/main/java/datadog/trace/instrumentation/logback/LoggingEventInstrumentation.java
+++ b/dd-java-agent/instrumentation/logback-1/src/main/java/datadog/trace/instrumentation/logback/LoggingEventInstrumentation.java
@@ -13,6 +13,7 @@ import datadog.trace.agent.tooling.log.UnionMap;
 import datadog.trace.api.Config;
 import datadog.trace.api.CorrelationIdentifier;
 import datadog.trace.api.DDSpanId;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -32,7 +33,7 @@ public class LoggingEventInstrumentation extends Instrumenter.Tracing
 
   @Override
   protected boolean defaultEnabled() {
-    return Config.get().isLogsInjectionEnabled();
+    return InstrumenterConfig.get().isLogsInjectionEnabled();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/scala-promise/scala-promise-2.10/src/main/java/datadog/trace/instrumentation/scala/concurrent/PromiseObjectInstrumentation210.java
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise-2.10/src/main/java/datadog/trace/instrumentation/scala/concurrent/PromiseObjectInstrumentation210.java
@@ -6,7 +6,7 @@ import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -58,7 +58,7 @@ public class PromiseObjectInstrumentation210 extends Instrumenter.Tracing
     // Only enable this if integrations have been enabled and the extra "integration"
     // scala_promise_completion_priority has been enabled specifically
     return super.isEnabled()
-        && Config.get()
+        && InstrumenterConfig.get()
             .isIntegrationEnabled(
                 Collections.singletonList("scala_promise_completion_priority"), false);
   }

--- a/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/src/main/java/datadog/trace/instrumentation/scala/concurrent/DefaultPromiseInstrumentation.java
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/src/main/java/datadog/trace/instrumentation/scala/concurrent/DefaultPromiseInstrumentation.java
@@ -7,7 +7,7 @@ import static scala.concurrent.impl.Promise.Transformation;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -57,7 +57,7 @@ public class DefaultPromiseInstrumentation extends Instrumenter.Tracing
     // Only enable this if integrations have been enabled and the extra "integration"
     // scala_promise_completion_priority has been enabled specifically
     return super.isEnabled()
-        && Config.get()
+        && InstrumenterConfig.get()
             .isIntegrationEnabled(
                 Collections.singletonList("scala_promise_completion_priority"), false);
   }

--- a/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/src/main/java/datadog/trace/instrumentation/scala/concurrent/PromiseObjectInstrumentation213.java
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/src/main/java/datadog/trace/instrumentation/scala/concurrent/PromiseObjectInstrumentation213.java
@@ -7,7 +7,7 @@ import static scala.concurrent.impl.Promise.Transformation;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -58,7 +58,7 @@ public class PromiseObjectInstrumentation213 extends Instrumenter.Tracing
     // Only enable this if integrations have been enabled and the extra "integration"
     // scala_promise_completion_priority has been enabled specifically
     return super.isEnabled()
-        && Config.get()
+        && InstrumenterConfig.get()
             .isIntegrationEnabled(
                 Collections.singletonList("scala_promise_completion_priority"), false);
   }

--- a/dd-java-agent/instrumentation/scala-promise/src/main/java/datadog/trace/instrumentation/scala/PromiseHelper.java
+++ b/dd-java-agent/instrumentation/scala-promise/src/main/java/datadog/trace/instrumentation/scala/PromiseHelper.java
@@ -4,7 +4,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScop
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.captureSpan;
 
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -17,7 +17,7 @@ import scala.util.Try;
 
 public class PromiseHelper {
   public static final boolean completionPriority =
-      Config.get()
+      InstrumenterConfig.get()
           .isIntegrationEnabled(
               Collections.singletonList("scala_promise_completion_priority"), false);
 

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java
@@ -7,7 +7,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOn
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers;
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -30,7 +30,7 @@ public final class TraceAnnotationsInstrumentation extends Instrumenter.Tracing
     super("trace", "trace-annotation");
     Set<String> annotations = new HashSet<>();
     annotations.add("datadog.trace.api.Trace");
-    final String configString = Config.get().getTraceAnnotations();
+    final String configString = InstrumenterConfig.get().getTraceAnnotations();
     if (configString == null) {
       annotations.addAll(
           Arrays.asList(

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
@@ -15,7 +15,7 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.util.Strings;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.util.Collections;
@@ -76,9 +76,8 @@ public class TraceConfigInstrumentation implements Instrumenter {
 
   @SuppressForbidden
   public TraceConfigInstrumentation() {
-    final String configString =
-        Config.get().getTraceMethods() == null ? null : Config.get().getTraceMethods().trim();
-    if (configString == null || configString.isEmpty()) {
+    final String configString = Strings.trim(InstrumenterConfig.get().getTraceMethods());
+    if (configString.isEmpty()) {
       classMethodsToTrace = Collections.emptyMap();
     } else {
       Map<String, Set<String>> toTrace = new HashMap<>();
@@ -202,12 +201,7 @@ public class TraceConfigInstrumentation implements Instrumenter {
     }
 
     public TracerClassInstrumentation(final String className, final Set<String> methodNames) {
-      super(
-          "trace",
-          "trace-config",
-          "trace-config_"
-              + className
-              + (!Config.get().isDebugEnabled() ? "" : "[" + Strings.join(",", methodNames) + "]"));
+      super("trace", "trace-config", "trace-config_" + className);
       this.className = className;
       this.methodNames = methodNames;
     }

--- a/dd-java-agent/testing/src/test/groovy/context/FieldInjectionForkedTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/context/FieldInjectionForkedTest.groovy
@@ -3,7 +3,7 @@ package context
 import datadog.trace.agent.test.AbortTransformationException
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.utils.ClasspathUtils
-import datadog.trace.api.Config
+import datadog.trace.api.InstrumenterConfig
 import datadog.trace.test.util.GCUtils
 import net.bytebuddy.agent.ByteBuddyAgent
 import net.bytebuddy.utility.JavaModule
@@ -112,7 +112,7 @@ class FieldInjectionForkedTest extends AgentTestRunner {
 
   def "serializability not impacted"() {
     setup:
-    assumeTrue(Config.get().isSerialVersionUIDFieldInjection())
+    assumeTrue(InstrumenterConfig.get().isSerialVersionUIDFieldInjection())
 
     expect:
     serialVersionUID(serializable) == serialVersionUID

--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEventFactory.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/ScopeEventFactory.java
@@ -13,7 +13,7 @@ import jdk.jfr.EventType;
 /** Event factory for {@link ScopeEvent} */
 public class ScopeEventFactory implements ExtendedScopeListener {
   private final ThreadCpuTimeProvider threadCpuTimeProvider =
-      ConfigProvider.createDefault().getBoolean(ProfilingConfig.PROFILING_HOTSPOTS_ENABLED, false)
+      ConfigProvider.getInstance().getBoolean(ProfilingConfig.PROFILING_HOTSPOTS_ENABLED, false)
           ? SystemAccess::getCurrentThreadCpuTime
           : () -> Long.MIN_VALUE;
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -80,7 +80,7 @@ class CoreTracerTest extends DDCoreSpecification {
     }
 
     when:
-    def constantTags = CoreTracer.generateConstantTags(Config.get())
+    def constantTags = CoreTracer.generateConstantTags(new Config())
 
     then:
     constantTags.size() == expectedSize

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -80,7 +80,7 @@ class CoreTracerTest extends DDCoreSpecification {
     }
 
     when:
-    def constantTags = CoreTracer.generateConstantTags(new Config())
+    def constantTags = CoreTracer.generateConstantTags(Config.get())
 
     then:
     constantTags.size() == expectedSize

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -13,6 +13,7 @@ excludedClassesCoverage += [
   "datadog.trace.api.StatsDClient",
   "datadog.trace.api.NoOpStatsDClient",
   "datadog.trace.api.TraceSegment.NoOp",
+  "datadog.trace.api.InstrumenterConfig",
   "datadog.trace.api.intake.TrackType",
   "datadog.trace.api.gateway.Events.ET",
   "datadog.trace.api.profiling.ProfilingSnapshot.Kind",

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -605,7 +605,7 @@ public class Config {
 
   // Read order: System Properties -> Env Variables, [-> properties file], [-> default value]
   private Config() {
-    this(InstrumenterConfig.get().configProvider()); // share config provider by default
+    this(ConfigProvider.createDefault());
   }
 
   private Config(final ConfigProvider configProvider) {
@@ -2563,7 +2563,7 @@ public class Config {
 
   // This has to be placed after all other static fields to give them a chance to initialize
   @SuppressFBWarnings("SI_INSTANCE_BEFORE_FINALS_ASSIGNED")
-  private static final Config INSTANCE = new Config();
+  private static final Config INSTANCE = new Config(ConfigProvider.getInstance());
 
   public static Config get() {
     return INSTANCE;

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -46,11 +46,9 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_TAINT_TRACKING_DEBUG
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_VULNERABILITIES_PER_REQUEST;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_WEAK_HASH_ALGORITHMS;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_INTEGRATIONS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_JMX_FETCH_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_LIMIT;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_LOGS_INJECTION_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PARTIAL_FLUSH_MIN_SPANS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PERF_METRICS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PRIORITY_SAMPLING_ENABLED;
@@ -64,12 +62,8 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_REMOTE_CONFIG_INTEGRITY_C
 import static datadog.trace.api.ConfigDefaults.DEFAULT_REMOTE_CONFIG_MAX_PAYLOAD_SIZE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_REMOTE_CONFIG_TARGETS_KEY;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_REMOTE_CONFIG_TARGETS_KEY_ID;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_RESOLVER_OUTLINE_POOL_SIZE;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_RESOLVER_TYPE_POOL_SIZE;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SCOPE_DEPTH_LIMIT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SCOPE_ITERATION_KEEP_ALIVE;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_SERIALVERSIONUID_FIELD_INJECTION;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVLET_ROOT_CONTEXT_SERVICE_NAME;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SITE;
@@ -78,10 +72,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_TELEMETRY_HEARTBEAT_INTER
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_PORT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_V05_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_ANALYTICS_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_ANNOTATIONS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_EXECUTORS_ALL;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_METHODS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_RATE_LIMIT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_REPORT_HOSTNAME;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_RESOLVER_ENABLED;
@@ -142,7 +133,6 @@ import static datadog.trace.api.config.GeneralConfig.GLOBAL_TAGS;
 import static datadog.trace.api.config.GeneralConfig.HEALTH_METRICS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.HEALTH_METRICS_STATSD_HOST;
 import static datadog.trace.api.config.GeneralConfig.HEALTH_METRICS_STATSD_PORT;
-import static datadog.trace.api.config.GeneralConfig.INTERNAL_EXIT_ON_FAILURE;
 import static datadog.trace.api.config.GeneralConfig.PERF_METRICS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.PRIMARY_TAG;
 import static datadog.trace.api.config.GeneralConfig.RUNTIME_ID_ENABLED;
@@ -240,15 +230,11 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_TA
 import static datadog.trace.api.config.TraceInstrumentationConfig.HYSTRIX_MEASURED_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HYSTRIX_TAGS_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.IGNITE_CACHE_INCLUDE_KEYS;
-import static datadog.trace.api.config.TraceInstrumentationConfig.INTEGRATIONS_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.INTEGRATION_SYNAPSE_LEGACY_OPERATION_NAME;
-import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_CONNECTION_CLASS_NAME;
-import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_PREPARED_STATEMENT_CLASS_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JMS_PROPAGATION_DISABLED_QUEUES;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JMS_PROPAGATION_DISABLED_TOPICS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.KAFKA_CLIENT_BASE64_DECODING_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.KAFKA_CLIENT_PROPAGATION_DISABLED_TOPICS;
-import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_INJECTION_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_MDC_TAGS_INJECTION_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.MESSAGE_BROKER_SPLIT_BY_DESTINATION;
 import static datadog.trace.api.config.TraceInstrumentationConfig.OBFUSCATION_QUERY_STRING_REGEXP;
@@ -256,25 +242,10 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.PLAY_REPORT_HT
 import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_INCLUDE_ROUTINGKEY_IN_RESOURCE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGATION_DISABLED_EXCHANGES;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGATION_DISABLED_QUEUES;
-import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_OUTLINE_POOL_ENABLED;
-import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_OUTLINE_POOL_SIZE;
-import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_TYPE_POOL_SIZE;
-import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_USE_LOADCLASS;
-import static datadog.trace.api.config.TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
-import static datadog.trace.api.config.TraceInstrumentationConfig.SERIALVERSIONUID_FIELD_INJECTION;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ASYNC_TIMEOUT_ERROR;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_PRINCIPAL_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ROOT_CONTEXT_SERVICE_NAME;
-import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ANNOTATIONS;
-import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE;
-import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE_FILE;
-import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSLOADERS_EXCLUDE;
-import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CODESOURCES_EXCLUDE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ENABLED;
-import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_EXECUTORS;
-import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_EXECUTORS_ALL;
-import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_METHODS;
-import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_THREAD_POOL_EXECUTORS_EXCLUDE;
 import static datadog.trace.api.config.TracerConfig.AGENT_HOST;
 import static datadog.trace.api.config.TracerConfig.AGENT_NAMED_PIPE;
 import static datadog.trace.api.config.TracerConfig.AGENT_PORT_LEGACY;
@@ -377,6 +348,8 @@ public class Config {
 
   private static final Logger log = LoggerFactory.getLogger(Config.class);
 
+  private final InstrumenterConfig instrumenterConfig = InstrumenterConfig.get();
+
   private final long startTimeMillis = System.currentTimeMillis();
 
   /**
@@ -404,7 +377,6 @@ public class Config {
   private final boolean serviceNameSetByUser;
   private final String rootContextServiceName;
   private final boolean traceEnabled;
-  private final boolean integrationsEnabled;
   private final boolean integrationSynapseLegacyOperationName;
   private final String writerType;
   private final boolean agentConfiguredUsingDefault;
@@ -422,10 +394,6 @@ public class Config {
   private final Map<String, String> tags;
   private final Map<String, String> spanTags;
   private final Map<String, String> jmxTags;
-  private final List<String> excludedClasses;
-  private final String excludedClassesFile;
-  private final Set<String> excludedClassLoaders;
-  private final List<String> excludedCodeSources;
   private final Map<String, String> requestHeaderTags;
   private final Map<String, String> responseHeaderTags;
   private final BitSet httpServerErrorStatuses;
@@ -446,8 +414,6 @@ public class Config {
   private final int scopeIterationKeepAlive;
   private final int partialFlushMinSpans;
   private final boolean traceStrictWritesEnabled;
-  private final boolean runtimeContextFieldInjection;
-  private final boolean serialVersionUIDFieldInjection;
   private final boolean logExtractHeaderNames;
   private final Set<PropagationStyle> propagationStylesToExtract;
   private final Set<PropagationStyle> propagationStylesToInject;
@@ -479,18 +445,8 @@ public class Config {
   private final int tracerMetricsMaxAggregates;
   private final int tracerMetricsMaxPending;
 
-  private final boolean logsInjectionEnabled;
   private final boolean logsMDCTagsInjectionEnabled;
   private final boolean reportHostName;
-
-  private final String traceAnnotations;
-
-  private final String traceMethods;
-
-  private final boolean traceExecutorsAll;
-  private final List<String> traceExecutors;
-
-  private final Set<String> traceThreadPoolExecutorsExclude;
 
   private final boolean traceAnalyticsEnabled;
   private final String traceClientIpHeader;
@@ -615,16 +571,6 @@ public class Config {
 
   private final IdGenerationStrategy idGenerationStrategy;
 
-  private final boolean internalExitOnFailure;
-
-  private final boolean resolverOutlinePoolEnabled;
-  private final int resolverOutlinePoolSize;
-  private final int resolverTypePoolSize;
-  private final boolean resolverUseLoadClassEnabled;
-
-  private final String jdbcPreparedStatementClassName;
-  private final String jdbcConnectionClassName;
-
   private final Set<String> grpcIgnoredInboundMethods;
   private final Set<String> grpcIgnoredOutboundMethods;
   private final boolean grpcServerTrimPackageResource;
@@ -659,7 +605,7 @@ public class Config {
 
   // Read order: System Properties -> Env Variables, [-> properties file], [-> default value]
   private Config() {
-    this(ConfigProvider.createDefault());
+    this(ConfigProvider.getInstance());
   }
 
   private Config(final ConfigProvider configProvider) {
@@ -708,8 +654,6 @@ public class Config {
             SERVLET_ROOT_CONTEXT_SERVICE_NAME, DEFAULT_SERVLET_ROOT_CONTEXT_SERVICE_NAME);
 
     traceEnabled = configProvider.getBoolean(TRACE_ENABLED, DEFAULT_TRACE_ENABLED);
-    integrationsEnabled =
-        configProvider.getBoolean(INTEGRATIONS_ENABLED, DEFAULT_INTEGRATIONS_ENABLED);
     integrationSynapseLegacyOperationName =
         configProvider.getBoolean(INTEGRATION_SYNAPSE_LEGACY_OPERATION_NAME, false);
     writerType = configProvider.getString(WRITER_TYPE, DEFAULT_AGENT_WRITER_TYPE);
@@ -824,11 +768,6 @@ public class Config {
 
     primaryTag = configProvider.getString(PRIMARY_TAG);
 
-    excludedClasses = tryMakeImmutableList(configProvider.getList(TRACE_CLASSES_EXCLUDE));
-    excludedClassesFile = configProvider.getString(TRACE_CLASSES_EXCLUDE_FILE);
-    excludedClassLoaders = tryMakeImmutableSet(configProvider.getList(TRACE_CLASSLOADERS_EXCLUDE));
-    excludedCodeSources = tryMakeImmutableList(configProvider.getList(TRACE_CODESOURCES_EXCLUDE));
-
     if (isEnabled(false, HEADER_TAGS, ".legacy.parsing.enabled")) {
       requestHeaderTags = configProvider.getMergedMap(HEADER_TAGS);
       responseHeaderTags = Collections.emptyMap();
@@ -903,13 +842,6 @@ public class Config {
 
     traceStrictWritesEnabled = configProvider.getBoolean(TRACE_STRICT_WRITES_ENABLED, false);
 
-    runtimeContextFieldInjection =
-        configProvider.getBoolean(
-            RUNTIME_CONTEXT_FIELD_INJECTION, DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION);
-    serialVersionUIDFieldInjection =
-        configProvider.getBoolean(
-            SERIALVERSIONUID_FIELD_INJECTION, DEFAULT_SERIALVERSIONUID_FIELD_INJECTION);
-
     logExtractHeaderNames =
         configProvider.getBoolean(
             PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED,
@@ -979,24 +911,12 @@ public class Config {
     tracerMetricsMaxAggregates = configProvider.getInteger(TRACER_METRICS_MAX_AGGREGATES, 2048);
     tracerMetricsMaxPending = configProvider.getInteger(TRACER_METRICS_MAX_PENDING, 2048);
 
-    logsInjectionEnabled =
-        configProvider.getBoolean(LOGS_INJECTION_ENABLED, DEFAULT_LOGS_INJECTION_ENABLED);
     logsMDCTagsInjectionEnabled = configProvider.getBoolean(LOGS_MDC_TAGS_INJECTION_ENABLED, true);
     reportHostName =
         configProvider.getBoolean(TRACE_REPORT_HOSTNAME, DEFAULT_TRACE_REPORT_HOSTNAME);
 
     traceAgentV05Enabled =
         configProvider.getBoolean(ENABLE_TRACE_AGENT_V05, DEFAULT_TRACE_AGENT_V05_ENABLED);
-
-    traceAnnotations = configProvider.getString(TRACE_ANNOTATIONS, DEFAULT_TRACE_ANNOTATIONS);
-
-    traceMethods = configProvider.getString(TRACE_METHODS, DEFAULT_TRACE_METHODS);
-
-    traceExecutorsAll = configProvider.getBoolean(TRACE_EXECUTORS_ALL, DEFAULT_TRACE_EXECUTORS_ALL);
-    traceExecutors = tryMakeImmutableList(configProvider.getList(TRACE_EXECUTORS));
-
-    traceThreadPoolExecutorsExclude =
-        tryMakeImmutableSet(configProvider.getList(TRACE_THREAD_POOL_EXECUTORS_EXCLUDE));
 
     traceAnalyticsEnabled =
         configProvider.getBoolean(TRACE_ANALYTICS_ENABLED, DEFAULT_TRACE_ANALYTICS_ENABLED);
@@ -1246,11 +1166,6 @@ public class Config {
             DEBUGGER_INSTRUMENT_THE_WORLD, DEFAULT_DEBUGGER_INSTRUMENT_THE_WORLD);
     debuggerExcludeFile = configProvider.getString(DEBUGGER_EXCLUDE_FILE);
 
-    jdbcPreparedStatementClassName =
-        configProvider.getString(JDBC_PREPARED_STATEMENT_CLASS_NAME, "");
-
-    jdbcConnectionClassName = configProvider.getString(JDBC_CONNECTION_CLASS_NAME, "");
-
     awsPropagationEnabled = isPropagationEnabled(true, "aws");
     sqsPropagationEnabled = awsPropagationEnabled && isPropagationEnabled(true, "sqs");
 
@@ -1308,15 +1223,6 @@ public class Config {
     servletAsyncTimeoutError = configProvider.getBoolean(SERVLET_ASYNC_TIMEOUT_ERROR, true);
 
     debugEnabled = isDebugMode();
-
-    internalExitOnFailure = configProvider.getBoolean(INTERNAL_EXIT_ON_FAILURE, false);
-
-    resolverOutlinePoolEnabled = configProvider.getBoolean(RESOLVER_OUTLINE_POOL_ENABLED, true);
-    resolverOutlinePoolSize =
-        configProvider.getInteger(RESOLVER_OUTLINE_POOL_SIZE, DEFAULT_RESOLVER_OUTLINE_POOL_SIZE);
-    resolverTypePoolSize =
-        configProvider.getInteger(RESOLVER_TYPE_POOL_SIZE, DEFAULT_RESOLVER_TYPE_POOL_SIZE);
-    resolverUseLoadClassEnabled = configProvider.getBoolean(RESOLVER_USE_LOADCLASS, true);
 
     cwsEnabled = configProvider.getBoolean(CWS_ENABLED, DEFAULT_CWS_ENABLED);
     cwsTlsRefresh = configProvider.getInteger(CWS_TLS_REFRESH, DEFAULT_CWS_TLS_REFRESH);
@@ -1396,10 +1302,6 @@ public class Config {
     return traceEnabled;
   }
 
-  public boolean isIntegrationsEnabled() {
-    return integrationsEnabled;
-  }
-
   public boolean isIntegrationSynapseLegacyOperationName() {
     return integrationSynapseLegacyOperationName;
   }
@@ -1466,22 +1368,6 @@ public class Config {
 
   public Map<String, String> getServiceMapping() {
     return serviceMapping;
-  }
-
-  public List<String> getExcludedClasses() {
-    return excludedClasses;
-  }
-
-  public String getExcludedClassesFile() {
-    return excludedClassesFile;
-  }
-
-  public Set<String> getExcludedClassLoaders() {
-    return excludedClassLoaders;
-  }
-
-  public List<String> getExcludedCodeSources() {
-    return excludedCodeSources;
   }
 
   public Map<String, String> getRequestHeaderTags() {
@@ -1562,14 +1448,6 @@ public class Config {
 
   public boolean isTraceStrictWritesEnabled() {
     return traceStrictWritesEnabled;
-  }
-
-  public boolean isRuntimeContextFieldInjection() {
-    return runtimeContextFieldInjection;
-  }
-
-  public boolean isSerialVersionUIDFieldInjection() {
-    return serialVersionUIDFieldInjection;
   }
 
   public boolean isLogExtractHeaderNames() {
@@ -1673,7 +1551,7 @@ public class Config {
   }
 
   public boolean isLogsInjectionEnabled() {
-    return logsInjectionEnabled;
+    return instrumenterConfig.isLogsInjectionEnabled();
   }
 
   public boolean isLogsMDCTagsInjectionEnabled() {
@@ -1682,26 +1560,6 @@ public class Config {
 
   public boolean isReportHostName() {
     return reportHostName;
-  }
-
-  public String getTraceAnnotations() {
-    return traceAnnotations;
-  }
-
-  public String getTraceMethods() {
-    return traceMethods;
-  }
-
-  public boolean isTraceExecutorsAll() {
-    return traceExecutorsAll;
-  }
-
-  public List<String> getTraceExecutors() {
-    return traceExecutors;
-  }
-
-  public Set<String> getTraceThreadPoolExecutorsExclude() {
-    return traceThreadPoolExecutorsExclude;
   }
 
   public boolean isTraceAnalyticsEnabled() {
@@ -2124,34 +1982,6 @@ public class Config {
     return idGenerationStrategy;
   }
 
-  public boolean isInternalExitOnFailure() {
-    return internalExitOnFailure;
-  }
-
-  public boolean isResolverOutlinePoolEnabled() {
-    return resolverOutlinePoolEnabled;
-  }
-
-  public int getResolverOutlinePoolSize() {
-    return resolverOutlinePoolSize;
-  }
-
-  public int getResolverTypePoolSize() {
-    return resolverTypePoolSize;
-  }
-
-  public boolean isResolverUseLoadClassEnabled() {
-    return resolverUseLoadClassEnabled;
-  }
-
-  public String getJdbcPreparedStatementClassName() {
-    return jdbcPreparedStatementClassName;
-  }
-
-  public String getJdbcConnectionClassName() {
-    return jdbcConnectionClassName;
-  }
-
   public Set<String> getGrpcIgnoredInboundMethods() {
     return grpcIgnoredInboundMethods;
   }
@@ -2449,20 +2279,9 @@ public class Config {
     }
   }
 
-  public boolean isIntegrationEnabled(
-      final Iterable<String> integrationNames, final boolean defaultEnabled) {
-    return isEnabled(integrationNames, "integration.", ".enabled", defaultEnabled);
-  }
-
-  public boolean isIntegrationShortcutMatchingEnabled(
-      final Iterable<String> integrationNames, final boolean defaultEnabled) {
-    return isEnabled(
-        integrationNames, "integration.", ".matching.shortcut.enabled", defaultEnabled);
-  }
-
   public boolean isJmxFetchIntegrationEnabled(
       final Iterable<String> integrationNames, final boolean defaultEnabled) {
-    return isEnabled(integrationNames, "jmxfetch.", ".enabled", defaultEnabled);
+    return configProvider.isEnabled(integrationNames, "jmxfetch.", ".enabled", defaultEnabled);
   }
 
   public boolean isRuleEnabled(final String name) {
@@ -2490,23 +2309,26 @@ public class Config {
 
   public boolean isEndToEndDurationEnabled(
       final boolean defaultEnabled, final String... integrationNames) {
-    return isEnabled(Arrays.asList(integrationNames), "", ".e2e.duration.enabled", defaultEnabled);
+    return configProvider.isEnabled(
+        Arrays.asList(integrationNames), "", ".e2e.duration.enabled", defaultEnabled);
   }
 
   public boolean isPropagationEnabled(
       final boolean defaultEnabled, final String... integrationNames) {
-    return isEnabled(Arrays.asList(integrationNames), "", ".propagation.enabled", defaultEnabled);
+    return configProvider.isEnabled(
+        Arrays.asList(integrationNames), "", ".propagation.enabled", defaultEnabled);
   }
 
   public boolean isLegacyTracingEnabled(
       final boolean defaultEnabled, final String... integrationNames) {
-    return isEnabled(
+    return configProvider.isEnabled(
         Arrays.asList(integrationNames), "", ".legacy.tracing.enabled", defaultEnabled);
   }
 
   public boolean isEnabled(
       final boolean defaultEnabled, final String settingName, String settingSuffix) {
-    return isEnabled(Collections.singletonList(settingName), "", settingSuffix, defaultEnabled);
+    return configProvider.isEnabled(
+        Collections.singletonList(settingName), "", settingSuffix, defaultEnabled);
   }
 
   private void logIngoredSettingWarning(
@@ -2520,12 +2342,13 @@ public class Config {
 
   public boolean isTraceAnalyticsIntegrationEnabled(
       final SortedSet<String> integrationNames, final boolean defaultEnabled) {
-    return isEnabled(integrationNames, "", ".analytics.enabled", defaultEnabled);
+    return configProvider.isEnabled(integrationNames, "", ".analytics.enabled", defaultEnabled);
   }
 
   public boolean isTraceAnalyticsIntegrationEnabled(
       final boolean defaultEnabled, final String... integrationNames) {
-    return isEnabled(Arrays.asList(integrationNames), "", ".analytics.enabled", defaultEnabled);
+    return configProvider.isEnabled(
+        Arrays.asList(integrationNames), "", ".analytics.enabled", defaultEnabled);
   }
 
   public boolean isSamplingMechanismValidationDisabled() {
@@ -2563,27 +2386,6 @@ public class Config {
   public static boolean traceAnalyticsIntegrationEnabled(
       final SortedSet<String> integrationNames, final boolean defaultEnabled) {
     return Config.get().isTraceAnalyticsIntegrationEnabled(integrationNames, defaultEnabled);
-  }
-
-  private boolean isEnabled(
-      final Iterable<String> integrationNames,
-      final String settingPrefix,
-      final String settingSuffix,
-      final boolean defaultEnabled) {
-    // If default is enabled, we want to disable individually.
-    // If default is disabled, we want to enable individually.
-    boolean anyEnabled = defaultEnabled;
-    for (final String name : integrationNames) {
-      final String configKey = settingPrefix + name + settingSuffix;
-      final String fullKey = configKey.startsWith("trace.") ? configKey : "trace." + configKey;
-      final boolean configEnabled = configProvider.getBoolean(fullKey, defaultEnabled, configKey);
-      if (defaultEnabled) {
-        anyEnabled &= configEnabled;
-      } else {
-        anyEnabled |= configEnabled;
-      }
-    }
-    return anyEnabled;
   }
 
   /**
@@ -2810,8 +2612,6 @@ public class Config {
         + rootContextServiceName
         + ", traceEnabled="
         + traceEnabled
-        + ", integrationsEnabled="
-        + integrationsEnabled
         + ", integrationSynapseLegacyOperationName="
         + integrationSynapseLegacyOperationName
         + ", writerType='"
@@ -2849,14 +2649,6 @@ public class Config {
         + spanTags
         + ", jmxTags="
         + jmxTags
-        + ", excludedClasses="
-        + excludedClasses
-        + ", excludedClassesFile="
-        + excludedClassesFile
-        + ", excludedClassLoaders="
-        + excludedClassLoaders
-        + ", excludedCodeSources="
-        + excludedCodeSources
         + ", requestHeaderTags="
         + requestHeaderTags
         + ", responseHeaderTags="
@@ -2897,10 +2689,6 @@ public class Config {
         + partialFlushMinSpans
         + ", traceStrictWritesEnabled="
         + traceStrictWritesEnabled
-        + ", runtimeContextFieldInjection="
-        + runtimeContextFieldInjection
-        + ", serialVersionUIDFieldInjection="
-        + serialVersionUIDFieldInjection
         + ", propagationStylesToExtract="
         + propagationStylesToExtract
         + ", propagationStylesToInject="
@@ -2950,22 +2738,10 @@ public class Config {
         + tracerMetricsMaxAggregates
         + ", tracerMetricsMaxPending="
         + tracerMetricsMaxPending
-        + ", logsInjectionEnabled="
-        + logsInjectionEnabled
         + ", logsMDCTagsInjectionEnabled="
         + logsMDCTagsInjectionEnabled
         + ", reportHostName="
         + reportHostName
-        + ", traceAnnotations='"
-        + traceAnnotations
-        + '\''
-        + ", traceMethods='"
-        + traceMethods
-        + '\''
-        + ", traceExecutorsAll="
-        + traceExecutorsAll
-        + ", traceExecutors="
-        + traceExecutors
         + ", traceAnalyticsEnabled="
         + traceAnalyticsEnabled
         + ", traceSamplingServiceRules="
@@ -3104,22 +2880,6 @@ public class Config {
         + '\''
         + ", idGenerationStrategy="
         + idGenerationStrategy
-        + ", internalExitOnFailure="
-        + internalExitOnFailure
-        + ", resolverOutlinePoolEnabled="
-        + resolverOutlinePoolEnabled
-        + ", resolverOutlinePoolSize="
-        + resolverOutlinePoolSize
-        + ", resolverTypePoolSize="
-        + resolverTypePoolSize
-        + ", resolverUseLoadClassEnabled="
-        + resolverUseLoadClassEnabled
-        + ", jdbcPreparedStatementClassName='"
-        + jdbcPreparedStatementClassName
-        + '\''
-        + ", jdbcConnectionClassName='"
-        + jdbcConnectionClassName
-        + '\''
         + ", grpcIgnoredInboundMethods="
         + grpcIgnoredInboundMethods
         + ", grpcIgnoredOutboundMethods="
@@ -3147,6 +2907,8 @@ public class Config {
         + cwsEnabled
         + ", cwsTlsRefresh="
         + cwsTlsRefresh
+        + ", instrumenterConfig="
+        + instrumenterConfig
         + '}';
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -605,7 +605,7 @@ public class Config {
 
   // Read order: System Properties -> Env Variables, [-> properties file], [-> default value]
   private Config() {
-    this(ConfigProvider.getInstance());
+    this(InstrumenterConfig.get().configProvider()); // share config provider by default
   }
 
   private Config(final ConfigProvider configProvider) {
@@ -1260,6 +1260,10 @@ public class Config {
     }
 
     log.debug("New instance: {}", this);
+  }
+
+  public ConfigProvider configProvider() {
+    return configProvider;
   }
 
   public long getStartTimeMillis() {

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -71,7 +71,7 @@ public class InstrumenterConfig {
   private final boolean internalExitOnFailure;
 
   private InstrumenterConfig() {
-    boolean collectConfig = !Platform.isIsNativeImageBuilder();
+    boolean collectConfig = !Platform.isNativeImageBuilder();
     configProvider = ConfigProvider.newInstance(collectConfig);
 
     integrationsEnabled =

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -71,8 +71,11 @@ public class InstrumenterConfig {
   private final boolean internalExitOnFailure;
 
   private InstrumenterConfig() {
-    boolean collectConfig = !Platform.isNativeImageBuilder();
-    configProvider = ConfigProvider.newInstance(collectConfig);
+    this(ConfigProvider.createDefault());
+  }
+
+  private InstrumenterConfig(ConfigProvider configProvider) {
+    this.configProvider = configProvider;
 
     integrationsEnabled =
         configProvider.getBoolean(INTEGRATIONS_ENABLED, DEFAULT_INTEGRATIONS_ENABLED);
@@ -113,10 +116,6 @@ public class InstrumenterConfig {
     traceMethods = configProvider.getString(TRACE_METHODS, DEFAULT_TRACE_METHODS);
 
     internalExitOnFailure = configProvider.getBoolean(INTERNAL_EXIT_ON_FAILURE, false);
-  }
-
-  public ConfigProvider configProvider() {
-    return configProvider;
   }
 
   public boolean isIntegrationsEnabled() {
@@ -218,7 +217,11 @@ public class InstrumenterConfig {
 
   // This has to be placed after all other static fields to give them a chance to initialize
   @SuppressFBWarnings("SI_INSTANCE_BEFORE_FINALS_ASSIGNED")
-  private static final InstrumenterConfig INSTANCE = new InstrumenterConfig();
+  private static final InstrumenterConfig INSTANCE =
+      new InstrumenterConfig(
+          Platform.isNativeImageBuilder()
+              ? ConfigProvider.withoutCollector()
+              : ConfigProvider.getInstance());
 
   public static InstrumenterConfig get() {
     return INSTANCE;

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -1,0 +1,274 @@
+package datadog.trace.api;
+
+import static datadog.trace.api.ConfigDefaults.DEFAULT_INTEGRATIONS_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_LOGS_INJECTION_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_RESOLVER_OUTLINE_POOL_SIZE;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_RESOLVER_TYPE_POOL_SIZE;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_SERIALVERSIONUID_FIELD_INJECTION;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_ANNOTATIONS;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_EXECUTORS_ALL;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_METHODS;
+import static datadog.trace.api.config.GeneralConfig.INTERNAL_EXIT_ON_FAILURE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.INTEGRATIONS_ENABLED;
+import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_CONNECTION_CLASS_NAME;
+import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_PREPARED_STATEMENT_CLASS_NAME;
+import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_INJECTION_ENABLED;
+import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_OUTLINE_POOL_ENABLED;
+import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_OUTLINE_POOL_SIZE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_TYPE_POOL_SIZE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_USE_LOADCLASS;
+import static datadog.trace.api.config.TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
+import static datadog.trace.api.config.TraceInstrumentationConfig.SERIALVERSIONUID_FIELD_INJECTION;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ANNOTATIONS;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE_FILE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSLOADERS_EXCLUDE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CODESOURCES_EXCLUDE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_EXECUTORS;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_EXECUTORS_ALL;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_METHODS;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_THREAD_POOL_EXECUTORS_EXCLUDE;
+import static datadog.trace.util.CollectionUtils.tryMakeImmutableList;
+import static datadog.trace.util.CollectionUtils.tryMakeImmutableSet;
+
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+public class InstrumenterConfig {
+  private final ConfigProvider configProvider;
+
+  private final boolean integrationsEnabled;
+
+  private final boolean logsInjectionEnabled;
+
+  private final boolean traceExecutorsAll;
+  private final List<String> traceExecutors;
+  private final Set<String> traceThreadPoolExecutorsExclude;
+
+  private final String jdbcPreparedStatementClassName;
+  private final String jdbcConnectionClassName;
+
+  private final List<String> excludedClasses;
+  private final String excludedClassesFile;
+  private final Set<String> excludedClassLoaders;
+  private final List<String> excludedCodeSources;
+
+  private final boolean resolverOutlinePoolEnabled;
+  private final int resolverOutlinePoolSize;
+  private final int resolverTypePoolSize;
+  private final boolean resolverUseLoadClassEnabled;
+
+  private final boolean runtimeContextFieldInjection;
+  private final boolean serialVersionUIDFieldInjection;
+
+  private final String traceAnnotations;
+  private final String traceMethods;
+
+  private final boolean internalExitOnFailure;
+
+  private InstrumenterConfig() {
+    this.configProvider =
+        Platform.isIsNativeImageBuilder()
+            ? ConfigProvider.newInstance(false)
+            : ConfigProvider.getInstance();
+
+    integrationsEnabled =
+        configProvider.getBoolean(INTEGRATIONS_ENABLED, DEFAULT_INTEGRATIONS_ENABLED);
+
+    logsInjectionEnabled =
+        configProvider.getBoolean(LOGS_INJECTION_ENABLED, DEFAULT_LOGS_INJECTION_ENABLED);
+
+    traceExecutorsAll = configProvider.getBoolean(TRACE_EXECUTORS_ALL, DEFAULT_TRACE_EXECUTORS_ALL);
+    traceExecutors = tryMakeImmutableList(configProvider.getList(TRACE_EXECUTORS));
+    traceThreadPoolExecutorsExclude =
+        tryMakeImmutableSet(configProvider.getList(TRACE_THREAD_POOL_EXECUTORS_EXCLUDE));
+
+    jdbcPreparedStatementClassName =
+        configProvider.getString(JDBC_PREPARED_STATEMENT_CLASS_NAME, "");
+
+    jdbcConnectionClassName = configProvider.getString(JDBC_CONNECTION_CLASS_NAME, "");
+
+    excludedClasses = tryMakeImmutableList(configProvider.getList(TRACE_CLASSES_EXCLUDE));
+    excludedClassesFile = configProvider.getString(TRACE_CLASSES_EXCLUDE_FILE);
+    excludedClassLoaders = tryMakeImmutableSet(configProvider.getList(TRACE_CLASSLOADERS_EXCLUDE));
+    excludedCodeSources = tryMakeImmutableList(configProvider.getList(TRACE_CODESOURCES_EXCLUDE));
+
+    resolverOutlinePoolEnabled = configProvider.getBoolean(RESOLVER_OUTLINE_POOL_ENABLED, true);
+    resolverOutlinePoolSize =
+        configProvider.getInteger(RESOLVER_OUTLINE_POOL_SIZE, DEFAULT_RESOLVER_OUTLINE_POOL_SIZE);
+    resolverTypePoolSize =
+        configProvider.getInteger(RESOLVER_TYPE_POOL_SIZE, DEFAULT_RESOLVER_TYPE_POOL_SIZE);
+    resolverUseLoadClassEnabled = configProvider.getBoolean(RESOLVER_USE_LOADCLASS, true);
+
+    runtimeContextFieldInjection =
+        configProvider.getBoolean(
+            RUNTIME_CONTEXT_FIELD_INJECTION, DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION);
+    serialVersionUIDFieldInjection =
+        configProvider.getBoolean(
+            SERIALVERSIONUID_FIELD_INJECTION, DEFAULT_SERIALVERSIONUID_FIELD_INJECTION);
+
+    traceAnnotations = configProvider.getString(TRACE_ANNOTATIONS, DEFAULT_TRACE_ANNOTATIONS);
+    traceMethods = configProvider.getString(TRACE_METHODS, DEFAULT_TRACE_METHODS);
+
+    internalExitOnFailure = configProvider.getBoolean(INTERNAL_EXIT_ON_FAILURE, false);
+  }
+
+  public boolean isIntegrationsEnabled() {
+    return integrationsEnabled;
+  }
+
+  public boolean isIntegrationEnabled(
+      final Iterable<String> integrationNames, final boolean defaultEnabled) {
+    return configProvider.isEnabled(integrationNames, "integration.", ".enabled", defaultEnabled);
+  }
+
+  public boolean isIntegrationShortcutMatchingEnabled(
+      final Iterable<String> integrationNames, final boolean defaultEnabled) {
+    return configProvider.isEnabled(
+        integrationNames, "integration.", ".matching.shortcut.enabled", defaultEnabled);
+  }
+
+  public boolean isLogsInjectionEnabled() {
+    return logsInjectionEnabled;
+  }
+
+  public boolean isTraceExecutorsAll() {
+    return traceExecutorsAll;
+  }
+
+  public List<String> getTraceExecutors() {
+    return traceExecutors;
+  }
+
+  public Set<String> getTraceThreadPoolExecutorsExclude() {
+    return traceThreadPoolExecutorsExclude;
+  }
+
+  public String getJdbcPreparedStatementClassName() {
+    return jdbcPreparedStatementClassName;
+  }
+
+  public String getJdbcConnectionClassName() {
+    return jdbcConnectionClassName;
+  }
+
+  public List<String> getExcludedClasses() {
+    return excludedClasses;
+  }
+
+  public String getExcludedClassesFile() {
+    return excludedClassesFile;
+  }
+
+  public Set<String> getExcludedClassLoaders() {
+    return excludedClassLoaders;
+  }
+
+  public List<String> getExcludedCodeSources() {
+    return excludedCodeSources;
+  }
+
+  public boolean isResolverOutlinePoolEnabled() {
+    return resolverOutlinePoolEnabled;
+  }
+
+  public int getResolverOutlinePoolSize() {
+    return resolverOutlinePoolSize;
+  }
+
+  public int getResolverTypePoolSize() {
+    return resolverTypePoolSize;
+  }
+
+  public boolean isResolverUseLoadClassEnabled() {
+    return resolverUseLoadClassEnabled;
+  }
+
+  public boolean isRuntimeContextFieldInjection() {
+    return runtimeContextFieldInjection;
+  }
+
+  public boolean isSerialVersionUIDFieldInjection() {
+    return serialVersionUIDFieldInjection;
+  }
+
+  public String getTraceAnnotations() {
+    return traceAnnotations;
+  }
+
+  public String getTraceMethods() {
+    return traceMethods;
+  }
+
+  public boolean isInternalExitOnFailure() {
+    return internalExitOnFailure;
+  }
+
+  public boolean isLegacyInstrumentationEnabled(
+      final boolean defaultEnabled, final String... integrationNames) {
+    return configProvider.isEnabled(
+        Arrays.asList(integrationNames), "", ".legacy.tracing.enabled", defaultEnabled);
+  }
+
+  // This has to be placed after all other static fields to give them a chance to initialize
+  @SuppressFBWarnings("SI_INSTANCE_BEFORE_FINALS_ASSIGNED")
+  private static final InstrumenterConfig INSTANCE = new InstrumenterConfig();
+
+  public static InstrumenterConfig get() {
+    return INSTANCE;
+  }
+
+  @Override
+  public String toString() {
+    return "InstrumenterConfig{"
+        + "integrationsEnabled="
+        + integrationsEnabled
+        + ", logsInjectionEnabled="
+        + logsInjectionEnabled
+        + ", traceExecutorsAll="
+        + traceExecutorsAll
+        + ", traceExecutors="
+        + traceExecutors
+        + ", jdbcPreparedStatementClassName='"
+        + jdbcPreparedStatementClassName
+        + '\''
+        + ", jdbcConnectionClassName='"
+        + jdbcConnectionClassName
+        + '\''
+        + ", excludedClasses="
+        + excludedClasses
+        + ", excludedClassesFile="
+        + excludedClassesFile
+        + ", excludedClassLoaders="
+        + excludedClassLoaders
+        + ", excludedCodeSources="
+        + excludedCodeSources
+        + ", resolverOutlinePoolEnabled="
+        + resolverOutlinePoolEnabled
+        + ", resolverOutlinePoolSize="
+        + resolverOutlinePoolSize
+        + ", resolverTypePoolSize="
+        + resolverTypePoolSize
+        + ", resolverUseLoadClassEnabled="
+        + resolverUseLoadClassEnabled
+        + ", runtimeContextFieldInjection="
+        + runtimeContextFieldInjection
+        + ", serialVersionUIDFieldInjection="
+        + serialVersionUIDFieldInjection
+        + ", traceAnnotations='"
+        + traceAnnotations
+        + '\''
+        + ", traceMethods='"
+        + traceMethods
+        + '\''
+        + ", internalExitOnFailure="
+        + internalExitOnFailure
+        + ", configProvider="
+        + configProvider
+        + '}';
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -71,10 +71,8 @@ public class InstrumenterConfig {
   private final boolean internalExitOnFailure;
 
   private InstrumenterConfig() {
-    this.configProvider =
-        Platform.isIsNativeImageBuilder()
-            ? ConfigProvider.newInstance(false)
-            : ConfigProvider.getInstance();
+    boolean collectConfig = !Platform.isIsNativeImageBuilder();
+    configProvider = ConfigProvider.newInstance(collectConfig);
 
     integrationsEnabled =
         configProvider.getBoolean(INTEGRATIONS_ENABLED, DEFAULT_INTEGRATIONS_ENABLED);
@@ -115,6 +113,10 @@ public class InstrumenterConfig {
     traceMethods = configProvider.getString(TRACE_METHODS, DEFAULT_TRACE_METHODS);
 
     internalExitOnFailure = configProvider.getBoolean(INTERNAL_EXIT_ON_FAILURE, false);
+  }
+
+  public ConfigProvider configProvider() {
+    return configProvider;
   }
 
   public boolean isIntegrationsEnabled() {

--- a/internal-api/src/main/java/datadog/trace/api/Platform.java
+++ b/internal-api/src/main/java/datadog/trace/api/Platform.java
@@ -9,8 +9,8 @@ public final class Platform {
   private static final Version JAVA_VERSION = parseJavaVersion(System.getProperty("java.version"));
   private static final JvmRuntime RUNTIME = new JvmRuntime();
 
-  private static final boolean HAS_JFR = checkJfr();
-  private static final boolean IS_NATIVE_IMAGE_BUILDER = checkIsNativeImageBuilder();
+  private static final boolean HAS_JFR = checkForJfr();
+  private static final boolean IS_NATIVE_IMAGE_BUILDER = checkForNativeImageBuilder();
 
   public static boolean hasJfr() {
     return HAS_JFR;
@@ -20,7 +20,7 @@ public final class Platform {
     return IS_NATIVE_IMAGE_BUILDER;
   }
 
-  private static boolean checkJfr() {
+  private static boolean checkForJfr() {
     try {
       /* Check only for the open-sources JFR implementation.
        * If it is ever needed to support also the closed sourced JDK 8 version the check should be
@@ -34,7 +34,7 @@ public final class Platform {
     }
   }
 
-  private static boolean checkIsNativeImageBuilder() {
+  private static boolean checkForNativeImageBuilder() {
     try {
       return "org.graalvm.nativeimage.builder".equals(System.getProperty("jdk.module.main"));
     } catch (Throwable e) {

--- a/internal-api/src/main/java/datadog/trace/api/Platform.java
+++ b/internal-api/src/main/java/datadog/trace/api/Platform.java
@@ -9,14 +9,37 @@ public final class Platform {
   private static final Version JAVA_VERSION = parseJavaVersion(System.getProperty("java.version"));
   private static final JvmRuntime RUNTIME = new JvmRuntime();
 
+  private static final boolean HAS_JFR = checkJfr();
+  private static final boolean IS_NATIVE_IMAGE_BUILDER = checkIsNativeImageBuilder();
+
   public static boolean hasJfr() {
-    /* Check only for the open-sources JFR implementation.
-     * If it is ever needed to support also the closed sourced JDK 8 version the check should be
-     * enhanced.
-     * Need this custom check because ClassLoaderMatchers.hasClassNamed() does not support bootstrap class loader yet.
-     * Note: the downside of this is that we load some JFR classes at startup.
-     */
-    return ClassLoader.getSystemClassLoader().getResource("jdk/jfr/Event.class") != null;
+    return HAS_JFR;
+  }
+
+  public static boolean isIsNativeImageBuilder() {
+    return IS_NATIVE_IMAGE_BUILDER;
+  }
+
+  private static boolean checkJfr() {
+    try {
+      /* Check only for the open-sources JFR implementation.
+       * If it is ever needed to support also the closed sourced JDK 8 version the check should be
+       * enhanced.
+       * Need this custom check because ClassLoaderMatchers.hasClassNamed() does not support bootstrap class loader yet.
+       * Note: the downside of this is that we load some JFR classes at startup.
+       */
+      return ClassLoader.getSystemClassLoader().getResource("jdk/jfr/Event.class") != null;
+    } catch (Throwable e) {
+      return false;
+    }
+  }
+
+  private static boolean checkIsNativeImageBuilder() {
+    try {
+      return "org.graalvm.nativeimage.builder".equals(System.getProperty("jdk.module.main"));
+    } catch (Throwable e) {
+      return false;
+    }
   }
 
   /* The method splits java version string by digits. Delimiters are: dot, underscore and plus */

--- a/internal-api/src/main/java/datadog/trace/api/Platform.java
+++ b/internal-api/src/main/java/datadog/trace/api/Platform.java
@@ -16,7 +16,7 @@ public final class Platform {
     return HAS_JFR;
   }
 
-  public static boolean isIsNativeImageBuilder() {
+  public static boolean isNativeImageBuilder() {
     return IS_NATIVE_IMAGE_BUILDER;
   }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
 
 public final class ConfigProvider {
   private static final class Singleton {
-    private static final ConfigProvider INSTANCE = ConfigProvider.createDefault();
+    private static final ConfigProvider INSTANCE = ConfigProvider.newInstance(true);
   }
 
   private static final Logger log = LoggerFactory.getLogger(ConfigProvider.class);
@@ -259,10 +259,6 @@ public final class ConfigProvider {
 
   public static ConfigProvider getInstance() {
     return Singleton.INSTANCE;
-  }
-
-  public static ConfigProvider createDefault() {
-    return newInstance(true);
   }
 
   public static ConfigProvider newInstance(boolean collectConfig) {

--- a/internal-api/src/test/groovy/datadog/trace/api/AzureAppServicesTagsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/AzureAppServicesTagsTest.groovy
@@ -11,7 +11,7 @@ class AzureAppServicesTagsTest extends DDSpecification {
     injectEnvConfig("WEBSITE_INSTANCE_ID", "someOtherValue", false)
 
     when:
-    def config = new Config()
+    def config = Config.get()
 
     then:
     !config.localRootSpanTags.keySet().any { it.startsWith("aas")}
@@ -23,7 +23,7 @@ class AzureAppServicesTagsTest extends DDSpecification {
     injectEnvConfig("WEBSITE_OWNER_NAME", "8c500027-5f00-400e-8f00-60000000000f+apm-dotnet-EastUSwebspace", false)
 
     when:
-    def config = new Config()
+    def config = Config.get()
 
     then:
     config.localRootSpanTags["aas.subscription.id"] == "8c500027-5f00-400e-8f00-60000000000f"
@@ -37,7 +37,7 @@ class AzureAppServicesTagsTest extends DDSpecification {
     injectEnvConfig("WEBSITE_SITE_NAME", "site", false)
 
     when:
-    def config = new Config()
+    def config = Config.get()
 
     then:
     config.localRootSpanTags["aas.resource.id"] == "/subscriptions/8c500027-5f00-400e-8f00-60000000000f/resourcegroups/group/providers/microsoft.web/sites/site"
@@ -48,7 +48,7 @@ class AzureAppServicesTagsTest extends DDSpecification {
     injectSysConfig(GeneralConfig.AZURE_APP_SERVICES, "true")
 
     when:
-    def config = new Config()
+    def config = Config.get()
 
     then:
     config.localRootSpanTags["aas.environment.instance_id"] == "unknown"
@@ -67,7 +67,7 @@ class AzureAppServicesTagsTest extends DDSpecification {
     injectEnvConfig("DD_AAS_JAVA_EXTENSION_VERSION", "99", false)
 
     when:
-    def config = new Config()
+    def config = Config.get()
 
     then:
     config.localRootSpanTags["aas.environment.instance_id"] == "someInstance"

--- a/internal-api/src/test/groovy/datadog/trace/api/AzureAppServicesTagsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/AzureAppServicesTagsTest.groovy
@@ -11,7 +11,7 @@ class AzureAppServicesTagsTest extends DDSpecification {
     injectEnvConfig("WEBSITE_INSTANCE_ID", "someOtherValue", false)
 
     when:
-    def config = Config.get()
+    def config = new Config()
 
     then:
     !config.localRootSpanTags.keySet().any { it.startsWith("aas")}
@@ -23,7 +23,7 @@ class AzureAppServicesTagsTest extends DDSpecification {
     injectEnvConfig("WEBSITE_OWNER_NAME", "8c500027-5f00-400e-8f00-60000000000f+apm-dotnet-EastUSwebspace", false)
 
     when:
-    def config = Config.get()
+    def config = new Config()
 
     then:
     config.localRootSpanTags["aas.subscription.id"] == "8c500027-5f00-400e-8f00-60000000000f"
@@ -37,7 +37,7 @@ class AzureAppServicesTagsTest extends DDSpecification {
     injectEnvConfig("WEBSITE_SITE_NAME", "site", false)
 
     when:
-    def config = Config.get()
+    def config = new Config()
 
     then:
     config.localRootSpanTags["aas.resource.id"] == "/subscriptions/8c500027-5f00-400e-8f00-60000000000f/resourcegroups/group/providers/microsoft.web/sites/site"
@@ -48,7 +48,7 @@ class AzureAppServicesTagsTest extends DDSpecification {
     injectSysConfig(GeneralConfig.AZURE_APP_SERVICES, "true")
 
     when:
-    def config = Config.get()
+    def config = new Config()
 
     then:
     config.localRootSpanTags["aas.environment.instance_id"] == "unknown"
@@ -67,7 +67,7 @@ class AzureAppServicesTagsTest extends DDSpecification {
     injectEnvConfig("DD_AAS_JAVA_EXTENSION_VERSION", "99", false)
 
     when:
-    def config = Config.get()
+    def config = new Config()
 
     then:
     config.localRootSpanTags["aas.environment.instance_id"] == "someInstance"

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigForkedTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigForkedTest.groovy
@@ -13,7 +13,7 @@ class ConfigForkedTest extends Specification {
     System.setProperty(PREFIX + RUNTIME_ID_ENABLED, "false")
 
     when:
-    def config = new Config()
+    def config = Config.get()
     then:
     config.runtimeId == ""
   }

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigForkedTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigForkedTest.groovy
@@ -13,7 +13,7 @@ class ConfigForkedTest extends Specification {
     System.setProperty(PREFIX + RUNTIME_ID_ENABLED, "false")
 
     when:
-    def config = Config.get()
+    def config = new Config()
     then:
     config.runtimeId == ""
   }

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -1192,7 +1192,7 @@ class ConfigTest extends DDSpecification {
     System.setProperty(PREFIX + CONFIGURATION_FILE, "src/test/resources/dd-java-tracer.properties")
 
     when:
-    def config = new Config()
+    def config = new Config(ConfigProvider.newInstance(false)) // force re-evaluation of sources
 
     then:
     config.configFileStatus == "src/test/resources/dd-java-tracer.properties"
@@ -1205,7 +1205,7 @@ class ConfigTest extends DDSpecification {
     System.setProperty(PREFIX + SERVICE_NAME, "set-in-system")
 
     when:
-    def config = new Config()
+    def config = new Config(ConfigProvider.newInstance(false)) // force re-evaluation of sources
 
     then:
     config.configFileStatus == "src/test/resources/dd-java-tracer.properties"
@@ -1218,7 +1218,7 @@ class ConfigTest extends DDSpecification {
     environmentVariables.set("DD_SERVICE_NAME", "set-in-env")
 
     when:
-    def config = new Config()
+    def config = new Config(ConfigProvider.newInstance(false)) // force re-evaluation of sources
 
     then:
     config.configFileStatus == "src/test/resources/dd-java-tracer.properties"

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -2058,6 +2058,11 @@ class ConfigTest extends DDSpecification {
     "1"        | null       | ProductActivationConfig.FULLY_ENABLED
   }
 
+  def "default config and instrumenterconfig share same provider"() {
+    expect:
+    Config.get().configProvider() == InstrumenterConfig.get().configProvider()
+  }
+
   static class ClassThrowsExceptionForValueOfMethod {
     static ClassThrowsExceptionForValueOfMethod valueOf(String ignored) {
       throw new Throwable()

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -252,7 +252,6 @@ class ConfigTest extends DDSpecification {
     config.splitByTags == ["some.tag1", "some.tag2"].toSet()
     config.partialFlushMinSpans == 15
     config.reportHostName == true
-    config.runtimeContextFieldInjection == false
     config.propagationStylesToExtract.toList() == [PropagationStyle.DATADOG, PropagationStyle.B3]
     config.propagationStylesToInject.toList() == [PropagationStyle.B3, PropagationStyle.DATADOG]
     config.jmxFetchEnabled == false
@@ -420,7 +419,6 @@ class ConfigTest extends DDSpecification {
     config.splitByTags == ["some.tag3", "some.tag2", "some.tag1"].toSet()
     config.partialFlushMinSpans == 25
     config.reportHostName == true
-    config.runtimeContextFieldInjection == false
     config.propagationStylesToExtract.toList() == [PropagationStyle.DATADOG, PropagationStyle.B3]
     config.propagationStylesToInject.toList() == [PropagationStyle.B3, PropagationStyle.DATADOG]
     config.jmxFetchEnabled == false
@@ -775,42 +773,6 @@ class ConfigTest extends DDSpecification {
 
     then:
     config.serviceName == "what actually wants"
-  }
-
-  def "verify integration config"() {
-    setup:
-    environmentVariables.set("DD_INTEGRATION_ORDER_ENABLED", "false")
-    environmentVariables.set("DD_INTEGRATION_TEST_ENV_ENABLED", "true")
-    environmentVariables.set("DD_INTEGRATION_DISABLED_ENV_ENABLED", "false")
-
-    System.setProperty("dd.integration.order.enabled", "true")
-    System.setProperty("dd.integration.test-prop.enabled", "true")
-    System.setProperty("dd.integration.disabled-prop.enabled", "false")
-
-    expect:
-    Config.get().isIntegrationEnabled(integrationNames, defaultEnabled) == expected
-
-    where:
-    // spotless:off
-    names                          | defaultEnabled | expected
-    []                             | true           | true
-    []                             | false          | false
-    ["invalid"]                    | true           | true
-    ["invalid"]                    | false          | false
-    ["test-prop"]                  | false          | true
-    ["test-env"]                   | false          | true
-    ["disabled-prop"]              | true           | false
-    ["disabled-env"]               | true           | false
-    ["other", "test-prop"]         | false          | true
-    ["other", "test-env"]          | false          | true
-    ["order"]                      | false          | true
-    ["test-prop", "disabled-prop"] | false          | true
-    ["disabled-env", "test-env"]   | false          | true
-    ["test-prop", "disabled-prop"] | true           | false
-    ["disabled-env", "test-env"]   | true           | false
-    // spotless:on
-
-    integrationNames = new TreeSet<>(names)
   }
 
   def "verify rule config #name"() {

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -1192,7 +1192,7 @@ class ConfigTest extends DDSpecification {
     System.setProperty(PREFIX + CONFIGURATION_FILE, "src/test/resources/dd-java-tracer.properties")
 
     when:
-    def config = new Config(ConfigProvider.newInstance(false)) // force re-evaluation of sources
+    def config = new Config()
 
     then:
     config.configFileStatus == "src/test/resources/dd-java-tracer.properties"
@@ -1205,7 +1205,7 @@ class ConfigTest extends DDSpecification {
     System.setProperty(PREFIX + SERVICE_NAME, "set-in-system")
 
     when:
-    def config = new Config(ConfigProvider.newInstance(false)) // force re-evaluation of sources
+    def config = new Config()
 
     then:
     config.configFileStatus == "src/test/resources/dd-java-tracer.properties"
@@ -1218,7 +1218,7 @@ class ConfigTest extends DDSpecification {
     environmentVariables.set("DD_SERVICE_NAME", "set-in-env")
 
     when:
-    def config = new Config(ConfigProvider.newInstance(false)) // force re-evaluation of sources
+    def config = new Config()
 
     then:
     config.configFileStatus == "src/test/resources/dd-java-tracer.properties"
@@ -2056,11 +2056,6 @@ class ConfigTest extends DDSpecification {
     "true"     | "true"     | ProductActivationConfig.FULLY_ENABLED
     "true"     | "1"        | ProductActivationConfig.FULLY_ENABLED
     "1"        | null       | ProductActivationConfig.FULLY_ENABLED
-  }
-
-  def "default config and instrumenterconfig share same provider"() {
-    expect:
-    Config.get().configProvider() == InstrumenterConfig.get().configProvider()
   }
 
   static class ClassThrowsExceptionForValueOfMethod {

--- a/internal-api/src/test/groovy/datadog/trace/api/InstrumenterConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/InstrumenterConfigTest.groovy
@@ -1,0 +1,42 @@
+package datadog.trace.api
+
+import datadog.trace.test.util.DDSpecification
+
+class InstrumenterConfigTest extends DDSpecification {
+
+  def "verify integration config"() {
+    setup:
+    environmentVariables.set("DD_INTEGRATION_ORDER_ENABLED", "false")
+    environmentVariables.set("DD_INTEGRATION_TEST_ENV_ENABLED", "true")
+    environmentVariables.set("DD_INTEGRATION_DISABLED_ENV_ENABLED", "false")
+
+    System.setProperty("dd.integration.order.enabled", "true")
+    System.setProperty("dd.integration.test-prop.enabled", "true")
+    System.setProperty("dd.integration.disabled-prop.enabled", "false")
+
+    expect:
+    InstrumenterConfig.get().isIntegrationEnabled(integrationNames, defaultEnabled) == expected
+
+    where:
+    // spotless:off
+    names                          | defaultEnabled | expected
+    []                             | true           | true
+    []                             | false          | false
+    ["invalid"]                    | true           | true
+    ["invalid"]                    | false          | false
+    ["test-prop"]                  | false          | true
+    ["test-env"]                   | false          | true
+    ["disabled-prop"]              | true           | false
+    ["disabled-env"]               | true           | false
+    ["other", "test-prop"]         | false          | true
+    ["other", "test-env"]          | false          | true
+    ["order"]                      | false          | true
+    ["test-prop", "disabled-prop"] | false          | true
+    ["disabled-env", "test-env"]   | false          | true
+    ["test-prop", "disabled-prop"] | true           | false
+    ["disabled-env", "test-env"]   | true           | false
+    // spotless:on
+
+    integrationNames = new TreeSet<>(names)
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/config/provider/ConfigProviderTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/config/provider/ConfigProviderTest.groovy
@@ -8,7 +8,7 @@ import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_SERVER_PATH_RESOU
 class ConfigProviderTest extends DDSpecification {
 
   @Shared
-  ConfigProvider configProvider = ConfigProvider.createDefault()
+  ConfigProvider configProvider = ConfigProvider.withoutCollector()
 
   def "properties take precedence over env vars for ordered map"() {
     setup:

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/config/provider/ConfigProviderTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/config/provider/ConfigProviderTest.groovy
@@ -8,7 +8,7 @@ import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_SERVER_PATH_RESOU
 class ConfigProviderTest extends DDSpecification {
 
   @Shared
-  ConfigProvider configProvider = ConfigProvider.newInstance(false)
+  ConfigProvider configProvider = ConfigProvider.createDefault()
 
   def "properties take precedence over env vars for ordered map"() {
     setup:

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/config/provider/ConfigProviderTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/config/provider/ConfigProviderTest.groovy
@@ -8,7 +8,7 @@ import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_SERVER_PATH_RESOU
 class ConfigProviderTest extends DDSpecification {
 
   @Shared
-  ConfigProvider configProvider = ConfigProvider.createDefault()
+  ConfigProvider configProvider = ConfigProvider.newInstance(false)
 
   def "properties take precedence over env vars for ordered map"() {
     setup:

--- a/utils/test-utils/src/main/groovy/datadog/trace/test/util/DDSpecification.groovy
+++ b/utils/test-utils/src/main/groovy/datadog/trace/test/util/DDSpecification.groovy
@@ -18,14 +18,18 @@ import static net.bytebuddy.description.modifier.FieldManifestation.VOLATILE
 import static net.bytebuddy.description.modifier.Ownership.STATIC
 import static net.bytebuddy.description.modifier.Visibility.PUBLIC
 import static net.bytebuddy.matcher.ElementMatchers.named
+import static net.bytebuddy.matcher.ElementMatchers.namedOneOf
 import static net.bytebuddy.matcher.ElementMatchers.none
 
 @SuppressForbidden
 abstract class DDSpecification extends Specification {
   private static final CHECK_TIMEOUT_MS = 3000
 
+  static final String INST_CONFIG = "datadog.trace.api.InstrumenterConfig"
   static final String CONFIG = "datadog.trace.api.Config"
 
+  private static Field instConfigInstanceField
+  private static Constructor instConfigConstructor
   private static Field configInstanceField
   private static Constructor configConstructor
 
@@ -65,7 +69,7 @@ abstract class DDSpecification extends Specification {
         new AgentBuilder.LocationStrategy.Simple(
         ClassFileLocator.ForClassLoader.ofSystemLoader()))
         .ignore(none()) // Allow transforming bootstrap classes
-        .type(named(CONFIG))
+        .type(namedOneOf(INST_CONFIG, CONFIG))
         .transform { builder, typeDescription, classLoader, module, pd ->
           builder
             .field(named("INSTANCE"))
@@ -74,13 +78,18 @@ abstract class DDSpecification extends Specification {
         .with(new ConfigInstrumentationFailedListener())
         .installOn(instrumentation)
 
+      Class instConfigClass = Class.forName(INST_CONFIG)
+      instConfigInstanceField = instConfigClass.getDeclaredField("INSTANCE")
+      instConfigConstructor = instConfigClass.getDeclaredConstructor()
+      instConfigConstructor.setAccessible(true)
       Class configClass = Class.forName(CONFIG)
       configInstanceField = configClass.getDeclaredField("INSTANCE")
       configConstructor = configClass.getDeclaredConstructor()
       configConstructor.setAccessible(true)
+
       isConfigInstanceModifiable = true
     } catch (ClassNotFoundException e) {
-      if (e.getMessage() == CONFIG) {
+      if (e.getMessage() == INST_CONFIG || e.getMessage() == CONFIG) {
         println("Config class not found in this classloader. Not transforming it")
       } else {
         configModificationFailed = true
@@ -238,20 +247,27 @@ abstract class DDSpecification extends Specification {
   synchronized static void rebuildConfig() {
     checkConfigTransformation()
 
+    def newInstConfig = instConfigConstructor.newInstance()
+    instConfigInstanceField.set(null, newInstConfig)
     def newConfig = configConstructor.newInstance()
     configInstanceField.set(null, newConfig)
   }
 
   private static void checkConfigTransformation() {
     // Ensure the class was re-transformed properly in DDSpecification.makeConfigInstanceModifiable()
-
     assert isConfigInstanceModifiable
-    assert configInstanceField != null
+    assert instConfigConstructor != null
+    checkWritable(instConfigInstanceField)
     assert configConstructor != null
-    assert Modifier.isPublic(configInstanceField.getModifiers())
-    assert Modifier.isStatic(configInstanceField.getModifiers())
-    assert Modifier.isVolatile(configInstanceField.getModifiers())
-    assert !Modifier.isFinal(configInstanceField.getModifiers())
+    checkWritable(configInstanceField)
+  }
+
+  private static void checkWritable(Field field) {
+    assert field != null
+    assert Modifier.isPublic(field.getModifiers())
+    assert Modifier.isStatic(field.getModifiers())
+    assert Modifier.isVolatile(field.getModifiers())
+    assert !Modifier.isFinal(field.getModifiers())
   }
 }
 


### PR DESCRIPTION
# What Does This Do

This PR separates config that's used at up-front at instrumentation build-time to configure `Instrumenters` and various byte-buddy caches from config that used once classes have been transformed and the application is running.

Another way of looking at this split is anything that's needed to configure `Instrumenters` before class-transformation should go in `InstrumenterConfig`, while everything else - including config used _inside_ method advice - should stay in `Config` (at least until that's refactored...)

# Motivation

This separation works better with GraalVM's native-image because the `Instrumenter` config will be eagerly created and baked into the final executable along with the transformed classes, while the rest of the config will be (re)configured at execution time.

# Additional Notes

This is currently labelled as a breaking-change because it affects `Config` even though this is technically part of the `internal-api` - if we decide to drop that label then we should still clearly call out this change in the release notes
