### PR TITLE
fix(dd-java-agent): Exclude bogus elasticsearch release

### DIFF
--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/build.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/build.gradle
@@ -9,7 +9,7 @@ muzzle {
     module = "elasticsearch"
     versions = "[2.0,3)"
     assertInverse = true
-    skipVersions = ["7.11.0"]
+    skipVersions = ["7.11.0", "7.17.8"]
   }
 }
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/build.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/build.gradle
@@ -5,14 +5,14 @@ muzzle {
     module = "transport"
     versions = "[5.3.0,6.0.0)"
     assertInverse = true
-    skipVersions = ["7.11.0"]
+    skipVersions = ["7.11.0", "7.17.8"]
   }
   pass {
     group = "org.elasticsearch"
     module = "elasticsearch"
     versions = "[5.3.0,6.0.0)"
     assertInverse = true
-    skipVersions = ["7.11.0"]
+    skipVersions = ["7.11.0", "7.17.8"]
   }
 }
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/build.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/build.gradle
@@ -11,14 +11,14 @@ muzzle {
     module = "transport"
     versions = "[5.0.0,5.3.0)"
     assertInverse = true
-    skipVersions = ["7.11.0"]
+    skipVersions = ["7.11.0", "7.17.8"]
   }
   pass {
     group = "org.elasticsearch"
     module = "elasticsearch"
     versions = "[5.0.0,5.3.0)"
     assertInverse = true
-    skipVersions = ["7.11.0"]
+    skipVersions = ["7.11.0", "7.17.8"]
   }
 }
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/build.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/build.gradle
@@ -4,14 +4,14 @@ muzzle {
     group = "org.elasticsearch.client"
     module = "transport"
     versions = "[6.0.0,8.0.0)"
-    skipVersions = ["7.11.0"]
+    skipVersions = ["7.11.0", "7.17.8"]
     assertInverse = true
   }
   pass {
     group = "org.elasticsearch"
     module = "elasticsearch"
     versions = "[6.0.0,8.0.0)"
-    skipVersions = ["7.11.0"]
+    skipVersions = ["7.11.0", "7.17.8"]
     assertInverse = true
   }
 }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-7.3/build.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-7.3/build.gradle
@@ -5,14 +5,14 @@ muzzle {
     module = "transport"
     versions = "[7.3,8.0.0)"
     assertInverse = true
-    skipVersions = ["7.11.0"]
+    skipVersions = ["7.11.0", "7.17.8"]
   }
   pass {
     group = "org.elasticsearch"
     module = "elasticsearch"
     versions = "[7.3,8.0.0)"
     assertInverse = true
-    skipVersions = ["7.11.0"]
+    skipVersions = ["7.11.0", "7.17.8"]
   }
 }
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport/build.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport/build.gradle
@@ -5,14 +5,14 @@ muzzle {
     module = "transport"
     versions = "[2.0,)"
     assertInverse = true
-    skipVersions = ["7.11.0"]
+    skipVersions = ["7.11.0", "7.17.8"]
   }
   pass {
     group = "org.elasticsearch"
     module = "elasticsearch"
     versions = "[2.0,)"
     assertInverse = true
-    skipVersions = ["7.11.0"]
+    skipVersions = ["7.11.0", "7.17.8"]
   }
 }
 


### PR DESCRIPTION
# What Does This Do

Exclude bogus `org.elasticsearch:elasticsearch` release from muzzle checks

# Motivation

The CI is failing.

# Additional Notes

I reported the issue on their GH repo: https://github.com/elastic/elasticsearch/issues/92383
