### PR TITLE
feat(core): Ensure aggregator thread starts for flush request

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -957,7 +957,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   @Override
   public void flushMetrics() {
     try {
-      metricsAggregator.forceReport().get(1_000, MILLISECONDS);
+      metricsAggregator.forceReport().get(2_500, MILLISECONDS);
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
       log.debug("Failed to wait for metrics flush.", e);
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
@@ -8,7 +8,11 @@ import datadog.trace.test.util.DDSpecification
 import spock.lang.Requires
 import spock.lang.Shared
 
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.function.Supplier
 
 import static datadog.trace.api.Platform.isJavaVersionAtLeast
 import static java.util.concurrent.TimeUnit.MILLISECONDS
@@ -432,6 +436,55 @@ class ConflatingMetricAggregatorTest extends DDSpecification {
 
     cleanup:
     aggregator.close()
+  }
+
+  def "force flush should not block if metrics are disabled"() {
+    setup:
+    int maxAggregates = 10
+    MetricWriter writer = Mock(MetricWriter)
+    Sink sink = Stub(Sink)
+    DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
+    ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      features, sink, writer, maxAggregates, queueSize, 1, SECONDS)
+    aggregator.start()
+
+    when:
+    def flushed = aggregator.forceReport().get(10, SECONDS)
+
+    then:
+    notThrown(TimeoutException)
+    !flushed
+  }
+
+  def "force flush should wait for aggregator to start"() {
+    setup:
+    int maxAggregates = 10
+    MetricWriter writer = Mock(MetricWriter)
+    Sink sink = Stub(Sink)
+    DDAgentFeaturesDiscovery features = Mock(DDAgentFeaturesDiscovery)
+    features.supportsMetrics() >> true
+    ConflatingMetricsAggregator aggregator = new ConflatingMetricsAggregator(empty,
+      features, sink, writer, maxAggregates, queueSize, 1, SECONDS)
+
+    when:
+    def async = CompletableFuture.supplyAsync(new Supplier<Boolean>() {
+        @Override
+        Boolean get() {
+          return aggregator.forceReport().get()
+        }
+      })
+    async.get(3, SECONDS)
+
+    then:
+    thrown(TimeoutException)
+
+    when:
+    aggregator.start()
+    def flushed = async.get(3, TimeUnit.SECONDS)
+
+    then:
+    notThrown(TimeoutException)
+    flushed
   }
 
   def reportAndWaitUntilEmpty(ConflatingMetricsAggregator aggregator) {


### PR DESCRIPTION
# What Does This Do

Ensure metrics aggregator thread is running and will handle the report signal.

# Motivation

Signal was not dispatched if the metrics aggregator thread was not running yet.

# Additional Notes

Required for https://github.com/DataDog/system-tests/pull/683.