### PR TITLE
Allow overwriting initial resource name

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -57,5 +57,8 @@ public final class GeneralConfig {
   public static final String TELEMETRY_ENABLED = "instrumentation.telemetry.enabled";
   public static final String TELEMETRY_HEARTBEAT_INTERVAL = "telemetry.heartbeat.interval";
 
+  public static final String OVERWRITE_INITIAL_RESOURCE_NAME_ALLOWED =
+      "trace.overwrite.initial.resource.name.allowed";
+
   private GeneralConfig() {}
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -115,6 +115,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   /** Nanosecond offset to counter clock drift */
   private volatile long counterDrift;
 
+  private final boolean allowOverwritingInitialResourceName;
+
   private final PendingTraceBuffer pendingTraceBuffer;
 
   /** Default service name if none provided on the trace or span */
@@ -407,6 +409,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     this.startNanoTicks = this.timeSource.getNanoTicks();
     this.clockSyncPeriod = Math.max(1_000_000L, SECONDS.toNanos(config.getClockSyncPeriod()));
     this.lastSyncTicks = startNanoTicks;
+
+    this.allowOverwritingInitialResourceName = config.isOverwriteInitialResourceNameAllowed();
 
     this.endpointCheckpointer = EndpointCheckpointerHolder.create();
     this.serviceName = serviceName;
@@ -1285,6 +1289,9 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       context.setAllTags(tags);
       context.setAllTags(coreTags);
       context.setAllTags(rootSpanTags);
+      if (allowOverwritingInitialResourceName) {
+        context.resetResourceNamePriority();
+      }
       return context;
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -227,6 +227,10 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext, TraceSe
     return resourceNamePriority;
   }
 
+  void resetResourceNamePriority() {
+    this.resourceNamePriority = ResourceNamePriorities.DEFAULT;
+  }
+
   public void setResourceName(final CharSequence resourceName, byte priority) {
     if (priority >= this.resourceNamePriority) {
       this.resourceNamePriority = priority;

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -127,6 +127,7 @@ import static datadog.trace.api.config.GeneralConfig.GLOBAL_TAGS;
 import static datadog.trace.api.config.GeneralConfig.HEALTH_METRICS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.HEALTH_METRICS_STATSD_HOST;
 import static datadog.trace.api.config.GeneralConfig.HEALTH_METRICS_STATSD_PORT;
+import static datadog.trace.api.config.GeneralConfig.OVERWRITE_INITIAL_RESOURCE_NAME_ALLOWED;
 import static datadog.trace.api.config.GeneralConfig.PERF_METRICS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.PRIMARY_TAG;
 import static datadog.trace.api.config.GeneralConfig.RUNTIME_ID_ENABLED;
@@ -533,7 +534,7 @@ public class Config {
   private final boolean grpcServerTrimPackageResource;
   private final BitSet grpcServerErrorStatuses;
   private final BitSet grpcClientErrorStatuses;
-
+  private final boolean overwriteInitialResourceNameAllowed;
   private final boolean cwsEnabled;
   private final int cwsTlsRefresh;
 
@@ -996,6 +997,9 @@ public class Config {
       telemetryInterval = DEFAULT_TELEMETRY_HEARTBEAT_INTERVAL;
     }
     telemetryHeartbeatInterval = telemetryInterval;
+
+    overwriteInitialResourceNameAllowed =
+        configProvider.getBoolean(OVERWRITE_INITIAL_RESOURCE_NAME_ALLOWED, true);
 
     this.clientIpEnabled = configProvider.getBoolean(CLIENT_IP_ENABLED, DEFAULT_CLIENT_IP_ENABLED);
 
@@ -1634,6 +1638,10 @@ public class Config {
 
   public int getTelemetryHeartbeatInterval() {
     return telemetryHeartbeatInterval;
+  }
+
+  public boolean isOverwriteInitialResourceNameAllowed() {
+    return overwriteInitialResourceNameAllowed;
   }
 
   public boolean isClientIpEnabled() {


### PR DESCRIPTION
# What Does This Do

If a resource name has been set via a tag interceptor during span creation, it can now be changed by later calls from instrumentations and _normal_ resource name setting.

This behavior can be changed with the property `dd.trace.overwrite.initial.resource.name.allowed` or environment variable `DD_TRACE_OVERWRITE_INITIAL_RESOURCE_NAME_ALLOWED`, which is default `true`.

# Motivation

Some third party libraries that use OpenTracing set an initial generic resource name for the span that due to resource name priorities won't be changed by instrumentations, leading to all requests ending up on the same resource.

# Additional Notes
