### PR TITLE
byte-buddy 1.12.18

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
   implementation(gradleApi())
   implementation(localGroovy())
 
-  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.12.17")
+  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.12.18")
 
   implementation("org.eclipse.aether", "aether-connector-basic", "1.1.0")
   implementation("org.eclipse.aether", "aether-transport-http", "1.1.0")

--- a/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
+++ b/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
@@ -23,7 +23,7 @@ class InstrumentPluginTest extends Specification {
     }
 
     dependencies {
-      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.12.17' // just to build TestPlugin
+      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.12.18' // just to build TestPlugin
     }
 
     apply plugin: 'instrument'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -15,7 +15,7 @@ final class CachedData {
     junit4        : "4.13.2",
     junit5        : "5.8.1",
     logback       : "1.2.3",
-    bytebuddy     : "1.12.17",
+    bytebuddy     : "1.12.18",
     scala         : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)
     scala210      : "2.10.7",
     scala211      : "2.11.12",


### PR DESCRIPTION
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.12.18

* Allow writing to field from enter `Advice` in constructor, as byte code allows it.
* Refactor Android plugin processor to avoid skipping local classes.
* Improve staleness filter for Maven plugin.
* Fix incorrect resolution of custom bound invokedynamic values in `Advice`.
