### PR TITLE
substitute jsch fork

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,15 @@
+buildscript {
+  dependencies {
+    classpath "pl.allegro.tech.build:axion-release-plugin:1.14.2"
+  }
+
+  configurations.all {
+    resolutionStrategy.dependencySubstitution {
+      substitute module("com.jcraft:jsch") using module("com.github.mwiede:jsch:0.2.4") because "jcraft jsch has been unmaintained for years."
+    }
+  }
+}
+
 plugins {
   id 'com.github.ben-manes.versions' version '0.27.0'
 


### PR DESCRIPTION
jcraft jsch was unmaintained for years.  Use com.github.mwiede fork instead.

