### PR TITLE
Fix shading of dd-trace-ot to leave all public API packages untouched

### DIFF
--- a/dd-trace-ot/build.gradle
+++ b/dd-trace-ot/build.gradle
@@ -98,6 +98,7 @@ shadowJar {
   }
   relocate('datadog.', 'ddtrot.dd.') {
     exclude('datadog.opentracing.*')
+    exclude('datadog.opentracing.resolver.*')
     exclude('datadog.trace.api.*')
     exclude('datadog.trace.api.config.*')
     exclude('datadog.trace.api.interceptor.*')

--- a/dd-trace-ot/build.gradle
+++ b/dd-trace-ot/build.gradle
@@ -99,6 +99,9 @@ shadowJar {
   relocate('datadog.', 'ddtrot.dd.') {
     exclude('datadog.opentracing.*')
     exclude('datadog.trace.api.*')
+    exclude('datadog.trace.api.config.*')
+    exclude('datadog.trace.api.interceptor.*')
+    exclude('datadog.trace.api.sampling.*')
     exclude('datadog.trace.context.*')
   }
   exclude('META-INF/maven/')


### PR DESCRIPTION
I added exclusions to cover all the packages in `dd-trace-api` as well as those in the original `dd-trace-ot`.

Without this change subpackages like `datadog.trace.api.interceptor` are shaded when they should be left untouched.
