### PR TITLE
Fix flaky tests for DSM caused by DataStreamsCheckpointer not clearing between tests

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DataStreamsCheckpointer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DataStreamsCheckpointer.java
@@ -17,4 +17,6 @@ public interface DataStreamsCheckpointer extends Consumer<StatsPoint>, AutoClose
 
   @Override
   void close();
+
+  void clear();
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsCheckpointer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsCheckpointer.java
@@ -217,6 +217,11 @@ public class DefaultDataStreamsCheckpointer
     }
   }
 
+  @Override
+  public void clear() {
+    timeToBucket.clear();
+  }
+
   void report() {
     inbox.offer(REPORT);
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/StubDataStreamsCheckpointer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/StubDataStreamsCheckpointer.java
@@ -31,4 +31,7 @@ public class StubDataStreamsCheckpointer implements DataStreamsCheckpointer {
 
   @Override
   public void close() {}
+
+  @Override
+  public void clear() {}
 }


### PR DESCRIPTION

# What Does This Do

# Motivation

# Additional Notes
