### PR TITLE
Bump RecordingDatastreamsPayloadWriter timeout to account for metrics timing changes in #4355

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/datastreams/RecordingDatastreamsPayloadWriter.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/datastreams/RecordingDatastreamsPayloadWriter.groovy
@@ -22,11 +22,11 @@ class RecordingDatastreamsPayloadWriter implements DatastreamsPayloadWriter {
     groups.clear()
   }
 
-  void waitForPayloads(int count, long timeout = TimeUnit.SECONDS.toMillis(1)) {
+  void waitForPayloads(int count, long timeout = TimeUnit.SECONDS.toMillis(2)) {
     waitFor(count, timeout, payloads)
   }
 
-  void waitForGroups(int count, long timeout = TimeUnit.SECONDS.toMillis(1)) {
+  void waitForGroups(int count, long timeout = TimeUnit.SECONDS.toMillis(2)) {
     waitFor(count, timeout, groups)
   }
 


### PR DESCRIPTION
# Motivation

This will hopefully fix the test failures in assertions added by #4266 (merged around the same time as #4355)