### PR TITLE
move `AgentSpan.getTag` up to `MutableSpan` for more efficient `TraceInterceptor`s

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelSpan.java
+++ b/dd-java-agent/instrumentation/opentelemetry/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelSpan.java
@@ -187,6 +187,11 @@ public class OtelSpan implements Span, MutableSpan {
   }
 
   @Override
+  public Object getTag(String key) {
+    return delegate.getTag(key);
+  }
+
+  @Override
   public MutableSpan setTag(final String tag, final String value) {
     return delegate.setTag(tag, value);
   }

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTSpan.java
@@ -198,6 +198,11 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
+  public Object getTag(String key) {
+    return delegate.getTag(key);
+  }
+
+  @Override
   public void finish() {
     delegate.finish();
   }

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTSpan.java
@@ -205,6 +205,11 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
+  public Object getTag(String key) {
+    return delegate.getTag(key);
+  }
+
+  @Override
   public void finish() {
     delegate.finish();
   }

--- a/dd-trace-api/build.gradle
+++ b/dd-trace-api/build.gradle
@@ -13,6 +13,7 @@ excludedClassesCoverage += [
   'datadog.trace.api.GlobalTracer*',
   'datadog.trace.api.PropagationStyle',
   'datadog.trace.api.SpanCorrelation*',
+  'datadog.trace.api.interceptor.MutableSpan'
 ]
 
 description = 'dd-trace-api'

--- a/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/interceptor/MutableSpan.java
@@ -40,6 +40,11 @@ public interface MutableSpan {
 
   Map<String, Object> getTags();
 
+  default Object getTag(String key) {
+    Map<String, Object> tags = getTags();
+    return tags == null ? null : tags.get(key);
+  }
+
   MutableSpan setTag(final String tag, final String value);
 
   MutableSpan setTag(final String tag, final boolean value);

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTSpan.java
@@ -204,6 +204,11 @@ class OTSpan implements Span, MutableSpan {
   }
 
   @Override
+  public Object getTag(String key) {
+    return delegate.getTag(key);
+  }
+
+  @Override
   public void finish() {
     delegate.finish();
   }


### PR DESCRIPTION
# What Does This Do

This pushes `AgentSpan.getTag` up to `MutableSpan` so that it can be used from `TraceInterceptor`s. Otherwise, the user has to take a copy of the tags to check a tag value, which is inefficient.

# Motivation

# Additional Notes
