### PR TITLE
Fix contextual profiling events

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/ContextualEvent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/ContextualEvent.java
@@ -2,29 +2,18 @@ package datadog.trace.bootstrap.instrumentation.jfr;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import jdk.jfr.Event;
-import jdk.jfr.Label;
 
-public class ContextualEvent extends Event {
-  @Label("Local Root Span Id")
-  private long localRootSpanId;
+public interface ContextualEvent {
 
-  @Label("Span Id")
-  private long spanId;
+  void setContext(long localRootSpanId, long spanId);
 
-  void setContext(long localRootSpanId, long spanId) {
-    this.localRootSpanId = localRootSpanId;
-    this.spanId = spanId;
-  }
-
-  public static <T extends ContextualEvent> T captureContext(T event) {
+  default void captureContext() {
     AgentSpan activeSpan = AgentTracer.activeSpan();
     if (activeSpan != null) {
       long spanId = activeSpan.getSpanId();
       AgentSpan rootSpan = activeSpan.getLocalRootSpan();
       long localRootSpanId = rootSpan == null ? spanId : rootSpan.getSpanId();
-      event.setContext(localRootSpanId, spanId);
+      setContext(localRootSpanId, spanId);
     }
-    return event;
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/directallocation/DirectAllocationProfiling.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/directallocation/DirectAllocationProfiling.java
@@ -1,7 +1,6 @@
 package datadog.trace.bootstrap.instrumentation.jfr.directallocation;
 
 import datadog.trace.api.Config;
-import datadog.trace.bootstrap.instrumentation.jfr.ContextualEvent;
 
 public class DirectAllocationProfiling {
 
@@ -40,8 +39,7 @@ public class DirectAllocationProfiling {
       DirectAllocationSource source, Class<?> caller, long bytes) {
     boolean firstHit = histogram.record(caller, source, bytes);
     if (sampler.sample() || firstHit) {
-      return ContextualEvent.captureContext(
-          new DirectAllocationSampleEvent(className(caller), source.name(), bytes));
+      return new DirectAllocationSampleEvent(className(caller), source.name(), bytes);
     }
     return null;
   }

--- a/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/directallocation/DirectAllocationSampleEvent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/directallocation/DirectAllocationSampleEvent.java
@@ -1,7 +1,12 @@
 package datadog.trace.bootstrap.instrumentation.jfr.directallocation;
 
 import datadog.trace.bootstrap.instrumentation.jfr.ContextualEvent;
-import jdk.jfr.*;
+import jdk.jfr.Category;
+import jdk.jfr.DataAmount;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
 
 @Name("datadog.DirectAllocationSample")
 @Label("Direct Allocation")

--- a/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/directallocation/DirectAllocationSampleEvent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/directallocation/DirectAllocationSampleEvent.java
@@ -1,17 +1,13 @@
 package datadog.trace.bootstrap.instrumentation.jfr.directallocation;
 
 import datadog.trace.bootstrap.instrumentation.jfr.ContextualEvent;
-import jdk.jfr.Category;
-import jdk.jfr.DataAmount;
-import jdk.jfr.Description;
-import jdk.jfr.Label;
-import jdk.jfr.Name;
+import jdk.jfr.*;
 
 @Name("datadog.DirectAllocationSample")
 @Label("Direct Allocation")
 @Description("Datadog event corresponding to a direct allocation.")
 @Category("Datadog")
-public class DirectAllocationSampleEvent extends ContextualEvent {
+public class DirectAllocationSampleEvent extends Event implements ContextualEvent {
 
   @Label("Bytes Allocated")
   @DataAmount
@@ -23,9 +19,22 @@ public class DirectAllocationSampleEvent extends ContextualEvent {
   @Label("Allocating Class")
   private final String allocatingClass;
 
+  @Label("Local Root Span Id")
+  private long localRootSpanId;
+
+  @Label("Span Id")
+  private long spanId;
+
   public DirectAllocationSampleEvent(String allocatingClass, String source, long allocated) {
     this.allocatingClass = allocatingClass;
     this.allocated = allocated;
     this.source = source;
+    captureContext();
+  }
+
+  @Override
+  public void setContext(long localRootSpanId, long spanId) {
+    this.localRootSpanId = localRootSpanId;
+    this.spanId = spanId;
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionProfiling.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionProfiling.java
@@ -1,7 +1,6 @@
 package datadog.trace.bootstrap.instrumentation.jfr.exceptions;
 
 import datadog.trace.api.Config;
-import datadog.trace.bootstrap.instrumentation.jfr.ContextualEvent;
 
 /**
  * JVM-wide singleton exception profiling service. Uses {@linkplain Config} class to configure
@@ -41,7 +40,7 @@ public final class ExceptionProfiling {
 
     final boolean sampled = sampler.sample();
     if (firstHit || sampled) {
-      return ContextualEvent.captureContext(new ExceptionSampleEvent(t, sampled, firstHit));
+      return new ExceptionSampleEvent(t, sampled, firstHit);
     }
     return null;
   }

--- a/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionSampleEvent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionSampleEvent.java
@@ -1,7 +1,11 @@
 package datadog.trace.bootstrap.instrumentation.jfr.exceptions;
 
 import datadog.trace.bootstrap.instrumentation.jfr.ContextualEvent;
-import jdk.jfr.*;
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
 
 @Name("datadog.ExceptionSample")
 @Label("ExceptionSample")

--- a/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionSampleEvent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionSampleEvent.java
@@ -1,16 +1,13 @@
 package datadog.trace.bootstrap.instrumentation.jfr.exceptions;
 
 import datadog.trace.bootstrap.instrumentation.jfr.ContextualEvent;
-import jdk.jfr.Category;
-import jdk.jfr.Description;
-import jdk.jfr.Label;
-import jdk.jfr.Name;
+import jdk.jfr.*;
 
 @Name("datadog.ExceptionSample")
 @Label("ExceptionSample")
 @Description("Datadog exception sample event.")
 @Category("Datadog")
-public class ExceptionSampleEvent extends ContextualEvent {
+public class ExceptionSampleEvent extends Event implements ContextualEvent {
   @Label("Exception Type")
   private final String type;
 
@@ -27,6 +24,12 @@ public class ExceptionSampleEvent extends ContextualEvent {
   @Label("First occurrence")
   private final boolean firstOccurrence;
 
+  @Label("Local Root Span Id")
+  private long localRootSpanId;
+
+  @Label("Span Id")
+  private long spanId;
+
   public ExceptionSampleEvent(Throwable e, boolean sampled, boolean firstOccurrence) {
     /*
      * TODO: we should have some tests for this class.
@@ -39,6 +42,7 @@ public class ExceptionSampleEvent extends ContextualEvent {
     this.stackDepth = getStackDepth(e);
     this.sampled = sampled;
     this.firstOccurrence = firstOccurrence;
+    captureContext();
   }
 
   private static String getMessage(Throwable t) {
@@ -57,5 +61,11 @@ public class ExceptionSampleEvent extends ContextualEvent {
       // be defensive about exceptions choking on a call to getStackTrace()
     }
     return 0;
+  }
+
+  @Override
+  public void setContext(long localRootSpanId, long spanId) {
+    this.localRootSpanId = localRootSpanId;
+    this.spanId = spanId;
   }
 }


### PR DESCRIPTION
# What Does This Do

Puts the context fields back on the exception sample events and makes sure they are present on direct allocation samples. This was broken by #4283 

# Motivation

# Additional Notes
