### PR TITLE
Treat `1` value as `true` for boolean tag values

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/TagInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/TagInterceptor.java
@@ -227,6 +227,7 @@ public class TagInterceptor {
 
   private static boolean asBoolean(Object value) {
     return Boolean.TRUE.equals(value)
+        || "1".equals(value)
         || (!Boolean.FALSE.equals(value) && Boolean.parseBoolean(String.valueOf(value)));
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/taginterceptor/TagInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/taginterceptor/TagInterceptorTest.groovy
@@ -575,4 +575,36 @@ class TagInterceptorTest extends DDCoreSpecification {
     cleanup:
     tracer.close()
   }
+
+  def "treat `1` value as `true` for boolean tag values"() {
+    setup:
+    def tracer = tracerBuilder()
+      .serviceName("some-service")
+      .writer(new LoggingWriter())
+      .sampler(new AllSampler())
+      .build()
+
+    when:
+    AgentSpan span = tracer.buildSpan("test").start()
+
+    then:
+    span.getSamplingPriority() == null
+
+    when:
+    span.setTag(tag, value)
+
+    then:
+    span.getSamplingPriority() == samplingPriority
+
+    where:
+    tag                | value | samplingPriority
+    DDTags.MANUAL_DROP | true  | PrioritySampling.USER_DROP
+    DDTags.MANUAL_DROP | "1"   | PrioritySampling.USER_DROP
+    DDTags.MANUAL_DROP | false | null
+    DDTags.MANUAL_DROP | "0"   | null
+    DDTags.MANUAL_KEEP | true  | PrioritySampling.USER_KEEP
+    DDTags.MANUAL_KEEP | "1"   | PrioritySampling.USER_KEEP
+    DDTags.MANUAL_KEEP | false | null
+    DDTags.MANUAL_KEEP | "0"   | null
+  }
 }


### PR DESCRIPTION
# What Does This Do

Treats `1` value as `true` for boolean tag values

# Motivation

This came up in system-tests:

https://github.com/DataDog/system-tests/blob/main/parametric/test_span_sampling.py#L327

# Additional Notes

N/A
