### PR TITLE
Add pitest support (mutation testing)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ plugins {
   id "com.github.johnrengelman.shadow" version "7.1.2" apply false
   id "me.champeau.jmh" version "0.6.5" apply false
   id 'org.gradle.playframework' version '0.12' apply false
+  id 'info.solidsoft.pitest' version '1.9.11'  apply false
 }
 
 description = 'dd-trace-java'

--- a/dd-java-agent/agent-iast/build.gradle
+++ b/dd-java-agent/agent-iast/build.gradle
@@ -89,3 +89,8 @@ jmh {
   jmhVersion = '1.28'
   duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
 }
+
+pitest {
+  targetClasses = ['com.datadog.iast.*']
+  jvmArgs = ['-Ddd.iast.enabled=true']
+}

--- a/dd-java-agent/appsec/build.gradle
+++ b/dd-java-agent/appsec/build.gradle
@@ -151,3 +151,8 @@ spotless {
     target 'src/**/*.java'
   }
 }
+
+pitest {
+  targetClasses = ['com.datadog.appsec.*']
+  jvmArgs = ['-Ddd.appsec.enabled=true']
+}

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -7,6 +7,7 @@ apply from: "$rootDir/gradle/forbiddenapis.gradle"
 apply from: "$rootDir/gradle/spotless.gradle"
 apply from: "$rootDir/gradle/spotbugs.gradle"
 apply from: "$rootDir/gradle/repositories.gradle"
+apply from: "$rootDir/gradle/pitest.gradle"
 
 // Only run one testcontainers test at a time
 ext.testcontainersLimit = gradle.sharedServices.registerIfAbsent("testcontainersLimit", BuildService) {

--- a/gradle/pitest.gradle
+++ b/gradle/pitest.gradle
@@ -1,0 +1,17 @@
+
+def pitestExcludedProjectNames = ['dd-java-agent']
+def pitestExcludedProjectPrefixes = [':dd-smoke-tests', ':dd-java-agent:instrumentation']
+def pitestSupported = !pitestExcludedProjectNames.any({project.name == it }) && !pitestExcludedProjectPrefixes.any({ project.path.startsWith(it) })
+
+if (pitestSupported) {
+  apply plugin: 'info.solidsoft.pitest'
+  pitest {
+    targetClasses = ['datadog.*', 'com.datadog.*']
+    excludedClasses = ['datadog.trace.api.Config', 'datadog.trace.api.InstrumenterConfig']
+    threads = 4
+    outputFormats = ['XML', 'HTML']
+    timestampedReports = false
+    mutators = ['STRONGER']
+    failWhenNoMutations = false
+  }
+}


### PR DESCRIPTION
# What Does This Do
Add [pitest](http://pitest.org/) support (mutation testing).

Tested modules: iast, appsec, telemetry.

# Additional notes

Even after https://github.com/DataDog/dd-trace-java/pull/4330, there are larger changes related to `Config` handling, `SpockRunner`, etc, to be able to use pitest in some submodules, such as `instrumentation/*`.

# How it works

Running pitest for the iast module: `./gradlew :dd-java-agent:agent-iast:pitest`

Reports are at `dd-java-agent/agent-iast/build/reports/pitest/index.html`.

![Screenshot from 2022-11-29 11-00-00](https://user-images.githubusercontent.com/23248/204498772-677038ec-89d9-44fe-9b5e-67b5a750d125.png)

![Screenshot from 2022-11-29 11-01-23](https://user-images.githubusercontent.com/23248/204499053-426058f1-65f6-4574-8bd1-a5fbfa009aeb.png)

![Screenshot from 2022-11-29 11-01-34](https://user-images.githubusercontent.com/23248/204499109-f8f9fe0f-536b-4388-9a04-fdbca704a360.png)
