### PR TITLE
Add non-root user to the `dd-lib-java-init` image

### DIFF
--- a/lib-injection/src/main/docker/Dockerfile
+++ b/lib-injection/src/main/docker/Dockerfile
@@ -1,5 +1,8 @@
 FROM busybox
 
+RUN addgroup -g 1000 -S datadog \
+    && adduser -S -G datadog -u 1000 datadog
 WORKDIR /datadog-init
 ADD copy-lib.sh /datadog-init/copy-lib.sh
 ADD dd-java-agent.jar /datadog-init/dd-java-agent.jar
+USER datadog


### PR DESCRIPTION
# What Does This Do
Adds a non-root user to the `dd-lib-java-init` image
Resolves https://github.com/DataDog/dd-trace-java/issues/4181

# Motivation
In Kubernetes Pod definitions where the following configuration is used, the init-container created from this image fails to start
```
securityContext:
        runAsNonRoot: true
```

# Additional Notes
