### PR TITLE
Lock down spring-framework versions

### DIFF
--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -289,6 +289,7 @@ class MuzzlePlugin implements Plugin<Project> {
 
     return filterAndLimitVersions(allRangeResult, muzzleDirective.skipVersions).collect { version ->
       final MuzzleDirective inverseDirective = new MuzzleDirective()
+      inverseDirective.name = muzzleDirective.name
       inverseDirective.group = muzzleDirective.group
       inverseDirective.module = muzzleDirective.module
       inverseDirective.versions = "$version"

--- a/dd-java-agent/instrumentation/spring-data-1.8/build.gradle
+++ b/dd-java-agent/instrumentation/spring-data-1.8/build.gradle
@@ -50,8 +50,8 @@ dependencies {
   testImplementation group: 'org.hsqldb', name: 'hsqldb', version: '2.0.0'
   testImplementation group: 'org.hibernate', name: 'hibernate-entitymanager', version: '4.3.0.Final'
 
-  latestDepTestImplementation group: 'org.springframework', name: 'spring-test', version: '+'
-  latestDepTestImplementation group: 'org.springframework', name: 'spring-context', version: '+'
+  latestDepTestImplementation group: 'org.springframework', name: 'spring-test', version: '5.+'
+  latestDepTestImplementation group: 'org.springframework', name: 'spring-context', version: '5.+'
 
   latestDepTestImplementation group: 'org.springframework.data', name: 'spring-data-commons', version: '+'
   latestDepTestImplementation group: 'org.springframework.data', name: 'spring-data-jpa', version: '2.3.+'

--- a/dd-java-agent/instrumentation/spring-jms-3.1/build.gradle
+++ b/dd-java-agent/instrumentation/spring-jms-3.1/build.gradle
@@ -42,6 +42,6 @@ dependencies {
   testImplementation group: 'org.apache.activemq', name: 'activemq-pool', version: '5.14.5'
   testImplementation group: 'org.apache.activemq', name: 'activemq-broker', version: '5.14.5'
 
-  latestDepTestImplementation group: 'org.springframework', name: 'spring-jms', version: '+'
-  latestDepTestImplementation group: 'org.springframework', name: 'spring-context', version: '+'
+  latestDepTestImplementation group: 'org.springframework', name: 'spring-jms', version: '5.+'
+  latestDepTestImplementation group: 'org.springframework', name: 'spring-context', version: '5.+'
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/build.gradle
+++ b/dd-java-agent/instrumentation/spring-webflux-5/build.gradle
@@ -8,8 +8,8 @@ muzzle {
     name = "webflux_5.0.0+_with_netty_0.8.0"
     group = "org.springframework"
     module = "spring-webflux"
-    versions = "[5.0.0.RELEASE,)"
-    assertInverse = true
+    versions = "[5.0.0.RELEASE,6)"
+    // assertInverse = true
     extraDependency "io.projectreactor.netty:reactor-netty:0.8.0.RELEASE"
   }
 
@@ -17,8 +17,8 @@ muzzle {
     name = "webflux_5.0.0_with_ipc_0.7.0"
     group = "org.springframework"
     module = "spring-webflux"
-    versions = "[5.0.0.RELEASE,)"
-    assertInverse = true
+    versions = "[5.0.0.RELEASE,6)"
+    // assertInverse = true
     extraDependency "io.projectreactor.ipc:reactor-netty:0.7.0.RELEASE"
   }
 


### PR DESCRIPTION
We need to lock `latestDepTestImplementation` to 5.+, as 6.x targets Java 17