### PR TITLE
simplify async-profiler config flags

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
@@ -295,14 +295,7 @@ public final class AsyncProfiler {
     }
     if (profilingModes.contains(ProfilingMode.WALL)) {
       // wall profiling is enabled.
-      cmd.append(",wall=");
-      if (isCollapsingWallclock()) {
-        cmd.append('~'); // this prefix will turn on wall-clock collapsing feature
-      }
-      cmd.append(getWallInterval()).append('m');
-      if (AsyncProfilerConfig.isWallThreadFilterEnabled()) {
-        cmd.append(",filter=0");
-      }
+      cmd.append(",wall=~").append(getWallInterval()).append('m').append(",filter=0");
       cmd.append(",loglevel=").append(AsyncProfilerConfig.getLogLevel());
     }
     if (profilingModes.contains(ProfilingMode.ALLOCATION)) {
@@ -339,12 +332,6 @@ public final class AsyncProfiler {
     return configProvider.getInteger(
         ProfilingConfig.PROFILING_ASYNC_WALL_INTERVAL,
         ProfilingConfig.PROFILING_ASYNC_WALL_INTERVAL_DEFAULT);
-  }
-
-  public boolean isCollapsingWallclock() {
-    return configProvider.getBoolean(
-        ProfilingConfig.PROFILING_ASYNC_WALL_COLLAPSE_SAMPLES,
-        ProfilingConfig.PROFILING_ASYNC_WALL_COLLAPSE_SAMPLES_DEFAULT);
   }
 
   private int getStackDepth() {

--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfilerConfig.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfilerConfig.java
@@ -1,6 +1,11 @@
 package com.datadog.profiling.async;
 
-import static datadog.trace.api.config.ProfilingConfig.*;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_ASYNC_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_ASYNC_ENABLED_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_ASYNC_LOG_LEVEL;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_ASYNC_LOG_LEVEL_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_ASYNC_WALL_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_ASYNC_WALL_ENABLED_DEFAULT;
 
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 
@@ -10,14 +15,12 @@ public class AsyncProfilerConfig {
       ConfigProvider.getInstance()
           .getBoolean(PROFILING_ASYNC_ENABLED, PROFILING_ASYNC_ENABLED_DEFAULT);
 
-  private static final boolean ASYNC_PROFILER_THREAD_FILTER_ENABLED =
+  private static final boolean ASYNC_PROFILER_WALLCLOCK_ENABLED =
       ConfigProvider.getInstance()
-          .getBoolean(
-              PROFILING_ASYNC_WALL_THREAD_FILTER_ENABLED,
-              PROFILING_ASYNC_WALL_THREAD_FILTER_ENABLED_DEFAULT);
+          .getBoolean(PROFILING_ASYNC_WALL_ENABLED, PROFILING_ASYNC_WALL_ENABLED_DEFAULT);
 
-  public static boolean isWallThreadFilterEnabled() {
-    return ASYNC_PROFILER_ENABLED && ASYNC_PROFILER_THREAD_FILTER_ENABLED;
+  public static boolean isWallClockProfilerEnabled() {
+    return ASYNC_PROFILER_ENABLED && ASYNC_PROFILER_WALLCLOCK_ENABLED;
   }
 
   public static String getLogLevel() {

--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/ContextThreadFilter.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/ContextThreadFilter.java
@@ -10,14 +10,14 @@ public class ContextThreadFilter implements ContextThreadListener {
 
   @Override
   public void onAttach() {
-    if (AsyncProfilerConfig.isWallThreadFilterEnabled()) {
+    if (AsyncProfilerConfig.isWallClockProfilerEnabled()) {
       AsyncProfiler.getInstance().addCurrentThread();
     }
   }
 
   @Override
   public void onDetach() {
-    if (AsyncProfilerConfig.isWallThreadFilterEnabled()) {
+    if (AsyncProfilerConfig.isWallClockProfilerEnabled()) {
       AsyncProfiler.getInstance().removeCurrentThread();
     }
   }

--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/SmokeTestUtils.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/SmokeTestUtils.java
@@ -44,13 +44,11 @@ final class SmokeTestUtils {
                     + cpuSamplerIntervalMs
                     + "ms",
                 "-Ddd." + ProfilingConfig.PROFILING_ASYNC_WALL_ENABLED + "=true",
-                "-Ddd." + ProfilingConfig.PROFILING_ASYNC_WALL_THREAD_FILTER_ENABLED + "=true",
                 "-Ddd."
                     + ProfilingConfig.PROFILING_ASYNC_WALL_INTERVAL
                     + "="
                     + wallSamplerIntervalMs
                     + "ms",
-                "-Ddd." + ProfilingConfig.PROFILING_ASYNC_WALL_COLLAPSE_SAMPLES + "=false",
                 "-Ddd." + ProfilingConfig.PROFILING_ASYNC_LOG_LEVEL + "=debug",
                 "-Ddd.profiling.agentless=false",
                 "-Ddd.profiling.start-delay=" + profilingStartDelaySecs,

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -91,7 +91,7 @@ abstract class AbstractSmokeTest extends ProcessManager {
     "-Ddd.profiling.upload.period=${PROFILING_RECORDING_UPLOAD_PERIOD_SECONDS}",
     "-Ddd.profiling.url=${getProfilingUrl()}",
     "-Ddd.profiling.async.enabled=true",
-    "-Ddd.profiling.tracing_context.enabled=true",
+    "-Ddd.profiling.async.wall.enabled=true",
     "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=${logLevel()}",
     "-Dorg.slf4j.simpleLogger.defaultLogLevel=${logLevel()}"
   ]

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -66,23 +66,13 @@ public final class ProfilingConfig {
   public static final String PROFILING_ASYNC_CPU_INTERVAL = "profiling.async.cpu.interval.ms";
   public static final int PROFILING_ASYNC_CPU_INTERVAL_DEFAULT = 10;
   public static final String PROFILING_ASYNC_WALL_ENABLED = "profiling.async.wall.enabled";
-  public static final boolean PROFILING_ASYNC_WALL_ENABLED_DEFAULT = true;
+  public static final boolean PROFILING_ASYNC_WALL_ENABLED_DEFAULT = false;
   public static final String PROFILING_ASYNC_WALL_INTERVAL = "profiling.async.wall.interval.ms";
   public static final int PROFILING_ASYNC_WALL_INTERVAL_DEFAULT = 10;
-
-  public static final String PROFILING_ASYNC_WALL_THREAD_FILTER_ENABLED =
-      "profiling.async.wall.thread.filter.enabled";
-
-  public static final boolean PROFILING_ASYNC_WALL_THREAD_FILTER_ENABLED_DEFAULT = true;
 
   public static final String PROFILING_ASYNC_LOG_LEVEL = "profiling.async.loglevel";
 
   public static final String PROFILING_ASYNC_LOG_LEVEL_DEFAULT = "NONE";
-
-  public static final String PROFILING_ASYNC_WALL_COLLAPSE_SAMPLES =
-      "profiling.async.wall.collapse.samples";
-  public static final boolean PROFILING_ASYNC_WALL_COLLAPSE_SAMPLES_DEFAULT = false;
-
   public static final String PROFILING_ASYNC_STACKDEPTH = "profiling.async.stackdepth";
   public static final int PROFILING_ASYNC_STACKDEPTH_DEFAULT = 512;
   public static final String PROFILING_ASYNC_CSTACK = "profiling.async.cstack";
@@ -96,7 +86,7 @@ public final class ProfilingConfig {
   public static final int PROFILING_ASYNC_MEMLEAK_CAPACITY_DEFAULT = 1024;
   public static final String PROFILING_TRACING_CONTEXT_ENABLED =
       "profiling.tracing_context.enabled";
-  public static final boolean PROFILING_TRACING_CONTEXT_ENABLED_DEFAULT = false;
+  public static final boolean PROFILING_TRACING_CONTEXT_ENABLED_DEFAULT = true;
   public static final String PROFILING_TRACING_CONTEXT_TRACKER_INACTIVE_SEC =
       "profiling.tracing_context.tracker.inactive.seconds";
   public static final int PROFILING_TRACING_CONTEXT_TRACKER_INACTIVE_DEFAULT = 90;


### PR DESCRIPTION
# What Does This Do

* Disable wallclock profiler by default, which we are less confident in than the CPU profiler. This allows us to GA the CPU profiler without risking users inadvertently using the wallclock profiler.
* When the wallclock profiler is enabled, we will always collapse samples and will always filter threads, so these options are removed. If users disabled these features very large profiles full of irrelevant samples would be produced.
* Enable tracing context by default, this means that whenever async-profiler is used, the profile will contain labeled events which already drastically improves code-hotspots.

# Motivation

# Additional Notes
