### PR TITLE
Fix intermittent failure in Lettuce4SyncClientTest

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
@@ -323,16 +323,16 @@ final class TypeFactory {
     }
 
     private TypeDescription outline() {
-      TypeDescription outline;
       if (createOutlines) {
-        outline = doResolve(true);
-      } else {
-        // temporarily switch to outlines as that's all we need
-        createOutlines = true;
-        outline = doResolve(true);
+        return doResolve(true);
+      }
+      // temporarily switch to outlines as that's all we need
+      createOutlines = true;
+      try {
+        return doResolve(true);
+      } finally {
         createOutlines = false;
       }
-      return outline;
     }
 
     @Override

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeOutline.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeOutline.java
@@ -79,6 +79,11 @@ final class TypeOutline extends WithName {
   }
 
   @Override
+  public TypeDescription getEnclosingType() {
+    return getDeclaringType(); // equivalent for outline purposes
+  }
+
+  @Override
   public int getModifiers() {
     return modifiers;
   }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactoryForkedTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactoryForkedTest.groovy
@@ -1,0 +1,59 @@
+package datadog.trace.agent.tooling.bytebuddy.outline
+
+import datadog.trace.agent.tooling.bytebuddy.ClassFileLocators
+import datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers
+import spock.lang.Shared
+import spock.lang.Specification
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named
+
+class TypeFactoryForkedTest extends Specification {
+
+  @Shared
+  def typeFactory = TypeFactory.typeFactory.get()
+
+  @Shared
+  def matchers = new DDElementMatchers()
+
+  @Shared
+  def hasSuperType = matchers.hasSuperType(named('java.util.concurrent.Future'))
+
+  @Shared
+  def hasSuperMethod = matchers.hasSuperMethod(named('tryFire'))
+
+  @Shared
+  def hasContextField = matchers.declaresContextField('java.lang.Runnable', 'java.lang.String')
+
+  def "can mix full types with outlines"() {
+    when:
+    def systemLoader = ClassLoader.systemClassLoader
+    def systemLocator = ClassFileLocators.classFileLocator(systemLoader)
+    def t0 = 'java.util.concurrent.Future'
+    def t1 = 'java.util.concurrent.ForkJoinTask'
+    def t2 = 'java.util.concurrent.CompletableFuture$Completion'
+    def t3 = 'java.util.concurrent.CompletableFuture$Signaller'
+
+    typeFactory.beginInstall()
+    typeFactory.switchContext(systemLoader)
+    typeFactory.beginTransform(t2, systemLocator.locate(t2).resolve())
+    // resolve t0 as outline type
+    TypeFactory.findType(t0).getDeclaredMethods()
+    typeFactory.enableFullDescriptions()
+    // resolve t1 and t2 as full types
+    TypeFactory.findType(t1).getDeclaredMethods()
+    TypeFactory.findType(t2).getDeclaredMethods()
+    typeFactory.endTransform()
+    typeFactory.beginTransform(t3, systemLocator.locate(t3).resolve())
+    def target = TypeFactory.findType(t3)
+
+    then:
+    // exercise going from outline (t3) to full types (t1, t2) and back again to outline (t0)
+    !hasContextField.matches(target)
+    target.getDeclaredMethods().find {hasSuperMethod.matches(it) }.name == 'tryFire'
+    hasSuperType.matches(target)
+
+    cleanup:
+    typeFactory.endTransform()
+    typeFactory.endInstall()
+  }
+}


### PR DESCRIPTION
# What Does This Do

When mixing full and outline types, byte-buddy might resort to checking the enclosing type
(when this happens we can fall back to the declaring type of the outline, if there is one)

