### PR TITLE
chore: Remove Java8+ check

### DIFF
--- a/communication/src/test/groovy/datadog/communication/ddagent/SharedCommunicationsObjectsSpecification.groovy
+++ b/communication/src/test/groovy/datadog/communication/ddagent/SharedCommunicationsObjectsSpecification.groovy
@@ -5,13 +5,7 @@ import datadog.trace.api.Config
 import datadog.trace.test.util.DDSpecification
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
-import spock.lang.Requires
 
-import static datadog.trace.api.Platform.isJavaVersionAtLeast
-
-@Requires({
-  isJavaVersionAtLeast(8)
-})
 class SharedCommunicationsObjectsSpecification extends DDSpecification {
   SharedCommunicationObjects sco = new SharedCommunicationObjects()
 

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/DatadogClassLoaderTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/DatadogClassLoaderTest.groovy
@@ -12,9 +12,6 @@ import java.util.concurrent.Future
 import java.util.concurrent.Phaser
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.api.Platform.isJavaVersionAtLeast
-import static org.junit.Assume.assumeTrue
-
 class DatadogClassLoaderTest extends DDSpecification {
   @Shared
   URL testJarLocation = new File("src/test/resources/classloader-test-jar/testjar-jdk8").toURI().toURL()
@@ -63,8 +60,6 @@ class DatadogClassLoaderTest extends DDSpecification {
 
   def "agent classloader successfully loads classes concurrently"() {
     given:
-    assumeTrue(isJavaVersionAtLeast(8))
-
     DatadogClassLoader ddLoader = new DatadogClassLoader(testJarLocation, null)
 
     when:
@@ -94,8 +89,6 @@ class DatadogClassLoaderTest extends DDSpecification {
 
   def "test load nested classes and call getEnclosingClass"() {
     given:
-    assumeTrue(isJavaVersionAtLeast(8))
-
     DatadogClassLoader ddLoader = new DatadogClassLoader(nestedTestJarLocation, null)
 
     when:

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -2,7 +2,6 @@ import com.google.common.util.concurrent.MoreExecutors
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.Platform
 import datadog.trace.api.function.TriConsumer
 import datadog.trace.api.gateway.Flow
 import datadog.trace.api.gateway.RequestContext
@@ -109,7 +108,7 @@ abstract class GrpcTest extends AgentTestRunner {
     }
     // wait here to make checkpoint asserts deterministic
     TEST_WRITER.waitForTraces(2)
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(2)
     }
 
@@ -188,7 +187,7 @@ abstract class GrpcTest extends AgentTestRunner {
     collectedAppSecReqMsgs.first().name == name
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(["direction:out", "type:grpc"])

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinPoolInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinPoolInstrumentation.java
@@ -10,7 +10,6 @@ import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.Platform;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import java.util.Map;
@@ -37,15 +36,9 @@ public class JavaForkJoinPoolInstrumentation extends Instrumenter.Tracing
 
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
-    if (Platform.isJavaVersionAtLeast(8)) {
-      transformation.applyAdvice(
-          isMethod().and(namedOneOf("externalPush", "externalSubmit")),
-          getClass().getName() + "$ExternalPush");
-    } else {
-      transformation.applyAdvice(
-          isMethod().and(namedOneOf("forkOrSubmit", "invoke")),
-          getClass().getName() + "$ExternalPush");
-    }
+    transformation.applyAdvice(
+        isMethod().and(namedOneOf("externalPush", "externalSubmit")),
+        getClass().getName() + "$ExternalPush");
   }
 
   public static final class ExternalPush {

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/RecursiveThreadPoolPropagationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/RecursiveThreadPoolPropagationTest.groovy
@@ -1,17 +1,11 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.core.DDSpan
 import io.netty.channel.DefaultEventLoopGroup
-import spock.lang.Requires
 import spock.lang.Shared
 
 import java.util.concurrent.Executors
 import java.util.concurrent.ForkJoinPool
 
-import static datadog.trace.api.Platform.isJavaVersionAtLeast
-
-@Requires({
-  isJavaVersionAtLeast(8)
-})
 class RecursiveThreadPoolPropagationTest extends AgentTestRunner {
 
   @Shared

--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/ProcessImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/ProcessImplInstrumentation.java
@@ -5,7 +5,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.Platform;
 import java.util.Map;
 
 @AutoService(Instrumenter.class)
@@ -19,11 +18,6 @@ public class ProcessImplInstrumentation extends Instrumenter.Tracing
   @Override
   public String instrumentedType() {
     return "java.lang.ProcessImpl";
-  }
-
-  @Override
-  public boolean isEnabled() {
-    return Platform.isJavaVersionAtLeast(8) && super.isEnabled();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/ProcessImplInstrumentationSpecification.groovy
+++ b/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/ProcessImplInstrumentationSpecification.groovy
@@ -4,15 +4,9 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.gateway.RequestContextSlot
 import datadog.trace.bootstrap.ActiveSubsystems
 import datadog.trace.core.DDSpan
-import spock.lang.Requires
 
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.api.Platform.isJavaVersionAtLeast
-
-@Requires({
-  isJavaVersionAtLeast(8)
-})
 class ProcessImplInstrumentationSpecification extends AgentTestRunner {
   def ss = TEST_TRACER.getSubscriptionService(RequestContextSlot.APPSEC)
 

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTest.groovy
@@ -1,5 +1,4 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.api.Platform
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.datastreams.StatsGroup
@@ -164,24 +163,22 @@ class KafkaClientTest extends AgentTestRunner {
     new String(headers.headers("x-datadog-trace-id").iterator().next().value()) == "${TEST_WRITER[0][2].traceId}"
     new String(headers.headers("x-datadog-parent-id").iterator().next().value()) == "${TEST_WRITER[0][2].spanId}"
 
-    if (Platform.isJavaVersionAtLeast(8)) {
-      StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
-      verifyAll(first) {
-        edgeTags == ["direction:out", "topic:$SHARED_TOPIC".toString(), "type:kafka"]
-        edgeTags.size() == 3
-      }
+    StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
+    verifyAll(first) {
+      edgeTags == ["direction:out", "topic:$SHARED_TOPIC".toString(), "type:kafka"]
+      edgeTags.size() == 3
+    }
 
-      StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
-      verifyAll(second) {
-        edgeTags == [
-          "direction:in",
-          "group:sender",
-          "partition:" + received.partition(),
-          "topic:$SHARED_TOPIC".toString(),
-          "type:kafka"
-        ]
-        edgeTags.size() == 5
-      }
+    StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
+    verifyAll(second) {
+      edgeTags == [
+        "direction:in",
+        "group:sender",
+        "partition:" + received.partition(),
+        "topic:$SHARED_TOPIC".toString(),
+        "type:kafka"
+      ]
+      edgeTags.size() == 5
     }
 
     cleanup:
@@ -291,24 +288,22 @@ class KafkaClientTest extends AgentTestRunner {
     new String(headers.headers("x-datadog-trace-id").iterator().next().value()) == "${TEST_WRITER[0][2].traceId}"
     new String(headers.headers("x-datadog-parent-id").iterator().next().value()) == "${TEST_WRITER[0][2].spanId}"
 
-    if (Platform.isJavaVersionAtLeast(8)) {
-      StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
-      verifyAll(first) {
-        edgeTags == ["direction:out", "topic:$SHARED_TOPIC".toString(), "type:kafka"]
-        edgeTags.size() == 3
-      }
+    StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
+    verifyAll(first) {
+      edgeTags == ["direction:out", "topic:$SHARED_TOPIC".toString(), "type:kafka"]
+      edgeTags.size() == 3
+    }
 
-      StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
-      verifyAll(second) {
-        edgeTags == [
-          "direction:in",
-          "group:sender",
-          "partition:" + received.partition(),
-          "topic:$SHARED_TOPIC".toString(),
-          "type:kafka"
-        ]
-        edgeTags.size() == 5
-      }
+    StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
+    verifyAll(second) {
+      edgeTags == [
+        "direction:in",
+        "group:sender",
+        "partition:" + received.partition(),
+        "topic:$SHARED_TOPIC".toString(),
+        "type:kafka"
+      ]
+      edgeTags.size() == 5
     }
 
     cleanup:
@@ -880,24 +875,22 @@ class KafkaClientTest extends AgentTestRunner {
       }
     }
 
-    if (Platform.isJavaVersionAtLeast(8)) {
-      StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
-      verifyAll(first) {
-        edgeTags == ["direction:out", "topic:$SHARED_TOPIC".toString(), "type:kafka"]
-        edgeTags.size() == 3
-      }
+    StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
+    verifyAll(first) {
+      edgeTags == ["direction:out", "topic:$SHARED_TOPIC".toString(), "type:kafka"]
+      edgeTags.size() == 3
+    }
 
-      StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
-      verifyAll(second) {
-        edgeTags == [
-          "direction:in",
-          "group:sender",
-          "partition:" + partition,
-          "topic:$SHARED_TOPIC".toString(),
-          "type:kafka"
-        ]
-        edgeTags.size() == 5
-      }
+    StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
+    verifyAll(second) {
+      edgeTags == [
+        "direction:in",
+        "group:sender",
+        "partition:" + partition,
+        "topic:$SHARED_TOPIC".toString(),
+        "type:kafka"
+      ]
+      edgeTags.size() == 5
     }
 
     cleanup:

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
@@ -1,6 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.asserts.TraceAssert
-import datadog.trace.api.Platform
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
@@ -108,7 +107,7 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
       }
       blockUntilChildSpansFinished(2)
     }
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(2)
     }
 
@@ -141,7 +140,7 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
     new String(headers.headers("x-datadog-trace-id").iterator().next().value()) == "${TEST_WRITER[0][2].traceId}"
     new String(headers.headers("x-datadog-parent-id").iterator().next().value()) == "${TEST_WRITER[0][2].spanId}"
 
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags == ["direction:out", "topic:$SHARED_TOPIC".toString(), "type:kafka"]
@@ -212,7 +211,7 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
       })
       blockUntilChildSpansFinished(2)
     }
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(2)
     }
 
@@ -245,7 +244,7 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
     new String(headers.headers("x-datadog-trace-id").iterator().next().value()) == "${TEST_WRITER[0][2].traceId}"
     new String(headers.headers("x-datadog-parent-id").iterator().next().value()) == "${TEST_WRITER[0][2].spanId}"
 
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags == ["direction:out", "topic:$SHARED_TOPIC".toString(), "type:kafka"]
@@ -651,7 +650,7 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
       }
       blockUntilChildSpansFinished(2 * greetings.size())
     }
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(2)
     }
 
@@ -706,7 +705,7 @@ abstract class KafkaClientTestBase extends AgentTestRunner {
       }
     }
 
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags == ["topic:$SHARED_TOPIC".toString(), "type:internal"]

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/latestDepTest/groovy/KafkaStreamsTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/latestDepTest/groovy/KafkaStreamsTest.groovy
@@ -1,5 +1,4 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.api.Platform
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.datastreams.StatsGroup
@@ -69,7 +68,7 @@ class KafkaStreamsTest extends AgentTestRunner {
           // this is the last processing step so we should see 2 traces here
           TEST_WRITER.waitForTraces(2)
           TEST_TRACER.activeSpan().setTag("testing", 123)
-          if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+          if (isDataStreamsEnabled()) {
             TEST_DATA_STREAMS_WRITER.waitForGroups(1)
           }
           records.add(record)
@@ -91,7 +90,7 @@ class KafkaStreamsTest extends AgentTestRunner {
         String apply(String textLine) {
           TEST_WRITER.waitForTraces(1) // ensure consistent ordering of traces
           TEST_TRACER.activeSpan().setTag("asdf", "testing")
-          if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+          if (isDataStreamsEnabled()) {
             TEST_DATA_STREAMS_WRITER.waitForGroups(1)
           }
           return textLine.toLowerCase()
@@ -207,7 +206,7 @@ class KafkaStreamsTest extends AgentTestRunner {
     new String(headers.headers("x-datadog-trace-id").iterator().next().value()) == "${TEST_WRITER[1][0].traceId}"
     new String(headers.headers("x-datadog-parent-id").iterator().next().value()) == "${TEST_WRITER[1][0].spanId}"
 
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup originProducerPoint = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(originProducerPoint) {
         edgeTags == ["direction:out", "topic:$STREAM_PENDING", "type:kafka"]

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTestBase.groovy
@@ -1,5 +1,4 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.api.Platform
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.datastreams.StatsGroup
@@ -71,7 +70,7 @@ abstract class KafkaStreamsTestBase extends AgentTestRunner {
           // this is the last processing step so we should see 2 traces here
           TEST_WRITER.waitForTraces(2)
           TEST_TRACER.activeSpan().setTag("testing", 123)
-          if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+          if (isDataStreamsEnabled()) {
             TEST_DATA_STREAMS_WRITER.waitForGroups(1)
           }
           records.add(record)
@@ -93,7 +92,7 @@ abstract class KafkaStreamsTestBase extends AgentTestRunner {
         String apply(String textLine) {
           TEST_WRITER.waitForTraces(1) // ensure consistent ordering of traces
           TEST_TRACER.activeSpan().setTag("asdf", "testing")
-          if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+          if (isDataStreamsEnabled()) {
             TEST_DATA_STREAMS_WRITER.waitForGroups(1)
           }
           return textLine.toLowerCase()
@@ -249,7 +248,7 @@ abstract class KafkaStreamsTestBase extends AgentTestRunner {
     new String(headers.headers("x-datadog-trace-id").iterator().next().value()) == "${TEST_WRITER[1][0].traceId}"
     new String(headers.headers("x-datadog-parent-id").iterator().next().value()) == "${TEST_WRITER[1][0].spanId}"
 
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup originProducerPoint = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(originProducerPoint) {
         edgeTags == ["topic:$STREAM_PENDING", "type:internal"]

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -10,7 +10,6 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.Platform
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
@@ -116,7 +115,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
       channel.basicPublish(exchangeName, routingKey, null, "Hello, world!".getBytes())
       return channel.basicGet(queueName, true)
     }
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(2)
     }
 
@@ -148,7 +147,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags == ["direction:out", "exchange:" + exchangeName, "has_routing_key:true", "type:rabbitmq"]
@@ -172,7 +171,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     String queueName = channel.queueDeclare().getQueue()
     channel.basicPublish("", queueName, null, "Hello, world!".getBytes())
     GetResponse response = channel.basicGet(queueName, true)
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(2)
     }
 
@@ -202,7 +201,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags == ["direction:out", "exchange:", "has_routing_key:true", "type:rabbitmq"]
@@ -250,7 +249,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
         channel.basicPublish(exchangeName, "", null, "msg $it".getBytes())
       }
       TEST_WRITER.waitForTraces(5 + ((it - 1) * 2))
-      if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+      if (isDataStreamsEnabled()) {
         TEST_DATA_STREAMS_WRITER.waitForGroups(it * 2)
       }
       phaser.arriveAndAwaitAdvance()
@@ -296,7 +295,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     deliveries == (1..messageCount).collect { "msg $it" }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       // Look for all StatsPoints created by the producer. They will have the same hash, which would be the consumer
       // points' parent hash.
       List<StatsGroup> producerPoints = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == 0 }
@@ -352,7 +351,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     channel.basicPublish(exchangeName, "", null, "msg".getBytes())
     TEST_WRITER.waitForTraces(3)
     phaser.arriveAndAwaitAdvance()
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(2)
     }
 
@@ -391,7 +390,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags == ["direction:out", "exchange:" + exchangeName, "has_routing_key:false", "type:rabbitmq"]
@@ -446,7 +445,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     AmqpTemplate template = new RabbitTemplate(connectionFactory)
     template.convertAndSend(queue.name, "foo")
     String message = (String) template.receiveAndConvert(queue.name)
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(2)
     }
 
@@ -476,7 +475,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(["direction:out", "exchange:", "has_routing_key:true", "type:rabbitmq"])
@@ -519,7 +518,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
       default:
         break
     }
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled() && !noParent) {
+    if (isDataStreamsEnabled() && !noParent) {
       // In the noParent case, the exchange is disabled so we don't expect any pathway injections.
       TEST_DATA_STREAMS_WRITER.waitForGroups(2)
     }
@@ -560,7 +559,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled() && !noParent) {
+    if (isDataStreamsEnabled() && !noParent) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags == ["direction:out", "exchange:" + exchangeName, "has_routing_key:true", "type:rabbitmq"]
@@ -612,7 +611,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
       default:
         break
     }
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled() && !noParent) {
+    if (isDataStreamsEnabled() && !noParent) {
       // In the noParent case, the queue is disabled so we don't expect any pathway injections.
       TEST_DATA_STREAMS_WRITER.waitForGroups(2)
     }
@@ -653,7 +652,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled() && !noParent) {
+    if (isDataStreamsEnabled() && !noParent) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags == ["direction:out", "exchange:" + exchangeName, "has_routing_key:true", "type:rabbitmq"]

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/Servlet3TestGetParameterInstrumentation.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/Servlet3TestGetParameterInstrumentation.groovy
@@ -1,17 +1,12 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.api.Platform
 import datadog.trace.api.config.TracerConfig
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.source.WebModule
 import foo.bar.smoketest.Servlet3TestSuite
-import spock.lang.IgnoreIf
 
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletRequestWrapper
 
-@IgnoreIf({
-  !Platform.isJavaVersionAtLeast(8)
-})
 class Servlet3TestGetParameterInstrumentation extends AgentTestRunner {
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/TestGetParameterInstrumentation.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/TestGetParameterInstrumentation.groovy
@@ -1,17 +1,12 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.api.Platform
 import datadog.trace.api.config.TracerConfig
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.smoketest.controller.TestSuite
 import datadog.trace.api.iast.source.WebModule
-import spock.lang.IgnoreIf
 
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletRequestWrapper
 
-@IgnoreIf({
-  !Platform.isJavaVersionAtLeast(8)
-})
 class TestGetParameterInstrumentation extends AgentTestRunner {
 
   @Override

--- a/dd-java-agent/instrumentation/synapse-3/src/test/groovy/datadog/trace/instrumentation/synapse3/SynapseTest.groovy
+++ b/dd-java-agent/instrumentation/synapse-3/src/test/groovy/datadog/trace/instrumentation/synapse3/SynapseTest.groovy
@@ -22,16 +22,10 @@ import org.apache.synapse.ServerConfigurationInformation
 import org.apache.synapse.ServerContextInformation
 import org.apache.synapse.ServerManager
 import org.apache.synapse.transport.passthru.PassThroughHttpListener
-import spock.lang.Requires
 import spock.lang.Shared
 
 import java.lang.reflect.Field
 
-import static datadog.trace.api.Platform.isJavaVersionAtLeast
-
-@Requires({
-  isJavaVersionAtLeast(8)
-})
 class SynapseTest extends AgentTestRunner {
 
   String expectedServiceName() {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -17,7 +17,6 @@ import datadog.trace.agent.tooling.bytebuddy.matcher.GlobalIgnores
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.IdGenerationStrategy
-import datadog.trace.api.Platform
 import datadog.trace.api.StatsDClient
 import datadog.trace.api.WellKnownTags
 import datadog.trace.api.config.TracerConfig
@@ -190,7 +189,7 @@ abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.L
         void register(EventListener listener) {}
       }
     TEST_DATA_STREAMS_CHECKPOINTER = new StubDataStreamsCheckpointer()
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       try {
         // Fast enough so tests don't take forever
         long bucketDuration = TimeUnit.MILLISECONDS.toNanos(50)

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -5,7 +5,6 @@ import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.server.http.HttpProxy
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
-import datadog.trace.api.Platform
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
 import datadog.trace.core.datastreams.StatsGroup
@@ -136,7 +135,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     when:
     injectSysConfig(HTTP_CLIENT_TAG_QUERY_STRING, "$tagQueryString")
     def status = doRequest(method, url)
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -149,7 +148,7 @@ abstract class HttpClientTest extends AgentTestRunner {
       server.distributedRequestTrace(it, trace(0).last())
     }
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -178,7 +177,7 @@ abstract class HttpClientTest extends AgentTestRunner {
 
     when:
     def status = doRequest(method, url)
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -192,7 +191,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -220,7 +219,7 @@ abstract class HttpClientTest extends AgentTestRunner {
       doRequest(method, url, [:], body)
     }
     println("RESPONSE: $status")
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -240,7 +239,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -259,7 +258,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     def status = runUnderTrace("parent") {
       doRequest(method, server.address.resolve("/success"), [:], body)
     }
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -274,7 +273,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -295,7 +294,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     def status = runUnderTrace("parent") {
       doRequest(method, uri)
     }
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -310,7 +309,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -332,7 +331,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     def status = runUnderTrace("parent") {
       doRequest(method, uri)
     }
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -347,7 +346,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -367,7 +366,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     when:
     injectSysConfig(HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "true")
     def status = doRequest(method, server.address.resolve("/success"))
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -381,7 +380,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -399,7 +398,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     def status = runUnderTrace("parent") {
       doRequest(method, server.address.resolve("/success"), ["is-dd-server": "false"])
     }
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -414,7 +413,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -439,7 +438,7 @@ abstract class HttpClientTest extends AgentTestRunner {
         }
       }
     }
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -456,7 +455,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -490,7 +489,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     for (int i = 0; i < traces.size(); i++) {
       TEST_WRITER.set(i, traces.get(i))
     }
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -507,7 +506,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -529,7 +528,7 @@ abstract class HttpClientTest extends AgentTestRunner {
 
     when:
     def status = doRequest(method, uri)
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -544,7 +543,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -563,7 +562,7 @@ abstract class HttpClientTest extends AgentTestRunner {
 
     when:
     def status = doRequest(method, uri)
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -579,7 +578,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -623,7 +622,7 @@ abstract class HttpClientTest extends AgentTestRunner {
 
     when:
     def status = doRequest(method, uri, [(BASIC_AUTH_KEY): BASIC_AUTH_VAL])
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -638,7 +637,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -709,7 +708,7 @@ abstract class HttpClientTest extends AgentTestRunner {
 
     when:
     def status = doRequest(method, uri)
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -722,7 +721,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -5,7 +5,6 @@ import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
-import datadog.trace.api.Platform
 import datadog.trace.api.config.GeneralConfig
 import datadog.trace.api.env.CapturedEnvironment
 import datadog.trace.api.function.TriConsumer
@@ -427,7 +426,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     List<Response> responses = (1..count).collect {
       return client.newCall(request).execute()
     }
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -454,7 +453,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
       }
     }
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -474,7 +473,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     def ip = FORWARDED.body
     def request = request(FORWARDED, method, body).header("x-forwarded-for", ip).build()
     def response = client.newCall(request).execute()
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -497,7 +496,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
       }
     }
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -519,7 +518,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
       .header("x-datadog-parent-id", parentId.toString())
       .build()
     def response = client.newCall(request).execute()
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -542,7 +541,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
       }
     }
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -561,7 +560,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
       .header(header, value)
       .build()
     def response = client.newCall(request).execute()
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -585,7 +584,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -610,7 +609,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     expect:
     response.code() == endpoint.status
     response.body().string() == endpoint.body
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -630,7 +629,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -651,7 +650,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
 
     when:
     Response response = client.newCall(request).execute()
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -675,7 +674,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -706,7 +705,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
 
     when:
     Response response = client.newCall(request).execute()
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -730,7 +729,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -754,7 +753,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     assumeTrue(testPathParam() != null)
     def request = request(PATH_PARAM, method, body).build()
     def response = client.newCall(request).execute()
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -778,7 +777,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -802,7 +801,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     def response = client.newCall(request).execute()
     response.body().string() == PATH_PARAM.body
     TEST_WRITER.waitForTraces(1)
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -811,7 +810,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     span.getTag(IG_PATH_PARAMS_TAG) == expectedIGPathParams()
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -831,7 +830,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
       .header("x-datadog-sampling-priority", "1, 1")
       .build()
     def response = client.newCall(request).execute()
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -855,7 +854,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -873,7 +872,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     assumeTrue(testRedirect())
     def request = request(REDIRECT, method, body).build()
     def response = client.newCall(request).execute()
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -902,7 +901,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -920,7 +919,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     String method = 'GET'
     def request = request(ERROR, method, null).build()
     def response = client.newCall(request).execute()
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -946,7 +945,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -960,7 +959,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     assumeTrue(testException())
     def request = request(EXCEPTION, method, body).build()
     def response = client.newCall(request).execute()
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -986,7 +985,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -1008,7 +1007,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
 
     def request = request(NOT_FOUND, method, body).build()
     def response = client.newCall(request).execute()
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -1031,7 +1030,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -1048,7 +1047,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
 
     when:
     def response = client.newCall(request).execute()
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -1073,7 +1072,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -1091,7 +1090,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     assumeTrue(testTimeout())
     def request = request(TIMEOUT_ERROR, method, body).build()
     def response = client.newCall(request).execute()
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -1118,7 +1117,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -1147,7 +1146,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
 
     when:
     def response = client.newCall(request).execute()
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -1176,7 +1175,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -1201,7 +1200,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
       RequestBody.create(MediaType.get('text/plain'), 'my body'))
       .build()
     def response = client.newCall(request).execute()
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -1217,7 +1216,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -1234,7 +1233,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
       RequestBody.create(MediaType.get('text/plain'), 'my body'))
       .build()
     def response = client.newCall(request).execute()
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -1250,7 +1249,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -1267,7 +1266,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
       RequestBody.create(MediaType.get('application/x-www-form-urlencoded'), 'a=x'))
       .build()
     def response = client.newCall(request).execute()
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -1283,7 +1282,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -1300,7 +1299,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
       RequestBody.create(MediaType.get('application/json'), '{"a": "x"}'))
       .build()
     def response = client.newCall(request).execute()
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -1316,7 +1315,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     }
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -1340,7 +1339,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
         it.build()
       }
     def response = client.newCall(request).execute()
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -1363,7 +1362,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     trace[0].tags['http.status_code'] == 418
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)
@@ -1387,7 +1386,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
       .addHeader('Accept', 'text/html')  // preference for html will be ignored
       .build()
     def response = client.newCall(request).execute()
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
 
@@ -1405,7 +1404,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     trace[0].tags['http.status_code'] == 418
 
     and:
-    if (Platform.isJavaVersionAtLeast(8) && isDataStreamsEnabled()) {
+    if (isDataStreamsEnabled()) {
       StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
       verifyAll(first) {
         edgeTags.containsAll(DSM_EDGE_TAGS)

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/datastreams/RecordingDatastreamsPayloadWriter.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/datastreams/RecordingDatastreamsPayloadWriter.groovy
@@ -1,6 +1,5 @@
 package datadog.trace.agent.test.datastreams
 
-import datadog.trace.api.Platform
 import datadog.trace.core.datastreams.DatastreamsPayloadWriter
 import datadog.trace.core.datastreams.StatsBucket
 import datadog.trace.core.datastreams.StatsGroup
@@ -31,13 +30,11 @@ class RecordingDatastreamsPayloadWriter implements DatastreamsPayloadWriter {
   }
 
   private static void waitFor(int count, long timeout, Collection collection) {
-    if (Platform.isJavaVersionAtLeast(8)) {
-      long deadline = System.currentTimeMillis() + timeout
-      while (collection.size() < count && System.currentTimeMillis() < deadline) {
-        Thread.sleep(20)
-      }
-
-      assert collection.size() >= count
+    long deadline = System.currentTimeMillis() + timeout
+    while (collection.size() < count && System.currentTimeMillis() < deadline) {
+      Thread.sleep(20)
     }
+
+    assert collection.size() >= count
   }
 }

--- a/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
@@ -1,18 +1,13 @@
 package datadog.smoketest
 
-import datadog.trace.api.Platform
 import datadog.trace.test.agent.decoder.DecodedSpan
 import groovy.json.JsonSlurper
 import okhttp3.Request
-import spock.lang.IgnoreIf
 import spock.util.concurrent.PollingConditions
 
 import java.util.function.Function
 import java.util.function.Predicate
 
-@IgnoreIf({
-  !Platform.isJavaVersionAtLeast(8)
-})
 class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
 
   private static final String TAG_NAME = '_dd.iast.json'

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/MonitoringImpl.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/MonitoringImpl.java
@@ -1,7 +1,5 @@
 package datadog.trace.core.monitor;
 
-import static datadog.trace.api.Platform.isJavaVersionAtLeast;
-
 import datadog.communication.monitor.Counter;
 import datadog.communication.monitor.Monitoring;
 import datadog.communication.monitor.NoOpCounter;
@@ -30,7 +28,7 @@ public final class MonitoringImpl implements Monitoring {
 
   @Override
   public Recording newTimer(final String name) {
-    if (!enabled || !isJavaVersionAtLeast(8)) {
+    if (!enabled) {
       return NoOpRecording.NO_OP;
     }
     return new Timer(name, statsd, flushAfterNanos);
@@ -38,7 +36,7 @@ public final class MonitoringImpl implements Monitoring {
 
   @Override
   public Recording newTimer(final String name, final String... tags) {
-    if (!enabled || !isJavaVersionAtLeast(8)) {
+    if (!enabled) {
       return NoOpRecording.NO_OP;
     }
     return new Timer(name, tags, statsd, flushAfterNanos);
@@ -46,7 +44,7 @@ public final class MonitoringImpl implements Monitoring {
 
   @Override
   public Recording newThreadLocalTimer(final String name) {
-    if (!enabled || !isJavaVersionAtLeast(8)) {
+    if (!enabled) {
       return NoOpRecording.NO_OP;
     }
     return new ThreadLocalRecording(

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AggregateMetricTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/AggregateMetricTest.groovy
@@ -1,8 +1,6 @@
 package datadog.trace.common.metrics
 
-
 import datadog.trace.test.util.DDSpecification
-import spock.lang.Requires
 
 import java.util.concurrent.BlockingDeque
 import java.util.concurrent.CountDownLatch
@@ -13,13 +11,9 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLongArray
 
-import static datadog.trace.api.Platform.isJavaVersionAtLeast
 import static datadog.trace.common.metrics.AggregateMetric.ERROR_TAG
 import static datadog.trace.common.metrics.AggregateMetric.TOP_LEVEL_TAG
 
-@Requires({
-  isJavaVersionAtLeast(8)
-})
 class AggregateMetricTest extends DDSpecification {
 
   def "record durations sums up to total"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/ConflatingMetricAggregatorTest.groovy
@@ -5,7 +5,6 @@ import datadog.trace.api.WellKnownTags
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString
 import datadog.trace.core.CoreSpan
 import datadog.trace.test.util.DDSpecification
-import spock.lang.Requires
 import spock.lang.Shared
 
 import java.util.concurrent.CompletableFuture
@@ -14,13 +13,9 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import java.util.function.Supplier
 
-import static datadog.trace.api.Platform.isJavaVersionAtLeast
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 import static java.util.concurrent.TimeUnit.SECONDS
 
-@Requires({
-  isJavaVersionAtLeast(8)
-})
 class ConflatingMetricAggregatorTest extends DDSpecification {
 
   static Set<String> empty = new HashSet<>()

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintForkedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/FootprintForkedTest.groovy
@@ -11,11 +11,10 @@ import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ThreadLocalRandom
 
-import static datadog.trace.api.Platform.isJavaVersionAtLeast
 import static java.util.concurrent.TimeUnit.SECONDS
 
 @Requires({
-  !System.getProperty("java.vendor").toUpperCase().contains("IBM") && isJavaVersionAtLeast(8)
+  !System.getProperty("java.vendor").toUpperCase().contains("IBM")
 })
 class FootprintForkedTest extends DDSpecification {
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/MetricsAggregatorFactoryTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/MetricsAggregatorFactoryTest.groovy
@@ -3,13 +3,7 @@ package datadog.trace.common.metrics
 import datadog.communication.ddagent.SharedCommunicationObjects
 import datadog.trace.api.Config
 import datadog.trace.test.util.DDSpecification
-import spock.lang.Requires
 
-import static datadog.trace.api.Platform.isJavaVersionAtLeast
-
-@Requires({
-  isJavaVersionAtLeast(8)
-})
 class MetricsAggregatorFactoryTest extends DDSpecification {
 
   def "when metrics disabled no-op aggregator created"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/OkHttpSinkTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/OkHttpSinkTest.groovy
@@ -8,23 +8,18 @@ import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody
-import spock.lang.Requires
 
 import java.nio.ByteBuffer
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicBoolean
 
-import static datadog.trace.api.Platform.isJavaVersionAtLeast
 import static datadog.trace.common.metrics.EventListener.EventType.BAD_PAYLOAD
 import static datadog.trace.common.metrics.EventListener.EventType.DOWNGRADED
 import static datadog.trace.common.metrics.EventListener.EventType.ERROR
 import static datadog.trace.common.metrics.EventListener.EventType.OK
 import static datadog.communication.ddagent.DDAgentFeaturesDiscovery.V6_METRICS_ENDPOINT
 
-@Requires({
-  isJavaVersionAtLeast(8)
-})
 class OkHttpSinkTest extends DDSpecification {
 
   def "http status code #responseCode yields #eventType"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
@@ -5,18 +5,13 @@ import datadog.trace.api.Pair
 import datadog.trace.test.util.DDSpecification
 import org.msgpack.core.MessagePack
 import org.msgpack.core.MessageUnpacker
-import spock.lang.Requires
 
 import java.nio.ByteBuffer
 import java.util.concurrent.atomic.AtomicLongArray
 
-import static datadog.trace.api.Platform.isJavaVersionAtLeast
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 import static java.util.concurrent.TimeUnit.SECONDS
 
-@Requires({
-  isJavaVersionAtLeast(8)
-})
 class SerializingMetricWriterTest extends DDSpecification {
 
   def "should produce correct message" () {
@@ -145,13 +140,9 @@ class SerializingMetricWriterTest extends DDSpecification {
     }
 
     private void validateSketch(MessageUnpacker unpacker) {
-      if (isJavaVersionAtLeast(8)) {
-        int length = unpacker.unpackBinaryHeader()
-        assert length > 0
-        unpacker.readPayload(length)
-      } else {
-        unpacker.skipValue()
-      }
+      int length = unpacker.unpackBinaryHeader()
+      assert length > 0
+      unpacker.readPayload(length)
     }
 
     boolean validatedInput() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/TimingTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/TimingTest.groovy
@@ -3,17 +3,12 @@ package datadog.trace.core.monitor
 import datadog.communication.monitor.Monitoring
 import datadog.communication.monitor.NoOpRecording
 import datadog.communication.monitor.Recording
-import datadog.trace.api.Platform
 import datadog.trace.api.StatsDClient
 import datadog.trace.test.util.DDSpecification
 import org.junit.Assert
-import spock.lang.Requires
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 
-@Requires({
-  Platform.isJavaVersionAtLeast(8)
-})
 class TimingTest extends DDSpecification {
 
   def "timer times stuff"() {

--- a/dd-trace-core/src/traceAgentTest/groovy/DataStreamsIntegrationTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/DataStreamsIntegrationTest.groovy
@@ -15,12 +15,11 @@ import spock.util.concurrent.PollingConditions
 
 import java.util.concurrent.CopyOnWriteArrayList
 
-import static datadog.trace.api.Platform.isJavaVersionAtLeast
 import static datadog.trace.common.metrics.EventListener.EventType.OK
 import static datadog.trace.core.datastreams.DefaultDataStreamsCheckpointer.DEFAULT_BUCKET_DURATION_NANOS
 
 @Requires({
-  "true" == System.getenv("CI") && isJavaVersionAtLeast(8)
+  "true" == System.getenv("CI")
 })
 @Ignore("The agent in CI doesn't have a valid API key. Unlike metrics and traces, data streams fails in this case")
 class DataStreamsIntegrationTest extends DDSpecification {

--- a/dd-trace-core/src/traceAgentTest/groovy/MetricsIntegrationTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/MetricsIntegrationTest.groovy
@@ -14,13 +14,12 @@ import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicLongArray
 
-import static datadog.trace.api.Platform.isJavaVersionAtLeast
 import static datadog.trace.common.metrics.EventListener.EventType.OK
 import static java.util.concurrent.TimeUnit.SECONDS
 import okhttp3.HttpUrl
 
 @Requires({
-  "true" == System.getenv("CI") && isJavaVersionAtLeast(8)
+  "true" == System.getenv("CI")
 })
 class MetricsIntegrationTest extends DDSpecification {
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -82,7 +82,6 @@ import static datadog.trace.api.DDTags.RUNTIME_ID_TAG;
 import static datadog.trace.api.DDTags.RUNTIME_VERSION_TAG;
 import static datadog.trace.api.DDTags.SERVICE;
 import static datadog.trace.api.DDTags.SERVICE_TAG;
-import static datadog.trace.api.Platform.isJavaVersionAtLeast;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_HTTP_BLOCKED_TEMPLATE_HTML;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_HTTP_BLOCKED_TEMPLATE_JSON;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_IP_ADDR_HEADER;
@@ -907,11 +906,9 @@ public class Config {
     healthMetricsStatsdPort = configProvider.getInteger(HEALTH_METRICS_STATSD_PORT);
     perfMetricsEnabled =
         runtimeMetricsEnabled
-            && isJavaVersionAtLeast(8)
             && configProvider.getBoolean(PERF_METRICS_ENABLED, DEFAULT_PERF_METRICS_ENABLED);
 
-    tracerMetricsEnabled =
-        isJavaVersionAtLeast(8) && configProvider.getBoolean(TRACER_METRICS_ENABLED, false);
+    tracerMetricsEnabled = configProvider.getBoolean(TRACER_METRICS_ENABLED, false);
     tracerMetricsBufferingEnabled =
         configProvider.getBoolean(TRACER_METRICS_BUFFERING_ENABLED, false);
     tracerMetricsMaxAggregates = configProvider.getInteger(TRACER_METRICS_MAX_AGGREGATES, 2048);


### PR DESCRIPTION
# What Does This Do

This PR removes the minimum Java 8 requirement checks. 

# Motivation

The project is now only compatible with Java 8+.

# Additional Notes
