### PR TITLE
Migrate Cassandra tests to testcontainers

### DIFF
--- a/dd-java-agent/instrumentation/datastax-cassandra-3/build.gradle
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 
   testImplementation group: 'com.datastax.cassandra', name: 'cassandra-driver-core', version: '3.2.0'
   testImplementation group: 'com.github.jbellis', name: 'jamm', version: '0.3.3'
-  testImplementation group: 'org.cassandraunit', name: 'cassandra-unit', version: '3.1.3.2'
+  testImplementation group: 'org.testcontainers', name: 'cassandra', version: '1.17.6'
 
   testImplementation project(':dd-java-agent:instrumentation:guava-10')
 

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/src/test/groovy/CassandraClientTest.groovy
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/src/test/groovy/CassandraClientTest.groovy
@@ -5,9 +5,10 @@ import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
-import org.cassandraunit.utils.EmbeddedCassandraServerHelper
+import org.testcontainers.containers.CassandraContainer
 import spock.lang.Shared
 
+import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -34,26 +35,21 @@ class CassandraClientTest extends AgentTestRunner {
   @Shared
   def executor = Executors.newCachedThreadPool()
 
-  def setupSpec() {
-    /*
-     This timeout seems excessive but we've seen tests fail with timeout of 40s.
-     TODO: if we continue to see failures we may want to consider using 'real' Cassandra
-     started in container like we do for memcached. Note: this will complicate things because
-     tests would have to assume they run under shared Cassandra and act accordingly.
-     */
-    EmbeddedCassandraServerHelper.startEmbeddedCassandra(EmbeddedCassandraServerHelper.CASSANDRA_RNDPORT_YML_FILE, 120000L)
+  @Shared
+  CassandraContainer container
 
-    cluster = EmbeddedCassandraServerHelper.getCluster()
-    port = EmbeddedCassandraServerHelper.getNativeTransportPort()
-    /*
-     Looks like sometimes our requests fail because Cassandra takes to long to respond,
-     Increase this timeout as well to try to cope with this.
-     */
+  def setupSpec() {
+    container = new CassandraContainer("cassandra:3").withStartupTimeout(Duration.ofSeconds(120))
+    container.start()
+    cluster = container.getCluster()
+    port = container.getMappedPort(9042)
+    // Looks like sometimes our requests fail because Cassandra takes to long to respond,
+    // Increase this timeout as well to try to cope with this.
     cluster.getConfiguration().getSocketOptions().setReadTimeoutMillis(120000)
   }
 
   def cleanupSpec() {
-    EmbeddedCassandraServerHelper.cleanEmbeddedCassandra()
+    container?.stop()
   }
 
   def "test sync"() {

--- a/dd-java-agent/instrumentation/datastax-cassandra-4/build.gradle
+++ b/dd-java-agent/instrumentation/datastax-cassandra-4/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 
   // ProgrammaticConfig, required to set the timeout, wasn't added until 4.0.1
   testImplementation group: 'com.datastax.oss', name: 'java-driver-core', version: '4.0.1'
-  testImplementation group: 'org.cassandraunit', name: 'cassandra-unit', version: '4.3.1.0'
+  testImplementation group: 'org.testcontainers', name: 'cassandra', version: '1.17.6'
 
   // Force 0.3.3 because 0.3.0 has a version parsing bug that fails on jdk 15
   testImplementation group: 'com.github.jbellis', name: "jamm", version: '0.3.3'


### PR DESCRIPTION
# What Does This Do

Migrate Cassandra to testcontainers, previously using cassandraunit.

# Motivation
Hopefully less flaky.

# Additional Notes
