### PR TITLE
Provide option to use identity hash+equality with DDCache

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/cache/DDCaches.java
+++ b/internal-api/src/main/java/datadog/trace/api/cache/DDCaches.java
@@ -21,6 +21,16 @@ public final class DDCaches {
   }
 
   /**
+   * Specialized fixed-size cache that uses {@link System#identityHashCode} for key hashing and
+   * equality.
+   *
+   * @see #newFixedSizeCache(int)
+   */
+  public static <K, V> DDCache<K, V> newFixedSizeIdentityCache(final int capacity) {
+    return new FixedSizeCache.IdentityHash<>(capacity);
+  }
+
+  /**
    * Specialized fixed-size cache that uses {@link java.util.Arrays} for key hashing and equality.
    *
    * @see #newFixedSizeCache(int)

--- a/internal-api/src/main/java/datadog/trace/api/cache/FixedSizeCache.java
+++ b/internal-api/src/main/java/datadog/trace/api/cache/FixedSizeCache.java
@@ -126,6 +126,20 @@ abstract class FixedSizeCache<K, V> implements DDCache<K, V> {
     }
   }
 
+  static final class IdentityHash<K, V> extends FixedSizeCache<K, V> {
+    IdentityHash(int capacity) {
+      super(capacity);
+    }
+
+    int hash(K key) {
+      return System.identityHashCode(key);
+    }
+
+    boolean equals(K key, Pair<K, V> current) {
+      return key == current.getLeft();
+    }
+  }
+
   static final class ArrayHash<K, V> extends FixedSizeCache<K[], V> {
     ArrayHash(int capacity) {
       super(capacity);

--- a/internal-api/src/test/groovy/datadog/trace/api/cache/FixedSizeCacheTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/cache/FixedSizeCacheTest.groovy
@@ -66,6 +66,35 @@ class FixedSizeCacheTest extends DDSpecification {
     null                                       | null           | 3     // do nothing
   }
 
+  static id1 = new TKey(1, 0, "one")
+  static id6 = new TKey(6, 0, "six")
+  static id10 = new TKey(10, 0, "ten")
+
+  def "identity cache should store and retrieve values"() {
+    setup:
+    def fsCache = DDCaches.newFixedSizeIdentityCache(15)
+    def creationCount = new AtomicInteger(0)
+    def tvc = new TVC(creationCount)
+    // insert some values that happen to be the chain of hashes 1 -> 6 -> 10
+    fsCache.computeIfAbsent(id1, tvc)
+    fsCache.computeIfAbsent(id6, tvc)
+    fsCache.computeIfAbsent(id10, tvc)
+
+    expect:
+    fsCache.computeIfAbsent(tk, tvc) == value
+    creationCount.get() == count
+
+    where:
+    tk                        | value          | count
+    id1                       | "one_value"    | 3     // used the cached id1
+    id6                       | "six_value"    | 3     // used the cached id6
+    id10                      | "ten_value"    | 3     // used the cached id10
+    new TKey(6, 0, "foo")     | "foo_value"    | 4     // create new value for key with different identity
+    new TKey(1, 0, "eleven")  | "eleven_value" | 4     // create new value in an occupied slot
+    new TKey(4, 0, "four")    | "four_value"   | 4     // create new value in empty slot
+    null                      | null           | 3     // do nothing
+  }
+
   def "chm cache should store and retrieve values"() {
     setup:
     def fsCache = DDCaches.newUnboundedCache(15)
@@ -132,7 +161,7 @@ class FixedSizeCacheTest extends DDSpecification {
     ]
   }
 
-  private class TVC implements Function<TKey, String> {
+  private static class TVC implements Function<TKey, String> {
     private final AtomicInteger count
 
     TVC(AtomicInteger count) {
@@ -160,7 +189,7 @@ class FixedSizeCacheTest extends DDSpecification {
     }
   }
 
-  private class TKey {
+  private static class TKey {
     private final int hash
     private final int eq
     private final String string


### PR DESCRIPTION
I need this for an upcoming PR that caches some type-resolver values based on the key's identity.