### PR TITLE
Don't shade third party dependencies for now

### DIFF
--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -35,31 +35,6 @@ ext.generalShadowJarConfig = {
   exclude '**/META-INF/*.kotlin_module'
   exclude '**/module-info.class'
 
-  /*
-   * Shade third party dependencies behind a 'ddlib.' prefix.
-   * (short package names have a trailing dot (.) to prevent unexpected renaming)
-   */
-  [
-    'cafe.',
-    'com.blogspot.mydailyjava.weaklockfree',
-    'com.fasterxml.jackson',
-    'com.google.re2j',
-    'com.googlecode.concurrentlinkedhashmap',
-    'com.squareup.moshi',
-    'com.timgroup.statsd',
-    'io.vertx.redis',
-    'jnr.',
-    'net.',
-    'okhttp3.',
-    'okio.',
-    'org.glassfish',
-    'org.yaml.snakeyaml',
-    'org.jctools',
-    'org.objectweb.asm',
-  ].forEach {
-    relocate it, 'ddlib.' + it
-  }
-
   // Prevents conflict with other SLF4J instances. Important for premain.
   relocate 'org.slf4j', 'datadog.slf4j'
   // rewrite dependencies calling Logger.getLogger

--- a/dd-java-agent/instrumentation/build.gradle
+++ b/dd-java-agent/instrumentation/build.gradle
@@ -90,8 +90,12 @@ subprojects { Project subProj ->
     }
   }
 
-  parent_project.dependencies {
-    implementation project(subProj.getPath())
+  def path = subProj.getPath()
+  // don't include the redis RequestImpl stub
+  if (!path.equals(':dd-java-agent:instrumentation:vertx-redis-client-3.9:stubs')) {
+    parent_project.dependencies {
+      implementation project(path)
+    }
   }
 }
 
@@ -107,4 +111,3 @@ tasks.named('shadowJar').configure {
   duplicatesStrategy = DuplicatesStrategy.FAIL
   dependencies deps.excludeShared
 }
-


### PR DESCRIPTION
# What Does This Do

Reverts the third party dependency shading in #4046 and excludes a vertx stub project so those classes are not packaged with the final `dd-java-agent.jar`

# Motivation

The relocation inadvertently moved some instrumentations so they targeted the wrong classes and some helper classes to the wrong package so they lost access to some classes.

# Additional Notes
