### PR TITLE
Update _dd.iast.enabled tag usage

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastTag.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastTag.java
@@ -1,0 +1,39 @@
+package com.datadog.iast;
+
+import datadog.trace.api.TraceSegment;
+import javax.annotation.Nullable;
+
+public interface IastTag {
+
+  Enabled REQUEST_SKIPPED = new Enabled(0);
+  Enabled REQUEST_ANALYZED = new Enabled(1);
+
+  String key();
+
+  Object value();
+
+  default void setTagTop(@Nullable final TraceSegment trace) {
+    if (trace != null) {
+      trace.setTagTop(key(), value());
+    }
+  }
+
+  class Enabled implements IastTag {
+
+    private final int value;
+
+    public Enabled(int value) {
+      this.value = value;
+    }
+
+    @Override
+    public String key() {
+      return "_dd.iast.enabled";
+    }
+
+    @Override
+    public Object value() {
+      return value;
+    }
+  }
+}

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastTagTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastTagTest.groovy
@@ -1,0 +1,39 @@
+package com.datadog.iast
+
+import datadog.trace.api.TraceSegment
+import datadog.trace.test.util.DDSpecification
+
+import static com.datadog.iast.IastTag.REQUEST_ANALYZED
+import static com.datadog.iast.IastTag.REQUEST_SKIPPED
+
+class IastTagTest extends DDSpecification {
+
+  void 'tags are sent on the segment'(final IastTag tag) {
+    given:
+    final segment = Mock(TraceSegment)
+
+    when:
+    tag.setTagTop(segment)
+
+    then:
+    1 * segment.setTagTop(tag.key(), tag.value())
+
+    where:
+    tag              | _
+    REQUEST_ANALYZED | _
+    REQUEST_SKIPPED  | _
+  }
+
+  void 'tags dont fail with null segment'(final IastTag tag) {
+    when:
+    tag.setTagTop(null)
+
+    then:
+    noExceptionThrown()
+
+    where:
+    tag              | _
+    REQUEST_ANALYZED | _
+    REQUEST_SKIPPED  | _
+  }
+}

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/RequestEndedHandlerTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/RequestEndedHandlerTest.groovy
@@ -51,6 +51,8 @@ class RequestEndedHandlerTest extends DDSpecification {
     flow.getAction() == Flow.Action.Noop.INSTANCE
     flow.getResult() == null
     1 * reqCtx.getData(RequestContextSlot.IAST) >> null
+    1 * reqCtx.getTraceSegment() >> traceSegment
+    1 * traceSegment.setTagTop("_dd.iast.enabled", 0)
     0 * overheadController.releaseRequest()
     0 * _
   }


### PR DESCRIPTION
# What Does This Do
Updates the usage of the tag `_dd.iast.enabled` in order to set a value when the request is skipped by the overhead controller

# Motivation

# Additional Notes
Overrides https://github.com/DataDog/dd-trace-java/pull/4425 due to issues with CI
