### PR TITLE
Eager initialization of Moshi in Telemetry

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -671,7 +671,7 @@ public class Agent {
           telemetrySystem.getMethod("startTelemetry", Instrumentation.class, scoClass);
       startTelemetry.invoke(null, inst, sco);
     } catch (final Throwable ex) {
-      log.warn("Unable start telemetry: {}", ex);
+      log.warn("Unable start telemetry", ex);
     }
   }
 

--- a/telemetry/src/main/java/datadog/telemetry/RequestBuilderSupplier.java
+++ b/telemetry/src/main/java/datadog/telemetry/RequestBuilderSupplier.java
@@ -1,20 +1,24 @@
 package datadog.telemetry;
 
+import com.squareup.moshi.JsonAdapter;
+import datadog.telemetry.api.Telemetry;
 import datadog.trace.api.function.Supplier;
 import okhttp3.HttpUrl;
 
 class RequestBuilderSupplier implements Supplier<RequestBuilder> {
+  final JsonAdapter<Telemetry> jsonAdapter;
   private final HttpUrl httpUrl;
   private RequestBuilder requestBuilder;
 
-  RequestBuilderSupplier(HttpUrl httpUrl) {
+  RequestBuilderSupplier(final JsonAdapter<Telemetry> jsonAdapter, final HttpUrl httpUrl) {
+    this.jsonAdapter = jsonAdapter;
     this.httpUrl = httpUrl;
   }
 
   @Override
   public RequestBuilder get() {
     if (requestBuilder == null) {
-      requestBuilder = new RequestBuilder(httpUrl);
+      requestBuilder = new RequestBuilder(jsonAdapter, httpUrl);
     }
     return requestBuilder;
   }


### PR DESCRIPTION
# What Does This Do
Eager initialization of Moshi can avoid issues with a SecurityManager. If it still fails, it's better that we fail early and avoid starting the telemetry subsystem.

# Motivation

# Additional Notes
