### PR TITLE
Fix side effects in CallSiteUtils causing bug

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteUtils.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteUtils.java
@@ -217,17 +217,10 @@ public abstract class CallSiteUtils {
       minIdx = Math.min(minIdx, index);
     }
 
-    // apply offset
-    for (int i = 0; i < indices.length; i++) {
-      indices[i] -= minIdx;
-    }
-    Type[] newArgumentTypes = new Type[argumentTypes.length - minIdx];
-    System.arraycopy(argumentTypes, minIdx, newArgumentTypes, 0, argumentTypes.length - minIdx);
-
     StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < newArgumentTypes.length; i++) {
-      sb.append(i + 1);
-      Type type = newArgumentTypes[i];
+    for (int i = minIdx; i < argumentTypes.length; i++) {
+      sb.append(i + 1 - minIdx);
+      Type type = argumentTypes[i];
       if (type == Type.LONG_TYPE || type == Type.DOUBLE_TYPE) {
         sb.append('L');
       }
@@ -235,7 +228,7 @@ public abstract class CallSiteUtils {
     sb.append('|');
     for (int index : indices) {
       Type type = argumentTypes[index];
-      sb.append(index + 1);
+      sb.append(index + 1 - minIdx);
       if (type == Type.LONG_TYPE || type == Type.DOUBLE_TYPE) {
         sb.append('L');
       }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteTransformerTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteTransformerTest.groovy
@@ -1,5 +1,6 @@
 package datadog.trace.agent.tooling.csi
 
+import datadog.trace.agent.tooling.bytebuddy.csi.Advices
 import datadog.trace.agent.tooling.bytebuddy.csi.CallSiteTransformer
 import datadog.trace.agent.tooling.csi.CallSiteAdvice.MethodHandler
 import datadog.trace.api.function.TriFunction
@@ -164,6 +165,46 @@ class CallSiteTransformerTest extends BaseCallSiteTest {
     }
   }
 
+  def 'dupParameters with owner argument'() {
+    // case where there is no annotation with @This but we're instrumenting an instance method
+    // (that is, the advice is not interested in the object whose method is being called)
+    setup:
+    Type source = Type.getType(CallSiteWithArraysExample)
+    Type target = renameType(source, 'Test')
+    Type helperType = Type.getType(InstrumentationHelper)
+    Type helperMethod = Type.getType(InstrumentationHelper.getDeclaredMethod('onInsertPartialArgs', int, char[], int))
+    Pointcut pointcut = stringBuilderInsertPointcut()
+    InvokeAdvice callSite = mockInvokeAdvice(pointcut, COMPUTE_MAX_STACK, helperType.className)
+    Advices advices = mockAdvices([callSite])
+    CallSiteTransformer callSiteTransformer = new CallSiteTransformer(advices)
+    def callbackArg
+    InstrumentationHelper.callback = { arg -> callbackArg = arg }
+
+    when:
+    byte[] transformedClass = transformType(source, target, callSiteTransformer)
+    def insert = loadType(target, transformedClass) as TriFunction<String, Integer, Integer, String>
+    insert.apply('Hello World!', 6, 5)
+
+    then:
+    callbackArg[0] == 0
+    callbackArg[1] == 'Hello World!'.toCharArray()
+    callbackArg[2] == 6
+    callbackArg.size() == 3
+    1 * callSite.apply(_ as MethodHandler, Opcodes.INVOKEVIRTUAL, pointcut.type(), pointcut.method(), pointcut.descriptor(), false) >> { params ->
+      MethodHandler handler = params[0]
+      int opcode = params[1]
+      String owner = params[2]
+      String name = params[3]
+      String descriptor = params[4]
+      boolean isInterface = params[5]
+
+      int[] parameterIndices = [0, 1, 2,] as int[]
+      handler.dupParameters(descriptor, parameterIndices, owner)
+      handler.method(Opcodes.INVOKESTATIC, helperType.internalName, 'onInsertPartialArgs', helperMethod.descriptor, false)
+      handler.method(opcode, owner, name, descriptor, isInterface)
+    }
+  }
+
   static class InstrumentationHelper {
 
     private static Consumer<Object[]> callback = null // codenarc forces the lowercase name
@@ -178,6 +219,10 @@ class CallSiteTransformerTest extends BaseCallSiteTest {
       if (callback != null) {
         callback.accept([index, str, offset, length] as Object[])
       }
+    }
+
+    static void onInsertPartialArgs(int index, char[] str, int offset) {
+      callback?.accept([index, str, offset])
     }
   }
 }


### PR DESCRIPTION
Fixes APPSEC-6856.

The problem occurs when some call site advice for
a) an instance method
b) that is not interested in the receiver of the call (doesn't use `@This`),
c) doesn't use all the arguments (or not all arguments in order), and
d) there is no stack manipulation capable of duplicating the required arguments in the stack without using an intermediary array.

In this case, the following code is executed:

```java
public static void dup(MethodVisitor mv, Type[] argumentTypes, int[] indices) {
  int[] opcodes = lookupParamDupOpcodes(argumentTypes, indices);
  if (opcodes == null) {
    pushArray(mv, argumentTypes.length, argumentTypes);
    loadArray(mv, argumentTypes.length, argumentTypes);
    loadArray(mv, argumentTypes, indices);
    mv.visitInsn(POP); // pop out array
  } else {
    // ...
  }
```

The problem is that `lookupParamDupOpcodes` modifies the argument `indices`, and therefore its content is wrong on the last call to `loadArray()`.