### PR TITLE
Openliberty: fix NPE after blocking response

### DIFF
--- a/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/LibertyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/LibertyServerInstrumentation.java
@@ -98,6 +98,9 @@ public final class LibertyServerInstrumentation extends Instrumenter.Tracing
       Flow.Action.RequestBlockingAction rba = span.getRequestBlockingAction();
       if (rba != null) {
         ServletBlockingHelper.commitBlockingResponse(request, (SRTServletResponse) resp, rba);
+        // prevent caching of the handler
+        req.setAttribute(
+            "javax.servlet.error.status_code", ((SRTServletResponse) resp).getStatusCode());
         return true; // skip method body
       }
 


### PR DESCRIPTION
A blocking response would cause a CacheServletWrapper to be created that contained an empty mapping because dispatchContext::servletMapping never had the opportunity to be filled. The next request to the same endpoint would then fail (and only then would this corrupted cache entry be evicted).

Seen in the system tests (PR https://github.com/DataDog/system-tests/pull/510).