### PR TITLE
Exclude tracer deps in telemetry

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/HostInfo.java
+++ b/telemetry/src/main/java/datadog/telemetry/HostInfo.java
@@ -9,6 +9,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.AccessControlException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -124,7 +125,7 @@ public class HostInfo {
       try {
         byte[] bytes = Files.readAllBytes(file);
         content = new String(bytes, StandardCharsets.ISO_8859_1);
-      } catch (IOException e) {
+      } catch (IOException | AccessControlException e) {
         log.debug("Could not read {}", file, e);
       }
     }
@@ -154,7 +155,8 @@ public class HostInfo {
               version = matcher.group("value");
             }
           }
-        } catch (IOException e) {
+        } catch (IOException | AccessControlException e) {
+          log.debug("Could not read {}", OS_RELEASE_PATH, e);
         }
         if (name != null && version != null) {
           return name + " " + version;

--- a/telemetry/src/main/java/datadog/telemetry/dependency/LocationsCollectingTransformer.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/LocationsCollectingTransformer.java
@@ -13,6 +13,17 @@ import org.slf4j.LoggerFactory;
 class LocationsCollectingTransformer implements ClassFileTransformer {
   private static final Logger log = LoggerFactory.getLogger(LocationsCollectingTransformer.class);
 
+  private static URL agentURL = null;
+
+  static {
+    try {
+      agentURL =
+          LocationsCollectingTransformer.class.getProtectionDomain().getCodeSource().getLocation();
+    } catch (Throwable ex) {
+      log.error("Error getting agent URL");
+    }
+  }
+
   private final DependencyServiceImpl dependencyService;
   private final Set<ProtectionDomain> seenDomains =
       Collections.newSetFromMap(new WeakHashMap<ProtectionDomain, Boolean>());
@@ -43,6 +54,10 @@ class LocationsCollectingTransformer implements ClassFileTransformer {
 
     URL location = codeSource.getLocation();
     if (location == null) {
+      return null;
+    }
+
+    if (location.equals(agentURL)) {
       return null;
     }
 

--- a/telemetry/src/main/java/datadog/telemetry/dependency/LocationsCollectingTransformer.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/LocationsCollectingTransformer.java
@@ -13,18 +13,6 @@ import org.slf4j.LoggerFactory;
 class LocationsCollectingTransformer implements ClassFileTransformer {
   private static final Logger log = LoggerFactory.getLogger(LocationsCollectingTransformer.class);
 
-  private static String agentUrl = null;
-
-  static {
-    try {
-      final URL agentUrlObj =
-          LocationsCollectingTransformer.class.getProtectionDomain().getCodeSource().getLocation();
-      agentUrl = agentUrlObj == null ? null : agentUrlObj.toString();
-    } catch (Throwable ex) {
-      log.error("Error getting agent URL");
-    }
-  }
-
   private final DependencyServiceImpl dependencyService;
   private final Set<ProtectionDomain> seenDomains =
       Collections.newSetFromMap(new WeakHashMap<ProtectionDomain, Boolean>());
@@ -56,10 +44,6 @@ class LocationsCollectingTransformer implements ClassFileTransformer {
 
     URL location = codeSource.getLocation();
     if (location == null) {
-      return null;
-    }
-
-    if (location.toString().equals(agentUrl)) {
       return null;
     }
 

--- a/telemetry/src/main/java/datadog/telemetry/dependency/LocationsCollectingTransformer.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/LocationsCollectingTransformer.java
@@ -13,23 +13,13 @@ import org.slf4j.LoggerFactory;
 class LocationsCollectingTransformer implements ClassFileTransformer {
   private static final Logger log = LoggerFactory.getLogger(LocationsCollectingTransformer.class);
 
-  private static URL agentURL = null;
-
-  static {
-    try {
-      agentURL =
-          LocationsCollectingTransformer.class.getProtectionDomain().getCodeSource().getLocation();
-    } catch (Throwable ex) {
-      log.error("Error getting agent URL");
-    }
-  }
-
   private final DependencyServiceImpl dependencyService;
   private final Set<ProtectionDomain> seenDomains =
       Collections.newSetFromMap(new WeakHashMap<ProtectionDomain, Boolean>());
 
   public LocationsCollectingTransformer(DependencyServiceImpl dependencyService) {
     this.dependencyService = dependencyService;
+    seenDomains.add(LocationsCollectingTransformer.class.getProtectionDomain());
   }
 
   @Override
@@ -54,10 +44,6 @@ class LocationsCollectingTransformer implements ClassFileTransformer {
 
     URL location = codeSource.getLocation();
     if (location == null) {
-      return null;
-    }
-
-    if (location.equals(agentURL)) {
       return null;
     }
 

--- a/telemetry/src/test/groovy/datadog/telemetry/dependency/LocationsCollectingTransformerSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/dependency/LocationsCollectingTransformerSpecification.groovy
@@ -1,0 +1,79 @@
+package datadog.telemetry.dependency
+
+import java.security.CodeSource
+import java.security.ProtectionDomain
+
+class LocationsCollectingTransformerSpecification extends DepSpecification {
+
+  DependencyServiceImpl depService = new DependencyServiceImpl()
+
+  LocationsCollectingTransformer transformer = new LocationsCollectingTransformer(depService)
+
+  void 'no dependency for agent jar'() {
+    when:
+    transformer.transform(null, null, null, getClass().getProtectionDomain(), null)
+
+    then:
+    depService.resolveOneDependency()
+    def dependencies = depService.drainDeterminedDependencies()
+    dependencies.isEmpty()
+  }
+
+  void 'no dependency if null protection domain'() {
+    when:
+    transformer.transform(null, null, null, null, null)
+
+    then:
+    depService.resolveOneDependency()
+    def dependencies = depService.drainDeterminedDependencies()
+    dependencies.isEmpty()
+  }
+
+  void 'no dependency if null code source'() {
+    when:
+    ProtectionDomain domain = new ProtectionDomain(null, null)
+    transformer.transform(null, null, null, domain, null)
+
+    then:
+    depService.resolveOneDependency()
+    def dependencies = depService.drainDeterminedDependencies()
+    dependencies.isEmpty()
+  }
+
+  void 'no dependency if null location'() {
+    when:
+    CodeSource source = new CodeSource(null, (java.security.cert.Certificate[])null)
+    ProtectionDomain domain = new ProtectionDomain(source, null)
+    transformer.transform(null, null, null, domain, null)
+
+    then:
+    depService.resolveOneDependency()
+    def dependencies = depService.drainDeterminedDependencies()
+    dependencies.isEmpty()
+  }
+
+  void 'one dependency if normal url'() {
+    when:
+    CodeSource source = new CodeSource(getJar('bson-4.2.0.jar').toURI().toURL(), (java.security.cert.Certificate[])null)
+    ProtectionDomain domain = new ProtectionDomain(source, null)
+    transformer.transform(null, null, null, domain, null)
+
+    then:
+    depService.resolveOneDependency()
+    def dependencies = depService.drainDeterminedDependencies()
+    dependencies.size()==1
+  }
+
+  void 'single dependency if repeated protection domain'() {
+    when:
+    CodeSource source = new CodeSource(getJar('bson-4.2.0.jar').toURI().toURL(), (java.security.cert.Certificate[])null)
+    ProtectionDomain domain = new ProtectionDomain(source, null)
+    transformer.transform(null, null, null, domain, null)
+    transformer.transform(null, null, null, domain, null)
+
+    then:
+    depService.resolveOneDependency()
+    def dependencies = depService.drainDeterminedDependencies()
+    dependencies.size()==1
+  }
+}


### PR DESCRIPTION
# What Does This Do

It does not report tracer internal dependencies in telemetry

# Motivation

Currently internal dependencies were reported as if they were from the application
