### PR TITLE
Move Config.isLogsMDCTagsInjectionEnabled() to InstrumenterConfig

### DIFF
--- a/dd-java-agent/instrumentation/jboss-logmanager/src/main/java/datadog/trace/instrumentation/jbosslogmanager/ExtLogRecordInstrumentation.java
+++ b/dd-java-agent/instrumentation/jboss-logmanager/src/main/java/datadog/trace/instrumentation/jbosslogmanager/ExtLogRecordInstrumentation.java
@@ -140,7 +140,7 @@ public class ExtLogRecordInstrumentation extends Instrumenter.Tracing
 
       AgentSpan.Context context =
           InstrumentationContext.get(ExtLogRecord.class, AgentSpan.Context.class).get(record);
-      boolean mdcTagsInjectionEnabled = Config.get().isLogsMDCTagsInjectionEnabled();
+      boolean mdcTagsInjectionEnabled = InstrumenterConfig.get().isLogsMDCTagsInjectionEnabled();
 
       // Nothing to add so return early
       if (context == null && !mdcTagsInjectionEnabled) {

--- a/dd-java-agent/instrumentation/log4j-2.7/src/main/java/datadog/trace/instrumentation/log4j27/SpanDecoratingContextDataInjector.java
+++ b/dd-java-agent/instrumentation/log4j-2.7/src/main/java/datadog/trace/instrumentation/log4j27/SpanDecoratingContextDataInjector.java
@@ -9,6 +9,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 import datadog.trace.api.Config;
 import datadog.trace.api.CorrelationIdentifier;
 import datadog.trace.api.DDSpanId;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.util.List;
@@ -32,7 +33,7 @@ public final class SpanDecoratingContextDataInjector implements ContextDataInjec
     // We're at most adding 5 tags
     StringMap newContextData = new SortedArrayStringMap(contextData.size() + 5);
 
-    if (Config.get().isLogsMDCTagsInjectionEnabled()) {
+    if (InstrumenterConfig.get().isLogsMDCTagsInjectionEnabled()) {
       String env = Config.get().getEnv();
       if (null != env && !env.isEmpty()) {
         newContextData.putValue(Tags.DD_ENV, env);

--- a/dd-java-agent/instrumentation/log4j1/src/main/java/datadog/trace/instrumentation/log4j1/LoggingEventInstrumentation.java
+++ b/dd-java-agent/instrumentation/log4j1/src/main/java/datadog/trace/instrumentation/log4j1/LoggingEventInstrumentation.java
@@ -123,7 +123,7 @@ public class LoggingEventInstrumentation extends Instrumenter.Tracing
 
         Hashtable mdc = new Hashtable();
 
-        if (Config.get().isLogsMDCTagsInjectionEnabled()) {
+        if (InstrumenterConfig.get().isLogsMDCTagsInjectionEnabled()) {
           String serviceName = Config.get().getServiceName();
           if (null != serviceName && !serviceName.isEmpty()) {
             mdc.put(Tags.DD_SERVICE, serviceName);

--- a/dd-java-agent/instrumentation/logback-1/src/main/java/datadog/trace/instrumentation/logback/LoggingEventInstrumentation.java
+++ b/dd-java-agent/instrumentation/logback-1/src/main/java/datadog/trace/instrumentation/logback/LoggingEventInstrumentation.java
@@ -81,7 +81,7 @@ public class LoggingEventInstrumentation extends Instrumenter.Tracing
 
       AgentSpan.Context context =
           InstrumentationContext.get(ILoggingEvent.class, AgentSpan.Context.class).get(event);
-      boolean mdcTagsInjectionEnabled = Config.get().isLogsMDCTagsInjectionEnabled();
+      boolean mdcTagsInjectionEnabled = InstrumenterConfig.get().isLogsMDCTagsInjectionEnabled();
 
       // Nothing to add so return early
       if (context == null && !mdcTagsInjectionEnabled) {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -190,7 +190,6 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.JMS_PROPAGATIO
 import static datadog.trace.api.config.TraceInstrumentationConfig.JMS_PROPAGATION_DISABLED_TOPICS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.KAFKA_CLIENT_BASE64_DECODING_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.KAFKA_CLIENT_PROPAGATION_DISABLED_TOPICS;
-import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_MDC_TAGS_INJECTION_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.MESSAGE_BROKER_SPLIT_BY_DESTINATION;
 import static datadog.trace.api.config.TraceInstrumentationConfig.OBFUSCATION_QUERY_STRING_REGEXP;
 import static datadog.trace.api.config.TraceInstrumentationConfig.PLAY_REPORT_HTTP_STATUS;
@@ -406,7 +405,6 @@ public class Config {
   private final int tracerMetricsMaxAggregates;
   private final int tracerMetricsMaxPending;
 
-  private final boolean logsMDCTagsInjectionEnabled;
   private final boolean reportHostName;
 
   private final boolean traceAnalyticsEnabled;
@@ -876,7 +874,6 @@ public class Config {
     tracerMetricsMaxAggregates = configProvider.getInteger(TRACER_METRICS_MAX_AGGREGATES, 2048);
     tracerMetricsMaxPending = configProvider.getInteger(TRACER_METRICS_MAX_PENDING, 2048);
 
-    logsMDCTagsInjectionEnabled = configProvider.getBoolean(LOGS_MDC_TAGS_INJECTION_ENABLED, true);
     reportHostName =
         configProvider.getBoolean(TRACE_REPORT_HOSTNAME, DEFAULT_TRACE_REPORT_HOSTNAME);
 
@@ -1507,10 +1504,6 @@ public class Config {
 
   public boolean isLogsInjectionEnabled() {
     return instrumenterConfig.isLogsInjectionEnabled();
-  }
-
-  public boolean isLogsMDCTagsInjectionEnabled() {
-    return logsMDCTagsInjectionEnabled;
   }
 
   public boolean isReportHostName() {
@@ -2698,8 +2691,6 @@ public class Config {
         + tracerMetricsMaxAggregates
         + ", tracerMetricsMaxPending="
         + tracerMetricsMaxPending
-        + ", logsMDCTagsInjectionEnabled="
-        + logsMDCTagsInjectionEnabled
         + ", reportHostName="
         + reportHostName
         + ", traceAnalyticsEnabled="

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -28,6 +28,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.INTEGRATIONS_E
 import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_CONNECTION_CLASS_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_PREPARED_STATEMENT_CLASS_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_INJECTION_ENABLED;
+import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_MDC_TAGS_INJECTION_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_OUTLINE_POOL_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_OUTLINE_POOL_SIZE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_RESET_INTERVAL;
@@ -62,6 +63,7 @@ public class InstrumenterConfig {
 
   private final boolean traceEnabled;
   private final boolean logsInjectionEnabled;
+  private final boolean logsMDCTagsInjectionEnabled;
   private final boolean profilingEnabled;
   private final boolean ciVisibilityEnabled;
   private final ProductActivation appSecActivation;
@@ -109,6 +111,7 @@ public class InstrumenterConfig {
     traceEnabled = configProvider.getBoolean(TRACE_ENABLED, DEFAULT_TRACE_ENABLED);
     logsInjectionEnabled =
         configProvider.getBoolean(LOGS_INJECTION_ENABLED, DEFAULT_LOGS_INJECTION_ENABLED);
+    logsMDCTagsInjectionEnabled = configProvider.getBoolean(LOGS_MDC_TAGS_INJECTION_ENABLED, true);
     profilingEnabled = configProvider.getBoolean(PROFILING_ENABLED, PROFILING_ENABLED_DEFAULT);
     ciVisibilityEnabled =
         configProvider.getBoolean(CIVISIBILITY_ENABLED, DEFAULT_CIVISIBILITY_ENABLED);
@@ -190,6 +193,10 @@ public class InstrumenterConfig {
     return logsInjectionEnabled;
   }
 
+  public boolean isLogsMDCTagsInjectionEnabled() {
+    return logsMDCTagsInjectionEnabled && !Platform.isNativeImageBuilder();
+  }
+
   public boolean isProfilingEnabled() {
     return profilingEnabled;
   }
@@ -267,7 +274,7 @@ public class InstrumenterConfig {
   }
 
   public int getResolverResetInterval() {
-    return resolverResetInterval;
+    return Platform.isNativeImageBuilder() ? 0 : resolverResetInterval;
   }
 
   public boolean isRuntimeContextFieldInjection() {
@@ -317,6 +324,8 @@ public class InstrumenterConfig {
         + traceEnabled
         + ", logsInjectionEnabled="
         + logsInjectionEnabled
+        + ", logsMDCTagsInjectionEnabled="
+        + logsMDCTagsInjectionEnabled
         + ", profilingEnabled="
         + profilingEnabled
         + ", ciVisibilityEnabled="


### PR DESCRIPTION
# Motivation

This allows instrumentation of logging backends during `native-image` analysis without having to load the entire `Config`