### PR TITLE
Add correlation id injection to dd-trace-ot

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/internal/InternalTracer.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/internal/InternalTracer.java
@@ -9,7 +9,7 @@ public interface InternalTracer {
    * Attach callbacks to the global scope manager.
    *
    * @param afterScopeActivatedCallback Callback on scope activation.
-   * @param afterScopeClosedCallback    Callback on scope close.
+   * @param afterScopeClosedCallback Callback on scope close.
    */
   void addScopeListener(Runnable afterScopeActivatedCallback, Runnable afterScopeClosedCallback);
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/internal/InternalTracer.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/internal/InternalTracer.java
@@ -5,6 +5,14 @@ package datadog.trace.api.internal;
  * at any time.
  */
 public interface InternalTracer {
+  /**
+   * Attach callbacks to the global scope manager.
+   *
+   * @param afterScopeActivatedCallback Callback on scope activation.
+   * @param afterScopeClosedCallback    Callback on scope close.
+   */
+  void addScopeListener(Runnable afterScopeActivatedCallback, Runnable afterScopeClosedCallback);
+
   void flush();
 
   void flushMetrics();

--- a/dd-trace-core/build.gradle
+++ b/dd-trace-core/build.gradle
@@ -24,6 +24,7 @@ excludedClassesCoverage += [
   'datadog.trace.core.scopemanager.ContinuableScopeManager.SingleContinuation',
   'datadog.trace.core.SpanCorrelationImpl',
   'datadog.trace.core.Base64Encoder',
+  'datadog.trace.core.CoreTracer.1',
   'datadog.trace.core.DDSpan.1',
   'datadog.trace.core.tagprocessor.QueryObfuscator.1'
 ]

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -949,6 +949,21 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   @Override
+  public void addScopeListener(Runnable afterScopeActivatedCallback, Runnable afterScopeClosedCallback) {
+    addScopeListener(new ScopeListener() {
+      @Override
+      public void afterScopeActivated() {
+        afterScopeActivatedCallback.run();
+      }
+
+      @Override
+      public void afterScopeClosed() {
+        afterScopeClosedCallback.run();
+      }
+    });
+  }
+
+  @Override
   public void flush() {
     pendingTraceBuffer.flush();
     writer.flush();

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -949,18 +949,20 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   @Override
-  public void addScopeListener(Runnable afterScopeActivatedCallback, Runnable afterScopeClosedCallback) {
-    addScopeListener(new ScopeListener() {
-      @Override
-      public void afterScopeActivated() {
-        afterScopeActivatedCallback.run();
-      }
+  public void addScopeListener(
+      Runnable afterScopeActivatedCallback, Runnable afterScopeClosedCallback) {
+    addScopeListener(
+        new ScopeListener() {
+          @Override
+          public void afterScopeActivated() {
+            afterScopeActivatedCallback.run();
+          }
 
-      @Override
-      public void afterScopeClosed() {
-        afterScopeClosedCallback.run();
-      }
-    });
+          @Override
+          public void afterScopeClosed() {
+            afterScopeClosedCallback.run();
+          }
+        });
   }
 
   @Override

--- a/dd-trace-ot/build.gradle
+++ b/dd-trace-ot/build.gradle
@@ -45,6 +45,7 @@ dependencies {
   api group: 'io.opentracing.contrib', name: 'opentracing-tracerresolver', version: '0.1.0'
 
   api deps.slf4j
+  implementation project(':dd-trace-ot:correlation-id-injection')
 
   testImplementation project(":dd-java-agent:testing")
 

--- a/dd-trace-ot/correlation-id-injection/build.gradle
+++ b/dd-trace-ot/correlation-id-injection/build.gradle
@@ -1,0 +1,28 @@
+apply from: "$rootDir/gradle/java.gradle"
+apply from: "$rootDir/gradle/publish.gradle"
+
+minimumBranchCoverage = 0.8
+
+excludedClassesCoverage += [
+  'datadog.trace.correlation.CorrelationIdInjectors',
+  'datadog.trace.correlation.CorrelationIdInjectors.InjectorType'
+]
+
+description = 'correlation-id-injection'
+
+def log4j1 = '1.2.17'
+def log4j2 = '2.19.0'
+def logback = '1.3.5'
+
+dependencies {
+  api project(':dd-trace-api')
+  implementation deps.slf4j
+  compileOnly "org.apache.logging.log4j:log4j-api:${log4j2}"
+  compileOnly "log4j:log4j:${log4j1}"
+
+  testImplementation deps.guava
+  testImplementation project(':dd-trace-ot')
+  testImplementation project(":dd-java-agent:testing")
+  testImplementation "org.apache.logging.log4j:log4j-core:${log4j2}"
+  testImplementation "ch.qos.logback:logback-core:${logback}"
+}

--- a/dd-trace-ot/correlation-id-injection/src/main/java/datadog/trace/correlation/AbstractCorrelationIdInjector.java
+++ b/dd-trace-ot/correlation-id-injection/src/main/java/datadog/trace/correlation/AbstractCorrelationIdInjector.java
@@ -1,0 +1,13 @@
+package datadog.trace.correlation;
+
+import datadog.trace.api.internal.InternalTracer;
+
+abstract class AbstractCorrelationIdInjector {
+  AbstractCorrelationIdInjector(InternalTracer tracer) {
+    tracer.addScopeListener(this::afterScopeActivatedCallback, this::afterScopeClosedCallback);
+  }
+
+  protected abstract void afterScopeActivatedCallback();
+
+  protected abstract void afterScopeClosedCallback();
+}

--- a/dd-trace-ot/correlation-id-injection/src/main/java/datadog/trace/correlation/CorrelationIdInjectors.java
+++ b/dd-trace-ot/correlation-id-injection/src/main/java/datadog/trace/correlation/CorrelationIdInjectors.java
@@ -1,0 +1,66 @@
+package datadog.trace.correlation;
+
+import datadog.trace.api.internal.InternalTracer;
+import de.thetaphi.forbiddenapis.SuppressForbidden;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Helper class to enable correlation identifier injection. */
+public final class CorrelationIdInjectors {
+  private static final Logger log = LoggerFactory.getLogger(CorrelationIdInjectors.class);
+
+  private CorrelationIdInjectors() {}
+
+  /**
+   * Register any applicable correlation identifier injectors.
+   *
+   * @param tracer The tracer to register the injectors to.
+   */
+  public static void register(InternalTracer tracer) {
+    for (InjectorType type : InjectorType.values()) {
+      type.register(tracer);
+    }
+  }
+
+  @SuppressForbidden
+  private static boolean isClassPresent(String className) {
+    try {
+      Class.forName(className);
+      return true;
+    } catch (ClassNotFoundException ignored) {
+      return false;
+    }
+  }
+
+  @SuppressForbidden
+  private static void enableInjector(String className, InternalTracer tracer) {
+    try {
+      Class<?> injectorClass = Class.forName(className);
+      injectorClass.getConstructor(InternalTracer.class).newInstance(tracer);
+    } catch (ReflectiveOperationException e) {
+      log.warn("Failed to enable injector " + className + ".", e);
+    }
+  }
+
+  private enum InjectorType {
+    LOG4J("org.apache.log4j.MDC", "datadog.trace.correlation.Log4jCorrelationIdInjector"),
+    LOG4J2(
+        "org.apache.logging.log4j.ThreadContext",
+        "datadog.trace.correlation.Log4j2CorrelationIdInjector"),
+    SLF4J_AND_LOGBACK("org.slf4j.MDC", "datadog.trace.correlation.Slf4jCorrelationIdInjector");
+
+    private final String mdcClassName;
+    private final String injectorClassName;
+
+    InjectorType(String mdcClassName, String injectorClassName) {
+      this.mdcClassName = mdcClassName;
+      this.injectorClassName = injectorClassName;
+    }
+
+    void register(InternalTracer tracer) {
+      if (isClassPresent(this.mdcClassName)) {
+        enableInjector(this.injectorClassName, tracer);
+      }
+    }
+  }
+}

--- a/dd-trace-ot/correlation-id-injection/src/main/java/datadog/trace/correlation/Log4j2CorrelationIdInjector.java
+++ b/dd-trace-ot/correlation-id-injection/src/main/java/datadog/trace/correlation/Log4j2CorrelationIdInjector.java
@@ -1,0 +1,25 @@
+package datadog.trace.correlation;
+
+import datadog.trace.api.CorrelationIdentifier;
+import datadog.trace.api.internal.InternalTracer;
+import org.apache.logging.log4j.ThreadContext;
+
+/** Inject trace and span identifiers using Log4j2 ThreadContext. */
+@SuppressWarnings("unused")
+class Log4j2CorrelationIdInjector extends AbstractCorrelationIdInjector {
+  public Log4j2CorrelationIdInjector(InternalTracer tracer) {
+    super(tracer);
+  }
+
+  @Override
+  protected void afterScopeActivatedCallback() {
+    ThreadContext.put(CorrelationIdentifier.getTraceIdKey(), CorrelationIdentifier.getTraceId());
+    ThreadContext.put(CorrelationIdentifier.getSpanIdKey(), CorrelationIdentifier.getSpanId());
+  }
+
+  @Override
+  protected void afterScopeClosedCallback() {
+    ThreadContext.remove(CorrelationIdentifier.getTraceIdKey());
+    ThreadContext.remove(CorrelationIdentifier.getSpanIdKey());
+  }
+}

--- a/dd-trace-ot/correlation-id-injection/src/main/java/datadog/trace/correlation/Log4jCorrelationIdInjector.java
+++ b/dd-trace-ot/correlation-id-injection/src/main/java/datadog/trace/correlation/Log4jCorrelationIdInjector.java
@@ -1,0 +1,29 @@
+package datadog.trace.correlation;
+
+import datadog.trace.api.CorrelationIdentifier;
+import datadog.trace.api.internal.InternalTracer;
+import org.apache.log4j.MDC;
+
+/**
+ * Inject trace and span identifiers using Log4j 1 MDC. MDC does not work from Java 9+. Check <a
+ * href="https://blogs.apache.org/logging/entry/moving_on_to_log4j_2">Apache logging blog</a> for
+ * more details.
+ */
+@SuppressWarnings("unused")
+class Log4jCorrelationIdInjector extends AbstractCorrelationIdInjector {
+  public Log4jCorrelationIdInjector(InternalTracer tracer) {
+    super(tracer);
+  }
+
+  @Override
+  protected void afterScopeActivatedCallback() {
+    MDC.put(CorrelationIdentifier.getTraceIdKey(), CorrelationIdentifier.getTraceId());
+    MDC.put(CorrelationIdentifier.getSpanIdKey(), CorrelationIdentifier.getSpanId());
+  }
+
+  @Override
+  protected void afterScopeClosedCallback() {
+    MDC.remove(CorrelationIdentifier.getTraceIdKey());
+    MDC.remove(CorrelationIdentifier.getSpanIdKey());
+  }
+}

--- a/dd-trace-ot/correlation-id-injection/src/main/java/datadog/trace/correlation/Slf4jCorrelationIdInjector.java
+++ b/dd-trace-ot/correlation-id-injection/src/main/java/datadog/trace/correlation/Slf4jCorrelationIdInjector.java
@@ -1,0 +1,28 @@
+package datadog.trace.correlation;
+
+import datadog.trace.api.CorrelationIdentifier;
+import datadog.trace.api.internal.InternalTracer;
+import org.slf4j.MDC;
+
+/**
+ * Inject trace and span identifiers using SLF4J MDC. This injector works with SLF4J and Logback
+ * API.
+ */
+@SuppressWarnings("unused")
+class Slf4jCorrelationIdInjector extends AbstractCorrelationIdInjector {
+  public Slf4jCorrelationIdInjector(InternalTracer tracer) {
+    super(tracer);
+  }
+
+  @Override
+  protected void afterScopeActivatedCallback() {
+    MDC.put(CorrelationIdentifier.getTraceIdKey(), CorrelationIdentifier.getTraceId());
+    MDC.put(CorrelationIdentifier.getSpanIdKey(), CorrelationIdentifier.getSpanId());
+  }
+
+  @Override
+  protected void afterScopeClosedCallback() {
+    MDC.remove(CorrelationIdentifier.getTraceIdKey());
+    MDC.remove(CorrelationIdentifier.getSpanIdKey());
+  }
+}

--- a/dd-trace-ot/correlation-id-injection/src/test/groovy/CorrelationIdInjectorTest.groovy
+++ b/dd-trace-ot/correlation-id-injection/src/test/groovy/CorrelationIdInjectorTest.groovy
@@ -1,0 +1,74 @@
+import datadog.opentracing.DDTracer
+import datadog.trace.api.CorrelationIdentifier
+import datadog.trace.api.GlobalTracer
+import datadog.trace.test.util.DDSpecification
+
+abstract class CorrelationIdInjectorTest extends DDSpecification {
+  def logPattern = "TRACE_ID=%X{${CorrelationIdentifier.getTraceIdKey()}} SPAN_ID=%X{${CorrelationIdentifier.getSpanIdKey()}} %m"
+
+  def "test correlation id injection"() {
+    setup:
+    def tracer = buildTracer()
+    def journal = buildJournal()
+    def logger = buildLogger()
+
+    when:
+    logger.log("Event without context")
+
+    then:
+    journal.nextLog() == "TRACE_ID= SPAN_ID= Event without context"
+
+    when:
+    def rootSpan = tracer.buildSpan("operation1").start()
+    def rootScope = tracer.activateSpan(rootSpan)
+    logger.log("Event with root span context")
+
+    then:
+    journal.nextLog() == "TRACE_ID=${CorrelationIdentifier.traceId} SPAN_ID=${CorrelationIdentifier.spanId} Event with root span context"
+
+    when:
+    def childSpan = tracer.buildSpan("operation1").asChildOf(rootSpan).start()
+    def childScope = tracer.activateSpan(childSpan)
+    logger.log("Event with child span context")
+
+    then:
+    journal.nextLog() == "TRACE_ID=${CorrelationIdentifier.traceId} SPAN_ID=${CorrelationIdentifier.spanId} Event with child span context"
+
+    when:
+    childScope.close()
+    childSpan.finish()
+    logger.log("Event with root span context")
+
+    then:
+    journal.nextLog() == "TRACE_ID=${CorrelationIdentifier.traceId} SPAN_ID=${CorrelationIdentifier.spanId} Event with root span context"
+
+    when:
+    rootScope.close()
+    rootSpan.finish()
+    logger.log("Event without context")
+
+    then:
+    journal.nextLog() == "TRACE_ID= SPAN_ID= Event without context"
+
+    cleanup:
+    tracer.close()
+  }
+
+  def buildTracer() {
+    DDTracer tracer = new DDTracer.DDTracerBuilder().build()
+    GlobalTracer.registerIfAbsent(tracer)
+    return tracer
+  }
+
+  abstract LogJournal buildJournal()
+
+  abstract TestLogger buildLogger()
+
+  interface LogJournal {
+    String nextLog()
+  }
+
+  interface TestLogger {
+    void log(String message)
+  }
+}

--- a/dd-trace-ot/correlation-id-injection/src/test/groovy/Log4j2CorrelationIdInjectorTest.groovy
+++ b/dd-trace-ot/correlation-id-injection/src/test/groovy/Log4j2CorrelationIdInjectorTest.groovy
@@ -1,0 +1,68 @@
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.core.Appender
+import org.apache.logging.log4j.core.Filter
+import org.apache.logging.log4j.core.LogEvent
+import org.apache.logging.log4j.core.LoggerContext
+import org.apache.logging.log4j.core.appender.AbstractAppender
+import org.apache.logging.log4j.core.config.Configuration
+import org.apache.logging.log4j.core.config.LoggerConfig
+import org.apache.logging.log4j.core.layout.PatternLayout
+
+class Log4j2CorrelationIdInjectorTest extends CorrelationIdInjectorTest {
+  @Override
+  LogJournal buildJournal() {
+    final LoggerContext context = LoggerContext.getContext(false)
+    final Configuration config = context.getConfiguration()
+
+    TestAppender appender = new TestAppender()
+    appender.start()
+    config.addAppender(appender)
+    updateLoggers(appender, config)
+    return appender
+  }
+
+  @Override
+  TestLogger buildLogger() {
+    def logger = LogManager.getLogger("TestLogger")
+    return { message -> logger.error(message) }
+  }
+
+  private static void updateLoggers(final Appender appender, final Configuration config) {
+    final Level level = null
+    final Filter filter = null
+    for (final LoggerConfig loggerConfig : config.getLoggers().values()) {
+      loggerConfig.addAppender(appender, level, filter)
+    }
+    config.getRootLogger().addAppender(appender, level, filter)
+  }
+
+  PatternLayout createLayout() {
+    return PatternLayout.newBuilder().withPattern(logPattern).build()
+  }
+
+  class TestAppender extends AbstractAppender implements CorrelationIdInjectorTest.LogJournal {
+    List events
+    int read
+
+    protected TestAppender() {
+      super("TestAppender", null, createLayout(), false, null)
+      events = []
+      read = 0
+    }
+
+    @Override
+    void append(LogEvent event) {
+      def log = getLayout().toSerializable(event)
+      events << log
+    }
+
+    @Override
+    String nextLog() {
+      if (events.size() <= read) {
+        return null
+      }
+      return events[read++]
+    }
+  }
+}

--- a/dd-trace-ot/correlation-id-injection/src/test/groovy/Slf4jCorrelationIdInjectorTest.groovy
+++ b/dd-trace-ot/correlation-id-injection/src/test/groovy/Slf4jCorrelationIdInjectorTest.groovy
@@ -1,0 +1,63 @@
+import ch.qos.logback.classic.LoggerContext
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class Slf4jCorrelationIdInjectorTest extends CorrelationIdInjectorTest {
+
+  def logger
+
+  @Override
+  LogJournal buildJournal() {
+    def logCtx = (LoggerContext) LoggerFactory.getILoggerFactory()
+    def logger = logCtx.getLogger("TestLogger")
+    this.logger = logger
+    def testAppender = new TestAppender(logCtx)
+    testAppender.start()
+    logger.addAppender(testAppender)
+    return testAppender
+  }
+
+  @Override
+  TestLogger buildLogger() {
+    Logger logger = LoggerFactory.getLogger("TestLogger")
+    return { message -> logger.error(message)}
+  }
+
+  class TestAppender extends AppenderBase<ILoggingEvent> implements CorrelationIdInjectorTest.LogJournal {
+    List events
+    int read
+    PatternLayoutEncoder encoder
+
+    TestAppender(LoggerContext logCtx) {
+      name = "TestAppender"
+      encoder = new PatternLayoutEncoder()
+      encoder.setContext(logCtx)
+      encoder.setPattern(logPattern)
+      events = []
+      read = 0
+    }
+
+    @Override
+    void start() {
+      encoder.start()
+      super.start()
+    }
+
+    @Override
+    void append(ILoggingEvent event) {
+      def log = this.encoder.getLayout().doLayout(event)
+      events << log
+    }
+
+    @Override
+    String nextLog() {
+      if (events.size() <= read) {
+        return null
+      }
+      return events[read++]
+    }
+  }
+}

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -474,6 +474,11 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer, InternalTrace
   }
 
   @Override
+  public void addScopeListener(Runnable afterScopeActivatedCallback, Runnable afterScopeClosedCallback) {
+    tracer.addScopeListener(afterScopeActivatedCallback, afterScopeClosedCallback);
+  }
+
+  @Override
   public void flush() {
     tracer.flush();
   }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -15,6 +15,7 @@ import datadog.trace.core.CoreTracer;
 import datadog.trace.core.DDSpanContext;
 import datadog.trace.core.propagation.ExtractedContext;
 import datadog.trace.core.propagation.HttpCodec;
+import datadog.trace.correlation.CorrelationIdInjectors;
 import io.opentracing.References;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
@@ -405,6 +406,8 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer, InternalTrace
     if (scopeManager == null) {
       this.scopeManager = new OTScopeManager(tracer, converter);
     }
+
+    CorrelationIdInjectors.register(this);
   }
 
   private static Map<String, String> customRuntimeTags(
@@ -474,7 +477,8 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer, InternalTrace
   }
 
   @Override
-  public void addScopeListener(Runnable afterScopeActivatedCallback, Runnable afterScopeClosedCallback) {
+  public void addScopeListener(
+      Runnable afterScopeActivatedCallback, Runnable afterScopeClosedCallback) {
     tracer.addScopeListener(afterScopeActivatedCallback, afterScopeClosedCallback);
   }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -278,6 +278,9 @@ public class AgentTracer {
     public void close() {}
 
     @Override
+    public void addScopeListener(Runnable afterScopeActivatedCallback, Runnable afterScopeClosedCallback) {}
+
+    @Override
     public void flush() {}
 
     @Override

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -278,7 +278,8 @@ public class AgentTracer {
     public void close() {}
 
     @Override
-    public void addScopeListener(Runnable afterScopeActivatedCallback, Runnable afterScopeClosedCallback) {}
+    public void addScopeListener(
+        Runnable afterScopeActivatedCallback, Runnable afterScopeClosedCallback) {}
 
     @Override
     public void flush() {}

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,6 +30,7 @@ rootProject.name = 'dd-trace-java'
 // external apis
 include ':dd-trace-api'
 include ':dd-trace-ot'
+include ':dd-trace-ot:correlation-id-injection'
 
 // agent projects
 include ':internal-api'


### PR DESCRIPTION
# What Does This Do

This PR adds automatic injection of Trace / Span Ids to MDC (Mapped Diagnostic Context) to `dd-trace-ot`.

# Motivation

As `ScopeListener` was removed from public API from `1.0.0` version, there is no way for users to do such injection.
I add it as a feature of `dd-trace-ot` but it's implemented in a separated module that can be reused for a coming OTEL support.

# Additional Notes

Fix #2066 