### PR TITLE
Implement log probe instrumentation

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
@@ -182,7 +182,7 @@ public class Snapshot {
       return;
     }
     // only rate limit if a condition is defined
-    if (probe.getScript() != null) {
+    if (probe.getScript() != null && probe.isSnapshotProbe()) {
       if (!ProbeRateLimiter.tryProbe(probe.id)) {
         DebuggerContext.skipSnapshot(probe.id, DebuggerContext.SkipCause.RATE);
         return;
@@ -346,6 +346,10 @@ public class Snapshot {
 
     public String getTags() {
       return tags;
+    }
+
+    public boolean isSnapshotProbe() {
+      return summaryBuilder instanceof SnapshotSummaryBuilder;
     }
 
     @Override

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/SnapshotProvider.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/SnapshotProvider.java
@@ -17,7 +17,7 @@ public final class SnapshotProvider {
       probeDetails = Snapshot.ProbeDetails.UNKNOWN;
     }
     // only rate limit if no condition are defined
-    if (probeDetails.getScript() == null) {
+    if (probeDetails.getScript() == null && probeDetails.isSnapshotProbe()) {
       if (!ProbeRateLimiter.tryProbe(probeDetails.getId())) {
         DebuggerContext.skipSnapshot(probeDetails.getId(), DebuggerContext.SkipCause.RATE);
         return null;

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/SnapshotSummaryBuilder.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/SnapshotSummaryBuilder.java
@@ -12,17 +12,18 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 /** Helper class for generating snapshot summaries */
-public class SnapshotSummaryBuilder {
-  private final Snapshot.ProbeDetails probe;
+public class SnapshotSummaryBuilder implements SummaryBuilder {
+  private final ProbeLocation probeLocation;
   private String arguments;
   private String method;
   private String returnValue;
   private String locals;
 
-  public SnapshotSummaryBuilder(Snapshot.ProbeDetails probe) {
-    this.probe = probe;
+  public SnapshotSummaryBuilder(ProbeLocation probeLocation) {
+    this.probeLocation = probeLocation;
   }
 
+  @Override
   public void addEntry(Snapshot.CapturedContext entry) {
     if (entry == null) {
       return;
@@ -32,6 +33,7 @@ public class SnapshotSummaryBuilder {
     }
   }
 
+  @Override
   public void addExit(Snapshot.CapturedContext exit) {
     if (exit == null) {
       return;
@@ -46,6 +48,7 @@ public class SnapshotSummaryBuilder {
     }
   }
 
+  @Override
   public void addLine(Snapshot.CapturedContext line) {
     if (line == null) {
       return;
@@ -58,14 +61,16 @@ public class SnapshotSummaryBuilder {
     }
   }
 
+  @Override
   public void addStack(List<CapturedStackFrame> stack) {
-    method = formatMethod(stack, probe.getLocation());
+    method = formatMethod(stack, probeLocation);
   }
 
+  @Override
   public String build() {
     StringBuilder sb = new StringBuilder();
     if (method == null) {
-      method = formatMethod(probe.getLocation());
+      method = formatMethod(probeLocation);
     }
     sb.append(method);
     sb.append("(");

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/SummaryBuilder.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/SummaryBuilder.java
@@ -1,0 +1,15 @@
+package datadog.trace.bootstrap.debugger;
+
+import java.util.List;
+
+public interface SummaryBuilder {
+  void addEntry(Snapshot.CapturedContext entry);
+
+  void addExit(Snapshot.CapturedContext exit);
+
+  void addLine(Snapshot.CapturedContext line);
+
+  void addStack(List<CapturedStackFrame> stack);
+
+  String build();
+}

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/test/java/datadog/trace/bootstrap/debugger/SnapshotSummaryTest.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/test/java/datadog/trace/bootstrap/debugger/SnapshotSummaryTest.java
@@ -18,9 +18,7 @@ import org.junit.jupiter.api.Test;
 public class SnapshotSummaryTest {
   private static final String CLASS_NAME = "com.datadog.debugger.SomeClass";
   private static final ProbeLocation PROBE_LOCATION =
-      new ProbeLocation(CLASS_NAME, "someMethod", null, null);
-  private static final ProbeDetails PROBE_DETAILS =
-      new ProbeDetails(UUID.randomUUID().toString(), PROBE_LOCATION);
+      new ProbeLocation(CLASS_NAME, "someMethod", null, null);;
 
   @BeforeAll
   public static void staticSetup() {
@@ -29,13 +27,21 @@ public class SnapshotSummaryTest {
 
   @Test
   public void testSummaryEmptySnapshot() {
-    Snapshot snapshot = new Snapshot(Thread.currentThread(), PROBE_DETAILS, CLASS_NAME);
+    Snapshot snapshot =
+        new Snapshot(
+            Thread.currentThread(),
+            new ProbeDetails(UUID.randomUUID().toString(), PROBE_LOCATION),
+            CLASS_NAME);
     assertEquals("SomeClass.someMethod()", snapshot.getSummary());
   }
 
   @Test
   public void testSummaryEntryExitSnapshot() {
-    Snapshot snapshot = new Snapshot(Thread.currentThread(), PROBE_DETAILS, CLASS_NAME);
+    Snapshot snapshot =
+        new Snapshot(
+            Thread.currentThread(),
+            new ProbeDetails(UUID.randomUUID().toString(), PROBE_LOCATION),
+            CLASS_NAME);
     CapturedContext entry = new CapturedContext();
     HashMap<String, String> argMap = new HashMap<>();
     argMap.put("foo", "bar");
@@ -61,7 +67,11 @@ public class SnapshotSummaryTest {
 
   @Test
   public void testSummaryEntryExitSnapshotWithLocalVars() {
-    Snapshot snapshot = new Snapshot(Thread.currentThread(), PROBE_DETAILS, CLASS_NAME);
+    Snapshot snapshot =
+        new Snapshot(
+            Thread.currentThread(),
+            new ProbeDetails(UUID.randomUUID().toString(), PROBE_LOCATION),
+            CLASS_NAME);
     CapturedContext entry = new CapturedContext();
     entry.addArguments(
         new Snapshot.CapturedValue[] {
@@ -91,7 +101,11 @@ public class SnapshotSummaryTest {
 
   @Test
   public void testSummaryLineSnapshot() {
-    Snapshot snapshot = new Snapshot(Thread.currentThread(), PROBE_DETAILS, CLASS_NAME);
+    Snapshot snapshot =
+        new Snapshot(
+            Thread.currentThread(),
+            new ProbeDetails(UUID.randomUUID().toString(), PROBE_LOCATION),
+            CLASS_NAME);
     StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
     // top frame is actually getStackTrace, we want the test method
     StackTraceElement topFrame = stackTrace[1];
@@ -125,11 +139,11 @@ public class SnapshotSummaryTest {
 
   @Test
   public void testUnexpectedStackFrameFormat() {
-    SnapshotSummaryBuilder snapshotSummaryBuilder = new SnapshotSummaryBuilder(PROBE_DETAILS);
+    SnapshotSummaryBuilder snapshotSummaryBuilder = new SnapshotSummaryBuilder(PROBE_LOCATION);
     snapshotSummaryBuilder.addStack(Arrays.asList(new CapturedStackFrame("foobar", 123)));
     assertEquals("foobar()", snapshotSummaryBuilder.build());
 
-    SnapshotSummaryBuilder snapshotSummaryBuilder2 = new SnapshotSummaryBuilder(PROBE_DETAILS);
+    SnapshotSummaryBuilder snapshotSummaryBuilder2 = new SnapshotSummaryBuilder(PROBE_LOCATION);
     snapshotSummaryBuilder2.addStack(Arrays.asList(new CapturedStackFrame("foobar()", 123)));
     assertEquals("foobar()", snapshotSummaryBuilder2.build());
   }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/ValueScript.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/ValueScript.java
@@ -72,14 +72,21 @@ public class ValueScript implements DebuggerScript {
   public static class ValueScriptAdapter extends JsonAdapter<ValueScript> {
     @Override
     public ValueScript fromJson(JsonReader jsonReader) throws IOException {
-      jsonReader.beginObject();
-      String fieldName = jsonReader.nextName();
-      if (fieldName.equals("expr")) {
+      if (jsonReader.peek() == JsonReader.Token.BEGIN_OBJECT) {
+        jsonReader.beginObject();
+        String fieldName = jsonReader.nextName();
+        if (fieldName.equals("expr")) {
+          Object obj = jsonReader.readJsonValue();
+          jsonReader.endObject();
+          return new ValueScript(obj);
+        } else {
+          throw new IOException("Invalid field: " + fieldName);
+        }
+      } else if (jsonReader.peek() == JsonReader.Token.STRING) {
         Object obj = jsonReader.readJsonValue();
-        jsonReader.endObject();
         return new ValueScript(obj);
       } else {
-        throw new IOException("Invalid field: " + fieldName);
+        throw new IOException("Invalid ValueScript format");
       }
     }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/LogMessageTemplateSummaryBuilder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/LogMessageTemplateSummaryBuilder.java
@@ -1,0 +1,56 @@
+package com.datadog.debugger.agent;
+
+import com.datadog.debugger.el.ValueScript;
+import com.datadog.debugger.probe.LogProbe;
+import datadog.trace.bootstrap.debugger.CapturedStackFrame;
+import datadog.trace.bootstrap.debugger.Snapshot;
+import datadog.trace.bootstrap.debugger.SummaryBuilder;
+import java.util.List;
+
+public class LogMessageTemplateSummaryBuilder implements SummaryBuilder {
+  private final LogProbe logProbe;
+
+  public LogMessageTemplateSummaryBuilder(LogProbe logProbe) {
+    this.logProbe = logProbe;
+  }
+
+  @Override
+  public void addEntry(Snapshot.CapturedContext entry) {
+    executeExpressions(entry);
+  }
+
+  private void executeExpressions(Snapshot.CapturedContext entry) {
+    for (LogProbe.Segment segment : logProbe.getSegments()) {
+      ValueScript parsedExr = segment.getParsedExpr();
+      if (parsedExr != null) {
+        parsedExr.execute(entry);
+      }
+    }
+  }
+
+  @Override
+  public void addExit(Snapshot.CapturedContext exit) {
+    executeExpressions(exit);
+  }
+
+  @Override
+  public void addLine(Snapshot.CapturedContext line) {
+    executeExpressions(line);
+  }
+
+  @Override
+  public void addStack(List<CapturedStackFrame> stack) {}
+
+  @Override
+  public String build() {
+    StringBuilder sb = new StringBuilder();
+    for (LogProbe.Segment segment : logProbe.getSegments()) {
+      if (segment.getStr() != null) {
+        sb.append(segment.getStr());
+      } else {
+        sb.append(segment.getParsedExpr().getResult().getValue());
+      }
+    }
+    return sb.toString();
+  }
+}

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/LogMessageTemplateSummaryBuilder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/LogMessageTemplateSummaryBuilder.java
@@ -19,15 +19,6 @@ public class LogMessageTemplateSummaryBuilder implements SummaryBuilder {
     executeExpressions(entry);
   }
 
-  private void executeExpressions(Snapshot.CapturedContext entry) {
-    for (LogProbe.Segment segment : logProbe.getSegments()) {
-      ValueScript parsedExr = segment.getParsedExpr();
-      if (parsedExr != null) {
-        parsedExr.execute(entry);
-      }
-    }
-  }
-
   @Override
   public void addExit(Snapshot.CapturedContext exit) {
     executeExpressions(exit);
@@ -52,5 +43,14 @@ public class LogMessageTemplateSummaryBuilder implements SummaryBuilder {
       }
     }
     return sb.toString();
+  }
+
+  private void executeExpressions(Snapshot.CapturedContext entry) {
+    for (LogProbe.Segment segment : logProbe.getSegments()) {
+      ValueScript parsedExr = segment.getParsedExpr();
+      if (parsedExr != null) {
+        parsedExr.execute(entry);
+      }
+    }
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
@@ -24,6 +24,7 @@ import org.objectweb.asm.tree.MethodNode;
 public class Instrumentor {
   protected static final String CONSTRUCTOR_NAME = "<init>";
 
+  protected final ProbeDefinition definition;
   protected final ClassLoader classLoader;
   protected final ClassNode classNode;
   protected final MethodNode methodNode;
@@ -33,7 +34,7 @@ public class Instrumentor {
   protected final LineMap lineMap = new LineMap();
   protected final LabelNode methodEnterLabel;
   protected int localVarBaseOffset;
-  protected int argOffset = 0;
+  protected int argOffset;
   protected final String[] argumentNames;
 
   public Instrumentor(
@@ -42,6 +43,7 @@ public class Instrumentor {
       ClassNode classNode,
       MethodNode methodNode,
       List<DiagnosticMessage> diagnostics) {
+    this.definition = definition;
     this.classLoader = classLoader;
     this.classNode = classNode;
     this.methodNode = methodNode;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/SnapshotInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/SnapshotInstrumentor.java
@@ -42,7 +42,7 @@ import org.objectweb.asm.tree.VarInsnNode;
 /** Handles generating instrumentation for snapshot method & line probes */
 public final class SnapshotInstrumentor extends Instrumentor {
   private final SnapshotProbe.Capture capture;
-  private final LogProbe logProbe;
+  private final boolean captureFullState;
   private final LabelNode snapshotInitLabel = new LabelNode();
   private int snapshotVar = -1;
   private LabelNode returnHandlerLabel = null;
@@ -55,7 +55,7 @@ public final class SnapshotInstrumentor extends Instrumentor {
       List<DiagnosticMessage> diagnostics) {
     super(snapshotProbe, classLoader, classNode, methodNode, diagnostics);
     this.capture = snapshotProbe.getCapture();
-    this.logProbe = null;
+    captureFullState = true;
   }
 
   public SnapshotInstrumentor(
@@ -66,7 +66,7 @@ public final class SnapshotInstrumentor extends Instrumentor {
       List<DiagnosticMessage> diagnostics) {
     super(logProbe, classLoader, classNode, methodNode, diagnostics);
     this.capture = null;
-    this.logProbe = logProbe;
+    this.captureFullState = false;
   }
 
   public void instrument() {
@@ -208,7 +208,7 @@ public final class SnapshotInstrumentor extends Instrumentor {
   }
 
   private void instrumentTryCatchHandlers() {
-    if (logProbe != null) {
+    if (!captureFullState) {
       // do not instrument try/catch for log probe
       return;
     }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -2,6 +2,7 @@ package com.datadog.debugger.probe;
 
 import com.datadog.debugger.agent.Generated;
 import com.datadog.debugger.el.ValueScript;
+import com.datadog.debugger.instrumentation.SnapshotInstrumentor;
 import datadog.trace.bootstrap.debugger.DiagnosticMessage;
 import datadog.trace.util.Strings;
 import java.util.ArrayList;
@@ -19,18 +20,18 @@ public class LogProbe extends ProbeDefinition {
   public static class Segment {
     private final String str;
     private final String expr;
-    private final ValueScript parsedExr;
+    private final ValueScript parsedExpr;
 
     public Segment(String str) {
       this.str = str;
       this.expr = null;
-      this.parsedExr = null;
+      this.parsedExpr = null;
     }
 
     public Segment(String expr, ValueScript valueScript) {
       this.str = null;
       this.expr = expr;
-      this.parsedExr = valueScript;
+      this.parsedExpr = valueScript;
     }
 
     public String getStr() {
@@ -41,8 +42,8 @@ public class LogProbe extends ProbeDefinition {
       return expr;
     }
 
-    public ValueScript getParsedExr() {
-      return parsedExr;
+    public ValueScript getParsedExpr() {
+      return parsedExpr;
     }
 
     @Generated
@@ -53,13 +54,13 @@ public class LogProbe extends ProbeDefinition {
       Segment segment = (Segment) o;
       return Objects.equals(str, segment.str)
           && Objects.equals(expr, segment.expr)
-          && Objects.equals(parsedExr, segment.parsedExr);
+          && Objects.equals(parsedExpr, segment.parsedExpr);
     }
 
     @Generated
     @Override
     public int hashCode() {
-      return Objects.hash(str, expr, parsedExr);
+      return Objects.hash(str, expr, parsedExpr);
     }
 
     @Generated
@@ -73,13 +74,19 @@ public class LogProbe extends ProbeDefinition {
           + expr
           + '\''
           + ", parsedExr="
-          + parsedExr
+          + parsedExpr
           + '}';
     }
   }
 
   private final String template;
   private final List<Segment> segments;
+
+  // no-arg constructor is required by Moshi to avoid creating instance with unsafe and by-passing
+  // constructors, including field initializers.
+  public LogProbe() {
+    this(LANGUAGE, null, true, null, null, null, new ArrayList<>());
+  }
 
   public LogProbe(
       String language,
@@ -107,7 +114,9 @@ public class LogProbe extends ProbeDefinition {
       ClassLoader classLoader,
       ClassNode classNode,
       MethodNode methodNode,
-      List<DiagnosticMessage> diagnostics) {}
+      List<DiagnosticMessage> diagnostics) {
+    new SnapshotInstrumentor(this, classLoader, classNode, methodNode, diagnostics).instrument();
+  }
 
   @Generated
   @Override

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SnapshotProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SnapshotProbe.java
@@ -2,7 +2,7 @@ package com.datadog.debugger.probe;
 
 import com.datadog.debugger.agent.Generated;
 import com.datadog.debugger.el.ProbeCondition;
-import com.datadog.debugger.instrumentation.MethodProbeInstrumentor;
+import com.datadog.debugger.instrumentation.SnapshotInstrumentor;
 import com.squareup.moshi.Json;
 import datadog.trace.bootstrap.debugger.DiagnosticMessage;
 import datadog.trace.bootstrap.debugger.Limits;
@@ -150,7 +150,7 @@ public class SnapshotProbe extends ProbeDefinition {
       ClassNode classNode,
       MethodNode methodNode,
       List<DiagnosticMessage> diagnostics) {
-    new MethodProbeInstrumentor(this, classLoader, classNode, methodNode, diagnostics).instrument();
+    new SnapshotInstrumentor(this, classLoader, classNode, methodNode, diagnostics).instrument();
   }
 
   public static class Builder {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -27,6 +27,7 @@ import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.debugger.Limits;
 import datadog.trace.bootstrap.debugger.ProbeRateLimiter;
 import datadog.trace.bootstrap.debugger.Snapshot;
+import datadog.trace.bootstrap.debugger.SnapshotSummaryBuilder;
 import datadog.trace.bootstrap.debugger.el.ValueReferences;
 import groovy.lang.GroovyClassLoader;
 import java.io.File;
@@ -1252,6 +1253,7 @@ public class CapturedSnapshotTest {
             location,
             probe.getProbeCondition(),
             probe.concatTags(),
+            new SnapshotSummaryBuilder(location),
             probe.getAdditionalProbes().stream()
                 .map(
                     (ProbeDefinition relatedProbe) ->
@@ -1259,7 +1261,8 @@ public class CapturedSnapshotTest {
                             relatedProbe.getId(),
                             location,
                             ((SnapshotProbe) relatedProbe).getProbeCondition(),
-                            ((SnapshotProbe) relatedProbe).concatTags()))
+                            relatedProbe.concatTags(),
+                            new SnapshotSummaryBuilder(location)))
                 .collect(Collectors.toList()));
       }
     }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
@@ -88,12 +88,14 @@ public class DebuggerTransformerTest {
 
   static class TestSnapshotListener implements DebuggerContext.Sink {
     boolean skipped;
+    DebuggerContext.SkipCause cause;
     List<Snapshot> snapshots = new ArrayList<>();
     Map<String, List<DiagnosticMessage>> errors = new HashMap<>();
 
     @Override
     public void skipSnapshot(String probeId, DebuggerContext.SkipCause cause) {
       skipped = true;
+      this.cause = cause;
     }
 
     @Override

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -1,0 +1,267 @@
+package com.datadog.debugger.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static utils.InstrumentationTestHelper.compileAndLoadClass;
+
+import com.datadog.debugger.instrumentation.InstrumentationResult;
+import com.datadog.debugger.probe.LogProbe;
+import com.datadog.debugger.probe.ProbeDefinition;
+import com.datadog.debugger.probe.SnapshotProbe;
+import com.datadog.debugger.probe.Where;
+import datadog.trace.api.Config;
+import datadog.trace.bootstrap.debugger.DebuggerContext;
+import datadog.trace.bootstrap.debugger.Snapshot;
+import datadog.trace.bootstrap.debugger.SnapshotSummaryBuilder;
+import java.io.IOException;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.Instrumentation;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import net.bytebuddy.agent.ByteBuddyAgent;
+import org.joor.Reflect;
+import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class LogProbesInstrumentationTest {
+  private static final String LANGUAGE = "java";
+  private static final String LOG_ID = "beae1807-f3b0-4ea8-a74f-826790c5e6f8";
+  private static final String LOG_ID1 = "beae1807-f3b0-4ea8-a74f-826790c5e6f6";
+  private static final String LOG_ID2 = "beae1807-f3b0-4ea8-a74f-826790c5e6f7";
+  private static final long ORG_ID = 2;
+  private static final String SERVICE_NAME = "service-name";
+
+  private Instrumentation instr = ByteBuddyAgent.install();
+  private ClassFileTransformer currentTransformer;
+
+  @AfterEach
+  public void after() {
+    if (currentTransformer != null) {
+      instr.removeTransformer(currentTransformer);
+    }
+  }
+
+  @Test
+  public void methodPlainLog() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot01";
+    DebuggerTransformerTest.TestSnapshotListener listener =
+        installSingleProbe("this is log line", CLASS_NAME, "main", "int (java.lang.String)");
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "1").get();
+    Assert.assertEquals(3, result);
+    Snapshot snapshot = assertOneSnapshot(listener);
+    assertEquals("this is log line", snapshot.getSummary());
+  }
+
+  @Test
+  public void methodTemplateArgLog() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot01";
+    DebuggerTransformerTest.TestSnapshotListener listener =
+        installSingleProbe(
+            "this is log line with arg={^arg}", CLASS_NAME, "main", "int (java.lang.String)");
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "1").get();
+    Assert.assertEquals(3, result);
+    Snapshot snapshot = assertOneSnapshot(listener);
+    assertEquals("this is log line with arg=1", snapshot.getSummary());
+  }
+
+  @Test
+  public void linePlainLog() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot01";
+    DebuggerTransformerTest.TestSnapshotListener listener =
+        installSingleProbe("this is log line", CLASS_NAME, "main", "int (java.lang.String)", "9");
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "1").get();
+    Assert.assertEquals(3, result);
+    Snapshot snapshot = assertOneSnapshot(listener);
+    assertEquals("this is log line", snapshot.getSummary());
+  }
+
+  @Test
+  public void lineTemplateVarLog() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot01";
+    DebuggerTransformerTest.TestSnapshotListener listener =
+        installSingleProbe(
+            "this is log line with local var={#var1}",
+            CLASS_NAME,
+            "main",
+            "int (java.lang.String)",
+            "9");
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "1").get();
+    Assert.assertEquals(3, result);
+    Snapshot snapshot = assertOneSnapshot(listener);
+    assertEquals("this is log line with local var=3", snapshot.getSummary());
+  }
+
+  @Test
+  public void lineTemplateMultipleVarLog() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot04";
+    DebuggerTransformerTest.TestSnapshotListener listener =
+        installSingleProbe(
+            "nullObject={#nullObject} sdata={#sdata.strValue} cdata={#cdata.s1.intValue}",
+            CLASS_NAME,
+            "main",
+            "int (java.lang.String)",
+            "25");
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "1").get();
+    Assert.assertEquals(143, result);
+    Snapshot snapshot = assertOneSnapshot(listener);
+    assertEquals("nullObject=NULL sdata=foo cdata=101", snapshot.getSummary());
+  }
+
+  @Test
+  public void lineTemplateEscapeLog() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot01";
+    DebuggerTransformerTest.TestSnapshotListener listener =
+        installSingleProbe(
+            "this is log line with {{curly braces}} and with local var={{{#var1}}}",
+            CLASS_NAME,
+            "main",
+            "int (java.lang.String)",
+            "9");
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "1").get();
+    Assert.assertEquals(3, result);
+    Snapshot snapshot = assertOneSnapshot(listener);
+    assertEquals(
+        "this is log line with {curly braces} and with local var={3}", snapshot.getSummary());
+  }
+
+  @Test
+  public void lineTemplateInvalidVarLog() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot01";
+    DebuggerTransformerTest.TestSnapshotListener listener =
+        installSingleProbe(
+            "this is log line with local var={#var42}",
+            CLASS_NAME,
+            "main",
+            "int (java.lang.String)",
+            "9");
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "1").get();
+    Assert.assertEquals(3, result);
+    Snapshot snapshot = assertOneSnapshot(listener);
+    assertEquals("this is log line with local var=UNDEFINED", snapshot.getSummary());
+    // TODO assert on eval errors from snapshot
+  }
+
+  private DebuggerTransformerTest.TestSnapshotListener installSingleProbe(
+      String template, String typeName, String methodName, String signature, String... lines) {
+    LogProbe logProbe = createProbe(LOG_ID, template, typeName, methodName, signature, lines);
+    return installProbes(
+        typeName, new Configuration(SERVICE_NAME, ORG_ID, null, null, Arrays.asList(logProbe)));
+  }
+
+  private static LogProbe createProbe(
+      String id,
+      String template,
+      String typeName,
+      String methodName,
+      String signature,
+      String... lines) {
+    return LogProbe.builder()
+        .language(LANGUAGE)
+        .logId(id)
+        .active(true)
+        .where(typeName, methodName, signature, lines)
+        .template(template)
+        .build();
+  }
+
+  private DebuggerTransformerTest.TestSnapshotListener installProbes(
+      String expectedClassName, Configuration configuration) {
+    Config config = mock(Config.class);
+    when(config.isDebuggerEnabled()).thenReturn(true);
+    when(config.isDebuggerClassFileDumpEnabled()).thenReturn(true);
+    when(config.isDebuggerVerifyByteCode()).thenReturn(true);
+    Map<String, InstrumentationResult> instrumentationResults = new ConcurrentHashMap<>();
+    currentTransformer =
+        new DebuggerTransformer(
+            config,
+            configuration,
+            (definition, result) -> instrumentationResults.put(definition.getId(), result));
+    instr.addTransformer(currentTransformer);
+    DebuggerTransformerTest.TestSnapshotListener listener =
+        new DebuggerTransformerTest.TestSnapshotListener();
+    DebuggerContext.init(
+        listener,
+        (id, callingClass) ->
+            resolver(
+                id,
+                callingClass,
+                expectedClassName,
+                configuration.getLogProbes(),
+                instrumentationResults),
+        null);
+    DebuggerContext.initClassFilter(new DenyListHelper(null));
+    DebuggerContext.initSnapshotSerializer(new JsonSnapshotSerializer());
+    return listener;
+  }
+
+  private Snapshot.ProbeDetails resolver(
+      String id,
+      Class<?> callingClass,
+      String expectedClassName,
+      Collection<LogProbe> logProbes,
+      Map<String, InstrumentationResult> instrumentationResults) {
+    Assert.assertEquals(expectedClassName, callingClass.getName());
+    for (LogProbe probe : logProbes) {
+      if (probe.getId().equals(id)) {
+        String typeName = probe.getWhere().getTypeName();
+        String methodName = probe.getWhere().getMethodName();
+        String sourceFile = probe.getWhere().getSourceFile();
+        InstrumentationResult result = instrumentationResults.get(probe.getId());
+        if (result != null) {
+          typeName = result.getTypeName();
+          methodName = result.getMethodName();
+        }
+        List<String> lines =
+            Arrays.stream(probe.getWhere().getSourceLines())
+                .map(Where.SourceLine::toString)
+                .collect(Collectors.toList());
+
+        Snapshot.ProbeLocation location =
+            new Snapshot.ProbeLocation(typeName, methodName, sourceFile, lines);
+
+        return new Snapshot.ProbeDetails(
+            id,
+            location,
+            null,
+            probe.concatTags(),
+            new LogMessageTemplateSummaryBuilder(probe),
+            probe.getAdditionalProbes().stream()
+                .map(
+                    (ProbeDefinition relatedProbe) ->
+                        new Snapshot.ProbeDetails(
+                            relatedProbe.getId(),
+                            location,
+                            relatedProbe instanceof SnapshotProbe
+                                ? ((SnapshotProbe) relatedProbe).getProbeCondition()
+                                : null,
+                            relatedProbe.concatTags(),
+                            relatedProbe instanceof SnapshotProbe
+                                ? new SnapshotSummaryBuilder(location)
+                                : new LogMessageTemplateSummaryBuilder((LogProbe) relatedProbe)))
+                .collect(Collectors.toList()));
+      }
+    }
+    return null;
+  }
+
+  private Snapshot assertOneSnapshot(DebuggerTransformerTest.TestSnapshotListener listener) {
+    Assert.assertEquals(1, listener.snapshots.size());
+    Snapshot snapshot = listener.snapshots.get(0);
+    Assert.assertEquals(LOG_ID, snapshot.getProbe().getId());
+    return snapshot;
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -89,12 +89,7 @@ public class LogProbesInstrumentationTest {
   public void lineTemplateVarLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
     DebuggerTransformerTest.TestSnapshotListener listener =
-        installSingleProbe(
-            "this is log line with local var={#var1}",
-            CLASS_NAME,
-            null,
-            null,
-            "9");
+        installSingleProbe("this is log line with local var={#var1}", CLASS_NAME, null, null, "9");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     Assert.assertEquals(3, result);
@@ -141,12 +136,7 @@ public class LogProbesInstrumentationTest {
   public void lineTemplateInvalidVarLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
     DebuggerTransformerTest.TestSnapshotListener listener =
-        installSingleProbe(
-            "this is log line with local var={#var42}",
-            CLASS_NAME,
-            null,
-            null,
-            "9");
+        installSingleProbe("this is log line with local var={#var42}", CLASS_NAME, null, null, "9");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     Assert.assertEquals(3, result);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -77,7 +77,7 @@ public class LogProbesInstrumentationTest {
   public void linePlainLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
     DebuggerTransformerTest.TestSnapshotListener listener =
-        installSingleProbe("this is log line", CLASS_NAME, "main", "int (java.lang.String)", "9");
+        installSingleProbe("this is log line", CLASS_NAME, null, null, "9");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     Assert.assertEquals(3, result);
@@ -92,8 +92,8 @@ public class LogProbesInstrumentationTest {
         installSingleProbe(
             "this is log line with local var={#var1}",
             CLASS_NAME,
-            "main",
-            "int (java.lang.String)",
+            null,
+            null,
             "9");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
@@ -109,8 +109,8 @@ public class LogProbesInstrumentationTest {
         installSingleProbe(
             "nullObject={#nullObject} sdata={#sdata.strValue} cdata={#cdata.s1.intValue}",
             CLASS_NAME,
-            "main",
-            "int (java.lang.String)",
+            null,
+            null,
             "25");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
@@ -126,8 +126,8 @@ public class LogProbesInstrumentationTest {
         installSingleProbe(
             "this is log line with {{curly braces}} and with local var={{{#var1}}}",
             CLASS_NAME,
-            "main",
-            "int (java.lang.String)",
+            null,
+            null,
             "9");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
@@ -144,8 +144,8 @@ public class LogProbesInstrumentationTest {
         installSingleProbe(
             "this is log line with local var={#var42}",
             CLASS_NAME,
-            "main",
-            "int (java.lang.String)",
+            null,
+            null,
             "9");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
@@ -259,6 +259,7 @@ public class LogProbesInstrumentationTest {
   }
 
   private Snapshot assertOneSnapshot(DebuggerTransformerTest.TestSnapshotListener listener) {
+    Assert.assertFalse("Snapshot skipped because " + listener.cause, listener.skipped);
     Assert.assertEquals(1, listener.snapshots.size());
     Snapshot snapshot = listener.snapshots.get(0);
     Assert.assertEquals(LOG_ID, snapshot.getProbe().getId());

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
@@ -29,7 +29,7 @@ import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
-public class ProbeMetricsOnDemandTest {
+public class MetricProbesInstrumentationTest {
   private static final String LANGUAGE = "java";
   private static final String METRIC_ID = "beae1807-f3b0-4ea8-a74f-826790c5e6f8";
   private static final String METRIC_ID1 = "beae1807-f3b0-4ea8-a74f-826790c5e6f6";

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
@@ -18,7 +18,7 @@ public class LogProbeTest {
     assertEquals(1, logProbe.getSegments().size());
     assertEquals("plain log line", logProbe.getSegments().get(0).getStr());
     assertNull(logProbe.getSegments().get(0).getExpr());
-    assertNull(logProbe.getSegments().get(0).getParsedExr());
+    assertNull(logProbe.getSegments().get(0).getParsedExpr());
     logProbe = createLog().template("simple template log line {arg}").build();
     assertEquals("simple template log line {arg}", logProbe.getTemplate());
     assertEquals(2, logProbe.getSegments().size());


### PR DESCRIPTION
# What Does This Do
Reuse snapshot instrumentation but with custom summary builder allowing to generate a message as log.
Variables are resolved reusing ValueScript class.

# Motivation
generate log line for log probes

# Additional Notes
Right now, logs will generate the same data than regular snapshots, but we will remove that later to just the data required for filling the template variable.
Error during evaluation will be also reported  in the snapshot in a later PR
