### PR TITLE
Avoid redundant feature discovery requests

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
+++ b/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
@@ -135,8 +135,6 @@ public class SharedCommunicationObjects {
     private String configUrl;
     private final SharedCommunicationObjects sco;
     private final Config config;
-    private long lastTry = 0;
-    private long retryInterval = 5000;
 
     private RetryConfigUrlSupplier(final SharedCommunicationObjects sco, final Config config) {
       this.sco = sco;
@@ -149,31 +147,13 @@ public class SharedCommunicationObjects {
         return configUrl;
       }
 
-      long now = System.currentTimeMillis();
-      long elapsed = now - lastTry;
-      if (elapsed > retryInterval) {
-
-        if (sco.featuresDiscovery == null) {
-          // Note that feature discovery initialization also runs discovery on its first call.
-          sco.featuresDiscovery(config);
-        } else {
-          // Feature discovery might have run elsewhere. In that case, we don't need another call.
-          if (sco.featuresDiscovery.getConfigEndpoint() == null) {
-            sco.featuresDiscovery.discover();
-          }
-          retryInterval = 60000;
-        }
-      } else {
-        return null;
-      }
-      lastTry = now;
-      String configEndpoint = sco.featuresDiscovery.getConfigEndpoint();
+      final DDAgentFeaturesDiscovery discovery = sco.featuresDiscovery(config);
+      discovery.discoverIfOutdated();
+      final String configEndpoint = discovery.getConfigEndpoint();
       if (configEndpoint == null) {
-        log.debug("Remote config endpoint not found");
         return null;
       }
-
-      this.configUrl = sco.featuresDiscovery.buildUrl(configEndpoint).toString();
+      this.configUrl = discovery.buildUrl(configEndpoint).toString();
       log.debug("Found remote config endpoint: {}", this.configUrl);
       return this.configUrl;
     }

--- a/communication/src/test/groovy/datadog/communication/ddagent/DDAgentFeaturesDiscoveryTest.groovy
+++ b/communication/src/test/groovy/datadog/communication/ddagent/DDAgentFeaturesDiscoveryTest.groovy
@@ -59,6 +59,32 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     features.getConfigEndpoint() == V7_CONFIG_ENDPOINT
     features.supportsDebugger()
     features.getVersion() == "0.99.0"
+    0 * _
+  }
+
+  def "test parse /info response with discoverIfOutdated"() {
+    setup:
+    OkHttpClient client = Mock(OkHttpClient)
+    DDAgentFeaturesDiscovery features = new DDAgentFeaturesDiscovery(client, monitoring, agentUrl, true, true)
+
+    when: "/info available"
+    features.discoverIfOutdated()
+    features.discoverIfOutdated()
+    features.discoverIfOutdated()
+
+    then:
+    1 * client.newCall(_) >> { Request request -> infoResponse(request, INFO_RESPONSE) }
+    features.getMetricsEndpoint() == V6_METRICS_ENDPOINT
+    features.supportsMetrics()
+    features.getTraceEndpoint() == "v0.5/traces"
+    !features.supportsDropping()
+    features.getDataStreamsEndpoint() == V01_DATASTREAMS_ENDPOINT
+    features.supportsDataStreams()
+    features.state() == INFO_STATE
+    features.getConfigEndpoint() == V7_CONFIG_ENDPOINT
+    features.supportsDebugger()
+    features.getVersion() == "0.99.0"
+    0 * _
   }
 
   def "test parse /info response with client dropping"() {
@@ -76,6 +102,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     features.getTraceEndpoint() == "v0.5/traces"
     features.supportsDropping()
     features.state() == INFO_WITH_CLIENT_DROPPING_STATE
+    0 * _
   }
 
 
@@ -95,6 +122,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     features.getDataStreamsEndpoint() == null
     !features.supportsDataStreams()
     features.state() == INFO_WITHOUT_DATA_STREAMS_STATE
+    0 * _
   }
 
   def "test fallback when /info not found"() {
@@ -116,6 +144,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     features.getTraceEndpoint() == "v0.5/traces"
     !features.supportsDropping()
     features.state() == PROBE_STATE
+    0 * _
   }
 
   def "test fallback when /info not found and agent returns ok"() {
@@ -135,6 +164,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     features.getTraceEndpoint() == "v0.5/traces"
     !features.supportsDropping()
     features.state() == PROBE_STATE
+    0 * _
   }
 
   def "test fallback when /info not found and v0.5 disabled"() {
@@ -156,6 +186,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     features.getTraceEndpoint() == "v0.4/traces"
     !features.supportsDropping()
     features.state() == PROBE_STATE
+    0 * _
   }
 
   def "test fallback when /info not found and v0.5 unavailable agent side"() {
@@ -177,6 +208,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     features.getTraceEndpoint() == "v0.4/traces"
     !features.supportsDropping()
     features.state() == PROBE_STATE
+    0 * _
   }
 
   def "test fallback on very old agent"() {
@@ -198,6 +230,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     features.getTraceEndpoint() == "v0.3/traces"
     !features.supportsDropping()
     features.state() == PROBE_STATE
+    0 * _
   }
 
   def "disabling metrics disables metrics and dropping"() {
@@ -236,6 +269,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     !features.supportsDropping()
     !(features as DroppingPolicy).active()
     features.state() == INFO_STATE
+    0 * _
   }
 
   def "discovery of metrics endpoint after agent upgrade enables dropping and metrics"() {
@@ -265,6 +299,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     features.supportsMetrics()
     (features as DroppingPolicy).active()
     features.state() == INFO_WITH_CLIENT_DROPPING_STATE
+    0 * _
   }
 
   def "disappearance of info endpoint after agent downgrade disables metrics and dropping"() {
@@ -295,6 +330,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     !features.supportsMetrics()
     !(features as DroppingPolicy).active()
     features.state() == PROBE_STATE
+    0 * _
   }
 
   def "disappearance of metrics endpoint after agent downgrade disables metrics and dropping"() {
@@ -326,6 +362,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     // but we don't permit dropping anyway
     !(features as DroppingPolicy).active()
     features.state() == INFO_WITHOUT_METRICS_STATE
+    0 * _
   }
 
   def countingNotFound(Request request, CountDownLatch latch) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -46,6 +46,7 @@ public class DebuggerAgent {
     boolean isSnapshotUploadThroughAgent = Objects.equals(finalDebuggerSnapshotUrl, agentUrl);
 
     DDAgentFeaturesDiscovery ddAgentFeaturesDiscovery = sco.featuresDiscovery(config);
+    ddAgentFeaturesDiscovery.discoverIfOutdated();
     agentVersion = ddAgentFeaturesDiscovery.getVersion();
 
     if (isSnapshotUploadThroughAgent && !ddAgentFeaturesDiscovery.supportsDebugger()) {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/datastreams/MockFeaturesDiscovery.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/datastreams/MockFeaturesDiscovery.java
@@ -16,6 +16,9 @@ public class MockFeaturesDiscovery extends DDAgentFeaturesDiscovery {
   public void discover() {}
 
   @Override
+  public void discoverIfOutdated() {}
+
+  @Override
   public boolean supportsDataStreams() {
     return supportsDataStreams;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -143,7 +143,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
   @Override
   public void start() {
     if (features.getMetricsEndpoint() == null) {
-      features.discover();
+      features.discoverIfOutdated();
     }
     if (features.supportsMetrics()) {
       sink.register(this);

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
@@ -97,7 +97,7 @@ public class DDAgentApi implements RemoteApi {
     final int sizeInBytes = payload.sizeInBytes();
     String tracesEndpoint = featuresDiscovery.getTraceEndpoint();
     if (null == tracesEndpoint) {
-      featuresDiscovery.discover();
+      featuresDiscovery.discoverIfOutdated();
       tracesEndpoint = featuresDiscovery.getTraceEndpoint();
       if (null == tracesEndpoint) {
         log.error("No datadog agent detected");

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsCheckpointer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsCheckpointer.java
@@ -101,7 +101,7 @@ public class DefaultDataStreamsCheckpointer
   @Override
   public void start() {
     if (features.getDataStreamsEndpoint() == null) {
-      features.discover();
+      features.discoverIfOutdated();
     }
 
     if (features.supportsDataStreams()) {
@@ -248,7 +248,7 @@ public class DefaultDataStreamsCheckpointer
   private void checkFeatures() {
     boolean oldValue = supportsDataStreams;
 
-    features.discover();
+    features.discoverIfOutdated();
     supportsDataStreams = features.supportsDataStreams();
     if (oldValue && !supportsDataStreams) {
       log.info("Disabling data streams reporting because it is not supported by the agent");


### PR DESCRIPTION
# What Does This Do

* ~Separate feature discovery instance creation from actual discovery.~
* Allow forced discovery (`discovery()`) for cases where we want to force discovery, such as detecting an agent downgrade or config change (e.g. receiving a 404 error on a known endpoint).
* For other cases, use `discoveryIfOld()`. Which will only run discovery if it has not been done in a while.
* Synchronize discovery to debounce requests.

# Motivation

We were doing some ugly hacks in remote config to ensure we didn't send extra feature discovery requests. As we extend this usage to telemetry, we saw ourselves doing the same hack again. Previous discussion is available at https://github.com/DataDog/dd-trace-java/pull/4042#discussion_r998163980

# Additional Notes
* This PR does not address resetting `dataStreamsEndpoint`, which was missing from `reset()`.