### PR TITLE
Add scheduled task to clear the resolver's type pools

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/DDCachingPoolStrategy.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/DDCachingPoolStrategy.java
@@ -136,6 +136,11 @@ public final class DDCachingPoolStrategy
   @Override
   public void endTransform() {}
 
+  @Override
+  public void clear() {
+    sharedResolutionCache.clear();
+  }
+
   private TypePool.CacheProvider createCacheProvider(
       final int loaderHash, final WeakReference<ClassLoader> loaderRef) {
     return new SharedResolutionCacheAdapter(

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/SharedTypePools.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/SharedTypePools.java
@@ -36,6 +36,10 @@ public final class SharedTypePools {
     SUPPLIER.endTransform();
   }
 
+  public static void clear() {
+    SUPPLIER.clear();
+  }
+
   public static synchronized void registerIfAbsent(Supplier supplier) {
     if (null == SUPPLIER) {
       SUPPLIER = supplier;
@@ -54,6 +58,8 @@ public final class SharedTypePools {
 
     /** Hints that the javaagent has finished calling {@link ClassFileTransformer#transform}. */
     void endTransform();
+
+    void clear();
   }
 
   /** Simple cache for use during the build when testing or validating muzzle ranges. */
@@ -72,6 +78,9 @@ public final class SharedTypePools {
 
       @Override
       public void endTransform() {}
+
+      @Override
+      public void clear() {}
     };
   }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/TypeInfoCache.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/TypeInfoCache.java
@@ -41,8 +41,12 @@ public final class TypeInfoCache<T> {
    * @return previously shared information for the named type
    */
   public SharedTypeInfo<T> share(String name, ClassLoader loader, URL classFile, T typeInfo) {
-    return this.sharedTypeInfo.put(
-        name, new SharedTypeInfo<>(loaderId(loader), classFile, typeInfo));
+    return sharedTypeInfo.put(name, new SharedTypeInfo<>(loaderId(loader), classFile, typeInfo));
+  }
+
+  /** Clears all type information from the shared cache. */
+  public void clear() {
+    sharedTypeInfo.clear();
   }
 
   private static LoaderId loaderId(ClassLoader loader) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
@@ -127,6 +127,11 @@ final class TypeFactory {
     clearReferences();
   }
 
+  static void clear() {
+    outlineTypes.clear();
+    fullTypes.clear();
+  }
+
   /**
    * New transform request; begins with type matching that only requires outline descriptions.
    *

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypePoolFacade.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypePoolFacade.java
@@ -53,6 +53,11 @@ public final class TypePoolFacade implements TypePool, SharedTypePools.Supplier 
   }
 
   @Override
+  public void clear() {
+    TypeFactory.clear();
+  }
+
+  @Override
   public Resolution describe(String name) {
     // describe elements as deferred types, lazily evaluated using the current context
     TypeDescription type = name.charAt(0) == '[' ? findDescriptor(name) : findType(name);
@@ -61,7 +66,4 @@ public final class TypePoolFacade implements TypePool, SharedTypePools.Supplier 
     }
     return new Resolution.Simple(type);
   }
-
-  @Override
-  public void clear() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -133,6 +133,7 @@ public final class ConfigDefaults {
 
   static final int DEFAULT_RESOLVER_OUTLINE_POOL_SIZE = 128;
   static final int DEFAULT_RESOLVER_TYPE_POOL_SIZE = 64;
+  static final int DEFAULT_RESOLVER_RESET_INTERVAL = 300; // seconds
 
   static final boolean DEFAULT_TELEMETRY_ENABLED = true;
   static final int DEFAULT_TELEMETRY_HEARTBEAT_INTERVAL = 60; // in seconds

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -94,6 +94,7 @@ public final class TraceInstrumentationConfig {
   public static final String RESOLVER_OUTLINE_POOL_SIZE = "resolver.outline.pool.size";
   public static final String RESOLVER_TYPE_POOL_SIZE = "resolver.type.pool.size";
   public static final String RESOLVER_USE_LOADCLASS = "resolver.use.loadclass";
+  public static final String RESOLVER_RESET_INTERVAL = "resolver.reset.interval";
 
   private TraceInstrumentationConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -3,6 +3,7 @@ package datadog.trace.api;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_INTEGRATIONS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_LOGS_INJECTION_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_RESOLVER_OUTLINE_POOL_SIZE;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_RESOLVER_RESET_INTERVAL;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_RESOLVER_TYPE_POOL_SIZE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SERIALVERSIONUID_FIELD_INJECTION;
@@ -16,6 +17,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_PREPARED_
 import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_INJECTION_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_OUTLINE_POOL_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_OUTLINE_POOL_SIZE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_RESET_INTERVAL;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_TYPE_POOL_SIZE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_USE_LOADCLASS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
@@ -61,6 +63,7 @@ public class InstrumenterConfig {
   private final int resolverOutlinePoolSize;
   private final int resolverTypePoolSize;
   private final boolean resolverUseLoadClassEnabled;
+  private final int resolverResetInterval;
 
   private final boolean runtimeContextFieldInjection;
   private final boolean serialVersionUIDFieldInjection;
@@ -104,6 +107,8 @@ public class InstrumenterConfig {
     resolverTypePoolSize =
         configProvider.getInteger(RESOLVER_TYPE_POOL_SIZE, DEFAULT_RESOLVER_TYPE_POOL_SIZE);
     resolverUseLoadClassEnabled = configProvider.getBoolean(RESOLVER_USE_LOADCLASS, true);
+    resolverResetInterval =
+        configProvider.getInteger(RESOLVER_RESET_INTERVAL, DEFAULT_RESOLVER_RESET_INTERVAL);
 
     runtimeContextFieldInjection =
         configProvider.getBoolean(
@@ -189,6 +194,10 @@ public class InstrumenterConfig {
     return resolverUseLoadClassEnabled;
   }
 
+  public int getResolverResetInterval() {
+    return resolverResetInterval;
+  }
+
   public boolean isRuntimeContextFieldInjection() {
     return runtimeContextFieldInjection;
   }
@@ -260,6 +269,8 @@ public class InstrumenterConfig {
         + resolverTypePoolSize
         + ", resolverUseLoadClassEnabled="
         + resolverUseLoadClassEnabled
+        + ", resolverResetInterval="
+        + resolverResetInterval
         + ", runtimeContextFieldInjection="
         + runtimeContextFieldInjection
         + ", serialVersionUIDFieldInjection="


### PR DESCRIPTION
# What Does This Do

Periodically resets the type-resolver state by clearing its shared type-pools.

# Motivation

Type transformations happen mainly at startup. By clearing the type-pools at a long enough interval after start we can reduce long-term memory overhead without impacting performance. The type-pools continue to be cleared at the same interval in case further types are transformed over the life of the application.

# Additional Notes

Defaults to every 5 minutes