### PR TITLE
byte-buddy 1.12.19

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
   implementation(gradleApi())
   implementation(localGroovy())
 
-  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.12.18")
+  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.12.19")
 
   implementation("org.eclipse.aether", "aether-connector-basic", "1.1.0")
   implementation("org.eclipse.aether", "aether-transport-http", "1.1.0")

--- a/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
+++ b/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
@@ -23,7 +23,7 @@ class InstrumentPluginTest extends Specification {
     }
 
     dependencies {
-      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.12.18' // just to build TestPlugin
+      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.12.19' // just to build TestPlugin
     }
 
     apply plugin: 'instrument'

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/DDCachingPoolStrategy.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/DDCachingPoolStrategy.java
@@ -246,7 +246,8 @@ public final class DDCachingPoolStrategy
   static final class SharedResolutionCacheAdapter implements TypePool.CacheProvider {
     private static final String OBJECT_NAME = "java.lang.Object";
     private static final TypePool.Resolution OBJECT_RESOLUTION =
-        new TypePool.Resolution.Simple(new CachingTypeDescription(TypeDescription.OBJECT));
+        new TypePool.Resolution.Simple(
+            new CachingTypeDescription(TypeDescription.ForLoadedType.of(Object.class)));
 
     private final int loaderHash;
     private final WeakReference<ClassLoader> loaderRef;

--- a/dd-java-agent/agent-builder/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/CacheProviderTest.groovy
+++ b/dd-java-agent/agent-builder/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/CacheProviderTest.groovy
@@ -98,7 +98,7 @@ class CacheProviderTest extends DDSpecification {
     def cacheProvider = poolStrat.createCacheProvider(loaderHash, loaderRef)
 
     when:
-    cacheProvider.register("foo", new TypePool.Resolution.Simple(TypeDescription.VOID))
+    cacheProvider.register("foo", new TypePool.Resolution.Simple(TypeDescription.ForLoadedType.of(void.class)))
 
     then:
     // not strictly guaranteed, but fine for this test
@@ -200,7 +200,7 @@ class CacheProviderTest extends DDSpecification {
   }
 
   static newVoid() {
-    return new TypePool.Resolution.Simple(TypeDescription.VOID)
+    return new TypePool.Resolution.Simple(TypeDescription.ForLoadedType.of(void.class))
   }
 
   static newClassLoader() {

--- a/dd-java-agent/agent-builder/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/matcher/FailSafeRawMatcherTest.groovy
+++ b/dd-java-agent/agent-builder/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/matcher/FailSafeRawMatcherTest.groovy
@@ -14,7 +14,7 @@ class FailSafeRawMatcherTest extends DDSpecification {
     def matcher = new FailSafeRawMatcher(mockTypeMatcher, mockLoaderMatcher, "test")
 
     when:
-    def result = matcher.matches(TypeDescription.OBJECT, null, null, null, null)
+    def result = matcher.matches(TypeDescription.ForLoadedType.of(Object), null, null, null, null)
 
     then:
     1 * mockLoaderMatcher.matches(_) >> loaderMatch
@@ -38,7 +38,7 @@ class FailSafeRawMatcherTest extends DDSpecification {
     def matcher = new FailSafeRawMatcher(mockTypeMatcher, mockLoaderMatcher, "test")
 
     when:
-    def result = matcher.matches(TypeDescription.OBJECT, null, null, null, null)
+    def result = matcher.matches(TypeDescription.ForLoadedType.of(Object), null, null, null, null)
 
     then:
     1 * mockLoaderMatcher.matches(_) >> { throw new Exception("matcher exception") }
@@ -52,7 +52,7 @@ class FailSafeRawMatcherTest extends DDSpecification {
     def matcher = new FailSafeRawMatcher(mockTypeMatcher, mockLoaderMatcher, "test")
 
     when:
-    def result = matcher.matches(TypeDescription.OBJECT, null, null, null, null)
+    def result = matcher.matches(TypeDescription.ForLoadedType.of(Object), null, null, null, null)
 
     then:
     1 * mockLoaderMatcher.matches(_) >> true

--- a/dd-java-agent/agent-iast/src/jmh/java/com/datadog/iast/propagation/StringConcatFactoryBatchBenchmark.java
+++ b/dd-java-agent/agent-iast/src/jmh/java/com/datadog/iast/propagation/StringConcatFactoryBatchBenchmark.java
@@ -153,11 +153,11 @@ public class StringConcatFactoryBatchBenchmark
   }
 
   private static MethodDescription.Latent makeConcatWithConstantsDescriptor() {
+    TypeDescription OBJECT = TypeDescription.ForLoadedType.of(Object.class);
+    TypeDescription STRING = TypeDescription.ForLoadedType.of(String.class);
     return new MethodDescription.Latent(
         new TypeDescription.Latent(
-            "java.lang.invoke.StringConcatFactory",
-            Opcodes.ACC_PUBLIC,
-            TypeDescription.Generic.OBJECT),
+            "java.lang.invoke.StringConcatFactory", Opcodes.ACC_PUBLIC, OBJECT.asGenericType()),
         "makeConcatWithConstants",
         Opcodes.ACC_STATIC | Opcodes.ACC_PUBLIC,
         Collections.emptyList(),
@@ -165,13 +165,11 @@ public class StringConcatFactoryBatchBenchmark
         Arrays.asList(
             new ParameterDescription.Token(
                 JavaType.METHOD_HANDLES_LOOKUP.getTypeStub().asGenericType()),
-            new ParameterDescription.Token(TypeDescription.STRING.asGenericType()),
+            new ParameterDescription.Token(STRING.asGenericType()),
             new ParameterDescription.Token(JavaType.METHOD_TYPE.getTypeStub().asGenericType()),
-            new ParameterDescription.Token(TypeDescription.STRING.asGenericType()),
+            new ParameterDescription.Token(STRING.asGenericType()),
             new ParameterDescription.Token(
-                TypeDescription.Generic.Builder.of(TypeDescription.OBJECT.asGenericType())
-                    .asArray()
-                    .build())),
+                TypeDescription.Generic.Builder.of(OBJECT.asGenericType()).asArray().build())),
         Collections.emptyList(),
         Collections.emptyList(),
         AnnotationValue.UNDEFINED,

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/CachingType.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/CachingType.java
@@ -12,8 +12,10 @@ import net.bytebuddy.description.type.TypeList;
 final class CachingType extends WithName {
 
   // non-null sentinels for fields that can legitimately be null
-  private static final Generic UNSET_SUPER_CLASS = Generic.VOID;
-  private static final TypeDescription UNSET_DECLARING_TYPE = TypeDescription.VOID;
+  private static final Generic UNSET_SUPER_CLASS =
+      Generic.OfNonGenericType.ForLoadedType.of(void.class);
+  private static final TypeDescription UNSET_DECLARING_TYPE =
+      TypeDescription.ForLoadedType.of(void.class);
 
   private final TypeDescription delegate;
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
@@ -68,10 +68,10 @@ final class TypeFactory {
     }
     for (TypeDescription loaded :
         new TypeDescription[] {
-          TypeDescription.OBJECT,
-          TypeDescription.STRING,
-          TypeDescription.CLASS,
-          TypeDescription.THROWABLE,
+          TypeDescription.ForLoadedType.of(Object.class),
+          TypeDescription.ForLoadedType.of(String.class),
+          TypeDescription.ForLoadedType.of(Class.class),
+          TypeDescription.ForLoadedType.of(Throwable.class),
           TypeDescription.ForLoadedType.of(Serializable.class),
           TypeDescription.ForLoadedType.of(Cloneable.class)
         }) {

--- a/dd-java-agent/instrumentation/spring-cloud-zuul-2/src/main/java/datadog/trace/instrumentation/springcloudzuul2/ZuulProxyRequestHelperInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-cloud-zuul-2/src/main/java/datadog/trace/instrumentation/springcloudzuul2/ZuulProxyRequestHelperInstrumentation.java
@@ -10,7 +10,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import net.bytebuddy.asm.Advice;
-import net.bytebuddy.description.type.TypeDescription;
 
 @AutoService(Instrumenter.class)
 public class ZuulProxyRequestHelperInstrumentation extends Instrumenter.Tracing
@@ -27,7 +26,7 @@ public class ZuulProxyRequestHelperInstrumentation extends Instrumenter.Tracing
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(
-        isMethod().and(named("isIncludedHeader")).and(takesArgument(0, TypeDescription.STRING)),
+        isMethod().and(named("isIncludedHeader")).and(takesArgument(0, String.class)),
         ZuulProxyRequestHelperInstrumentation.class.getName() + "$ProxyRequestHelperAdvice");
   }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -15,7 +15,7 @@ final class CachedData {
     junit4        : "4.13.2",
     junit5        : "5.8.1",
     logback       : "1.2.3",
-    bytebuddy     : "1.12.18",
+    bytebuddy     : "1.12.19",
     scala         : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)
     scala210      : "2.10.7",
     scala211      : "2.11.12",


### PR DESCRIPTION
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.12.19

* Avoid possible lock through circular class loading of TypeDescription subtypes.
* Avoid access error when using unsafe API on Java 17 with an active security manager.
* Close URL class loader used in Gradle plugin.