### PR TITLE
Ignore TaintedMapTest case on J9

### DIFF
--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedMapTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedMapTest.groovy
@@ -1,8 +1,10 @@
 package com.datadog.iast.taint
 
 import com.datadog.iast.model.Range
+import datadog.trace.api.Platform
 import datadog.trace.test.util.CircularBuffer
 import datadog.trace.test.util.DDSpecification
+import spock.lang.IgnoreIf
 
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.Callable
@@ -174,6 +176,7 @@ class TaintedMapTest extends DDSpecification {
     presentObjects >= DefaultTaintedMap.DEFAULT_FLAT_MODE_THRESHOLD * 0.9
   }
 
+  @IgnoreIf({ Platform.isJ9() })
   def 'single-threaded put-intensive workflow with garbage collection interaction and over max size'() {
     given:
     int nTotalObjects = DefaultTaintedMap.DEFAULT_FLAT_MODE_THRESHOLD * 4


### PR DESCRIPTION
# What Does This Do

# Motivation
This is particularly flaky on OpenJ9, presumably because of its default GC policy.

# Additional Notes
When we get to review this test case, we'll need to revisit what and how we want to test here.