### PR TITLE
Modify rate limit regarding probe conditions

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
@@ -181,9 +181,12 @@ public class Snapshot {
       }
       return;
     }
-    if (!ProbeRateLimiter.tryProbe(probe.id)) {
-      DebuggerContext.skipSnapshot(probe.id, DebuggerContext.SkipCause.RATE);
-      return;
+    // only rate limit if a condition is defined
+    if (probe.getScript() != null) {
+      if (!ProbeRateLimiter.tryProbe(probe.id)) {
+        DebuggerContext.skipSnapshot(probe.id, DebuggerContext.SkipCause.RATE);
+        return;
+      }
     }
     // generates id only when effectively committing
     this.id = UUID.randomUUID().toString();

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/SnapshotProvider.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/SnapshotProvider.java
@@ -16,6 +16,13 @@ public final class SnapshotProvider {
       LOG.info("Cannot resolve the probe: {}", uuid);
       probeDetails = Snapshot.ProbeDetails.UNKNOWN;
     }
+    // only rate limit if no condition are defined
+    if (probeDetails.getScript() == null) {
+      if (!ProbeRateLimiter.tryProbe(probeDetails.getId())) {
+        DebuggerContext.skipSnapshot(probeDetails.getId(), DebuggerContext.SkipCause.RATE);
+        return null;
+      }
+    }
     return new Snapshot(Thread.currentThread(), probeDetails, callingClass.getTypeName());
   }
 }


### PR DESCRIPTION
# What Does This Do
rate limiting is applied at snapshot creation time only if no condition is defined, and rate limiting is applied at commit time only if a condition is defined.

# Motivation
Having the rate limiting only at commit time makes the serialization cost paid for all snapshots even if they are dropped in the end

# Additional Notes
