### PR TITLE
LogManagerSetter should check 'java.vm.vendor', not 'java.vendor' to match Platform check

### DIFF
--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomLogManagerTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomLogManagerTest.groovy
@@ -1,9 +1,7 @@
 package datadog.trace.agent
 
 import datadog.trace.agent.test.IntegrationTestUtils
-import datadog.trace.api.Platform
 import jvmbootstraptest.LogManagerSetter
-import spock.lang.IgnoreIf
 import spock.lang.Specification
 import spock.lang.Timeout
 
@@ -45,7 +43,6 @@ class CustomLogManagerTest extends Specification {
       , true) == 0
   }
 
-  @IgnoreIf({ Platform.isJavaVersion(8) && Platform.isSemeru() })
   def "agent services startup is delayed with java.util.logging.manager sysprop"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogManagerSetter.getName()
@@ -78,7 +75,6 @@ class CustomLogManagerTest extends Specification {
       , true) == 0
   }
 
-  @IgnoreIf({ Platform.isJavaVersion(8) && Platform.isSemeru() })
   def "agent services startup delayed with JBOSS_HOME environment variable"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogManagerSetter.getName()

--- a/dd-java-agent/src/test/java/jvmbootstraptest/LogManagerSetter.java
+++ b/dd-java-agent/src/test/java/jvmbootstraptest/LogManagerSetter.java
@@ -216,7 +216,7 @@ public class LogManagerSetter {
   }
 
   private static boolean okHttpMayIndirectlyLoadJUL() {
-    if ("IBM Corporation".equals(System.getProperty("java.vendor"))) {
+    if ("IBM Corporation".equals(System.getProperty("java.vm.vendor"))) {
       return true; // IBM JDKs ship with 'IBMSASL' which will load JUL when OkHttp accesses TLS
     }
     if (!System.getProperty("java.version").startsWith("1.")) {

--- a/internal-api/src/main/java/datadog/trace/api/Platform.java
+++ b/internal-api/src/main/java/datadog/trace/api/Platform.java
@@ -235,10 +235,6 @@ public final class Platform {
         && !RUNTIME.name.contains("OpenJDK");
   }
 
-  public static boolean isSemeru() {
-    return RUNTIME.name.contains("Semeru");
-  }
-
   public static boolean isJ9() {
     return System.getProperty("java.vm.name").contains("J9");
   }


### PR DESCRIPTION
# What Does This Do

This class runs isolated from the tracer code, so it can't re-use Platform. It's important to have the same check in both places so their expectations about delayed startup match.

# Motivation

Normally these values are identical, however for the recent Semeru builds 'java.vendor' is 'IBM Corporation' while 'java.vm.vendor' is 'Eclipse OpenJ9' leading to inconsistent expectations.
