### PR TITLE
Add flush traces and metrics API

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/internal/InternalTracer.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/internal/InternalTracer.java
@@ -1,0 +1,11 @@
+package datadog.trace.api.internal;
+
+/**
+ * Tracer internal features. Those features are not part of public API and can change or be removed
+ * at any time.
+ */
+public interface InternalTracer {
+  void flush();
+
+  void flushMetrics();
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
@@ -63,7 +63,7 @@ final class Aggregator implements Runnable {
       try {
         InboxItem item = inbox.take();
         if (item instanceof StopSignal) {
-          report(wallClockTime(), (StopSignal) item);
+          stop((StopSignal) item);
           break;
         } else if (item instanceof ReportSignal) {
           report(wallClockTime(), (ReportSignal) item);
@@ -89,6 +89,16 @@ final class Aggregator implements Runnable {
       }
     }
     log.debug("metrics aggregator exited");
+  }
+
+  private void stop(StopSignal stopSignal) {
+    report(wallClockTime(), stopSignal);
+    for (InboxItem item : inbox) {
+      if (item instanceof SignalItem) {
+        ((SignalItem) item).ignore();
+      }
+    }
+    stopSignal.complete();
   }
 
   private void report(long when, SignalItem signal) {

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Batch.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Batch.java
@@ -12,16 +12,13 @@ import java.util.concurrent.atomic.AtomicLongArray;
  * <p>A batch can currently take at most 64 values. Attempts to add the 65th update will be
  * rejected.
  */
-public final class Batch {
+public final class Batch implements InboxItem {
 
   private static final int MAX_BATCH_SIZE = 64;
   private static final AtomicIntegerFieldUpdater<Batch> COUNT =
       AtomicIntegerFieldUpdater.newUpdater(Batch.class, "count");
   private static final AtomicIntegerFieldUpdater<Batch> COMMITTED =
       AtomicIntegerFieldUpdater.newUpdater(Batch.class, "committed");
-  static final Batch NULL = new Batch((AtomicLongArray) null);
-  static final Batch REPORT = new Batch((AtomicLongArray) null);
-  static final Batch REPORT_AND_NOTIFY = new Batch((AtomicLongArray) null);
 
   /**
    * This counter has two states:

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Batch.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Batch.java
@@ -21,6 +21,7 @@ public final class Batch {
       AtomicIntegerFieldUpdater.newUpdater(Batch.class, "committed");
   static final Batch NULL = new Batch((AtomicLongArray) null);
   static final Batch REPORT = new Batch((AtomicLongArray) null);
+  static final Batch REPORT_AND_NOTIFY = new Batch((AtomicLongArray) null);
 
   /**
    * This counter has two states:

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/InboxItem.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/InboxItem.java
@@ -15,6 +15,10 @@ abstract class SignalItem implements InboxItem {
     this.future.complete(true);
   }
 
+  void ignore() {
+    this.future.complete(false);
+  }
+
   static final class StopSignal extends SignalItem {
     static final StopSignal STOP = new StopSignal();
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/InboxItem.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/InboxItem.java
@@ -1,0 +1,27 @@
+package datadog.trace.common.metrics;
+
+import java.util.concurrent.CompletableFuture;
+
+interface InboxItem {}
+
+abstract class SignalItem implements InboxItem {
+  final CompletableFuture<Boolean> future;
+
+  public SignalItem() {
+    this.future = new CompletableFuture<>();
+  }
+
+  void complete() {
+    this.future.complete(true);
+  }
+
+  static final class StopSignal extends SignalItem {
+    static final StopSignal STOP = new StopSignal();
+
+    private StopSignal() {}
+  }
+
+  static final class ReportSignal extends SignalItem {
+    static final ReportSignal REPORT = new ReportSignal();
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/MetricsAggregator.java
@@ -2,11 +2,14 @@ package datadog.trace.common.metrics;
 
 import datadog.trace.core.CoreSpan;
 import java.util.List;
+import java.util.concurrent.Future;
 
 public interface MetricsAggregator extends AutoCloseable {
   void start();
 
   boolean report();
+
+  Future<Boolean> forceReport();
 
   boolean publish(List<? extends CoreSpan<?>> trace);
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/NoOpMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/NoOpMetricsAggregator.java
@@ -1,7 +1,11 @@
 package datadog.trace.common.metrics;
 
+import static java.lang.Boolean.FALSE;
+
 import datadog.trace.core.CoreSpan;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 
 public final class NoOpMetricsAggregator implements MetricsAggregator {
 
@@ -13,6 +17,11 @@ public final class NoOpMetricsAggregator implements MetricsAggregator {
   @Override
   public boolean report() {
     return false;
+  }
+
+  @Override
+  public Future<Boolean> forceReport() {
+    return CompletableFuture.completedFuture(FALSE);
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -81,6 +81,7 @@ import java.util.ServiceLoader;
 import java.util.SortedSet;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -957,9 +958,9 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   @Override
   public void flushMetrics() {
     try {
-      metricsAggregator.forceReport().get();
-    } catch (InterruptedException | ExecutionException e) {
-      log.debug("Failed to wait for metrics flush.");
+      metricsAggregator.forceReport().get(1_000, MILLISECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      log.debug("Failed to wait for metrics flush.", e);
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -80,6 +80,7 @@ import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.SortedSet;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.ExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -951,6 +952,15 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   public void flush() {
     pendingTraceBuffer.flush();
     writer.flush();
+  }
+
+  @Override
+  public void flushMetrics() {
+    try {
+      metricsAggregator.forceReport().get();
+    } catch (InterruptedException | ExecutionException e) {
+      log.debug("Failed to wait for metrics flush.");
+    }
   }
 
   private static StatsDClient createStatsDClient(final Config config) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTraceBuffer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTraceBuffer.java
@@ -66,6 +66,7 @@ public abstract class PendingTraceBuffer implements AutoCloseable {
 
     @Override
     public void close() {
+      flush();
       closed = true;
       worker.interrupt();
       try {
@@ -85,7 +86,6 @@ public abstract class PendingTraceBuffer implements AutoCloseable {
       }
     }
 
-    // Only used from within tests
     @Override
     public void flush() {
       if (worker.isAlive()) {

--- a/dd-trace-ot/build.gradle
+++ b/dd-trace-ot/build.gradle
@@ -102,6 +102,7 @@ shadowJar {
     exclude('datadog.trace.api.*')
     exclude('datadog.trace.api.config.*')
     exclude('datadog.trace.api.interceptor.*')
+    exclude('datadog.trace.api.internal.*')
     exclude('datadog.trace.api.sampling.*')
     exclude('datadog.trace.context.*')
   }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -5,6 +5,7 @@ import datadog.trace.api.DDTags;
 import datadog.trace.api.GlobalTracer;
 import datadog.trace.api.StatsDClient;
 import datadog.trace.api.interceptor.TraceInterceptor;
+import datadog.trace.api.internal.InternalTracer;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -35,7 +36,7 @@ import org.slf4j.LoggerFactory;
  * DDTracer implements the <code>io.opentracing.Tracer</code> interface to make it easy to send
  * traces and spans to Datadog using the OpenTracing API.
  */
-public class DDTracer implements Tracer, datadog.trace.api.Tracer {
+public class DDTracer implements Tracer, datadog.trace.api.Tracer, InternalTracer {
 
   private static final Logger log = LoggerFactory.getLogger(DDTracer.class);
 
@@ -470,6 +471,16 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer {
       log.debug("Unsupported format for propagation - {}", format.getClass().getName());
       return null;
     }
+  }
+
+  @Override
+  public void flush() {
+    tracer.flush();
+  }
+
+  @Override
+  public void flushMetrics() {
+    tracer.flushMetrics();
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -12,6 +12,7 @@ import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.gateway.SubscriptionService;
 import datadog.trace.api.interceptor.TraceInterceptor;
+import datadog.trace.api.internal.InternalTracer;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.api.scopemanager.ScopeListener;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context;
@@ -115,7 +116,7 @@ public class AgentTracer {
   private AgentTracer() {}
 
   public interface TracerAPI
-      extends datadog.trace.api.Tracer, AgentPropagation, EndpointCheckpointer {
+      extends datadog.trace.api.Tracer, InternalTracer, AgentPropagation, EndpointCheckpointer {
     AgentSpan startSpan(CharSequence spanName);
 
     AgentSpan startSpan(CharSequence spanName, long startTimeMicros);
@@ -145,8 +146,6 @@ public class AgentTracer {
     SpanBuilder buildSpan(CharSequence spanName);
 
     void close();
-
-    void flush();
 
     /**
      * Attach a scope listener to the global scope manager
@@ -289,6 +288,9 @@ public class AgentTracer {
 
     @Override
     public void flush() {}
+
+    @Override
+    public void flushMetrics() {}
 
     @Override
     public String getTraceId() {


### PR DESCRIPTION
# What Does This Do

This PR creates a new *internal* API in order to control traces and metrics flush.

# Motivation

Its goal is to improve test stability and allow proper `system tests` implementation (no more introspection from Java client code).

# Additional Notes

Tracer will also try to flush at close in order prevent data loss.