### PR TITLE
Create spans for vulnerabilities outside of requests

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastModuleImpl.java
@@ -53,7 +53,7 @@ public final class IastModuleImpl implements IastModule {
     Vulnerability vulnerability =
         new Vulnerability(
             VulnerabilityType.WEAK_CIPHER,
-            Location.forSpanAndStack(span.getSpanId(), stackTraceElement),
+            Location.forSpanAndStack(spanId(span), stackTraceElement),
             new Evidence(algorithm));
     reporter.report(span, vulnerability);
   }
@@ -76,7 +76,7 @@ public final class IastModuleImpl implements IastModule {
     Vulnerability vulnerability =
         new Vulnerability(
             VulnerabilityType.WEAK_HASH,
-            Location.forSpanAndStack(span.getSpanId(), stackTraceElement),
+            Location.forSpanAndStack(spanId(span), stackTraceElement),
             new Evidence(algorithm));
     reporter.report(span, vulnerability);
   }
@@ -159,5 +159,9 @@ public final class IastModuleImpl implements IastModule {
 
   private static boolean canBeTainted(final String s) {
     return s != null && !s.isEmpty();
+  }
+
+  private static long spanId(@Nullable final AgentSpan span) {
+    return span == null ? 0 : span.getSpanId();
   }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Location.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Location.java
@@ -6,7 +6,7 @@ public final class Location {
 
   private final int line;
 
-  private final Long spanId;
+  private Long spanId;
 
   private Location(final long spanId, final String path, final int line) {
     this.spanId = spanId == 0 ? null : spanId;
@@ -28,5 +28,9 @@ public final class Location {
 
   public int getLine() {
     return line;
+  }
+
+  public void updateSpan(final long spanId) {
+    this.spanId = spanId;
   }
 }

--- a/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -1,7 +1,7 @@
 package datadog.smoketest.springboot.controller;
 
+import ddtest.client.sources.Hasher;
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import org.apache.catalina.servlet4preview.http.HttpServletRequest;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,6 +10,18 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class IastWebController {
+
+  private final Hasher hasher;
+
+  public IastWebController() {
+    this.hasher = new Hasher();
+    try {
+      hasher.sha1();
+    } catch (NoSuchAlgorithmException e) {
+      // ignore it
+    }
+  }
+
   @RequestMapping("/greeting")
   public String greeting() {
     return "Sup Dawg";
@@ -18,7 +30,7 @@ public class IastWebController {
   @RequestMapping("/weakhash")
   public String weakhash() {
     try {
-      MessageDigest.getInstance("MD5").digest("Message body".getBytes(StandardCharsets.UTF_8));
+      hasher.md5().digest("Message body".getBytes(StandardCharsets.UTF_8));
     } catch (NoSuchAlgorithmException e) {
       return "Error: " + e.toString();
     }

--- a/dd-smoke-tests/springboot/src/main/java/ddtest/client/sources/Hasher.java
+++ b/dd-smoke-tests/springboot/src/main/java/ddtest/client/sources/Hasher.java
@@ -4,7 +4,11 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 public class Hasher {
-  public void executeHash() throws NoSuchAlgorithmException {
-    MessageDigest.getInstance("MD5");
+  public MessageDigest sha1() throws NoSuchAlgorithmException {
+    return MessageDigest.getInstance("SHA1");
+  }
+
+  public MessageDigest md5() throws NoSuchAlgorithmException {
+    return MessageDigest.getInstance("MD5");
   }
 }

--- a/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
@@ -2,16 +2,20 @@ package datadog.smoketest
 
 import datadog.trace.api.Platform
 import datadog.trace.test.agent.decoder.DecodedSpan
+import groovy.json.JsonSlurper
 import okhttp3.Request
 import spock.lang.IgnoreIf
 import spock.util.concurrent.PollingConditions
 
 import java.util.function.Function
+import java.util.function.Predicate
 
 @IgnoreIf({
   !Platform.isJavaVersionAtLeast(8)
 })
 class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
+
+  private static final String TAG_NAME = '_dd.iast.json'
 
   @Override
   def logLevel() {
@@ -103,14 +107,6 @@ class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
     waitForSpan(new PollingConditions(timeout: 5), hasMetric('_dd.iast.enabled', 1))
   }
 
-  private static Function<DecodedSpan, Boolean> hasMetric(final String name, final Object value) {
-    return { span -> value == span.metrics.get(name) }
-  }
-
-  private static Function<DecodedSpan, Boolean> hasVulnerability(final String vulnerabilityName) {
-    return { span -> span.toString().contains(vulnerabilityName) }
-  }
-
   def "weak hash vulnerability is present"() {
     setup:
     String url = "http://localhost:${httpPort}/weakhash"
@@ -120,7 +116,19 @@ class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
     client.newCall(request).execute()
 
     then:
-    waitForSpan(new PollingConditions(timeout: 5), hasVulnerability("WEAK_HASH"))
+    waitForSpan(new PollingConditions(timeout: 5), hasVulnerability(type('WEAK_HASH').and(evidence('MD5'))))
+  }
+
+  def "weak hash vulnerability is present on boot"() {
+    setup:
+    String url = "http://localhost:${httpPort}/greeting"
+    def request = new Request.Builder().url(url).get().build()
+
+    when: 'ensure the controller is loaded'
+    client.newCall(request).execute()
+
+    then: 'a vulnerability pops in the logs (startup traces might not always be available)'
+    hasVulnerabilityInLogs(type('WEAK_HASH').and(evidence('SHA1')).and(withSpan()))
   }
 
   def "getParameter taints string"() {
@@ -142,5 +150,75 @@ class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
       }
     }
     foundTaintedString
+  }
+
+  private static Function<DecodedSpan, Boolean> hasMetric(final String name, final Object value) {
+    return { span -> value == span.metrics.get(name) }
+  }
+
+  private static Function<DecodedSpan, Boolean> hasVulnerability(final Predicate<?> predicate) {
+    return { span ->
+      final iastMeta = span.meta.get(TAG_NAME)
+      if (!iastMeta) {
+        return false
+      }
+      final vulnerabilities = parseVulnerabilities(iastMeta)
+      return vulnerabilities.stream().anyMatch(predicate)
+    }
+  }
+
+  private boolean hasVulnerabilityInLogs(final Predicate<?> predicate) {
+    def found = false
+    checkLog { final String log ->
+      final index = log.indexOf(TAG_NAME)
+      if (index >= 0) {
+        final vulnerabilities = parseVulnerabilities(log, index)
+        found |= vulnerabilities.stream().anyMatch(predicate)
+      }
+    }
+    return found
+  }
+
+  private static Collection<?> parseVulnerabilities(final String log, final int startIndex) {
+    final chars = log.toCharArray()
+    final builder = new StringBuilder()
+    def level = 0
+    for (int i = log.indexOf('{', startIndex); i < chars.length; i++) {
+      final current = chars[i]
+      if (current == '{' as char) {
+        level++
+      } else if (current == '}' as char) {
+        level--
+      }
+      builder.append(chars[i])
+      if (level == 0) {
+        break
+      }
+    }
+    return parseVulnerabilities(builder.toString())
+  }
+
+  private static Collection<?> parseVulnerabilities(final String iastJson) {
+    final slurper = new JsonSlurper()
+    final parsed = slurper.parseText(iastJson)
+    return parsed['vulnerabilities'] as Collection
+  }
+
+  private static Predicate<?> type(final String type) {
+    return { vul ->
+      vul.type == type
+    }
+  }
+
+  private static Predicate<?> evidence(final String value) {
+    return { vul ->
+      vul.evidence.value == value
+    }
+  }
+
+  private static Predicate<?> withSpan() {
+    return { vul ->
+      vul.location.spanId > 0
+    }
   }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDSpanTypes.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDSpanTypes.java
@@ -27,4 +27,6 @@ public class DDSpanTypes {
   public static final String GRAPHQL = "graphql";
 
   public static final String TEST = "test";
+
+  public static final String IAST = "iast";
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InternalSpanTypes.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InternalSpanTypes.java
@@ -35,4 +35,6 @@ public class InternalSpanTypes {
   public static final CharSequence GRAPHQL = UTF8BytesString.create(DDSpanTypes.GRAPHQL);
 
   public static final CharSequence TEST = UTF8BytesString.create(DDSpanTypes.TEST);
+
+  public static final CharSequence IAST = UTF8BytesString.create(DDSpanTypes.IAST);
 }


### PR DESCRIPTION
# What Does This Do
Creates a new span for vulnerabilities where there is no current context

# Motivation
Vulnerabilities are not only found during the execution of a request, they can be present at boot time, background processes ... this PR tries to enable the creation of custom spans when there is no requests.

# Additional Notes