### PR TITLE
Prevent IllegalAccessError in OpenJDK 17.0.4 by excluding javax.management.* & javax.swing.*

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
+++ b/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
@@ -83,6 +83,9 @@
 0 sun.rmi.server.*
 0 sun.rmi.transport.*
 0 sun.nio.ch.FileChannelImpl
+# Prevent IllegalAccessError in OpenJDK 17.0.4
+1 javax.management.*
+1 javax.swing.*
 
 # -------- ADDITIONAL IGNORES --------
 


### PR DESCRIPTION
# What Does This Do

Prevent `IllegalAccessError` in OpenJDK 17.0.4 by excluding javax.management.* & javax.swing.*

# Motivation

Customer case APMS-8366

```
java.lang.IllegalAccessError: superinterface check failed: class javax.swing.RepaintManager$ProcessingRunnable (in module java.desktop) cannot access class datadog.trace.bootstrap.FieldBackedContextAccessor (in unnamed module @0x3ed242a4) because module java.desktop does not read unnamed module @0x3ed242a4
```

# Additional Notes
