### PR TITLE
Upgrade jamm to fix NumberFormatException when running Cassandra under openj9

### DIFF
--- a/dd-java-agent/instrumentation/datastax-cassandra-3/build.gradle
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/build.gradle
@@ -50,6 +50,7 @@ dependencies {
   compileOnly group: 'com.google.guava', name: 'guava', version: '18.0'
 
   testImplementation group: 'com.datastax.cassandra', name: 'cassandra-driver-core', version: '3.2.0'
+  testImplementation group: 'com.github.jbellis', name: 'jamm', version: '0.3.3'
   testImplementation group: 'org.cassandraunit', name: 'cassandra-unit', version: '3.1.3.2'
 
   testImplementation project(':dd-java-agent:instrumentation:guava-10')


### PR DESCRIPTION
This should fix the failures seen under SEMERU8 on Circle-CI