### PR TITLE
Catch AccessControlException in telemetry RequestBuilder when initialize Moshi

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/RequestBuilder.java
+++ b/telemetry/src/main/java/datadog/telemetry/RequestBuilder.java
@@ -30,11 +30,8 @@ public class RequestBuilder {
 
   private static final Logger log = LoggerFactory.getLogger(RequestBuilder.class);
 
-  private static final JsonAdapter<Telemetry> JSON_ADAPTER =
-      new Moshi.Builder()
-          .add(new PolymorphicAdapterFactory(Payload.class))
-          .build()
-          .adapter(Telemetry.class);
+  private final JsonAdapter<Telemetry> JSON_ADAPTER;
+
   private static final AtomicLong SEQ_ID = new AtomicLong();
 
   private final HttpUrl httpUrl;
@@ -43,6 +40,14 @@ public class RequestBuilder {
   private final String runtimeId;
 
   public RequestBuilder(HttpUrl httpUrl) {
+
+    // May throw AccessControlException when using SecurityManager
+    JSON_ADAPTER =
+        new Moshi.Builder()
+            .add(new PolymorphicAdapterFactory(Payload.class))
+            .build()
+            .adapter(Telemetry.class);
+
     this.httpUrl = httpUrl.newBuilder().addPathSegments(API_ENDPOINT).build();
 
     Config config = Config.get();


### PR DESCRIPTION
# What Does This Do

# Motivation
Failed to send telemetry data because of Moshi couldn't be initialised with SecurityManager.

# Additional Notes
Test case:
```
import javax.xml.parsers.SAXParser;
import javax.xml.parsers.SAXParserFactory;
import org.xml.sax.SAXNotRecognizedException;

public class Bug6359330 {

    public static void main(String[] args) throws Throwable {
        System.setSecurityManager(new SecurityManager());
        try {
            SAXParserFactory spf = SAXParserFactory.newInstance();
            spf.setNamespaceAware(true);
            spf.setValidating(true);
            SAXParser sp = spf.newSAXParser();
            // The following line shouldn't throw a
            // java.security.AccessControlException.
            sp.setProperty("foo", "bar");
        } catch (SAXNotRecognizedException e) {
            // Ignore this expected exception.
        }
    }
}
```
Exception:

```
[dd.trace 2022-11-07 09:00:40:933 +0100] [dd-telemetry] ERROR datadog.telemetry.TelemetryRunnable - Uncaught exception in dd-telemetry
java.lang.ExceptionInInitializerError
	at datadog.telemetry.RequestBuilderSupplier.get(RequestBuilderSupplier.java:17)
	at datadog.telemetry.RequestBuilderSupplier.get(RequestBuilderSupplier.java:6)
	at datadog.telemetry.TelemetryServiceImpl.addStartedRequest(TelemetryServiceImpl.java:59)
	at datadog.telemetry.TelemetryRunnable.run(TelemetryRunnable.java:57)
	at java.base/java.lang.Thread.run(Thread.java:844)
Caused by: java.security.AccessControlException: access denied ("java.lang.reflect.ReflectPermission" "suppressAccessChecks")
	at java.base/java.security.AccessControlContext.checkPermission(AccessControlContext.java:472)
	at java.base/java.security.AccessController.checkPermission(AccessController.java:895)
	at java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:558)
	at java.base/java.lang.reflect.AccessibleObject.checkPermission(AccessibleObject.java:85)
	at java.base/java.lang.reflect.Field.setAccessible(Field.java:169)
	at com.squareup.moshi.ClassJsonAdapter$1.createFieldBindings(ClassJsonAdapter.java:145)
	at com.squareup.moshi.ClassJsonAdapter$1.create(ClassJsonAdapter.java:106)
	at com.squareup.moshi.Moshi.adapter(Moshi.java:145)
	at com.squareup.moshi.Moshi.adapter(Moshi.java:105)
	at com.squareup.moshi.Moshi.adapter(Moshi.java:79)
	at datadog.telemetry.RequestBuilder.<clinit>(RequestBuilder.java:37)
	... 5 more
[dd.trace 2022-11-07 09:00:41:026 +0100] [dd-trace-processor] DEBUG datadog.trace.agent.common.writer.TraceProcessingWorker - Datadog trace processor exited. Publishing traces stopped
```