### PR TITLE
Use closePrevious/activateNext for SQS receive polling

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java8/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
@@ -1,12 +1,15 @@
 package datadog.trace.instrumentation.aws.v2;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateNext;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.closePrevious;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.aws.v2.AwsSdkClientDecorator.AWS_HTTP;
 import static datadog.trace.instrumentation.aws.v2.AwsSdkClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
@@ -21,11 +24,16 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
   @Override
   public void beforeExecution(
       final Context.BeforeExecution context, final ExecutionAttributes executionAttributes) {
-    final AgentSpan span = startSpan(AWS_HTTP);
-    try (final AgentScope scope = activateSpan(span)) {
-      DECORATE.afterStart(span);
-      executionAttributes.putAttribute(SPAN_ATTRIBUTE, span);
+    boolean isPolling = isPollingRequest(context.request());
+    if (isPolling) {
+      closePrevious(true);
     }
+    final AgentSpan span = startSpan(AWS_HTTP);
+    DECORATE.afterStart(span);
+    if (isPolling) {
+      activateNext(span); // this scope will last until next poll
+    }
+    executionAttributes.putAttribute(SPAN_ATTRIBUTE, span);
   }
 
   @Override
@@ -59,7 +67,11 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
       DECORATE.onResponse(span, context.response());
       DECORATE.onResponse(span, context.httpResponse());
       DECORATE.beforeFinish(span);
-      span.finish();
+      if (isPollingRequest(context.request())) {
+        // will be finished on next poll
+      } else {
+        span.finish();
+      }
     }
   }
 
@@ -71,8 +83,18 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
       executionAttributes.putAttribute(SPAN_ATTRIBUTE, null);
       DECORATE.onError(span, context.exception());
       DECORATE.beforeFinish(span);
-      span.finish();
+      if (isPollingRequest(context.request())) {
+        // will be finished on next poll
+      } else {
+        span.finish();
+      }
     }
+  }
+
+  private static boolean isPollingRequest(SdkRequest request) {
+    return null != request
+        && "software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest"
+            .equals(request.getClass().getName());
   }
 
   public static void muzzleCheck() {

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -52,7 +52,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE = false;
   static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX = false;
   static final int DEFAULT_SCOPE_DEPTH_LIMIT = 100;
-  static final int DEFAULT_SCOPE_ITERATION_KEEP_ALIVE = 10; // in seconds
+  static final int DEFAULT_SCOPE_ITERATION_KEEP_ALIVE = 30; // in seconds
   static final int DEFAULT_PARTIAL_FLUSH_MIN_SPANS = 1000;
   static final boolean DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED = false;
   static final String DEFAULT_PROPAGATION_STYLE_EXTRACT = PropagationStyle.DATADOG.name();


### PR DESCRIPTION
This means that any work done between `receive` requests when polling is associated with the most recent `receive` request, just like we do for JMS/Kafka/RabbitMQ.

I also bumped the keep-alive timeout for iteration/polling scopes to cover the maximum long polling wait time for SQS.