### PR TITLE
Rework TaintedMapTest

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/DefaultTaintedMap.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/DefaultTaintedMap.java
@@ -30,9 +30,9 @@ public final class DefaultTaintedMap implements TaintedMap {
   /** Default flat mode threshold. */
   public static final int DEFAULT_FLAT_MODE_THRESHOLD = 1 << 13;
   /** Periodicity of table purges, as number of put operations. It MUST be a power of two. */
-  private static final int PURGE_COUNT = 1 << 6;
+  static final int PURGE_COUNT = 1 << 6;
   /** Bitmask for fast modulo with PURGE_COUNT. */
-  private static final int PURGE_MASK = PURGE_COUNT - 1;
+  static final int PURGE_MASK = PURGE_COUNT - 1;
   /** Bitmask to convert hashes to positive integers. */
   static final int POSITIVE_MASK = Integer.MAX_VALUE;
 
@@ -47,7 +47,7 @@ public final class DefaultTaintedMap implements TaintedMap {
    */
   private final AtomicInteger estimatedSize = new AtomicInteger(0);
   /** Reference queue for garbage-collected entries. */
-  private ReferenceQueue<Object> referenceQueue = new ReferenceQueue<>();
+  private ReferenceQueue<Object> referenceQueue;
   /**
    * Whether flat mode is enabled or not. Once this is true, it is not set to false again unless
    * {@link #clear()} is called.
@@ -60,7 +60,7 @@ public final class DefaultTaintedMap implements TaintedMap {
    * Default constructor. Uses {@link #DEFAULT_CAPACITY} and {@link #DEFAULT_FLAT_MODE_THRESHOLD}.
    */
   public DefaultTaintedMap() {
-    this(DEFAULT_CAPACITY, DEFAULT_FLAT_MODE_THRESHOLD);
+    this(DEFAULT_CAPACITY, DEFAULT_FLAT_MODE_THRESHOLD, new ReferenceQueue<>());
   }
 
   /**
@@ -68,12 +68,15 @@ public final class DefaultTaintedMap implements TaintedMap {
    *
    * @param capacity Capacity of the internal array. It must be a power of 2.
    * @param flatModeThreshold Limit of entries before switching to flat mode.
+   * @param queue Reference queue. Only for tests.
    */
   @SuppressWarnings("unchecked")
-  private DefaultTaintedMap(final int capacity, final int flatModeThreshold) {
+  DefaultTaintedMap(
+      final int capacity, final int flatModeThreshold, final ReferenceQueue<Object> queue) {
     table = new TaintedObject[capacity];
     lengthMask = table.length - 1;
     this.flatModeThreshold = flatModeThreshold;
+    this.referenceQueue = queue;
   }
 
   /**

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/ObjectGen.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/ObjectGen.groovy
@@ -1,7 +1,5 @@
 package com.datadog.iast.taint
 
-import java.util.function.Predicate
-
 import static com.datadog.iast.taint.DefaultTaintedMap.POSITIVE_MASK
 import static com.datadog.iast.taint.DefaultTaintedMap.PURGE_MASK
 
@@ -23,35 +21,25 @@ class ObjectGen {
   }
 
   def genBuckets(int nBuckets, int nObjects) {
-    return genBuckets(nBuckets, nObjects, { true })
+    return genBuckets(nBuckets, nObjects, TRUE)
   }
 
-  def genBuckets(int nBuckets, int nObjects, Predicate<Integer> isValid) {
+  def genBuckets(int nBuckets, int nObjects, Closure<Boolean> isValid) {
     assert nBuckets > 0
     assert nObjects > 0
     def excludedBuckets = new HashSet<Integer>()
     return (1..nBuckets).collect {
-      def bucket = genBucket(nObjects, isValid & { !excludedBuckets.contains(it) })
+      def bucket = genBucket(nObjects, { isValid.call(it) && !excludedBuckets.contains(it) })
       excludedBuckets.add(getIndex(bucket.get(0)))
       bucket
     }
   }
 
-  def genBucket(int nObjects) {
-    assert nObjects > 0
-    genBucket(nObjects, new HashSet<Integer>())
-  }
-
-  def genBucket(int nObjects, Set<Integer> excludedBuckets) {
-    assert nObjects > 0
-    genBucket(nObjects, { !excludedBuckets.contains(it) })
-  }
-
-  def genBucket(int nObjects, Predicate<Integer> isValid) {
+  def genBucket(int nObjects, Closure<Boolean> isValid) {
     assert nObjects > 0
     while (true) {
       for (int i = 0; i < capacity; i++) {
-        if (!isValid.test(i)) {
+        if (!isValid.call(i)) {
           continue
         }
         def objLst = pool.get(i)
@@ -67,12 +55,12 @@ class ObjectGen {
     }
   }
 
-  def genObjects(int nObjects, Predicate<Integer> isValid) {
+  def genObjects(int nObjects, Closure<Boolean> isValid) {
     def res = new ArrayList(nObjects)
     while (res.size() < nObjects) {
       def obj = new Object()
       int bucket = getIndex(obj)
-      if (isValid.test(bucket)) {
+      if (isValid.call(bucket)) {
         res.add(obj)
       } else {
         pool.get(bucket).add(obj)
@@ -81,23 +69,24 @@ class ObjectGen {
     return res
   }
 
-  private genObject() {
+  def genObject() {
     def obj = new Object()
     int bucket = getIndex(obj)
     pool.get(bucket).add(obj)
     return bucket
   }
 
-  private int getIndex(Object obj) {
+  int getIndex(Object obj) {
     return getIndex(capacity, obj)
   }
 
-  private int getIndex(int capacity, Object obj) {
+  int getIndex(int capacity, Object obj) {
     int positiveHashCode = System.identityHashCode(obj) & POSITIVE_MASK
     int bucket = positiveHashCode & (capacity - 1)
     return bucket
   }
 
-  public static final Predicate<Integer> TRIGGERS_PURGE = { i -> (i & PURGE_MASK) == 0 }
-  public static final Predicate<Integer> DOES_NOT_TRIGGER_PURGE = { i -> (i & PURGE_MASK) != 0 }
+  static final Closure<Boolean> TRIGGERS_PURGE = { i -> (i & PURGE_MASK) == 0 }
+  static final Closure<Boolean> DOES_NOT_TRIGGER_PURGE = { i -> (i & PURGE_MASK) != 0 }
+  static final Closure<Boolean> TRUE = { i -> true }
 }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/ObjectGen.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/ObjectGen.groovy
@@ -1,0 +1,103 @@
+package com.datadog.iast.taint
+
+import java.util.function.Predicate
+
+import static com.datadog.iast.taint.DefaultTaintedMap.POSITIVE_MASK
+import static com.datadog.iast.taint.DefaultTaintedMap.PURGE_MASK
+
+/**
+ * Generate objects to test {@link DefaultTaintedMap}.
+ */
+class ObjectGen {
+
+  final int capacity
+  final Map<Integer, List<Object>> pool
+
+  ObjectGen(int capacity) {
+    assert (capacity & (capacity - 1)) == 0, 'capacity must be a power of 2'
+    this.capacity = capacity
+    this.pool = new HashMap<>(capacity)
+    for (int i = 0; i < capacity; i++) {
+      this.pool.put(i, new ArrayList<Object>())
+    }
+  }
+
+  def genBuckets(int nBuckets, int nObjects) {
+    return genBuckets(nBuckets, nObjects, { true })
+  }
+
+  def genBuckets(int nBuckets, int nObjects, Predicate<Integer> isValid) {
+    assert nBuckets > 0
+    assert nObjects > 0
+    def excludedBuckets = new HashSet<Integer>()
+    return (1..nBuckets).collect {
+      def bucket = genBucket(nObjects, isValid & { !excludedBuckets.contains(it) })
+      excludedBuckets.add(getIndex(bucket.get(0)))
+      bucket
+    }
+  }
+
+  def genBucket(int nObjects) {
+    assert nObjects > 0
+    genBucket(nObjects, new HashSet<Integer>())
+  }
+
+  def genBucket(int nObjects, Set<Integer> excludedBuckets) {
+    assert nObjects > 0
+    genBucket(nObjects, { !excludedBuckets.contains(it) })
+  }
+
+  def genBucket(int nObjects, Predicate<Integer> isValid) {
+    assert nObjects > 0
+    while (true) {
+      for (int i = 0; i < capacity; i++) {
+        if (!isValid.test(i)) {
+          continue
+        }
+        def objLst = pool.get(i)
+        if (objLst.size() >= nObjects) {
+          def res = new ArrayList<>(objLst[0..nObjects-1])
+          pool.put(i, objLst.drop(nObjects))
+          return res
+        }
+      }
+      for (int i = 0; i < capacity; i++) {
+        genObject()
+      }
+    }
+  }
+
+  def genObjects(int nObjects, Predicate<Integer> isValid) {
+    def res = new ArrayList(nObjects)
+    while (res.size() < nObjects) {
+      def obj = new Object()
+      int bucket = getIndex(obj)
+      if (isValid.test(bucket)) {
+        res.add(obj)
+      } else {
+        pool.get(bucket).add(obj)
+      }
+    }
+    return res
+  }
+
+  private genObject() {
+    def obj = new Object()
+    int bucket = getIndex(obj)
+    pool.get(bucket).add(obj)
+    return bucket
+  }
+
+  private int getIndex(Object obj) {
+    return getIndex(capacity, obj)
+  }
+
+  private int getIndex(int capacity, Object obj) {
+    int positiveHashCode = System.identityHashCode(obj) & POSITIVE_MASK
+    int bucket = positiveHashCode & (capacity - 1)
+    return bucket
+  }
+
+  public static final Predicate<Integer> TRIGGERS_PURGE = { i -> (i & PURGE_MASK) == 0 }
+  public static final Predicate<Integer> DOES_NOT_TRIGGER_PURGE = { i -> (i & PURGE_MASK) != 0 }
+}

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/ObjectGenTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/ObjectGenTest.groovy
@@ -17,7 +17,7 @@ class ObjectGenTest extends Specification {
     def n = 5
 
     when:
-    def objects = objectGen.genBucket(n)
+    def objects = objectGen.genBucket(n, ObjectGen.TRUE)
 
     then:
     objects.size() == n

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/ObjectGenTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/ObjectGenTest.groovy
@@ -1,0 +1,55 @@
+package com.datadog.iast.taint
+
+import spock.lang.Shared
+import spock.lang.Specification
+
+
+class ObjectGenTest extends Specification {
+
+  @Shared
+  def capacity = 128
+
+  @Shared
+  def objectGen = new ObjectGen(128)
+
+  def 'genBucket'() {
+    given:
+    def n = 5
+
+    when:
+    def objects = objectGen.genBucket(n)
+
+    then:
+    objects.size() == n
+    objects.toSet().size() == n
+    objects.groupBy({ (System.identityHashCode(it) & Integer.MAX_VALUE) % capacity }).size() == 1
+  }
+
+  def 'genBuckets'() {
+    given:
+    def m = 10
+    def n = 5
+
+    when:
+    def objects = objectGen.genBuckets(m, n)
+
+    then:
+    objects.size() == m
+    for (def objLst : objects) {
+      assert objLst.size() == n
+      assert objLst.toSet().size() == n
+      assert objLst.groupBy({ (System.identityHashCode(it) & Integer.MAX_VALUE) % capacity }).size() == 1
+    }
+
+    when: 'again'
+    objects = objectGen.genBuckets(m, n)
+
+    then:
+    objects.size() == m
+    for (def objLst : objects) {
+      assert objLst.size() == n
+      assert objLst.toSet().size() == n
+      assert objLst.groupBy({ (System.identityHashCode(it) & Integer.MAX_VALUE) % capacity }).size() == 1
+    }
+  }
+}

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedMapTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedMapTest.groovy
@@ -1,20 +1,14 @@
 package com.datadog.iast.taint
 
 import com.datadog.iast.model.Range
-import datadog.trace.api.Platform
 import datadog.trace.test.util.CircularBuffer
 import datadog.trace.test.util.DDSpecification
-import spock.lang.IgnoreIf
 
-import java.util.concurrent.ArrayBlockingQueue
-import java.util.concurrent.Callable
-import java.util.concurrent.ConcurrentHashMap
+import java.lang.ref.Reference
+import java.lang.ref.ReferenceQueue
+import java.lang.ref.WeakReference
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
-
-import static datadog.trace.test.util.GCUtils.awaitGC
-import static java.util.concurrent.TimeUnit.SECONDS
 
 class TaintedMapTest extends DDSpecification {
 
@@ -45,10 +39,24 @@ class TaintedMapTest extends DDSpecification {
     map.toList().size() == 0
   }
 
+  def 'get non-existent object'() {
+    given:
+    def map = new DefaultTaintedMap()
+    final o = new Object()
+
+    expect:
+    !map.isFlat()
+    map.get(o) == null
+    map.size() == 0
+    map.toList().size() == 0
+  }
+
   def 'last put always exists'() {
     given:
-    int nTotalObjects = DefaultTaintedMap.DEFAULT_CAPACITY
-    def map = new DefaultTaintedMap()
+    int capacity = 256
+    int flatModeThreshold = (int) (capacity / 2)
+    def map = new DefaultTaintedMap(capacity, flatModeThreshold, new ReferenceQueue<>())
+    int nTotalObjects = capacity * 10
 
     expect:
     (1..nTotalObjects).each { i ->
@@ -59,37 +67,154 @@ class TaintedMapTest extends DDSpecification {
     }
   }
 
-  def 'garbage-collected entries are purged'() {
+  def 'do not fail on extraneous reference'() {
     given:
-    int iters = 16
-    int nObjectsPerIter = 1024
-    int nRetainedObjects = 8
-    def map = new DefaultTaintedMap()
-    def objectBuffer = new CircularBuffer<Object>(nRetainedObjects)
+    int capacity = 256
+    int flatModeThreshold = (int) (capacity / 2)
+    def queue = new MockReferenceQueue()
+    def map = new DefaultTaintedMap(capacity, flatModeThreshold, queue)
+    def gen = new ObjectGen(capacity)
+
+    when: 'extraneous reference in enqueued'
+    queue.free(new WeakReference<Object>(new Object()))
+
+    and: 'purge is triggered'
+    gen.genObjects(1, ObjectGen.TRIGGERS_PURGE).each { o ->
+      final to = new TaintedObject(o, [] as Range[], map.getReferenceQueue())
+      queue.hold(o, to)
+      map.put(to)
+    }
+
+    then:
+    !map.isFlat()
+    map.toList().size() == 1
+  }
+
+  def 'do not fail on double free'() {
+    given:
+    int capacity = 256
+    int flatModeThreshold = (int) (capacity / 2)
+    def queue = new MockReferenceQueue()
+    def map = new DefaultTaintedMap(capacity, flatModeThreshold, queue)
+    def gen = new ObjectGen(capacity)
+
+    when: 'reference to non-present object in enqueued'
+    queue.free(new TaintedObject(new Object(), new Range[0] as Range[], queue))
+
+    and: 'purge is triggered'
+    gen.genObjects(1, ObjectGen.TRIGGERS_PURGE).each { o ->
+      final to = new TaintedObject(o, [] as Range[], map.getReferenceQueue())
+      queue.hold(o, to)
+      map.put(to)
+    }
+
+    then:
+    !map.isFlat()
+    map.toList().size() == 1
+  }
+
+  def 'do not fail on double free with previous data'() {
+    given:
+    int capacity = 256
+    int flatModeThreshold = (int) (capacity / 2)
+    def queue = new MockReferenceQueue()
+    def map = new DefaultTaintedMap(capacity, flatModeThreshold, queue)
+    def gen = new ObjectGen(capacity)
+    def bucket = gen.genBucket(2, ObjectGen.TRIGGERS_PURGE)
 
     when:
-    (1..nRetainedObjects).each {
-      final o = new Object()
+    queue.free(new TaintedObject(bucket[0], new Range[0] as Range[], queue))
+    final to = new TaintedObject(bucket[1], [] as Range[], map.getReferenceQueue())
+    map.put(to)
+
+    then:
+    !map.isFlat()
+    map.toList().size() == 1
+  }
+
+  def 'flat mode - last put wins'() {
+    given:
+    int capacity = 256
+    int flatModeThreshold = (int) (capacity / 2)
+    def queue = new MockReferenceQueue()
+    def map = new DefaultTaintedMap(capacity, flatModeThreshold, queue)
+    def gen = new ObjectGen(capacity)
+
+    when:
+    // Number of purges required to switch to flat mode (in the absence of garbage collection)
+    final int purgesToFlatMode = (int) (flatModeThreshold / DefaultTaintedMap.PURGE_COUNT) + 1
+    gen.genObjects(purgesToFlatMode, ObjectGen.TRIGGERS_PURGE).each { o ->
       final to = new TaintedObject(o, [] as Range[], map.getReferenceQueue())
+      queue.hold(o, to)
       map.put(to)
-      objectBuffer.add(o)
-      assert map.get(o) == to
     }
-    (1..iters).each {
-      final refs = (1..nObjectsPerIter).collect {
-        final o = new Object()
+
+    then:
+    map.isFlat()
+
+    when:
+    def lastPuts = []
+    def nonLastPuts = []
+    gen.genBuckets(capacity, 2).each { bucket ->
+      bucket.each { o ->
         final to = new TaintedObject(o, [] as Range[], map.getReferenceQueue())
+        queue.hold(o, to)
         map.put(to)
-        return to
       }
-      awaitCollected(refs)
+      lastPuts.add(bucket[-1])
+      nonLastPuts.addAll(bucket[0..-2])
+    }
+
+    then:
+    map.toList().size() == capacity
+
+    and: 'last puts are present'
+    lastPuts.each { o ->
+      assert map.get(o).get() == o
+    }
+
+    and: 'non-last puts are not present'
+    nonLastPuts.each { o ->
+      assert map.get(o) == null
+    }
+  }
+
+  def 'garbage-collected entries are purged'() {
+    given:
+    int capacity = 128
+    int flatModeThreshold = 64
+    def queue = new MockReferenceQueue()
+    def map = new DefaultTaintedMap(capacity, flatModeThreshold, queue)
+
+    int iters = 16
+    int nObjectsPerIter = flatModeThreshold - 1
+    def gen = new ObjectGen(capacity)
+    def objectBuffer = new CircularBuffer<Object>(iters)
+
+    when:
+    (1..iters).each {
+      // Insert objects that do not trigger purge
+      gen.genObjects(nObjectsPerIter, ObjectGen.DOES_NOT_TRIGGER_PURGE).each { o ->
+        final to = new TaintedObject(o, [] as Range[], map.getReferenceQueue())
+        queue.hold(o, to)
+        map.put(to)
+      }
+      // Clear previous objects
+      queue.clear()
+      // Trigger purge
+      final o = gen.genObjects(1, ObjectGen.TRIGGERS_PURGE)[0]
+      final to = new TaintedObject(o, [] as Range[], map.getReferenceQueue())
+      objectBuffer.add(o)
+      map.put(to)
     }
 
     then:
     !map.isFlat()
     final entries = map.toList()
-    entries.size() <= nRetainedObjects + nObjectsPerIter
-    entries.findAll { it.get() != null }.size() == nRetainedObjects
+    entries.size() == iters
+    entries.findAll { it.get() != null }.size() == iters
+
+    and: 'all objects are as expected'
     objectBuffer.each { o ->
       final to = map.get(o)
       assert to != null
@@ -97,287 +222,197 @@ class TaintedMapTest extends DDSpecification {
     }
   }
 
-  def 'single-threaded put-intensive workflow without garbage collection interaction and under max size'() {
+  def 'garbage-collected entries are purged in flat mode'() {
     given:
-    int nTotalObjects = 1024
-    int nRetainedObjects = 1024
-    def map = new DefaultTaintedMap()
-    def objectBuffer = new CircularBuffer<Tuple2<Object, TaintedObject>>(nRetainedObjects)
+    int capacity = 128
+    int flatModeThreshold = 64
+    def queue = new MockReferenceQueue()
+    def map = new DefaultTaintedMap(capacity, flatModeThreshold, queue)
 
-    when: 'perform puts'
-    (1..nTotalObjects).each { i ->
-      final o = new Object()
+    int iters = 1
+    def gen = new ObjectGen(capacity)
+    def objectBuffer = new CircularBuffer<Object>(iters)
+
+    when:
+    // Number of purges required to switch to flat mode (in the absence of garbage collection)
+    final int purgesToFlatMode = (int) (flatModeThreshold / DefaultTaintedMap.PURGE_COUNT) + 1
+    gen.genObjects(purgesToFlatMode, ObjectGen.TRIGGERS_PURGE).each { o ->
       final to = new TaintedObject(o, [] as Range[], map.getReferenceQueue())
-      objectBuffer.add(new Tuple2(o, to))
+      queue.hold(o, to)
       map.put(to)
     }
 
-    then: 'map contains exact amount of objects'
-    map.toList().size() == nTotalObjects
-
-    and: 'all objects are as expected'
-    objectBuffer.each {
-      assert map.get(it.get(0)) == it.get(1)
-    }
-  }
-
-  def 'single-threaded put-intensive workflow with garbage collection interaction and under max size'() {
-    given:
-    int nTotalObjects = 1024 * 2
-    int nRetainedObjects = 1024
-    def map = new DefaultTaintedMap()
-    def objectBuffer = new CircularBuffer<Tuple2<Object, TaintedObject>>(nRetainedObjects)
-
-    when: 'perform puts'
-    (1..nTotalObjects).each { i ->
-      final o = new Object()
-      final to = new TaintedObject(o, [] as Range[], map.getReferenceQueue())
-      objectBuffer.add(new Tuple2(o, to))
-      map.put(to)
-    }
-
-    then: 'map is not in flat mode'
-    !map.isFlat()
-
-    and: 'map contains exact amount of objects'
-    map.toList().size() == nTotalObjects
-
-    and: 'all objects are as expected'
-    objectBuffer.each {
-      assert map.get(it.get(0)) == it.get(1)
-    }
-  }
-
-  def 'single-threaded put-intensive workflow without garbage collection interaction and over max size'() {
-    given:
-    int nTotalObjects = DefaultTaintedMap.DEFAULT_FLAT_MODE_THRESHOLD * 4
-    int nRetainedObjects = nTotalObjects
-    def map = new DefaultTaintedMap()
-    def objectBuffer = new CircularBuffer<Tuple2<Object, TaintedObject>>(nRetainedObjects)
-
-    when: 'perform puts'
-    (1..nTotalObjects).each { i ->
-      final o = new Object()
-      final to = new TaintedObject(o, [] as Range[], map.getReferenceQueue())
-      objectBuffer.add(new Tuple2(o, to))
-      map.put(to)
-    }
-
-    then: 'map is in flat mode'
+    then:
     map.isFlat()
 
-    and: 'map contains enough objects'
-    map.toList().size() >= DefaultTaintedMap.DEFAULT_FLAT_MODE_THRESHOLD * 0.9
-
-    and: 'all objects are as expected'
-    int presentObjects = objectBuffer.count {
-      map.get(it.get(0)) == it.get(1)
-    }
-    presentObjects >= DefaultTaintedMap.DEFAULT_FLAT_MODE_THRESHOLD * 0.9
-  }
-
-  @IgnoreIf({ Platform.isJ9() })
-  def 'single-threaded put-intensive workflow with garbage collection interaction and over max size'() {
-    given:
-    int nTotalObjects = DefaultTaintedMap.DEFAULT_FLAT_MODE_THRESHOLD * 4
-    int nRetainedObjects = 1024
-    def map = new DefaultTaintedMap()
-    def objectBuffer = new CircularBuffer<Tuple2<Object, Object>>(nRetainedObjects)
-
-    when: 'perform puts'
-    (1..nTotalObjects).each { i ->
-      final o = new Object()
+    when:
+    (1..iters).each {
+      // Clear previous objects
+      queue.clear()
+      // Trigger purge
+      final o = gen.genObjects(1, ObjectGen.TRIGGERS_PURGE)[0]
       final to = new TaintedObject(o, [] as Range[], map.getReferenceQueue())
-      objectBuffer.add(new Tuple2(o, to))
+      objectBuffer.add(o)
       map.put(to)
     }
 
-    then: 'map is in flat mode'
+    then:
     map.isFlat()
-
-    and: 'map contains enough objects'
-    map.toList().size() >= DefaultTaintedMap.DEFAULT_FLAT_MODE_THRESHOLD * 0.6
+    final entries = map.toList()
+    entries.size() == iters
+    entries.findAll { it.get() != null }.size() == iters
 
     and: 'all objects are as expected'
-    // FIXME: This might need improvement, we remove too many new objects.
-    int presentObjects = objectBuffer.count {
-      map.get(it.get(0)) == it.get(1)
+    objectBuffer.each { o ->
+      final to = map.get(o)
+      assert to != null
+      assert to.get() == o
     }
-    presentObjects >= nRetainedObjects * 0.9
   }
 
-  def 'multi-threaded put-intensive workflow without garbage collection interaction and under max size'() {
+  def 'multi-threaded with no collisions, no GC, non-flat mode'() {
     given:
-    float maxAcceptableLoss = 0.999
-    int nThreads = 32
-    int nObjectsPerThread = (int) Math.floor((DefaultTaintedMap.DEFAULT_FLAT_MODE_THRESHOLD - 4096) / nThreads)
-    int nTotalObjects = nThreads * nObjectsPerThread
+    int capacity = 128
+    int flatModeThreshold = 64
+    def queue = new MockReferenceQueue()
+    def map = new DefaultTaintedMap(capacity, flatModeThreshold, queue)
+
+    and:
+    int nThreads = 16
+    int nObjectsPerThread = 1000
+    def gen = new ObjectGen(capacity)
     def executorService = Executors.newFixedThreadPool(nThreads)
-    def startLatch = new CountDownLatch(nThreads)
-    def map = new DefaultTaintedMap()
+    def latch = new CountDownLatch(nThreads)
+    def buckets = gen.genBuckets(nThreads, nObjectsPerThread, ObjectGen.DOES_NOT_TRIGGER_PURGE)
 
-    // Holder to avoid objects being garbage collected
-    def objectHolder = new ConcurrentHashMap<Object, TaintedObject>()
-
-    when: 'perform a high amount of concurrent puts'
-    def futures = (1..nThreads).collect { thread ->
+    when: 'puts from different threads to different buckets'
+    def futures = (0..nThreads-1).collect { thread ->
       executorService.submit({
         ->
-        final tuples = new ArrayList<Tuple2<Object, TaintedObject>>(nObjectsPerThread)
-        for (int i = 1; i <= nObjectsPerThread; i++) {
-          final o = new Object()
+        latch.countDown()
+        latch.await()
+        buckets[thread].each { o ->
           final to = new TaintedObject(o, [] as Range[], map.getReferenceQueue())
-          tuples.add(new Tuple2<Object, TaintedObject>(o, to))
-          objectHolder.put(o, to)
+          map.put(to)
         }
-        startLatch.countDown()
-        startLatch.await()
-        tuples.each { map.put(it.get(1)) }
       } as Runnable)
     }
     futures.collect({
       it.get()
     })
 
-    then: 'map is not in flat mode'
+    then:
     !map.isFlat()
-
-    then: 'map does not contain extra objects'
-    map.toList().size() <= nTotalObjects
-
-    and: 'map did not lose too many objects'
-    map.toList().size() >= nTotalObjects * maxAcceptableLoss
-
-    and: 'sanity check'
-    objectHolder.size() == nTotalObjects
+    nThreads == buckets.size()
 
     and: 'all objects are as expected'
-    objectHolder.count {
-      map.get(it.getKey()) == it.getValue()
-    } >= nTotalObjects * maxAcceptableLoss
+    buckets.each { bucket ->
+      bucket.each { o ->
+        assert map.get(o) != null
+        assert map.get(o).get() == o
+      }
+    }
 
     cleanup:
     executorService?.shutdown()
   }
 
-
-  def 'multi-threaded put-intensive workflow with garbage collection interaction and under max size'() {
+  def 'multi-threaded with no collisions, no GC, flat mode'() {
     given:
-    float maxAcceptableLoss = 0.99
-    float maxAcceptableLossPerThread = 0.9
+    int capacity = 128
+    int flatModeThreshold = 64
+    def queue = new MockReferenceQueue()
+    def map = new DefaultTaintedMap(capacity, flatModeThreshold, queue)
+
+    and:
     int nThreads = 16
-    int nObjectsPerThread = (int) Math.floor(DefaultTaintedMap.DEFAULT_FLAT_MODE_THRESHOLD / nThreads) * 2
-    int nRetainedObjectsPerThread = 128
-    // Each thread will wait for garbage collection after this number of puts.
-    int nBeforeWaitGC = 64
-
-    // Total number of puts should go over the flat mode threshold.
-    assert nObjectsPerThread * nThreads > DefaultTaintedMap.DEFAULT_FLAT_MODE_THRESHOLD
-    // Total retained objects (plus a wide margin given the probabilistic size estimate) should not go
-    // over the flat mode threshold.
-    assert nRetainedObjectsPerThread * 2 * nThreads < DefaultTaintedMap.DEFAULT_FLAT_MODE_THRESHOLD
-    assert nBeforeWaitGC <= nRetainedObjectsPerThread
-
+    def gen = new ObjectGen(capacity)
     def executorService = Executors.newFixedThreadPool(nThreads)
-    def startLatch = new CountDownLatch(nThreads)
-    def map = new DefaultTaintedMap()
+    def latch = new CountDownLatch(nThreads)
 
-    // Holders to avoid objects being garbage collected
-    def objectHolders = (1..nThreads).collect { new CircularBuffer<>(nRetainedObjectsPerThread) }
+    when:
+    // Number of purges required to switch to flat mode (in the absence of garbage collection)
+    final int purgesToFlatMode = (int) (flatModeThreshold / DefaultTaintedMap.PURGE_COUNT) + 1
+    gen.genObjects(purgesToFlatMode, ObjectGen.TRIGGERS_PURGE).each { o ->
+      final to = new TaintedObject(o, [] as Range[], map.getReferenceQueue())
+      queue.hold(o, to)
+      map.put(to)
+    }
 
-    when: 'perform a high amount of concurrent puts'
-    def futures = (1..nThreads).collect { thread ->
+    then:
+    map.isFlat()
+
+    when: 'puts from different threads to any buckets'
+    def objectHolder = []
+    def futures = (0..nThreads-1).collect { thread ->
+      // Each thread has multiple objects for each bucket
+      def objects = gen.genBuckets(capacity, 10).flatten()
+      objectHolder.addAll(objects)
+      Collections.shuffle(objects)
+
       executorService.submit({
         ->
-        final unreferenced = new ArrayList<TaintedObject>()
-        final buffer = objectHolders.get(thread - 1)
-        final tuples = new ArrayBlockingQueue<Tuple2<Object, TaintedObject>>(nObjectsPerThread)
-        for (int i = 1; i <= nObjectsPerThread; i++) {
-          final o = new Object()
+        latch.countDown()
+        latch.await()
+        objects.each { o ->
           final to = new TaintedObject(o, [] as Range[], map.getReferenceQueue())
-          tuples.add(new Tuple2<Object, TaintedObject>(o, to))
+          map.put(to)
         }
-        startLatch.countDown()
-        startLatch.await()
-        for (int i = 1; i <= nObjectsPerThread; i++) {
-          if (i % nBeforeWaitGC == 0) {
-            awaitCollected(unreferenced)
-          }
-          def tuple = tuples.poll()
-          final previous = buffer.add(tuple.getFirst())
-          if (previous != null) {
-            final to = map.get(previous)
-            if (to != null) {
-              unreferenced.add(to)
-            }
-          }
-          map.put(tuple.getSecond())
-        }
-        while (!tuples.isEmpty()) {
-          def tuple = tuples.poll()
-          final previous = buffer.add(tuple.getFirst())
-          if (previous != null) {
-            final to = map.get(previous)
-            if (to != null) {
-              unreferenced.add(to)
-            }
-          }
-          map.put(tuple.getSecond())
-        }
-        return unreferenced
-      } as Callable<List<TaintedObject>>)
+      } as Runnable)
     }
-    final unreferenced = futures.collectMany { it.get() }
-    awaitCollected(unreferenced)
+    futures.collect({
+      it.get()
+    })
 
-    then: 'map is not in flat mode'
-    !map.isFlat()
-
-    and: 'map does not contain too many extra entries'
-    map.toList().size() <= nThreads * nRetainedObjectsPerThread * 2
-
-    and: 'map does not contain extra objects'
-    map.toList().findAll { it.get() != null }.size() <= nThreads * nRetainedObjectsPerThread + nBeforeWaitGC
-
-    and: 'map did not lose too many objects'
-    map.toList().findAll { it.get() != null }.size() >= nThreads * nRetainedObjectsPerThread * maxAcceptableLoss
-
-    and: 'sanity check'
-    objectHolders.every { it.size() == nRetainedObjectsPerThread }
-
-    and: 'all objects are as expected'
-    for (final CircularBuffer<Object> objectHolder : objectHolders) {
-      assert objectHolder.count {
-        map.get(it) != null && map.get(it).get() == it
-      } >= nRetainedObjectsPerThread * maxAcceptableLossPerThread
-    }
+    then:
+    map.isFlat()
+    map.toList().size() == capacity
+    map.toList().findAll({ it.get() }).size() == capacity
+    map.toList().collect({ it.get() }).toSet().size() == capacity
 
     cleanup:
     executorService?.shutdown()
   }
 
-  private static void awaitCollected(final List<TaintedObject> objects, final long duration = 1, final TimeUnit unit = SECONDS) {
-    def attempts = 3
-    while (!objects.empty && attempts > 0) {
-      objects.removeAll { awaitCollected(it, duration, unit) }
-      attempts--
-    }
-    if (!objects.empty) {
-      // ok so once we got here ... the GC didn't want to collect our instances and not for the lack of trying,
-      // let's simulate the collection and keep on with our lives
-      objects.each {it.enqueue() }
-      objects.clear()
-    }
-  }
+  private static class MockReferenceQueue extends ReferenceQueue<Object> {
+    private List<Reference<?>> queue = new ArrayList()
+    private Map<Object, Reference<?>> objects = new HashMap<>()
 
-  private static boolean awaitCollected(final TaintedObject to, final long duration, final TimeUnit unit) {
-    try {
-      if (to.get() != null) {
-        awaitGC(to, duration, unit)
+    void hold(Object referent, Reference<?> reference) {
+      objects.put(referent, reference)
+    }
+
+    void free(Reference<?> ref) {
+      def referent = ref.get()
+      ref.clear()
+      queue.push(ref)
+      if (referent != null) {
+        objects.remove(referent)
       }
-      return true
-    } catch (final Exception e) {
-      return false
+    }
+
+    void clear() {
+      objects.values().toList().each {
+        free(it)
+      }
+    }
+
+    @Override
+    Reference<?> poll() {
+      if (queue.isEmpty()) {
+        return null
+      }
+      return queue.pop()
+    }
+
+    @Override
+    Reference<?> remove() throws InterruptedException {
+      throw new UnsupportedOperationException("NOT IMPLEMENTED")
+    }
+
+    @Override
+    Reference<?> remove(long timeout) throws IllegalArgumentException, InterruptedException {
+      throw new UnsupportedOperationException("NOT IMPLEMENTED")
     }
   }
 }


### PR DESCRIPTION
# What Does This Do
* Avoid depending directly on the garbage collector during testing. Each GC scenario is simulated with a mocked ReferenceQueue.
* Finer-grained control over edge cases.

# Motivation
Previous approach was dependent on GC, which made it slow, and flaky.

# Additional Notes
See https://github.com/DataDog/dd-trace-java/issues/4098
