### PR TITLE
[Tomcat 10.1.x] Fix request corruption

### DIFF
--- a/dd-java-agent/instrumentation/tomcat-5.5/build.gradle
+++ b/dd-java-agent/instrumentation/tomcat-5.5/build.gradle
@@ -87,8 +87,7 @@ dependencies {
   testImplementation project(':dd-java-agent:instrumentation:servlet:request-2')
   testImplementation project(':dd-java-agent:instrumentation:servlet:request-3')
 
-  // Tomcat 10.1.+ seems to require Java 11. Limit to fix build.
-  latestDepTestImplementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '10.1.+'
+  latestDepTestImplementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '10+'
   latestDepTestImplementation group: 'org.apache.tomcat', name: 'jakartaee-migration', version: '1.+'
 
   latestDepTestImplementation(project(':dd-java-agent:instrumentation:tomcat-appsec-6'))

--- a/dd-java-agent/instrumentation/tomcat-5.5/build.gradle
+++ b/dd-java-agent/instrumentation/tomcat-5.5/build.gradle
@@ -48,6 +48,17 @@ configurations.all {
   }
 }
 
+tasks.named("latestDepTest").configure {
+  javaLauncher = getJavaLauncherFor(11)
+}
+tasks.named("compileLatestDepTestJava").configure {
+  setJavaVersion(it, 11)
+}
+tasks.named("compileLatestDepTestGroovy").configure {
+  javaLauncher = getJavaLauncherFor(11)
+}
+
+
 dependencies {
   compileOnly group: 'tomcat', name: 'catalina', version: tomcatVersion
   compileOnly group: 'tomcat', name: 'tomcat-coyote', version: tomcatVersion
@@ -77,7 +88,9 @@ dependencies {
   testImplementation project(':dd-java-agent:instrumentation:servlet:request-3')
 
   // Tomcat 10.1.+ seems to require Java 11. Limit to fix build.
-  latestDepTestImplementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '10.0.+'
+  latestDepTestImplementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '10.1.+'
+  latestDepTestImplementation group: 'org.apache.tomcat', name: 'jakartaee-migration', version: '1.+'
+
   latestDepTestImplementation(project(':dd-java-agent:instrumentation:tomcat-appsec-6'))
 }
 

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/latestDepTest/groovy/AbstractServletTest.groovy
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/latestDepTest/groovy/AbstractServletTest.groovy
@@ -1,6 +1,9 @@
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.instrumentation.tomcat.TomcatDecorator
 import jakarta.servlet.Servlet
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.Response
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.UNKNOWN
@@ -36,6 +39,20 @@ abstract class AbstractServletTest<SERVER, CONTEXT> extends HttpServerTest<SERVE
 
   boolean isDispatch() {
     return false
+  }
+
+  @Override
+  OkHttpClient getClient() {
+    return super.getClient().newBuilder()
+      .addInterceptor(new Interceptor() {
+        @Override
+        Response intercept(Interceptor.Chain chain) throws IOException {
+          return chain.proceed(chain.request().newBuilder()
+            .header("Cookie", "somethingcouldbreaktherequest="+ UUID.randomUUID())
+
+            .build())
+        }
+      }).build()
   }
 
   abstract String getContext()

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/latestDepTest/groovy/TomcatServletTest.groovy
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/latestDepTest/groovy/TomcatServletTest.groovy
@@ -144,6 +144,7 @@ class TomcatServletTest extends AbstractServletTest<Tomcat, Context> {
     Wrapper wrapper = servletContext.createWrapper()
     wrapper.name = UUID.randomUUID()
     wrapper.servletClass = servlet.name
+    wrapper.asyncSupported =true
     servletContext.addChild(wrapper)
     servletContext.addServletMappingDecoded(path, wrapper.name)
   }

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/ExtractAdapter.java
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/ExtractAdapter.java
@@ -7,6 +7,17 @@ import org.apache.tomcat.util.http.MimeHeaders;
 public abstract class ExtractAdapter<T> implements AgentPropagation.ContextVisitor<T> {
   abstract MimeHeaders getMimeHeaders(T t);
 
+  static String messageBytesToString(final MessageBytes messageBytes) {
+    switch (messageBytes.getType()) {
+      case MessageBytes.T_BYTES:
+        return messageBytes.getByteChunk().toString();
+      case MessageBytes.T_CHARS:
+        return messageBytes.getCharChunk().toString();
+      default:
+        return messageBytes.toString();
+    }
+  }
+
   @Override
   public void forEachKey(T carrier, AgentPropagation.KeyClassifier classifier) {
     MimeHeaders headers = getMimeHeaders(carrier);
@@ -16,7 +27,7 @@ public abstract class ExtractAdapter<T> implements AgentPropagation.ContextVisit
     for (int i = 0; i < headers.size(); ++i) {
       MessageBytes header = headers.getName(i);
       MessageBytes value = headers.getValue(i);
-      if (!classifier.accept(header.toString(), value.toString())) {
+      if (!classifier.accept(messageBytesToString(header), messageBytesToString(value))) {
         return;
       }
     }


### PR DESCRIPTION
# What Does This Do

Starting from Tomcat 10.1.X `MessageBytes` class has been refactored and now caches string representation when calling toString(). 
We're calling toString on `MimeHeaders` before the service method  causing changing byte buffers to string.  When the postParse is called, the request is parsed starting from the content of the mime headers.

This is corrupting the request processing making unusable the agent on spring boot 3 or tomcat 10.1.x powered webapps.

We did not detect because of latestDep tests were not done with this version and also we lacked tests with http headers.
I added both

# Motivation

# Additional Notes
