### PR TITLE
Fix ProbeCondition snapshot serialization

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/ProbeCondition.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/ProbeCondition.java
@@ -45,10 +45,14 @@ public final class ProbeCondition implements DebuggerScript {
 
     @Override
     public void toJson(@NonNull JsonWriter jsonWriter, ProbeCondition value) throws IOException {
-      if (value != null) {
-        throw new UnsupportedOperationException();
+      if (value == null) {
+        jsonWriter.nullValue();
+        return;
       }
-      jsonWriter.nullValue();
+      jsonWriter.beginObject();
+      jsonWriter.name("dsl");
+      jsonWriter.value(value.dslExpression);
+      jsonWriter.endObject();
     }
   }
 

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
@@ -49,8 +49,7 @@ public class ProbeConditionTest {
     JsonAdapter<ProbeCondition> jsonAdapter = moshi.adapter(ProbeCondition.class);
     assertNull(jsonAdapter.fromJson("null"));
     assertEquals(jsonAdapter.toJson(null), "null");
-    assertThrows(
-        UnsupportedOperationException.class, () -> jsonAdapter.toJson(ProbeCondition.NONE));
+    assertEquals("{\"dsl\":\"\"}", jsonAdapter.toJson(ProbeCondition.NONE));
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do
serialize DSL expression of the probe condition into probe details section of the snapshot

# Motivation
if a condition is set in a probe, it was not serialized in the probeDetails section of the snapshot

# Additional Notes
