### PR TITLE
Allow call sites in the benchmark

### DIFF
--- a/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog.trace.instrumentation.iastinstrumenter/iast_exclusion.trie
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog.trace.instrumentation.iastinstrumenter/iast_exclusion.trie
@@ -158,6 +158,8 @@
 1 org.mongodb.*
 1 org.osgi.*
 1 org.owasp.*
+# https://github.com/OWASP-Benchmark/BenchmarkJava
+0 org.owasp.benchmark.*
 # https://github.com/WebGoat/WebGoat
 0 org.owasp.webgoat.*
 1 org.picketlink.*


### PR DESCRIPTION
# What Does This Do
Do not exclude OWASP benchmark

# Motivation

# Additional Notes
