### PR TITLE
skip profiling tests to make sure we don't try to use JFR on J9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -653,7 +653,7 @@ build_test_jobs: &build_test_jobs
         - build
       name: z_test_<< matrix.testJvm >>_base
       triggeredBy: *core_modules
-      gradleParameters: "-PskipInstTests -PskipSmokeTests"
+      gradleParameters: "-PskipInstTests -PskipSmokeTests -PskipProfilingTests"
       stage: core
       maxWorkers: 6
       matrix:
@@ -664,7 +664,7 @@ build_test_jobs: &build_test_jobs
         - build
       name: z_test_8_base
       triggeredBy: *core_modules
-      gradleParameters: "-PskipInstTests -PskipSmokeTests"
+      gradleParameters: "-PskipInstTests -PskipSmokeTests -PskipProfilingTests"
       testTask: test jacocoTestReport jacocoTestCoverageVerification
       stage: core
       maxWorkers: 6


### PR DESCRIPTION
# What Does This Do

Fixes build spec error introduced in #4271

# Motivation

# Additional Notes
