### PR TITLE
Handle telemetry errors gracefully

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
@@ -83,7 +83,13 @@ public class TelemetryRunnable implements Runnable {
     Queue<Request> queue = telemetryService.prepareRequests();
     Request request;
     while ((request = queue.peek()) != null) {
-      if (!sendRequest(request)) {
+      final SendResult result = sendRequest(request);
+      if (result == SendResult.DROP) {
+        // If we need to drop, clear the queue and return as if it was success.
+        // We will not retry if the telemetry endpoint is disabled.
+        queue.clear();
+        return true;
+      } else if (result == SendResult.FAILURE) {
         return false;
       }
       // remove request from queue, in case of success submitting
@@ -95,11 +101,7 @@ public class TelemetryRunnable implements Runnable {
 
   private void successWait() {
     consecutiveFailures = 0;
-    int waitMs = telemetryService.getHeartbeatInterval();
-
-    // Wait between iterations no longer than 10 seconds
-    if (waitMs > 10000) waitMs = 10000;
-
+    final int waitMs = telemetryService.getHeartbeatInterval();
     sleeper.sleep(waitMs);
   }
 
@@ -116,23 +118,33 @@ public class TelemetryRunnable implements Runnable {
     sleeper.sleep((long) (waitSeconds * 1000L));
   }
 
-  private boolean sendRequest(Request request) {
+  private SendResult sendRequest(Request request) {
     Response response;
     try {
       response = okHttpClient.newCall(request).execute();
     } catch (IOException e) {
-      log.warn("IOException on HTTP request to Telemetry Intake Service", e);
-      return false;
+      log.warn("IOException on HTTP request to Telemetry Intake Service: {}", e.toString());
+      return SendResult.FAILURE;
     }
 
+    if (response.code() == 404) {
+      log.debug("Telemetry endpoint is disabled, dropping message");
+      return SendResult.DROP;
+    }
     if (response.code() != 202) {
       log.warn(
-          "Telemetry Intake Service responded with: " + response.code() + " " + response.message());
-      return false;
+          "Telemetry Intake Service responded with: {} {} ", response.code(), response.message());
+      return SendResult.FAILURE;
     }
 
     log.debug("Telemetry message sent successfully");
-    return true;
+    return SendResult.SUCCESS;
+  }
+
+  enum SendResult {
+    SUCCESS,
+    FAILURE,
+    DROP;
   }
 
   interface ThreadSleeper {

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryRunnableSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryRunnableSpecification.groovy
@@ -13,15 +13,13 @@ class TelemetryRunnableSpecification extends DDSpecification {
   private static final Response OK_RESPONSE = new Response.Builder()
   .request(REQUEST).protocol(Protocol.HTTP_1_0).message("msg").code(202).build()
   private static final Response BAD_RESPONSE = new Response.Builder()
+  .request(REQUEST).protocol(Protocol.HTTP_1_0).message("msg").code(500).build()
+  private static final Response NOT_FOUND_RESPONSE = new Response.Builder()
   .request(REQUEST).protocol(Protocol.HTTP_1_0).message("msg").code(404).build()
-
-  Call call = Mock()
 
   OkHttpClient okHttpClient = Mock()
   TelemetryRunnable.ThreadSleeper sleeper = Mock()
-  TelemetryServiceImpl telemetryService = Mock {
-    getHeartbeatInterval() >> 10000
-  }
+  TelemetryServiceImpl telemetryService = Mock()
   TelemetryRunnable.TelemetryPeriodicAction periodicAction = Mock()
   TelemetryRunnable runnable = new TelemetryRunnable(okHttpClient, telemetryService, [periodicAction], sleeper)
   Thread t = new Thread(runnable)
@@ -34,13 +32,16 @@ class TelemetryRunnableSpecification extends DDSpecification {
   }
 
   void 'one loop run with one request'() {
+    setup:
     def queue = new ArrayDeque<>([REQUEST])
+    Call call = Mock()
 
     when:
     t.start()
     t.join()
 
     then:
+    1 * telemetryService.addConfiguration(_)
     1 * periodicAction.doIteration(telemetryService)
     1 * telemetryService.addStartedRequest()
 
@@ -52,22 +53,101 @@ class TelemetryRunnableSpecification extends DDSpecification {
     queue.size() == 0
 
     then:
+    1 * telemetryService.getHeartbeatInterval() >> 10_000L
     1 * sleeper.sleep(10_000L) >> { t.interrupt() }
 
     then:
     1 * telemetryService.appClosingRequest() >> REQUEST
     1 * okHttpClient.newCall(REQUEST) >> call
     1 * call.execute() >> OK_RESPONSE
+    0 * _
   }
 
-  void 'backoff time increases'() {
-    def queue = new ArrayDeque<>([REQUEST])
+  void 'one loop run with two requests'() {
+    setup:
+    def request1 = new Request.Builder()
+      .url('https://example.com/1').build()
+    def request2 = new Request.Builder()
+      .url('https://example.com/2').build()
+    def request3 = new Request.Builder()
+      .url('https://example.com/3').build()
+    def queue = new ArrayDeque<>([request1, request2])
+    Call call1 = Mock()
+    Call call2 = Mock()
+    Call call3 = Mock()
 
     when:
     t.start()
     t.join()
 
     then:
+    1 * telemetryService.addConfiguration(_)
+    1 * periodicAction.doIteration(telemetryService)
+    1 * telemetryService.addStartedRequest()
+
+    then:
+    1 * periodicAction.doIteration(telemetryService)
+    1 * telemetryService.prepareRequests() >> queue
+    1 * okHttpClient.newCall(request1) >> call1
+    1 * call1.execute() >> OK_RESPONSE
+    1 * okHttpClient.newCall(request2) >> call2
+    1 * call2.execute() >> OK_RESPONSE
+    queue.size() == 0
+
+    then:
+    1 * telemetryService.getHeartbeatInterval() >> 10_000L
+    1 * sleeper.sleep(10_000L) >> { t.interrupt() }
+
+    then:
+    1 * telemetryService.appClosingRequest() >> request3
+    1 * okHttpClient.newCall(request3) >> call3
+    1 * call3.execute() >> OK_RESPONSE
+    0 * _
+  }
+
+  void 'endpoint not found'() {
+    setup:
+    def queue = new ArrayDeque<>([REQUEST, REQUEST])
+    Call call = Mock()
+
+    when:
+    t.start()
+    t.join()
+
+    then:
+    1 * telemetryService.addConfiguration(_)
+    1 * periodicAction.doIteration(telemetryService)
+    1 * telemetryService.addStartedRequest()
+
+    then:
+    1 * periodicAction.doIteration(telemetryService)
+    1 * telemetryService.prepareRequests() >> queue
+    1 * okHttpClient.newCall(REQUEST) >> call
+    1 * call.execute() >> NOT_FOUND_RESPONSE
+    queue.size() == 0
+
+    then:
+    1 * telemetryService.getHeartbeatInterval() >> 10_000L
+    1 * sleeper.sleep(10_000L) >> { t.interrupt() }
+
+    then:
+    1 * telemetryService.appClosingRequest() >> REQUEST
+    1 * okHttpClient.newCall(REQUEST) >> call
+    1 * call.execute() >> OK_RESPONSE
+    0 * _
+  }
+
+  void 'backoff time increases'() {
+    setup:
+    def queue = new ArrayDeque<>([REQUEST])
+    Call call = Mock()
+
+    when:
+    t.start()
+    t.join()
+
+    then:
+    1 * telemetryService.addConfiguration(_)
     1 * periodicAction.doIteration(telemetryService)
     1 * telemetryService.addStartedRequest()
 
@@ -97,5 +177,6 @@ class TelemetryRunnableSpecification extends DDSpecification {
     1 * telemetryService.appClosingRequest() >> REQUEST
     1 * okHttpClient.newCall(REQUEST) >> call
     1 * call.execute() >> OK_RESPONSE
+    0 * _
   }
 }


### PR DESCRIPTION
# What Does This Do

* Absent telemetry endpoint (error 404) will only log to debug, and drop remaining messages in the telemetry iteration.
* IO errors will log a warning with the exception message, not the full stacktrace.
* Fixed telemetry interval to honor the default (60 seconds), rather than capping it at 10 seconds.

# Motivation

See https://github.com/DataDog/dd-trace-java/issues/4203
When telemetry was disabled in the agent, we were spamming logs with warnings.

# Additional Notes

* A more comprehensive solution will be merged soon: https://github.com/DataDog/dd-trace-java/pull/4289 (this PR stems from that work, thanks @ValentinZakharov)
* This PR takes a modest approach to just mitigate the ongoing issues with agents with telemetry disabled (or old agents).

After this PR, starting with an agent that does not support telemetry, then stopping the agent, and then upgrading the agent, leads to the following logs:

```
web_1    | [dd.trace 2022-11-22 19:33:03:831 +0000] [dd-telemetry] DEBUG datadog.telemetry.TelemetryRunnable - Adding APP_STARTED telemetry event
web_1    | [dd.trace 2022-11-22 19:33:03:838 +0000] [dd-telemetry] DEBUG datadog.telemetry.TelemetryRunnable - Telemetry endpoint is disabled, dropping message
web_1    | [dd.trace 2022-11-22 19:34:03:843 +0000] [dd-telemetry] DEBUG datadog.telemetry.TelemetryRunnable - Telemetry endpoint is disabled, dropping message
web_1    | [dd.trace 2022-11-22 19:35:03:846 +0000] [dd-telemetry] WARN datadog.telemetry.TelemetryRunnable - IOException on HTTP request to Telemetry Intake Service: java.net.UnknownHostException: agent: Temporary failure in name resolution
web_1    | [dd.trace 2022-11-22 19:35:03:846 +0000] [dd-telemetry] DEBUG datadog.telemetry.TelemetryRunnable - Last attempt to send telemetry failed; will retry in 3.0 seconds (num failures: 1)
web_1    | [dd.trace 2022-11-22 19:35:06:847 +0000] [dd-telemetry] DEBUG datadog.telemetry.TelemetryRunnable - IOException on HTTP request to Telemetry Intake Service: java.net.UnknownHostException: agent
web_1    | [dd.trace 2022-11-22 19:35:06:847 +0000] [dd-telemetry] DEBUG datadog.telemetry.TelemetryRunnable - Last attempt to send telemetry failed; will retry in 9.0 seconds (num failures: 2)
web_1    | [dd.trace 2022-11-22 19:37:04:419 +0000] [dd-telemetry] DEBUG datadog.telemetry.TelemetryRunnable - Telemetry message sent successfully
```

So, with an unsupported agent, we drop messages silently (log to debug). If there's an HTTP error, we log it to WARN level the first time, but next attempts are logged to the debug. After an upgrade, telemetry messages continue being sent.
