### PR TITLE
[lib-injection] Set the pre built artifact that is used to build the image as its own stage 

### DIFF
--- a/lib-injection/src/main/docker/Dockerfile
+++ b/lib-injection/src/main/docker/Dockerfile
@@ -1,9 +1,14 @@
+FROM scratch AS java_agent
+COPY dd-java-agent.jar /
+
 FROM busybox
 
 ARG UID=10000
 RUN addgroup -g 10000 -S datadog \
     && adduser -S -G datadog -u ${UID} datadog
 WORKDIR /datadog-init
-ADD copy-lib.sh /datadog-init/copy-lib.sh
-ADD dd-java-agent.jar /datadog-init/dd-java-agent.jar
+COPY copy-lib.sh /datadog-init/copy-lib.sh
+# using a separate stage for holding a jar - can allow us to build this dockerfile remotely, 
+# and replace the jar - when needed
+COPY --from=java_agent dd-java-agent.jar /datadog-init/dd-java-agent.jar
 USER ${UID}


### PR DESCRIPTION
+ ADD docker commands should be avoided as they can invoke shell scripts. - COPY is more cache friendly

Example use after this change (not requires latest docker - esp buildx and buildkit - to be installed)
```
mkdir build/
touch build/dd-java-agent.jar
docker buildx build https://github.com/DataDog/dd-trace-java.git#pawel/better_lib_injection_dockerfile:lib-injection/src/main/docker --build-context java_agent=./build/
```
