### PR TITLE
Introduce named presets for the resolver cache, to make it easier to configure

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -85,7 +85,7 @@ public class AgentInstaller {
       final AgentBuilder.Listener... listeners) {
     Utils.setInstrumentation(inst);
 
-    if (InstrumenterConfig.get().isResolverOutlinePoolEnabled()) {
+    if (InstrumenterConfig.get().isResolverOutliningEnabled()) {
       DDOutlinePoolStrategy.registerTypePoolFacade();
     } else {
       DDCachingPoolStrategy.registerAsSupplier();

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentStrategies.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentStrategies.java
@@ -50,7 +50,7 @@ public class AgentStrategies {
   private static final TypeStrategy TYPE_STRATEGY;
 
   static {
-    if (InstrumenterConfig.get().isResolverOutlinePoolEnabled()) {
+    if (InstrumenterConfig.get().isResolverOutliningEnabled()) {
       POOL_STRATEGY = DDOutlinePoolStrategy.INSTANCE;
       BUFFER_STRATEGY = DDOutlineTypeStrategy.INSTANCE;
       TYPE_STRATEGY = DDOutlineTypeStrategy.INSTANCE;

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -131,8 +131,6 @@ public final class ConfigDefaults {
 
   static final boolean DEFAULT_DATA_STREAMS_ENABLED = false;
 
-  static final int DEFAULT_RESOLVER_OUTLINE_POOL_SIZE = 128;
-  static final int DEFAULT_RESOLVER_TYPE_POOL_SIZE = 64;
   static final int DEFAULT_RESOLVER_RESET_INTERVAL = 300; // seconds
 
   static final boolean DEFAULT_TELEMETRY_ENABLED = true;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -90,9 +90,7 @@ public final class TraceInstrumentationConfig {
   public static final String SERVLET_ROOT_CONTEXT_SERVICE_NAME =
       "trace.servlet.root-context.service.name";
 
-  public static final String RESOLVER_OUTLINE_POOL_ENABLED = "resolver.outline.pool.enabled";
-  public static final String RESOLVER_OUTLINE_POOL_SIZE = "resolver.outline.pool.size";
-  public static final String RESOLVER_TYPE_POOL_SIZE = "resolver.type.pool.size";
+  public static final String RESOLVER_CACHE_CONFIG = "resolver.cache.config";
   public static final String RESOLVER_USE_LOADCLASS = "resolver.use.loadclass";
   public static final String RESOLVER_RESET_INTERVAL = "resolver.reset.interval";
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -2941,8 +2941,6 @@ public class Config {
         + grpcServerErrorStatuses
         + ", grpcClientErrorStatuses="
         + grpcClientErrorStatuses
-        + ", configProvider="
-        + configProvider
         + ", clientIpEnabled="
         + clientIpEnabled
         + ", appSecReportingInband="

--- a/internal-api/src/main/java/datadog/trace/api/ResolverCacheConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/ResolverCacheConfig.java
@@ -1,0 +1,61 @@
+package datadog.trace.api;
+
+/** Named presets to help configure various caches inside the type resolver/matcher. */
+public enum ResolverCacheConfig {
+
+  /** Pool sizes to fit large enterprise apps. */
+  LARGE {
+    @Override
+    public int outlinePoolSize() {
+      return 4096;
+    }
+
+    @Override
+    public int typePoolSize() {
+      return 256;
+    }
+  },
+
+  /** Pool sizes to fit the average sized app. */
+  DEFAULT {
+    @Override
+    public int outlinePoolSize() {
+      return 256;
+    }
+
+    @Override
+    public int typePoolSize() {
+      return 32;
+    }
+  },
+
+  /** Pool sizes to fit small microservice apps. */
+  SMALL {
+    @Override
+    public int outlinePoolSize() {
+      return 32;
+    }
+
+    @Override
+    public int typePoolSize() {
+      return 16;
+    }
+  },
+
+  /** The old {@code DDCachingPoolStrategy} behaviour. */
+  LEGACY {
+    @Override
+    public int outlinePoolSize() {
+      return 0;
+    }
+
+    @Override
+    public int typePoolSize() {
+      return 64;
+    }
+  };
+
+  public abstract int outlinePoolSize();
+
+  public abstract int typePoolSize();
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/InstrumenterConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/InstrumenterConfigTest.groovy
@@ -39,4 +39,32 @@ class InstrumenterConfigTest extends DDSpecification {
 
     integrationNames = new TreeSet<>(names)
   }
+
+  def "valid resolver presets"() {
+    setup:
+    injectSysConfig("resolver.cache.config", preset)
+
+    expect:
+    InstrumenterConfig.get().resolverOutliningEnabled == outlining
+
+    where:
+    // spotless:off
+    preset    | outlining
+    'LARGE'   | true
+    'SMALL'   | true
+    'DEFAULT' | true
+    'LEGACY'  | false
+    // spotless:on
+  }
+
+  def "invalid resolver presets"() {
+    setup:
+    injectSysConfig("resolver.cache.config", preset)
+
+    expect:
+    InstrumenterConfig.get().resolverOutliningEnabled
+
+    where:
+    preset << ['INVALID', '']
+  }
 }

--- a/internal-api/src/test/groovy/datadog/trace/api/InstrumenterConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/InstrumenterConfigTest.groovy
@@ -14,8 +14,17 @@ class InstrumenterConfigTest extends DDSpecification {
     System.setProperty("dd.integration.test-prop.enabled", "true")
     System.setProperty("dd.integration.disabled-prop.enabled", "false")
 
+    environmentVariables.set("DD_INTEGRATION_ORDER_MATCHING_SHORTCUT_ENABLED", "false")
+    environmentVariables.set("DD_INTEGRATION_TEST_ENV_MATCHING_SHORTCUT_ENABLED", "true")
+    environmentVariables.set("DD_INTEGRATION_DISABLED_ENV_MATCHING_SHORTCUT_ENABLED", "false")
+
+    System.setProperty("dd.integration.order.matching.shortcut.enabled", "true")
+    System.setProperty("dd.integration.test-prop.matching.shortcut.enabled", "true")
+    System.setProperty("dd.integration.disabled-prop.matching.shortcut.enabled", "false")
+
     expect:
     InstrumenterConfig.get().isIntegrationEnabled(integrationNames, defaultEnabled) == expected
+    InstrumenterConfig.get().isIntegrationShortcutMatchingEnabled(integrationNames, defaultEnabled) == expected
 
     where:
     // spotless:off


### PR DESCRIPTION
The following named presets are currently supported:
```
DEFAULT     # Pool sizes to fit the average sized app

LARGE       # Pool sizes to fit large enterprise apps

SMALL       # Pool sizes to fit small microservice apps

LEGACY      # Revert to the behaviour before 0.104.0
```

System property:
```
-Ddd.resolver.cache.config=LARGE
```
Environment variable:
```
DD_RESOLVER_CACHE_CONFIG=LARGE
```

I also adjusted the default sizes to allow for more outline types vs full types, by profiling how many outlines vs full-types were parsed for a selection of applications. (Recent changes mean we now use type outlines more than we did before.)