### PR TITLE
Fix number of dropped spans metric in the Single Span Sampling worker

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/SpanSamplingWorker.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/SpanSamplingWorker.java
@@ -145,7 +145,7 @@ public class SpanSamplingWorker implements AutoCloseable {
             log.debug(
                 "Trace is empty after single span sampling. Counted but dropping trace: {}", trace);
           } else {
-            healthMetrics.onPartialPublish(sampledSpans.size());
+            healthMetrics.onPartialPublish(unsampledSpans.size());
             log.debug(
                 "Unsampled spans dropped after single span sampling because Dropping Policy is active or the queue is full. Counted partial trace: {}",
                 sampledSpans);

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/SpanSamplingWorkerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/SpanSamplingWorkerTest.groovy
@@ -316,20 +316,22 @@ class SpanSamplingWorkerTest extends DDSpecification {
 
     DDSpan span1 = Mock(DDSpan)
     DDSpan span2 = Mock(DDSpan)
+    DDSpan span3 = Mock(DDSpan)
     span1.samplingPriority() >> PrioritySampling.SAMPLER_DROP
     singleSpanSampler.setSamplingPriority(span1) >> false
     singleSpanSampler.setSamplingPriority(span2) >> true
+    singleSpanSampler.setSamplingPriority(span3) >> false
 
     def queue = worker.getSpanSamplingQueue()
 
     when:
-    assert queue.offer([span1, span2])
+    assert queue.offer([span1, span2, span3])
 
     then:
     primaryQueue.take() == [span2]
 
     then:
-    1 * healthMetrics.onPartialPublish(1)
+    1 * healthMetrics.onPartialPublish(2)
     0 * healthMetrics.onFailedPublish(_)
     0 * healthMetrics.onPublish(_, _)
 


### PR DESCRIPTION
# What Does This Do

Fixes the dropped spans metric call. It must pass number of dropped spans instead of number of sampled spans.

# Motivation

`healthMetrics.onPartialPublish` expects number of dropped spans passed as a param.

# Additional Notes

@PerfectSlayer, thanks for you help finding this issue!
