### PR TITLE
Move abstract checks to hierarchy matchers

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/DDElementMatchers.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/DDElementMatchers.java
@@ -40,6 +40,12 @@ public class DDElementMatchers implements HierarchyMatchers.Supplier {
   }
 
   @Override
+  @SuppressForbidden
+  public ElementMatcher.Junction<TypeDescription> abstractClass() {
+    return ElementMatchers.isAbstract();
+  }
+
+  @Override
   public ElementMatcher.Junction<TypeDescription> extendsClass(
       ElementMatcher.Junction<? super TypeDescription> matcher) {
     return new SafeHasSuperTypeMatcher<>(matcher, false, true, false);

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/HierarchyMatchers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/HierarchyMatchers.java
@@ -39,6 +39,10 @@ public final class HierarchyMatchers {
     return SUPPLIER.declaresMethod(matcher);
   }
 
+  public static ElementMatcher.Junction<TypeDescription> abstractClass() {
+    return SUPPLIER.abstractClass();
+  }
+
   public static ElementMatcher.Junction<TypeDescription> extendsClass(
       ElementMatcher.Junction<? super TypeDescription> matcher) {
     return SUPPLIER.extendsClass(matcher);
@@ -107,6 +111,8 @@ public final class HierarchyMatchers {
     ElementMatcher.Junction<TypeDescription> declaresMethod(
         ElementMatcher.Junction<? super MethodDescription> matcher);
 
+    ElementMatcher.Junction<TypeDescription> abstractClass();
+
     ElementMatcher.Junction<TypeDescription> extendsClass(
         ElementMatcher.Junction<? super TypeDescription> matcher);
 
@@ -148,6 +154,12 @@ public final class HierarchyMatchers {
       public ElementMatcher.Junction<TypeDescription> declaresMethod(
           ElementMatcher.Junction<? super MethodDescription> matcher) {
         return ElementMatchers.declaresMethod(matcher);
+      }
+
+      @Override
+      @SuppressForbidden
+      public ElementMatcher.Junction<TypeDescription> abstractClass() {
+        return ElementMatchers.isAbstract();
       }
 
       @Override

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGradlePlugin.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGradlePlugin.java
@@ -1,8 +1,8 @@
 package datadog.trace.agent.tooling.muzzle;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.abstractClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.isAbstract;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import datadog.trace.agent.tooling.Instrumenter;
@@ -29,7 +29,7 @@ public class MuzzleGradlePlugin extends Plugin.ForElementMatcher {
   private final File targetDir;
 
   public MuzzleGradlePlugin(File targetDir) {
-    super(not(isAbstract()).and(extendsClass(named(Instrumenter.Default.class.getName()))));
+    super(not(abstractClass()).and(extendsClass(named(Instrumenter.Default.class.getName()))));
     this.targetDir = targetDir;
   }
 

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientInstrumentation.java
@@ -2,9 +2,7 @@ package datadog.trace.instrumentation.apachehttpclient;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.isAbstract;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
@@ -84,7 +82,6 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Tracing
     transformation.applyAdvice(
         isMethod()
             .and(named("execute"))
-            .and(not(isAbstract()))
             .and(takesArguments(1))
             .and(takesArgument(0, named("org.apache.http.client.methods.HttpUriRequest"))),
         ApacheHttpClientInstrumentation.class.getName() + "$UriRequestAdvice");
@@ -92,7 +89,6 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Tracing
     transformation.applyAdvice(
         isMethod()
             .and(named("execute"))
-            .and(not(isAbstract()))
             .and(takesArguments(2))
             .and(takesArgument(0, named("org.apache.http.client.methods.HttpUriRequest")))
             .and(takesArgument(1, named("org.apache.http.protocol.HttpContext"))),
@@ -101,7 +97,6 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Tracing
     transformation.applyAdvice(
         isMethod()
             .and(named("execute"))
-            .and(not(isAbstract()))
             .and(takesArguments(2))
             .and(takesArgument(0, named("org.apache.http.client.methods.HttpUriRequest")))
             .and(takesArgument(1, named("org.apache.http.client.ResponseHandler"))),
@@ -110,7 +105,6 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Tracing
     transformation.applyAdvice(
         isMethod()
             .and(named("execute"))
-            .and(not(isAbstract()))
             .and(takesArguments(3))
             .and(takesArgument(0, named("org.apache.http.client.methods.HttpUriRequest")))
             .and(takesArgument(1, named("org.apache.http.client.ResponseHandler")))
@@ -120,7 +114,6 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Tracing
     transformation.applyAdvice(
         isMethod()
             .and(named("execute"))
-            .and(not(isAbstract()))
             .and(takesArguments(2))
             .and(takesArgument(0, named("org.apache.http.HttpHost")))
             .and(takesArgument(1, named("org.apache.http.HttpRequest"))),
@@ -129,7 +122,6 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Tracing
     transformation.applyAdvice(
         isMethod()
             .and(named("execute"))
-            .and(not(isAbstract()))
             .and(takesArguments(3))
             .and(takesArgument(0, named("org.apache.http.HttpHost")))
             .and(takesArgument(1, named("org.apache.http.HttpRequest")))
@@ -139,7 +131,6 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Tracing
     transformation.applyAdvice(
         isMethod()
             .and(named("execute"))
-            .and(not(isAbstract()))
             .and(takesArguments(3))
             .and(takesArgument(0, named("org.apache.http.HttpHost")))
             .and(takesArgument(1, named("org.apache.http.HttpRequest")))
@@ -149,7 +140,6 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Tracing
     transformation.applyAdvice(
         isMethod()
             .and(named("execute"))
-            .and(not(isAbstract()))
             .and(takesArguments(4))
             .and(takesArgument(0, named("org.apache.http.HttpHost")))
             .and(takesArgument(1, named("org.apache.http.HttpRequest")))

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpClientInstrumentation.java
@@ -2,9 +2,7 @@ package datadog.trace.instrumentation.apachehttpclient5;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.isAbstract;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
@@ -69,7 +67,6 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Tracing
     transformation.applyAdvice(
         isMethod()
             .and(named("execute"))
-            .and(not(isAbstract()))
             .and(takesArguments(1))
             .and(takesArgument(0, named("org.apache.hc.core5.http.ClassicHttpRequest"))),
         ApacheHttpClientInstrumentation.class.getName() + "$RequestAdvice");
@@ -77,7 +74,6 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Tracing
     transformation.applyAdvice(
         isMethod()
             .and(named("execute"))
-            .and(not(isAbstract()))
             .and(takesArguments(2))
             .and(takesArgument(0, named("org.apache.hc.core5.http.ClassicHttpRequest")))
             .and(takesArgument(1, named("org.apache.hc.core5.http.protocol.HttpContext"))),
@@ -86,7 +82,6 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Tracing
     transformation.applyAdvice(
         isMethod()
             .and(named("execute"))
-            .and(not(isAbstract()))
             .and(takesArguments(3))
             .and(takesArgument(0, named("org.apache.hc.core5.http.HttpHost")))
             .and(takesArgument(1, named("org.apache.hc.core5.http.ClassicHttpRequest")))
@@ -96,7 +91,6 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Tracing
     transformation.applyAdvice(
         isMethod()
             .and(named("execute"))
-            .and(not(isAbstract()))
             .and(takesArguments(2))
             .and(takesArgument(0, named("org.apache.hc.core5.http.HttpHost")))
             .and(takesArgument(1, named("org.apache.hc.core5.http.ClassicHttpRequest"))),
@@ -105,7 +99,6 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Tracing
     transformation.applyAdvice(
         isMethod()
             .and(named("execute"))
-            .and(not(isAbstract()))
             .and(takesArguments(4))
             .and(takesArgument(0, named("org.apache.hc.core5.http.HttpHost")))
             .and(takesArgument(1, named("org.apache.hc.core5.http.ClassicHttpRequest")))

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSHttpClientInstrumentation.java
@@ -3,9 +3,7 @@ package datadog.trace.instrumentation.aws.v0;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.instrumentation.aws.v0.OnErrorDecorator.DECORATE;
 import static datadog.trace.instrumentation.aws.v0.OnErrorDecorator.SCOPE_CONTEXT_KEY;
-import static net.bytebuddy.matcher.ElementMatchers.isAbstract;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
@@ -42,7 +40,7 @@ public class AWSHttpClientInstrumentation extends Instrumenter.Tracing
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(
-        isMethod().and(not(isAbstract())).and(named("doExecute")),
+        isMethod().and(named("doExecute")),
         AWSHttpClientInstrumentation.class.getName() + "$HttpClientAdvice");
   }
 
@@ -85,7 +83,7 @@ public class AWSHttpClientInstrumentation extends Instrumenter.Tracing
     @Override
     public void adviceTransformations(AdviceTransformation transformation) {
       transformation.applyAdvice(
-          isMethod().and(not(isAbstract())).and(named("doExecute")),
+          isMethod().and(named("doExecute")),
           RequestExecutorInstrumentation.class.getName() + "$RequestExecutorAdvice");
     }
 

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/ServerErrorHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/ServerErrorHandlerInstrumentation.java
@@ -1,8 +1,8 @@
 package datadog.trace.instrumentation.ratpack;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.abstractClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.isAbstract;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
@@ -26,7 +26,7 @@ public class ServerErrorHandlerInstrumentation extends Instrumenter.Tracing
 
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
-    return not(isAbstract()).and(implementsInterface(named(hierarchyMarkerType())));
+    return not(abstractClass()).and(implementsInterface(named(hierarchyMarkerType())));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/HandlerAdapterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/HandlerAdapterInstrumentation.java
@@ -1,8 +1,8 @@
 package datadog.trace.instrumentation.springwebflux.server;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.abstractClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.isAbstract;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.not;
@@ -25,7 +25,7 @@ public final class HandlerAdapterInstrumentation extends AbstractWebfluxInstrume
 
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
-    return not(isAbstract()).and(implementsInterface(named(hierarchyMarkerType())));
+    return not(abstractClass()).and(implementsInterface(named(hierarchyMarkerType())));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/RouterFunctionInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/RouterFunctionInstrumentation.java
@@ -1,8 +1,8 @@
 package datadog.trace.instrumentation.springwebflux.server;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.abstractClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.isAbstract;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.not;
@@ -30,7 +30,7 @@ public final class RouterFunctionInstrumentation extends AbstractWebfluxInstrume
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
     // TODO: this doesn't handle nested routes (DefaultNestedRouterFunction)
-    return not(isAbstract()).and(extendsClass(named(hierarchyMarkerType())));
+    return not(abstractClass()).and(extendsClass(named(hierarchyMarkerType())));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioAsyncInstrumentation.java
+++ b/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioAsyncInstrumentation.java
@@ -8,10 +8,8 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.twilio.TwilioClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.twilio.TwilioClientDecorator.TWILIO_SDK;
-import static net.bytebuddy.matcher.ElementMatchers.isAbstract;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
 
 import com.google.auto.service.AutoService;
@@ -81,7 +79,6 @@ public class TwilioAsyncInstrumentation extends Instrumenter.Tracing
         isMethod()
             .and(namedOneOf("createAsync", "deleteAsync", "readAsync", "fetchAsync", "updateAsync"))
             .and(isPublic())
-            .and(not(isAbstract()))
             .and(returns(named("com.google.common.util.concurrent.ListenableFuture"))),
         TwilioAsyncInstrumentation.class.getName() + "$TwilioClientAsyncAdvice");
   }

--- a/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioSyncInstrumentation.java
+++ b/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioSyncInstrumentation.java
@@ -6,10 +6,8 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.twilio.TwilioClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.twilio.TwilioClientDecorator.TWILIO_SDK;
-import static net.bytebuddy.matcher.ElementMatchers.isAbstract;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
 import com.twilio.Twilio;
@@ -65,10 +63,7 @@ public class TwilioSyncInstrumentation extends Instrumenter.Tracing
        which we weren't interested in annotating.
     */
     transformation.applyAdvice(
-        isMethod()
-            .and(isPublic())
-            .and(not(isAbstract()))
-            .and(namedOneOf("create", "delete", "read", "fetch", "update")),
+        isMethod().and(isPublic()).and(namedOneOf("create", "delete", "read", "fetch", "update")),
         TwilioSyncInstrumentation.class.getName() + "$TwilioClientAdvice");
   }
 

--- a/gradle/forbiddenApiFilters/main.txt
+++ b/gradle/forbiddenApiFilters/main.txt
@@ -19,4 +19,6 @@ net.bytebuddy.matcher.ElementMatchers#declaresAnnotation(net.bytebuddy.matcher.E
 net.bytebuddy.matcher.ElementMatchers#isAnnotatedWith(net.bytebuddy.matcher.ElementMatcher)
 net.bytebuddy.matcher.ElementMatchers#inheritsAnnotation(net.bytebuddy.matcher.ElementMatcher)
 net.bytebuddy.matcher.ElementMatchers#hasAnnotation(net.bytebuddy.matcher.ElementMatcher)
+net.bytebuddy.matcher.ElementMatchers#isInterface()
+net.bytebuddy.matcher.ElementMatchers#isAbstract()
 


### PR DESCRIPTION
# Motivation

This is so we can optimize them - this PR also removes a few unnecessary abstract method checks
(because only non-abstract methods declared on each matched class can have advice applied)