### PR TITLE
TypeFactory.installing should default to false…

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
@@ -94,7 +94,7 @@ final class TypeFactory {
 
   private final Function<String, LazyType> deferType = LazyType::new;
 
-  boolean installing = true;
+  boolean installing = false;
 
   boolean createOutlines = true;
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
@@ -25,7 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Context-aware factory that provides different kinds of type descriptions:
+ * Context-aware thread-local type factory that provides different kinds of type descriptions:
  *
  * <ul>
  *   <li>minimally parsed type outlines for matching purposes


### PR DESCRIPTION
…so new threads loading types after the byte-buddy agent is installed are in the right state.

(`beginInstall` sets 'installing' to true, `endInstall` sets it to false, everywhere else it should be false)