### PR TITLE
Fix rmic Gradle task

### DIFF
--- a/dd-java-agent/instrumentation/rmi/build.gradle
+++ b/dd-java-agent/instrumentation/rmi/build.gradle
@@ -13,13 +13,23 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-def rmic = tasks.register('rmic') {
+def rmic = tasks.register('rmic', Exec) {
   dependsOn testClasses
+
+  Provider<JavaLauncher> javaLauncher = getJavaLauncherFor(8)
+  def toolchainPath = javaLauncher.get().metadata.installationPath
+
   def clazz = 'rmi.app.ServerLegacy'
-  String command = """rmic -g -keep -classpath ${sourceSets.test.output.classesDirs.asPath} -d ${buildDir}/classes/java/test ${clazz}"""
-  command.execute().text
+  commandLine(
+    "${toolchainPath}/bin/rmic",
+    "-g",
+    "-keep",
+    "-classpath", sourceSets.test.output.classesDirs.asPath,
+    "-d", "${buildDir}/classes/java/test",
+    clazz
+  )
 }
 
 tasks.named("test").configure {
-  dependsOn "rmic"
+  dependsOn rmic
 }

--- a/dd-java-agent/instrumentation/rmi/build.gradle
+++ b/dd-java-agent/instrumentation/rmi/build.gradle
@@ -21,11 +21,11 @@ def rmic = tasks.register('rmic', Exec) {
 
   def clazz = 'rmi.app.ServerLegacy'
   commandLine(
-    "${toolchainPath}/bin/rmic",
+    toolchainPath.file("bin/rmic").toString(),
     "-g",
     "-keep",
     "-classpath", sourceSets.test.output.classesDirs.asPath,
-    "-d", "${buildDir}/classes/java/test",
+    "-d", layout.buildDirectory.dir("classes/java/test").get().toString(),
     clazz
   )
 }

--- a/dd-java-agent/instrumentation/rmi/build.gradle
+++ b/dd-java-agent/instrumentation/rmi/build.gradle
@@ -27,7 +27,7 @@ def rmic = tasks.register('rmic', Exec) {
     "-classpath", sourceSets.test.output.classesDirs.asPath,
     "-d", layout.buildDirectory.dir("classes/java/test").get().toString(),
     clazz
-  )
+    )
 }
 
 tasks.named("test").configure {


### PR DESCRIPTION
# What Does This Do
Makes `rmic` Gradle task use `rmic` binary provided with Java 8 toolchain. Also changes the task type to `Exec` and refactors the command a bit.

Also, this ( 7c875e842adf387d8b162e487ca2356a2d823790 ) makes the paths to resolve properly on Windows (or any other OS). Not sure if the rest of the project will work properly on Windows, but this part will work now. :slightly_smiling_face: 

# Motivation
Without this change the task will fail if `rmic` binary is not on the Path env var. 
This is bad for 2 reasons:

- [Contribution guide](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md) doesn't mention anywhere it has to be on the path.
- Makes the build unpredictable. Since the rest of the modules are built with Java 8, it's better to explicitly specify the toolchain to use here.

# Additional Notes
Without this change I couldn't even import this project in IntelliJ.