### PR TITLE
Add dd-api sanity check to dd-trace-ot smoke test

### DIFF
--- a/dd-smoke-tests/opentracing/src/main/java/datadog/smoketest/opentracing/ApiVerification.java
+++ b/dd-smoke-tests/opentracing/src/main/java/datadog/smoketest/opentracing/ApiVerification.java
@@ -1,0 +1,28 @@
+package datadog.smoketest.opentracing;
+
+import datadog.trace.api.Tracer;
+import datadog.trace.api.interceptor.MutableSpan;
+import datadog.trace.api.interceptor.TraceInterceptor;
+import java.util.Collection;
+
+public final class ApiVerification {
+  private ApiVerification() {}
+
+  public static void verifyInterceptors(Tracer otTracer) {
+    TraceInterceptor interceptor =
+        new TraceInterceptor() {
+          @Override
+          public Collection<? extends MutableSpan> onTraceComplete(
+              Collection<? extends MutableSpan> trace) {
+            return trace;
+          }
+
+          @Override
+          public int priority() {
+            return 1729;
+          }
+        };
+
+    ((datadog.trace.api.Tracer) otTracer).addTraceInterceptor(interceptor);
+  }
+}

--- a/dd-smoke-tests/opentracing/src/main/java/datadog/smoketest/opentracing/OTWithAgentApplication.java
+++ b/dd-smoke-tests/opentracing/src/main/java/datadog/smoketest/opentracing/OTWithAgentApplication.java
@@ -12,6 +12,8 @@ public class OTWithAgentApplication {
   public static void main(final String[] args) throws InterruptedException {
     final Tracer tracer = GlobalTracer.get();
 
+    ApiVerification.verifyInterceptors(datadog.trace.api.GlobalTracer.get());
+
     final Span span = tracer.buildSpan("someOperation").start();
     try (final Scope scope = tracer.activateSpan(span)) {
       span.setTag(DDTags.SERVICE_NAME, "someService");

--- a/dd-smoke-tests/opentracing/src/main/java/datadog/smoketest/opentracing/OTWithoutAgentApplication.java
+++ b/dd-smoke-tests/opentracing/src/main/java/datadog/smoketest/opentracing/OTWithoutAgentApplication.java
@@ -13,6 +13,8 @@ public class OTWithoutAgentApplication {
     // register the same tracer with the Datadog API
     datadog.trace.api.GlobalTracer.registerIfAbsent(tracer);
 
+    ApiVerification.verifyInterceptors(tracer);
+
     final Span span = tracer.buildSpan("someOperation").start();
     try (final Scope scope = tracer.activateSpan(span)) {
       span.setTag(DDTags.SERVICE_NAME, "someService");


### PR DESCRIPTION
# What Does This Do

Adds a simple sanity check of the `TraceInterceptor` API to the OpenTracing smoke test that uses `dd-trace-ot`.

# Motivation

Verify that shading and relocation doesn't move the public classes.

# Additional Notes
