### PR TITLE
Add support for JTDS 1.2 connections

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/ConnectionInstrumentation.java
@@ -66,7 +66,8 @@ public class ConnectionInstrumentation extends AbstractConnectionInstrumentation
     "org.apache.calcite.avatica.AvaticaConnection",
     "oadd.org.apache.calcite.avatica.AvaticaConnection",
     // jtds (for SQL Server and Sybase)
-    "net.sourceforge.jtds.jdbc.JtdsConnection",
+    "net.sourceforge.jtds.jdbc.ConnectionJDBC2", // 1.2
+    "net.sourceforge.jtds.jdbc.JtdsConnection", // 1.3
     // SAP HANA in-memory DB
     "com.sap.db.jdbc.ConnectionSapDB",
     // aws-mysql-jdbc


### PR DESCRIPTION
# What Does This Do

Adds support for the older `ConnectionJDBC2` class from JTDS 1.2

