### PR TITLE
Fix port conflict in NettyResteasyAppsecTest

### DIFF
--- a/dd-java-agent/instrumentation/resteasy-appsec/src/nettyTest/groovy/datadog/trace/instrumentation/resteasy/NettyResteasyAppsecTest.groovy
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/nettyTest/groovy/datadog/trace/instrumentation/resteasy/NettyResteasyAppsecTest.groovy
@@ -1,13 +1,11 @@
 package datadog.trace.instrumentation.resteasy
 
+import datadog.trace.agent.test.utils.PortUtils
 import org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer
 import org.jboss.resteasy.spi.ResteasyDeployment
-import spock.lang.Ignore
 import spock.lang.Shared
 
-@Ignore("Regularly times out the build completely https://github.com/DataDog/dd-trace-java/issues/3862")
 class NettyResteasyAppsecTest extends AbstractResteasyAppsecTest {
-  private final static int PORT = 59152
 
   @Shared
   NettyJaxrsServer netty
@@ -24,11 +22,11 @@ class NettyResteasyAppsecTest extends AbstractResteasyAppsecTest {
     deployment.application = new TestJaxRsApplication()
 
     netty.deployment = deployment
-    netty.port = PORT
+    netty.port = PortUtils.randomOpenPort()
     netty.rootResourcePath = ''
     netty.securityDomain = null
     netty.start()
-    address = URI.create("http://localhost:$PORT/")
+    address = URI.create("http://localhost:${netty.port}/")
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

Fix port conflict in NettyResteasyAppsecTest

# Motivation

This should fix test flakiness in this suite.

# Additional Notes
* Fixes https://github.com/DataDog/dd-trace-java/issues/3862 (probably).
