### PR TITLE
Unify hostname detection in config and telemetry

### DIFF
--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -77,7 +77,7 @@ excludedClassesCoverage += [
   // a stub
   "datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration.NoOp"
 ]
-excludedClassesBranchCoverage = ['datadog.trace.api.ProductActivationConfig',]
+excludedClassesBranchCoverage = ['datadog.trace.api.ProductActivationConfig', 'datadog.trace.api.Config']
 
 compileTestJava.dependsOn 'generateTestClassNameTries'
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -256,6 +256,7 @@ import datadog.trace.api.config.TracerConfig;
 import datadog.trace.bootstrap.config.provider.CapturedEnvironmentConfigSource;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import datadog.trace.bootstrap.config.provider.SystemPropertiesConfigSource;
+import datadog.trace.util.Strings;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -2464,9 +2465,10 @@ public class Config {
       } catch (Throwable t) {
         // Ignore
       }
-      if (possibleHostname != null && !possibleHostname.trim().isEmpty()) {
+      possibleHostname = Strings.trim(possibleHostname);
+      if (!possibleHostname.isEmpty()) {
         log.debug("Determined hostname from file {}", hostNameFile);
-        return possibleHostname.trim();
+        return possibleHostname;
       }
     }
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -267,7 +267,9 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2435,7 +2437,7 @@ public class Config {
   }
 
   /** Returns the detected hostname. First tries locally, then using DNS */
-  private static String initHostName() {
+  static String initHostName() {
     String possibleHostname;
 
     // Try environment variable.  This works in almost all environments
@@ -2448,6 +2450,24 @@ public class Config {
     if (possibleHostname != null && !possibleHostname.isEmpty()) {
       log.debug("Determined hostname from environment variable");
       return possibleHostname.trim();
+    }
+
+    // Try hostname files
+    final String[] hostNameFiles = new String[] {"/proc/sys/kernel/hostname", "/etc/hostname"};
+    for (final String hostNameFile : hostNameFiles) {
+      try {
+        final Path hostNamePath = FileSystems.getDefault().getPath(hostNameFile);
+        if (Files.isRegularFile(hostNamePath)) {
+          byte[] bytes = Files.readAllBytes(hostNamePath);
+          possibleHostname = new String(bytes, StandardCharsets.ISO_8859_1);
+        }
+      } catch (Throwable t) {
+        // Ignore
+      }
+      if (possibleHostname != null && !possibleHostname.trim().isEmpty()) {
+        log.debug("Determined hostname from file {}", hostNameFile);
+        return possibleHostname.trim();
+      }
     }
 
     // Try hostname command

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -2058,6 +2058,32 @@ class ConfigTest extends DDSpecification {
     "1"        | null       | ProductActivation.FULLY_ENABLED
   }
 
+  def "hostname discovery with environment variables"() {
+    setup:
+    final expectedHostname = "myhostname"
+    environmentVariables.set("HOSTNAME", expectedHostname)
+    environmentVariables.set("COMPUTERNAME", expectedHostname)
+
+    when:
+    def hostname = Config.initHostName()
+
+    then:
+    hostname == expectedHostname
+  }
+
+  def "hostname discovery without environment variables"() {
+    setup:
+    environmentVariables.set("HOSTNAME", "")
+    environmentVariables.set("COMPUTERNAME", "")
+
+    when:
+    def hostname = Config.initHostName()
+
+    then:
+    hostname != null
+    !hostname.trim().isEmpty()
+  }
+
   static class ClassThrowsExceptionForValueOfMethod {
     static ClassThrowsExceptionForValueOfMethod valueOf(String ignored) {
       throw new Throwable()

--- a/telemetry/src/main/java/datadog/telemetry/HostInfo.java
+++ b/telemetry/src/main/java/datadog/telemetry/HostInfo.java
@@ -1,16 +1,14 @@
 package datadog.telemetry;
 
+import datadog.trace.api.Config;
 import datadog.trace.api.Platform;
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.AccessControlException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -24,8 +22,6 @@ public class HostInfo {
   private static final Path ETC_HOSTNAME = FileSystems.getDefault().getPath("/etc/hostname");
 
   private static final Path PROC_VERSION = FileSystems.getDefault().getPath("/proc/version");
-  private static final List<Path> HOSTNAME_FILES = Arrays.asList(PROC_HOSTNAME, ETC_HOSTNAME);
-
   private static final Logger log = LoggerFactory.getLogger(RequestBuilder.class);
 
   private static String hostname;
@@ -38,30 +34,7 @@ public class HostInfo {
     if (hostname != null) {
       return hostname;
     }
-    String hostname = null;
-    for (Path file : HOSTNAME_FILES) {
-      hostname = tryReadFile(file);
-      if (null != hostname) {
-        break;
-      }
-    }
-
-    if (hostname == null) {
-      try {
-        hostname = getHostNameFromLocalHost();
-      } catch (UnknownHostException e) {
-        // purposefully left empty
-      }
-    }
-
-    if (hostname != null) {
-      hostname = hostname.trim();
-    } else {
-      log.warn("Could not determine hostname");
-      hostname = "";
-    }
-
-    HostInfo.hostname = hostname;
+    HostInfo.hostname = Config.get().getHostName();
     return hostname;
   }
 
@@ -113,10 +86,6 @@ public class HostInfo {
       }
     }
     return kernelVersion;
-  }
-
-  private static String getHostNameFromLocalHost() throws UnknownHostException {
-    return InetAddress.getLocalHost().getHostName();
   }
 
   private static String tryReadFile(Path file) {


### PR DESCRIPTION
# What Does This Do
* In telemetry, use the hostname discovered in Config initialization.
* In Config, try `/proc/sys/kernel/hostname` and `/etc/hostname` before the `hostname` command.

# Motivation
We detected hostname twice, and in slightly different ways (Telemetry wouldn't use environment variables, Config wouldn't use hostname files).

# Additional Notes
Initially discovered while monitoring the execution of external process, which was triggered Config's execution of `hostname`