### PR TITLE
Fix embedded test so we can remove redundant MethodHandles

### DIFF
--- a/dd-java-agent/instrumentation/liberty-20/src/test/groovy/datadog/trace/instrumentation/liberty20/Liberty20Test.groovy
+++ b/dd-java-agent/instrumentation/liberty-20/src/test/groovy/datadog/trace/instrumentation/liberty20/Liberty20Test.groovy
@@ -31,7 +31,9 @@ class Liberty20Test extends HttpServerTest<Server> {
       changeServerXml()
       ServerBuilder sb = new ServerBuilder(name: 'defaultServer')
       server = sb.build()
-      def result = server.start().get(45, TimeUnit.SECONDS)
+      // set bootdelegation to mimic how our -javaagent delegates requests for our shaded slf4j package
+      // (at this point in the build we haven't shaded slf4j or transformed any framework class-loaders)
+      def result = server.start(["org.osgi.framework.bootdelegation":"org.slf4j"]).get(45, TimeUnit.SECONDS)
       if (!result.successful()) {
         throw new IllegalStateException("OpenLiberty startup has failed")
       }

--- a/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/ServletBlockingHelper.java
+++ b/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/ServletBlockingHelper.java
@@ -5,44 +5,13 @@ import datadog.trace.bootstrap.blocking.BlockingActionHelper;
 import datadog.trace.bootstrap.blocking.BlockingActionHelper.TemplateType;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ServletBlockingHelper {
-  private static final MethodHandle DEBUG_MH;
-  private static final MethodHandle WARN_MH;
-  private static final MethodHandle WARN_THR_MH;
-
-  static {
-    MethodHandle debugMH = null, warnMH = null, warnThrMH = null;
-    try {
-      Logger log = LoggerFactory.getLogger(ServletBlockingHelper.class);
-      debugMH =
-          MethodHandles.lookup()
-              .findVirtual(Logger.class, "debug", MethodType.methodType(void.class, String.class));
-      debugMH = debugMH.bindTo(log);
-      warnMH =
-          MethodHandles.lookup()
-              .findVirtual(Logger.class, "warn", MethodType.methodType(void.class, String.class));
-      warnMH = warnMH.bindTo(log);
-      warnThrMH =
-          MethodHandles.lookup()
-              .findVirtual(
-                  Logger.class,
-                  "warn",
-                  MethodType.methodType(void.class, String.class, Throwable.class));
-      warnThrMH = warnThrMH.bindTo(log);
-    } catch (NoClassDefFoundError | NoSuchMethodException | IllegalAccessException err) {
-    }
-    DEBUG_MH = debugMH;
-    WARN_MH = warnMH;
-    WARN_THR_MH = warnThrMH;
-  }
+  private static final Logger log = LoggerFactory.getLogger(ServletBlockingHelper.class);
 
   public static void commitBlockingResponse(
       HttpServletRequest httpServletRequest,
@@ -66,49 +35,16 @@ public class ServletBlockingHelper {
       os.write(template);
       os.close();
     } catch (IOException e) {
-      warn("Error sending error page", e);
-    }
-  }
-
-  private static void warn(String msg, Throwable t) {
-    if (WARN_THR_MH == null) {
-      return;
-    }
-
-    try {
-      WARN_THR_MH.invoke(msg, t);
-    } catch (Throwable ex) {
-    }
-  }
-
-  private static void warn(String msg) {
-    if (WARN_MH == null) {
-      return;
-    }
-
-    try {
-      WARN_MH.invoke(msg);
-    } catch (Throwable ex) {
-    }
-  }
-
-  private static void debug(String msg) {
-    if (DEBUG_MH == null) {
-      return;
-    }
-
-    try {
-      DEBUG_MH.invoke(msg);
-    } catch (Throwable ex) {
+      log.warn("Error sending error page", e);
     }
   }
 
   private static boolean start(HttpServletResponse resp, int statusCode) {
     if (resp.isCommitted()) {
-      warn("response already committed, we can't change it");
+      log.warn("response already committed, we can't change it");
     }
 
-    debug("Committing blocking response");
+    log.debug("Committing blocking response");
 
     resp.reset();
     resp.setStatus(statusCode);


### PR DESCRIPTION
# Background

`Liberty20Test` creates an embedded instance of Liberty, which is based on OSGi. This means the application and servlet jars are isolated from the rest of the test JVM.

Note that the instrumentation being tested still uses the `org.slf4j` package for its logging because the repackaging to `datadog.slf4j` only happens when all instrumentations are collected in the final `dd-java-agent` jar. It also doesn't have the classloading instrumentation installed which would normally delegate `datadog.slf4j` requests to the boot-class-path.

The end result of this was that the original `ServletBlockingHelper` was failing to load for `Liberty20Test`, because it referred to `org.slf4j` and the embedded liberty server was not allowing requests for that package to delegate to the boot-class-path.

So PR #4258 changed `ServletBlockingHelper` to use MethodHandles to access the logger indirectly - however this indirection is not necessary with the final `dd-java-agent`, it's only there because `Liberty20Test` doesn't mimic the boot delegation provided by `dd-java-agent`

# What Does This Do

This PR fixes `Liberty20Test` to delegate `org.slf4j` requests to the boot-class-path, which is what happens automatically when using `dd-java-agent`. This lets us revert the MethodHandles change so logging can be accessed the same way as in all the other advice. The liberty-based smoke test shows us that the expected boot-class-path delegation works when using the final `dd-java-agent`.