### PR TITLE
Retransform class-loader types before transforming any types loaded by them

### DIFF
--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
@@ -55,9 +55,7 @@ public final class AgentBootstrap {
 
     try {
       final URL agentJarURL = installAgentJar(inst);
-
-      final Class<?> agentClass =
-          ClassLoader.getSystemClassLoader().loadClass("datadog.trace.bootstrap.Agent");
+      final Class<?> agentClass = Class.forName("datadog.trace.bootstrap.Agent", true, null);
       if (agentClass.getClassLoader() != null) {
         throw new IllegalStateException("DD Java Agent NOT added to bootstrap classpath.");
       }

--- a/dd-smoke-tests/custom-systemloader/build.gradle
+++ b/dd-smoke-tests/custom-systemloader/build.gradle
@@ -1,0 +1,28 @@
+plugins {
+  id "com.github.johnrengelman.shadow"
+}
+
+description = 'Check classes loaded by custom system class-loader are transformed'
+apply from: "$rootDir/gradle/java.gradle"
+
+jar {
+  manifest {
+    attributes('Main-Class': 'sample.app.App')
+  }
+}
+
+shadowJar {
+  configurations = [project.configurations.runtimeClasspath]
+}
+
+dependencies {
+  api group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0'
+
+  testImplementation project(':dd-smoke-tests')
+}
+
+tasks.withType(Test).configureEach {
+  dependsOn "shadowJar"
+
+  jvmArgs "-Ddatadog.smoketest.systemloader.shadowJar.path=${tasks.shadowJar.archivePath}"
+}

--- a/dd-smoke-tests/custom-systemloader/src/main/java/datadog/smoketest/systemloader/TestHelper.java
+++ b/dd-smoke-tests/custom-systemloader/src/main/java/datadog/smoketest/systemloader/TestHelper.java
@@ -1,0 +1,26 @@
+package datadog.smoketest.systemloader;
+
+import de.thetaphi.forbiddenapis.SuppressForbidden;
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class TestHelper {
+  @SuppressForbidden
+  static URL[] classPath() {
+    String[] paths = System.getProperty("java.class.path").split(File.pathSeparator);
+    URL[] classPath = new URL[paths.length];
+    for (int i = 0; i < paths.length; i++) {
+      classPath[i] = toURL(paths[i]);
+    }
+    return classPath;
+  }
+
+  static URL toURL(String path) {
+    try {
+      return new File(path).toURI().toURL();
+    } catch (MalformedURLException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+}

--- a/dd-smoke-tests/custom-systemloader/src/main/java/datadog/smoketest/systemloader/TestLoader.java
+++ b/dd-smoke-tests/custom-systemloader/src/main/java/datadog/smoketest/systemloader/TestLoader.java
@@ -1,0 +1,52 @@
+package datadog.smoketest.systemloader;
+
+import java.net.URLClassLoader;
+
+public class TestLoader extends URLClassLoader {
+
+  public TestLoader(ClassLoader parent) {
+    super(TestHelper.classPath(), parent);
+    try {
+      // trigger loading from this class-loader before our agent is installed
+      loadClass("sample.app.Resource$Test1");
+      loadClass("sample.app.Resource$Test2");
+      loadClass("sample.app.Resource$Test3");
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+    if (name.startsWith("java")
+        || name.startsWith("jdk")
+        || name.startsWith("sun")
+        || name.startsWith("com.sun")
+        || name.startsWith("com.ibm")
+        || name.startsWith("openj9")) {
+      System.out.println("Loading " + name + " from JDK");
+      return super.loadClass(name, resolve); // delegate JDK classes to boot-class-path
+    } else {
+      System.out.println("Loading " + name + " from TestLoader");
+      return loadLocalClass(name, resolve); // otherwise only look locally for the type
+    }
+  }
+
+  private Class<?> loadLocalClass(String name, boolean resolve) throws ClassNotFoundException {
+    synchronized (getClassLoadingLock(name)) {
+      Class<?> clazz = findLoadedClass(name);
+      if (null == clazz) {
+        clazz = findClass(name);
+      }
+      if (resolve) {
+        resolveClass(clazz);
+      }
+      return clazz;
+    }
+  }
+
+  // see https://docs.oracle.com/javase/9/docs/api/java/lang/instrument/package-summary.html
+  void appendToClassPathForInstrumentation(String path) {
+    addURL(TestHelper.toURL(path));
+  }
+}

--- a/dd-smoke-tests/custom-systemloader/src/main/java/sample/app/App.java
+++ b/dd-smoke-tests/custom-systemloader/src/main/java/sample/app/App.java
@@ -1,0 +1,7 @@
+package sample.app;
+
+public class App {
+  public static void main(final String[] args) {
+    System.out.println("FIN");
+  }
+}

--- a/dd-smoke-tests/custom-systemloader/src/main/java/sample/app/Resource.java
+++ b/dd-smoke-tests/custom-systemloader/src/main/java/sample/app/Resource.java
@@ -1,0 +1,51 @@
+package sample.app;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+// Sample JAX-RS resource that we expect to be instrumented
+@Path("/ignored")
+public interface Resource {
+  @Path("ignored")
+  String hello(final String name);
+
+  @Path("/test")
+  interface SubResource extends Cloneable, Resource {
+    @Override
+    @POST
+    @Path("/hello/{name}")
+    String hello(@PathParam("name") final String name);
+  }
+
+  class Test1 implements SubResource {
+    @Override
+    public String hello(final String name) {
+      return "Test1 " + name + "!";
+    }
+  }
+
+  @Path("/test2")
+  class Test2 implements SubResource {
+    @Override
+    public String hello(final String name) {
+      return "Test2 " + name + "!";
+    }
+  }
+
+  @Path("/test3")
+  class Test3 implements SubResource {
+    @Override
+    @POST
+    @Path("/hi/{name}")
+    public String hello(@PathParam("name") final String name) {
+      return "Test3 " + name + "!";
+    }
+
+    @POST
+    @Path("/nested")
+    public String nested() {
+      return hello("nested");
+    }
+  }
+}

--- a/dd-smoke-tests/custom-systemloader/src/test/groovy/datadog/smoketest/CustomSystemLoaderSmokeTest.groovy
+++ b/dd-smoke-tests/custom-systemloader/src/test/groovy/datadog/smoketest/CustomSystemLoaderSmokeTest.groovy
@@ -1,0 +1,52 @@
+package datadog.smoketest
+
+import spock.lang.Timeout
+
+import java.util.concurrent.TimeUnit
+
+class CustomSystemLoaderSmokeTest extends AbstractSmokeTest {
+  private static final int TIMEOUT_SECS = 30
+
+  @Override
+  def logLevel() {
+    "debug"
+  }
+
+  @Override
+  ProcessBuilder createProcessBuilder() {
+    String appJar = System.getProperty("datadog.smoketest.systemloader.shadowJar.path")
+    assert new File(appJar).isFile()
+
+    List<String> command = new ArrayList<>()
+    command.add(javaPath())
+    command.addAll(defaultJavaProperties)
+    command.add("-Djava.system.class.loader=datadog.smoketest.systemloader.TestLoader")
+    command.addAll((String[]) ["-jar", appJar])
+
+    ProcessBuilder processBuilder = new ProcessBuilder(command)
+    processBuilder.directory(new File(buildDirectory))
+
+    return processBuilder
+  }
+
+  @Timeout(value = TIMEOUT_SECS, unit = TimeUnit.SECONDS)
+  def "resource types loaded by custom system class-loader are transformed"() {
+    when:
+    testedProcess.waitFor()
+    int loadedResources = 0
+    int transformedResources = 0
+    checkLog {
+      if (it =~ /Loading sample.app.Resource[$]Test[1-3] from TestLoader/) {
+        loadedResources++
+      }
+      if (it =~ /Transformed.*class=sample.app.Resource[$]Test[1-3].*classloader=datadog.smoketest.systemloader.TestLoader/) {
+        transformedResources++
+      }
+    }
+    then:
+    testedProcess.exitValue() == 0
+    loadedResources == 3
+    transformedResources == 3
+    !logHasErrors
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -91,6 +91,7 @@ include ':utils:version-utils'
 
 // smoke tests
 include ':dd-smoke-tests:cli'
+include ':dd-smoke-tests:custom-systemloader'
 include ':dd-smoke-tests:field-injection'
 include ':dd-smoke-tests:java9-modules'
 include ':dd-smoke-tests:jboss-modules'


### PR DESCRIPTION
When the Java tracer is installed it looks at classes that have already been loaded into the JVM so it can re-transform them. It does this in batches, because re-transforming might bring in additional classes. This stops when there are no more loaded classes to be re-transformed.

One of the re-transformations we need to do is make sure custom class-loaders delegate to the boot-class-path for key tracer types. If we're not able to do this then the class-loader will fail the delegation check in `ClassLoaderMatchers` and it will be marked as skipped from that point onwards. This means that anything loaded by that class-loader will be ignored by the Java tracer.

If a user specifies a custom system class-loader with `-Djava.system.class.loader=<class-name>` then it's possible for that class-loader and some of its types to already be loaded at the point the tracer is installed. In other words both the loader and its types could be in the same re-transformation batch. This means we could check the custom system class-loader for the expected delegation before we've had a chance to re-transform it (since the checks are performed at the start of the batch, and re-transformations are only committed at the end of the batch.) It would then be marked as skipped, and anything subsequently loaded by that class-loader would be ignored.

To avoid this we add an extra check for non-bootstrap types: if that type's class-loader type has not yet been processed then we delay processing the child type until the next batch.  We also only update the visited set once we've processed the whole batch, so we know what has definitely been re-transformed (vs. what will be re-transformed next.)

Finally the check in `AgentBootstrap` to see if the `Agent` class is on the boot-class-path has been changed to query the boot-class-path directly, rather than indirectly via the system class-loader. This avoids a related bootstrapping issue when the custom system class-loader does not initially delegate to the boot-class-path for the `Agent` class.