### PR TITLE
[Help Wanted/ISSUE-1478] - Java http client instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/java-httpclient/build.gradle
+++ b/dd-java-agent/instrumentation/java-httpclient/build.gradle
@@ -1,0 +1,30 @@
+ext {
+  minJavaVersionForTests = JavaVersion.VERSION_11
+}
+
+muzzle {
+  pass {
+    coreJdk()
+  }
+}
+
+apply from: "$rootDir/gradle/java.gradle"
+apply plugin: "idea"
+
+tasks.withType(JavaCompile) {
+  options.release = 11
+}
+
+[compileJava, compileTestJava].each {
+  it.configure {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+    setJavaVersion(it, 11)
+  }
+}
+
+idea {
+  module {
+    jdkName = '11'
+  }
+}

--- a/dd-java-agent/instrumentation/java-httpclient/src/main/java/datadog/trace/instrumentation/javahttpclient/JavaHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-httpclient/src/main/java/datadog/trace/instrumentation/javahttpclient/JavaHttpClientInstrumentation.java
@@ -1,0 +1,79 @@
+package datadog.trace.instrumentation.javahttpclient;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Platform;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+import java.net.http.HttpRequest;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+@AutoService(Instrumenter.class)
+public class JavaHttpClientInstrumentation extends Instrumenter.Tracing
+    implements Instrumenter.ForTypeHierarchy {
+  public JavaHttpClientInstrumentation() {
+    super("httpclient", "java-httpclient", "java-http-client");
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return Platform.isJavaVersionAtLeast(11) && super.isEnabled(); }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "java.net.http.HttpClient";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return extendsClass(named(hierarchyMarkerType()));
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod()
+            .and(named("send"))
+            .and(isPublic())
+            .and(takesArguments(2))
+            .and(takesArgument(0, named("java.net.http.HttpRequest"))),
+        JavaHttpClientInstrumentation.class.getName() + "$SendAdvice");
+  }
+
+  public static class SendAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static AgentScope methodEnter(@Advice.Argument(value = 0) HttpRequest httpRequest) {
+      final AgentSpan span = startSpan("hello");
+      final AgentScope scope = activateSpan(span);
+      span.setOperationName("test.span");
+      span.setResourceName("failing");
+
+      return scope;
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void methodExit(
+        @Advice.Enter final AgentScope scope,
+        @Advice.Return final Object result,
+        @Advice.Thrown final Throwable throwable) {
+      if (scope == null) {
+        return;
+      }
+      final AgentSpan span = scope.span();
+      scope.close();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/java-httpclient/src/test/groovy/Test.groovy
+++ b/dd-java-agent/instrumentation/java-httpclient/src/test/groovy/Test.groovy
@@ -1,0 +1,71 @@
+import datadog.trace.agent.test.AgentTestRunner
+import net.bytebuddy.description.method.MethodDescription
+import net.bytebuddy.description.type.TypeDescription
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass
+import static net.bytebuddy.matcher.ElementMatchers.isMethod
+import static net.bytebuddy.matcher.ElementMatchers.isPublic
+import static net.bytebuddy.matcher.ElementMatchers.named
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments
+
+class Test extends AgentTestRunner {
+
+  @Shared
+  @AutoCleanup
+  def server = httpServer {
+    handlers {
+      all {
+        String msg = "Hello."
+        response.status(200).send(msg)
+      }
+    }
+  }
+
+  def "see it should work"() {
+    setup:
+    def client = HttpClient.newHttpClient()
+    def clientType = new TypeDescription.ForLoadedType(client.getClass())
+
+    def typeMatcher = extendsClass(named("java.net.http.HttpClient"))
+    assert typeMatcher.matches(clientType)
+
+    def elementMatcher = isMethod()
+      .and(named("send"))
+      .and(isPublic())
+      .and(takesArguments(2))
+      .and(takesArgument(0, named("java.net.http.HttpRequest")))
+    def clientSendMethod = new MethodDescription.ForLoadedMethod(client.getClass()
+      .getMethod("send", HttpRequest.class, HttpResponse.BodyHandler.class))
+    assert elementMatcher.matches(clientSendMethod)
+  }
+
+  def "why you no work"() {
+    setup:
+    def client = HttpClient.newHttpClient()
+    def request = HttpRequest.newBuilder(server.address)
+      .header("kill", "me")
+      .GET()
+      .build()
+
+    when:
+    client.send(request, HttpResponse.BodyHandlers.discarding())
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "test.span"
+          resourceName "failing"
+        }
+      }
+    }
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -318,6 +318,7 @@ include ':dd-java-agent:instrumentation:vertx-rx-3.5'
 include ':dd-java-agent:instrumentation:vertx-web-3.4'
 include ':dd-java-agent:instrumentation:vertx-web-4.0'
 include ':dd-java-agent:instrumentation:redisson-2.0.0'
+include ':dd-java-agent:instrumentation:java-httpclient'
 
 // benchmark
 include ':dd-java-agent:benchmark'


### PR DESCRIPTION
# Why did I open this?
A while back I took a stab at adding java http client instrumentation but I could not seem to get the instrumenter to apply the byte buddy advice - https://github.com/DataDog/dd-trace-java/pull/3639. What I have done here is start from scratch to reduce the number of potential issues. Even still, I cannot seem to get the instrumentation to be applied. 

I have written 2 tests, one that proves out the byte buddy element and type matching `"see it should work"`, and another basic to test to see if the instrumentation is being applied (it is not).

I am not really sure what else to try and would love some help. I have a feeling it is some silly issue, I would really appreciate any 👀 on this.

### TLDR: I am stuck, I cannot get the java http client instrumentation to be applied.
