### PR TITLE
Fix profiler event labeling

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/AsyncProfilerScopeListener.java
+++ b/dd-java-agent/agent-profiling/profiling-context/src/main/java/com/datadog/profiling/context/AsyncProfilerScopeListener.java
@@ -14,7 +14,7 @@ public class AsyncProfilerScopeListener implements ExtendedScopeListener {
   @Override
   public void afterScopeActivated(DDId traceId, DDId localRootSpanId, DDId spanId) {
     if (ASYNC_PROFILER.isAvailable()) {
-      ASYNC_PROFILER.setContext(localRootSpanId.toLong(), spanId.toLong());
+      ASYNC_PROFILER.setContext(spanId.toLong(), localRootSpanId.toLong());
     }
   }
 


### PR DESCRIPTION
# What Does This Do

Currently the `spanId` and `rootSpanId` fields are transposed, this fixes it and adds a check to detect this.

# Motivation

# Additional Notes
