### PR TITLE
feat(dd-trace-ot): Add MDC injection config support

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -407,7 +407,10 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer, InternalTrace
       this.scopeManager = new OTScopeManager(tracer, converter);
     }
 
-    CorrelationIdInjectors.register(this);
+    if ((config != null && config.isLogsInjectionEnabled())
+        || (config == null && Config.get().isLogsInjectionEnabled())) {
+      CorrelationIdInjectors.register(this);
+    }
   }
 
   private static Map<String, String> customRuntimeTags(


### PR DESCRIPTION
# What Does This Do

This PR makes the MDC injection from `dd-trace-ot` respects the `dd.logs.injection` config.

# Motivation

Requested by @bantonsson. It will match the instrumentation behavior.

# Additional Notes

Complement to #4396 