### PR TITLE
Ensure that only one muzzle task is building instrumenters at a given time

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ClassLoaderMatchers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ClassLoaderMatchers.java
@@ -90,7 +90,8 @@ public final class ClassLoaderMatchers {
   public static ElementMatcher.Junction<ClassLoader> hasClassNamed(String className) {
     ElementMatcher.Junction<ClassLoader> matcher = hasClassMatchers.get(className);
     if (null == matcher) {
-      hasClassMatchers.put(className, matcher = new HasClassMatcher(hasClassMatchers.size()));
+      // each matcher is given an id based on where to find its resource-name in the sequence
+      hasClassMatchers.put(className, matcher = new HasClassMatcher(hasClassResourceNames.size()));
       hasClassResourceNames.add(Strings.getResourceName(className));
     }
     return matcher;


### PR DESCRIPTION
This matches the current expectation that agent installation is single-threaded
which lets us keep the installer/builder code simple while still allowing for parallel
MuzzleVersionScan tasks in the same JVM.
