### PR TITLE
Reduce the amount of full-type parsing needed for instrumentation

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/CachingType.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/CachingType.java
@@ -10,10 +10,16 @@ import net.bytebuddy.description.type.TypeList;
 
 /** Type description that lazily caches expensive results. */
 final class CachingType extends WithName {
+
+  // non-null sentinels for fields that can legitimately be null
+  private static final Generic UNSET_SUPER_CLASS = Generic.VOID;
+  private static final TypeDescription UNSET_DECLARING_TYPE = TypeDescription.VOID;
+
   private final TypeDescription delegate;
 
-  private Generic superClass;
+  private Generic superClass = UNSET_SUPER_CLASS;
   private TypeList.Generic interfaces;
+  private TypeDescription declaringType = UNSET_DECLARING_TYPE;
   private AnnotationList annotations;
   private FieldList<FieldDescription.InDefinedShape> fields;
   private MethodList<MethodDescription.InDefinedShape> methods;
@@ -30,7 +36,7 @@ final class CachingType extends WithName {
 
   @Override
   public Generic getSuperClass() {
-    if (superClass == null) {
+    if (superClass == UNSET_SUPER_CLASS) {
       superClass = delegate.getSuperClass();
     }
     return superClass;
@@ -42,6 +48,14 @@ final class CachingType extends WithName {
       interfaces = delegate.getInterfaces();
     }
     return interfaces;
+  }
+
+  @Override
+  public TypeDescription getDeclaringType() {
+    if (declaringType == UNSET_DECLARING_TYPE) {
+      declaringType = delegate.getDeclaringType();
+    }
+    return declaringType;
   }
 
   @Override

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/OutlineTypeParser.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/OutlineTypeParser.java
@@ -40,6 +40,11 @@ final class OutlineTypeParser implements TypeParser {
             null != superClass ? superClass.getName() : null,
             extractTypeNames(loadedType.getInterfaces()));
 
+    Class<?> declaringClass = loadedType.getDeclaringClass();
+    if (null != declaringClass) {
+      typeOutline.declaredBy(declaringClass.getName());
+    }
+
     for (Annotation a : loadedType.getDeclaredAnnotations()) {
       typeOutline.declare(annotationOutline(Type.getDescriptor(a.annotationType())));
     }
@@ -100,6 +105,13 @@ final class OutlineTypeParser implements TypeParser {
         String superName,
         String[] interfaces) {
       typeOutline = new TypeOutline(version, access, name, superName, interfaces);
+    }
+
+    @Override
+    public void visitInnerClass(String name, String outerName, String innerName, int access) {
+      if (null != outerName && typeOutline.getInternalName().equals(name)) {
+        typeOutline.declaredBy(outerName);
+      }
     }
 
     @Override

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.description.type.TypeList;
 import net.bytebuddy.dynamic.ClassFileLocator;
 import net.bytebuddy.jar.asm.Type;
 import net.bytebuddy.pool.TypePool;
@@ -302,13 +303,46 @@ final class TypeFactory {
     }
 
     @Override
+    public int getModifiers() {
+      return outline().getModifiers();
+    }
+
+    @Override
+    public Generic getSuperClass() {
+      return outline().getSuperClass();
+    }
+
+    @Override
+    public TypeList.Generic getInterfaces() {
+      return outline().getInterfaces();
+    }
+
+    @Override
+    public TypeDescription getDeclaringType() {
+      return outline().getDeclaringType();
+    }
+
+    private TypeDescription outline() {
+      TypeDescription outline;
+      if (createOutlines) {
+        outline = doResolve(true);
+      } else {
+        // temporarily switch to outlines as that's all we need
+        createOutlines = true;
+        outline = doResolve(true);
+        createOutlines = false;
+      }
+      return outline;
+    }
+
+    @Override
     protected TypeDescription delegate() {
       return doResolve(true);
     }
 
     TypeDescription doResolve(boolean throwIfMissing) {
       // re-resolve type when switching to full descriptions
-      if (null == delegate || createOutlines != isOutline) {
+      if (null == delegate || (isOutline && !createOutlines)) {
         delegate = resolveType(name);
         isOutline = createOutlines;
         if (throwIfMissing && null == delegate) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeOutline.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeOutline.java
@@ -30,6 +30,7 @@ final class TypeOutline extends WithName {
   private final int modifiers;
   private final String superName;
   private final String[] interfaces;
+  private String declaringName;
 
   private List<AnnotationDescription> declaredAnnotations;
 
@@ -70,6 +71,14 @@ final class TypeOutline extends WithName {
   }
 
   @Override
+  public TypeDescription getDeclaringType() {
+    if (null != declaringName) {
+      return findType(declaringName.replace('/', '.'));
+    }
+    return null;
+  }
+
+  @Override
   public int getModifiers() {
     return modifiers;
   }
@@ -94,6 +103,10 @@ final class TypeOutline extends WithName {
   @Override
   public MethodList<MethodDescription.InDefinedShape> getDeclaredMethods() {
     return declaredMethods.isEmpty() ? NO_METHODS : new MethodList.Explicit<>(declaredMethods);
+  }
+
+  void declaredBy(String declaringName) {
+    this.declaringName = declaringName;
   }
 
   void declare(AnnotationDescription annotation) {


### PR DESCRIPTION
# What Does This Do

For certain metadata (class modifiers, the names of interfaces and any super-class) we only need the outline of the declaring type, regardless whether we're matching or transforming. This PR temporarily switches the type-factory to always create outlines when looking up this kind of metadata.

The delegate check in `LazyType` has also been adjusted to allow re-use of full-types even when we only want outlines. 

# Motivation

Outline type parsing is faster and uses less memory than full-type parsing.

# Additional notes

For a small apps like petclinic this reduces the amount of full-types parsed from ~1200 to less than 300