### PR TITLE
Add transitive dependencies to IAST short-circuits in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ profiling_test_matrix: &profiling_test_matrix
 agent_integration_tests_modules: &agent_integration_tests_modules "dd-trace-core|communication|internal-api|utils"
 core_modules: &core_modules "dd-java-agent|dd-trace-core|communication|internal-api|telemetry|utils|dd-java-agent/agent-bootstrap|dd-java-agent/agent-installer|dd-java-agent/agent-tooling|dd-java-agent/agent-builder|dd-java-agent/appsec"
 instrumentation_modules: &instrumentation_modules "dd-java-agent/instrumentation|dd-java-agent/agent-tooling|dd-java-agent/agent-installer|dd-java-agent/agent-builder|dd-java-agent/agent-bootstrap|dd-java-agent/appsec|dd-trace-core|dd-trace-api|internal-api"
-iast_modules: &iast_modules "dd-java-agent/agent-iast|internal-api|utils/test-utils"
+iast_modules: &iast_modules "dd-java-agent/agent-iast|communication|dd-java-agent/agent-bootstrap|dd-java-agent/agent-builder|dd-java-agent/agent-crashtracking|dd-java-agent/agent-tooling|dd-java-agent/instrumentation/iast-instrumenter|dd-java-agent/instrumentation/java-lang|dd-trace-api|dd-trace-core|internal-api|internal-api/internal-api-8|internal-api/internal-api-9|utils/test-utils|utils/time-utils|utils/version-utils"
 debugger_modules: &debugger_modules "dd-java-agent/agent-debugger|dd-java-agent/agent-bootstrap|dd-java-agent/agent-builder|internal-api|communication|dd-trace-core"
 profiling_modules: &profiling_modules "dd-java-agent/agent-profiling|dd-trace-core/jfr-openjdk"
 


### PR DESCRIPTION
# What Does This Do
Add agent-iast transitive dependencies to CI triggers.

# Motivation
Avoid skipping agent-iast tests for anything that can affect it.

# Additional Notes
Generated with:
```
JAVA_HOME=$JAVA_8_HOME ./gradlew :dd-java-agent:agent-iast:dependencies > out
echo $(cat out | grep 'project :' | sed -e 's~.*project :~~g' -e 's~ .*~~g' -e 's~:~/~g'|sort|uniq) | sed -e 's~ ~|~g'
```
plus some manual filtering.