### PR TITLE
Only add OrderedServletPathRequestFilter when Filter interface is available

### DIFF
--- a/dd-java-agent/instrumentation/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/ServletPathRequestFilterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/ServletPathRequestFilterInstrumentation.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.springweb;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.hasClassNamed;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.hasClassNamedOneOf;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
@@ -28,7 +29,8 @@ public class ServletPathRequestFilterInstrumentation extends Instrumenter.Tracin
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
-    return hasClassNamed("org.springframework.web.filter.ServletRequestPathFilter");
+    return hasClassNamed("org.springframework.web.filter.ServletRequestPathFilter")
+        .and(hasClassNamedOneOf("javax.servlet.Filter", "jakarta.servlet.Filter"));
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

Stops the instrumentation from adding `OrderedServletPathRequestFilter` when there is no `...Filter` interface available on the class path.

# Motivation

# Additional Notes
