### PR TITLE
disable async-profiler for the time being

### DIFF
--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -91,6 +91,7 @@ abstract class AbstractSmokeTest extends ProcessManager {
     "-Ddd.profiling.start-delay=${PROFILING_START_DELAY_SECONDS}",
     "-Ddd.profiling.upload.period=${PROFILING_RECORDING_UPLOAD_PERIOD_SECONDS}",
     "-Ddd.profiling.url=${getProfilingUrl()}",
+    "-Ddd.profiling.async.enabled=true",
     "-Ddd.profiling.async.wall.enabled=true",
     "-Ddd.profiling.async.alloc.enabled=" + !isIBM,
     "-Ddd.profiling.async.cstack=dwarf",

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -951,7 +951,7 @@ public class Config {
         configProvider.getBoolean(PROFILING_AGENTLESS, PROFILING_AGENTLESS_DEFAULT);
     isAsyncProfilerEnabled =
         configProvider.getBoolean(
-            PROFILING_ASYNC_ENABLED, isAsyncProfilerSafeInCurrentEnvironment());
+            PROFILING_ASYNC_ENABLED, false /*isAsyncProfilerSafeInCurrentEnvironment()*/);
     profilingUrl = configProvider.getString(PROFILING_URL);
 
     if (tmpApiKey == null) {


### PR DESCRIPTION
# What Does This Do

We found a crash related to musl so will disable until it's been fixed.

# Motivation

# Additional Notes
