### PR TITLE
Clean up shaded resources  

### DIFF
--- a/dd-java-agent/dd-java-agent.gradle
+++ b/dd-java-agent/dd-java-agent.gradle
@@ -30,6 +30,9 @@ targetCompatibility = JavaVersion.VERSION_1_7
 ext.generalShadowJarConfig = {
   mergeServiceFiles()
 
+  exclude '**/META-INF/maven/'
+  exclude '**/META-INF/proguard/'
+  exclude '**/META-INF/*.kotlin_module'
   exclude '**/module-info.class'
 
   // Prevents conflict with other SLF4J instances. Important for premain.

--- a/dd-trace-ot/dd-trace-ot.gradle
+++ b/dd-trace-ot/dd-trace-ot.gradle
@@ -101,7 +101,9 @@ shadowJar {
     exclude('datadog.trace.api.*')
     exclude('datadog.trace.context.*')
   }
-  exclude('META-INF/maven/**')
+  exclude('META-INF/maven/')
+  exclude('META-INF/proguard/')
+  exclude('/META-INF/*.kotlin_module')
 }
 
 jmh {


### PR DESCRIPTION
# What Does This Do

This PR removes Maven, Proguard configurations and kotlin module files from shaded `dd-trace-ot` and `dd-java-agent` artifacts.

# Motivation

Asked by @bantonsson for `project/java-8`.

# Additional Notes

Here is the difference of included resources (left = before patch / right = after patch):

## `dd-trace-ot`
```diff
 ./META-INF							 ./META-INF
 ./META-INF/MANIFEST.MF						 ./META-INF/MANIFEST.MF
 ./META-INF/moshi.kotlin_module				      <
 ./META-INF/NOTICE						 ./META-INF/NOTICE
 ./META-INF/proguard					      <
 ./META-INF/proguard/okhttp3.pro			      <
 ./META-INF/proguard/moshi.pro				      <
 ./META-INF/services						 ./META-INF/services
 ./META-INF/services/io.opentracing.contrib.tracerresolver.Tr	 ./META-INF/services/io.opentracing.contrib.tracerresolver.Tr
```

## `dd-java-agent`

```diff
 ./iast/META-INF						 ./iast/META-INF
 ./iast/META-INF/MANIFEST.MF					 ./iast/META-INF/MANIFEST.MF
 ./metrics/META-INF						 ./metrics/META-INF
 ./metrics/META-INF/MANIFEST.MF					 ./metrics/META-INF/MANIFEST.MF
 ./metrics/META-INF/LICENSE.renamed				 ./metrics/META-INF/LICENSE.renamed
 ./metrics/META-INF/maven				      <
 ./metrics/META-INF/maven/com.fasterxml.jackson.jr	      <
 ./metrics/META-INF/maven/com.fasterxml.jackson.jr/jackson-jr <
 ./metrics/META-INF/maven/com.fasterxml.jackson.jr/jackson-jr <
 ./metrics/META-INF/maven/com.fasterxml.jackson.jr/jackson-jr <
 ./metrics/META-INF/maven/com.fasterxml.jackson.core	      <
 ./metrics/META-INF/maven/com.fasterxml.jackson.core/jackson- <
 ./metrics/META-INF/maven/com.fasterxml.jackson.core/jackson- <
 ./metrics/META-INF/maven/com.fasterxml.jackson.core/jackson- <
 ./metrics/META-INF/maven/com.datadoghq			      <
 ./metrics/META-INF/maven/com.datadoghq/jmxfetch	      <
 ./metrics/META-INF/maven/com.datadoghq/jmxfetch/pom.xml      <
 ./metrics/META-INF/maven/com.datadoghq/jmxfetch/pom.properti <
 ./metrics/META-INF/maven/org.yaml			      <
 ./metrics/META-INF/maven/org.yaml/snakeyaml		      <
 ./metrics/META-INF/maven/org.yaml/snakeyaml/pom.xml	      <
 ./metrics/META-INF/maven/org.yaml/snakeyaml/pom.properties   <
 ./metrics/META-INF/NOTICE					 ./metrics/META-INF/NOTICE
 ./metrics/META-INF/services					 ./metrics/META-INF/services
 ./metrics/META-INF/services/com.fasterxml.jackson.core.JsonF	 ./metrics/META-INF/services/com.fasterxml.jackson.core.JsonF
 ./shared/META-INF						 ./shared/META-INF
 ./shared/META-INF/MANIFEST.MF					 ./shared/META-INF/MANIFEST.MF
 ./shared/META-INF/maven				      <
 ./shared/META-INF/maven/com.github.jnr			      <
 ./shared/META-INF/maven/com.github.jnr/jnr-a64asm	      <
 ./shared/META-INF/maven/com.github.jnr/jnr-a64asm/pom.xml    <
 ./shared/META-INF/maven/com.github.jnr/jnr-a64asm/pom.proper <
 ./shared/META-INF/maven/com.github.jnr/jnr-x86asm	      <
 ./shared/META-INF/maven/com.github.jnr/jnr-x86asm/pom.xml    <
 ./shared/META-INF/maven/com.github.jnr/jnr-x86asm/pom.proper <
 ./shared/META-INF/maven/com.github.jnr/jnr-posix	      <
 ./shared/META-INF/maven/com.github.jnr/jnr-posix/pom.xml     <
 ./shared/META-INF/maven/com.github.jnr/jnr-posix/pom.propert <
 ./shared/META-INF/maven/com.github.jnr/jnr-enxio	      <
 ./shared/META-INF/maven/com.github.jnr/jnr-enxio/pom.xml     <
 ./shared/META-INF/maven/com.github.jnr/jnr-enxio/pom.propert <
 ./shared/META-INF/maven/com.github.jnr/jnr-unixsocket	      <
 ./shared/META-INF/maven/com.github.jnr/jnr-unixsocket/pom.xm <
 ./shared/META-INF/maven/com.github.jnr/jnr-unixsocket/pom.pr <
 ./shared/META-INF/maven/com.github.jnr/jnr-constants	      <
 ./shared/META-INF/maven/com.github.jnr/jnr-constants/pom.xml <
 ./shared/META-INF/maven/com.github.jnr/jnr-constants/pom.pro <
 ./shared/META-INF/maven/com.github.jnr/jffi		      <
 ./shared/META-INF/maven/com.github.jnr/jffi/pom.xml	      <
 ./shared/META-INF/maven/com.github.jnr/jffi/pom.properties   <
 ./shared/META-INF/maven/com.github.jnr/jnr-ffi		      <
 ./shared/META-INF/maven/com.github.jnr/jnr-ffi/pom.xml	      <
 ./shared/META-INF/maven/com.github.jnr/jnr-ffi/pom.propertie <
 ./shared/META-INF/maven/com.squareup.okio		      <
 ./shared/META-INF/maven/com.squareup.okio/okio		      <
 ./shared/META-INF/maven/com.squareup.okio/okio/pom.xml	      <
 ./shared/META-INF/maven/com.squareup.okio/okio/pom.propertie <
 ./shared/META-INF/maven/org.jctools			      <
 ./shared/META-INF/maven/org.jctools/jctools-core	      <
 ./shared/META-INF/maven/org.jctools/jctools-core/pom.xml     <
 ./shared/META-INF/maven/org.jctools/jctools-core/pom.propert <
 ./shared/META-INF/maven/com.datadoghq.okhttp3		      <
 ./shared/META-INF/maven/com.datadoghq.okhttp3/okhttp	      <
 ./shared/META-INF/maven/com.datadoghq.okhttp3/okhttp/pom.xml <
 ./shared/META-INF/maven/com.datadoghq.okhttp3/okhttp/pom.pro <
 ./shared/META-INF/maven/com.datadoghq			      <
 ./shared/META-INF/maven/com.datadoghq/java-dogstatsd-client  <
 ./shared/META-INF/maven/com.datadoghq/java-dogstatsd-client/ <
 ./shared/META-INF/maven/com.datadoghq/java-dogstatsd-client/ <
 ./shared/META-INF/moshi.kotlin_module			      <
 ./shared/META-INF/NOTICE					 ./shared/META-INF/NOTICE
 ./shared/META-INF/proguard				      <
 ./shared/META-INF/proguard/okhttp3.pro			      <
 ./shared/META-INF/proguard/moshi.pro			      <
 ./META-INF							 ./META-INF
 ./META-INF/MANIFEST.MF						 ./META-INF/MANIFEST.MF
 ./META-INF/maven					      <
 ./META-INF/maven/org.slf4j				      <
 ./META-INF/maven/org.slf4j/slf4j-api			      <
 ./META-INF/maven/org.slf4j/slf4j-api/pom.xml		      <
 ./META-INF/maven/org.slf4j/slf4j-api/pom.properties	      <
 ./appsec/META-INF						 ./appsec/META-INF
 ./appsec/META-INF/MANIFEST.MF					 ./appsec/META-INF/MANIFEST.MF
 ./appsec/META-INF/services					 ./appsec/META-INF/services
 ./appsec/META-INF/services/com.datadog.appsec.AppSecModule	 ./appsec/META-INF/services/com.datadog.appsec.AppSecModule
 ./profiling/META-INF						 ./profiling/META-INF
 ./profiling/META-INF/MANIFEST.MF				 ./profiling/META-INF/MANIFEST.MF
 ./profiling/META-INF/services					 ./profiling/META-INF/services
 ./profiling/META-INF/services/com.datadog.profiling.auxiliar	 ./profiling/META-INF/services/com.datadog.profiling.auxiliar
 ./debugger/META-INF						 ./debugger/META-INF
 ./debugger/META-INF/MANIFEST.MF				 ./debugger/META-INF/MANIFEST.MF
 ./inst/META-INF						 ./inst/META-INF
 ./inst/META-INF/MANIFEST.MF					 ./inst/META-INF/MANIFEST.MF
 ./inst/META-INF/LICENSE.renamed				 ./inst/META-INF/LICENSE.renamed
 ./inst/META-INF/licenses					 ./inst/META-INF/licenses
 ./inst/META-INF/licenses/ASM					 ./inst/META-INF/licenses/ASM
 ./inst/META-INF/maven					      <
 ./inst/META-INF/maven/net.bytebuddy			      <
 ./inst/META-INF/maven/net.bytebuddy/byte-buddy		      <
 ./inst/META-INF/maven/net.bytebuddy/byte-buddy/pom.xml	      <
 ./inst/META-INF/maven/net.bytebuddy/byte-buddy/pom.propertie <
 ./inst/META-INF/maven/net.bytebuddy/byte-buddy-agent	      <
 ./inst/META-INF/maven/net.bytebuddy/byte-buddy-agent/pom.xml <
 ./inst/META-INF/maven/net.bytebuddy/byte-buddy-agent/pom.pro <
 ./inst/META-INF/maven/com.googlecode.concurrentlinkedhashmap <
 ./inst/META-INF/maven/com.googlecode.concurrentlinkedhashmap <
 ./inst/META-INF/maven/com.googlecode.concurrentlinkedhashmap <
 ./inst/META-INF/maven/com.googlecode.concurrentlinkedhashmap <
 ./inst/META-INF/maven/com.blogspot.mydailyjava		      <
 ./inst/META-INF/maven/com.blogspot.mydailyjava/weak-lock-fre <
 ./inst/META-INF/maven/com.blogspot.mydailyjava/weak-lock-fre <
 ./inst/META-INF/maven/com.blogspot.mydailyjava/weak-lock-fre <
 ./inst/META-INF/NOTICE						 ./inst/META-INF/NOTICE
 ./inst/META-INF/services					 ./inst/META-INF/services
 ./inst/META-INF/services/datadog.trace.agent.tooling.Instrum	 ./inst/META-INF/services/datadog.trace.agent.tooling.Instru
```
