### PR TITLE
Add span probe configuration

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/Configuration.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/Configuration.java
@@ -4,6 +4,7 @@ import com.datadog.debugger.probe.LogProbe;
 import com.datadog.debugger.probe.MetricProbe;
 import com.datadog.debugger.probe.ProbeDefinition;
 import com.datadog.debugger.probe.SnapshotProbe;
+import com.datadog.debugger.probe.SpanProbe;
 import com.squareup.moshi.Json;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -63,20 +64,13 @@ public class Configuration {
   private final Collection<SnapshotProbe> snapshotProbes;
   private final Collection<MetricProbe> metricProbes;
   private final Collection<LogProbe> logProbes;
+  private final Collection<SpanProbe> spanProbes;
   private final FilterList allowList;
   private final FilterList denyList;
   private final SnapshotProbe.Sampling sampling;
 
   public Configuration(String service, Collection<SnapshotProbe> snapshotProbes) {
-    this(service, snapshotProbes, null, null);
-  }
-
-  public Configuration(
-      String serviceName,
-      Collection<SnapshotProbe> snapshotProbes,
-      Collection<MetricProbe> metricProbes,
-      Collection<LogProbe> logProbes) {
-    this(serviceName, snapshotProbes, metricProbes, logProbes, null, null, null);
+    this(service, snapshotProbes, null, null, null);
   }
 
   public Configuration(
@@ -84,6 +78,16 @@ public class Configuration {
       Collection<SnapshotProbe> snapshotProbes,
       Collection<MetricProbe> metricProbes,
       Collection<LogProbe> logProbes,
+      Collection<SpanProbe> spanProbes) {
+    this(serviceName, snapshotProbes, metricProbes, logProbes, spanProbes, null, null, null);
+  }
+
+  public Configuration(
+      String serviceName,
+      Collection<SnapshotProbe> snapshotProbes,
+      Collection<MetricProbe> metricProbes,
+      Collection<LogProbe> logProbes,
+      Collection<SpanProbe> spanProbes,
       FilterList allowList,
       FilterList denyList,
       SnapshotProbe.Sampling sampling) {
@@ -91,6 +95,7 @@ public class Configuration {
     this.snapshotProbes = snapshotProbes;
     this.metricProbes = metricProbes;
     this.logProbes = logProbes;
+    this.spanProbes = spanProbes;
     this.allowList = allowList;
     this.denyList = denyList;
     this.sampling = sampling;
@@ -110,6 +115,10 @@ public class Configuration {
 
   public Collection<LogProbe> getLogProbes() {
     return logProbes;
+  }
+
+  public Collection<SpanProbe> getSpanProbes() {
+    return spanProbes;
   }
 
   public FilterList getAllowList() {
@@ -134,6 +143,9 @@ public class Configuration {
     }
     if (logProbes != null) {
       result.addAll(logProbes);
+    }
+    if (spanProbes != null) {
+      result.addAll(spanProbes);
     }
     return result;
   }
@@ -190,6 +202,7 @@ public class Configuration {
     private List<SnapshotProbe> snapshotProbes = null;
     private List<MetricProbe> metricProbes = null;
     private List<LogProbe> logProbes = null;
+    private List<SpanProbe> spanProbes = null;
     private FilterList allowList = null;
     private FilterList denyList = null;
     private SnapshotProbe.Sampling sampling = null;
@@ -220,6 +233,14 @@ public class Configuration {
         logProbes = new ArrayList<>();
       }
       logProbes.add(probe);
+      return this;
+    }
+
+    public Configuration.Builder add(SpanProbe probe) {
+      if (spanProbes == null) {
+        spanProbes = new ArrayList<>();
+      }
+      spanProbes.add(probe);
       return this;
     }
 
@@ -260,6 +281,16 @@ public class Configuration {
       return this;
     }
 
+    public Configuration.Builder addSpanProbes(Collection<SpanProbe> probes) {
+      if (probes == null) {
+        return this;
+      }
+      for (SpanProbe probe : probes) {
+        add(probe);
+      }
+      return this;
+    }
+
     public Configuration.Builder addAllowList(FilterList newAllowList) {
       if (newAllowList == null) {
         return this;
@@ -284,6 +315,11 @@ public class Configuration {
       return this;
     }
 
+    public Configuration.Builder setSampling(SnapshotProbe.Sampling sampling) {
+      this.sampling = sampling;
+      return this;
+    }
+
     public Configuration.Builder add(Configuration other) {
       if (other.service != null) {
         this.service = other.service;
@@ -299,7 +335,14 @@ public class Configuration {
 
     public Configuration build() {
       return new Configuration(
-          service, snapshotProbes, metricProbes, logProbes, allowList, denyList, sampling);
+          service,
+          snapshotProbes,
+          metricProbes,
+          logProbes,
+          spanProbes,
+          allowList,
+          denyList,
+          sampling);
     }
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanProbe.java
@@ -1,0 +1,101 @@
+package com.datadog.debugger.probe;
+
+import com.datadog.debugger.agent.Generated;
+import datadog.trace.bootstrap.debugger.DiagnosticMessage;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
+
+public class SpanProbe extends ProbeDefinition {
+  private String name;
+  // no-arg constructor is required by Moshi to avoid creating instance with unsafe and by-passing
+  // constructors, including field initializers.
+  public SpanProbe() {
+    this(LANGUAGE, null, true, null, null, null);
+  }
+
+  public SpanProbe(
+      String language, String id, boolean active, String[] tagStrs, Where where, String name) {
+    super(language, id, active, tagStrs, where, MethodLocation.DEFAULT);
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public void instrument(
+      ClassLoader classLoader,
+      ClassNode classNode,
+      MethodNode methodNode,
+      List<DiagnosticMessage> diagnostics) {}
+
+  @Generated
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(language, id, active, tagMap, where, evaluateAt, name);
+    result = 31 * result + Arrays.hashCode(tags);
+    return result;
+  }
+
+  @Generated
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    SpanProbe that = (SpanProbe) o;
+    return active == that.active
+        && Objects.equals(language, that.language)
+        && Objects.equals(id, that.id)
+        && Arrays.equals(tags, that.tags)
+        && Objects.equals(tagMap, that.tagMap)
+        && Objects.equals(where, that.where)
+        && Objects.equals(evaluateAt, that.evaluateAt)
+        && Objects.equals(name, that.name);
+  }
+
+  @Generated
+  @Override
+  public String toString() {
+    return "SpanProbe{"
+        + "language='"
+        + language
+        + '\''
+        + ", id='"
+        + id
+        + '\''
+        + ", active="
+        + active
+        + ", tags="
+        + Arrays.toString(tags)
+        + ", tagMap="
+        + tagMap
+        + ", where="
+        + where
+        + ", evaluateAt="
+        + evaluateAt
+        + ", name="
+        + name
+        + "} ";
+  }
+
+  public static SpanProbe.Builder builder() {
+    return new SpanProbe.Builder();
+  }
+
+  public static class Builder extends ProbeDefinition.Builder<Builder> {
+    private String name;
+
+    public SpanProbe.Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public SpanProbe build() {
+      return new SpanProbe(LANGUAGE, probeId, active, tagStrs, where, name);
+    }
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationComparerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationComparerTest.java
@@ -164,14 +164,11 @@ class ConfigurationComparerTest {
   public void hasProbeRelatedChangesFilteredChanged() {
     Configuration empty = createConfig(Collections.emptyList());
     Configuration config =
-        new Configuration(
-            SERVICE_NAME,
-            Collections.emptyList(),
-            Collections.emptyList(),
-            Collections.emptyList(),
-            new Configuration.FilterList(Arrays.asList("com.datadog"), Collections.emptyList()),
-            null,
-            null);
+        Configuration.builder()
+            .setService(SERVICE_NAME)
+            .addAllowList(
+                new Configuration.FilterList(Arrays.asList("com.datadog"), Collections.emptyList()))
+            .build();
     ConfigurationComparer configurationComparer =
         new ConfigurationComparer(empty, config, Collections.emptyMap());
     Assertions.assertTrue(configurationComparer.hasProbeRelatedChanges());

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.agent;
 
+import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -15,6 +16,7 @@ import com.datadog.debugger.probe.LogProbe;
 import com.datadog.debugger.probe.MetricProbe;
 import com.datadog.debugger.probe.ProbeDefinition;
 import com.datadog.debugger.probe.SnapshotProbe;
+import com.datadog.debugger.probe.SpanProbe;
 import com.datadog.debugger.sink.DebuggerSink;
 import com.datadog.debugger.sink.ProbeStatusSink;
 import datadog.trace.api.Config;
@@ -224,7 +226,7 @@ public class ConfigurationUpdaterTest {
     List<MetricProbe> metricProbes =
         Arrays.asList(
             MetricProbe.builder().probeId(METRIC_ID).where("java.lang.String", "concat").build());
-    configurationUpdater.accept(createApp(snapshotProbes, metricProbes, Collections.emptyList()));
+    configurationUpdater.accept(createApp(snapshotProbes, metricProbes, emptyList(), emptyList()));
     verify(inst).addTransformer(any(), eq(true));
     verify(inst).getAllLoadedClasses();
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
@@ -514,7 +516,7 @@ public class ConfigurationUpdaterTest {
         new ConfigurationUpdater(inst, this::createTransformer, tracerConfig);
     configurationUpdater.accept(createApp(snapshotProbes));
     Assertions.assertEquals(
-        ConfigurationUpdater.MAX_ALLOWED_PROBES,
+        ConfigurationUpdater.MAX_ALLOWED_SNAPSHOT_PROBES,
         configurationUpdater.getAppliedDefinitions().size());
   }
 
@@ -735,8 +737,9 @@ public class ConfigurationUpdaterTest {
   private static Configuration createApp(
       List<SnapshotProbe> snapshotProbes,
       List<MetricProbe> metricProbes,
-      List<LogProbe> logProbes) {
-    return new Configuration(SERVICE_NAME, snapshotProbes, metricProbes, logProbes);
+      List<LogProbe> logProbes,
+      List<SpanProbe> spanProbes) {
+    return new Configuration(SERVICE_NAME, snapshotProbes, metricProbes, logProbes, spanProbes);
   }
 
   private static Configuration createAppMetrics(List<MetricProbe> metricProbes) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/TransformerDefinitionMatcherTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/TransformerDefinitionMatcherTest.java
@@ -7,6 +7,7 @@ import com.datadog.debugger.probe.LogProbe;
 import com.datadog.debugger.probe.MetricProbe;
 import com.datadog.debugger.probe.ProbeDefinition;
 import com.datadog.debugger.probe.SnapshotProbe;
+import com.datadog.debugger.probe.SpanProbe;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -23,7 +24,8 @@ public class TransformerDefinitionMatcherTest {
 
   @Test
   public void empty() {
-    TransformerDefinitionMatcher matcher = createMatcher(emptyList(), emptyList(), emptyList());
+    TransformerDefinitionMatcher matcher =
+        createMatcher(emptyList(), emptyList(), emptyList(), emptyList());
     assertTrue(matcher.isEmpty());
   }
 
@@ -31,7 +33,7 @@ public class TransformerDefinitionMatcherTest {
   public void fullQualifiedClassName() {
     SnapshotProbe probe = createProbe(PROBE_ID1, "java.lang.String", "indexOf");
     TransformerDefinitionMatcher matcher =
-        createMatcher(Arrays.asList(probe), emptyList(), emptyList());
+        createMatcher(Arrays.asList(probe), emptyList(), emptyList(), emptyList());
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
     assertEquals(1, probeDefinitions.size());
     assertEquals(PROBE_ID1, probeDefinitions.get(0).getId());
@@ -41,7 +43,7 @@ public class TransformerDefinitionMatcherTest {
   public void simpleClassName() {
     SnapshotProbe probe = createProbe(PROBE_ID1, "String", "indexOf");
     TransformerDefinitionMatcher matcher =
-        createMatcher(Arrays.asList(probe), emptyList(), emptyList());
+        createMatcher(Arrays.asList(probe), emptyList(), emptyList(), emptyList());
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
     assertEquals(1, probeDefinitions.size());
     assertEquals(PROBE_ID1, probeDefinitions.get(0).getId());
@@ -51,7 +53,7 @@ public class TransformerDefinitionMatcherTest {
   public void simpleClassNameNoClassRedefined() {
     SnapshotProbe probe = createProbe(PROBE_ID1, "String", "indexOf");
     TransformerDefinitionMatcher matcher =
-        createMatcher(Arrays.asList(probe), emptyList(), emptyList());
+        createMatcher(Arrays.asList(probe), emptyList(), emptyList(), emptyList());
     List<ProbeDefinition> probeDefinitions =
         matcher.match(
             null,
@@ -66,7 +68,7 @@ public class TransformerDefinitionMatcherTest {
   public void sourceFileFullFileName() {
     SnapshotProbe probe = createProbe(PROBE_ID1, "src/main/java/java/lang/String.java", 23);
     TransformerDefinitionMatcher matcher =
-        createMatcher(Arrays.asList(probe), emptyList(), emptyList());
+        createMatcher(Arrays.asList(probe), emptyList(), emptyList(), emptyList());
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
     assertEquals(1, probeDefinitions.size());
     assertEquals(PROBE_ID1, probeDefinitions.get(0).getId());
@@ -77,7 +79,7 @@ public class TransformerDefinitionMatcherTest {
     SnapshotProbe probe =
         createProbe(PROBE_ID1, "/home/user/project/src/main/java/java/lang/String.java", 23);
     TransformerDefinitionMatcher matcher =
-        createMatcher(Arrays.asList(probe), emptyList(), emptyList());
+        createMatcher(Arrays.asList(probe), emptyList(), emptyList(), emptyList());
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
     assertEquals(1, probeDefinitions.size());
     assertEquals(PROBE_ID1, probeDefinitions.get(0).getId());
@@ -87,7 +89,7 @@ public class TransformerDefinitionMatcherTest {
   public void sourceFileSimpleFileName() {
     SnapshotProbe probe = createProbe(PROBE_ID1, "String.java", 23);
     TransformerDefinitionMatcher matcher =
-        createMatcher(Arrays.asList(probe), emptyList(), emptyList());
+        createMatcher(Arrays.asList(probe), emptyList(), emptyList(), emptyList());
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
     assertEquals(1, probeDefinitions.size());
     assertEquals(PROBE_ID1, probeDefinitions.get(0).getId());
@@ -98,7 +100,7 @@ public class TransformerDefinitionMatcherTest {
     SnapshotProbe probe1 = createProbe(PROBE_ID1, "java.lang.String", "indexOf");
     SnapshotProbe probe2 = createProbe(PROBE_ID2, "java.lang.String", "substring");
     TransformerDefinitionMatcher matcher =
-        createMatcher(Arrays.asList(probe1, probe2), emptyList(), emptyList());
+        createMatcher(Arrays.asList(probe1, probe2), emptyList(), emptyList(), emptyList());
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
     assertEquals(2, probeDefinitions.size());
     assertEquals(PROBE_ID1, probeDefinitions.get(0).getId());
@@ -110,7 +112,7 @@ public class TransformerDefinitionMatcherTest {
     SnapshotProbe probe1 = createProbe(PROBE_ID1, "String", "indexOf");
     SnapshotProbe probe2 = createProbe(PROBE_ID2, "String", "substring");
     TransformerDefinitionMatcher matcher =
-        createMatcher(Arrays.asList(probe1, probe2), emptyList(), emptyList());
+        createMatcher(Arrays.asList(probe1, probe2), emptyList(), emptyList(), emptyList());
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
     assertEquals(2, probeDefinitions.size());
     assertEquals(PROBE_ID1, probeDefinitions.get(0).getId());
@@ -122,7 +124,7 @@ public class TransformerDefinitionMatcherTest {
     SnapshotProbe probe1 = createProbe(PROBE_ID1, "src/main/java/java/lang/String.java", 23);
     SnapshotProbe probe2 = createProbe(PROBE_ID2, "src/main/java/java/lang/String.java", 42);
     TransformerDefinitionMatcher matcher =
-        createMatcher(Arrays.asList(probe1, probe2), emptyList(), emptyList());
+        createMatcher(Arrays.asList(probe1, probe2), emptyList(), emptyList(), emptyList());
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
     assertEquals(2, probeDefinitions.size());
     assertEquals(PROBE_ID1, probeDefinitions.get(0).getId());
@@ -134,7 +136,7 @@ public class TransformerDefinitionMatcherTest {
     SnapshotProbe probe1 = createProbe(PROBE_ID1, "java.lang.String", "indexOf");
     SnapshotProbe probe2 = createProbe(PROBE_ID2, "String", "substring");
     TransformerDefinitionMatcher matcher =
-        createMatcher(Arrays.asList(probe1, probe2), emptyList(), emptyList());
+        createMatcher(Arrays.asList(probe1, probe2), emptyList(), emptyList(), emptyList());
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
     assertEquals(2, probeDefinitions.size());
     assertEquals(PROBE_ID1, probeDefinitions.get(0).getId());
@@ -146,7 +148,7 @@ public class TransformerDefinitionMatcherTest {
     SnapshotProbe probe1 = createProbe(PROBE_ID1, "java.lang.String", "indexOf");
     MetricProbe probe2 = createMetric(PROBE_ID2, "String", "substring");
     TransformerDefinitionMatcher matcher =
-        createMatcher(Arrays.asList(probe1), Arrays.asList(probe2), emptyList());
+        createMatcher(Arrays.asList(probe1), Arrays.asList(probe2), emptyList(), emptyList());
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
     assertEquals(2, probeDefinitions.size());
     assertEquals(PROBE_ID1, probeDefinitions.get(0).getId());
@@ -157,7 +159,7 @@ public class TransformerDefinitionMatcherTest {
   public void partialSimpleNameShouldNotMatch() {
     SnapshotProbe probe1 = createProbe(PROBE_ID1, "SuperString.java", 11);
     TransformerDefinitionMatcher matcher =
-        createMatcher(Arrays.asList(probe1), emptyList(), emptyList());
+        createMatcher(Arrays.asList(probe1), emptyList(), emptyList(), emptyList());
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
     assertEquals(0, probeDefinitions.size());
   }
@@ -165,9 +167,10 @@ public class TransformerDefinitionMatcherTest {
   private TransformerDefinitionMatcher createMatcher(
       Collection<SnapshotProbe> snapshotProbes,
       Collection<MetricProbe> metricProbes,
-      Collection<LogProbe> logProbes) {
+      Collection<LogProbe> logProbes,
+      Collection<SpanProbe> spanProbes) {
     return new TransformerDefinitionMatcher(
-        new Configuration(SERVICE_NAME, snapshotProbes, metricProbes, logProbes));
+        new Configuration(SERVICE_NAME, snapshotProbes, metricProbes, logProbes, spanProbes));
   }
 
   private static List<ProbeDefinition> match(TransformerDefinitionMatcher matcher, Class<?> clazz) {

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
@@ -227,7 +227,8 @@ public abstract class BaseIntegrationTest {
       Collection<SnapshotProbe> snapshotProbes,
       Configuration.FilterList allowList,
       Configuration.FilterList denyList) {
-    return new Configuration(getAppId(), snapshotProbes, null, null, allowList, denyList, null);
+    return new Configuration(
+        getAppId(), snapshotProbes, null, null, null, allowList, denyList, null);
   }
 
   protected void assertCaptureArgs(


### PR DESCRIPTION
# What Does This Do
Add support for incoming debugger span probes.
Add in debugger configuration and deserialization model

# Motivation
Configuration model for new debugger span probes

# Additional Notes
