### PR TITLE
jetty11: fix servletpath and context path instrumentations

### DIFF
--- a/dd-java-agent/instrumentation/jetty-11/build.gradle
+++ b/dd-java-agent/instrumentation/jetty-11/build.gradle
@@ -54,6 +54,9 @@ dependencies {
   testImplementation ("org.eclipse.jetty:jetty-server:11.0.0") {
     exclude group: 'org.slf4j', module: 'slf4j-api'
   }
+  testImplementation ("org.eclipse.jetty:jetty-servlet:11.0.0") {
+    exclude group: 'org.slf4j', module: 'slf4j-api'
+  }
   testImplementation(project(':dd-java-agent:instrumentation:jetty-appsec-9.3'))
 
   //latestDepTestImplementation group: 'org.eclipse.jetty', name: 'jetty-server', version: '11.+'

--- a/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/SetContextPathAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/SetContextPathAdvice.java
@@ -1,9 +1,11 @@
 package datadog.trace.instrumentation.jetty11;
 
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.SERVLET_CONTEXT;
+import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.SERVLET_PATH;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_DISPATCH_SPAN_ATTRIBUTE;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
 import static datadog.trace.instrumentation.jetty11.JettyDecorator.DD_CONTEXT_PATH_ATTRIBUTE;
+import static datadog.trace.instrumentation.jetty11.JettyDecorator.DD_SERVLET_PATH_ATTRIBUTE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import net.bytebuddy.asm.Advice;
@@ -24,8 +26,19 @@ public class SetContextPathAdvice {
       Object span = req.getAttribute(DD_SPAN_ATTRIBUTE);
       // Don't want to update while being dispatched to new servlet
       if (span instanceof AgentSpan && req.getAttribute(DD_DISPATCH_SPAN_ATTRIBUTE) == null) {
-        ((AgentSpan) span).setTag(SERVLET_CONTEXT, contextPath);
-        req.setAttribute(DD_CONTEXT_PATH_ATTRIBUTE, contextPath);
+        if (context != null && context.getContextPath() != null) {
+          final String servletContext = context.getContextPath();
+          ((AgentSpan) span).setTag(SERVLET_CONTEXT, servletContext);
+          req.setAttribute(DD_CONTEXT_PATH_ATTRIBUTE, servletContext);
+          if (contextPath != null) {
+            final String relativePath =
+                contextPath.startsWith(servletContext)
+                    ? contextPath.substring(servletContext.length())
+                    : contextPath;
+            ((AgentSpan) span).setTag(SERVLET_PATH, relativePath);
+            req.setAttribute(DD_SERVLET_PATH_ATTRIBUTE, relativePath);
+          }
+        }
       }
     }
   }

--- a/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/SetContextPathAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/SetContextPathAdvice.java
@@ -21,23 +21,21 @@ public class SetContextPathAdvice {
   public static void updateContextPath(
       @Advice.This final Request req,
       @Advice.Argument(0) final ContextHandler.Context context,
-      @Advice.Argument(1) final String contextPath) {
-    if (contextPath != null) {
-      Object span = req.getAttribute(DD_SPAN_ATTRIBUTE);
-      // Don't want to update while being dispatched to new servlet
-      if (span instanceof AgentSpan && req.getAttribute(DD_DISPATCH_SPAN_ATTRIBUTE) == null) {
-        if (context != null && context.getContextPath() != null) {
-          final String servletContext = context.getContextPath();
-          ((AgentSpan) span).setTag(SERVLET_CONTEXT, servletContext);
-          req.setAttribute(DD_CONTEXT_PATH_ATTRIBUTE, servletContext);
-          if (contextPath != null) {
-            final String relativePath =
-                contextPath.startsWith(servletContext)
-                    ? contextPath.substring(servletContext.length())
-                    : contextPath;
-            ((AgentSpan) span).setTag(SERVLET_PATH, relativePath);
-            req.setAttribute(DD_SERVLET_PATH_ATTRIBUTE, relativePath);
-          }
+      @Advice.Argument(1) final String pathInContext) {
+    Object span = req.getAttribute(DD_SPAN_ATTRIBUTE);
+    // Don't want to update while being dispatched to new servlet
+    if (span instanceof AgentSpan && req.getAttribute(DD_DISPATCH_SPAN_ATTRIBUTE) == null) {
+      if (context != null && context.getContextPath() != null) {
+        final String servletContext = context.getContextPath();
+        ((AgentSpan) span).setTag(SERVLET_CONTEXT, servletContext);
+        req.setAttribute(DD_CONTEXT_PATH_ATTRIBUTE, servletContext);
+        if (pathInContext != null) {
+          final String relativePath =
+              pathInContext.startsWith(servletContext)
+                  ? pathInContext.substring(servletContext.length())
+                  : pathInContext;
+          ((AgentSpan) span).setTag(SERVLET_PATH, relativePath);
+          req.setAttribute(DD_SERVLET_PATH_ATTRIBUTE, relativePath);
         }
       }
     }


### PR DESCRIPTION
# What Does This Do

Usually, servlet instrumentations are setting the tag servlet.context and servlet.path.
When setting servlet.context some interceptors are triggered in order to also set the service name.

By debugging it turns out that:

1. `contextPath` is not the contextPath but contains the concatenation of contextPath + servlet request URI
2. servlet path was missing

This PR aims fixing this behaviour and the test case supports it.

I also tested with a jetty sample the different behaviour. It's a simple war deploying a servlet with a context path `/test` .

Without it looks like:
![Screenshot 2022-11-22 at 16 22 22](https://user-images.githubusercontent.com/7393723/203353796-bead7c93-0b15-4859-a01a-2865d0f0f089.png)


And with this PR is now showing more coherent information:

![image](https://user-images.githubusercontent.com/7393723/203354286-e573c77e-40e9-40cc-8bda-782a717f3b1e.png)



# Motivation

# Additional Notes
