### PR TITLE
Refactor common code from DDAgentApi and DDIntakeApi

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteApi.java
@@ -1,10 +1,84 @@
 package datadog.trace.common.writer;
 
-public interface RemoteApi {
+import datadog.trace.relocate.api.IOLogger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-  Response sendSerializedTraces(final Payload payload);
+import java.io.IOException;
 
-  void addResponseListener(final RemoteResponseListener listener);
+public abstract class RemoteApi {
+
+  protected static final Logger log = LoggerFactory.getLogger(RemoteApi.class);
+  protected final IOLogger ioLogger = new IOLogger(log);
+
+  protected long totalTraces = 0;
+  protected long receivedTraces = 0;
+  protected long sentTraces = 0;
+  protected long failedTraces = 0;
+
+  protected void countAndLogSuccessfulSend(final int traceCount, final int sizeInBytes) {
+    // count the successful traces
+    this.sentTraces += traceCount;
+
+    ioLogger.success(createSendLogMessage(traceCount, sizeInBytes, "Success"));
+  }
+
+  protected void countAndLogFailedSend(
+      final int traceCount,
+      final int sizeInBytes,
+      final okhttp3.Response response,
+      final IOException outer) {
+    // count the failed traces
+    this.failedTraces += traceCount;
+    // these are used to catch and log if there is a failure in debug logging the response body
+    String responseBody = getResponseBody(response);
+    String sendErrorString =
+        createSendLogMessage(traceCount, sizeInBytes, responseBody.isEmpty() ? "Error" : responseBody);
+
+    ioLogger.error(sendErrorString, toLoggerResponse(response, responseBody), outer);
+  }
+
+  protected static IOLogger.Response toLoggerResponse(okhttp3.Response response, String body) {
+    if (response == null) {
+      return null;
+    }
+    return new IOLogger.Response(response.code(), response.message(), body);
+  }
+
+  protected String createSendLogMessage(
+      final int traceCount, final int sizeInBytes, final String prefix) {
+    String sizeString = sizeInBytes > 1024 ? (sizeInBytes / 1024) + "KB" : sizeInBytes + "B";
+    return prefix
+        + " while sending "
+        + traceCount
+        + " (size="
+        + sizeString
+        + ")"
+        + " traces."
+        + " Total: "
+        + this.totalTraces
+        + ", Received: "
+        + this.receivedTraces
+        + ", Sent: "
+        + this.sentTraces
+        + ", Failed: "
+        + this.failedTraces
+        + ".";
+  }
+
+  protected static String getResponseBody(okhttp3.Response response) {
+    if (response != null) {
+      try {
+        return response.body().string().trim();
+      } catch (NullPointerException | IOException ignored) {
+      }
+    }
+    return "";
+  }
+
+  protected abstract Response sendSerializedTraces(final Payload payload);
+
+  protected abstract void addResponseListener(final RemoteResponseListener listener);
 
   /**
    * Encapsulates an attempted response from the remote location.
@@ -18,7 +92,7 @@ public interface RemoteApi {
    * <p>NOTE: A successful communication may still contain an exception if there was a problem
    * parsing the response from the Datadog agent.
    */
-  final class Response {
+  public static final class Response {
     /** Factory method for a successful request with a trivial response body */
     public static Response success(final int status) {
       return new Response(true, status, null, null);

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
@@ -13,7 +13,6 @@ import datadog.trace.common.writer.Payload;
 import datadog.trace.common.writer.RemoteApi;
 import datadog.trace.common.writer.RemoteResponseListener;
 import datadog.trace.core.DDTraceCoreInfo;
-import datadog.trace.relocate.api.IOLogger;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -23,14 +22,11 @@ import java.util.Objects;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** The API pointing to a DD agent */
-public class DDAgentApi implements RemoteApi {
+public class DDAgentApi extends RemoteApi {
 
   public static final String DATADOG_META_TRACER_VERSION = "Datadog-Meta-Tracer-Version";
-  private static final Logger log = LoggerFactory.getLogger(DDAgentApi.class);
 
   private static final String DATADOG_CLIENT_COMPUTED_STATS = "Datadog-Client-Computed-Stats";
   // this is not intended to be a toggled feature,
@@ -44,11 +40,6 @@ public class DDAgentApi implements RemoteApi {
 
   private final List<RemoteResponseListener> responseListeners = new ArrayList<>();
   private final boolean metricsEnabled;
-
-  private long totalTraces = 0;
-  private long receivedTraces = 0;
-  private long sentTraces = 0;
-  private long failedTraces = 0;
 
   private final Recording sendPayloadTimer;
   private final Counter agentErrorCounter;
@@ -66,8 +57,6 @@ public class DDAgentApi implements RemoteApi {
   private final OkHttpClient httpClient;
   private final HttpUrl agentUrl;
   private final Map<String, String> headers;
-
-  private final IOLogger ioLogger = new IOLogger(log);
 
   public DDAgentApi(
       OkHttpClient client,
@@ -159,63 +148,4 @@ public class DDAgentApi implements RemoteApi {
     }
   }
 
-  private void countAndLogSuccessfulSend(final int traceCount, final int sizeInBytes) {
-    // count the successful traces
-    this.sentTraces += traceCount;
-
-    ioLogger.success(createSendLogMessage(traceCount, sizeInBytes, "Success"));
-  }
-
-  private void countAndLogFailedSend(
-      final int traceCount,
-      final int sizeInBytes,
-      final okhttp3.Response response,
-      final IOException outer) {
-    // count the failed traces
-    this.failedTraces += traceCount;
-    // these are used to catch and log if there is a failure in debug logging the response body
-    String agentError = getResponseBody(response);
-    String sendErrorString =
-        createSendLogMessage(traceCount, sizeInBytes, agentError.isEmpty() ? "Error" : agentError);
-
-    ioLogger.error(sendErrorString, toLoggerResponse(response, agentError), outer);
-  }
-
-  private static IOLogger.Response toLoggerResponse(okhttp3.Response response, String body) {
-    if (response == null) {
-      return null;
-    }
-    return new IOLogger.Response(response.code(), response.message(), body);
-  }
-
-  private static String getResponseBody(okhttp3.Response response) {
-    if (response != null) {
-      try {
-        return response.body().string().trim();
-      } catch (NullPointerException | IOException ignored) {
-      }
-    }
-    return "";
-  }
-
-  private String createSendLogMessage(
-      final int traceCount, final int sizeInBytes, final String prefix) {
-    String sizeString = sizeInBytes > 1024 ? (sizeInBytes / 1024) + "KB" : sizeInBytes + "B";
-    return prefix
-        + " while sending "
-        + traceCount
-        + " (size="
-        + sizeString
-        + ")"
-        + " traces to the DD agent."
-        + " Total: "
-        + this.totalTraces
-        + ", Received: "
-        + this.receivedTraces
-        + ", Sent: "
-        + this.sentTraces
-        + ", Failed: "
-        + this.failedTraces
-        + ".";
-  }
 }


### PR DESCRIPTION
# What Does This Do

Turns `RemoteApi` from an interface to an abstract class and moves the common code from their two child classes there. Some of this code required minor modifications.

# Motivation

I will be adding a third `RemoteApi` child class and I didn't want to have a third copy-paste of the same code.

# Additional Notes

There is a small difference in the log message printed by `createSendLogMessage` that I didn't preserve.
Before my change it said  `Success when sending X traces to the DD Intake` or `Success when sending X traces to the DD agent` while now it just says `Success when sending X traces`. I think we have information about the type of writer elsewhere in the logs, but if you think this should be included I can add some form of it back.