### PR TITLE
refactor snapshots to report probe version

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
@@ -21,7 +21,7 @@ public class DebuggerContext {
   public interface Sink {
     void addSnapshot(Snapshot snapshot);
 
-    void addDiagnostics(String probeId, List<DiagnosticMessage> messages);
+    void addDiagnostics(String probeId, Long probeVersion, List<DiagnosticMessage> messages);
 
     default void skipSnapshot(String probeId, SkipCause cause) {}
   }
@@ -90,12 +90,13 @@ public class DebuggerContext {
   }
 
   /** Add diagnostics message to the underlying sink No-op if not implementation available */
-  public static void reportDiagnostics(String probeId, List<DiagnosticMessage> messages) {
+  public static void reportDiagnostics(
+      String probeId, Long probeVersion, List<DiagnosticMessage> messages) {
     Sink localSink = sink;
     if (localSink == null) {
       return;
     }
-    localSink.addDiagnostics(probeId, messages);
+    localSink.addDiagnostics(probeId, probeVersion, messages);
   }
 
   /**

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/ProbeDiagnostic.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/ProbeDiagnostic.java
@@ -6,15 +6,21 @@ import java.util.Objects;
 /** Stores a collection of DiagnosticMessages related to a probe */
 public final class ProbeDiagnostic {
   private final String probeId;
+  private final Long probeVersion;
   private final List<DiagnosticMessage> messages;
 
-  public ProbeDiagnostic(String probeId, List<DiagnosticMessage> messages) {
+  public ProbeDiagnostic(String probeId, Long probeVersion, List<DiagnosticMessage> messages) {
     this.probeId = probeId;
+    this.probeVersion = probeVersion;
     this.messages = messages;
   }
 
   public String getProbeId() {
     return probeId;
+  }
+
+  public Long getProbeVersion() {
+    return probeVersion;
   }
 
   public List<DiagnosticMessage> getMessages() {
@@ -23,7 +29,14 @@ public final class ProbeDiagnostic {
 
   @Override
   public String toString() {
-    return "ProbeDiagnostic{" + "probeId='" + probeId + '\'' + ", messages=" + messages + '}';
+    return "ProbeDiagnostic{"
+        + "probeId='"
+        + probeId
+        + "', probeVersion="
+        + probeVersion
+        + ", messages="
+        + messages
+        + '}';
   }
 
   @Override
@@ -31,11 +44,13 @@ public final class ProbeDiagnostic {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     ProbeDiagnostic that = (ProbeDiagnostic) o;
-    return Objects.equals(probeId, that.probeId) && Objects.equals(messages, that.messages);
+    return Objects.equals(probeId, that.probeId)
+        && Objects.equals(probeVersion, that.probeVersion)
+        && Objects.equals(messages, that.messages);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(probeId, messages);
+    return Objects.hash(probeId, probeVersion, messages);
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
@@ -231,7 +231,13 @@ public class Snapshot {
         stack,
         captures,
         new ProbeDetails(
-            probeId, probe.location, probe.evaluateAt, probe.script, probe.tags, summaryBuilder),
+            probeId,
+            probe.location,
+            probe.source,
+            probe.evaluateAt,
+            probe.script,
+            probe.tags,
+            summaryBuilder),
         language,
         thread,
         thisClassName,
@@ -321,22 +327,25 @@ public class Snapshot {
   /** Probe information associated with a snapshot */
   public static class ProbeDetails {
     public static final String ITW_PROBE_ID = "instrument-the-world-probe";
-    public static final ProbeDetails UNKNOWN = new ProbeDetails("UNKNOWN", ProbeLocation.UNKNOWN);
+    public static final ProbeDetails UNKNOWN =
+        new ProbeDetails("UNKNOWN", ProbeLocation.UNKNOWN, null);
     public static final ProbeDetails ITW_PROBE =
-        new ProbeDetails(ITW_PROBE_ID, ProbeLocation.UNKNOWN);
+        new ProbeDetails(ITW_PROBE_ID, ProbeLocation.UNKNOWN, null);
 
     private final String id;
     private final ProbeLocation location;
+    private final ProbeSource source;
     private final MethodLocation evaluateAt;
     private final DebuggerScript script;
     private final transient List<ProbeDetails> additionalProbes;
     private final String tags;
     private final transient SummaryBuilder summaryBuilder;
 
-    public ProbeDetails(String id, ProbeLocation location) {
+    public ProbeDetails(String id, ProbeLocation location, ProbeSource source) {
       this(
           id,
           location,
+          source,
           MethodLocation.DEFAULT,
           null,
           null,
@@ -347,16 +356,18 @@ public class Snapshot {
     public ProbeDetails(
         String id,
         ProbeLocation location,
+        ProbeSource source,
         MethodLocation evaluateAt,
         DebuggerScript script,
         String tags,
         SummaryBuilder summaryBuilder) {
-      this(id, location, evaluateAt, script, tags, summaryBuilder, Collections.emptyList());
+      this(id, location, source, evaluateAt, script, tags, summaryBuilder, Collections.emptyList());
     }
 
     public ProbeDetails(
         String id,
         ProbeLocation location,
+        ProbeSource source,
         MethodLocation evaluateAt,
         DebuggerScript script,
         String tags,
@@ -364,6 +375,7 @@ public class Snapshot {
         List<ProbeDetails> additionalProbes) {
       this.id = id;
       this.location = location;
+      this.source = source;
       this.evaluateAt = evaluateAt;
       this.script = script;
       this.additionalProbes = additionalProbes;
@@ -377,6 +389,10 @@ public class Snapshot {
 
     public ProbeLocation getLocation() {
       return location;
+    }
+
+    public ProbeSource getSource() {
+      return source;
     }
 
     public MethodLocation getEvaluateAt() {
@@ -402,13 +418,15 @@ public class Snapshot {
       ProbeDetails that = (ProbeDetails) o;
       return Objects.equals(id, that.id)
           && Objects.equals(location, that.location)
+          && Objects.equals(source, that.source)
+          && Objects.equals(evaluateAt, that.evaluateAt)
           && Objects.equals(script, that.script)
           && Objects.equals(tags, that.tags);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(id, location, script, tags);
+      return Objects.hash(id, location, source, evaluateAt, script, tags);
     }
 
     @Override
@@ -419,6 +437,8 @@ public class Snapshot {
           + '\''
           + ", probeLocation="
           + location
+          + ", probeSource="
+          + source
           + ", script="
           + script
           + ", tags="
@@ -491,6 +511,43 @@ public class Snapshot {
           + ", lines="
           + lines
           + '}';
+    }
+  }
+
+  /** Probe source information used in ProbeDetails class */
+  public static class ProbeSource {
+    private final String config;
+    private final long version;
+
+    public ProbeSource(String config, long version) {
+      this.config = config;
+      this.version = version;
+    }
+
+    public String getConfig() {
+      return config;
+    }
+
+    public long getVerison() {
+      return version;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      ProbeSource that = (ProbeSource) o;
+      return Objects.equals(config, that.config) && version == that.version;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(config, version);
+    }
+
+    @Override
+    public String toString() {
+      return "ProbeSource{" + "config='" + config + '\'' + ", version=" + version + '}';
     }
   }
 

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/test/java/datadog/trace/bootstrap/debugger/SnapshotSummaryTest.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/test/java/datadog/trace/bootstrap/debugger/SnapshotSummaryTest.java
@@ -30,7 +30,7 @@ public class SnapshotSummaryTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new ProbeDetails(UUID.randomUUID().toString(), PROBE_LOCATION),
+            new ProbeDetails(UUID.randomUUID().toString(), PROBE_LOCATION, null),
             CLASS_NAME);
     assertEquals("SomeClass.someMethod()", snapshot.getSummary());
   }
@@ -40,7 +40,7 @@ public class SnapshotSummaryTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new ProbeDetails(UUID.randomUUID().toString(), PROBE_LOCATION),
+            new ProbeDetails(UUID.randomUUID().toString(), PROBE_LOCATION, null),
             CLASS_NAME);
     CapturedContext entry = new CapturedContext();
     HashMap<String, String> argMap = new HashMap<>();
@@ -70,7 +70,7 @@ public class SnapshotSummaryTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new ProbeDetails(UUID.randomUUID().toString(), PROBE_LOCATION),
+            new ProbeDetails(UUID.randomUUID().toString(), PROBE_LOCATION, null),
             CLASS_NAME);
     CapturedContext entry = new CapturedContext();
     entry.addArguments(
@@ -104,7 +104,7 @@ public class SnapshotSummaryTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new ProbeDetails(UUID.randomUUID().toString(), PROBE_LOCATION),
+            new ProbeDetails(UUID.randomUUID().toString(), PROBE_LOCATION, null),
             CLASS_NAME);
     StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
     // top frame is actually getStackTrace, we want the test method
@@ -154,7 +154,7 @@ public class SnapshotSummaryTest {
         new ProbeLocation(null, null, "SomeFile", Collections.singletonList("13"));
     // if the line probe had a stacktrace we would use the method information from the stacktrace
     Snapshot snapshot =
-        new Snapshot(Thread.currentThread(), new ProbeDetails("id", location), CLASS_NAME);
+        new Snapshot(Thread.currentThread(), new ProbeDetails("id", location, null), CLASS_NAME);
 
     CapturedContext lineCapture = new CapturedContext();
     lineCapture.addLocals(new Snapshot.CapturedValue[] {});

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/test/java/datadog/trace/bootstrap/debugger/SnapshotSummaryTest.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/test/java/datadog/trace/bootstrap/debugger/SnapshotSummaryTest.java
@@ -30,7 +30,7 @@ public class SnapshotSummaryTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new ProbeDetails(UUID.randomUUID().toString(), PROBE_LOCATION, null),
+            new ProbeDetails(UUID.randomUUID().toString(), 1L, PROBE_LOCATION),
             CLASS_NAME);
     assertEquals("SomeClass.someMethod()", snapshot.getSummary());
   }
@@ -40,7 +40,7 @@ public class SnapshotSummaryTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new ProbeDetails(UUID.randomUUID().toString(), PROBE_LOCATION, null),
+            new ProbeDetails(UUID.randomUUID().toString(), 1L, PROBE_LOCATION),
             CLASS_NAME);
     CapturedContext entry = new CapturedContext();
     HashMap<String, String> argMap = new HashMap<>();
@@ -70,7 +70,7 @@ public class SnapshotSummaryTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new ProbeDetails(UUID.randomUUID().toString(), PROBE_LOCATION, null),
+            new ProbeDetails(UUID.randomUUID().toString(), 1L, PROBE_LOCATION),
             CLASS_NAME);
     CapturedContext entry = new CapturedContext();
     entry.addArguments(
@@ -104,7 +104,7 @@ public class SnapshotSummaryTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new ProbeDetails(UUID.randomUUID().toString(), PROBE_LOCATION, null),
+            new ProbeDetails(UUID.randomUUID().toString(), 1L, PROBE_LOCATION),
             CLASS_NAME);
     StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
     // top frame is actually getStackTrace, we want the test method
@@ -154,7 +154,7 @@ public class SnapshotSummaryTest {
         new ProbeLocation(null, null, "SomeFile", Collections.singletonList("13"));
     // if the line probe had a stacktrace we would use the method information from the stacktrace
     Snapshot snapshot =
-        new Snapshot(Thread.currentThread(), new ProbeDetails("id", location, null), CLASS_NAME);
+        new Snapshot(Thread.currentThread(), new ProbeDetails("id", 1L, location), CLASS_NAME);
 
     CapturedContext lineCapture = new CapturedContext();
     lineCapture.addLocals(new Snapshot.CapturedValue[] {});

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/Configuration.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/Configuration.java
@@ -6,12 +6,9 @@ import com.datadog.debugger.probe.ProbeDefinition;
 import com.datadog.debugger.probe.SnapshotProbe;
 import com.datadog.debugger.probe.SpanProbe;
 import com.squareup.moshi.Json;
-import datadog.trace.bootstrap.debugger.Snapshot;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -71,7 +68,6 @@ public class Configuration {
   private final FilterList allowList;
   private final FilterList denyList;
   private final SnapshotProbe.Sampling sampling;
-  private final Map<String, Snapshot.ProbeSource> probesSource;
 
   public Configuration(String service) {
     this(service, null, null, null, null);
@@ -95,18 +91,6 @@ public class Configuration {
       FilterList allowList,
       FilterList denyList,
       SnapshotProbe.Sampling sampling) {
-    this(serviceName, snapshotProbes, metricProbes, logProbes, allowList, denyList, sampling, null);
-  }
-
-  public Configuration(
-      String serviceName,
-      Collection<SnapshotProbe> snapshotProbes,
-      Collection<MetricProbe> metricProbes,
-      Collection<LogProbe> logProbes,
-      FilterList allowList,
-      FilterList denyList,
-      SnapshotProbe.Sampling sampling,
-      Map<String, Snapshot.ProbeSource> probesSource) {
     this.service = serviceName;
     this.snapshotProbes = snapshotProbes;
     this.metricProbes = metricProbes;
@@ -115,7 +99,6 @@ public class Configuration {
     this.allowList = allowList;
     this.denyList = denyList;
     this.sampling = sampling;
-    this.probesSource = probesSource;
   }
 
   public String getService() {
@@ -167,17 +150,6 @@ public class Configuration {
     return result;
   }
 
-  public Map<String, Snapshot.ProbeSource> getProbesSource() {
-    return probesSource;
-  }
-
-  public Snapshot.ProbeSource getProbeSource(ProbeDefinition definition) {
-    if (probesSource == null) {
-      return null;
-    }
-    return probesSource.get(definition.getId());
-  }
-
   @Generated
   @Override
   public String toString() {
@@ -190,14 +162,14 @@ public class Configuration {
         + metricProbes
         + ", logProbes="
         + logProbes
+        + ", spanProbes="
+        + spanProbes
         + ", allowList="
         + allowList
         + ", denyList="
         + denyList
         + ", sampling="
         + sampling
-        + ", probesSource="
-        + probesSource
         + '}';
   }
 
@@ -211,10 +183,10 @@ public class Configuration {
         && Objects.equals(snapshotProbes, that.snapshotProbes)
         && Objects.equals(metricProbes, that.metricProbes)
         && Objects.equals(logProbes, that.logProbes)
+        && Objects.equals(spanProbes, that.spanProbes)
         && Objects.equals(allowList, that.allowList)
         && Objects.equals(denyList, that.denyList)
-        && Objects.equals(sampling, that.sampling)
-        && Objects.equals(probesSource, that.probesSource);
+        && Objects.equals(sampling, that.sampling);
   }
 
   @Generated
@@ -225,10 +197,10 @@ public class Configuration {
         snapshotProbes,
         metricProbes,
         logProbes,
+        spanProbes,
         allowList,
         denyList,
-        sampling,
-        probesSource);
+        sampling);
   }
 
   public static Configuration.Builder builder() {
@@ -244,63 +216,33 @@ public class Configuration {
     private FilterList allowList = null;
     private FilterList denyList = null;
     private SnapshotProbe.Sampling sampling = null;
-    private Map<String, Snapshot.ProbeSource> probesSource = null;
 
     public Configuration.Builder setService(String service) {
       this.service = service;
       return this;
     }
 
-    private void setProbeSource(ProbeDefinition probe, Snapshot.ProbeSource source) {
-      if (source == null) {
-        if (probesSource != null) {
-          probesSource.remove(probe.getId());
-        }
-        return;
-      }
-
-      if (probesSource == null) {
-        probesSource = new HashMap<>();
-      }
-      probesSource.put(probe.getId(), source);
-    }
-
     public Configuration.Builder add(SnapshotProbe probe) {
-      return this.add(probe, null);
-    }
-
-    public Configuration.Builder add(SnapshotProbe probe, Snapshot.ProbeSource source) {
       if (snapshotProbes == null) {
         snapshotProbes = new ArrayList<>();
       }
       snapshotProbes.add(probe);
-      setProbeSource(probe, source);
       return this;
     }
 
     public Configuration.Builder add(MetricProbe probe) {
-      return this.add(probe, null);
-    }
-
-    public Configuration.Builder add(MetricProbe probe, Snapshot.ProbeSource source) {
       if (metricProbes == null) {
         metricProbes = new ArrayList<>();
       }
       metricProbes.add(probe);
-      setProbeSource(probe, source);
       return this;
     }
 
     public Configuration.Builder add(LogProbe probe) {
-      return this.add(probe, null);
-    }
-
-    public Configuration.Builder add(LogProbe probe, Snapshot.ProbeSource source) {
       if (logProbes == null) {
         logProbes = new ArrayList<>();
       }
       logProbes.add(probe);
-      setProbeSource(probe, source);
       return this;
     }
 
@@ -320,46 +262,31 @@ public class Configuration {
     }
 
     public Configuration.Builder addSnapshotsProbes(Collection<SnapshotProbe> probes) {
-      return addSnapshotsProbes(probes, null);
-    }
-
-    public Configuration.Builder addSnapshotsProbes(
-        Collection<SnapshotProbe> probes, Snapshot.ProbeSource source) {
       if (probes == null) {
         return this;
       }
       for (SnapshotProbe probe : probes) {
-        add(probe, source);
+        add(probe);
       }
       return this;
     }
 
     public Configuration.Builder addMetricProbes(Collection<MetricProbe> probes) {
-      return addMetricProbes(probes, null);
-    }
-
-    public Configuration.Builder addMetricProbes(
-        Collection<MetricProbe> probes, Snapshot.ProbeSource source) {
       if (probes == null) {
         return this;
       }
       for (MetricProbe probe : probes) {
-        add(probe, source);
+        add(probe);
       }
       return this;
     }
 
     public Configuration.Builder addLogProbes(Collection<LogProbe> probes) {
-      return addLogProbes(probes, null);
-    }
-
-    public Configuration.Builder addLogProbes(
-        Collection<LogProbe> probes, Snapshot.ProbeSource source) {
       if (probes == null) {
         return this;
       }
       for (LogProbe probe : probes) {
-        add(probe, source);
+        add(probe);
       }
       return this;
     }
@@ -404,16 +331,13 @@ public class Configuration {
     }
 
     public Configuration.Builder add(Configuration other) {
-      return add(other, null);
-    }
-
-    public Configuration.Builder add(Configuration other, Snapshot.ProbeSource source) {
       if (other.service != null) {
         this.service = other.service;
       }
-      addSnapshotsProbes(other.getSnapshotProbes(), source);
-      addMetricProbes(other.getMetricProbes(), source);
-      addLogProbes(other.getLogProbes(), source);
+      addSnapshotsProbes(other.getSnapshotProbes());
+      addMetricProbes(other.getMetricProbes());
+      addLogProbes(other.getLogProbes());
+      addSpanProbes(other.getSpanProbes());
       addAllowList(other.getAllowList());
       addDenyList(other.getDenyList());
       add(other.getSampling());
@@ -429,8 +353,7 @@ public class Configuration {
           spanProbes,
           allowList,
           denyList,
-          sampling,
-          probesSource);
+          sampling);
     }
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationComparer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationComparer.java
@@ -103,7 +103,7 @@ public class ConfigurationComparer {
       LOGGER.debug(
           "instrumented class changed: {} for probe ids: {}",
           key,
-          definition.getAllProbeIds().collect(Collectors.toList()));
+          definition.getAllProbes().map((probe) -> probe.getId()).collect(Collectors.toList()));
       changedClasses.insert(reverseStr(key));
     }
     for (String typeName : changedBlockedTypes) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -136,7 +136,8 @@ public class ConfigurationUpdater
         spanProbes,
         configuration.getAllowList(),
         configuration.getDenyList(),
-        configuration.getSampling());
+        configuration.getSampling(),
+        configuration.getProbesSource());
   }
 
   private <E extends ProbeDefinition> Collection<E> filterProbes(
@@ -221,7 +222,7 @@ public class ConfigurationUpdater
           .setSampling(currentConfiguration.getSampling())
           .build();
     }
-    return Configuration.builder().setService(serviceName).build();
+    return new Configuration(serviceName);
   }
 
   private void retransformClasses(List<Class<?>> classesToBeTransformed) {
@@ -286,6 +287,7 @@ public class ConfigurationUpdater
     return new Snapshot.ProbeDetails(
         probe.getId(),
         location,
+        currentConfiguration.getProbeSource(probe),
         convertMethodLocation(probe.getEvaluateAt()),
         probeCondition,
         probe.concatTags(),

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -136,8 +136,7 @@ public class ConfigurationUpdater
         spanProbes,
         configuration.getAllowList(),
         configuration.getDenyList(),
-        configuration.getSampling(),
-        configuration.getProbesSource());
+        configuration.getSampling());
   }
 
   private <E extends ProbeDefinition> Collection<E> filterProbes(
@@ -183,10 +182,10 @@ public class ConfigurationUpdater
 
   private void reportReceived(ConfigurationComparer changes) {
     for (ProbeDefinition def : changes.getAddedDefinitions()) {
-      def.getAllProbeIds().forEach(sink::addReceived);
+      def.getAllProbes().forEach(sink::addReceived);
     }
     for (ProbeDefinition def : changes.getRemovedDefinitions()) {
-      def.getAllProbeIds().forEach(sink::removeDiagnostics);
+      def.getAllProbes().forEach(sink::removeDiagnostics);
     }
   }
 
@@ -207,9 +206,9 @@ public class ConfigurationUpdater
       ProbeDefinition definition, InstrumentationResult instrumentationResult) {
     instrumentationResults.put(definition.getId(), instrumentationResult);
     if (instrumentationResult.isInstalled()) {
-      definition.getAllProbeIds().forEach(sink::addInstalled);
+      definition.getAllProbes().forEach(sink::addInstalled);
     } else if (instrumentationResult.isBlocked()) {
-      definition.getAllProbeIds().forEach(sink::addBlocked);
+      definition.getAllProbes().forEach(sink::addBlocked);
     }
   }
 
@@ -286,14 +285,14 @@ public class ConfigurationUpdater
     }
     return new Snapshot.ProbeDetails(
         probe.getId(),
+        probe.getVersion(),
         location,
-        currentConfiguration.getProbeSource(probe),
         convertMethodLocation(probe.getEvaluateAt()),
         probeCondition,
         probe.concatTags(),
         summaryBuilder,
         probe.getAdditionalProbes().stream()
-            .map(relatedProbe -> convertToProbeDetails(((SnapshotProbe) relatedProbe), location))
+            .map(relatedProbe -> convertToProbeDetails(relatedProbe, location))
             .collect(Collectors.toList()));
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -331,7 +331,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
             fullyQualifiedClassName,
             methodNode.name,
             methodNode.desc,
-            definition.getAllProbeIds().collect(Collectors.toList()));
+            definition.getAllProbes().map((probe)->probe.getId()).collect(Collectors.toList()));
         InstrumentationResult result =
             applyInstrumentation(loader, classNode, definition, methodNode);
         transformed |= result.isInstalled();
@@ -339,7 +339,8 @@ public class DebuggerTransformer implements ClassFileTransformer {
           listener.instrumentationResult(definition, result);
         }
         if (!result.getDiagnostics().isEmpty()) {
-          DebuggerContext.reportDiagnostics(definition.getId(), result.getDiagnostics());
+          DebuggerContext.reportDiagnostics(
+              definition.getId(), definition.getVersion(), result.getDiagnostics());
         }
       }
     }
@@ -359,7 +360,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
     String msg = String.format(format, className, location);
     DiagnosticMessage diagnosticMessage = new DiagnosticMessage(DiagnosticMessage.Kind.ERROR, msg);
     DebuggerContext.reportDiagnostics(
-        definition.getId(), Collections.singletonList(diagnosticMessage));
+        definition.getId(), definition.getVersion(), Collections.singletonList(diagnosticMessage));
     log.debug("{} for definition: {}", msg, definition);
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ProbeStatus.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ProbeStatus.java
@@ -105,18 +105,24 @@ public class ProbeStatus {
   /** Stores status information for a probe */
   public static class Diagnostics {
     private final String probeId;
+    private final Long probeVersion;
     private final Status status;
 
     private final ProbeException exception;
 
-    public Diagnostics(String probeId, Status status, ProbeException exception) {
+    public Diagnostics(String probeId, Long probeVersion, Status status, ProbeException exception) {
       this.probeId = probeId;
+      this.probeVersion = probeVersion;
       this.status = status;
       this.exception = exception;
     }
 
     public String getProbeId() {
       return probeId;
+    }
+
+    public Long getProbeVersion() {
+      return probeVersion;
     }
 
     public Status getStatus() {
@@ -134,6 +140,7 @@ public class ProbeStatus {
       if (o == null || getClass() != o.getClass()) return false;
       Diagnostics that = (Diagnostics) o;
       return probeId.equals(that.probeId)
+          && Objects.equals(probeVersion, that.probeVersion)
           && status == that.status
           && Objects.equals(exception, that.exception);
     }
@@ -141,7 +148,7 @@ public class ProbeStatus {
     @Generated
     @Override
     public int hashCode() {
-      return Objects.hash(probeId, status, exception);
+      return Objects.hash(probeId, probeVersion, status, exception);
     }
 
     @Generated
@@ -150,7 +157,8 @@ public class ProbeStatus {
       return "Diagnostics{"
           + "probeId='"
           + probeId
-          + '\''
+          + "', probeVerison="
+          + probeVersion
           + ", status="
           + status
           + ", exception="
@@ -233,33 +241,34 @@ public class ProbeStatus {
       this.serviceName = TagsHelper.sanitize(config.getServiceName());
     }
 
-    public ProbeStatus receivedMessage(String probeId) {
+    public ProbeStatus receivedMessage(String probeId, Long probeVersion) {
       return new ProbeStatus(
           this.serviceName,
-          "Received probe " + probeId + ".",
-          new Diagnostics(probeId, Status.RECEIVED, null));
+          "Received probe " + probeId + " (version: " + probeVersion + ").",
+          new Diagnostics(probeId, probeVersion, Status.RECEIVED, null));
     }
 
-    public ProbeStatus installedMessage(String probeId) {
+    public ProbeStatus installedMessage(String probeId, Long probeVersion) {
       return new ProbeStatus(
           this.serviceName,
-          "Installed probe " + probeId + ".",
-          new Diagnostics(probeId, Status.INSTALLED, null));
+          "Installed probe " + probeId + " (version: " + probeVersion + ").",
+          new Diagnostics(probeId, probeVersion, Status.INSTALLED, null));
     }
 
-    public ProbeStatus blockedMessage(String probeId) {
+    public ProbeStatus blockedMessage(String probeId, Long probeVersion) {
       return new ProbeStatus(
           this.serviceName,
-          "Blocked probe " + probeId + ".",
-          new Diagnostics(probeId, Status.BLOCKED, null));
+          "Blocked probe " + probeId + " (version: " + probeVersion + ").",
+          new Diagnostics(probeId, probeVersion, Status.BLOCKED, null));
     }
 
-    public ProbeStatus errorMessage(String probeId, Throwable ex) {
+    public ProbeStatus errorMessage(String probeId, Long probeVersion, Throwable ex) {
       return new ProbeStatus(
           this.serviceName,
-          "Error installing probe " + probeId + ".",
+          "Error installing probe " + probeId + " (version: " + probeVersion + ").",
           new Diagnostics(
               probeId,
+              probeVersion,
               Status.ERROR,
               new ProbeException(
                   ex.getClass().getTypeName(),
@@ -269,12 +278,13 @@ public class ProbeStatus {
                       .collect(Collectors.toList()))));
     }
 
-    public ProbeStatus errorMessage(String probeId, String message) {
+    public ProbeStatus errorMessage(String probeId, Long probeVersion, String message) {
       return new ProbeStatus(
           this.serviceName,
-          "Error installing probe " + probeId + ".",
+          "Error installing probe " + probeId + " (version: " + probeVersion + ").",
           new Diagnostics(
               probeId,
+              probeVersion,
               Status.ERROR,
               new ProbeException("NO_TYPE", message, Collections.emptyList())));
     }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -116,19 +116,20 @@ public class LogProbe extends ProbeDefinition {
   // no-arg constructor is required by Moshi to avoid creating instance with unsafe and by-passing
   // constructors, including field initializers.
   public LogProbe() {
-    this(LANGUAGE, null, true, null, null, MethodLocation.DEFAULT, null, new ArrayList<>());
+    this(LANGUAGE, null, null, true, null, null, MethodLocation.DEFAULT, null, new ArrayList<>());
   }
 
   public LogProbe(
       String language,
       String id,
+      Long version,
       boolean active,
       String[] tagStrs,
       Where where,
       MethodLocation evaluateAt,
       String template,
       List<Segment> segments) {
-    super(language, id, active, tagStrs, where, evaluateAt);
+    super(language, id, version, active, tagStrs, where, evaluateAt);
     this.template = template;
     this.segments = segments;
   }
@@ -170,7 +171,8 @@ public class LogProbe extends ProbeDefinition {
   @Generated
   @Override
   public int hashCode() {
-    int result = Objects.hash(language, id, active, tagMap, where, evaluateAt, template, segments);
+    int result =
+        Objects.hash(language, id, version, active, tagMap, where, evaluateAt, template, segments);
     result = 31 * result + Arrays.hashCode(tags);
     return result;
   }
@@ -181,10 +183,10 @@ public class LogProbe extends ProbeDefinition {
     return "LogProbe{"
         + "language='"
         + language
-        + '\''
-        + ", id='"
+        + "', id='"
         + id
-        + '\''
+        + "', version="
+        + version
         + ", active="
         + active
         + ", tags="
@@ -197,8 +199,7 @@ public class LogProbe extends ProbeDefinition {
         + evaluateAt
         + ", template='"
         + template
-        + '\''
-        + ", segments="
+        + "', segments="
         + segments
         + "} ";
   }
@@ -219,7 +220,7 @@ public class LogProbe extends ProbeDefinition {
 
     public LogProbe build() {
       return new LogProbe(
-          language, probeId, active, tagStrs, where, evaluateAt, template, segments);
+          language, probeId, version, active, tagStrs, where, evaluateAt, template, segments);
     }
 
     private static List<Segment> parseTemplate(String template) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/MetricProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/MetricProbe.java
@@ -26,12 +26,23 @@ public class MetricProbe extends ProbeDefinition {
   // no-arg constructor is required by Moshi to avoid creating instance with unsafe and by-passing
   // constructors, including field initializers.
   public MetricProbe() {
-    this(LANGUAGE, null, true, null, null, MethodLocation.DEFAULT, MetricKind.COUNT, null, null);
+    this(
+        LANGUAGE,
+        null,
+        null,
+        true,
+        null,
+        null,
+        MethodLocation.DEFAULT,
+        MetricKind.COUNT,
+        null,
+        null);
   }
 
   public MetricProbe(
       String language,
       String probeId,
+      Long version,
       boolean active,
       String[] tagStrs,
       Where where,
@@ -39,7 +50,7 @@ public class MetricProbe extends ProbeDefinition {
       MetricKind kind,
       String metricName,
       ValueScript value) {
-    super(language, probeId, active, tagStrs, where, evaluateAt);
+    super(language, probeId, version, active, tagStrs, where, evaluateAt);
     this.kind = kind;
     this.metricName = metricName;
     this.value = value;
@@ -92,7 +103,16 @@ public class MetricProbe extends ProbeDefinition {
 
     public MetricProbe build() {
       return new MetricProbe(
-          language, probeId, active, tagStrs, where, evaluateAt, kind, metricName, valueScript);
+          language,
+          probeId,
+          version,
+          active,
+          tagStrs,
+          where,
+          evaluateAt,
+          kind,
+          metricName,
+          valueScript);
     }
   }
 
@@ -105,6 +125,7 @@ public class MetricProbe extends ProbeDefinition {
     return active == that.active
         && Objects.equals(language, that.language)
         && Objects.equals(id, that.id)
+        && Objects.equals(version, that.version)
         && Arrays.equals(tags, that.tags)
         && Objects.equals(tagMap, that.tagMap)
         && Objects.equals(where, that.where)
@@ -118,7 +139,8 @@ public class MetricProbe extends ProbeDefinition {
   @Override
   public int hashCode() {
     int result =
-        Objects.hash(language, id, active, tagMap, where, evaluateAt, kind, metricName, value);
+        Objects.hash(
+            language, id, version, active, tagMap, where, evaluateAt, kind, metricName, value);
     result = 31 * result + Arrays.hashCode(tags);
     return result;
   }
@@ -129,10 +151,10 @@ public class MetricProbe extends ProbeDefinition {
     return "MetricProbe{"
         + "language='"
         + language
-        + '\''
-        + ", id='"
+        + "', id='"
         + id
-        + '\''
+        + "', version="
+        + version
         + ", active="
         + active
         + ", tags="
@@ -149,7 +171,6 @@ public class MetricProbe extends ProbeDefinition {
         + metricName
         + ", valueScript='"
         + value
-        + '\''
-        + "} ";
+        + "'} ";
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
@@ -28,6 +28,8 @@ public abstract class ProbeDefinition {
 
   protected final String language;
   protected final String id;
+  // transient for no serialization and Long type, as null used for unknown-version
+  protected transient Long version = null;
   protected final boolean active;
   protected final Tag[] tags;
   protected final Map<String, String> tagMap = new HashMap<>();
@@ -43,6 +45,17 @@ public abstract class ProbeDefinition {
       String[] tagStrs,
       Where where,
       MethodLocation evaluateAt) {
+    this(language, id, null, active, tagStrs, where, evaluateAt);
+  }
+
+  public ProbeDefinition(
+      String language,
+      String id,
+      Long version,
+      boolean active,
+      String[] tagStrs,
+      Where where,
+      MethodLocation evaluateAt) {
     this.language = language;
     this.id = id;
     this.active = active;
@@ -50,10 +63,19 @@ public abstract class ProbeDefinition {
     initTagMap(tagMap, tags);
     this.where = where;
     this.evaluateAt = evaluateAt;
+    this.version = version;
   }
 
   public String getId() {
     return id;
+  }
+
+  public Long getVersion() {
+    return version;
+  }
+
+  public void setVersion(long version) {
+    this.version = version;
   }
 
   public String getLanguage() {
@@ -102,9 +124,8 @@ public abstract class ProbeDefinition {
     return additionalProbes;
   }
 
-  public Stream<String> getAllProbeIds() {
-    return Stream.concat(Stream.of(this), getAdditionalProbes().stream())
-        .map(ProbeDefinition::getId);
+  public Stream<ProbeDefinition> getAllProbes() {
+    return Stream.concat(Stream.of(this), getAdditionalProbes().stream());
   }
 
   private static void initTagMap(Map<String, String> tagMap, Tag[] tags) {
@@ -129,6 +150,7 @@ public abstract class ProbeDefinition {
     protected String[] tagStrs;
     protected Where where;
     protected MethodLocation evaluateAt = MethodLocation.DEFAULT;
+    protected Long version = null;
 
     public T language(String language) {
       this.language = language;
@@ -137,6 +159,11 @@ public abstract class ProbeDefinition {
 
     public T probeId(String probeId) {
       this.probeId = probeId;
+      return (T) this;
+    }
+
+    public T version(long version) {
+      this.version = version;
       return (T) this;
     }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SnapshotProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SnapshotProbe.java
@@ -9,7 +9,6 @@ import datadog.trace.bootstrap.debugger.Limits;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.MethodNode;
 
@@ -109,9 +108,16 @@ public class SnapshotProbe extends ProbeDefinition {
   private final Capture capture;
   private final Sampling sampling;
 
+  // no-arg constructor is required by Moshi to avoid creating instance with unsafe and by-passing
+  // constructors, including field initializers.
+  public SnapshotProbe() {
+    this(LANGUAGE, null, null, true, null, null, MethodLocation.DEFAULT, null, null, null);
+  }
+
   public SnapshotProbe(
       String language,
       String probeId,
+      Long version,
       boolean active,
       String[] tagStrs,
       Where where,
@@ -119,23 +125,10 @@ public class SnapshotProbe extends ProbeDefinition {
       ProbeCondition probeCondition,
       Capture capture,
       Sampling sampling) {
-    super(language, probeId, active, tagStrs, where, evaluateAt);
+    super(language, probeId, version, active, tagStrs, where, evaluateAt);
     this.probeCondition = probeCondition;
     this.capture = capture;
     this.sampling = sampling != null ? sampling : new Sampling(1.0);
-  }
-
-  public SnapshotProbe() {
-    this(
-        LANGUAGE,
-        UUID.randomUUID().toString(),
-        true,
-        null,
-        new Where(),
-        MethodLocation.DEFAULT,
-        null,
-        null,
-        null);
   }
 
   public static Builder builder() {
@@ -194,7 +187,16 @@ public class SnapshotProbe extends ProbeDefinition {
 
     public SnapshotProbe build() {
       return new SnapshotProbe(
-          language, probeId, active, tagStrs, where, evaluateAt, probeCondition, capture, sampling);
+          language,
+          probeId,
+          version,
+          active,
+          tagStrs,
+          where,
+          evaluateAt,
+          probeCondition,
+          capture,
+          sampling);
     }
   }
 
@@ -204,10 +206,10 @@ public class SnapshotProbe extends ProbeDefinition {
     return "DebuggerProbe{"
         + "language='"
         + language
-        + '\''
-        + ", id='"
+        + "', id='"
         + id
-        + '\''
+        + "', version='"
+        + version
         + ", active="
         + active
         + ", where="
@@ -238,6 +240,7 @@ public class SnapshotProbe extends ProbeDefinition {
     return active == that.active
         && Objects.equals(language, that.language)
         && Objects.equals(id, that.id)
+        && Objects.equals(version, that.version)
         && Objects.equals(where, that.where)
         && Objects.equals(evaluateAt, that.evaluateAt)
         && Objects.equals(probeCondition, that.probeCondition)
@@ -255,6 +258,7 @@ public class SnapshotProbe extends ProbeDefinition {
         Objects.hash(
             language,
             id,
+            version,
             active,
             where,
             evaluateAt,

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanProbe.java
@@ -13,12 +13,18 @@ public class SpanProbe extends ProbeDefinition {
   // no-arg constructor is required by Moshi to avoid creating instance with unsafe and by-passing
   // constructors, including field initializers.
   public SpanProbe() {
-    this(LANGUAGE, null, true, null, null, null);
+    this(LANGUAGE, null, null, true, null, null, null);
   }
 
   public SpanProbe(
-      String language, String id, boolean active, String[] tagStrs, Where where, String name) {
-    super(language, id, active, tagStrs, where, MethodLocation.DEFAULT);
+      String language,
+      String id,
+      Long version,
+      boolean active,
+      String[] tagStrs,
+      Where where,
+      String name) {
+    super(language, id, version, active, tagStrs, where, MethodLocation.DEFAULT);
     this.name = name;
   }
 
@@ -36,7 +42,7 @@ public class SpanProbe extends ProbeDefinition {
   @Generated
   @Override
   public int hashCode() {
-    int result = Objects.hash(language, id, active, tagMap, where, evaluateAt, name);
+    int result = Objects.hash(language, id, version, active, tagMap, where, evaluateAt, name);
     result = 31 * result + Arrays.hashCode(tags);
     return result;
   }
@@ -50,6 +56,7 @@ public class SpanProbe extends ProbeDefinition {
     return active == that.active
         && Objects.equals(language, that.language)
         && Objects.equals(id, that.id)
+        && Objects.equals(version, that.version)
         && Arrays.equals(tags, that.tags)
         && Objects.equals(tagMap, that.tagMap)
         && Objects.equals(where, that.where)
@@ -63,10 +70,10 @@ public class SpanProbe extends ProbeDefinition {
     return "SpanProbe{"
         + "language='"
         + language
-        + '\''
-        + ", id='"
+        + "', id='"
         + id
-        + '\''
+        + "', version="
+        + version
         + ", active="
         + active
         + ", tags="
@@ -95,7 +102,7 @@ public class SpanProbe extends ProbeDefinition {
     }
 
     public SpanProbe build() {
-      return new SpanProbe(LANGUAGE, probeId, active, tagStrs, where, name);
+      return new SpanProbe(LANGUAGE, probeId, version, active, tagStrs, where, name);
     }
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.sink;
 
 import com.datadog.debugger.agent.DebuggerAgent;
+import com.datadog.debugger.probe.ProbeDefinition;
 import com.datadog.debugger.uploader.BatchUploader;
 import com.datadog.debugger.util.DebuggerMetrics;
 import datadog.trace.api.Config;
@@ -205,24 +206,24 @@ public class DebuggerSink implements DebuggerContext.Sink {
     }
   }
 
-  public void addReceived(String probeId) {
-    probeStatusSink.addReceived(probeId);
+  public void addReceived(ProbeDefinition probe) {
+    probeStatusSink.addReceived(probe.getId(), probe.getVersion());
   }
 
-  public void addInstalled(String probeId) {
-    probeStatusSink.addInstalled(probeId);
+  public void addInstalled(ProbeDefinition probe) {
+    probeStatusSink.addInstalled(probe.getId(), probe.getVersion());
   }
 
-  public void addBlocked(String probeId) {
-    probeStatusSink.addBlocked(probeId);
+  public void addBlocked(ProbeDefinition probe) {
+    probeStatusSink.addBlocked(probe.getId(), probe.getVersion());
   }
 
-  public void removeDiagnostics(String probeId) {
-    probeStatusSink.removeDiagnostics(probeId);
+  public void removeDiagnostics(ProbeDefinition probe) {
+    probeStatusSink.removeDiagnostics(probe.getId());
   }
 
   @Override
-  public void addDiagnostics(String probeId, List<DiagnosticMessage> messages) {
+  public void addDiagnostics(String probeId, Long probeVersion, List<DiagnosticMessage> messages) {
     for (DiagnosticMessage msg : messages) {
       switch (msg.getKind()) {
         case INFO:
@@ -233,18 +234,18 @@ public class DebuggerSink implements DebuggerContext.Sink {
           break;
         case ERROR:
           log.error(msg.getMessage());
-          reportError(probeId, msg);
+          reportError(probeId, probeVersion, msg);
           break;
       }
     }
   }
 
-  private void reportError(String probeId, DiagnosticMessage msg) {
+  private void reportError(String probeId, Long probeVersion, DiagnosticMessage msg) {
     Throwable throwable = msg.getThrowable();
     if (throwable != null) {
-      probeStatusSink.addError(probeId, throwable);
+      probeStatusSink.addError(probeId, probeVersion, throwable);
     } else {
-      probeStatusSink.addError(probeId, msg.getMessage());
+      probeStatusSink.addError(probeId, probeVersion, msg.getMessage());
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
@@ -40,24 +40,24 @@ public class ProbeStatusSink {
     this.isInstrumentTheWorld = config.isDebuggerInstrumentTheWorld();
   }
 
-  public void addReceived(String probeId) {
-    addDiagnostics(messageBuilder.receivedMessage(probeId));
+  public void addReceived(String probeId, Long probeVersion) {
+    addDiagnostics(messageBuilder.receivedMessage(probeId, probeVersion));
   }
 
-  public void addInstalled(String probeId) {
-    addDiagnostics(messageBuilder.installedMessage(probeId));
+  public void addInstalled(String probeId, Long probeVersion) {
+    addDiagnostics(messageBuilder.installedMessage(probeId, probeVersion));
   }
 
-  public void addBlocked(String probeId) {
-    addDiagnostics(messageBuilder.blockedMessage(probeId));
+  public void addBlocked(String probeId, Long probeVersion) {
+    addDiagnostics(messageBuilder.blockedMessage(probeId, probeVersion));
   }
 
-  public void addError(String probeId, Throwable ex) {
-    addDiagnostics(messageBuilder.errorMessage(probeId, ex));
+  public void addError(String probeId, Long probeVersion, Throwable ex) {
+    addDiagnostics(messageBuilder.errorMessage(probeId, probeVersion, ex));
   }
 
-  public void addError(String probeId, String message) {
-    addDiagnostics(messageBuilder.errorMessage(probeId, message));
+  public void addError(String probeId, Long probeVersion, String message) {
+    addDiagnostics(messageBuilder.errorMessage(probeId, probeVersion, message));
   }
 
   public List<String> getSerializedDiagnostics() {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1330,8 +1330,8 @@ public class CapturedSnapshotTest {
 
         return new Snapshot.ProbeDetails(
             id,
+            probe.getVersion(),
             location,
-            null,
             Snapshot.MethodLocation.DEFAULT,
             probe.getProbeCondition(),
             probe.concatTags(),
@@ -1341,8 +1341,8 @@ public class CapturedSnapshotTest {
                     (ProbeDefinition relatedProbe) ->
                         new Snapshot.ProbeDetails(
                             relatedProbe.getId(),
+                            relatedProbe.getVersion(),
                             location,
-                            null,
                             Snapshot.MethodLocation.DEFAULT,
                             ((SnapshotProbe) relatedProbe).getProbeCondition(),
                             relatedProbe.concatTags(),

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1331,6 +1331,7 @@ public class CapturedSnapshotTest {
         return new Snapshot.ProbeDetails(
             id,
             location,
+            null,
             Snapshot.MethodLocation.DEFAULT,
             probe.getProbeCondition(),
             probe.concatTags(),
@@ -1341,6 +1342,7 @@ public class CapturedSnapshotTest {
                         new Snapshot.ProbeDetails(
                             relatedProbe.getId(),
                             location,
+                            null,
                             Snapshot.MethodLocation.DEFAULT,
                             ((SnapshotProbe) relatedProbe).getProbeCondition(),
                             relatedProbe.concatTags(),

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationComparerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationComparerTest.java
@@ -439,6 +439,9 @@ class ConfigurationComparerTest {
   }
 
   private static Configuration createConfig(List<SnapshotProbe> snapshotProbes) {
-    return new Configuration(SERVICE_NAME, snapshotProbes);
+    return Configuration.builder()
+        .setService(SERVICE_NAME)
+        .addSnapshotsProbes(snapshotProbes)
+        .build();
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
@@ -161,7 +161,7 @@ public class ConfigurationTest {
     SnapshotProbe snapshotProbe1 = config0.getSnapshotProbes().iterator().next();
     assertEquals("java.lang.String", snapshotProbe1.getWhere().getTypeName());
     assertEquals(ProbeDefinition.MethodLocation.ENTRY, snapshotProbe1.getEvaluateAt());
-    assertEquals(1, snapshotProbe1.getAllProbeIds().count());
+    assertEquals(1, snapshotProbe1.getAllProbes().count());
     assertEquals(2, snapshotProbe1.getTags().length);
     assertEquals("tag1:value1", snapshotProbe1.getTags()[0].toString());
     assertEquals("tag2:value2", snapshotProbe1.getTags()[1].toString());
@@ -177,7 +177,7 @@ public class ConfigurationTest {
     assertEquals("metric_count", metricProbe1.getMetricName());
     assertEquals(COUNT, metricProbe1.getKind());
     assertEquals(0, metricProbe1.getAdditionalProbes().size());
-    assertEquals(1, metricProbe1.getAllProbeIds().count());
+    assertEquals(1, metricProbe1.getAllProbes().count());
     // log probe
     assertEquals(1, config0.getLogProbes().size());
     LogProbe logProbe1 = config0.getLogProbes().iterator().next();

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
@@ -730,7 +730,7 @@ public class ConfigurationUpdaterTest {
   private static Configuration createApp(List<SnapshotProbe> snapshotProbes) {
     return Configuration.builder()
         .setService(SERVICE_NAME)
-        .addSnapshotsProbes(snapshotProbes)
+        .addSnapshotsProbes(snapshotProbes, null)
         .build();
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
@@ -102,7 +102,8 @@ public class DebuggerTransformerTest {
     }
 
     @Override
-    public void addDiagnostics(String probeId, List<DiagnosticMessage> messages) {
+    public void addDiagnostics(
+        String probeId, Long probeVersion, List<DiagnosticMessage> messages) {
       errors.computeIfAbsent(probeId, k -> new ArrayList<>()).addAll(messages);
     }
   }
@@ -465,7 +466,7 @@ public class DebuggerTransformerTest {
                       .collect(Collectors.toList())
                   : null;
           return new Snapshot.ProbeDetails(
-              id, new Snapshot.ProbeLocation(typeName, methodName, sourceFile, lines), null);
+              id, 1L, new Snapshot.ProbeLocation(typeName, methodName, sourceFile, lines));
         },
         null);
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
@@ -41,7 +41,6 @@ import java.net.URL;
 import java.security.ProtectionDomain;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -117,10 +116,7 @@ public class DebuggerTransformerTest {
       assertTrue(codeOutput != null && codeOutput.length == 2);
       this.targetClassName = targetClassName;
       this.delegate =
-          new DebuggerTransformer(
-              Config.get(),
-              new Configuration(SERVICE_NAME, Collections.singletonList(probe)),
-              null);
+          new DebuggerTransformer(Config.get(), Configuration.builder().add(probe).build(), null);
       this.codeOutput = codeOutput;
     }
 
@@ -240,10 +236,7 @@ public class DebuggerTransformerTest {
     SnapshotProbe snapshotProbe =
         SnapshotProbe.builder().where("java.util.ArrayList", "add").build();
     DebuggerTransformer debuggerTransformer =
-        new DebuggerTransformer(
-            config,
-            new Configuration(SERVICE_NAME, Collections.singletonList(snapshotProbe)),
-            null);
+        new DebuggerTransformer(config, Configuration.builder().add(snapshotProbe).build(), null);
     debuggerTransformer.transform(
         ClassLoader.getSystemClassLoader(),
         "java.util.ArrayList",
@@ -284,7 +277,8 @@ public class DebuggerTransformerTest {
               .build();
       snapshotProbes.add(snapshotProbe);
     }
-    Configuration configuration = new Configuration(SERVICE_NAME, snapshotProbes);
+    Configuration configuration =
+        Configuration.builder().setService(SERVICE_NAME).addSnapshotsProbes(snapshotProbes).build();
     DebuggerTransformer debuggerTransformer = new DebuggerTransformer(config, configuration);
     for (ProbeTestInfo probeInfo : probeInfos) {
       byte[] newClassBuffer =
@@ -339,7 +333,8 @@ public class DebuggerTransformerTest {
                 .active(false)
                 .where("java.util.HashMap", "<init>", "void ()")
                 .build());
-    Configuration configuration = new Configuration(SERVICE_NAME, snapshotProbes);
+    Configuration configuration =
+        Configuration.builder().setService(SERVICE_NAME).addSnapshotsProbes(snapshotProbes).build();
     DebuggerTransformer debuggerTransformer = new DebuggerTransformer(config, configuration);
     byte[] newClassBuffer =
         debuggerTransformer.transform(
@@ -370,7 +365,8 @@ public class DebuggerTransformerTest {
                 .active(true)
                 .where("java.lang.String", "toString")
                 .build());
-    Configuration configuration = new Configuration(SERVICE_NAME, snapshotProbes);
+    Configuration configuration =
+        Configuration.builder().setService(SERVICE_NAME).addSnapshotsProbes(snapshotProbes).build();
     AtomicReference<InstrumentationResult> lastResult = new AtomicReference<>(null);
     DebuggerTransformer debuggerTransformer =
         new DebuggerTransformer(
@@ -394,7 +390,7 @@ public class DebuggerTransformerTest {
     Config config = mock(Config.class);
     SnapshotProbe snapshotProbe = SnapshotProbe.builder().where("ArrayList", "add").build();
     Configuration configuration =
-        new Configuration(SERVICE_NAME, Collections.singletonList(snapshotProbe));
+        Configuration.builder().setService(SERVICE_NAME).add(snapshotProbe).build();
     AtomicReference<InstrumentationResult> lastResult = new AtomicReference<>(null);
     DebuggerTransformer debuggerTransformer =
         new DebuggerTransformer(
@@ -469,7 +465,7 @@ public class DebuggerTransformerTest {
                       .collect(Collectors.toList())
                   : null;
           return new Snapshot.ProbeDetails(
-              id, new Snapshot.ProbeLocation(typeName, methodName, sourceFile, lines));
+              id, new Snapshot.ProbeLocation(typeName, methodName, sourceFile, lines), null);
         },
         null);
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -256,6 +256,7 @@ public class LogProbesInstrumentationTest {
         return new Snapshot.ProbeDetails(
             id,
             location,
+            null,
             Snapshot.MethodLocation.DEFAULT,
             null,
             probe.concatTags(),
@@ -266,6 +267,7 @@ public class LogProbesInstrumentationTest {
                         new Snapshot.ProbeDetails(
                             relatedProbe.getId(),
                             location,
+                            null,
                             Snapshot.MethodLocation.DEFAULT,
                             relatedProbe instanceof SnapshotProbe
                                 ? ((SnapshotProbe) relatedProbe).getProbeCondition()

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -255,8 +255,8 @@ public class LogProbesInstrumentationTest {
 
         return new Snapshot.ProbeDetails(
             id,
+            probe.getVersion(),
             location,
-            null,
             Snapshot.MethodLocation.DEFAULT,
             null,
             probe.concatTags(),
@@ -266,8 +266,8 @@ public class LogProbesInstrumentationTest {
                     (ProbeDefinition relatedProbe) ->
                         new Snapshot.ProbeDetails(
                             relatedProbe.getId(),
+                            relatedProbe.getVersion(),
                             location,
-                            null,
                             Snapshot.MethodLocation.DEFAULT,
                             relatedProbe instanceof SnapshotProbe
                                 ? ((SnapshotProbe) relatedProbe).getProbeCondition()

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
@@ -785,7 +785,8 @@ public class MetricProbesInstrumentationTest {
     public void addSnapshot(Snapshot snapshot) {}
 
     @Override
-    public void addDiagnostics(String probeId, List<DiagnosticMessage> messages) {
+    public void addDiagnostics(
+        String probeId, Long probeVersion, List<DiagnosticMessage> messages) {
       for (DiagnosticMessage msg : messages) {
         System.out.println(msg);
       }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ProbeStatusTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ProbeStatusTest.java
@@ -24,9 +24,11 @@ class ProbeStatusTest {
 
   private static final String SERVICE_NAME = "service-name";
   private static final String PROBE_ID = "probe-id";
-  private static final String RECEIVED_MESSAGE = "Received probe " + PROBE_ID + ".";
-  private static final String INSTALLED_MESSAGE = "Installed probe " + PROBE_ID + ".";
-  private static final String ERROR_MESSAGE = "Error installing probe " + PROBE_ID + ".";
+
+  private static final String RECEIVED_MESSAGE = "Received probe " + PROBE_ID + " (version: 1).";
+  private static final String INSTALLED_MESSAGE = "Installed probe " + PROBE_ID + " (version: 1).";
+  private static final String ERROR_MESSAGE =
+      "Error installing probe " + PROBE_ID + " (version: 1).";
 
   @Mock private Config config;
 
@@ -42,8 +44,8 @@ class ProbeStatusTest {
   void builderReceived() {
     ProbeStatus expected =
         new ProbeStatus(
-            SERVICE_NAME, RECEIVED_MESSAGE, new Diagnostics(PROBE_ID, Status.RECEIVED, null));
-    ProbeStatus actual = builder.receivedMessage(PROBE_ID);
+            SERVICE_NAME, RECEIVED_MESSAGE, new Diagnostics(PROBE_ID, 1L, Status.RECEIVED, null));
+    ProbeStatus actual = builder.receivedMessage(PROBE_ID, 1L);
     assertEquals(expected, actual);
   }
 
@@ -51,8 +53,8 @@ class ProbeStatusTest {
   void builderInstalled() {
     ProbeStatus expected =
         new ProbeStatus(
-            SERVICE_NAME, INSTALLED_MESSAGE, new Diagnostics(PROBE_ID, Status.INSTALLED, null));
-    ProbeStatus actual = builder.installedMessage(PROBE_ID);
+            SERVICE_NAME, INSTALLED_MESSAGE, new Diagnostics(PROBE_ID, 1L, Status.INSTALLED, null));
+    ProbeStatus actual = builder.installedMessage(PROBE_ID, 1L);
     assertEquals(expected, actual);
   }
 
@@ -65,9 +67,10 @@ class ProbeStatusTest {
             ERROR_MESSAGE,
             new Diagnostics(
                 PROBE_ID,
+                1L,
                 Status.ERROR,
                 new ProbeException("NO_TYPE", exceptionMessage, Collections.emptyList())));
-    ProbeStatus actual = builder.errorMessage(PROBE_ID, exceptionMessage);
+    ProbeStatus actual = builder.errorMessage(PROBE_ID, 1L, exceptionMessage);
     assertEquals(expected, actual);
   }
 
@@ -85,15 +88,16 @@ class ProbeStatusTest {
             ERROR_MESSAGE,
             new Diagnostics(
                 PROBE_ID,
+                1L,
                 Status.ERROR,
                 new ProbeException("java.lang.Exception", exceptionMessage, capturedStackFrames)));
-    ProbeStatus actual = builder.errorMessage(PROBE_ID, exception);
+    ProbeStatus actual = builder.errorMessage(PROBE_ID, 1L, exception);
     assertEquals(expected, actual);
   }
 
   @Test
   void received() {
-    Diagnostics diagnostics = new Diagnostics(PROBE_ID, Status.RECEIVED, null);
+    Diagnostics diagnostics = new Diagnostics(PROBE_ID, 1L, Status.RECEIVED, null);
     ProbeStatus message = new ProbeStatus(SERVICE_NAME, RECEIVED_MESSAGE, diagnostics);
     assertEquals(SERVICE_NAME, message.getService());
     assertEquals(RECEIVED_MESSAGE, message.getMessage());
@@ -102,7 +106,7 @@ class ProbeStatusTest {
 
   @Test
   void installed() {
-    Diagnostics diagnostics = new Diagnostics(PROBE_ID, Status.INSTALLED, null);
+    Diagnostics diagnostics = new Diagnostics(PROBE_ID, 1L, Status.INSTALLED, null);
     ProbeStatus message = new ProbeStatus(SERVICE_NAME, INSTALLED_MESSAGE, diagnostics);
     assertEquals(SERVICE_NAME, message.getService());
     assertEquals(INSTALLED_MESSAGE, message.getMessage());
@@ -113,7 +117,7 @@ class ProbeStatusTest {
   void errorMessage() {
     ProbeException exception =
         new ProbeException("NO_TYPE", ERROR_MESSAGE, Collections.emptyList());
-    Diagnostics diagnostics = new Diagnostics(PROBE_ID, Status.ERROR, exception);
+    Diagnostics diagnostics = new Diagnostics(PROBE_ID, 1L, Status.ERROR, exception);
     ProbeStatus message = new ProbeStatus(SERVICE_NAME, ERROR_MESSAGE, diagnostics);
     assertEquals(SERVICE_NAME, message.getService());
     assertEquals(ERROR_MESSAGE, message.getMessage());
@@ -129,7 +133,7 @@ class ProbeStatusTest {
             .collect(Collectors.toList());
     ProbeException probeException =
         new ProbeException("java.lang.Exception", ERROR_MESSAGE, stackTrace);
-    Diagnostics diagnostics = new Diagnostics(PROBE_ID, Status.ERROR, probeException);
+    Diagnostics diagnostics = new Diagnostics(PROBE_ID, 1L, Status.ERROR, probeException);
     ProbeStatus message = new ProbeStatus(SERVICE_NAME, ERROR_MESSAGE, diagnostics);
     assertEquals(SERVICE_NAME, message.getService());
     assertEquals(ERROR_MESSAGE, message.getMessage());

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
@@ -51,8 +51,6 @@ public class SnapshotSerializationTest {
       new Snapshot.ProbeLocation(
           "java.lang.String", "indexOf", "String.java", Arrays.asList("12-15", "23"));
 
-  private static final Snapshot.ProbeSource PROBE_SOURCE = new Snapshot.ProbeSource("config", 1);
-
   @BeforeEach
   public void setup() {
     DebuggerContext.initClassFilter(new DenyListHelper(null));
@@ -67,13 +65,11 @@ public class SnapshotSerializationTest {
 
     Snapshot deserializedSnapshot = adapter.fromJson(buffer);
     Snapshot.ProbeLocation location = deserializedSnapshot.getProbe().getLocation();
-    Snapshot.ProbeSource source = deserializedSnapshot.getProbe().getSource();
+
     Assert.assertEquals(PROBE_LOCATION.getType(), location.getType());
     Assert.assertEquals(PROBE_LOCATION.getFile(), location.getFile());
     Assert.assertEquals(PROBE_LOCATION.getMethod(), location.getMethod());
     Assert.assertEquals(PROBE_LOCATION.getLines(), location.getLines());
-    Assert.assertEquals(PROBE_SOURCE.getConfig(), source.getConfig());
-    Assert.assertEquals(PROBE_SOURCE.getVerison(), source.getVerison());
   }
 
   @Test
@@ -213,8 +209,8 @@ public class SnapshotSerializationTest {
             Thread.currentThread(),
             new Snapshot.ProbeDetails(
                 PROBE_ID,
+                1L,
                 PROBE_LOCATION,
-                null,
                 Snapshot.MethodLocation.DEFAULT,
                 new ProbeCondition(DSL.when(DSL.gt(DSL.ref("^n"), DSL.value(0))), "^n > 0"),
                 "",
@@ -1037,7 +1033,7 @@ public class SnapshotSerializationTest {
   private Snapshot createSnapshot() {
     return new Snapshot(
         Thread.currentThread(),
-        new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, PROBE_SOURCE),
+        new Snapshot.ProbeDetails(PROBE_ID, 1L, PROBE_LOCATION),
         String.class.getTypeName());
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
@@ -51,6 +51,8 @@ public class SnapshotSerializationTest {
       new Snapshot.ProbeLocation(
           "java.lang.String", "indexOf", "String.java", Arrays.asList("12-15", "23"));
 
+  private static final Snapshot.ProbeSource PROBE_SOURCE = new Snapshot.ProbeSource("config", 1);
+
   @BeforeEach
   public void setup() {
     DebuggerContext.initClassFilter(new DenyListHelper(null));
@@ -65,10 +67,13 @@ public class SnapshotSerializationTest {
 
     Snapshot deserializedSnapshot = adapter.fromJson(buffer);
     Snapshot.ProbeLocation location = deserializedSnapshot.getProbe().getLocation();
+    Snapshot.ProbeSource source = deserializedSnapshot.getProbe().getSource();
     Assert.assertEquals(PROBE_LOCATION.getType(), location.getType());
     Assert.assertEquals(PROBE_LOCATION.getFile(), location.getFile());
     Assert.assertEquals(PROBE_LOCATION.getMethod(), location.getMethod());
     Assert.assertEquals(PROBE_LOCATION.getLines(), location.getLines());
+    Assert.assertEquals(PROBE_SOURCE.getConfig(), source.getConfig());
+    Assert.assertEquals(PROBE_SOURCE.getVerison(), source.getVerison());
   }
 
   @Test
@@ -209,6 +214,7 @@ public class SnapshotSerializationTest {
             new Snapshot.ProbeDetails(
                 PROBE_ID,
                 PROBE_LOCATION,
+                null,
                 Snapshot.MethodLocation.DEFAULT,
                 new ProbeCondition(DSL.when(DSL.gt(DSL.ref("^n"), DSL.value(0))), "^n > 0"),
                 "",
@@ -1031,7 +1037,7 @@ public class SnapshotSerializationTest {
   private Snapshot createSnapshot() {
     return new Snapshot(
         Thread.currentThread(),
-        new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION),
+        new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, PROBE_SOURCE),
         String.class.getTypeName());
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import static utils.TestHelper.getFixtureContent;
 
 import com.datadog.debugger.agent.JsonSnapshotSerializer;
+import com.datadog.debugger.probe.SnapshotProbe;
 import com.datadog.debugger.uploader.BatchUploader;
 import com.datadog.debugger.util.DebuggerMetrics;
 import datadog.trace.api.Config;
@@ -69,7 +70,7 @@ public class DebuggerSinkTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, null),
+            new Snapshot.ProbeDetails(PROBE_ID, 1L, PROBE_LOCATION),
             String.class.getTypeName());
     sink.addSnapshot(snapshot);
     String fixtureContent = getFixtureContent(SINK_FIXTURE_PREFIX + "/snapshotRegex.txt");
@@ -87,7 +88,7 @@ public class DebuggerSinkTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, null),
+            new Snapshot.ProbeDetails(PROBE_ID, 1L, PROBE_LOCATION),
             String.class.getTypeName());
     Arrays.asList(snapshot, snapshot).forEach(sink::addSnapshot);
 
@@ -106,7 +107,7 @@ public class DebuggerSinkTest {
     Snapshot largeSnapshot =
         new Snapshot(
             Thread.currentThread(),
-            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, null),
+            new Snapshot.ProbeDetails(PROBE_ID, 1L, PROBE_LOCATION),
             String.class.getTypeName());
     for (int i = 0; i < 15_000; i++) {
       largeSnapshot.getStack().add(new CapturedStackFrame("f" + i, i));
@@ -127,7 +128,7 @@ public class DebuggerSinkTest {
     Snapshot largeSnapshot =
         new Snapshot(
             Thread.currentThread(),
-            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, null),
+            new Snapshot.ProbeDetails(PROBE_ID, 1L, PROBE_LOCATION),
             String.class.getTypeName());
     for (int i = 0; i < 150_000; i++) {
       largeSnapshot.getStack().add(new CapturedStackFrame("f" + i, i));
@@ -143,7 +144,7 @@ public class DebuggerSinkTest {
     Snapshot largeSnapshot =
         new Snapshot(
             Thread.currentThread(),
-            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, null),
+            new Snapshot.ProbeDetails(PROBE_ID, 1L, PROBE_LOCATION),
             String.class.getTypeName());
     for (int i = 0; i < 140_000; i++) {
       largeSnapshot.getStack().add(new CapturedStackFrame("f€" + i, i));
@@ -163,7 +164,7 @@ public class DebuggerSinkTest {
   @Test
   public void addDiagnostics() throws URISyntaxException, IOException {
     DebuggerSink sink = new DebuggerSink(config, batchUploader);
-    sink.addReceived("1");
+    sink.addReceived(SnapshotProbe.builder().probeId(PROBE_ID).version(1L).build());
     String fixtureContent = getFixtureContent(SINK_FIXTURE_PREFIX + "/diagnosticsRegex.txt");
     String regex = fixtureContent.replaceAll("\\n", "");
     sink.flush(sink);
@@ -177,7 +178,7 @@ public class DebuggerSinkTest {
     when(config.getDebuggerUploadBatchSize()).thenReturn(100);
     DebuggerSink sink = new DebuggerSink(config, batchUploader);
     for (String probeId : Arrays.asList("1", "2")) {
-      sink.addReceived(probeId);
+      sink.addReceived(SnapshotProbe.builder().probeId(probeId).version(1L).build());
     }
 
     String fixtureContent =
@@ -199,7 +200,7 @@ public class DebuggerSinkTest {
     }
     String largeMessage = largeMessageBuilder.toString();
     for (int i = 0; i < 100; i++) {
-      sink.getProbeDiagnosticsSink().addError(String.valueOf(i), largeMessage);
+      sink.getProbeDiagnosticsSink().addError(String.valueOf(i), 1L, largeMessage);
     }
     sink.flush(sink);
     verify(batchUploader, times(2))
@@ -217,7 +218,7 @@ public class DebuggerSinkTest {
       tooLargeMessageBuilder.append("f");
     }
     String tooLargeMessage = tooLargeMessageBuilder.toString();
-    sink.getProbeDiagnosticsSink().addError("1", tooLargeMessage);
+    sink.getProbeDiagnosticsSink().addError("1", 1L, tooLargeMessage);
     sink.flush(sink);
     verifyNoInteractions(batchUploader);
   }
@@ -231,7 +232,7 @@ public class DebuggerSinkTest {
       tooLargeMessageBuilder.append("\uD80C\uDCF0"); // 4 bytes
     }
     String tooLargeMessage = tooLargeMessageBuilder.toString();
-    sink.getProbeDiagnosticsSink().addError("1", tooLargeMessage);
+    sink.getProbeDiagnosticsSink().addError("1", 1L, tooLargeMessage);
     sink.flush(sink);
     verifyNoInteractions(batchUploader);
   }
@@ -250,7 +251,7 @@ public class DebuggerSinkTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, null),
+            new Snapshot.ProbeDetails(PROBE_ID, 1L, PROBE_LOCATION),
             String.class.getTypeName());
     sink.addSnapshot(snapshot);
     sink.doReconsiderFlushInterval();
@@ -266,7 +267,7 @@ public class DebuggerSinkTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, null),
+            new Snapshot.ProbeDetails(PROBE_ID, 1L, PROBE_LOCATION),
             String.class.getTypeName());
     for (int i = 0; i < 1000; i++) {
       sink.addSnapshot(snapshot);
@@ -283,7 +284,7 @@ public class DebuggerSinkTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, null),
+            new Snapshot.ProbeDetails(PROBE_ID, 1L, PROBE_LOCATION),
             String.class.getTypeName());
     for (int i = 0; i < 500; i++) {
       sink.addSnapshot(snapshot);
@@ -305,7 +306,7 @@ public class DebuggerSinkTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, null),
+            new Snapshot.ProbeDetails(PROBE_ID, 1L, PROBE_LOCATION),
             String.class.getTypeName());
     snapshot.setEntry(entry);
     sink.addSnapshot(snapshot);
@@ -326,7 +327,7 @@ public class DebuggerSinkTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, null),
+            new Snapshot.ProbeDetails(PROBE_ID, 1L, PROBE_LOCATION),
             String.class.getTypeName());
     snapshot.setEntry(entry);
     sink.addSnapshot(snapshot);
@@ -345,7 +346,7 @@ public class DebuggerSinkTest {
     DiagnosticMessage info = new DiagnosticMessage(DiagnosticMessage.Kind.INFO, "info message");
     DiagnosticMessage warn = new DiagnosticMessage(DiagnosticMessage.Kind.WARN, "info message");
     DiagnosticMessage error = new DiagnosticMessage(DiagnosticMessage.Kind.ERROR, "info message");
-    sink.addDiagnostics(PROBE_ID, Arrays.asList(info, warn, error));
+    sink.addDiagnostics(PROBE_ID, 1L, Arrays.asList(info, warn, error));
     // ensure just that the code is executed to have coverage (just logging)
   }
 
@@ -356,7 +357,7 @@ public class DebuggerSinkTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, null),
+            new Snapshot.ProbeDetails(PROBE_ID, 1L, PROBE_LOCATION),
             String.class.getTypeName());
     sink.skipSnapshot(snapshot.getProbe().getId(), DebuggerContext.SkipCause.CONDITION);
     verify(debuggerMetrics)

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
@@ -69,7 +69,7 @@ public class DebuggerSinkTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION),
+            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, null),
             String.class.getTypeName());
     sink.addSnapshot(snapshot);
     String fixtureContent = getFixtureContent(SINK_FIXTURE_PREFIX + "/snapshotRegex.txt");
@@ -87,7 +87,7 @@ public class DebuggerSinkTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION),
+            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, null),
             String.class.getTypeName());
     Arrays.asList(snapshot, snapshot).forEach(sink::addSnapshot);
 
@@ -106,7 +106,7 @@ public class DebuggerSinkTest {
     Snapshot largeSnapshot =
         new Snapshot(
             Thread.currentThread(),
-            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION),
+            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, null),
             String.class.getTypeName());
     for (int i = 0; i < 15_000; i++) {
       largeSnapshot.getStack().add(new CapturedStackFrame("f" + i, i));
@@ -127,7 +127,7 @@ public class DebuggerSinkTest {
     Snapshot largeSnapshot =
         new Snapshot(
             Thread.currentThread(),
-            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION),
+            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, null),
             String.class.getTypeName());
     for (int i = 0; i < 150_000; i++) {
       largeSnapshot.getStack().add(new CapturedStackFrame("f" + i, i));
@@ -143,7 +143,7 @@ public class DebuggerSinkTest {
     Snapshot largeSnapshot =
         new Snapshot(
             Thread.currentThread(),
-            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION),
+            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, null),
             String.class.getTypeName());
     for (int i = 0; i < 140_000; i++) {
       largeSnapshot.getStack().add(new CapturedStackFrame("f€" + i, i));
@@ -250,7 +250,7 @@ public class DebuggerSinkTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION),
+            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, null),
             String.class.getTypeName());
     sink.addSnapshot(snapshot);
     sink.doReconsiderFlushInterval();
@@ -266,7 +266,7 @@ public class DebuggerSinkTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION),
+            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, null),
             String.class.getTypeName());
     for (int i = 0; i < 1000; i++) {
       sink.addSnapshot(snapshot);
@@ -283,7 +283,7 @@ public class DebuggerSinkTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION),
+            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, null),
             String.class.getTypeName());
     for (int i = 0; i < 500; i++) {
       sink.addSnapshot(snapshot);
@@ -305,7 +305,7 @@ public class DebuggerSinkTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION),
+            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, null),
             String.class.getTypeName());
     snapshot.setEntry(entry);
     sink.addSnapshot(snapshot);
@@ -326,7 +326,7 @@ public class DebuggerSinkTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION),
+            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, null),
             String.class.getTypeName());
     snapshot.setEntry(entry);
     sink.addSnapshot(snapshot);
@@ -356,7 +356,7 @@ public class DebuggerSinkTest {
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
-            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION),
+            new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION, null),
             String.class.getTypeName());
     sink.skipSnapshot(snapshot.getProbe().getId(), DebuggerContext.SkipCause.CONDITION);
     verify(debuggerMetrics)

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/ProbeStatusSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/ProbeStatusSinkTest.java
@@ -30,6 +30,7 @@ class ProbeStatusSinkTest {
   private static final String SERVICE_NAME = "service-name";
   private static final String PROBE_ID = UUID.randomUUID().toString();
   private static final String PROBE_ID2 = UUID.randomUUID().toString();
+  private static final Long PROBE_VERSION = 1L;
   private static final String MESSAGE = "Foo";
   private static final int DIAGNOSTICS_INTERVAL = 60 * 60; // in seconds = 1h
   private static final Instant AFTER_INTERVAL_HAS_PASSED =
@@ -53,90 +54,96 @@ class ProbeStatusSinkTest {
 
   @Test
   void addReceived() {
-    probeStatusSink.addReceived(PROBE_ID);
+    probeStatusSink.addReceived(PROBE_ID, PROBE_VERSION);
     assertEquals(
-        Collections.singletonList(builder.receivedMessage(PROBE_ID)),
+        Collections.singletonList(builder.receivedMessage(PROBE_ID, PROBE_VERSION)),
         probeStatusSink.getDiagnostics());
   }
 
   @Test
   void addInstalled() {
-    probeStatusSink.addInstalled(PROBE_ID);
+    probeStatusSink.addInstalled(PROBE_ID, PROBE_VERSION);
     assertEquals(
-        Collections.singletonList(builder.installedMessage(PROBE_ID)),
+        Collections.singletonList(builder.installedMessage(PROBE_ID, PROBE_VERSION)),
         probeStatusSink.getDiagnostics());
   }
 
   @Test
   void addBlocked() {
-    probeStatusSink.addBlocked(PROBE_ID);
+    probeStatusSink.addBlocked(PROBE_ID, PROBE_VERSION);
     assertEquals(
-        Collections.singletonList(builder.blockedMessage(PROBE_ID)),
+        Collections.singletonList(builder.blockedMessage(PROBE_ID, PROBE_VERSION)),
         probeStatusSink.getDiagnostics());
   }
 
   @Test
   void addError() {
-    probeStatusSink.addError(PROBE_ID, MESSAGE);
+    probeStatusSink.addError(PROBE_ID, PROBE_VERSION, MESSAGE);
     assertEquals(
-        Collections.singletonList(builder.errorMessage(PROBE_ID, MESSAGE)),
+        Collections.singletonList(builder.errorMessage(PROBE_ID, PROBE_VERSION, MESSAGE)),
         probeStatusSink.getDiagnostics());
   }
 
   @Test
   void addReceivedThenInstalled() {
-    probeStatusSink.addReceived(PROBE_ID);
-    probeStatusSink.addInstalled(PROBE_ID);
+    probeStatusSink.addReceived(PROBE_ID, PROBE_VERSION);
+    probeStatusSink.addInstalled(PROBE_ID, PROBE_VERSION);
     assertEquals(
-        Arrays.asList(builder.receivedMessage(PROBE_ID), builder.installedMessage(PROBE_ID)),
+        Arrays.asList(
+            builder.receivedMessage(PROBE_ID, PROBE_VERSION),
+            builder.installedMessage(PROBE_ID, PROBE_VERSION)),
         probeStatusSink.getDiagnostics());
   }
 
   @Test
   void addReceivedThenBlocked() {
-    probeStatusSink.addReceived(PROBE_ID);
-    probeStatusSink.addBlocked(PROBE_ID);
+    probeStatusSink.addReceived(PROBE_ID, PROBE_VERSION);
+    probeStatusSink.addBlocked(PROBE_ID, PROBE_VERSION);
     assertEquals(
-        Arrays.asList(builder.receivedMessage(PROBE_ID), builder.blockedMessage(PROBE_ID)),
+        Arrays.asList(
+            builder.receivedMessage(PROBE_ID, PROBE_VERSION),
+            builder.blockedMessage(PROBE_ID, PROBE_VERSION)),
         probeStatusSink.getDiagnostics());
   }
 
   @Test
   void addReceivedThenError() {
-    probeStatusSink.addReceived(PROBE_ID);
-    probeStatusSink.addError(PROBE_ID, MESSAGE);
+    probeStatusSink.addReceived(PROBE_ID, PROBE_VERSION);
+    probeStatusSink.addError(PROBE_ID, PROBE_VERSION, MESSAGE);
     assertEquals(
-        Arrays.asList(builder.receivedMessage(PROBE_ID), builder.errorMessage(PROBE_ID, MESSAGE)),
+        Arrays.asList(
+            builder.receivedMessage(PROBE_ID, PROBE_VERSION),
+            builder.errorMessage(PROBE_ID, PROBE_VERSION, MESSAGE)),
         probeStatusSink.getDiagnostics());
   }
 
   @Test
   void addReceivedThenInstalledThenError() {
-    probeStatusSink.addReceived(PROBE_ID);
-    probeStatusSink.addInstalled(PROBE_ID);
-    probeStatusSink.addError(PROBE_ID, MESSAGE);
+    probeStatusSink.addReceived(PROBE_ID, PROBE_VERSION);
+    probeStatusSink.addInstalled(PROBE_ID, PROBE_VERSION);
+    probeStatusSink.addError(PROBE_ID, PROBE_VERSION, MESSAGE);
     assertEquals(
         Arrays.asList(
-            builder.receivedMessage(PROBE_ID),
-            builder.installedMessage(PROBE_ID),
-            builder.errorMessage(PROBE_ID, MESSAGE)),
+            builder.receivedMessage(PROBE_ID, PROBE_VERSION),
+            builder.installedMessage(PROBE_ID, PROBE_VERSION),
+            builder.errorMessage(PROBE_ID, PROBE_VERSION, MESSAGE)),
         probeStatusSink.getDiagnostics());
   }
 
   @Test
   void addErrorWithThrowable() {
     Throwable throwable = new Exception("test");
-    probeStatusSink.addError(PROBE_ID, throwable);
+    probeStatusSink.addError(PROBE_ID, PROBE_VERSION, throwable);
     assertEquals(
-        Collections.singletonList(builder.errorMessage(PROBE_ID, throwable)),
+        Collections.singletonList(builder.errorMessage(PROBE_ID, PROBE_VERSION, throwable)),
         probeStatusSink.getDiagnostics());
   }
 
   @Test
   void removeDiagnostic() {
-    probeStatusSink.addReceived(PROBE_ID);
+    probeStatusSink.addReceived(PROBE_ID, PROBE_VERSION);
     assertEquals(
-        Collections.singletonList(builder.receivedMessage(PROBE_ID)),
+        Collections.singletonList(builder.receivedMessage(PROBE_ID, PROBE_VERSION)),
         probeStatusSink.getDiagnostics());
     probeStatusSink.removeDiagnostics(PROBE_ID);
     assertEquals(Collections.emptyList(), probeStatusSink.getDiagnostics());
@@ -144,17 +151,18 @@ class ProbeStatusSinkTest {
 
   @Test
   void doNotDoubleEmitMessageIfIntervalHasntPassed() {
-    probeStatusSink.addError(PROBE_ID, MESSAGE);
+    probeStatusSink.addError(PROBE_ID, PROBE_VERSION, MESSAGE);
     assertEquals(
-        Collections.singletonList(builder.errorMessage(PROBE_ID, MESSAGE)),
+        Collections.singletonList(builder.errorMessage(PROBE_ID, PROBE_VERSION, MESSAGE)),
         probeStatusSink.getDiagnostics());
     assertEquals(Collections.emptyList(), probeStatusSink.getDiagnostics());
   }
 
   @Test
   void reemitOnInterval() {
-    probeStatusSink.addReceived(PROBE_ID);
-    List<ProbeStatus> expected = Collections.singletonList(builder.receivedMessage(PROBE_ID));
+    probeStatusSink.addReceived(PROBE_ID, PROBE_VERSION);
+    List<ProbeStatus> expected =
+        Collections.singletonList(builder.receivedMessage(PROBE_ID, PROBE_VERSION));
     assertEquals(expected, probeStatusSink.getDiagnostics());
     assertEquals(Collections.emptyList(), probeStatusSink.getDiagnostics());
     Clock fixed = Clock.fixed(AFTER_INTERVAL_HAS_PASSED, ZoneId.systemDefault());
@@ -163,16 +171,19 @@ class ProbeStatusSinkTest {
 
   @Test
   void reemitOnlyLatestMessage() {
-    probeStatusSink.addReceived(PROBE_ID);
-    probeStatusSink.addError(PROBE_ID, MESSAGE);
+    probeStatusSink.addReceived(PROBE_ID, PROBE_VERSION);
+    probeStatusSink.addError(PROBE_ID, PROBE_VERSION, MESSAGE);
     List<ProbeStatus> firstDiagnostics = probeStatusSink.getDiagnostics();
     assertEquals(
-        Arrays.asList(builder.receivedMessage(PROBE_ID), builder.errorMessage(PROBE_ID, MESSAGE)),
+        Arrays.asList(
+            builder.receivedMessage(PROBE_ID, PROBE_VERSION),
+            builder.errorMessage(PROBE_ID, PROBE_VERSION, MESSAGE)),
         firstDiagnostics);
     Clock fixed = Clock.fixed(AFTER_INTERVAL_HAS_PASSED, ZoneId.systemDefault());
     List<ProbeStatus> secondDiagnostics = probeStatusSink.getDiagnostics(fixed);
     assertEquals(
-        Collections.singletonList(builder.errorMessage(PROBE_ID, MESSAGE)), secondDiagnostics);
+        Collections.singletonList(builder.errorMessage(PROBE_ID, PROBE_VERSION, MESSAGE)),
+        secondDiagnostics);
 
     // expect timestamp to be updated
     assertTrue(firstDiagnostics.get(1).getTimestamp() < secondDiagnostics.get(0).getTimestamp());
@@ -180,9 +191,9 @@ class ProbeStatusSinkTest {
 
   @Test
   void doNotReemitIfIntervalHasNotPassedBetweenAddingAndNextCall() {
-    probeStatusSink.addReceived(PROBE_ID);
+    probeStatusSink.addReceived(PROBE_ID, PROBE_VERSION);
     assertEquals(
-        Collections.singletonList(builder.receivedMessage(PROBE_ID)),
+        Collections.singletonList(builder.receivedMessage(PROBE_ID, PROBE_VERSION)),
         probeStatusSink.getDiagnostics());
     Clock fixed = Clock.fixed(BEFORE_INTERVAL_HAS_PASSED, ZoneId.systemDefault());
     assertEquals(Collections.emptyList(), probeStatusSink.getDiagnostics(fixed));
@@ -190,14 +201,14 @@ class ProbeStatusSinkTest {
 
   @Test
   void doNotReemitIfIntervalHasNotPassedBetweenAddingAndNextCallNewStatus() {
-    probeStatusSink.addReceived(PROBE_ID);
+    probeStatusSink.addReceived(PROBE_ID, PROBE_VERSION);
     assertEquals(
-        Collections.singletonList(builder.receivedMessage(PROBE_ID)),
+        Collections.singletonList(builder.receivedMessage(PROBE_ID, PROBE_VERSION)),
         probeStatusSink.getDiagnostics());
-    probeStatusSink.addInstalled(PROBE_ID);
+    probeStatusSink.addInstalled(PROBE_ID, PROBE_VERSION);
     Clock fixed = Clock.fixed(BEFORE_INTERVAL_HAS_PASSED, ZoneId.systemDefault());
     assertEquals(
-        Collections.singletonList(builder.installedMessage(PROBE_ID)),
+        Collections.singletonList(builder.installedMessage(PROBE_ID, PROBE_VERSION)),
         probeStatusSink.getDiagnostics(fixed));
   }
 
@@ -206,29 +217,31 @@ class ProbeStatusSinkTest {
     String secondProbeId = UUID.randomUUID().toString();
 
     // Emit both right-away after adding the messages
-    probeStatusSink.addReceived(PROBE_ID);
-    probeStatusSink.addReceived(secondProbeId);
+    probeStatusSink.addReceived(PROBE_ID, PROBE_VERSION);
+    probeStatusSink.addReceived(secondProbeId, PROBE_VERSION);
     assertEquals(
-        Arrays.asList(builder.receivedMessage(PROBE_ID), builder.receivedMessage(secondProbeId)),
+        Arrays.asList(
+            builder.receivedMessage(PROBE_ID, PROBE_VERSION),
+            builder.receivedMessage(secondProbeId, PROBE_VERSION)),
         probeStatusSink.getDiagnostics());
 
     // Change stored diagnostic for PROBE_ID
-    probeStatusSink.addInstalled(PROBE_ID);
+    probeStatusSink.addInstalled(PROBE_ID, PROBE_VERSION);
 
     // Assert only new (installed) message for PROBE_ID is emitted before DIAGNOSTICS_INTERVAL has
     // passed
     Instant beforeIntervalHasPassed = Instant.now();
     Clock fixed = Clock.fixed(beforeIntervalHasPassed, ZoneId.systemDefault());
     assertEquals(
-        Collections.singletonList(builder.installedMessage(PROBE_ID)),
+        Collections.singletonList(builder.installedMessage(PROBE_ID, PROBE_VERSION)),
         probeStatusSink.getDiagnostics(fixed));
   }
 
   @Test
   void doNotReemitRemovedMessage() {
-    probeStatusSink.addReceived(PROBE_ID);
+    probeStatusSink.addReceived(PROBE_ID, PROBE_VERSION);
     assertEquals(
-        Collections.singletonList(builder.receivedMessage(PROBE_ID)),
+        Collections.singletonList(builder.receivedMessage(PROBE_ID, PROBE_VERSION)),
         probeStatusSink.getDiagnostics());
     probeStatusSink.removeDiagnostics(PROBE_ID);
     assertEquals(Collections.emptyList(), probeStatusSink.getDiagnostics());
@@ -236,34 +249,34 @@ class ProbeStatusSinkTest {
 
   @Test
   void dropRepeatingDiagnostics() {
-    probeStatusSink.addReceived(PROBE_ID);
+    probeStatusSink.addReceived(PROBE_ID, PROBE_VERSION);
 
     // enqueues only a single error message (checking if queue already have that message).
     for (int i = 1; i <= 100; i++) {
-      probeStatusSink.addError(PROBE_ID, "bar");
+      probeStatusSink.addError(PROBE_ID, PROBE_VERSION, "bar");
     }
     // this will enqueue a new error message
-    probeStatusSink.addError(PROBE_ID, "foo");
+    probeStatusSink.addError(PROBE_ID, PROBE_VERSION, "foo");
     assertEquals(
         Arrays.asList(
-            builder.receivedMessage(PROBE_ID),
-            builder.errorMessage(PROBE_ID, "bar"),
-            builder.errorMessage(PROBE_ID, "foo")),
+            builder.receivedMessage(PROBE_ID, PROBE_VERSION),
+            builder.errorMessage(PROBE_ID, PROBE_VERSION, "bar"),
+            builder.errorMessage(PROBE_ID, PROBE_VERSION, "foo")),
         probeStatusSink.getDiagnostics());
   }
 
   @Test
   void dealingFullQueueDroppedDiagnostics() {
-    probeStatusSink.addReceived(PROBE_ID);
+    probeStatusSink.addReceived(PROBE_ID, PROBE_VERSION);
     // enqueues all messages
     for (int i = 1; i <= 199; i++) {
-      probeStatusSink.addError(PROBE_ID, "bar " + i);
+      probeStatusSink.addError(PROBE_ID, PROBE_VERSION, "bar " + i);
     }
     // those two messages would be dropped because the queue is full.
     // However, getDiagnostics will ensure we emit the last message for each probe once it is
     // drained
-    probeStatusSink.addReceived(PROBE_ID2);
-    probeStatusSink.addInstalled(PROBE_ID2);
+    probeStatusSink.addReceived(PROBE_ID2, PROBE_VERSION);
+    probeStatusSink.addInstalled(PROBE_ID2, PROBE_VERSION);
 
     List<ProbeStatus> firstBatch = probeStatusSink.getDiagnostics();
     List<ProbeStatus> secondBatch = probeStatusSink.getDiagnostics();
@@ -274,7 +287,7 @@ class ProbeStatusSinkTest {
 
     // when fetching all messages the queue will reset and only send last messages for ecah probe
 
-    assertEquals(Arrays.asList(builder.installedMessage(PROBE_ID2)), thirdBatch);
+    assertEquals(Arrays.asList(builder.installedMessage(PROBE_ID2, PROBE_VERSION)), thirdBatch);
   }
 
   @Test
@@ -284,7 +297,8 @@ class ProbeStatusSinkTest {
   }
 
   private String serialize() {
-    ProbeStatus probeStatus = builder.errorMessage(PROBE_ID, new NullPointerException("null"));
+    ProbeStatus probeStatus =
+        builder.errorMessage(PROBE_ID, PROBE_VERSION, new NullPointerException("null"));
     JsonAdapter<ProbeStatus> adapter =
         MoshiHelper.createMoshiProbeStatus().adapter(ProbeStatus.class);
     return adapter.toJson(probeStatus);
@@ -296,7 +310,9 @@ class ProbeStatusSinkTest {
     ProbeStatus probeStatus = adapter.fromJson(buffer);
     assertEquals("dd_debugger", probeStatus.getDdSource());
     assertEquals(SERVICE_NAME, probeStatus.getService());
-    assertEquals("Error installing probe " + PROBE_ID + ".", probeStatus.getMessage());
+    assertEquals(
+        "Error installing probe " + PROBE_ID + " (version: " + PROBE_VERSION + ").",
+        probeStatus.getMessage());
     assertEquals(PROBE_ID, probeStatus.getDiagnostics().getProbeId());
     assertEquals(ProbeStatus.Status.ERROR, probeStatus.getDiagnostics().getStatus());
     assertEquals("null", probeStatus.getDiagnostics().getException().getMessage());

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/diagnosticsRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/diagnosticsRegex.txt
@@ -2,11 +2,12 @@
 "ddsource":"dd_debugger",
 "debugger":\{
 "diagnostics":\{
-"probeId":"\d",
+"probeId":"12fd-8490-c111-4374-ffde",
+"probeVersion":\d,
 "status":"RECEIVED"
 \}
 \},
-"message":"Received probe \d.",
+"message":"Received probe 12fd-8490-c111-4374-ffde \(version: \d\).",
 "service":"service-name",
 "timestamp":\d+
 \}\]

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/multipleDiagnosticsRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/multipleDiagnosticsRegex.txt
@@ -4,10 +4,11 @@
 "debugger":\{
 "diagnostics":\{
 "probeId":"\d",
+"probeVersion":\d,
 "status":"RECEIVED"
 \}
 \},
-"message":"Received probe \d.",
+"message":"Received probe \d \(version: \d\).",
 "service":"service-name",
 "timestamp":\d+
 \},
@@ -16,10 +17,11 @@
 "debugger":\{
 "diagnostics":\{
 "probeId":"\d",
+"probeVersion":\d,
 "status":"RECEIVED"
 \}
 \},
-"message":"Received probe \d.",
+"message":"Received probe \d \(version: \d\).",
 "service":"service-name",
 "timestamp":\d+
 \}

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/multipleSnapshotRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/multipleSnapshotRegex.txt
@@ -4,7 +4,7 @@
 "snapshot":\{
 "captures":\{\},
 "language":"java",
-"probe":\{"evaluateAt":"DEFAULT","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
+"probe":\{"evaluateAt":"DEFAULT","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\},"version":1\},
 "stack":\[\],
 "timestamp":\d+
 \}\},
@@ -24,7 +24,7 @@
 "snapshot":\{
 "captures":\{\},
 "language":"java",
-"probe":\{"evaluateAt":"DEFAULT","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
+"probe":\{"evaluateAt":"DEFAULT","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\},"version":1\},
 "stack":\[\],
 "timestamp":\d+
 \}\},

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotCapturedValueRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotCapturedValueRegex.txt
@@ -58,6 +58,10 @@
 "lines":\["12-15","23"\],
 "method":"indexOf",
 "type":"java.lang.String"
+\},
+"source":\{
+"config":"config",
+"version":1
 \}
 \},
 "stack":\[\],

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotCapturedValueRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotCapturedValueRegex.txt
@@ -59,10 +59,7 @@
 "method":"indexOf",
 "type":"java.lang.String"
 \},
-"source":\{
-"config":"config",
 "version":1
-\}
 \},
 "stack":\[\],
 "timestamp":\d+

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotRegex.txt
@@ -4,7 +4,7 @@
 "snapshot":\{
 "captures":\{\},
 "language":"java",
-"probe":\{"evaluateAt":"DEFAULT","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
+"probe":\{"evaluateAt":"DEFAULT","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\},"version":1\},
 "stack":\[\],
 "timestamp":\d+
 \}\},

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotWithCorrelationIdsRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotWithCorrelationIdsRegex.txt
@@ -6,7 +6,7 @@
 "snapshot":\{
 "captures":\{"entry":\{"arguments":\{\},"locals":\{\}\}\},
 "language":"java",
-"probe":\{"evaluateAt":"DEFAULT","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
+"probe":\{"evaluateAt":"DEFAULT","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\},"version":1\},
 "stack":\[\],
 "timestamp":\d+
 \}\},

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotWithEvalErrorRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotWithEvalErrorRegex.txt
@@ -5,7 +5,7 @@
 "captures":\{"entry":\{"arguments":\{\},"locals":\{\}\}\},
 "evaluationErrors":\[\{"expr":"obj.field","message":"Cannot dereference obj"\}\],
 "language":"java",
-"probe":\{"evaluateAt":"DEFAULT","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
+"probe":\{"evaluateAt":"DEFAULT","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\},"version":1\},
 "stack":\[\],
 "timestamp":\d+
 \}\},

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
@@ -216,19 +216,26 @@ public abstract class BaseIntegrationTest {
   }
 
   protected Configuration createConfig(SnapshotProbe snapshotProbe) {
-    return createConfig(Arrays.asList(snapshotProbe));
+    return Configuration.builder().setService(getAppId()).add(snapshotProbe).build();
   }
 
   protected Configuration createConfig(Collection<SnapshotProbe> snapshotProbes) {
-    return new Configuration(getAppId(), snapshotProbes);
+    return Configuration.builder()
+        .setService(getAppId())
+        .addSnapshotsProbes(snapshotProbes)
+        .build();
   }
 
   protected Configuration createConfig(
       Collection<SnapshotProbe> snapshotProbes,
       Configuration.FilterList allowList,
       Configuration.FilterList denyList) {
-    return new Configuration(
-        getAppId(), snapshotProbes, null, null, null, allowList, denyList, null);
+    return Configuration.builder()
+        .setService(getAppId())
+        .addSnapshotsProbes(snapshotProbes)
+        .addAllowList(allowList)
+        .addDenyList(denyList)
+        .build();
   }
 
   protected void assertCaptureArgs(

--- a/remote-config/src/main/java/datadog/remoteconfig/state/ProductListener.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/state/ProductListener.java
@@ -7,6 +7,7 @@ public interface ProductListener {
   void accept(
       ParsedConfigKey configKey,
       byte[] content,
+      long version,
       ConfigurationChangesListener.PollingRateHinter pollingRateHinter)
       throws IOException;
 

--- a/remote-config/src/main/java/datadog/remoteconfig/state/ProductState.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/state/ProductState.java
@@ -58,7 +58,7 @@ public class ProductState {
         if (isTargetChanged(configKey, target)) {
           changesDetected = true;
           byte[] content = getTargetFileContent(fleetResponse, configKey);
-          callListenerApplyTarget(fleetResponse, hinter, configKey, content);
+          callListenerApplyTarget(fleetResponse, hinter, configKey, content, target.custom.version);
         }
 
       } catch (ConfigurationPoller.ReportableException e) {
@@ -89,10 +89,11 @@ public class ProductState {
       RemoteConfigResponse fleetResponse,
       ConfigurationChangesListener.PollingRateHinter hinter,
       ParsedConfigKey configKey,
-      byte[] content) {
+      byte[] content,
+      long version) {
 
     try {
-      listener.accept(configKey, content, hinter);
+      listener.accept(configKey, content, version, hinter);
       updateConfigState(fleetResponse, configKey, null);
     } catch (ConfigurationPoller.ReportableException e) {
       recordError(e);

--- a/remote-config/src/main/java/datadog/remoteconfig/state/SimpleProductListener.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/state/SimpleProductListener.java
@@ -14,6 +14,7 @@ public class SimpleProductListener implements ProductListener {
   public void accept(
       ParsedConfigKey configKey,
       byte[] content,
+      long version,
       ConfigurationChangesListener.PollingRateHinter pollingRateHinter)
       throws IOException {
     listener.accept(configKey.toString(), content, pollingRateHinter);

--- a/remote-config/src/test/groovy/datadog/remoteconfig/ConfigurationPollerSpecification.groovy
+++ b/remote-config/src/test/groovy/datadog/remoteconfig/ConfigurationPollerSpecification.groovy
@@ -711,7 +711,7 @@ class ConfigurationPollerSpecification extends DDSpecification {
     then:
     1 * okHttpClient.newCall(_ as Request) >> { request = it[0]; call }
     1 * call.execute() >> { buildOKResponse(SAMPLE_RESP_BODY) }
-    1 * listener.accept(_, { it != null }, _) >> false
+    1 * listener.accept(_, { it != null }, 1, _) >> false
     1 * listener.commit(_)
     0 * _._
 


### PR DESCRIPTION
# What Does This Do

Snapshots now able to report the config-id and version of the probe used to generate the probe. 
This allow the Datadog app to show the right probe details for each snapshot

# Motivation

Support historical versions of probe details when inspecting a snapshot

# Additional Notes
