### PR TITLE
Support for EVP Proxy in DDAgentFeaturesDiscovery

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
+++ b/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
@@ -41,6 +41,8 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
 
   public static final String V01_DATASTREAMS_ENDPOINT = "v0.1/pipeline_stats";
 
+  public static final String V2_EVP_PROXY_ENDPOINT = "evp_proxy/v2/";
+
   public static final String DATADOG_AGENT_STATE = "Datadog-Agent-State";
 
   public static final String DEBUGGER_ENDPOINT = "debugger/v1/input";
@@ -55,6 +57,7 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
   private final String[] configEndpoints = {V7_CONFIG_ENDPOINT};
   private final boolean metricsEnabled;
   private final String[] dataStreamsEndpoints = {V01_DATASTREAMS_ENDPOINT};
+  private final String[] evpProxyEndpoints = {V2_EVP_PROXY_ENDPOINT};
 
   private volatile String traceEndpoint;
   private volatile String metricsEndpoint;
@@ -63,6 +66,7 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
   private volatile String state;
   private volatile String configEndpoint;
   private volatile String debuggerEndpoint;
+  private volatile String evpProxyEndpoint;
   private volatile String version;
 
   private long lastTimeDiscovered;
@@ -90,6 +94,8 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
     state = null;
     configEndpoint = null;
     debuggerEndpoint = null;
+    dataStreamsEndpoint = null;
+    evpProxyEndpoint = null;
     version = null;
     lastTimeDiscovered = 0;
   }
@@ -149,11 +155,12 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
 
     if (log.isDebugEnabled()) {
       log.debug(
-          "discovered traceEndpoint={}, metricsEndpoint={}, supportsDropping={}, dataStreamsEndpoint={}, configEndpoint={}",
+          "discovered traceEndpoint={}, metricsEndpoint={}, supportsDropping={}, dataStreamsEndpoint={}, configEndpoint={}, evpProxyEndpoint={}",
           traceEndpoint,
           metricsEndpoint,
           supportsDropping,
           dataStreamsEndpoint,
+          evpProxyEndpoint,
           configEndpoint);
     }
   }
@@ -218,16 +225,20 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
         debuggerEndpoint = DEBUGGER_ENDPOINT;
       }
 
-      String foundDatastreamsEndpoint = null;
       for (String endpoint : dataStreamsEndpoints) {
         if (endpoints.contains(endpoint) || endpoints.contains("/" + endpoint)) {
-          foundDatastreamsEndpoint = endpoint;
+          dataStreamsEndpoint = endpoint;
           break;
         }
       }
 
-      // This is done outside of the loop to set dataStreamsEndpoint to null if not found
-      dataStreamsEndpoint = foundDatastreamsEndpoint;
+      for (String endpoint : evpProxyEndpoints) {
+        if (endpoints.contains(endpoint) || endpoints.contains("/" + endpoint)) {
+          evpProxyEndpoint = endpoint;
+          break;
+        }
+      }
+
 
       if (metricsEnabled) {
         Object canDrop = map.get("client_drop_p0s");
@@ -288,12 +299,20 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
     return dataStreamsEndpoint;
   }
 
+  public String getEvpProxyEndpoint() {
+    return evpProxyEndpoint;
+  }
+
   public HttpUrl buildUrl(String endpoint) {
     return agentBaseUrl.resolve(endpoint);
   }
 
   public boolean supportsDataStreams() {
     return dataStreamsEndpoint != null;
+  }
+
+  public boolean supportsEvpProxy() {
+    return evpProxyEndpoint != null;
   }
 
   public String getConfigEndpoint() {

--- a/communication/src/test/groovy/datadog/communication/ddagent/DDAgentFeaturesDiscoveryTest.groovy
+++ b/communication/src/test/groovy/datadog/communication/ddagent/DDAgentFeaturesDiscoveryTest.groovy
@@ -58,6 +58,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     features.state() == INFO_STATE
     features.getConfigEndpoint() == V7_CONFIG_ENDPOINT
     features.supportsDebugger()
+    features.supportsEvpProxy()
     features.getVersion() == "0.99.0"
     0 * _
   }
@@ -83,6 +84,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     features.state() == INFO_STATE
     features.getConfigEndpoint() == V7_CONFIG_ENDPOINT
     features.supportsDebugger()
+    features.supportsEvpProxy()
     features.getVersion() == "0.99.0"
     0 * _
   }

--- a/communication/src/test/resources/agent-features/agent-info.json
+++ b/communication/src/test/resources/agent-features/agent-info.json
@@ -11,6 +11,8 @@
     "/v0.6/stats",
     "/profiling/v1/input",
     "/v0.1/pipeline_stats",
+    "/evp_proxy/v1/",
+    "/evp_proxy/v2/",
     "/debugger/v1/input",
     "/v0.7/config"
   ],


### PR DESCRIPTION
# What Does This Do

Updates `DDAgentFeaturesDiscovery` to also check if the Agent supports the EVP Proxy feature.

# Motivation

The EVP Proxy is a reverse proxy in the Agent that can be used to send payloads to Datadog intakes from the tracers. It is a lightweight, synchronous proxy that enriches the payloads with tags from the Agent (ie: container tags, default env tag) and adds the API Key header before forwarding the request.

This will allow upcoming changes to use this Agent proxy to send CI VIsibility Protocol payloads to the CI Visibility intake. This is currently only possible in Agentless mode.
