### PR TITLE
Upgrade to Spock 2

### DIFF
--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastModuleImplOnStringBuilderAppendTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastModuleImplOnStringBuilderAppendTest.groovy
@@ -19,7 +19,7 @@ class IastModuleImplOnStringBuilderAppendTest extends IastModuleImplTestBase {
     objectHolder.clear()
   }
 
-  void 'onStringBuilderAppend null or empty (#builder, #param)'(final StringBuilder builder, final String param) {
+  void 'onStringBuilderAppend null or empty (#builder, #param)'() {
     given:
     final result = builder?.append(param)
 
@@ -35,7 +35,7 @@ class IastModuleImplOnStringBuilderAppendTest extends IastModuleImplTestBase {
     sb('')  | ''
   }
 
-  void 'onStringBuilderAppend without span (#builder, #param)'(final StringBuilder builder, final String param, final int mockCalls) {
+  void 'onStringBuilderAppend without span (#builder, #param)'() {
     given:
     final result = builder?.append(param)
 
@@ -52,7 +52,7 @@ class IastModuleImplOnStringBuilderAppendTest extends IastModuleImplTestBase {
     sb('3') | '4'   | 1
   }
 
-  void 'onStringBuilderAppend (#builder, #param)'(StringBuilder builder, String param, final int mockCalls, final String expected) {
+  void 'onStringBuilderAppend (#builder, #param)'() {
     given:
     final span = Mock(AgentSpan)
     tracer.activeSpan() >> span

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastModuleImplOnStringBuilderInitTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastModuleImplOnStringBuilderInitTest.groovy
@@ -19,7 +19,7 @@ class IastModuleImplOnStringBuilderInitTest extends IastModuleImplTestBase {
     objectHolder.clear()
   }
 
-  void 'onStringBuilderInit null or empty (#builder, #param)'(final StringBuilder builder, final String param) {
+  void 'onStringBuilderInit null or empty (#builder, #param)'() {
     given:
     final result = builder?.append(param)
 
@@ -35,7 +35,7 @@ class IastModuleImplOnStringBuilderInitTest extends IastModuleImplTestBase {
     sb('')  | ''
   }
 
-  void 'onStringBuilderInit without span (#builder, #param)'(final StringBuilder builder, final String param, final int mockCalls) {
+  void 'onStringBuilderInit without span (#builder, #param)'() {
     given:
     final result = builder?.append(param)
 
@@ -52,7 +52,7 @@ class IastModuleImplOnStringBuilderInitTest extends IastModuleImplTestBase {
     sb()    | '4'   | 1
   }
 
-  void 'onStringBuilderInit (#builder, #param)'(StringBuilder builder, String param, final int mockCalls, final String expected) {
+  void 'onStringBuilderInit (#builder, #param)'() {
     given:
     final span = Mock(AgentSpan)
     tracer.activeSpan() >> span

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastModuleImplOnStringBuilderToStringTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastModuleImplOnStringBuilderToStringTest.groovy
@@ -32,7 +32,7 @@ class IastModuleImplOnStringBuilderToStringTest extends IastModuleImplTestBase {
     0 * _
   }
 
-  void 'onStringBuilderToString (#originalBuilder)'(final StringBuilder originalBuilder, final String expected) {
+  void 'onStringBuilderToString (#originalBuilder)'() {
     given:
     final span = Mock(AgentSpan)
     tracer.activeSpan() >> span

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastModuleImplOnStringBuilderToStringTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastModuleImplOnStringBuilderToStringTest.groovy
@@ -32,7 +32,7 @@ class IastModuleImplOnStringBuilderToStringTest extends IastModuleImplTestBase {
     0 * _
   }
 
-  void 'onStringBuilderToString (#builder)'(StringBuilder builder, final String expected) {
+  void 'onStringBuilderToString (#originalBuilder)'(final StringBuilder originalBuilder, final String expected) {
     given:
     final span = Mock(AgentSpan)
     tracer.activeSpan() >> span
@@ -43,7 +43,7 @@ class IastModuleImplOnStringBuilderToStringTest extends IastModuleImplTestBase {
 
     and:
     final taintedObjects = ctx.getTaintedObjects()
-    builder = addFromTaintFormat(taintedObjects, builder)
+    final builder = addFromTaintFormat(taintedObjects, originalBuilder)
     objectHolder.add(builder)
 
     and:
@@ -70,7 +70,7 @@ class IastModuleImplOnStringBuilderToStringTest extends IastModuleImplTestBase {
     }
 
     where:
-    builder            | expected
+    originalBuilder    | expected
     sb('123')          | '123'
     sb('==>123<==')    | '==>123<=='
     sb('==>123<==456') | '==>123<==456'

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/overhead/OverheadControllerTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/overhead/OverheadControllerTest.groovy
@@ -201,9 +201,8 @@ class OverheadControllerTest extends DDSpecification {
             sem.release()
             overheadController.releaseRequest()
             return true
-          } else {
-            return false
           }
+          return false
         }
       } as Callable<Boolean[]>)
     }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/overhead/OverheadControllerTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/overhead/OverheadControllerTest.groovy
@@ -193,20 +193,18 @@ class OverheadControllerTest extends DDSpecification {
         ->
         startLatch.countDown()
         startLatch.await()
-        final results = new Boolean[nIters]
-        for (int j = 0; j < nIters; j++) {
+        return (0..nIters-1).collect { j ->
           if (overheadController.acquireRequest()) {
-            results[j] = true
             if (!sem.tryAcquire()) {
               throw new RuntimeException("Could not acquire semaphore")
             }
             sem.release()
             overheadController.releaseRequest()
+            return true
           } else {
-            results[j] = false
+            return false
           }
         }
-        return results
       } as Callable<Boolean[]>)
     }
     def results = futures.collect({

--- a/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
@@ -11,7 +11,6 @@ import util.AbstractCouchbaseTest
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
-@Unroll
 class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
   static final int TIMEOUT = 30
 

--- a/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
@@ -13,7 +13,6 @@ import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 @Retry
-@Unroll
 class CouchbaseClientTest extends AbstractCouchbaseTest {
   def "test hasBucket #type"() {
     setup:

--- a/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
@@ -21,7 +21,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
   // TODO Java 17: This version of spring-data doesn't support Java 17
   new BigDecimal(System.getProperty("java.specification.version")).isAtLeast(17.0)
 })
-@Unroll
 class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
   static final Closure<Doc> FIND
   static {

--- a/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringTemplateTest.groovy
@@ -16,7 +16,6 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
 @Retry(count = 10, delay = 500)
-@Unroll
 class CouchbaseSpringTemplateTest extends AbstractCouchbaseTest {
 
   @Override

--- a/dd-java-agent/instrumentation/iast-instrumenter/src/test/groovy/IastExclusionTrieTest.groovy
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/test/groovy/IastExclusionTrieTest.groovy
@@ -4,7 +4,6 @@ import spock.lang.Unroll
 
 class IastExclusionTrieTest extends DDSpecification {
 
-  @Unroll
   def 'Test that #name should be included? #expected'(final String name, final int expected) {
     when:
     final result = IastExclusionTrie.apply(name)

--- a/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/test/groovy/JakartaRsFilterTest.groovy
+++ b/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/test/groovy/JakartaRsFilterTest.groovy
@@ -13,7 +13,6 @@ import jakarta.ws.rs.ext.Provider
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
-@Unroll
 abstract class JakartaRsFilterTest extends AgentTestRunner {
 
   @Shared

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ExecutorInstrumentationTest.groovy
@@ -64,7 +64,6 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
     injectSysConfig("trace.thread-pool-executors.exclude", "ExecutorInstrumentationTest\$ToBeIgnoredExecutor")
   }
 
-  @Unroll
   def "#poolImpl '#name' propagates"() {
     setup:
     assumeTrue(poolImpl != null) // skip for Java 7 CompletableFuture, non-Linux Netty EPoll
@@ -223,7 +222,6 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
     // spotless:on
   }
 
-  @Unroll
   def "#poolImpl '#name' doesn't propagate"() {
     setup:
     def pool = poolImpl
@@ -337,7 +335,6 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
     }
   }
 
-  @Unroll
   def "#poolImpl '#name' wraps"() {
     setup:
     def pool = poolImpl
@@ -374,7 +371,6 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
     "schedule Runnable" | scheduleRunnable | { new RunnableWrapper(it) } | new ScheduledThreadPoolExecutor(1)
   }
 
-  @Unroll
   def "#poolImpl '#name' reports after canceled jobs"() {
     setup:
     assumeTrue(poolImpl != null) // skip for non-Linux Netty EPoll

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/test/groovy/JaxRsFilterTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/test/groovy/JaxRsFilterTest.groovy
@@ -20,7 +20,6 @@ import javax.ws.rs.ext.Provider
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
-@Unroll
 abstract class JaxRsFilterTest extends AgentTestRunner {
 
   @Shared

--- a/dd-java-agent/instrumentation/jdbc/scalikejdbc/src/test/groovy/ScalikeJDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/scalikejdbc/src/test/groovy/ScalikeJDBCInstrumentationTest.groovy
@@ -132,7 +132,6 @@ class ScalikeJDBCInstrumentationTest extends AgentTestRunner {
     }
   }
 
-  @Unroll
   def "scalikejdbc query test"() {
     setup:
     runUnderTrace("parent") {

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
@@ -162,7 +162,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     }
   }
 
-  @Unroll
   def "basic statement with #connection.getClass().getCanonicalName() on #driver generates spans"() {
     setup:
     injectSysConfig(DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "$renameService")
@@ -232,7 +231,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     "hsqldb" | cpDatasources.get("c3p0").get(driver).getConnection()   | false         | "SELECT 3 FROM INFORMATION_SCHEMA.SYSTEM_USERS" | "SELECT"  | "SELECT ? FROM INFORMATION_SCHEMA.SYSTEM_USERS"
   }
 
-  @Unroll
   def "prepared statement execute on #driver with #connection.getClass().getCanonicalName() generates a span"() {
     setup:
     PreparedStatement statement = connection.prepareStatement(query)
@@ -287,7 +285,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     "derby" | cpDatasources.get("c3p0").get(driver).getConnection()   | "SELECT 3 FROM SYSIBM.SYSDUMMY1" | "SELECT"  | "SELECT ? FROM SYSIBM.SYSDUMMY1"
   }
 
-  @Unroll
   def "prepared statement query on #driver with #connection.getClass().getCanonicalName() generates a span"() {
     setup:
     PreparedStatement statement = connection.prepareStatement(query)
@@ -341,7 +338,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     "derby" | cpDatasources.get("c3p0").get(driver).getConnection()   | "SELECT 3 FROM SYSIBM.SYSDUMMY1" | "SELECT"  | "SELECT ? FROM SYSIBM.SYSDUMMY1"
   }
 
-  @Unroll
   def "prepared call on #driver with #connection.getClass().getCanonicalName() generates a span"() {
     setup:
     CallableStatement statement = connection.prepareCall(query)
@@ -395,7 +391,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     "derby" | cpDatasources.get("c3p0").get(driver).getConnection()   | "SELECT 3 FROM SYSIBM.SYSDUMMY1" | "SELECT"  | "SELECT ? FROM SYSIBM.SYSDUMMY1"
   }
 
-  @Unroll
   def "statement update on #driver with #connection.getClass().getCanonicalName() generates a span"() {
     setup:
     Statement statement = connection.createStatement()
@@ -452,7 +447,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     "hsqldb" | cpDatasources.get("c3p0").get(driver).getConnection()   | "CREATE TABLE PUBLIC.S_HSQLDB_C3P0 (id INTEGER not NULL, PRIMARY KEY ( id ))"   | "CREATE"
   }
 
-  @Unroll
   def "prepared statement update on #driver with #connection.getClass().getCanonicalName() generates a span"() {
     setup:
     def sql = connection.nativeSQL(query)
@@ -504,7 +498,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     "derby" | cpDatasources.get("c3p0").get(driver).getConnection()   | "APP"    | "CREATE TABLE PS_DERBY_C3P0 (id INTEGER not NULL, PRIMARY KEY ( id ))"   | "CREATE"
   }
 
-  @Unroll
   def "connection constructor throwing then generating correct spans after recovery using #driver connection (prepare statement = #prepareStatement)"() {
     setup:
     Connection connection = null
@@ -684,7 +677,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     obfuscatedQuery = "testing ?"
   }
 
-  @Unroll
   def "#connectionPoolName connections should be cached in case of wrapped connections"() {
     setup:
     String dbType = "hsqldb"

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
@@ -177,7 +177,6 @@ class RemoteJDBCInstrumentationTest extends AgentTestRunner {
     mysql?.close()
   }
 
-  @Unroll
   def "basic statement with #connection.getClass().getCanonicalName() on #driver generates spans"() {
     setup:
     injectSysConfig(DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "$renameService")
@@ -236,7 +235,6 @@ class RemoteJDBCInstrumentationTest extends AgentTestRunner {
     "postgresql" | cpDatasources.get("c3p0").get(driver).getConnection()   | false         | "SELECT 3 FROM pg_user" | "SELECT"  | "SELECT ? FROM pg_user"
   }
 
-  @Unroll
   def "prepared statement execute on #driver with #connection.getClass().getCanonicalName() generates a span"() {
     setup:
     PreparedStatement statement = connection.prepareStatement(query)
@@ -296,7 +294,6 @@ class RemoteJDBCInstrumentationTest extends AgentTestRunner {
     "postgresql" | cpDatasources.get("c3p0").get(driver).getConnection()   | "SELECT 3 from pg_user" | "SELECT"  | "SELECT ? from pg_user"
   }
 
-  @Unroll
   def "prepared statement query on #driver with #connection.getClass().getCanonicalName() generates a span"() {
     setup:
     PreparedStatement statement = connection.prepareStatement(query)
@@ -354,7 +351,6 @@ class RemoteJDBCInstrumentationTest extends AgentTestRunner {
     "postgresql" | cpDatasources.get("c3p0").get(driver).getConnection()   | "SELECT 3 from pg_user" | "SELECT"  | "SELECT ? from pg_user"
   }
 
-  @Unroll
   def "prepared call on #driver with #connection.getClass().getCanonicalName() generates a span"() {
     setup:
     CallableStatement statement = connection.prepareCall(query)
@@ -412,7 +408,6 @@ class RemoteJDBCInstrumentationTest extends AgentTestRunner {
     "postgresql" | cpDatasources.get("c3p0").get(driver).getConnection()   | "SELECT 3 from pg_user" | "SELECT"  | "SELECT ? from pg_user"
   }
 
-  @Unroll
   def "statement update on #driver with #connection.getClass().getCanonicalName() generates a span"() {
     setup:
     Statement statement = connection.createStatement()

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
@@ -10,7 +10,6 @@ import org.eclipse.jetty.http.HttpStatus
 import spock.lang.Unroll
 
 class JSPInstrumentationBasicTests extends JSPTestBase {
-  @Unroll
   def "non-erroneous GET #test test"() {
     setup:
     String reqUrl = baseUrl + "/$jspFileName"
@@ -230,7 +229,6 @@ class JSPInstrumentationBasicTests extends JSPTestBase {
     res.close()
   }
 
-  @Unroll
   def "erroneous runtime errors GET jsp with #test test"() {
     setup:
     String reqUrl = baseUrl + "/$jspFileName"

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
@@ -7,7 +7,6 @@ import org.eclipse.jetty.http.HttpStatus
 import spock.lang.Unroll
 
 class JSPInstrumentationForwardTests extends JSPTestBase {
-  @Unroll
   def "non-erroneous GET forward to #forwardTo"() {
     setup:
     String reqUrl = baseUrl + "/$forwardFromFileName"

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTest.groovy
@@ -905,7 +905,6 @@ class KafkaClientTest extends AgentTestRunner {
     container?.stop()
   }
 
-  @Unroll
   def "test kafka client header propagation manual config"() {
     setup:
     def producerProps = KafkaTestUtils.producerProps(embeddedKafka.getBrokersAsString())

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientCustomPropagationConfigTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientCustomPropagationConfigTest.groovy
@@ -55,7 +55,6 @@ class KafkaClientCustomPropagationConfigTest extends AgentTestRunner {
     injectSysConfig("dd.kafka.e2e.duration.enabled", "true")
   }
 
-  @Unroll
   def "test kafka client header propagation with topic filters"() {
     setup:
     injectSysConfig(TraceInstrumentationConfig.KAFKA_CLIENT_PROPAGATION_DISABLED_TOPICS, value as String)
@@ -161,7 +160,6 @@ class KafkaClientCustomPropagationConfigTest extends AgentTestRunner {
     [value, expected1, expected2, expected3, expected4]<< dataTable()
   }
 
-  @Unroll
   def "test consumer with topic filters"() {
     setup:
     injectSysConfig(TraceInstrumentationConfig.KAFKA_CLIENT_PROPAGATION_DISABLED_TOPICS, value as String)

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
@@ -725,7 +725,6 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
     container?.stop()
   }
 
-  @Unroll
   def "test kafka client header propagation manual config"() {
     setup:
     def senderProps = KafkaTestUtils.senderProps(embeddedKafka.getBrokersAsString())

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
@@ -29,7 +29,6 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.TIMEOU
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.TIMEOUT_ERROR
 import static datadog.trace.instrumentation.servlet3.TestServlet3.SERVLET_TIMEOUT
 
-@Unroll
 abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> {
 
   @Shared

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/datadog/trace/instrumentation/springweb/HandlerMappingResourceNameFilterTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/datadog/trace/instrumentation/springweb/HandlerMappingResourceNameFilterTest.groovy
@@ -32,7 +32,6 @@ class HandlerMappingResourceNameFilterTest extends AgentTestRunner {
   @Autowired
   HandlerMappingResourceNameFilter filter
 
-  @Unroll
   def "test filter doesn't make externally visible changes to request object - url: #url"() {
     given:
     def request = new MockHttpServletRequest("GET", url)

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/latestDepTest/groovy/TomcatServletTest.groovy
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/latestDepTest/groovy/TomcatServletTest.groovy
@@ -19,7 +19,6 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.TIMEOUT_ERROR
 import static org.junit.Assume.assumeTrue
 
-@Unroll
 class TomcatServletTest extends AbstractServletTest<Tomcat, Context> {
 
   class TomcatServer implements HttpServer {

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/test/groovy/TomcatServletTest.groovy
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/test/groovy/TomcatServletTest.groovy
@@ -24,7 +24,6 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.TIMEOU
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static org.junit.Assume.assumeTrue
 
-@Unroll
 class TomcatServletTest extends AbstractServletTest<Embedded, Context> {
 
   class TomcatServer implements HttpServer {

--- a/dd-java-agent/instrumentation/vertx-mysql-client-3.9/src/test/groovy/VertxSqlClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-mysql-client-3.9/src/test/groovy/VertxSqlClientForkedTest.groovy
@@ -38,7 +38,6 @@ class VertxSqlClientForkedTest extends AgentTestRunner {
   @Shared
   def vertx = Vertx.vertx(new VertxOptions())
 
-  @Unroll
   def "test #type"() {
     when:
     AsyncResult<RowSet<Row>> asyncResult = runUnderTrace("parent") {
@@ -72,7 +71,6 @@ class VertxSqlClientForkedTest extends AgentTestRunner {
     'prepared statement' | pool() | prepare(connection(pool), "SELECT 7").query() | true
   }
 
-  @Unroll
   def "test #type without parent"() {
     when:
     AsyncResult<RowSet<Row>> asyncResult = executeQueryWithHandler(query)
@@ -105,7 +103,6 @@ class VertxSqlClientForkedTest extends AgentTestRunner {
     'prepared statement' | pool() | prepare(connection(pool), "SELECT 7").query() | true
   }
 
-  @Unroll
   def "test #type mapped"() {
     setup:
     def mapped = query.mapping({row ->
@@ -144,7 +141,6 @@ class VertxSqlClientForkedTest extends AgentTestRunner {
     'prepared statement' | pool() | prepare(connection(pool), "SELECT 7").query() | true
   }
 
-  @Unroll
   def "test #type mapped without parent"() {
     setup:
     def mapped = query.mapping({row ->

--- a/dd-java-agent/testing/build.gradle
+++ b/dd-java-agent/testing/build.gradle
@@ -56,4 +56,7 @@ dependencies {
   // We have autoservices defined in test subtree, looks like we need this to be able to properly rebuild this
   testAnnotationProcessor deps.autoserviceProcessor
   testCompileOnly deps.autoserviceAnnotation
+
+  annotationProcessor deps.autoserviceProcessor
+  compileOnly deps.autoserviceAnnotation
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -77,7 +77,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.closePrevi
  */
 // CodeNarc incorrectly thinks ".class" is unnecessary in @RunWith
 @SuppressWarnings('UnnecessaryDotClass')
-@RunWith(SpockRunner.class)
 abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.Listener {
   private static final long TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(10)
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/DDTestClassExtension.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/DDTestClassExtension.java
@@ -79,7 +79,8 @@ public class DDTestClassExtension implements TestInstanceFactory, BeforeTestExec
   @Override
   public Object createTestInstance(final TestInstanceFactoryContext factoryCtx, final ExtensionContext extCtx) throws TestInstantiationException {
     final Class<?> clazz = factoryCtx.getTestClass();
-    final Class<?> shadowClass = shadowTestClass(factoryCtx.getTestClass());
+    //final Class<?> shadowClass = shadowTestClass(factoryCtx.getTestClass());
+    final Class<?> shadowClass = clazz;
     assertNoBootstrapClassesInTestClass(clazz);
 
     // Save our custom class loader for later use during test runs.
@@ -90,11 +91,6 @@ public class DDTestClassExtension implements TestInstanceFactory, BeforeTestExec
     } catch (ReflectiveOperationException ex) {
       throw new TestInstantiationException("Failed to create test class", ex);
     }
-  }
-
-  private ExtensionContext.Store getStore(final ExtensionContext ctx) {
-    final ExtensionContext.Namespace ns = ExtensionContext.Namespace.create(ctx.getTestClass().get());
-    return ctx.getStore(ns);
   }
 
   @Override
@@ -118,6 +114,11 @@ public class DDTestClassExtension implements TestInstanceFactory, BeforeTestExec
       throw new Exception("BAD");
     }
     Thread.currentThread().setContextClassLoader(originalContextLoader);
+  }
+
+  private ExtensionContext.Store getStore(final ExtensionContext ctx) {
+    final ExtensionContext.Namespace ns = ExtensionContext.Namespace.create(ctx.getTestClass().get());
+    return ctx.getStore(ns);
   }
 
   private static void assertNoBootstrapClassesInTestClass(final Class<?> testClass) {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -23,7 +23,6 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_CLIENT_HO
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_CLIENT_TAG_QUERY_STRING
 import static org.junit.Assume.assumeTrue
 
-@Unroll
 abstract class HttpClientTest extends AgentTestRunner {
   protected static final BODY_METHODS = ["POST", "PUT"]
   protected static final int CONNECT_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(3) as int

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -68,7 +68,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.get
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan
 import static org.junit.Assume.assumeTrue
 
-@Unroll
 abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
 
   public static final Logger SERVER_LOGGER = LoggerFactory.getLogger("http-server")

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
@@ -9,7 +9,6 @@ import datadog.trace.bootstrap.instrumentation.decorator.TestDecorator
 import spock.lang.Shared
 import spock.lang.Unroll
 
-@Unroll
 abstract class TestFrameworkTest extends AgentTestRunner {
 
   @Override

--- a/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/AgentTestRunnerTest.groovy
@@ -1,6 +1,7 @@
 import com.google.common.reflect.ClassPath
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.SpockRunner
+import datadog.trace.agent.test.DDTestClassExtension
+
 import datadog.trace.agent.test.utils.ClasspathUtils
 import datadog.trace.api.GlobalTracer
 import datadog.trace.bootstrap.Constants
@@ -37,7 +38,7 @@ class AgentTestRunnerTest extends AgentTestRunner {
 
   def "spock runner bootstrap prefixes correct for test setup"() {
     expect:
-    SpockRunner.BOOTSTRAP_PACKAGE_PREFIXES_COPY == Constants.BOOTSTRAP_PACKAGE_PREFIXES
+    DDTestClassExtension.BOOTSTRAP_PACKAGE_PREFIXES_COPY == Constants.BOOTSTRAP_PACKAGE_PREFIXES
   }
 
   def "classpath setup"() {

--- a/gradle/configure_tests.gradle
+++ b/gradle/configure_tests.gradle
@@ -14,9 +14,9 @@ def testTimeoutDuration = Duration.of(9, ChronoUnit.MINUTES)
 
 // Go through the Test tasks and configure them
 tasks.withType(Test).configureEach {
-  if (project.findProperty("enableJunitPlatform") == true) {
+  //if (project.findProperty("enableJunitPlatform") == true) {
     useJUnitPlatform()
-  }
+  //}
 
   // All tests must complete within 15 minutes.
   // This value is quite big because with lower values (3 mins) we were experiencing large number of false positives

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,5 +1,5 @@
 final class CachedData {
-  static groovyVer = "2.5.13"
+  static groovyVer = "2.5.19"
   static spockGroovyVer = groovyVer.replaceAll(/\.\d+$/, '')
 
   static versions = [

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,7 +10,7 @@ final class CachedData {
     okhttp_legacy : "[3.0,3.12.12]", // 3.12.x is last version to support Java7)
     okio          : "1.16.0",
 
-    spock         : "1.3-groovy-$spockGroovyVer",
+    spock         : "2.3-groovy-$spockGroovyVer",
     groovy        : groovyVer,
     junit4        : "4.13.2",
     junit5        : "5.8.1",
@@ -63,7 +63,7 @@ final class CachedData {
       // Used by Spock for mocking:
       "org.objenesis:objenesis:2.6" // Last version to support Java7
     ],
-    groovy               : "org.codehaus.groovy:groovy-all:${versions.groovy}",
+    groovy               : "org.apache.groovy:groovy-all:${versions.groovy}",
     junit4               : "junit:junit:${versions.junit4}",
     junit5               : [
       "org.junit.jupiter:junit-jupiter:${versions.junit5}",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -63,7 +63,7 @@ final class CachedData {
       // Used by Spock for mocking:
       "org.objenesis:objenesis:2.6" // Last version to support Java7
     ],
-    groovy               : "org.apache.groovy:groovy-all:${versions.groovy}",
+    groovy               : "org.codehaus.groovy:groovy-all:${versions.groovy}",
     junit4               : "junit:junit:${versions.junit4}",
     junit5               : [
       "org.junit.jupiter:junit-jupiter:${versions.junit5}",

--- a/gradle/java_deps.gradle
+++ b/gradle/java_deps.gradle
@@ -4,5 +4,4 @@ dependencies {
   testImplementation deps.spock
   testImplementation deps.groovy
   testImplementation deps.testLogging
-  testImplementation group: 'info.solidsoft.spock', name: 'spock-global-unroll', version: '0.5.1'
 }

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -1996,7 +1996,6 @@ class ConfigTest extends DDSpecification {
     config.getMetricsIgnoredResources() == ["GET /healthcheck", "SELECT foo from bar"].toSet()
   }
 
-  @Unroll
   def "appsec state with sys = #sys env = #env"() {
     setup:
     if (sys != null) {

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/api/URIDataAdapterTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/api/URIDataAdapterTest.groovy
@@ -11,7 +11,6 @@ abstract class URIDataAdapterTest extends DDSpecification {
     return true
   }
 
-  @Unroll
   def "test URI parts #input"() {
     setup:
     def uri = new URI(input)

--- a/utils/container-utils/src/test/groovy/ContainerInfoTest.groovy
+++ b/utils/container-utils/src/test/groovy/ContainerInfoTest.groovy
@@ -10,7 +10,6 @@ import java.text.ParseException
 
 class ContainerInfoTest extends DDSpecification {
 
-  @Unroll
   def "CGroupInfo is parsed from individual lines"() {
     when:
     ContainerInfo.CGroupInfo cGroupInfo = ContainerInfo.parseLine(line)
@@ -90,7 +89,6 @@ class ContainerInfoTest extends DDSpecification {
     // spotless:on
   }
 
-  @Unroll
   def "Container info parsed from file content"() {
     when:
     ContainerInfo containerInfo = ContainerInfo.parse(content)


### PR DESCRIPTION
# What Does This Do
Upgrade to Spock 2.

# Motivation
Our versions of Spock is stuck at 1.x, which also gets us stuck at Groovy 2.x, which has some annoying bugs (like https://issues.apache.org/jira/browse/GROOVY-10137).

# Additional Notes
**Very far from ready.**

Blockers:
* `SpockRunner` needs a completely different approach, since the JUnit 4 runner API is gone. Unfortunately, JUnit 5 / Spock 2 do not seem to support features that would allow to do these class transformations and classloader injection (see https://github.com/junit-team/junit5/issues/201). I think we'll end up with a small Java agent for this task.
