### PR TITLE
Limit Spring AMQP versions to avoid Spring 6 that requires Java 17

### DIFF
--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/build.gradle
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/build.gradle
@@ -27,7 +27,7 @@ dependencies {
   testImplementation group: 'org.testcontainers', name: 'rabbitmq', version: versions.testcontainers
 
   latestDepTestImplementation group: 'com.rabbitmq', name: 'amqp-client', version: '+'
-  latestDepTestImplementation group: 'org.springframework.amqp', name: 'spring-rabbit', version: '+'
+  latestDepTestImplementation group: 'org.springframework.amqp', name: 'spring-rabbit', version: '2.+'
 }
 
 configurations.testRuntimeClasspath {

--- a/dd-java-agent/instrumentation/spring-rabbit/build.gradle
+++ b/dd-java-agent/instrumentation/spring-rabbit/build.gradle
@@ -6,7 +6,7 @@ muzzle {
   pass {
     group = 'org.springframework.boot'
     module = 'spring-boot-starter-amqp'
-    versions = '[1.5.0.RELEASE,]'
+    versions = '[1.5.0.RELEASE,3)'
     extraDependency 'com.rabbitmq:amqp-client:2.7.0'
   }
 }
@@ -31,7 +31,7 @@ dependencies {
   testImplementation group: 'org.testcontainers', name: 'rabbitmq', version: versions.testcontainers
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-amqp', version: '2.4.0'
 
-  latestDepTestImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-amqp', version: '+'
+  latestDepTestImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-amqp', version: '2.+'
 }
 
 tasks.withType(Test).configureEach {


### PR DESCRIPTION
# What Does This Do

# Motivation

# Additional Notes
