### PR TITLE
Add parent field support collecting fields

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/FieldExtractor.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/FieldExtractor.java
@@ -3,6 +3,7 @@ package datadog.trace.bootstrap.debugger;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.ObjIntConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,7 +29,7 @@ public class FieldExtractor {
       Limits limits,
       Fields.ProcessField onField,
       BiConsumer<Exception, Field> exHandling,
-      ObjIntConsumer<Field> maxFieldCount) {
+      Consumer<Field> maxFieldCount) {
     if (obj == null) {
       return;
     }

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/FieldExtractor.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/FieldExtractor.java
@@ -4,7 +4,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.function.ObjIntConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Fields.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Fields.java
@@ -3,6 +3,7 @@ package datadog.trace.bootstrap.debugger;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.ObjIntConsumer;
 import java.util.function.Predicate;
 
@@ -17,29 +18,31 @@ public class Fields {
       Predicate<Field> filteringIn,
       ProcessField processing,
       BiConsumer<Exception, Field> exHandling,
-      ObjIntConsumer<Field> onMaxFieldCount,
+      Consumer<Field> onMaxFieldCount,
       int maxFieldCount,
       int maxDepth) {
-    Field[] fields = o.getClass().getDeclaredFields();
+    Class<?> currentClass = o.getClass();
     int processedFieldCount = 0;
-    for (Field field : fields) {
-      try {
-        if (!filteringIn.test(field)) {
-          continue;
+    do {
+      Field[] fields = currentClass.getDeclaredFields();
+      for (Field field : fields) {
+        try {
+          if (!filteringIn.test(field)) {
+            continue;
+          }
+          field.setAccessible(true);
+          Object value = field.get(o);
+          processing.accept(field, value, maxDepth);
+          processedFieldCount++;
+          if (processedFieldCount >= maxFieldCount) {
+            onMaxFieldCount.accept(field);
+            return;
+          }
+        } catch (Exception e) {
+          exHandling.accept(e, field);
         }
-        field.setAccessible(true);
-        Object value = field.get(o);
-        processing.accept(field, value, maxDepth);
-        processedFieldCount++;
-        if (processedFieldCount >= maxFieldCount) {
-          int total = (int) Arrays.stream(fields).filter(filteringIn::test).count();
-          onMaxFieldCount.accept(field, total);
-          break;
-        }
-      } catch (Exception e) {
-        exHandling.accept(e, field);
       }
-    }
+    } while ((currentClass = currentClass.getSuperclass()) != null);
   }
 
   static boolean isPrimitiveClass(Object obj) {

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Fields.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Fields.java
@@ -1,10 +1,8 @@
 package datadog.trace.bootstrap.debugger;
 
 import java.lang.reflect.Field;
-import java.util.Arrays;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.function.ObjIntConsumer;
 import java.util.function.Predicate;
 
 /** Helper class for processing fields of an instance */

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
@@ -359,7 +359,8 @@ public class MoshiSnapshotHelper {
               }
               jsonReader.endArray();
               if (type.equals(List.class.getTypeName())
-                  || type.equals(ArrayList.class.getTypeName())) {
+                  || type.equals(ArrayList.class.getTypeName())
+                  || type.equals("java.util.Collections$UnmodifiableRandomAccessList")) {
                 List<Object> list = new ArrayList<>();
                 for (Snapshot.CapturedValue cValue : values) {
                   list.add(cValue.getValue());
@@ -621,7 +622,7 @@ public class MoshiSnapshotHelper {
                 jsonWriter.name(fieldName);
                 jsonWriter.beginObject();
                 jsonWriter.name(TYPE);
-                jsonWriter.value(field.getType().getName());
+                jsonWriter.value(field.getType().getTypeName());
                 jsonWriter.name(NOT_CAPTURED_REASON);
                 jsonWriter.value(ex.toString());
                 jsonWriter.endObject();

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1127,6 +1127,24 @@ public class CapturedSnapshotTest {
     assertCaptureReturnValue(snapshot.getCaptures().getReturn(), "java.lang.Integer", "50");
   }
 
+  @Test
+  public void exceptionAsLocalVariable() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot18";
+    DebuggerTransformerTest.TestSnapshotListener listener =
+        installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, null, null, "14"));
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "2").get();
+    Assert.assertEquals(42, result);
+    Snapshot snapshot = assertOneSnapshot(listener);
+    Map<String, String> expectedFields = new HashMap<>();
+    expectedFields.put("detailMessage", "For input string: \"a\"");
+    assertCaptureLocals(
+        snapshot.getCaptures().getLines().get(14),
+        "ex",
+        "java.lang.NumberFormatException",
+        expectedFields);
+  }
+
   private DebuggerTransformerTest.TestSnapshotListener setupInstrumentTheWorldTransformer(
       String excludeFileName) {
     Config config = mock(Config.class);
@@ -1266,6 +1284,26 @@ public class CapturedSnapshotTest {
     Snapshot.CapturedValue localVar = context.getLocals().get(name);
     Assert.assertEquals(typeName, localVar.getType());
     Assert.assertEquals(value, getValue(localVar));
+  }
+
+  private void assertCaptureLocals(
+      Snapshot.CapturedContext context,
+      String name,
+      String typeName,
+      Map<String, String> expectedFields) {
+    Snapshot.CapturedValue localVar = context.getLocals().get(name);
+    Assert.assertEquals(typeName, localVar.getType());
+    Map<String, Snapshot.CapturedValue> fields = getFields(localVar);
+    for (Map.Entry<String, String> entry : expectedFields.entrySet()) {
+      Assert.assertTrue(fields.containsKey(entry.getKey()));
+      Snapshot.CapturedValue fieldCapturedValue = fields.get(entry.getKey());
+      if (fieldCapturedValue.getNotCapturedReason() != null) {
+        Assert.assertEquals(
+            entry.getValue(), String.valueOf(fieldCapturedValue.getNotCapturedReason()));
+      } else {
+        Assert.assertEquals(entry.getValue(), String.valueOf(fieldCapturedValue.getValue()));
+      }
+    }
   }
 
   private void assertCaptureFields(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/el/ELIntegrationSanityTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/el/ELIntegrationSanityTest.java
@@ -62,7 +62,7 @@ public class ELIntegrationSanityTest {
                   limits.maxFieldCount));
         },
         (e, field) -> {},
-        (field, value) -> {});
+        (field) -> {});
 
     capturedContext.addFields(flds.toArray(new Snapshot.CapturedValue[0]));
 

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot18.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot18.java
@@ -1,0 +1,17 @@
+package com.datadog.debugger;
+
+public class CapturedSnapshot18 {
+  public static int main(String arg) {
+    processWithException();
+    return 42;
+  }
+
+  private static void processWithException() {
+    try {
+      Integer.parseInt("a");
+    } catch (Exception ex) {
+      ex.fillInStackTrace();
+      ex.printStackTrace();
+    }
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotCapturedValueRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotCapturedValueRegex.txt
@@ -27,6 +27,16 @@
 \{
 "type":"com.sun.management.internal.OperatingSystemImpl.ContainerCpuTicks",
 "notCapturedReason":"java.lang.reflect.InaccessibleObjectException: Unable to make field private com.sun.management.internal.OperatingSystemImpl.ContainerCpuTicks com.sun.management.internal.OperatingSystemImpl.processLoadTicks accessible: module jdk.management does not \\"opens com.sun.management.internal\\" to unnamed module @[0-9a-f]+"
+\},
+"jvm":
+\{
+"type":"sun.management.VMManagement",
+"notCapturedReason":"java.lang.reflect.InaccessibleObjectException: Unable to make field private final sun.management.VMManagement sun.management.BaseOperatingSystemImpl.jvm accessible: module java.management does not \\"opens sun.management\\" to unnamed module @[0-9a-f]+"
+\},
+"loadavg":
+\{
+"type":"double\[\]",
+"notCapturedReason":"java.lang.reflect.InaccessibleObjectException: Unable to make field private double\[\] sun.management.BaseOperatingSystemImpl.loadavg accessible: module java.management does not \\"opens sun.management\\" to unnamed module @[0-9a-f]+"
 \}
 \}\},
 "normalValuedField":\{


### PR DESCRIPTION
# What Does This Do
Respect max field count starting from the leaf up to the root. if max field count is reached during parent traversal, we stop in the middle.

# Motivation
Exception captured was not collecting relevant data as the exception is message is defined in `Throwable` class.

# Additional Notes
