### PR TITLE
do not reference Filter interface

### DIFF
--- a/dd-java-agent/instrumentation/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/OrderedServletPathRequestFilter.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/OrderedServletPathRequestFilter.java
@@ -1,25 +1,19 @@
 package datadog.trace.instrumentation.springweb;
 
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
 import org.springframework.beans.factory.annotation.AnnotatedGenericBeanDefinition;
 import org.springframework.core.Ordered;
+import org.springframework.web.filter.DelegatingFilterProxy;
 import org.springframework.web.filter.ServletRequestPathFilter;
 
-public class OrderedServletPathRequestFilter extends ServletRequestPathFilter implements Ordered {
-  @Override
-  public void init(FilterConfig filterConfig) throws ServletException {
-    // intentionally left blank
-  }
-
-  @Override
-  public void destroy() {
-    // intentionally left blank
-  }
+public class OrderedServletPathRequestFilter extends DelegatingFilterProxy implements Ordered {
 
   @Override
   public int getOrder() {
     return Ordered.HIGHEST_PRECEDENCE;
+  }
+
+  public OrderedServletPathRequestFilter() {
+    super(new ServletRequestPathFilter());
   }
 
   public static class BeanDefinition extends AnnotatedGenericBeanDefinition {

--- a/dd-java-agent/instrumentation/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/ServletPathRequestFilterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/ServletPathRequestFilterInstrumentation.java
@@ -1,7 +1,6 @@
 package datadog.trace.instrumentation.springweb;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.hasClassNamed;
-import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.hasClassNamedOneOf;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
@@ -24,13 +23,13 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 public class ServletPathRequestFilterInstrumentation extends Instrumenter.Tracing
     implements Instrumenter.ForTypeHierarchy {
   public ServletPathRequestFilterInstrumentation() {
-    super("spring-web");
+    super("spring-web", "spring-path-filter");
   }
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     return hasClassNamed("org.springframework.web.filter.ServletRequestPathFilter")
-        .and(hasClassNamedOneOf("javax.servlet.Filter", "jakarta.servlet.Filter"));
+        .and(hasClassNamed("javax.servlet.Filter"));
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

Avoid referencing Filter interface but it relies on spring DelegatingFilterProxy for the same.

Also allow disabling the instrumentation by providing an alternate name `spring-path-filter` to inject the `OrderedServletPathRequestFilter`

# Motivation

# Additional Notes

Tested on:
* Spring web 5.3 with tomcat 8 -> working ok
* Spring web 5.3 (boot 2.7.x) -> working ok
* Spring webflux 5.3 (boot 2.7.x) -> Muzzled expected
* Spring webflux 6 (boot 3) -> Muzzled expected
* Spring web 6 (boot 3) -> Muzzled expected