### PR TITLE
Revert "fix: Fix agent shading specification"

### DIFF
--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/integration/classloading/ShadowPackageRenamingTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/integration/classloading/ShadowPackageRenamingTest.groovy
@@ -14,27 +14,17 @@ class ShadowPackageRenamingTest extends Specification {
       .loadClass("datadog.trace.agent.tooling.AgentInstaller")
     final URL userOkio =
       BufferedSink.getProtectionDomain().getCodeSource().getLocation()
-    final URL agentSource =
-      ddClass.getProtectionDomain().getCodeSource().getLocation()
-
-    when: "trying to load shaded class from its default FQDN with agent classloader"
-    ddClass
-      .getClassLoader()
-      .loadClass(BufferedSink.canonicalName)
-
-    then: "class must not be found"
-    thrown(ClassNotFoundException)
-
-    when: "trying to load shaded class with shading prefix with agent classloader"
     final URL agentOkioDep =
       ddClass
       .getClassLoader()
-      .loadClass("ddlib.okio.BufferedSink")
+      .loadClass("okio.BufferedSink")
       .getProtectionDomain()
       .getCodeSource()
       .getLocation()
+    final URL agentSource =
+      ddClass.getProtectionDomain().getCodeSource().getLocation()
 
-    then: "shaded class must be found from the agent jar"
+    expect:
     agentSource.getFile() =~ ".*/dd-java-agent/build/libs/dd-java-agent-.*.jar"
     agentSource.getProtocol() == "file"
     agentSource == agentOkioDep


### PR DESCRIPTION
# What Does This Do

This reverts commit 1e1592c4e9d492a96017a74e87a1267146cd98c4.

# Motivation

Should have happened together with #4246

# Additional Notes

Why did this not run on CI for that PR? There is something broken with the short circuit things!