### PR TITLE
Add evaluateAt support for probe instrumentations

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
@@ -92,7 +92,7 @@ public class Snapshot {
   public void setEntry(CapturedContext context) {
     summaryBuilder.addEntry(context);
     context.setThisClassName(thisClassName);
-    if ((probe.getEvaluateAt() == MethodLocation.NONE
+    if ((probe.getEvaluateAt() == MethodLocation.DEFAULT
             || probe.getEvaluateAt() == MethodLocation.ENTRY)
         && checkCapture(context)) {
       captures.setEntry(context);
@@ -104,7 +104,7 @@ public class Snapshot {
     context.addExtension(ValueReferences.DURATION_EXTENSION_NAME, duration);
     summaryBuilder.addExit(context);
     context.setThisClassName(thisClassName);
-    if ((probe.getEvaluateAt() == MethodLocation.NONE
+    if ((probe.getEvaluateAt() == MethodLocation.DEFAULT
             || probe.getEvaluateAt() == MethodLocation.EXIT)
         && checkCapture(context)) {
       captures.setReturn(context);
@@ -296,7 +296,7 @@ public class Snapshot {
   }
 
   public enum MethodLocation {
-    NONE,
+    DEFAULT,
     ENTRY,
     EXIT
   }
@@ -320,7 +320,7 @@ public class Snapshot {
       this(
           id,
           location,
-          MethodLocation.NONE,
+          MethodLocation.DEFAULT,
           null,
           null,
           new SnapshotSummaryBuilder(location),

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
@@ -92,7 +92,9 @@ public class Snapshot {
   public void setEntry(CapturedContext context) {
     summaryBuilder.addEntry(context);
     context.setThisClassName(thisClassName);
-    if (checkCapture(context)) {
+    if ((probe.getEvaluateAt() == MethodLocation.NONE
+            || probe.getEvaluateAt() == MethodLocation.ENTRY)
+        && checkCapture(context)) {
       captures.setEntry(context);
     }
   }
@@ -102,7 +104,9 @@ public class Snapshot {
     context.addExtension(ValueReferences.DURATION_EXTENSION_NAME, duration);
     summaryBuilder.addExit(context);
     context.setThisClassName(thisClassName);
-    if (checkCapture(context)) {
+    if ((probe.getEvaluateAt() == MethodLocation.NONE
+            || probe.getEvaluateAt() == MethodLocation.EXIT)
+        && checkCapture(context)) {
       captures.setReturn(context);
     }
   }
@@ -220,7 +224,8 @@ public class Snapshot {
         duration,
         stack,
         captures,
-        new ProbeDetails(probeId, probe.location, probe.script, probe.tags, summaryBuilder),
+        new ProbeDetails(
+            probeId, probe.location, probe.evaluateAt, probe.script, probe.tags, summaryBuilder),
         language,
         thread,
         thisClassName,
@@ -290,6 +295,12 @@ public class Snapshot {
     AFTER;
   }
 
+  public enum MethodLocation {
+    NONE,
+    ENTRY,
+    EXIT
+  }
+
   /** Probe information associated with a snapshot */
   public static class ProbeDetails {
     public static final String ITW_PROBE_ID = "instrument-the-world-probe";
@@ -299,33 +310,44 @@ public class Snapshot {
 
     private final String id;
     private final ProbeLocation location;
+    private final MethodLocation evaluateAt;
     private final DebuggerScript script;
     private final transient List<ProbeDetails> additionalProbes;
     private final String tags;
     private final transient SummaryBuilder summaryBuilder;
 
     public ProbeDetails(String id, ProbeLocation location) {
-      this(id, location, null, null, new SnapshotSummaryBuilder(location), Collections.emptyList());
+      this(
+          id,
+          location,
+          MethodLocation.NONE,
+          null,
+          null,
+          new SnapshotSummaryBuilder(location),
+          Collections.emptyList());
     }
 
     public ProbeDetails(
         String id,
         ProbeLocation location,
+        MethodLocation evaluateAt,
         DebuggerScript script,
         String tags,
         SummaryBuilder summaryBuilder) {
-      this(id, location, script, tags, summaryBuilder, Collections.emptyList());
+      this(id, location, evaluateAt, script, tags, summaryBuilder, Collections.emptyList());
     }
 
     public ProbeDetails(
         String id,
         ProbeLocation location,
+        MethodLocation evaluateAt,
         DebuggerScript script,
         String tags,
         SummaryBuilder summaryBuilder,
         List<ProbeDetails> additionalProbes) {
       this.id = id;
       this.location = location;
+      this.evaluateAt = evaluateAt;
       this.script = script;
       this.additionalProbes = additionalProbes;
       this.tags = tags;
@@ -338,6 +360,10 @@ public class Snapshot {
 
     public ProbeLocation getLocation() {
       return location;
+    }
+
+    public MethodLocation getEvaluateAt() {
+      return evaluateAt;
     }
 
     public DebuggerScript getScript() {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -306,8 +306,8 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver {
   private Snapshot.MethodLocation convertMethodLocation(
       ProbeDefinition.MethodLocation methodLocation) {
     switch (methodLocation) {
-      case NONE:
-        return Snapshot.MethodLocation.NONE;
+      case DEFAULT:
+        return Snapshot.MethodLocation.DEFAULT;
       case ENTRY:
         return Snapshot.MethodLocation.ENTRY;
       case EXIT:

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -294,12 +294,26 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver {
     return new Snapshot.ProbeDetails(
         probe.getId(),
         location,
+        convertMethodLocation(probe.getEvaluateAt()),
         probeCondition,
         probe.concatTags(),
         summaryBuilder,
         probe.getAdditionalProbes().stream()
             .map(relatedProbe -> convertToProbeDetails(((SnapshotProbe) relatedProbe), location))
             .collect(Collectors.toList()));
+  }
+
+  private Snapshot.MethodLocation convertMethodLocation(
+      ProbeDefinition.MethodLocation methodLocation) {
+    switch (methodLocation) {
+      case NONE:
+        return Snapshot.MethodLocation.NONE;
+      case ENTRY:
+        return Snapshot.MethodLocation.ENTRY;
+      case EXIT:
+        return Snapshot.MethodLocation.EXIT;
+    }
+    return null;
   }
 
   private void applyRateLimiter(ConfigurationComparer changes) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
@@ -180,7 +180,9 @@ public class Instrumentor {
 
   protected LabelNode getReturnHandler(AbstractInsnNode exitNode) {
     // exit node must have been removed from the original instruction list
-    assert exitNode.getNext() == null && exitNode.getPrevious() == null;
+    if (exitNode.getNext() != null || exitNode.getPrevious() != null) {
+      throw new IllegalArgumentException("exitNode is not removed from original instruction list");
+    }
     if (returnHandlerLabel != null) {
       return returnHandlerLabel;
     }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
@@ -36,6 +36,7 @@ public class Instrumentor {
   protected int localVarBaseOffset;
   protected int argOffset;
   protected final String[] argumentNames;
+  protected LabelNode returnHandlerLabel;
 
   public Instrumentor(
       ProbeDefinition definition,
@@ -132,6 +133,68 @@ public class Instrumentor {
       }
       node = node.getNext();
     }
+  }
+
+  protected void processInstructions() {
+    AbstractInsnNode node = methodNode.instructions.getFirst();
+    while (node != null && !node.equals(returnHandlerLabel)) {
+      if (node.getType() == AbstractInsnNode.LINE) {
+        lineMap.addLine((LineNumberNode) node);
+      } else {
+        node = processInstruction(node);
+      }
+      node = node.getNext();
+    }
+    if (returnHandlerLabel == null) {
+      // if no return found, fallback to use the last instruction as last resort
+      returnHandlerLabel = new LabelNode();
+      methodNode.instructions.insert(methodNode.instructions.getLast(), returnHandlerLabel);
+    }
+  }
+
+  protected AbstractInsnNode processInstruction(AbstractInsnNode node) {
+    switch (node.getOpcode()) {
+      case Opcodes.RET:
+      case Opcodes.RETURN:
+      case Opcodes.IRETURN:
+      case Opcodes.FRETURN:
+      case Opcodes.LRETURN:
+      case Opcodes.DRETURN:
+      case Opcodes.ARETURN:
+        {
+          InsnList beforeReturnInsnList = getBeforeReturnInsnList(node);
+          methodNode.instructions.insertBefore(node, beforeReturnInsnList);
+          AbstractInsnNode prev = node.getPrevious();
+          methodNode.instructions.remove(node);
+          methodNode.instructions.insert(
+              prev, new JumpInsnNode(Opcodes.GOTO, getReturnHandler(node)));
+          return prev;
+        }
+    }
+    return node;
+  }
+
+  protected InsnList getBeforeReturnInsnList(AbstractInsnNode node) {
+    return null;
+  }
+
+  protected LabelNode getReturnHandler(AbstractInsnNode exitNode) {
+    // exit node must have been removed from the original instruction list
+    assert exitNode.getNext() == null && exitNode.getPrevious() == null;
+    if (returnHandlerLabel != null) {
+      return returnHandlerLabel;
+    }
+    returnHandlerLabel = new LabelNode();
+    methodNode.instructions.add(returnHandlerLabel);
+    // stack top is return value (if any)
+    InsnList handler = getReturnHandlerInsnList();
+    handler.add(exitNode); // stack: []
+    methodNode.instructions.add(handler);
+    return returnHandlerLabel;
+  }
+
+  protected InsnList getReturnHandlerInsnList() {
+    return new InsnList();
   }
 
   protected static void invokeStatic(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
@@ -58,7 +58,7 @@ public class MetricInstrumentor extends Instrumentor {
     } else {
       switch (definition.getEvaluateAt()) {
         case ENTRY:
-        case NONE:
+        case DEFAULT:
           {
             InsnList insnList = callMetric(metricProbe);
             methodNode.instructions.insert(methodEnterLabel, insnList);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -180,7 +180,7 @@ public class LogProbe extends ProbeDefinition {
     private String template;
     private List<Segment> segments;
 
-    public LogProbe.Builder template(String template) {
+    public Builder template(String template) {
       this.template = template;
       this.segments = parseTemplate(template);
       return this;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -85,7 +85,7 @@ public class LogProbe extends ProbeDefinition {
   // no-arg constructor is required by Moshi to avoid creating instance with unsafe and by-passing
   // constructors, including field initializers.
   public LogProbe() {
-    this(LANGUAGE, null, true, null, null, MethodLocation.NONE, null, new ArrayList<>());
+    this(LANGUAGE, null, true, null, null, MethodLocation.DEFAULT, null, new ArrayList<>());
   }
 
   public LogProbe(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/MetricProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/MetricProbe.java
@@ -26,7 +26,7 @@ public class MetricProbe extends ProbeDefinition {
   // no-arg constructor is required by Moshi to avoid creating instance with unsafe and by-passing
   // constructors, including field initializers.
   public MetricProbe() {
-    this(LANGUAGE, null, true, null, null, MethodLocation.NONE, MetricKind.COUNT, null, null);
+    this(LANGUAGE, null, true, null, null, MethodLocation.DEFAULT, MetricKind.COUNT, null, null);
   }
 
   public MetricProbe(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
@@ -21,7 +21,7 @@ public abstract class ProbeDefinition {
   protected static final String LANGUAGE = "java";
 
   public enum MethodLocation {
-    NONE,
+    DEFAULT,
     ENTRY,
     EXIT;
   }
@@ -128,7 +128,7 @@ public abstract class ProbeDefinition {
     protected boolean active = true;
     protected String[] tagStrs;
     protected Where where;
-    protected MethodLocation evaluateAt = MethodLocation.NONE;
+    protected MethodLocation evaluateAt = MethodLocation.DEFAULT;
 
     public T language(String language) {
       this.language = language;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SnapshotProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SnapshotProbe.java
@@ -132,7 +132,7 @@ public class SnapshotProbe extends ProbeDefinition {
         true,
         null,
         new Where(),
-        MethodLocation.NONE,
+        MethodLocation.DEFAULT,
         null,
         null,
         null);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1307,7 +1307,7 @@ public class CapturedSnapshotTest {
         return new Snapshot.ProbeDetails(
             id,
             location,
-            Snapshot.MethodLocation.NONE,
+            Snapshot.MethodLocation.DEFAULT,
             probe.getProbeCondition(),
             probe.concatTags(),
             new SnapshotSummaryBuilder(location),
@@ -1317,7 +1317,7 @@ public class CapturedSnapshotTest {
                         new Snapshot.ProbeDetails(
                             relatedProbe.getId(),
                             location,
-                            Snapshot.MethodLocation.NONE,
+                            Snapshot.MethodLocation.DEFAULT,
                             ((SnapshotProbe) relatedProbe).getProbeCondition(),
                             relatedProbe.concatTags(),
                             new SnapshotSummaryBuilder(location)))

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1146,6 +1146,62 @@ public class CapturedSnapshotTest {
         expectedFields);
   }
 
+  @Test
+  public void evaluateAtEntry() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot01";
+    SnapshotProbe snapshotProbe =
+        createProbeBuilder(PROBE_ID, CLASS_NAME, "main", "int (java.lang.String)")
+            .when(
+                new ProbeCondition(
+                    DSL.when(DSL.eq(DSL.ref("^arg"), DSL.value("1"))), "^arg == '1'"))
+            .evaluateAt(ProbeDefinition.MethodLocation.ENTRY)
+            .build();
+    DebuggerTransformerTest.TestSnapshotListener listener =
+        installProbes(CLASS_NAME, snapshotProbe);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "1").get();
+    Assert.assertEquals(3, result);
+    assertOneSnapshot(listener);
+  }
+
+  @Test
+  public void evaluateAtExit() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot01";
+    SnapshotProbe snapshotProbe =
+        createProbeBuilder(PROBE_ID, CLASS_NAME, "main", "int (java.lang.String)")
+            .when(
+                new ProbeCondition(
+                    DSL.when(DSL.eq(DSL.ref("@return"), DSL.value(3))), "@return == 3"))
+            .evaluateAt(ProbeDefinition.MethodLocation.EXIT)
+            .build();
+    DebuggerTransformerTest.TestSnapshotListener listener =
+        installProbes(CLASS_NAME, snapshotProbe);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "1").get();
+    Assert.assertEquals(3, result);
+    assertOneSnapshot(listener);
+  }
+
+  @Test
+  public void evaluateAtExitFalse() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot01";
+    SnapshotProbe snapshotProbe =
+        createProbeBuilder(PROBE_ID, CLASS_NAME, "main", "int (java.lang.String)")
+            .when(
+                new ProbeCondition(
+                    DSL.when(DSL.eq(DSL.ref("@return"), DSL.value(0))), "@return == 0"))
+            .evaluateAt(ProbeDefinition.MethodLocation.EXIT)
+            .build();
+    DebuggerTransformerTest.TestSnapshotListener listener =
+        installProbes(CLASS_NAME, snapshotProbe);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "1").get();
+    Assert.assertEquals(3, result);
+    Assert.assertEquals(0, listener.snapshots.size());
+    Assert.assertTrue(listener.skipped);
+    Assert.assertEquals(DebuggerContext.SkipCause.CONDITION, listener.cause);
+  }
+
   private DebuggerTransformerTest.TestSnapshotListener setupInstrumentTheWorldTransformer(
       String excludeFileName) {
     Config config = mock(Config.class);
@@ -1251,6 +1307,7 @@ public class CapturedSnapshotTest {
         return new Snapshot.ProbeDetails(
             id,
             location,
+            Snapshot.MethodLocation.NONE,
             probe.getProbeCondition(),
             probe.concatTags(),
             new SnapshotSummaryBuilder(location),
@@ -1260,6 +1317,7 @@ public class CapturedSnapshotTest {
                         new Snapshot.ProbeDetails(
                             relatedProbe.getId(),
                             location,
+                            Snapshot.MethodLocation.NONE,
                             ((SnapshotProbe) relatedProbe).getProbeCondition(),
                             relatedProbe.concatTags(),
                             new SnapshotSummaryBuilder(location)))

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -239,7 +239,7 @@ public class LogProbesInstrumentationTest {
         return new Snapshot.ProbeDetails(
             id,
             location,
-            Snapshot.MethodLocation.NONE,
+            Snapshot.MethodLocation.DEFAULT,
             null,
             probe.concatTags(),
             new LogMessageTemplateSummaryBuilder(probe),
@@ -249,7 +249,7 @@ public class LogProbesInstrumentationTest {
                         new Snapshot.ProbeDetails(
                             relatedProbe.getId(),
                             location,
-                            Snapshot.MethodLocation.NONE,
+                            Snapshot.MethodLocation.DEFAULT,
                             relatedProbe instanceof SnapshotProbe
                                 ? ((SnapshotProbe) relatedProbe).getProbeCondition()
                                 : null,

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -74,6 +74,19 @@ public class LogProbesInstrumentationTest {
   }
 
   @Test
+  public void methodTemplateArgLogEvaluateAtExit() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot01";
+    DebuggerTransformerTest.TestSnapshotListener listener =
+        installSingleProbe(
+            "this is log line with return={@return}", CLASS_NAME, "main", "int (java.lang.String)");
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "1").get();
+    Assert.assertEquals(3, result);
+    Snapshot snapshot = assertOneSnapshot(listener);
+    assertEquals("this is log line with return=3", snapshot.getSummary());
+  }
+
+  @Test
   public void linePlainLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
     DebuggerTransformerTest.TestSnapshotListener listener =
@@ -226,6 +239,7 @@ public class LogProbesInstrumentationTest {
         return new Snapshot.ProbeDetails(
             id,
             location,
+            Snapshot.MethodLocation.NONE,
             null,
             probe.concatTags(),
             new LogMessageTemplateSummaryBuilder(probe),
@@ -235,6 +249,7 @@ public class LogProbesInstrumentationTest {
                         new Snapshot.ProbeDetails(
                             relatedProbe.getId(),
                             location,
+                            Snapshot.MethodLocation.NONE,
                             relatedProbe instanceof SnapshotProbe
                                 ? ((SnapshotProbe) relatedProbe).getProbeCondition()
                                 : null,

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
@@ -209,6 +209,7 @@ public class SnapshotSerializationTest {
             new Snapshot.ProbeDetails(
                 PROBE_ID,
                 PROBE_LOCATION,
+                Snapshot.MethodLocation.DEFAULT,
                 new ProbeCondition(DSL.when(DSL.gt(DSL.ref("^n"), DSL.value(0))), "^n > 0"),
                 "",
                 new SnapshotSummaryBuilder(PROBE_LOCATION)),

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/multipleSnapshotRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/multipleSnapshotRegex.txt
@@ -4,7 +4,7 @@
 "snapshot":\{
 "captures":\{\},
 "language":"java",
-"probe":\{"evaluateAt":"NONE","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
+"probe":\{"evaluateAt":"DEFAULT","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
 "stack":\[\],
 "timestamp":\d+
 \}\},
@@ -24,7 +24,7 @@
 "snapshot":\{
 "captures":\{\},
 "language":"java",
-"probe":\{"evaluateAt":"NONE","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
+"probe":\{"evaluateAt":"DEFAULT","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
 "stack":\[\],
 "timestamp":\d+
 \}\},

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/multipleSnapshotRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/multipleSnapshotRegex.txt
@@ -4,7 +4,7 @@
 "snapshot":\{
 "captures":\{\},
 "language":"java",
-"probe":\{"id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
+"probe":\{"evaluateAt":"NONE","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
 "stack":\[\],
 "timestamp":\d+
 \}\},
@@ -24,7 +24,7 @@
 "snapshot":\{
 "captures":\{\},
 "language":"java",
-"probe":\{"id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
+"probe":\{"evaluateAt":"NONE","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
 "stack":\[\],
 "timestamp":\d+
 \}\},

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotCapturedValueRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotCapturedValueRegex.txt
@@ -51,7 +51,7 @@
 \},
 "language":"java",
 "probe":\{
-"evaluateAt":"NONE",
+"evaluateAt":"DEFAULT",
 "id":"12fd-8490-c111-4374-ffde",
 "location":\{
 "file":"String.java",

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotCapturedValueRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotCapturedValueRegex.txt
@@ -51,6 +51,7 @@
 \},
 "language":"java",
 "probe":\{
+"evaluateAt":"NONE",
 "id":"12fd-8490-c111-4374-ffde",
 "location":\{
 "file":"String.java",

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotRegex.txt
@@ -4,7 +4,7 @@
 "snapshot":\{
 "captures":\{\},
 "language":"java",
-"probe":\{"id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
+"probe":\{"evaluateAt":"NONE","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
 "stack":\[\],
 "timestamp":\d+
 \}\},

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotRegex.txt
@@ -4,7 +4,7 @@
 "snapshot":\{
 "captures":\{\},
 "language":"java",
-"probe":\{"evaluateAt":"NONE","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
+"probe":\{"evaluateAt":"DEFAULT","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
 "stack":\[\],
 "timestamp":\d+
 \}\},

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotWithCorrelationIdsRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotWithCorrelationIdsRegex.txt
@@ -6,7 +6,7 @@
 "snapshot":\{
 "captures":\{"entry":\{"arguments":\{\},"locals":\{\}\}\},
 "language":"java",
-"probe":\{"evaluateAt":"NONE","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
+"probe":\{"evaluateAt":"DEFAULT","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
 "stack":\[\],
 "timestamp":\d+
 \}\},

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotWithCorrelationIdsRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotWithCorrelationIdsRegex.txt
@@ -6,7 +6,7 @@
 "snapshot":\{
 "captures":\{"entry":\{"arguments":\{\},"locals":\{\}\}\},
 "language":"java",
-"probe":\{"id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
+"probe":\{"evaluateAt":"NONE","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
 "stack":\[\],
 "timestamp":\d+
 \}\},


### PR DESCRIPTION
# What Does This Do
 * Snapshot: indicates for method probe where conditions are evaluated before serializing data. Either at entry or exit of the method.
 * Metric: indicates for method probe where the metric is emitted and with which values. For example at Exit of the method you can emit the return value of the method.
 * Log: use the same mechanism than snapshot but can report for example at exit of the method the return value.

# Motivation
following #4313 

# Additional Notes
