### PR TITLE
Refactor probe definition to separate package

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/Configuration.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/Configuration.java
@@ -1,5 +1,8 @@
 package com.datadog.debugger.agent;
 
+import com.datadog.debugger.probe.MetricProbe;
+import com.datadog.debugger.probe.ProbeDefinition;
+import com.datadog.debugger.probe.SnapshotProbe;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationComparer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationComparer.java
@@ -4,6 +4,7 @@ import static com.datadog.debugger.agent.Trie.reverseStr;
 import static com.datadog.debugger.agent.TypeNameHelper.extractSimpleName;
 
 import com.datadog.debugger.instrumentation.InstrumentationResult;
+import com.datadog.debugger.probe.ProbeDefinition;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -1,6 +1,10 @@
 package com.datadog.debugger.agent;
 
 import com.datadog.debugger.instrumentation.InstrumentationResult;
+import com.datadog.debugger.probe.MetricProbe;
+import com.datadog.debugger.probe.ProbeDefinition;
+import com.datadog.debugger.probe.SnapshotProbe;
+import com.datadog.debugger.probe.Where;
 import com.datadog.debugger.sink.DebuggerSink;
 import com.datadog.debugger.util.ExceptionHelper;
 import datadog.trace.api.Config;
@@ -281,7 +285,7 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver {
   private Snapshot.ProbeDetails convertToProbeDetails(
       SnapshotProbe probe, Snapshot.ProbeLocation location) {
     return new Snapshot.ProbeDetails(
-        probe.id,
+        probe.getId(),
         location,
         probe.getProbeCondition(),
         probe.concatTags(),

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -1,6 +1,8 @@
 package com.datadog.debugger.agent;
 
 import com.datadog.debugger.instrumentation.InstrumentationResult;
+import com.datadog.debugger.probe.ProbeDefinition;
+import com.datadog.debugger.probe.SnapshotProbe;
 import com.datadog.debugger.util.ExceptionHelper;
 import datadog.trace.agent.tooling.AgentStrategies;
 import datadog.trace.api.Config;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/EnvironmentAndVersionChecker.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/EnvironmentAndVersionChecker.java
@@ -1,5 +1,7 @@
 package com.datadog.debugger.agent;
 
+import com.datadog.debugger.probe.ProbeDefinition;
+import com.datadog.debugger.probe.SnapshotProbe;
 import datadog.trace.api.Config;
 import datadog.trace.util.TagsHelper;
 import java.util.Arrays;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/TransformerDefinitionMatcher.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/TransformerDefinitionMatcher.java
@@ -2,6 +2,7 @@ package com.datadog.debugger.agent;
 
 import static com.datadog.debugger.agent.Trie.reverseStr;
 
+import com.datadog.debugger.probe.ProbeDefinition;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
@@ -1,7 +1,7 @@
 package com.datadog.debugger.instrumentation;
 
-import com.datadog.debugger.agent.ProbeDefinition;
-import com.datadog.debugger.agent.Where;
+import com.datadog.debugger.probe.ProbeDefinition;
+import com.datadog.debugger.probe.Where;
 import datadog.trace.bootstrap.debugger.DiagnosticMessage;
 import datadog.trace.bootstrap.debugger.DiagnosticMessage.Kind;
 import java.util.List;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MethodProbeInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MethodProbeInstrumentor.java
@@ -11,8 +11,8 @@ import static com.datadog.debugger.instrumentation.Types.STRING_TYPE;
 import static com.datadog.debugger.instrumentation.Types.THROWABLE_TYPE;
 import static org.objectweb.asm.Type.INT_TYPE;
 
-import com.datadog.debugger.agent.SnapshotProbe;
-import com.datadog.debugger.agent.Where;
+import com.datadog.debugger.probe.SnapshotProbe;
+import com.datadog.debugger.probe.Where;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.CorrelationAccess;
 import datadog.trace.bootstrap.debugger.DiagnosticMessage;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
@@ -2,12 +2,12 @@ package com.datadog.debugger.instrumentation;
 
 import static com.datadog.debugger.instrumentation.Types.*;
 
-import com.datadog.debugger.agent.MetricProbe;
-import com.datadog.debugger.agent.ProbeDefinition;
-import com.datadog.debugger.agent.Where;
 import com.datadog.debugger.el.InvalidValueException;
 import com.datadog.debugger.el.Literal;
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.probe.MetricProbe;
+import com.datadog.debugger.probe.ProbeDefinition;
+import com.datadog.debugger.probe.Where;
 import datadog.trace.bootstrap.debugger.DiagnosticMessage;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.ValueReferences;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/MetricProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/MetricProbe.java
@@ -1,5 +1,6 @@
-package com.datadog.debugger.agent;
+package com.datadog.debugger.probe;
 
+import com.datadog.debugger.agent.Generated;
 import com.datadog.debugger.el.ValueScript;
 import com.datadog.debugger.instrumentation.MetricInstrumentor;
 import datadog.trace.bootstrap.debugger.DiagnosticMessage;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
@@ -1,5 +1,6 @@
-package com.datadog.debugger.agent;
+package com.datadog.debugger.probe;
 
+import com.datadog.debugger.agent.Generated;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.JsonWriter;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SnapshotProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SnapshotProbe.java
@@ -1,5 +1,6 @@
-package com.datadog.debugger.agent;
+package com.datadog.debugger.probe;
 
+import com.datadog.debugger.agent.Generated;
 import com.datadog.debugger.el.ProbeCondition;
 import com.datadog.debugger.instrumentation.MethodProbeInstrumentor;
 import com.squareup.moshi.Json;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/Where.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/Where.java
@@ -1,5 +1,6 @@
-package com.datadog.debugger.agent;
+package com.datadog.debugger.probe;
 
+import com.datadog.debugger.agent.Generated;
 import com.datadog.debugger.instrumentation.Types;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.JsonReader;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiHelper.java
@@ -1,10 +1,10 @@
 package com.datadog.debugger.util;
 
-import com.datadog.debugger.agent.ProbeDefinition;
 import com.datadog.debugger.agent.ProbeStatus;
-import com.datadog.debugger.agent.Where;
 import com.datadog.debugger.el.ProbeCondition;
 import com.datadog.debugger.el.ValueScript;
+import com.datadog.debugger.probe.ProbeDefinition;
+import com.datadog.debugger.probe.Where;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -15,6 +15,9 @@ import static utils.TestHelper.getFixtureContent;
 import com.datadog.debugger.el.DSL;
 import com.datadog.debugger.el.ProbeCondition;
 import com.datadog.debugger.instrumentation.InstrumentationResult;
+import com.datadog.debugger.probe.ProbeDefinition;
+import com.datadog.debugger.probe.SnapshotProbe;
+import com.datadog.debugger.probe.Where;
 import com.datadog.debugger.util.MoshiHelper;
 import com.datadog.debugger.util.MoshiSnapshotHelper;
 import com.squareup.moshi.JsonAdapter;
@@ -104,7 +107,7 @@ public class CapturedSnapshotTest {
   public void lineNotFound() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
     DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, CLASS_NAME + ".java", "42"));
+        installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, CLASS_NAME + ".java", 42));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "2").get();
     Assert.assertEquals(2, result);
@@ -368,7 +371,7 @@ public class CapturedSnapshotTest {
   public void sourceFileProbe() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot03";
     DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, CLASS_NAME + ".java", "4"));
+        installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, CLASS_NAME + ".java", 4));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
     Assert.assertEquals(48, result);
@@ -385,7 +388,7 @@ public class CapturedSnapshotTest {
   public void simpleSourceFileProbe() throws IOException, URISyntaxException {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot10";
     DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, "CapturedSnapshot10.java", "11"));
+        installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, "CapturedSnapshot10.java", 11));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "2").get();
     Assert.assertEquals(2, result);
@@ -405,7 +408,7 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener =
         installProbes(
             CLASS_NAME,
-            createSourceFileProbe(PROBE_ID, "src/main/java/" + DIR_CLASS_NAME + ".java", "11"));
+            createSourceFileProbe(PROBE_ID, "src/main/java/" + DIR_CLASS_NAME + ".java", 11));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "2").get();
     Assert.assertEquals(2, result);
@@ -425,7 +428,7 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener =
         installProbes(
             "com.datadog.debugger.TopLevel01",
-            createSourceFileProbe(PROBE_ID, "src/main/java/" + DIR_CLASS_NAME + ".java", "21"));
+            createSourceFileProbe(PROBE_ID, "src/main/java/" + DIR_CLASS_NAME + ".java", 21));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     Assert.assertEquals(42 * 42, result);
@@ -446,7 +449,7 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener =
         installProbes(
             CLASS_NAME,
-            createSourceFileProbe(PROBE_ID1, "src/main/java/" + DIR_CLASS_NAME + ".java", "10"),
+            createSourceFileProbe(PROBE_ID1, "src/main/java/" + DIR_CLASS_NAME + ".java", 10),
             createProbe(PROBE_ID2, CLASS_NAME, "main", null));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "2").get();
@@ -474,7 +477,7 @@ public class CapturedSnapshotTest {
     final String CLASS_NAME = "CapturedSnapshot101";
     final String FILE_NAME = CLASS_NAME + ".scala";
     DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, FILE_NAME, "3"));
+        installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, FILE_NAME, 3));
     String source = getFixtureContent("/" + FILE_NAME);
     Class<?> testClass = ScalaHelper.compileAndLoad(source, CLASS_NAME, FILE_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
@@ -492,7 +495,7 @@ public class CapturedSnapshotTest {
   public void sourceFileProbeGroovy() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot201";
     DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, CLASS_NAME + ".groovy", "4"));
+        installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, CLASS_NAME + ".groovy", 4));
     String source = getFixtureContent("/" + CLASS_NAME + ".groovy");
     GroovyClassLoader groovyClassLoader = new GroovyClassLoader();
     Class<?> testClass = groovyClassLoader.parseClass(source);
@@ -511,7 +514,7 @@ public class CapturedSnapshotTest {
   public void sourceFileProbeKotlin() {
     final String CLASS_NAME = "CapturedSnapshot301";
     DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, CLASS_NAME + ".kt", "4"));
+        installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, CLASS_NAME + ".kt", 4));
     URL resource = CapturedSnapshotTest.class.getResource("/" + CLASS_NAME + ".kt");
     Assert.assertNotNull(resource);
     List<File> filesToDelete = new ArrayList<>();
@@ -759,15 +762,13 @@ public class CapturedSnapshotTest {
   public void rateLimitSnapshot() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
     SnapshotProbe snapshotProbe =
-        new SnapshotProbe(
-            LANGUAGE,
-            PROBE_ID,
-            true,
-            null,
-            new Where(CLASS_NAME, "main", "int (java.lang.String)", new String[] {"8"}, null),
-            ProbeCondition.NONE,
-            null,
-            new SnapshotProbe.Sampling(1));
+        new SnapshotProbe.Builder()
+            .language(LANGUAGE)
+            .probeId(PROBE_ID)
+            .active(true)
+            .where(CLASS_NAME, "main", "int (java.lang.String)", "8")
+            .sampling(new SnapshotProbe.Sampling(1))
+            .build();
     DebuggerTransformerTest.TestSnapshotListener listener =
         installProbes(CLASS_NAME, snapshotProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
@@ -1231,11 +1232,11 @@ public class CapturedSnapshotTest {
             location,
             probe.getProbeCondition(),
             probe.concatTags(),
-            probe.additionalProbes.stream()
+            probe.getAdditionalProbes().stream()
                 .map(
                     (ProbeDefinition relatedProbe) ->
                         new Snapshot.ProbeDetails(
-                            relatedProbe.id,
+                            relatedProbe.getId(),
                             location,
                             ((SnapshotProbe) relatedProbe).getProbeCondition(),
                             ((SnapshotProbe) relatedProbe).concatTags()))
@@ -1450,17 +1451,13 @@ public class CapturedSnapshotTest {
         .sampling(new SnapshotProbe.Sampling(100));
   }
 
-  private static SnapshotProbe createSourceFileProbe(
-      String id, String sourceFile, String... lines) {
-    return new SnapshotProbe(
-        LANGUAGE,
-        id,
-        true,
-        null,
-        new Where(null, null, null, lines, sourceFile),
-        ProbeCondition.NONE,
-        null,
-        null);
+  private static SnapshotProbe createSourceFileProbe(String id, String sourceFile, int line) {
+    return new SnapshotProbe.Builder()
+        .language(LANGUAGE)
+        .probeId(id)
+        .active(true)
+        .where(null, null, null, line, sourceFile)
+        .build();
   }
 
   static class KotlinHelper {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationComparerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationComparerTest.java
@@ -4,6 +4,8 @@ import static com.datadog.debugger.agent.Trie.reverseStr;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.instrumentation.InstrumentationResult;
+import com.datadog.debugger.probe.ProbeDefinition;
+import com.datadog.debugger.probe.SnapshotProbe;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
@@ -1,9 +1,11 @@
 package com.datadog.debugger.agent;
 
-import static com.datadog.debugger.agent.MetricProbe.MetricKind.COUNT;
-import static com.datadog.debugger.agent.MetricProbe.MetricKind.GAUGE;
+import static com.datadog.debugger.probe.MetricProbe.MetricKind.COUNT;
+import static com.datadog.debugger.probe.MetricProbe.MetricKind.GAUGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.datadog.debugger.probe.MetricProbe;
+import com.datadog.debugger.probe.SnapshotProbe;
 import com.datadog.debugger.util.MoshiHelper;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Types;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
@@ -11,6 +11,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.datadog.debugger.probe.MetricProbe;
+import com.datadog.debugger.probe.ProbeDefinition;
+import com.datadog.debugger.probe.SnapshotProbe;
 import com.datadog.debugger.sink.DebuggerSink;
 import com.datadog.debugger.sink.ProbeStatusSink;
 import datadog.trace.api.Config;
@@ -399,7 +402,7 @@ public class ConfigurationUpdaterTest {
     assertEquals(HashMap.class, allValues.get(2)); // for removing instrumentation
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     Assertions.assertEquals(1, appliedDefinitions.size());
-    assertTrue(appliedDefinitions.containsKey(probe1.id));
+    assertTrue(appliedDefinitions.containsKey(probe1.getId()));
   }
 
   @Test
@@ -443,7 +446,7 @@ public class ConfigurationUpdaterTest {
     assertEquals(String.class, allValues.get(1));
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     Assertions.assertEquals(1, appliedDefinitions.size());
-    assertTrue(appliedDefinitions.containsKey(probe1.id));
+    assertTrue(appliedDefinitions.containsKey(probe1.getId()));
   }
 
   @Test
@@ -610,7 +613,7 @@ public class ConfigurationUpdaterTest {
     assertEquals(HashMap.class, allValues.get(2)); // for removing instrumentation
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     assertEquals(1, appliedDefinitions.size());
-    assertTrue(appliedDefinitions.containsKey(metricProbe1.id));
+    assertTrue(appliedDefinitions.containsKey(metricProbe1.getId()));
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
@@ -9,6 +9,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.datadog.debugger.instrumentation.InstrumentationResult;
+import com.datadog.debugger.probe.SnapshotProbe;
+import com.datadog.debugger.probe.Where;
 import datadog.trace.api.Config;
 import datadog.trace.api.GlobalTracer;
 import datadog.trace.api.Tracer;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/EnvironmentAndVersionCheckerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/EnvironmentAndVersionCheckerTest.java
@@ -3,6 +3,8 @@ package com.datadog.debugger.agent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.lenient;
 
+import com.datadog.debugger.probe.ProbeDefinition;
+import com.datadog.debugger.probe.SnapshotProbe;
 import datadog.trace.api.Config;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -104,7 +106,7 @@ public class EnvironmentAndVersionCheckerTest {
             getProbeWithTags("version:" + SERVICE_VERSION_2.toLowerCase())));
   }
 
-  private com.datadog.debugger.agent.ProbeDefinition getProbeWithTags(String... tags) {
+  private ProbeDefinition getProbeWithTags(String... tags) {
     SnapshotProbe probe = new SnapshotProbe("java", "1", true, tags, null, null, null, null);
 
     return probe;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ProbeMetricsOnDemandTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ProbeMetricsOnDemandTest.java
@@ -1,14 +1,15 @@
 package com.datadog.debugger.agent;
 
-import static com.datadog.debugger.agent.MetricProbe.MetricKind.COUNT;
-import static com.datadog.debugger.agent.MetricProbe.MetricKind.GAUGE;
-import static com.datadog.debugger.agent.MetricProbe.MetricKind.HISTOGRAM;
+import static com.datadog.debugger.probe.MetricProbe.MetricKind.COUNT;
+import static com.datadog.debugger.probe.MetricProbe.MetricKind.GAUGE;
+import static com.datadog.debugger.probe.MetricProbe.MetricKind.HISTOGRAM;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static utils.InstrumentationTestHelper.compileAndLoadClass;
 
 import com.datadog.debugger.el.ValueScript;
 import com.datadog.debugger.instrumentation.InsnListValue;
+import com.datadog.debugger.probe.MetricProbe;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.debugger.DiagnosticMessage;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/TransformerDefinitionMatcherTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/TransformerDefinitionMatcherTest.java
@@ -2,6 +2,9 @@ package com.datadog.debugger.agent;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.datadog.debugger.probe.MetricProbe;
+import com.datadog.debugger.probe.ProbeDefinition;
+import com.datadog.debugger.probe.SnapshotProbe;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/MetricProbeTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/MetricProbeTest.java
@@ -1,4 +1,4 @@
-package com.datadog.debugger.agent;
+package com.datadog.debugger.probe;
 
 import com.datadog.debugger.el.ValueScript;
 import org.junit.Assert;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/SnapshotProbeTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/SnapshotProbeTest.java
@@ -1,4 +1,4 @@
-package com.datadog.debugger.agent;
+package com.datadog.debugger.probe;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/WhereTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/WhereTest.java
@@ -1,4 +1,4 @@
-package com.datadog.debugger.agent;
+package com.datadog.debugger.probe;
 
 import com.datadog.debugger.util.MoshiHelper;
 import com.squareup.moshi.JsonAdapter;

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
@@ -7,7 +7,7 @@ import static org.junit.Assert.assertNotNull;
 import com.datadog.debugger.agent.Configuration;
 import com.datadog.debugger.agent.JsonSnapshotSerializer;
 import com.datadog.debugger.agent.ProbeStatus;
-import com.datadog.debugger.agent.SnapshotProbe;
+import com.datadog.debugger.probe.SnapshotProbe;
 import com.datadog.debugger.util.MoshiHelper;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Types;

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/DebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/DebuggerIntegrationTest.java
@@ -7,7 +7,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.datadog.debugger.agent.JsonSnapshotSerializer;
-import com.datadog.debugger.agent.SnapshotProbe;
+import com.datadog.debugger.probe.SnapshotProbe;
 import com.squareup.moshi.JsonAdapter;
 import datadog.trace.api.Platform;
 import datadog.trace.bootstrap.debugger.Snapshot;

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ServerDebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ServerDebuggerIntegrationTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.datadog.debugger.agent.Configuration;
 import com.datadog.debugger.agent.JsonSnapshotSerializer;
 import com.datadog.debugger.agent.ProbeStatus;
-import com.datadog.debugger.agent.SnapshotProbe;
+import com.datadog.debugger.probe.SnapshotProbe;
 import com.squareup.moshi.JsonAdapter;
 import datadog.trace.bootstrap.debugger.Snapshot;
 import datadog.trace.util.TagsHelper;

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/TracerDebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/TracerDebuggerIntegrationTest.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.datadog.debugger.agent.JsonSnapshotSerializer;
-import com.datadog.debugger.agent.SnapshotProbe;
+import com.datadog.debugger.probe.SnapshotProbe;
 import com.squareup.moshi.JsonAdapter;
 import datadog.trace.agent.test.utils.PortUtils;
 import datadog.trace.bootstrap.debugger.Snapshot;


### PR DESCRIPTION
# What Does This Do
Move probe definitions to `com.datadog.debugger.probe` package

# Motivation
more probes to come (log, span)

# Additional Notes
