### PR TITLE
mark all endpoints as sampled when async-profiler is enabled

### DIFF
--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/JFRCheckpointer.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/JFRCheckpointer.java
@@ -24,6 +24,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class JFRCheckpointer implements Checkpointer, ProfilingListener<ProfilingSnapshot> {
+
+  // FIXME - remove this when async-profiler is GA and checkpoints have been removed
+  private final boolean isAsyncProfilerEnabled;
+
   private static final Logger log = LoggerFactory.getLogger(JFRCheckpointer.class);
 
   static class SamplerConfig {
@@ -136,6 +140,11 @@ public class JFRCheckpointer implements Checkpointer, ProfilingListener<Profilin
         configProvider.getBoolean(
             ProfilingConfig.PROFILING_ENDPOINT_COLLECTION_ENABLED,
             ProfilingConfig.PROFILING_ENDPOINT_COLLECTION_ENABLED_DEFAULT);
+
+    isAsyncProfilerEnabled =
+        configProvider.getBoolean(
+            ProfilingConfig.PROFILING_ASYNC_ENABLED,
+            ProfilingConfig.PROFILING_ASYNC_ENABLED_DEFAULT);
   }
 
   @Override
@@ -219,8 +228,9 @@ public class JFRCheckpointer implements Checkpointer, ProfilingListener<Profilin
   public final void onRootSpanFinished(final AgentSpan rootSpan, final boolean published) {
     if (isEndpointCollectionEnabled) {
       if (rootSpan instanceof DDSpan) {
-        final Boolean emittingCheckpoints = rootSpan.isEmittingCheckpoints();
-        boolean checkpointsSampled = emittingCheckpoints != null && emittingCheckpoints;
+        Boolean emittingCheckpoints = rootSpan.isEmittingCheckpoints();
+        boolean checkpointsSampled =
+            isAsyncProfilerEnabled || (emittingCheckpoints != null && emittingCheckpoints);
         DDSpan span = (DDSpan) rootSpan;
         EndpointTracker tracker = span.getEndpointTracker();
         if (tracker != null) {


### PR DESCRIPTION
# What Does This Do

# Motivation

# Additional Notes
