### PR TITLE
allow specification of arbitrary perf events to schedule samples

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
@@ -291,7 +291,18 @@ public final class AsyncProfiler {
     cmd.append(",safemode=").append(getSafeMode());
     if (profilingModes.contains(ProfilingMode.CPU)) {
       // cpu profiling is enabled.
-      cmd.append(",cpu=").append(getCpuInterval()).append('m');
+      String schedulingEvent = getSchedulingEvent();
+      if (schedulingEvent != null && !schedulingEvent.isEmpty()) {
+        // using a user-specified event, e.g. L1-dcache-load-misses
+        cmd.append(",event=").append(schedulingEvent);
+        Integer interval = getSchedulingEventInterval();
+        if (interval != null) {
+          cmd.append(",interval=").append(interval);
+        }
+      } else {
+        // using cpu time schedule
+        cmd.append(",cpu=").append(getCpuInterval()).append('m');
+      }
     }
     if (profilingModes.contains(ProfilingMode.WALL)) {
       // wall profiling is enabled.
@@ -332,6 +343,14 @@ public final class AsyncProfiler {
     return configProvider.getInteger(
         ProfilingConfig.PROFILING_ASYNC_WALL_INTERVAL,
         ProfilingConfig.PROFILING_ASYNC_WALL_INTERVAL_DEFAULT);
+  }
+
+  public String getSchedulingEvent() {
+    return configProvider.getString(ProfilingConfig.PROFILING_ASYNC_SCHEDULING_EVENT);
+  }
+
+  public Integer getSchedulingEventInterval() {
+    return configProvider.getInteger(ProfilingConfig.PROFILING_ASYNC_SCHEDULING_EVENT_INTERVAL);
   }
 
   private int getStackDepth() {

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -79,6 +79,12 @@ public final class ProfilingConfig {
   public static final String PROFILING_ASYNC_WALL_INTERVAL = "profiling.async.wall.interval.ms";
   public static final int PROFILING_ASYNC_WALL_INTERVAL_DEFAULT = 10;
 
+  public static final String PROFILING_ASYNC_SCHEDULING_EVENT =
+      "profiling.experimental.async.scheduling.event";
+
+  public static final String PROFILING_ASYNC_SCHEDULING_EVENT_INTERVAL =
+      "profiling.experimental.async.scheduling.event.interval";
+
   public static final String PROFILING_ASYNC_LOG_LEVEL = "profiling.async.loglevel";
 
   public static final String PROFILING_ASYNC_LOG_LEVEL_DEFAULT = "NONE";


### PR DESCRIPTION
# What Does This Do

Allows a user to choose which perf event should be used to schedule sampling, overloading the CPU engine. E.g. to capture stack traces every 1000 `L1-dcache-load-misses`, set:
```
-Ddd.profiling.experimental.async.scheduling.event=L1-dcache-load-misses
-Ddd.profiling.experimental.async.scheduling.event.interval=1000
```

Omitting `dd.profiling.experimental.async.scheduling.event.interval` will result in defaults for each event chosen by the profiler. To drive sampling based on branch misses, with a default interval, set:

```
-Ddd.profiling.experimental.async.scheduling.event=branch-misses
```

Setting an alternative scheduling event is mutually exclusive with the default CPU profiling.

# Motivation

# Additional Notes
