### PR TITLE
Split up B3 propagator into multi and single header

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/B3HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/B3HttpCodec.java
@@ -8,18 +8,14 @@ import datadog.trace.api.DDTraceId;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.core.DDSpanContext;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * A codec designed for HTTP transport via headers using B3 headers
- *
- * <p>TODO: there is fair amount of code duplication between DatadogHttpCodec and this class,
- * especially in part where TagContext is handled. We may want to refactor that and avoid special
- * handling of TagContext in other places (i.e. CompoundExtractor).
- */
+/** A codec designed for HTTP transport via headers using B3 headers */
 class B3HttpCodec {
 
   private static final Logger log = LoggerFactory.getLogger(B3HttpCodec.class);
@@ -38,95 +34,150 @@ class B3HttpCodec {
     // This class should not be created. This also makes code coverage checks happy.
   }
 
-  public static final HttpCodec.Injector INJECTOR = new Injector();
+  // Only used in tests
+  static final HttpCodec.Injector INJECTOR =
+      new HttpCodec.Injector() {
+        @Override
+        public <C> void inject(
+            DDSpanContext context, C carrier, AgentPropagation.Setter<C> setter) {
+          SINGLE_INJECTOR.inject(context, carrier, setter);
+          MULTI_INJECTOR.inject(context, carrier, setter);
+        }
+      };
 
-  private static class Injector implements HttpCodec.Injector {
+  public static final HttpCodec.Injector MULTI_INJECTOR = new B3MultiInjector();
 
+  public static final HttpCodec.Injector SINGLE_INJECTOR = new B3SingleInjector();
+
+  private static class B3MultiInjector implements HttpCodec.Injector {
     @Override
     public <C> void inject(
         final DDSpanContext context, final C carrier, final AgentPropagation.Setter<C> setter) {
-      try {
-        final String injectedTraceId = context.getTraceId().toHexStringOrOriginal();
-        final String injectedSpanId = DDSpanId.toHexString(context.getSpanId());
-        setter.set(carrier, TRACE_ID_KEY, injectedTraceId);
-        setter.set(carrier, SPAN_ID_KEY, injectedSpanId);
-
-        final StringBuilder injectedB3Id = new StringBuilder(100);
-        injectedB3Id.append(injectedTraceId).append('-').append(injectedSpanId);
-
-        if (context.lockSamplingPriority()) {
-          final String injectedSamplingPriority =
-              convertSamplingPriority(context.getSamplingPriority());
-          setter.set(carrier, SAMPLING_PRIORITY_KEY, injectedSamplingPriority);
-
-          injectedB3Id.append('-').append(injectedSamplingPriority);
-        }
-        setter.set(carrier, B3_KEY, injectedB3Id.toString());
-
-        log.debug("{} - B3 parent context injected - {}", context.getTraceId(), injectedTraceId);
-      } catch (final NumberFormatException e) {
-        if (log.isDebugEnabled()) {
-          log.debug(
-              "Cannot parse context id(s): {} {}", context.getTraceId(), context.getSpanId(), e);
-        }
+      final String injectedTraceId = context.getTraceId().toHexStringOrOriginal();
+      final String injectedSpanId = DDSpanId.toHexString(context.getSpanId());
+      setter.set(carrier, TRACE_ID_KEY, injectedTraceId);
+      setter.set(carrier, SPAN_ID_KEY, injectedSpanId);
+      if (context.lockSamplingPriority()) {
+        final String injectedSamplingPriority =
+            convertSamplingPriority(context.getSamplingPriority());
+        setter.set(carrier, SAMPLING_PRIORITY_KEY, injectedSamplingPriority);
       }
-    }
-
-    private String convertSamplingPriority(final int samplingPriority) {
-      return samplingPriority > 0 ? SAMPLING_PRIORITY_ACCEPT : SAMPLING_PRIORITY_DROP;
+      log.debug("{} - B3 parent context injected - {}", context.getTraceId(), injectedTraceId);
     }
   }
 
-  public static HttpCodec.Extractor newExtractor(final Map<String, String> tagMapping) {
+  private static class B3SingleInjector implements HttpCodec.Injector {
+    @Override
+    public <C> void inject(
+        final DDSpanContext context, final C carrier, final AgentPropagation.Setter<C> setter) {
+      final String injectedTraceId = context.getTraceId().toHexStringOrOriginal();
+      final String injectedSpanId = DDSpanId.toHexString(context.getSpanId());
+      final StringBuilder injectedB3Id = new StringBuilder(100);
+      injectedB3Id.append(injectedTraceId).append('-').append(injectedSpanId);
+
+      if (context.lockSamplingPriority()) {
+        final String injectedSamplingPriority =
+            convertSamplingPriority(context.getSamplingPriority());
+        injectedB3Id.append('-').append(injectedSamplingPriority);
+      }
+      setter.set(carrier, B3_KEY, injectedB3Id.toString());
+      log.debug("{} - B3 parent context injected - {}", context.getTraceId(), injectedTraceId);
+    }
+  }
+
+  private static String convertSamplingPriority(final int samplingPriority) {
+    return samplingPriority > 0 ? SAMPLING_PRIORITY_ACCEPT : SAMPLING_PRIORITY_DROP;
+  }
+
+  // Only used from tests
+  static HttpCodec.Extractor newExtractor(final Map<String, String> tagMapping) {
+    Config config = Config.get();
+    final List<HttpCodec.Extractor> extractors = new ArrayList<>(2);
+    extractors.add(newSingleExtractor(tagMapping, config));
+    extractors.add(newMultiExtractor(tagMapping, config));
+    return new HttpCodec.CompoundExtractor(extractors);
+  }
+
+  public static HttpCodec.Extractor newMultiExtractor(
+      final Map<String, String> tagMapping, final Config config) {
     return new TagContextExtractor(
         tagMapping,
         new ContextInterpreter.Factory() {
           @Override
           protected ContextInterpreter construct(final Map<String, String> mapping) {
-            return new B3ContextInterpreter(mapping);
+            return new B3MultiContextInterpreter(mapping, config);
           }
         });
   }
 
-  private static class B3ContextInterpreter extends ContextInterpreter {
+  public static HttpCodec.Extractor newSingleExtractor(
+      final Map<String, String> tagMapping, final Config config) {
+    return new TagContextExtractor(
+        tagMapping,
+        new ContextInterpreter.Factory() {
+          @Override
+          protected ContextInterpreter construct(final Map<String, String> mapping) {
+            return new B3SingleContextInterpreter(mapping, config);
+          }
+        });
+  }
 
-    private static final int TRACE_ID = 0;
-    private static final int SPAN_ID = 1;
-    private static final int TAGS = 2;
-    private static final int SAMPLING_PRIORITY = 3;
-    private static final int B3_ID = 4;
-    private static final int IGNORE = -1;
+  private abstract static class B3BaseContextInterpreter extends ContextInterpreter {
+    public B3BaseContextInterpreter(Map<String, String> taggedHeaders, Config config) {
+      super(taggedHeaders, config);
+    }
 
-    private B3ContextInterpreter(final Map<String, String> taggedHeaders) {
-      super(taggedHeaders, Config.get());
+    protected void setSpanId(final String sId) {
+      spanId = DDSpanId.fromHex(sId);
+      if (tags.isEmpty()) {
+        tags = new TreeMap<>();
+      }
+      tags.put(B3_SPAN_ID, sId);
+    }
+
+    protected boolean setTraceId(final String tId) {
+      final int length = tId.length();
+      if (length > 32) {
+        log.debug("Header {} exceeded max length of 32: {}", TRACE_ID_KEY, tId);
+        traceId = DDTraceId.ZERO;
+        return false;
+      } else {
+        traceId = DDTraceId.fromHexTruncatedWithOriginal(tId);
+      }
+      if (tags.isEmpty()) {
+        tags = new TreeMap<>();
+      }
+      tags.put(B3_TRACE_ID, tId);
+      return true;
+    }
+  }
+
+  private static final class B3MultiContextInterpreter extends B3BaseContextInterpreter {
+    private B3MultiContextInterpreter(final Map<String, String> taggedHeaders, Config config) {
+      super(taggedHeaders, config);
     }
 
     @Override
     public boolean accept(final String key, final String value) {
-      if (null == key || key.isEmpty()) {
+      if (null == key || key.isEmpty() || null == value || value.isEmpty()) {
         return true;
       }
       if (LOG_EXTRACT_HEADER_NAMES) {
         log.debug("Header: {}", key);
       }
-      String lowerCaseKey = null;
-      int classification = IGNORE;
-      // Prioritize b3 header. If b3 has already propagated traceId, spanId, and Sampling, we won't
-      // overwrite those
-      if (B3_KEY.equals(key)) {
-        classification = B3_ID;
-      } else {
+      try {
         char first = Character.toLowerCase(key.charAt(0));
         switch (first) {
           case 'x':
-            if ((traceId == null || traceId == DDTraceId.ZERO)
-                && TRACE_ID_KEY.equalsIgnoreCase(key)) {
-              classification = TRACE_ID;
-            } else if ((spanId == DDSpanId.ZERO) && SPAN_ID_KEY.equalsIgnoreCase(key)) {
-              classification = SPAN_ID;
-            } else if (samplingPriority == defaultSamplingPriority()
-                && SAMPLING_PRIORITY_KEY.equalsIgnoreCase(key)) {
-              classification = SAMPLING_PRIORITY;
+            if (TRACE_ID_KEY.equalsIgnoreCase(key)) {
+              setTraceId(firstHeaderValue(value));
+              return true;
+            } else if (SPAN_ID_KEY.equalsIgnoreCase(key)) {
+              setSpanId(firstHeaderValue(value));
+              return true;
+            } else if (SAMPLING_PRIORITY_KEY.equalsIgnoreCase(key)) {
+              samplingPriority = convertSamplingPriority(firstHeaderValue(value));
+              return true;
             } else if (handledXForwarding(key, value)) {
               return true;
             }
@@ -143,59 +194,63 @@ class B3HttpCodec {
             break;
           default:
         }
-      }
-
-      if (handledIpHeaders(key, value)) {
-        return true;
-      }
-
-      if (!taggedHeaders.isEmpty() && classification == IGNORE) {
-        lowerCaseKey = toLowerCase(key);
-        if (taggedHeaders.containsKey(lowerCaseKey)) {
-          classification = TAGS;
+        if (handledIpHeaders(key, value)) {
+          return true;
         }
+        handleTags(key, value);
+      } catch (RuntimeException e) {
+        invalidateContext();
+        log.debug("Exception when extracting context", e);
+        return false;
       }
-      if (classification != IGNORE) {
-        try {
-          final String firstValue = firstHeaderValue(value);
-          if (null != firstValue) {
-            switch (classification) {
-              case B3_ID:
-                if (extractB3(firstValue)) {
-                  return true;
-                }
-                break;
-              case TRACE_ID:
-                {
-                  if (setTraceId(firstValue)) {
-                    return true;
-                  }
-                  break;
-                }
-              case SPAN_ID:
-                setSpanId(firstValue);
-                break;
-              case SAMPLING_PRIORITY:
-                samplingPriority = convertSamplingPriority(firstValue);
-                break;
-              case TAGS:
-                {
-                  final String mappedKey = taggedHeaders.get(lowerCaseKey);
-                  if (null != mappedKey) {
-                    if (tags.isEmpty()) {
-                      tags = new TreeMap<>();
-                    }
-                    tags.put(mappedKey, HttpCodec.decode(firstValue));
-                  }
-                  break;
-                }
-            }
+      return true;
+    }
+  }
+
+  private static final class B3SingleContextInterpreter extends B3BaseContextInterpreter {
+    public B3SingleContextInterpreter(Map<String, String> taggedHeaders, Config config) {
+      super(taggedHeaders, config);
+    }
+
+    @Override
+    public boolean accept(String key, String value) {
+      try {
+        if (null == key || key.isEmpty() || null == value || value.isEmpty()) {
+          return true;
+        }
+        if (LOG_EXTRACT_HEADER_NAMES) {
+          log.debug("Header: {}", key);
+        }
+        if (B3_KEY.equals(key)) {
+          return extractB3(firstHeaderValue(value));
+        } else {
+          char first = Character.toLowerCase(key.charAt(0));
+          switch (first) {
+            case 'x':
+              if (handledXForwarding(key, value)) {
+                return true;
+              }
+              break;
+            case 'f':
+              if (handledForwarding(key, value)) {
+                return true;
+              }
+              break;
+            case 'u':
+              if (handledUserAgent(key, value)) {
+                return true;
+              }
+              break;
           }
-        } catch (final RuntimeException e) {
-          invalidateContext();
-          log.debug("Exception when extracting context", e);
-          return false;
         }
+        if (handledIpHeaders(key, value)) {
+          return true;
+        }
+        handleTags(key, value);
+      } catch (RuntimeException e) {
+        invalidateContext();
+        log.debug("Exception when extracting context", e);
+        return false;
       }
       return true;
     }
@@ -208,8 +263,8 @@ class B3HttpCodec {
         final int secondIndex = firstValue.indexOf("-", firstIndex + 1);
         if (firstIndex != -1) {
           final String b3TraceId = firstValue.substring(0, firstIndex);
-          if (setTraceId(b3TraceId)) {
-            return true;
+          if (!setTraceId(b3TraceId)) {
+            return false;
           }
         }
         if (secondIndex == -1) {
@@ -222,37 +277,13 @@ class B3HttpCodec {
           samplingPriority = convertSamplingPriority(b3SamplingId);
         }
       }
-      return false;
+      return true;
     }
+  }
 
-    private void setSpanId(final String sId) {
-      spanId = DDSpanId.fromHex(sId);
-      if (tags.isEmpty()) {
-        tags = new TreeMap<>();
-      }
-      tags.put(B3_SPAN_ID, sId);
-    }
-
-    private boolean setTraceId(final String tId) {
-      final int length = tId.length();
-      if (length > 32) {
-        log.debug("Header {} exceeded max length of 32: {}", TRACE_ID_KEY, tId);
-        traceId = DDTraceId.ZERO;
-        return true;
-      } else {
-        traceId = DDTraceId.fromHexTruncatedWithOriginal(tId);
-      }
-      if (tags.isEmpty()) {
-        tags = new TreeMap<>();
-      }
-      tags.put(B3_TRACE_ID, tId);
-      return false;
-    }
-
-    private int convertSamplingPriority(final String samplingPriority) {
-      return "1".equals(samplingPriority)
-          ? PrioritySampling.SAMPLER_KEEP
-          : PrioritySampling.SAMPLER_DROP;
-    }
+  private static int convertSamplingPriority(final String samplingPriority) {
+    return "1".equals(samplingPriority)
+        ? PrioritySampling.SAMPLER_KEEP
+        : PrioritySampling.SAMPLER_DROP;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
@@ -10,7 +10,6 @@ import java.util.Map;
 public class ExtractedContext extends TagContext {
   private final DDTraceId traceId;
   private final long spanId;
-  private final int samplingPriority;
   private final long endToEndStartTime;
   private final Map<String, String> baggage;
   private final DatadogTags datadogTags;
@@ -25,10 +24,9 @@ public class ExtractedContext extends TagContext {
       final Map<String, String> tags,
       final HttpHeaders httpHeaders,
       final DatadogTags datadogTags) {
-    super(origin, tags, httpHeaders);
+    super(origin, tags, httpHeaders, samplingPriority);
     this.traceId = traceId;
     this.spanId = spanId;
-    this.samplingPriority = samplingPriority;
     this.endToEndStartTime = endToEndStartTime;
     this.baggage = baggage;
     this.datadogTags = datadogTags;
@@ -47,10 +45,6 @@ public class ExtractedContext extends TagContext {
   @Override
   public final long getSpanId() {
     return spanId;
-  }
-
-  public final int getSamplingPriority() {
-    return samplingPriority;
   }
 
   public final long getEndToEndStartTime() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -50,7 +50,8 @@ public class HttpCodec {
         DatadogHttpCodec.INJECTOR.inject(context, carrier, setter);
         break;
       case B3:
-        B3HttpCodec.INJECTOR.inject(context, carrier, setter);
+        B3HttpCodec.SINGLE_INJECTOR.inject(context, carrier, setter);
+        B3HttpCodec.MULTI_INJECTOR.inject(context, carrier, setter);
         break;
       case HAYSTACK:
         HaystackHttpCodec.INJECTOR.inject(context, carrier, setter);
@@ -72,7 +73,8 @@ public class HttpCodec {
           injectors.add(DatadogHttpCodec.INJECTOR);
           break;
         case B3:
-          injectors.add(B3HttpCodec.INJECTOR);
+          injectors.add(B3HttpCodec.SINGLE_INJECTOR);
+          injectors.add(B3HttpCodec.MULTI_INJECTOR);
           break;
         case HAYSTACK:
           injectors.add(HaystackHttpCodec.INJECTOR);
@@ -97,7 +99,8 @@ public class HttpCodec {
           extractors.add(DatadogHttpCodec.newExtractor(taggedHeaders, config));
           break;
         case B3:
-          extractors.add(B3HttpCodec.newExtractor(taggedHeaders));
+          extractors.add(B3HttpCodec.newSingleExtractor(taggedHeaders, config));
+          extractors.add(B3HttpCodec.newMultiExtractor(taggedHeaders, config));
           break;
         case HAYSTACK:
           extractors.add(HaystackHttpCodec.newExtractor(taggedHeaders));

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/XRayHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/XRayHttpCodec.java
@@ -164,16 +164,8 @@ class XRayHttpCodec {
 
         if (handledIpHeaders(key, value)) {
           return true;
-        }
-
-        if (!taggedHeaders.isEmpty()) {
-          String mappedKey = taggedHeaders.get(toLowerCase(key));
-          if (null != mappedKey) {
-            if (tags.isEmpty()) {
-              tags = new TreeMap<>();
-            }
-            tags.put(mappedKey, HttpCodec.decode(value));
-          }
+        } else {
+          handleTags(key, value);
         }
         return true;
       } catch (RuntimeException e) {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpExtractorTest.groovy
@@ -101,9 +101,9 @@ class B3HttpExtractorTest extends DDSpecification {
     where:
     b3      | expectedTraceId | expectedSpanId | expectedSamplingPriority
     "2-3-0" | 2G              | 3G             | PrioritySampling.SAMPLER_DROP
-    "2-3"   | 2G              | 3G             | PrioritySampling.SAMPLER_KEEP
-    "0"     | 1G              | 2G             | PrioritySampling.SAMPLER_DROP
-    null    | 1G              | 2G             | PrioritySampling.SAMPLER_KEEP
+    "2-3"   | 2G              | 3G             | PrioritySampling.UNSET
+    "0"     | 1G              | 2G             | PrioritySampling.SAMPLER_KEEP // B3 Multi used instead
+    null    | 1G              | 2G             | PrioritySampling.SAMPLER_KEEP // B3 Multi used instead
 
     traceId = 1G
     spanId = 2G
@@ -125,12 +125,12 @@ class B3HttpExtractorTest extends DDSpecification {
     }
 
     when:
-    final ExtractedContext context = extractor.extract(headers, ContextVisitors.stringValuesMap())
+    final TagContext context = extractor.extract(headers, ContextVisitors.stringValuesMap())
 
     then:
     context.traceId == DDTraceId.from("$expectedTraceId")
     context.spanId == DDSpanId.from("$expectedSpanId")
-    context.baggage == [:]
+    context.baggageItems().empty
     context.tags == [
       "b3.traceid": context.traceId.toHexStringOrOriginal(),
       "b3.spanid" : DDSpanId.toHexString(context.spanId),
@@ -142,9 +142,9 @@ class B3HttpExtractorTest extends DDSpecification {
     where:
     b3      | expectedTraceId | expectedSpanId | expectedSamplingPriority
     "2-3-0" | 2G              | 3G             | PrioritySampling.SAMPLER_DROP
-    "2-3"   | 2G              | 3G             | PrioritySampling.SAMPLER_KEEP
-    "0"     | 1G              | 2G             | PrioritySampling.SAMPLER_DROP
-    null    | 1G              | 2G             | PrioritySampling.SAMPLER_KEEP
+    "2-3"   | 2G              | 3G             | PrioritySampling.UNSET
+    "0"     | 1G              | 2G             | PrioritySampling.SAMPLER_KEEP // B3 Multi used instead
+    null    | 1G              | 2G             | PrioritySampling.SAMPLER_KEEP // B3 Multi used instead
 
     traceId = 1G
     spanId = 2G

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
@@ -2,6 +2,7 @@ package datadog.trace.bootstrap.instrumentation.api;
 
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
+import datadog.trace.api.sampling.PrioritySampling;
 import java.util.Collections;
 import java.util.Map;
 
@@ -11,24 +12,33 @@ import java.util.Map;
  */
 public class TagContext implements AgentSpan.Context.Extracted {
 
+  private static final HttpHeaders EMPTY_HTTP_HEADERS = new HttpHeaders();
+
   private final String origin;
   private final Map<String, String> tags;
   private Object requestContextDataAppSec;
   private Object requestContextDataIast;
   private final HttpHeaders httpHeaders;
 
+  private final int samplingPriority;
+
   public TagContext() {
     this(null, null);
   }
 
   public TagContext(final String origin, final Map<String, String> tags) {
-    this(origin, tags, null);
+    this(origin, tags, null, PrioritySampling.UNSET);
   }
 
-  public TagContext(final String origin, final Map<String, String> tags, HttpHeaders httpHeaders) {
+  public TagContext(
+      final String origin,
+      final Map<String, String> tags,
+      HttpHeaders httpHeaders,
+      int samplingPriority) {
     this.origin = origin;
     this.tags = tags;
-    this.httpHeaders = httpHeaders;
+    this.httpHeaders = httpHeaders == null ? EMPTY_HTTP_HEADERS : httpHeaders;
+    this.samplingPriority = samplingPriority;
   }
 
   public final String getOrigin() {
@@ -37,118 +47,80 @@ public class TagContext implements AgentSpan.Context.Extracted {
 
   @Override
   public String getForwarded() {
-    if (httpHeaders == null) {
-      return null;
-    }
     return httpHeaders.forwarded;
   }
 
   @Override
   public String getXForwardedProto() {
-    if (httpHeaders == null) {
-      return null;
-    }
     return httpHeaders.xForwardedProto;
   }
 
   @Override
   public String getXForwardedHost() {
-    if (httpHeaders == null) {
-      return null;
-    }
     return httpHeaders.xForwardedHost;
   }
 
   @Override
   public String getXForwardedPort() {
-    if (httpHeaders == null) {
-      return null;
-    }
     return httpHeaders.xForwardedPort;
   }
 
   @Override
   public String getForwardedFor() {
-    if (httpHeaders == null) {
-      return null;
-    }
     return httpHeaders.forwardedFor;
   }
 
   @Override
   public String getXForwarded() {
-    if (httpHeaders == null) {
-      return null;
-    }
     return httpHeaders.xForwarded;
   }
 
   @Override
   public String getXForwardedFor() {
-    if (httpHeaders == null) {
-      return null;
-    }
     return httpHeaders.xForwardedFor;
   }
 
   @Override
   public String getXClusterClientIp() {
-    if (httpHeaders == null) {
-      return null;
-    }
     return httpHeaders.xClusterClientIp;
   }
 
   @Override
   public String getXRealIp() {
-    if (httpHeaders == null) {
-      return null;
-    }
     return httpHeaders.xRealIp;
   }
 
   @Override
   public String getClientIp() {
-    if (httpHeaders == null) {
-      return null;
-    }
     return httpHeaders.clientIp;
   }
 
   @Override
   public String getUserAgent() {
-    if (httpHeaders == null) {
-      return null;
-    }
     return httpHeaders.userAgent;
   }
 
   @Override
   public String getVia() {
-    if (httpHeaders == null) {
-      return null;
-    }
     return httpHeaders.via;
   }
 
   @Override
   public String getTrueClientIp() {
-    if (httpHeaders == null) {
-      return null;
-    }
     return httpHeaders.trueClientIp;
   }
 
   @Override
   public String getCustomIpHeader() {
-    if (httpHeaders == null) {
-      return null;
-    }
     return httpHeaders.customIpHeader;
   }
 
   public final Map<String, String> getTags() {
     return tags;
+  }
+
+  public final int getSamplingPriority() {
+    return samplingPriority;
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

Splits up the B3 propagator into multi header and single header versions

# Motivation

They are separate

# Additional Notes

This is in preparation for new configuration variables and propagation style names.
