### PR TITLE
Changed dependency detection resolver log level from warn to debug

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolverQueue.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolverQueue.java
@@ -53,11 +53,7 @@ public class DependencyResolverQueue {
 
     List<Dependency> dep = DependencyResolver.resolve(uri);
     if (dep.isEmpty()) {
-      if ("jrt".equals(uri.getScheme()) || "x-internal-jar".equals(uri.getScheme())) {
-        log.debug("unable to detect dependency for URI {}", uri);
-      } else {
-        log.debug("unable to detect dependency for URI {}", uri);
-      }
+      log.debug("unable to detect dependency for URI {}", uri);
       return Collections.emptyList();
     }
     if (log.isDebugEnabled()) {

--- a/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolverQueue.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolverQueue.java
@@ -56,7 +56,7 @@ public class DependencyResolverQueue {
       if ("jrt".equals(uri.getScheme()) || "x-internal-jar".equals(uri.getScheme())) {
         log.debug("unable to detect dependency for URI {}", uri);
       } else {
-        log.warn("unable to detect dependency for URI {}", uri);
+        log.debug("unable to detect dependency for URI {}", uri);
       }
       return Collections.emptyList();
     }


### PR DESCRIPTION
# What Does This Do
Changes the log level of the DependencyResolverQueue log statement
# Motivation
Customers are seeing the log statement because it is at WARN level.
# Additional Notes
