### PR TITLE
record sizes of pools FJP and TPE threads belong to

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/AsyncProfiler.java
@@ -415,6 +415,18 @@ public final class AsyncProfiler {
     }
   }
 
+  public void setPoolParallelism(int tid, int parallelism) {
+    if (asyncProfiler != null && tid >= 0) {
+      asyncProfiler.setPoolParallelism(tid, parallelism);
+    }
+  }
+
+  public void clearPoolParallelism(int tid) {
+    if (asyncProfiler != null && tid >= 0) {
+      asyncProfiler.clearPoolParallelism(tid);
+    }
+  }
+
   public int getNativeThreadId() {
     if (asyncProfiler != null) {
       return asyncProfiler.getNativeThreadId();

--- a/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/ContextThreadFilter.java
+++ b/dd-java-agent/agent-profiling/profiling-async/src/main/java/com/datadog/profiling/async/ContextThreadFilter.java
@@ -30,6 +30,16 @@ public class ContextThreadFilter implements ProfilingContextIntegration {
   }
 
   @Override
+  public void setPoolParallelism(int parallelism) {
+    ASYNC_PROFILER.setPoolParallelism(getNativeThreadId(), parallelism);
+  }
+
+  @Override
+  public void clearPoolParallelism() {
+    ASYNC_PROFILER.clearPoolParallelism(getNativeThreadId());
+  }
+
+  @Override
   public int getNativeThreadId() {
     return ASYNC_PROFILER.getNativeThreadId();
   }

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinWorkerThreadInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinWorkerThreadInstrumentation.java
@@ -1,0 +1,43 @@
+package datadog.trace.instrumentation.java.concurrent;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.util.concurrent.ForkJoinWorkerThread;
+import net.bytebuddy.asm.Advice;
+
+@AutoService(Instrumenter.class)
+public class JavaForkJoinWorkerThreadInstrumentation extends Instrumenter.Profiling
+    implements Instrumenter.ForBootstrap, Instrumenter.ForSingleType {
+  public JavaForkJoinWorkerThreadInstrumentation() {
+    super(AbstractExecutorInstrumentation.EXEC_NAME, "pool-parallelism", "fjp-parallelism");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "java.util.concurrent.ForkJoinWorkerThread";
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod().and(named("run")).and(takesArguments(0)),
+        getClass().getName() + "$RecordPoolParallelism");
+  }
+
+  public static final class RecordPoolParallelism {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void enter(@Advice.This ForkJoinWorkerThread thread) {
+      AgentTracer.get().recordCurrentThreadPoolParallelism(thread.getPool().getParallelism());
+    }
+
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void exit() {
+      AgentTracer.get().clearCurrentThreadPoolParallelism();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorWorkerInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorWorkerInstrumentation.java
@@ -1,0 +1,50 @@
+package datadog.trace.instrumentation.java.concurrent;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.util.concurrent.ThreadPoolExecutor;
+import net.bytebuddy.asm.Advice;
+
+@AutoService(Instrumenter.class)
+public class ThreadPoolExecutorWorkerInstrumentation extends Instrumenter.Profiling
+    implements Instrumenter.ForBootstrap, Instrumenter.ForSingleType {
+
+  public ThreadPoolExecutorWorkerInstrumentation() {
+    super(AbstractExecutorInstrumentation.EXEC_NAME, "pool-parallelism", "tpe-parallelism");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "java.util.concurrent.ThreadPoolExecutor$Worker";
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod().and(named("run")).and(takesArguments(0)),
+        getClass().getName() + "$RecordWorkerParallelism");
+  }
+
+  public static final class RecordWorkerParallelism {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void enter(@Advice.FieldValue("this$0") ThreadPoolExecutor tpe) {
+      int parallelism =
+          tpe.getMaximumPoolSize() == Integer.MAX_VALUE
+              ? tpe.getCorePoolSize()
+              : tpe.getMaximumPoolSize();
+      if (parallelism != 0) {
+        AgentTracer.get().recordCurrentThreadPoolParallelism(parallelism);
+      }
+    }
+
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void exit() {
+      AgentTracer.get().clearCurrentThreadPoolParallelism();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ParallelismTrackingTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ParallelismTrackingTest.groovy
@@ -1,0 +1,45 @@
+import datadog.trace.agent.test.AgentTestRunner
+
+import java.util.concurrent.Executors
+import java.util.concurrent.ForkJoinPool
+
+class ParallelismTrackingTest extends AgentTestRunner {
+
+  @Override
+  void configurePreAgent() {
+    super.configurePreAgent()
+
+    injectSysConfig("dd.profiling.enabled", "true")
+  }
+
+  def "#name: test record parallelism = #expectedParallelism"() {
+    when:
+    def executor = executorSupplier()
+    for (int i = 0; i < 20; i++) {
+      executor.submit({}).get()
+    }
+
+    then:
+    expectedParallelism < 0 || !TEST_PROFILING_CONTEXT_INTEGRATION.poolParallelism.isEmpty()
+    for (def pair : TEST_PROFILING_CONTEXT_INTEGRATION.poolParallelism.entrySet()) {
+      assert pair.value == expectedParallelism
+    }
+
+    cleanup:
+    if (executor != ForkJoinPool.commonPool()) {
+      executor.shutdown()
+    }
+
+    where:
+    expectedParallelism                | name               | executorSupplier
+    1                                  | "fixed-tpe-1"      | { Executors.newFixedThreadPool(1) }
+    10                                 | "fixed-tpe-10"     | { Executors.newFixedThreadPool(10) }
+    1                                  | "fixed-tpe-single" | { Executors.newSingleThreadExecutor() }
+    -1 /* won't record it */           | "cached-tpe"       | { Executors.newCachedThreadPool() }
+    10                                 | "scheduled-10"     | { Executors.newScheduledThreadPool(10) }
+    1                                  | "scheduled-1"      | { Executors.newScheduledThreadPool(1) }
+    1                                  | "scheduled-single" | { Executors.newSingleThreadScheduledExecutor() }
+    10                                 | "fjp-10"           | { Executors.newWorkStealingPool(10) }
+    ForkJoinPool.commonPoolParallelism | "fjp-common"       | { ForkJoinPool.commonPool() }
+  }
+}

--- a/dd-java-agent/testing/build.gradle
+++ b/dd-java-agent/testing/build.gradle
@@ -24,6 +24,7 @@ excludedClassesCoverage += [
   'datadog.trace.agent.test.AgentTestRunner**',
   'datadog.trace.agent.test.checkpoints.**',
   'datadog.trace.agent.test.datastreams.**',
+  'datadog.trace.agent.test.TestProfilingContextIntegration'
 ]
 
 dependencies {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -247,6 +247,7 @@ abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.L
     TEST_WRITER.start()
     TEST_DATA_STREAMS_WRITER.clear()
     TEST_DATA_STREAMS_CHECKPOINTER.clear()
+    TEST_PROFILING_CONTEXT_INTEGRATION.clear()
 
     def util = new MockUtil()
     util.attachMock(STATS_D_CLIENT, this)

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/TestProfilingContextIntegration.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/TestProfilingContextIntegration.groovy
@@ -1,12 +1,16 @@
 package datadog.trace.agent.test
 
+import com.google.common.collect.Sets
 import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration
 
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
 class TestProfilingContextIntegration implements ProfilingContextIntegration {
   final AtomicInteger attachments = new AtomicInteger()
   final AtomicInteger detachments = new AtomicInteger()
+  final Map<Integer, Integer> poolParallelism = new ConcurrentHashMap<>()
+  final Set<Integer> clearedPoolParallelism = Sets.newConcurrentHashSet()
   @Override
   void onAttach(int tid) {
     attachments.incrementAndGet()
@@ -22,7 +26,24 @@ class TestProfilingContextIntegration implements ProfilingContextIntegration {
   }
 
   @Override
+  void setPoolParallelism(int parallelism) {
+    poolParallelism.put(getNativeThreadId(), parallelism)
+  }
+
+  @Override
+  void clearPoolParallelism() {
+    clearedPoolParallelism.add(getNativeThreadId())
+  }
+
+  @Override
   int getNativeThreadId() {
-    return -1
+    return (int) Thread.currentThread().id
+  }
+
+  void clear() {
+    attachments.set(0)
+    detachments.set(0)
+    poolParallelism.clear()
+    clearedPoolParallelism.clear()
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -837,6 +837,16 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     LambdaHandler.notifyEndInvocation(span, result, isError);
   }
 
+  @Override
+  public void recordCurrentThreadPoolParallelism(int parallelism) {
+    profilingContextIntegration.setPoolParallelism(parallelism);
+  }
+
+  @Override
+  public void clearCurrentThreadPoolParallelism() {
+    profilingContextIntegration.clearPoolParallelism();
+  }
+
   private final RatelimitedLogger rlLog = new RatelimitedLogger(log, 1, MINUTES);
 
   /**

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -172,6 +172,10 @@ public class AgentTracer {
     AgentSpan.Context notifyExtensionStart(Object event);
 
     void notifyExtensionEnd(AgentSpan span, Object result, boolean isError);
+
+    void recordCurrentThreadPoolParallelism(int parallelism);
+
+    void clearCurrentThreadPoolParallelism();
   }
 
   public interface SpanBuilder {
@@ -380,6 +384,12 @@ public class AgentTracer {
 
     @Override
     public void notifyExtensionEnd(AgentSpan span, Object result, boolean isError) {}
+
+    @Override
+    public void recordCurrentThreadPoolParallelism(int parallelism) {}
+
+    @Override
+    public void clearCurrentThreadPoolParallelism() {}
   }
 
   public static final class NoopAgentSpan implements AgentSpan {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ProfilingContextIntegration.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ProfilingContextIntegration.java
@@ -9,6 +9,10 @@ public interface ProfilingContextIntegration {
 
   void setContext(int tid, long rootSpanId, long spanId);
 
+  void setPoolParallelism(int parallelism);
+
+  void clearPoolParallelism();
+
   int getNativeThreadId();
 
   final class NoOp implements ProfilingContextIntegration {
@@ -23,6 +27,12 @@ public interface ProfilingContextIntegration {
 
     @Override
     public void setContext(int tid, long rootSpanId, long spanId) {}
+
+    @Override
+    public void setPoolParallelism(int parallelism) {}
+
+    @Override
+    public void clearPoolParallelism() {}
 
     @Override
     public int getNativeThreadId() {


### PR DESCRIPTION
# What Does This Do

Records thread pool sizes, depends on https://github.com/DataDog/async-profiler/pull/140

# Motivation

# Additional Notes
