### PR TITLE
use host header to fill undertow http tags

### DIFF
--- a/dd-java-agent/instrumentation/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/HttpServerExchangeURIDataAdapter.java
+++ b/dd-java-agent/instrumentation/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/HttpServerExchangeURIDataAdapter.java
@@ -17,12 +17,12 @@ final class HttpServerExchangeURIDataAdapter extends URIRawDataAdapter {
 
   @Override
   public String host() {
-    return httpServerExchange.getDestinationAddress().getHostName();
+    return httpServerExchange.getHostName();
   }
 
   @Override
   public int port() {
-    return httpServerExchange.getDestinationAddress().getPort();
+    return httpServerExchange.getHostPort();
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

Fix the way undertow instrumentation is filling http related tag. Host and port are today taken from the socket that has been bound. This differs the way we do on other instrumentations (like tomcat).

The correct thing should be to take what has been put in the host header of the request (like tomcat is doing).

Tested with spring boot and undertow (calling a host alias my.local.address):

Today:

![image](https://user-images.githubusercontent.com/7393723/208139801-05d6efdd-6b3d-4cd1-9816-9e2b65e11e32.png)


With this fix:

![image](https://user-images.githubusercontent.com/7393723/208139904-74565694-730e-491f-87df-ca116faa4b22.png)


# Motivation

# Additional Notes
