### PR TITLE
[DSM] Don't send null tags with data streams checkpoint

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
@@ -107,6 +107,9 @@ public class DefaultPathwayContext implements PathwayContext {
 
       for (Map.Entry<String, String> entry : sortedTags.entrySet()) {
         String tag = TagsProcessor.createTag(entry.getKey(), entry.getValue());
+        if (tag == null) {
+          continue;
+        }
         if (hashableTagKeys.contains(entry.getKey())) {
           pathwayHashBuilder.addTag(tag);
         }

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/TagsProcessor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/TagsProcessor.java
@@ -81,7 +81,12 @@ public class TagsProcessor {
     return result;
   }
 
+  // Creates the tag string using the provided tagKey and tagValue.
+  // Returns null if either tagKey or tagValue is null.
   public static String createTag(String tagKey, String tagValue) {
+    if (tagKey == null || tagValue == null) {
+      return null;
+    }
     DDCache<String, String> cache = TAG_TO_CACHE.get(tagKey);
     Function<String, String> prefix = TAG_TO_PREFIX.get(tagKey);
     if (cache != null && prefix != null) {


### PR DESCRIPTION
# What Does This Do
This PR will remove any null tags that we try to send along in a data streams checkpoint.

# Motivation
Null tags cause deserialization issues in the Data Streams backend, causing checkpoints to be dropped.

# Additional Notes
