### PR TITLE
Update to libsqreen 5.2.0

### DIFF
--- a/dd-java-agent/appsec/build.gradle
+++ b/dd-java-agent/appsec/build.gradle
@@ -24,7 +24,7 @@ dependencies {
   implementation project(':internal-api')
   implementation project(':communication')
   implementation project(':telemetry')
-  implementation group: 'io.sqreen', name: 'libsqreen', version: '5.1.0'
+  implementation group: 'io.sqreen', name: 'libsqreen', version: '5.2.0'
   implementation group: 'com.squareup.moshi', name: 'moshi', version: versions.moshi
 
   annotationProcessor deps.autoserviceProcessor


### PR DESCRIPTION
Provides support for exclusions, including input exclusions. libddwaf version is v1.6.0-beta0.