### PR TITLE
Fixed NPE if the remote config is absent

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
@@ -64,7 +64,7 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
             if (DEFAULT_WAF_CONFIG == null) {
               throw new IllegalStateException("Expected default waf config to be available");
             }
-            log.info(
+            log.debug(
                 "AppSec config given by remote config was pulled. Restoring default WAF config");
             newConfig = DEFAULT_WAF_CONFIG;
           }
@@ -114,7 +114,7 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
         AppSecRuleTogglingDeserializer.INSTANCE,
         (configKey, newConfig, hinter) -> {
           if (newConfig == null) {
-            log.info("Rule toggling configuration was pulled. Enabling all the rules");
+            log.debug("Rule toggling configuration was pulled. Enabling all the rules");
             newConfig = Collections.emptyMap();
           }
           this.lastConfig.put("waf_rules_override", newConfig);

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
@@ -32,6 +32,7 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
   private static final Logger log = LoggerFactory.getLogger(AppSecConfigServiceImpl.class);
 
   private static final String DEFAULT_CONFIG_LOCATION = "default_config.json";
+  private static AppSecConfig DEFAULT_WAF_CONFIG;
 
   // for new subconfig subscribers
   private final ConcurrentHashMap<String, Object> lastConfig = new ConcurrentHashMap<>();
@@ -60,8 +61,12 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
         AppSecConfigDeserializer.INSTANCE,
         (configKey, newConfig, hinter) -> {
           if (newConfig == null) {
-            log.warn("AppSec configuration was pulled out by remote config. This has no effect");
-            return;
+            if (DEFAULT_WAF_CONFIG == null) {
+              throw new IllegalStateException("Expected default waf config to be available");
+            }
+            log.info(
+                "AppSec config given by remote config was pulled. Restoring default WAF config");
+            newConfig = DEFAULT_WAF_CONFIG;
           }
           Map<String, Object> configMap = Collections.singletonMap("waf", newConfig);
           this.lastConfig.put("waf", newConfig);
@@ -108,6 +113,10 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
         Product.ASM,
         AppSecRuleTogglingDeserializer.INSTANCE,
         (configKey, newConfig, hinter) -> {
+          if (newConfig == null) {
+            log.info("Rule toggling configuration was pulled. Enabling all the rules");
+            newConfig = Collections.emptyMap();
+          }
           this.lastConfig.put("waf_rules_override", newConfig);
           Map<String, Object> wafRulesOverride =
               Collections.singletonMap("waf_rules_override", newConfig);
@@ -236,6 +245,7 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
         StandardizedLogging.numLoadedRules(log, "<bundled config>", countRules(ret));
       }
 
+      DEFAULT_WAF_CONFIG = ret;
       return ret;
     }
   }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/AppSecSystemSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/AppSecSystemSpecification.groovy
@@ -174,6 +174,41 @@ class AppSecSystemSpecification extends DDSpecification {
     AppSecSystem.REPLACEABLE_EVENT_PRODUCER.cur != initialEPS
   }
 
+  void 'removing rule toggling config resets waf_rules_override'() {
+    ConfigurationChangesTypedListener<AppSecConfig> savedConfListener
+    AppSecConfig cfg = new AppSecConfig.AppSecConfigV2()
+    cfg.@version = '2.0.1'
+    AppSecConfig origCfg
+
+    when:
+    AppSecSystem.start(subService, sharedCommunicationObjects())
+
+    then:
+    1 * poller.addListener(Product.ASM_DD, _, _) >> {
+      savedConfListener = it[2]
+    }
+    AppSecSystem.APP_SEC_CONFIG_SERVICE.lastConfig['waf'] != null
+
+    when:
+    origCfg = AppSecSystem.APP_SEC_CONFIG_SERVICE.lastConfig['waf']
+    savedConfListener.accept(
+      'ignored config key', cfg, null)
+
+    then:
+    AppSecSystem.APP_SEC_CONFIG_SERVICE.lastConfig['waf']  == cfg
+
+    when:
+    savedConfListener.accept(
+      'ignored config key', null, null)
+
+    then:
+    AppSecSystem.APP_SEC_CONFIG_SERVICE.lastConfig['waf']  == origCfg
+  }
+
+  void 'removing rule config resets to default configuration'() {
+
+  }
+
   private SharedCommunicationObjects sharedCommunicationObjects() {
     def sco = new SharedCommunicationObjects(
       ) {


### PR DESCRIPTION
# What Does This Do
Added checkers to validate if remote config is `null`

# Motivation
Reported NullPointerException:
```[dd.trace 2022-12-06 10:42:24:019 +0100] [dd-remote-config] WARN datadog.remoteconfig.state.ProductState - Error handling configuration removal for datadog/2/ASM/asm_configuration/config (Will not log errors for 5 minutes)
java.lang.NullPointerException
	at java.base/java.util.concurrent.ConcurrentHashMap.putVal(ConcurrentHashMap.java:1011)
	at java.base/java.util.concurrent.ConcurrentHashMap.put(ConcurrentHashMap.java:1006)
	at com.datadog.appsec.config.AppSecConfigServiceImpl.lambda$subscribeConfigurationPoller$2(AppSecConfigServiceImpl.java:111)
	at datadog.remoteconfig.ConfigurationChangesTypedListener$Builder.lambda$useDeserializer$0(ConfigurationChangesTypedListener.java:24)
	at datadog.remoteconfig.state.SimpleProductListener.remove(SimpleProductListener.java:26)
	at datadog.remoteconfig.state.ProductState.callListenerRemoveTarget(ProductState.java:108)
	at datadog.remoteconfig.state.ProductState.apply(ProductState.java:76)
	at datadog.remoteconfig.ConfigurationPoller.handleAgentResponse(ConfigurationPoller.java:369)
	at datadog.remoteconfig.ConfigurationPoller.sendRequest(ConfigurationPoller.java:285)
	at datadog.remoteconfig.ConfigurationPoller.poll(ConfigurationPoller.java:193)
	at datadog.trace.util.AgentTaskScheduler$PeriodicTask.run(AgentTaskScheduler.java:299)
	at datadog.trace.util.AgentTaskScheduler$Worker.run(AgentTaskScheduler.java:254)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

# Additional Notes
