### PR TITLE
Update the README and add SECURITY and SUPPORT pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,36 @@
+![Datadog logo](https://imgix.datadoghq.com/img/about/presskit/logo-h/dd_horizontal_white.png)
+
 # Datadog Java APM
 
-## Usage
+![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/datadog/dd-trace-java)
+![GitHub all releases](https://img.shields.io/github/downloads/datadog/dd-trace-java/total)
+![GitHub](https://img.shields.io/github/license/datadog/dd-trace-java)
 
-To use and configure Datadog Java APM, see [https://docs.datadoghq.com/tracing/languages/java](https://docs.datadoghq.com/tracing/languages/java)
+
+This repository contains `dd-trace-java`, Datadog's APM client Java library.
+`dd-trace-java` contains APIs to automatically or manually [trace](https://docs.datadoghq.com/tracing/visualization/#trace) and [profile](https://docs.datadoghq.com/tracing/profiler/) Java applications.
+
+These features power [Distributed Tracing](https://docs.datadoghq.com/tracing/) with [Automatic Instrumentation](https://docs.datadoghq.com/tracing/trace_collection/compatibility/java/#integrations),
+ [Continuous Profiling](https://docs.datadoghq.com/tracing/profiler/),
+ [Error Tracking](https://docs.datadoghq.com/tracing/error_tracking/),
+ [Continuous Integration Visibility](https://docs.datadoghq.com/continuous_integration/),
+ [Deployment Tracking](https://docs.datadoghq.com/tracing/deployment_tracking/),
+ [Code Hotspots](https://docs.datadoghq.com/tracing/profiler/connect_traces_and_profiles/) and more.
+
+## Getting Started
+
+To use and configure, check out the [setup documentation][setup docs].
+
+For advanced usage, check out the [configuration reference][configuration reference] and [custom instrumentation API][api docs].
+
+Confused about the terminology of APM?
+Take a look at the [APM Glossary][visualization docs].
+
+[setup docs]: https://docs.datadoghq.com/tracing/languages/java
+[configuration reference]: https://docs.datadoghq.com/tracing/trace_collection/library_config/java
+[api docs]: https://docs.datadoghq.com/tracing/trace_collection/custom_instrumentation/java/
+[visualization docs]: https://docs.datadoghq.com/tracing/visualization/
 
 ## Contributing
 
-See [CONTRIBUTING](CONTRIBUTING.md)
+Before contributing to the project, please take a moment to read our brief [Contribution Guidelines](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Datadog Java APM
 
-![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/datadog/dd-trace-java)
-![GitHub all releases](https://img.shields.io/github/downloads/datadog/dd-trace-java/total)
-![GitHub](https://img.shields.io/github/license/datadog/dd-trace-java)
+[![GitHub latest release](https://img.shields.io/github/v/release/datadog/dd-trace-java)](https://github.com/DataDog/dd-trace-java/releases/latest/)
+[![GitHub all releases](https://img.shields.io/github/downloads/datadog/dd-trace-java/total)](https://github.com/DataDog/dd-trace-java/releases)
+[![GitHub](https://img.shields.io/github/license/datadog/dd-trace-java)](/LICENSE)
 
 
 This repository contains `dd-trace-java`, Datadog's APM client Java library.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security
+
+## Security Vulnerabilities
+
+If you have found a security issue, please contact the security team directly at security@datadoghq.com.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,3 @@
+# Support
+
+To get support for the Datadog Java APM, please check [the Datadog support page](https://www.datadoghq.com/support/).


### PR DESCRIPTION
# What Does This Do

This PR tries to make the GitHub project a little more welcoming.
Compared to the other tracers README ([.Net](https://github.com/DataDog/dd-trace-dotnet), [JavaScript](https://github.com/DataDog/dd-trace-js), [PHP](https://github.com/DataDog/dd-trace-php), [Python](https://github.com/DataDog/dd-trace-py) and [C++](https://github.com/DataDog/dd-trace-cpp)), our really feels minimal.

# Motivation

As the v1 is coming, I thought it might be the right time to upgrade it before users come back to check latest changes, migration guide, bug reports…

# Additional Notes

This PR is mainly a proposal.
As a non native english, it might worth it to review and update its content to fit the product vision.
I encourage you to add commits to the PR 🙏 
