### PR TITLE
Add support for tainting cookies

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastModuleImpl.java
@@ -443,6 +443,21 @@ public final class IastModuleImpl implements IastModule {
     checkInjection(VulnerabilityType.PATH_TRAVERSAL, rangeProvider);
   }
 
+  @Override
+  public void onCookie(@Nonnull String... cookieStrings) {
+    final IastRequestContext ctx = IastRequestContext.get();
+    if (ctx == null) {
+      return;
+    }
+    final TaintedObjects taintedObjects = ctx.getTaintedObjects();
+    for (String cookieString : cookieStrings) {
+      if (canBeTaintedNullSafe(cookieString)) {
+        taintedObjects.taintInputString(
+            cookieString, new Source(SourceType.REQUEST_COOKIE, cookieString, null));
+      }
+    }
+  }
+
   private <E> void checkInjection(
       @Nonnull final InjectionType type, @Nonnull final RangesProvider<E> rangeProvider) {
     final int rangeCount = rangeProvider.rangeCount();

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastModuleImpl.java
@@ -444,17 +444,36 @@ public final class IastModuleImpl implements IastModule {
   }
 
   @Override
-  public void onCookie(@Nonnull String... cookieStrings) {
+  public void onCookie(
+      final String comment,
+      final String domain,
+      final String value,
+      final String name,
+      final String path) {
     final IastRequestContext ctx = IastRequestContext.get();
     if (ctx == null) {
       return;
     }
     final TaintedObjects taintedObjects = ctx.getTaintedObjects();
-    for (String cookieString : cookieStrings) {
-      if (canBeTaintedNullSafe(cookieString)) {
-        taintedObjects.taintInputString(
-            cookieString, new Source(SourceType.REQUEST_COOKIE, cookieString, null));
-      }
+    if (canBeTaintedNullSafe(comment)) {
+      taintedObjects.taintInputString(
+          comment, new Source(SourceType.REQUEST_COOKIE, "http.request.cookie.comment", comment));
+    }
+    if (canBeTaintedNullSafe(domain)) {
+      taintedObjects.taintInputString(
+          domain, new Source(SourceType.REQUEST_COOKIE, "http.request.cookie.domain", domain));
+    }
+    if (canBeTaintedNullSafe(value)) {
+      taintedObjects.taintInputString(
+          value, new Source(SourceType.REQUEST_COOKIE, "http.request.cookie.value", value));
+    }
+    if (canBeTaintedNullSafe(name)) {
+      taintedObjects.taintInputString(
+          name, new Source(SourceType.REQUEST_COOKIE, "http.request.cookie.name", name));
+    }
+    if (canBeTaintedNullSafe(path)) {
+      taintedObjects.taintInputString(
+          path, new Source(SourceType.REQUEST_COOKIE, "http.request.cookie.path", path));
     }
   }
 

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastModuleImpl.java
@@ -132,6 +132,34 @@ public final class IastModuleImpl implements IastModule {
   }
 
   @Override
+  public void onHeaderName(@Nullable final String headerName) {
+    if (canBeTaintedNullSafe(headerName)) {
+      return;
+    }
+    final IastRequestContext ctx = IastRequestContext.get();
+    if (ctx == null) {
+      return;
+    }
+    final TaintedObjects taintedObjects = ctx.getTaintedObjects();
+    taintedObjects.taintInputString(
+        headerName, new Source(SourceType.REQUEST_HEADER_NAME, headerName, null));
+  }
+
+  @Override
+  public void onHeaderValue(@Nullable final String headerName, @Nullable final String headerValue) {
+    if (canBeTaintedNullSafe(headerValue)) {
+      return;
+    }
+    final IastRequestContext ctx = IastRequestContext.get();
+    if (ctx == null) {
+      return;
+    }
+    final TaintedObjects taintedObjects = ctx.getTaintedObjects();
+    taintedObjects.taintInputString(
+        headerValue, new Source(SourceType.REQUEST_HEADER_VALUE, headerName, headerValue));
+  }
+
+  @Override
   public void onStringConcat(
       @Nonnull final String left, @Nullable final String right, @Nonnull final String result) {
     if (!canBeTainted(result)) {

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/SourceType.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/SourceType.java
@@ -10,6 +10,10 @@ public final class SourceType {
   static final String REQUEST_PARAMETER_NAME_STRING = "http.request.parameter.name";
   public static final byte REQUEST_PARAMETER_VALUE = 2;
   static final String REQUEST_PARAMETER_VALUE_STRING = "http.request.parameter";
+  public static final byte REQUEST_HEADER_NAME = 3;
+  static final String REQUEST_HEADER_NAME_STRING = "http.request.header.name";
+  public static final byte REQUEST_HEADER_VALUE = 4;
+  static final String REQUEST_HEADER_VALUE_STRING = "http.request.header";
 
   public static String toString(final byte sourceType) {
     switch (sourceType) {
@@ -17,6 +21,10 @@ public final class SourceType {
         return REQUEST_PARAMETER_NAME_STRING;
       case REQUEST_PARAMETER_VALUE:
         return REQUEST_PARAMETER_VALUE_STRING;
+      case REQUEST_HEADER_NAME:
+        return REQUEST_HEADER_NAME_STRING;
+      case REQUEST_HEADER_VALUE:
+        return REQUEST_HEADER_VALUE_STRING;
       default:
         return null;
     }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/SourceType.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/SourceType.java
@@ -15,6 +15,9 @@ public final class SourceType {
   public static final byte REQUEST_HEADER_VALUE = 4;
   static final String REQUEST_HEADER_VALUE_STRING = "http.request.header";
 
+  public static final byte REQUEST_COOKIE = 5;
+  static final String REQUEST_COOKIE_STRING = "http.request.cookie";
+
   public static String toString(final byte sourceType) {
     switch (sourceType) {
       case REQUEST_PARAMETER_NAME:
@@ -25,6 +28,8 @@ public final class SourceType {
         return REQUEST_HEADER_NAME_STRING;
       case REQUEST_HEADER_VALUE:
         return REQUEST_HEADER_VALUE_STRING;
+      case REQUEST_COOKIE:
+        return REQUEST_COOKIE_STRING;
       default:
         return null;
     }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastModuleImplOnCookieTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastModuleImplOnCookieTest.groovy
@@ -1,0 +1,53 @@
+package com.datadog.iast
+
+import com.datadog.iast.model.Source
+import com.datadog.iast.model.SourceType
+import datadog.trace.api.gateway.RequestContext
+import datadog.trace.api.gateway.RequestContextSlot
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+
+class IastModuleImplOnCookieTest extends IastModuleImplTestBase {
+
+  void 'onCookie without span'() {
+    when:
+    module.onParameterName(cookieString)
+
+    then:
+    1 * tracer.activeSpan() >> null
+    0 * _
+
+    where:
+    cookieString   | _
+    "cookieString" | _
+  }
+
+  void 'onCookie'() {
+    given:
+    final span = Mock(AgentSpan)
+    tracer.activeSpan() >> span
+    final reqCtx = Mock(RequestContext)
+    span.getRequestContext() >> reqCtx
+    final ctx = new IastRequestContext()
+    reqCtx.getData(RequestContextSlot.IAST) >> ctx
+
+    when:
+    module.onCookie(cookieString)
+
+    then:
+    1 * tracer.activeSpan() >> span
+    1 * span.getRequestContext() >> reqCtx
+    1 * reqCtx.getData(RequestContextSlot.IAST) >> ctx
+    0 * _
+    def to = ctx.getTaintedObjects().get(cookieString)
+    to != null
+    to.get() == cookieString
+    to.ranges.size() == 1
+    to.ranges[0].start == 0
+    to.ranges[0].length == cookieString.length()
+    to.ranges[0].source == new Source(SourceType.REQUEST_COOKIE, cookieString, null)
+
+    where:
+    cookieString    | _
+    'cookieStrings' | _
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
@@ -1,0 +1,70 @@
+package datadog.trace.instrumentation.servlet.request;
+
+import datadog.trace.agent.tooling.csi.CallSite;
+import datadog.trace.api.iast.IastAdvice;
+import datadog.trace.api.iast.InstrumentationBridge;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+
+@CallSite(spi = IastAdvice.class)
+public class HttpServletRequestCallSite {
+
+  @CallSite.AfterArray({
+    @CallSite.After(
+        "java.lang.String javax.servlet.http.HttpServletRequest.getHeader(java.lang.String)"),
+    @CallSite.After(
+        "java.lang.String javax.servlet.http.HttpServletRequestWrapper.getHeader(java.lang.String)"),
+  })
+  public static String afterGetHeader(
+      @CallSite.This final HttpServletRequest self,
+      @CallSite.Argument final String headerName,
+      @CallSite.Return final String headerValue) {
+    InstrumentationBridge.onHeaderValue(headerName, headerValue);
+    return headerValue;
+  }
+
+  @CallSite.AfterArray({
+    @CallSite.After(
+        "java.util.Enumeration javax.servlet.http.HttpServletRequest.getHeaders(java.lang.String)"),
+    @CallSite.After(
+        "java.util.Enumeration javax.servlet.http.HttpServletRequestWrapper.getHeaders(java.lang.String)"),
+  })
+  public static Enumeration<?> afterGetHeaders(
+      @CallSite.This final HttpServletRequest self,
+      @CallSite.Argument final String headerName,
+      @CallSite.Return final Enumeration<?> enumeration) {
+    if (enumeration == null) {
+      return null;
+    }
+    final List<String> result = new ArrayList<>();
+    while (enumeration.hasMoreElements()) {
+      final String headerValue = (String) enumeration.nextElement();
+      InstrumentationBridge.onHeaderValue(headerName, headerValue);
+      result.add(headerValue);
+    }
+    return Collections.enumeration(result);
+  }
+
+  @CallSite.AfterArray({
+    @CallSite.After("java.util.Enumeration javax.servlet.http.HttpServletRequest.getHeaderNames()"),
+    @CallSite.After(
+        "java.util.Enumeration javax.servlet.http.HttpServletRequestWrapper.getHeaderNames()"),
+  })
+  public static Enumeration<?> afterGetHeaderNames(
+      @CallSite.This final HttpServletRequest self,
+      @CallSite.Return final Enumeration<?> enumeration) {
+    if (enumeration == null) {
+      return null;
+    }
+    final List<String> result = new ArrayList<>();
+    while (enumeration.hasMoreElements()) {
+      final String headerName = (String) enumeration.nextElement();
+      InstrumentationBridge.onHeaderName(headerName);
+      result.add(headerName);
+    }
+    return Collections.enumeration(result);
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletRequestCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletRequestCallSiteTest.groovy
@@ -1,0 +1,85 @@
+import datadog.smoketest.controller.TestHttpServletRequestCallSiteSuite
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.Platform
+import datadog.trace.api.iast.IastModule
+import datadog.trace.api.iast.InstrumentationBridge
+import spock.lang.IgnoreIf
+
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletRequestWrapper
+
+@IgnoreIf({
+  !Platform.isJavaVersionAtLeast(8)
+})
+class HttpServletRequestCallSiteTest extends AgentTestRunner {
+
+  @Override
+  protected void configurePreAgent() {
+    injectSysConfig("dd.iast.enabled", "true")
+  }
+
+  def 'test getHeader'(final HttpServletRequest request) {
+    setup:
+    IastModule iastModule = Mock(IastModule)
+    InstrumentationBridge.registerIastModule(iastModule)
+    final testSuite = new TestHttpServletRequestCallSiteSuite(request)
+
+    when:
+    final result = testSuite.getHeader('header')
+
+    then:
+    result == 'value'
+    1 * iastModule.onHeaderValue('header', 'value')
+
+    where:
+    request                                | _
+    prepareMock(HttpServletRequest)        | _
+    prepareMock(HttpServletRequestWrapper) | _
+  }
+
+  def 'test getHeaders'(final HttpServletRequest request) {
+    setup:
+    IastModule iastModule = Mock(IastModule)
+    InstrumentationBridge.registerIastModule(iastModule)
+    final testSuite = new TestHttpServletRequestCallSiteSuite(request)
+
+    when:
+    final result = testSuite.getHeaders('header')?.toList()
+
+    then:
+    result == ['value1', 'value2']
+    1 * iastModule.onHeaderValue('header', 'value')
+
+    where:
+    request                                | _
+    prepareMock(HttpServletRequest)        | _
+    prepareMock(HttpServletRequestWrapper) | _
+  }
+
+  def 'test getHeaderNames'(final HttpServletRequest request) {
+    setup:
+    IastModule iastModule = Mock(IastModule)
+    InstrumentationBridge.registerIastModule(iastModule)
+    final testSuite = new TestHttpServletRequestCallSiteSuite(request)
+
+    when:
+    final result = testSuite.getHeaderNames()?.toList()
+
+    then:
+    result == ['header']
+    1 * iastModule.onHeaderName('header')
+
+    where:
+    request                                | _
+    prepareMock(HttpServletRequest)        | _
+    prepareMock(HttpServletRequestWrapper) | _
+  }
+
+  private HttpServletRequest prepareMock(final Class<? extends HttpServletRequest> clazz) {
+    return Mock(clazz) { HttpServletRequest it ->
+      it.getHeader('header') >> 'value'
+      it.getHeaders('headers') >> Collections.enumeration(['value1', 'value2'])
+      it.getHeaderNames() >> Collections.enumeration(['header'])
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/src/test/java/datadog/smoketest/controller/TestHttpServletRequestCallSiteSuite.java
+++ b/dd-java-agent/instrumentation/servlet/src/test/java/datadog/smoketest/controller/TestHttpServletRequestCallSiteSuite.java
@@ -1,0 +1,25 @@
+package datadog.smoketest.controller;
+
+import java.util.Enumeration;
+import javax.servlet.http.HttpServletRequest;
+
+public class TestHttpServletRequestCallSiteSuite {
+
+  private HttpServletRequest request;
+
+  public TestHttpServletRequestCallSiteSuite(final HttpServletRequest request) {
+    this.request = request;
+  }
+
+  public String getHeader(final String headerName) {
+    return request.getHeader(headerName);
+  }
+
+  public Enumeration<?> getHeaders(final String headerName) {
+    return request.getHeaders(headerName);
+  }
+
+  public Enumeration<?> getHeaderNames() {
+    return request.getHeaderNames();
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/iast/IastModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/IastModule.java
@@ -26,6 +26,10 @@ public interface IastModule {
    */
   void onParameterValue(@Nullable String paramName, @Nullable String paramValue);
 
+  void onHeaderName(@Nullable String headerName);
+
+  void onHeaderValue(@Nullable String headerName, @Nullable String headerValue);
+
   void onStringConcat(@Nonnull String left, @Nullable String right, @Nonnull String result);
 
   void onStringBuilderInit(@Nonnull StringBuilder builder, @Nullable CharSequence param);

--- a/internal-api/src/main/java/datadog/trace/api/iast/IastModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/IastModule.java
@@ -59,5 +59,10 @@ public interface IastModule {
 
   void onPathTraversal(@Nullable File parent, @Nonnull String child);
 
-  void onCookie(@Nonnull String... cookieStrings);
+  void onCookie(
+      final String comment,
+      final String domain,
+      final String value,
+      final String name,
+      final String path);
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/IastModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/IastModule.java
@@ -58,4 +58,6 @@ public interface IastModule {
   void onPathTraversal(@Nonnull URI uri);
 
   void onPathTraversal(@Nullable File parent, @Nonnull String child);
+
+  void onCookie(@Nonnull String... cookieStrings);
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/InstrumentationBridge.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/InstrumentationBridge.java
@@ -76,6 +76,26 @@ public abstract class InstrumentationBridge {
     }
   }
 
+  public static void onHeaderName(final String headerName) {
+    try {
+      if (MODULE != null) {
+        MODULE.onHeaderName(headerName);
+      }
+    } catch (final Throwable t) {
+      onUnexpectedException("Callback for onHeaderName threw.", t);
+    }
+  }
+
+  public static void onHeaderValue(final String headerName, final String headerValue) {
+    try {
+      if (MODULE != null) {
+        MODULE.onHeaderValue(headerName, headerValue);
+      }
+    } catch (final Throwable t) {
+      onUnexpectedException("Callback for onHeaderValue threw.", t);
+    }
+  }
+
   public static void onStringConcat(
       @Nonnull final String self, @Nullable final String param, @Nonnull final String result) {
     try {

--- a/internal-api/src/main/java/datadog/trace/api/iast/InstrumentationBridge.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/InstrumentationBridge.java
@@ -236,6 +236,16 @@ public abstract class InstrumentationBridge {
     }
   }
 
+  public static void onCookie(@Nonnull final String... cookieStrings) {
+    try {
+      if (MODULE != null) {
+        MODULE.onCookie(cookieStrings);
+      }
+    } catch (final Throwable t) {
+      onUnexpectedException("Callback for onGetCookies threw.", t);
+    }
+  }
+
   private static void onUnexpectedException(final String message, final Throwable error) {
     LOG.warn(message, error);
   }

--- a/internal-api/src/main/java/datadog/trace/api/iast/InstrumentationBridge.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/InstrumentationBridge.java
@@ -236,10 +236,15 @@ public abstract class InstrumentationBridge {
     }
   }
 
-  public static void onCookie(@Nonnull final String... cookieStrings) {
+  public static void onCookie(
+      final String comment,
+      final String domain,
+      final String value,
+      final String name,
+      final String path) {
     try {
       if (MODULE != null) {
-        MODULE.onCookie(cookieStrings);
+        MODULE.onCookie(comment, domain, value, name, path);
       }
     } catch (final Throwable t) {
       onUnexpectedException("Callback for onGetCookies threw.", t);

--- a/internal-api/src/test/groovy/datadog/trace/api/iast/InstrumentationBridgeTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/iast/InstrumentationBridgeTest.groovy
@@ -39,7 +39,8 @@ class InstrumentationBridgeTest extends DDSpecification {
     new BridgeMethod('onPathTraversal', ['/var', 'log'], 'onPathTraversal'),
     new BridgeMethod('onPathTraversal', ['/var', ['log', 'log.txt'] as String[]], 'onPathTraversal'),
     new BridgeMethod('onPathTraversal', [new File('/var'), '/log/log.txt'], 'onPathTraversal'),
-    new BridgeMethod('onPathTraversal', [new URI('file:/tmp')], 'onPathTraversal')
+    new BridgeMethod('onPathTraversal', [new URI('file:/tmp')], 'onPathTraversal'),
+    new BridgeMethod('onCookie', [['cookieName', 'cookieValue'] as String[]], 'onCookie')
   ]
 
   void '#bridgeMethod does not fail when module is not set'(final BridgeMethod bridgeMethod) {


### PR DESCRIPTION
# What Does This Do

Add support for tainting cookies by instrumenting [getCookies](https://javaee.github.io/javaee-spec/javadocs/javax/servlet/http/HttpServletRequest.html#getCookies--)()

# Motivation

# Additional Notes

Quick version using all String properties from [Cookie](https://javaee.github.io/javaee-spec/javadocs/javax/servlet/http/Cookie.html)