### PR TITLE
Make StatsDClient flush immediately in tests

### DIFF
--- a/communication/src/main/java/datadog/communication/monitor/DDAgentStatsDConnection.java
+++ b/communication/src/main/java/datadog/communication/monitor/DDAgentStatsDConnection.java
@@ -37,6 +37,7 @@ final class DDAgentStatsDConnection implements StatsDClientErrorHandler {
   private volatile String host;
   private volatile Integer port;
   private final String namedPipe;
+  private final boolean useAggregation;
 
   private final AtomicInteger clientCount = new AtomicInteger(0);
   private final AtomicInteger errorCount = new AtomicInteger(0);
@@ -44,10 +45,12 @@ final class DDAgentStatsDConnection implements StatsDClientErrorHandler {
 
   volatile com.timgroup.statsd.StatsDClient statsd = NO_OP;
 
-  DDAgentStatsDConnection(final String host, final Integer port, final String namedPipe) {
+  DDAgentStatsDConnection(
+      final String host, final Integer port, final String namedPipe, boolean useAggregation) {
     this.host = host;
     this.port = port;
     this.namedPipe = namedPipe;
+    this.useAggregation = useAggregation;
   }
 
   @Override
@@ -105,6 +108,7 @@ final class DDAgentStatsDConnection implements StatsDClientErrorHandler {
             new NonBlockingStatsDClientBuilder()
                 .threadFactory(STATSD_CLIENT_THREAD_FACTORY)
                 .enableTelemetry(false)
+                .enableAggregation(useAggregation)
                 .hostname(host)
                 .port(port)
                 .namedPipe(namedPipe)

--- a/communication/src/test/groovy/datadog/communication/monitor/DDAgentStatsDClientTest.groovy
+++ b/communication/src/test/groovy/datadog/communication/monitor/DDAgentStatsDClientTest.groovy
@@ -14,7 +14,7 @@ class DDAgentStatsDClientTest extends DDSpecification {
     def server = new StatsDServer()
     server.start()
 
-    def client = statsDClientManager().statsDClient('127.0.0.1', server.socket.localPort, null, namespace, constantTags as String[])
+    def client = statsDClientManager().statsDClient('127.0.0.1', server.socket.localPort, null, namespace, constantTags as String[], false)
 
     String metricName = "test.metric"
     String checkName = "test.check"
@@ -108,10 +108,10 @@ class DDAgentStatsDClientTest extends DDSpecification {
     def server = new StatsDServer()
     server.start()
 
-    def client1 = statsDClientManager().statsDClient('127.0.0.1', server.socket.localPort, null, null, null)
-    def client2 = statsDClientManager().statsDClient('127.0.0.1', server.socket.localPort, null, "example", null)
-    def client3 = statsDClientManager().statsDClient('127.0.0.1', server.socket.localPort, null, null, ["lang:java", "lang_version:1.8.0"] as String[])
-    def client4 = statsDClientManager().statsDClient('127.0.0.1', server.socket.localPort, null, "example", ["lang:java", "lang_version:1.8.0"] as String[])
+    def client1 = statsDClientManager().statsDClient('127.0.0.1', server.socket.localPort, null, null, null, false)
+    def client2 = statsDClientManager().statsDClient('127.0.0.1', server.socket.localPort, null, "example", null, false)
+    def client3 = statsDClientManager().statsDClient('127.0.0.1', server.socket.localPort, null, null, ["lang:java", "lang_version:1.8.0"] as String[], false)
+    def client4 = statsDClientManager().statsDClient('127.0.0.1', server.socket.localPort, null, "example", ["lang:java", "lang_version:1.8.0"] as String[], false)
 
     String metricName = "test.metric"
     String[] metricTags = ["type:BufferPool", "jmx_domain:java.nio"]

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -71,7 +71,9 @@ excludedClassesCoverage += [
   "datadog.trace.api.Config.HostNameHolder",
   "datadog.trace.api.Config.RuntimeIdHolder",
   // can't reliably force same identity hash for different instance to cover branch
-  "datadog.trace.api.cache.FixedSizeCache.IdentityHash"
+  "datadog.trace.api.cache.FixedSizeCache.IdentityHash",
+  // Interface with default method
+  "datadog.trace.api.StatsDClientManager"
 ]
 excludedClassesBranchCoverage = ['datadog.trace.api.ProductActivationConfig',]
 

--- a/internal-api/src/main/java/datadog/trace/api/StatsDClientManager.java
+++ b/internal-api/src/main/java/datadog/trace/api/StatsDClientManager.java
@@ -1,6 +1,16 @@
 package datadog.trace.api;
 
 public interface StatsDClientManager {
+  default StatsDClient statsDClient(
+      String host, Integer port, String namedPipe, String namespace, String[] constantTags) {
+    return statsDClient(host, port, namedPipe, namespace, constantTags, true);
+  }
+
   StatsDClient statsDClient(
-      String host, Integer port, String namedPipe, String namespace, String[] constantTags);
+      String host,
+      Integer port,
+      String namedPipe,
+      String namespace,
+      String[] constantTags,
+      boolean useAggregation);
 }


### PR DESCRIPTION
# What Does This Do

Makes the `StatsDClient` used in tests flush immediately, so we don't wait 10 seconds between a lot of the test cases. The test time goes from more than 1 minute 30 seconds to less than 10 seconds.

# Motivation

Slow tests are slow...

# Additional Notes
