### PR TITLE
enable async allocation profiling in non-J9 smoke tests

### DIFF
--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -93,6 +93,7 @@ abstract class AbstractSmokeTest extends ProcessManager {
     "-Ddd.profiling.url=${getProfilingUrl()}",
     "-Ddd.profiling.async.enabled=true",
     "-Ddd.profiling.async.wall.enabled=true",
+    "-Ddd.profiling.async.alloc.enabled=" + !isIBM,
     "-Ddd.profiling.async.cstack=dwarf",
     "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=${logLevel()}",
     "-Dorg.slf4j.simpleLogger.defaultLogLevel=${logLevel()}"


### PR DESCRIPTION
# What Does This Do

Runs the smoke tests with async-profiler allocation profiling enabled, except on J9 where we know it can crash.

# Motivation

# Additional Notes
