### PR TITLE
Provide access to the original location of TypeDescriptions

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/ClassFileLocators.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/ClassFileLocators.java
@@ -100,6 +100,7 @@ public final class ClassFileLocators {
 
   public static final class LazyResolution implements Resolution {
     private final URL url;
+    private byte[] bytecode;
 
     LazyResolution(URL url) {
       this.url = url;
@@ -116,15 +117,18 @@ public final class ClassFileLocators {
 
     @Override
     public byte[] resolve() {
-      try {
-        URLConnection uc = url.openConnection();
-        uc.setUseCaches(false);
-        try (InputStream in = uc.getInputStream()) {
-          return StreamDrainer.DEFAULT.drain(in);
+      if (null == bytecode) {
+        try {
+          URLConnection uc = url.openConnection();
+          uc.setUseCaches(false);
+          try (InputStream in = uc.getInputStream()) {
+            bytecode = StreamDrainer.DEFAULT.drain(in);
+          }
+        } catch (IOException e) {
+          throw new IllegalStateException("Error while reading class file", e);
         }
-      } catch (IOException e) {
-        throw new IllegalStateException("Error while reading class file", e);
       }
+      return bytecode;
     }
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/TypeInfoCache.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/TypeInfoCache.java
@@ -93,8 +93,8 @@ public final class TypeInfoCache<T> {
     }
 
     public boolean sameClassFile(URL classFile) {
-      return UNKNOWN_CLASS_FILE != this.classFile
-          && UNKNOWN_CLASS_FILE != classFile
+      return UNKNOWN_CLASS_FILE != classFile
+          && UNKNOWN_CLASS_FILE != this.classFile
           && sameClassFile(this.classFile, classFile);
     }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
@@ -313,10 +313,13 @@ final class TypeFactory {
     }
 
     private TypeDescription outline() {
+      if (null != delegate) {
+        return delegate; // will be at least an outline, no need to re-resolve
+      }
       if (createOutlines) {
         return doResolve(true);
       }
-      // temporarily switch to outlines as that's all we need
+      // temporarily switch to generating (fast) outlines as that's all we need
       createOutlines = true;
       try {
         return doResolve(true);

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
@@ -106,6 +106,10 @@ final class TypeFactory {
     }
   }
 
+  ClassLoader currentContext() {
+    return classLoader;
+  }
+
   void beginInstall() {
     installing = true;
   }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
@@ -145,11 +145,13 @@ final class TypeFactory {
 
   /** Cleans-up local caches to minimise memory use once we're done with the type-factory. */
   void endTransform() {
+    if (null == targetName) {
+      return; // transformation didn't reach resolve step
+    }
+
     if (installing) {
-      // was there a nested transform during install?
-      if (null != targetName) {
-        switchContext(originalClassLoader);
-      }
+      // just finished transforming a support type, restore the original matching context
+      switchContext(originalClassLoader);
     } else {
       clearReferences();
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
@@ -147,6 +147,13 @@ final class TypeFactory {
     createOutlines = false;
   }
 
+  /** Temporarily turn off full description parsing; returns {@code true} if it was enabled. */
+  boolean disableFullDescriptions() {
+    boolean wasEnabled = !createOutlines;
+    createOutlines = true;
+    return wasEnabled;
+  }
+
   /** Cleans-up local caches to minimise memory use once we're done with the type-factory. */
   void endTransform() {
     if (null == targetName) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypePoolFacade.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypePoolFacade.java
@@ -27,6 +27,10 @@ public final class TypePoolFacade implements TypePool, SharedTypePools.Supplier 
     typeFactory.get().switchContext(classLoader);
   }
 
+  public static ClassLoader currentContext() {
+    return typeFactory.get().currentContext();
+  }
+
   @Override
   public void annotationOfInterest(String name) {
     AnnotationOutline.prepareAnnotationOutline(name);

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypePoolFacade.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypePoolFacade.java
@@ -51,6 +51,11 @@ public final class TypePoolFacade implements TypePool, SharedTypePools.Supplier 
     typeFactory.get().enableFullDescriptions();
   }
 
+  /** Temporarily switch back to outlines, e.g. for last-minute memoization. */
+  public static boolean disableFullDescriptions() {
+    return typeFactory.get().disableFullDescriptions();
+  }
+
   @Override
   public void endTransform() {
     typeFactory.get().endTransform();

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/WithLocation.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/WithLocation.java
@@ -1,0 +1,12 @@
+package datadog.trace.agent.tooling.bytebuddy.outline;
+
+import java.net.URL;
+
+/** Provides details of where the resolved type was defined. */
+public interface WithLocation {
+  ClassLoader getClassLoader();
+
+  URL getClassFile();
+
+  byte[] getBytecode();
+}


### PR DESCRIPTION
# What Does This Do

The main change in this PR is the introduction of an interface `WithLocation` that lets us share the class-file location of `TypeDescription`s supplied by our type-pool. This also lets us re-use the original bytecode when replacing an outline type with its fully-parsed description, instead of having to re-read the class-file.

Other additions in this PR:
* Support temporarily switching back to type outlines during transformation (e.g. for last-minute memoization)
* Support getting the class-loader context of the current transformation

plus a few other related improvements to the type-pool internals.

# Motivation

Mostly preparation for memoization of type matching, so we can distinguish between `TypeDescription`s with the same name that come from different class-files. The ability to re-use the bytecode when re-parsing the type is a bonus.