### PR TITLE
Add evaluation error reporting for expressions

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/test/java/datadog/trace/bootstrap/debugger/SnapshotSummaryTest.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/test/java/datadog/trace/bootstrap/debugger/SnapshotSummaryTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 public class SnapshotSummaryTest {
   private static final String CLASS_NAME = "com.datadog.debugger.SomeClass";
   private static final ProbeLocation PROBE_LOCATION =
-      new ProbeLocation(CLASS_NAME, "someMethod", null, null);;
+      new ProbeLocation(CLASS_NAME, "someMethod", null, null);
 
   @BeforeAll
   public static void staticSetup() {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -823,11 +823,11 @@ public class CapturedSnapshotTest {
                                 DSL.eq(DSL.ref(".fld"), DSL.value(11)),
                                 // this reference chain needs to use reflection
                                 DSL.eq(DSL.ref(".typed.fld.fld.msg"), DSL.value("hello"))),
-                            DSL.or(
+                            DSL.and(
                                 DSL.eq(DSL.ref(ValueReferences.argument("arg")), DSL.value("5")),
-                                DSL.gt(
-                                    DSL.ref(ValueReferences.DURATION_REF), DSL.value(500_000L))))),
-                    "(.fld == 11 && .typed.fld.fld.msg == 'hello') && (#arg == '5' || @duration > 500000)"))
+                                DSL.gt(DSL.ref(ValueReferences.DURATION_REF), DSL.value(0L))))),
+                    "(.fld == 11 && .typed.fld.fld.msg == 'hello') && (#arg == '5' && @duration > 0)"))
+            .evaluateAt(ProbeDefinition.MethodLocation.EXIT)
             .build();
     DebuggerTransformerTest.TestSnapshotListener listener =
         installProbes(CLASS_NAME, snapshotProbe);
@@ -837,10 +837,30 @@ public class CapturedSnapshotTest {
       Assert.assertTrue((i == 2 && result == 2) || result == 3);
     }
     Assert.assertEquals(1, listener.snapshots.size());
-    Snapshot.CapturedValue argument =
-        listener.snapshots.get(0).getCaptures().getEntry().getArguments().get("arg");
-    Assert.assertEquals("5", getValue(argument));
-    Assert.assertEquals("java.lang.String", argument.getType());
+    assertCaptureArgs(
+        listener.snapshots.get(0).getCaptures().getReturn(), "arg", "java.lang.String", "5");
+  }
+
+  @Test
+  public void nullCondition() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot08";
+    SnapshotProbe snapshotProbe =
+        createProbeBuilder(PROBE_ID, CLASS_NAME, "doit", "int (java.lang.String)")
+            .when(
+                new ProbeCondition(
+                    DSL.when(DSL.eq(DSL.ref(".nullTyped.fld.fld.msg"), DSL.value("hello"))),
+                    ".nullTyped.fld.fld.msg == 'hello'"))
+            .build();
+    DebuggerTransformerTest.TestSnapshotListener listener =
+        installProbes(CLASS_NAME, snapshotProbe);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "1").get();
+    Assert.assertEquals(1, listener.snapshots.size());
+    List<Snapshot.EvaluationError> evaluationErrors =
+        listener.snapshots.get(0).getEvaluationErrors();
+    Assert.assertEquals(1, evaluationErrors.size());
+    Assert.assertEquals(".nullTyped.fld.fld.msg", evaluationErrors.get(0).getExpr());
+    Assert.assertEquals("Cannot dereference to field: fld", evaluationErrors.get(0).getMessage());
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -155,7 +155,28 @@ public class LogProbesInstrumentationTest {
     Assert.assertEquals(3, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertEquals("this is log line with local var=UNDEFINED", snapshot.getSummary());
-    // TODO assert on eval errors from snapshot
+    assertEquals(1, snapshot.getEvaluationErrors().size());
+    assertEquals("#var42", snapshot.getEvaluationErrors().get(0).getExpr());
+    assertEquals(
+        "Cannot find local var: var42", snapshot.getEvaluationErrors().get(0).getMessage());
+  }
+
+  @Test
+  public void lineTemplateNullFieldLog() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot04";
+    DebuggerTransformerTest.TestSnapshotListener listener =
+        installSingleProbe(
+            "this is log line with field={#nullObject.intValue}", CLASS_NAME, null, null, "25");
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "").get();
+    Assert.assertEquals(143, result);
+    Snapshot snapshot = assertOneSnapshot(listener);
+    assertEquals("this is log line with field=UNDEFINED", snapshot.getSummary());
+    assertEquals(1, snapshot.getEvaluationErrors().size());
+    assertEquals("#nullObject.intValue", snapshot.getEvaluationErrors().get(0).getExpr());
+    assertEquals(
+        "Cannot dereference to field: intValue",
+        snapshot.getEvaluationErrors().get(0).getMessage());
   }
 
   private DebuggerTransformerTest.TestSnapshotListener installSingleProbe(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
@@ -40,11 +40,6 @@ public class DebuggerSinkTest {
   private static final String PROBE_ID = "12fd-8490-c111-4374-ffde";
   private static final Snapshot.ProbeLocation PROBE_LOCATION =
       new Snapshot.ProbeLocation("java.lang.String", "indexOf", null, null);
-  private static final Snapshot SNAPSHOT =
-      new Snapshot(
-          Thread.currentThread(),
-          new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION),
-          String.class.getTypeName());
   public static final int MAX_PAYLOAD = 5 * 1024 * 1024;
 
   @Mock private Config config;
@@ -71,7 +66,12 @@ public class DebuggerSinkTest {
   @Test
   public void addSnapshot() throws URISyntaxException, IOException {
     DebuggerSink sink = new DebuggerSink(config, batchUploader);
-    sink.addSnapshot(SNAPSHOT);
+    Snapshot snapshot =
+        new Snapshot(
+            Thread.currentThread(),
+            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION),
+            String.class.getTypeName());
+    sink.addSnapshot(snapshot);
     String fixtureContent = getFixtureContent(SINK_FIXTURE_PREFIX + "/snapshotRegex.txt");
     String regex = fixtureContent.replaceAll("\\n", "");
     sink.flush(sink);
@@ -84,7 +84,12 @@ public class DebuggerSinkTest {
   public void addMultipleSnapshots() throws URISyntaxException, IOException {
     when(config.getDebuggerUploadBatchSize()).thenReturn(2);
     DebuggerSink sink = new DebuggerSink(config, batchUploader);
-    Arrays.asList(SNAPSHOT, SNAPSHOT).forEach(sink::addSnapshot);
+    Snapshot snapshot =
+        new Snapshot(
+            Thread.currentThread(),
+            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION),
+            String.class.getTypeName());
+    Arrays.asList(snapshot, snapshot).forEach(sink::addSnapshot);
 
     String fixtureContent = getFixtureContent(SINK_FIXTURE_PREFIX + "/multipleSnapshotRegex.txt");
     String regex = fixtureContent.replaceAll("\\n", "");
@@ -242,7 +247,12 @@ public class DebuggerSinkTest {
   public void reconsiderFlushIntervalIncreaseFlushInterval() {
     DebuggerSink sink = new DebuggerSink(config, batchUploader);
     long currentFlushInterval = sink.getCurrentFlushInterval();
-    sink.addSnapshot(SNAPSHOT);
+    Snapshot snapshot =
+        new Snapshot(
+            Thread.currentThread(),
+            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION),
+            String.class.getTypeName());
+    sink.addSnapshot(snapshot);
     sink.doReconsiderFlushInterval();
     long newFlushInterval = sink.getCurrentFlushInterval();
     assertEquals(currentFlushInterval + DebuggerSink.STEP_SIZE, newFlushInterval);
@@ -253,8 +263,13 @@ public class DebuggerSinkTest {
     DebuggerSink sink = new DebuggerSink(config, batchUploader);
     long currentFlushInterval = sink.getCurrentFlushInterval();
     sink.flush(sink);
+    Snapshot snapshot =
+        new Snapshot(
+            Thread.currentThread(),
+            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION),
+            String.class.getTypeName());
     for (int i = 0; i < 1000; i++) {
-      sink.addSnapshot(SNAPSHOT);
+      sink.addSnapshot(snapshot);
     }
     sink.doReconsiderFlushInterval();
     long newFlushInterval = sink.getCurrentFlushInterval();
@@ -265,8 +280,13 @@ public class DebuggerSinkTest {
   public void reconsiderFlushIntervalNoChange() {
     DebuggerSink sink = new DebuggerSink(config, batchUploader);
     long currentFlushInterval = sink.getCurrentFlushInterval();
+    Snapshot snapshot =
+        new Snapshot(
+            Thread.currentThread(),
+            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION),
+            String.class.getTypeName());
     for (int i = 0; i < 500; i++) {
-      sink.addSnapshot(SNAPSHOT);
+      sink.addSnapshot(snapshot);
     }
     sink.doReconsiderFlushInterval();
     long newFlushInterval = sink.getCurrentFlushInterval();
@@ -282,10 +302,36 @@ public class DebuggerSinkTest {
           Snapshot.CapturedValue.of("dd.trace_id", "java.lang.String", "123"),
           Snapshot.CapturedValue.of("dd.span_id", "java.lang.String", "456"),
         });
-    SNAPSHOT.setEntry(entry);
-    sink.addSnapshot(SNAPSHOT);
+    Snapshot snapshot =
+        new Snapshot(
+            Thread.currentThread(),
+            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION),
+            String.class.getTypeName());
+    snapshot.setEntry(entry);
+    sink.addSnapshot(snapshot);
     String fixtureContent =
         getFixtureContent(SINK_FIXTURE_PREFIX + "/snapshotWithCorrelationIdsRegex.txt");
+    String regex = fixtureContent.replaceAll("\\n", "");
+    sink.flush(sink);
+    verify(batchUploader).upload(payloadCaptor.capture(), matches(EXPECTED_SNAPSHOT_TAGS));
+    String strPayload = new String(payloadCaptor.getValue(), StandardCharsets.UTF_8);
+    assertTrue(strPayload.matches(regex), strPayload);
+  }
+
+  @Test
+  public void addSnapshotWithEvalErrors() throws URISyntaxException, IOException {
+    DebuggerSink sink = new DebuggerSink(config, batchUploader);
+    Snapshot.CapturedContext entry = new Snapshot.CapturedContext();
+    entry.addEvalError("obj.field", "Cannot dereference obj");
+    Snapshot snapshot =
+        new Snapshot(
+            Thread.currentThread(),
+            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION),
+            String.class.getTypeName());
+    snapshot.setEntry(entry);
+    sink.addSnapshot(snapshot);
+    String fixtureContent =
+        getFixtureContent(SINK_FIXTURE_PREFIX + "/snapshotWithEvalErrorRegex.txt");
     String regex = fixtureContent.replaceAll("\\n", "");
     sink.flush(sink);
     verify(batchUploader).upload(payloadCaptor.capture(), matches(EXPECTED_SNAPSHOT_TAGS));

--- a/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot08.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot08.java
@@ -22,6 +22,7 @@ public class CapturedSnapshot08 {
 
   private int fld = 11;
   private Type1 typed = new Type1(new Type2(new Type3("hello")));
+  private Type1 nullTyped = new Type1(null);
 
   private static final CapturedSnapshot08 INSTANCE = new CapturedSnapshot08();
 

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotWithEvalErrorRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotWithEvalErrorRegex.txt
@@ -5,7 +5,7 @@
 "captures":\{"entry":\{"arguments":\{\},"locals":\{\}\}\},
 "evaluationErrors":\[\{"expr":"obj.field","message":"Cannot dereference obj"\}\],
 "language":"java",
-"probe":\{"evaluateAt":"NONE","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
+"probe":\{"evaluateAt":"DEFAULT","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
 "stack":\[\],
 "timestamp":\d+
 \}\},

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotWithEvalErrorRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotWithEvalErrorRegex.txt
@@ -1,0 +1,21 @@
+^\[\{
+"ddsource":"dd_debugger",
+"debugger":\{
+"snapshot":\{
+"captures":\{"entry":\{"arguments":\{\},"locals":\{\}\}\},
+"evaluationErrors":\[\{"expr":"obj.field","message":"Cannot dereference obj"\}\],
+"language":"java",
+"probe":\{"evaluateAt":"NONE","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
+"stack":\[\],
+"timestamp":\d+
+\}\},
+"duration":0,
+"logger.method":"indexOf",
+"logger.name":"java.lang.String",
+"logger.thread_id":\d+,
+"logger.thread_name":"Test worker",
+"logger.version":2,
+"message":"String.indexOf\(\)",
+"service":"service-name",
+"timestamp":\d+
+\}\]$


### PR DESCRIPTION
# What Does This Do
Reports runtime evaluation error (like NPE) into snapshots in `evaluationErrors` attribute.

# Motivation

# Additional Notes
