### PR TITLE
Remove cache of ForLoadedType common types as outlining is faster

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
@@ -11,7 +11,6 @@ import datadog.trace.agent.tooling.bytebuddy.TypeInfoCache.SharedTypeInfo;
 import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
-import java.io.Serializable;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
@@ -47,7 +46,7 @@ final class TypeFactory {
 
   private static final Map<String, TypeDescription> primitiveDescriptorTypes = new HashMap<>();
 
-  private static final Map<String, TypeDescription> commonLoadedTypes = new HashMap<>();
+  private static final Map<String, TypeDescription> primitiveTypes = new HashMap<>();
 
   static {
     for (Class<?> primitive :
@@ -64,18 +63,7 @@ final class TypeFactory {
         }) {
       TypeDescription primitiveType = TypeDescription.ForLoadedType.of(primitive);
       primitiveDescriptorTypes.put(Type.getDescriptor(primitive), primitiveType);
-      commonLoadedTypes.put(primitive.getName(), primitiveType);
-    }
-    for (TypeDescription loaded :
-        new TypeDescription[] {
-          TypeDescription.ForLoadedType.of(Object.class),
-          TypeDescription.ForLoadedType.of(String.class),
-          TypeDescription.ForLoadedType.of(Class.class),
-          TypeDescription.ForLoadedType.of(Throwable.class),
-          TypeDescription.ForLoadedType.of(Serializable.class),
-          TypeDescription.ForLoadedType.of(Cloneable.class)
-        }) {
-      commonLoadedTypes.put(loaded.getName(), loaded);
+      primitiveTypes.put(primitive.getName(), primitiveType);
     }
   }
 
@@ -198,11 +186,13 @@ final class TypeFactory {
   }
 
   static TypeDescription findType(String name) {
-    TypeDescription type = commonLoadedTypes.get(name);
-    if (null == type) {
-      type = typeFactory.get().deferTypeResolution(name);
+    if (name.length() < 8) { // possible primitive name
+      TypeDescription type = primitiveTypes.get(name);
+      if (null != type) {
+        return type;
+      }
     }
-    return type;
+    return typeFactory.get().deferTypeResolution(name);
   }
 
   private TypeDescription deferTypeResolution(String name) {


### PR DESCRIPTION
also use simple name-length check to skip checking the primitive type cache for the majority of type lookups