### PR TITLE
Update overhead controller and add debug info

### DIFF
--- a/dd-java-agent/agent-iast/src/jmh/java/com/datadog/iast/overhead/OverheadControllerBenchmark.java
+++ b/dd-java-agent/agent-iast/src/jmh/java/com/datadog/iast/overhead/OverheadControllerBenchmark.java
@@ -27,7 +27,7 @@ public class OverheadControllerBenchmark {
   public void setup() {
     System.setProperty("dd.iast.request-sampling", "100");
     System.setProperty("dd.iast.max-context-operations", "100000");
-    overheadController = new OverheadController(Config.get(), null);
+    overheadController = OverheadController.build(Config.get(), null);
   }
 
   @Benchmark

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastRequestContext.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastRequestContext.java
@@ -21,7 +21,7 @@ public class IastRequestContext {
     this.vulnerabilityBatch = new VulnerabilityBatch();
     this.spanDataIsSet = new AtomicBoolean(false);
     this.overheadContext = new OverheadContext();
-    this.taintedObjects = new TaintedObjects();
+    this.taintedObjects = TaintedObjects.build();
   }
 
   public VulnerabilityBatch getVulnerabilityBatch() {

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/overhead/Operations.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/overhead/Operations.java
@@ -21,5 +21,10 @@ public class Operations {
           }
           return context.consumeQuota(1);
         }
+
+        @Override
+        public String toString() {
+          return "Operation#REPORT_VULNERABILITY";
+        }
       };
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/overhead/OverheadController.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/overhead/OverheadController.java
@@ -1,92 +1,185 @@
 package com.datadog.iast.overhead;
 
 import com.datadog.iast.IastRequestContext;
+import com.datadog.iast.IastSystem;
+import com.datadog.iast.util.NonBlockingSemaphore;
 import datadog.trace.api.Config;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.util.AgentTaskScheduler;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public class OverheadController {
+public interface OverheadController {
 
-  private final int maxConcurrentRequests;
-  private final int sampling;
+  boolean acquireRequest();
 
-  final AtomicInteger availableRequests;
+  void reset();
 
-  final AtomicInteger executedRequests = new AtomicInteger(0);
+  int releaseRequest();
 
-  final OverheadContext globalContext = new OverheadContext();
+  boolean hasQuota(final Operation operation, final AgentSpan span);
 
-  public OverheadController(final Config config, final AgentTaskScheduler taskScheduler) {
-    maxConcurrentRequests = config.getIastMaxConcurrentRequests();
-    sampling = computeSamplingParameter(config.getIastRequestSampling());
-    availableRequests = new AtomicInteger(maxConcurrentRequests);
-    if (taskScheduler != null) {
-      taskScheduler.scheduleAtFixedRate(this::reset, 60, 60, TimeUnit.SECONDS);
+  boolean consumeQuota(final Operation operation, final AgentSpan span);
+
+  static OverheadController build(final Config config, final AgentTaskScheduler scheduler) {
+    final OverheadControllerImpl result = new OverheadControllerImpl(config, scheduler);
+    return IastSystem.DEBUG ? new OverheadControllerDebugAdapter(result) : result;
+  }
+
+  class OverheadControllerDebugAdapter implements OverheadController {
+
+    static Logger LOGGER = LoggerFactory.getLogger(OverheadController.class);
+
+    private final OverheadControllerImpl delegate;
+
+    public OverheadControllerDebugAdapter(final OverheadControllerImpl delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public boolean acquireRequest() {
+      final boolean result = delegate.acquireRequest();
+      if (LOGGER.isDebugEnabled()) {
+        final int available = delegate.availableRequests.available();
+        LOGGER.debug(
+            "acquireRequest: acquired={}, availableRequests={}, span={}",
+            result,
+            available,
+            AgentTracer.activeSpan());
+      }
+      return result;
+    }
+
+    @Override
+    public int releaseRequest() {
+      int result = delegate.releaseRequest();
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug(
+            "releaseRequest: availableRequests={}, span={}", result, AgentTracer.activeSpan());
+      }
+      return result;
+    }
+
+    @Override
+    public boolean hasQuota(final Operation operation, final AgentSpan span) {
+      final boolean result = delegate.hasQuota(operation, span);
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug(
+            "hasQuota: operation={}, result={}, availableQuota={}, span={}",
+            operation,
+            result,
+            getAvailableQuote(span),
+            span);
+      }
+      return result;
+    }
+
+    @Override
+    public boolean consumeQuota(final Operation operation, final AgentSpan span) {
+      final boolean result = delegate.consumeQuota(operation, span);
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug(
+            "consumeQuota: operation={}, result={}, availableQuota={}, span={}",
+            operation,
+            result,
+            getAvailableQuote(span),
+            span);
+      }
+      return result;
+    }
+
+    @Override
+    public void reset() {
+      delegate.reset();
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("reset: span={}", AgentTracer.activeSpan());
+      }
+    }
+
+    private int getAvailableQuote(final AgentSpan span) {
+      final OverheadContext context = delegate.getContext(span);
+      return context == null ? -1 : context.getAvailableQuota();
     }
   }
 
-  protected OverheadController() {
-    // for testing
-    this.maxConcurrentRequests = 0;
-    this.sampling = 0;
-    this.availableRequests = new AtomicInteger();
-  }
+  class OverheadControllerImpl implements OverheadController {
+    private final int maxConcurrentRequests;
+    private final int sampling;
 
-  public boolean acquireRequest() {
-    if (executedRequests.incrementAndGet() % sampling != 0) {
-      // Skipped by sampling
-      return false;
+    final NonBlockingSemaphore availableRequests;
+
+    final AtomicInteger executedRequests = new AtomicInteger(0);
+
+    final OverheadContext globalContext = new OverheadContext();
+
+    public OverheadControllerImpl(final Config config, final AgentTaskScheduler taskScheduler) {
+      maxConcurrentRequests = config.getIastMaxConcurrentRequests();
+      sampling = computeSamplingParameter(config.getIastRequestSampling());
+      availableRequests =
+          NonBlockingSemaphore.withPermitCount(config.getIastMaxConcurrentRequests());
+      if (taskScheduler != null) {
+        taskScheduler.scheduleAtFixedRate(this::reset, 60, 60, TimeUnit.SECONDS);
+      }
     }
-    if (availableRequests.get() <= 0) {
-      return false;
+
+    @Override
+    public boolean acquireRequest() {
+      if (executedRequests.incrementAndGet() % sampling != 0) {
+        // Skipped by sampling
+        return false;
+      }
+      return availableRequests.acquire();
     }
-    final int beforeUpdate = availableRequests.getAndUpdate(x -> (x > 0) ? x - 1 : x);
-    return beforeUpdate >= 1;
-  }
 
-  public void releaseRequest() {
-    availableRequests.updateAndGet(x -> (x < maxConcurrentRequests) ? x + 1 : x);
-  }
-
-  public boolean hasQuota(final Operation operation, final AgentSpan span) {
-    return operation.hasQuota(getContext(span));
-  }
-
-  public boolean consumeQuota(final Operation operation, final AgentSpan span) {
-    return operation.consumeQuota(getContext(span));
-  }
-
-  public OverheadContext getContext(AgentSpan span) {
-    final RequestContext requestContext = span != null ? span.getRequestContext() : null;
-    if (requestContext != null) {
-      IastRequestContext iastRequestContext = requestContext.getData(RequestContextSlot.IAST);
-      return iastRequestContext != null ? iastRequestContext.getOverheadContext() : null;
+    @Override
+    public int releaseRequest() {
+      return availableRequests.release();
     }
-    return globalContext;
-  }
 
-  static int computeSamplingParameter(final float pct) {
-    if (pct >= 100) {
-      return 1;
+    @Override
+    public boolean hasQuota(final Operation operation, final AgentSpan span) {
+      return operation.hasQuota(getContext(span));
     }
-    if (pct <= 0) {
-      // We don't support disabling IAST by setting it, so we set it to 100%.
-      // TODO: We probably want a warning here.
-      return 1;
-    }
-    return Math.round(100 / pct);
-  }
 
-  public void reset() {
-    globalContext.reset();
-    // Periodic reset of maximum concurrent requests. This guards us against exhausting concurrent
-    // requests if some bug led us to lose a request end event. This will lead to periodically
-    // going above the max concurrent requests. But overall, it should be self-stabilizing. So for
-    // practical purposes, the max concurrent requests is a hint.
-    availableRequests.set(maxConcurrentRequests);
+    @Override
+    public boolean consumeQuota(final Operation operation, final AgentSpan span) {
+      return operation.consumeQuota(getContext(span));
+    }
+
+    public OverheadContext getContext(final AgentSpan span) {
+      final RequestContext requestContext = span != null ? span.getRequestContext() : null;
+      if (requestContext != null) {
+        IastRequestContext iastRequestContext = requestContext.getData(RequestContextSlot.IAST);
+        return iastRequestContext != null ? iastRequestContext.getOverheadContext() : null;
+      }
+      return globalContext;
+    }
+
+    static int computeSamplingParameter(final float pct) {
+      if (pct >= 100) {
+        return 1;
+      }
+      if (pct <= 0) {
+        // We don't support disabling IAST by setting it, so we set it to 100%.
+        // TODO: We probably want a warning here.
+        return 1;
+      }
+      return Math.round(100 / pct);
+    }
+
+    @Override
+    public void reset() {
+      globalContext.reset();
+      // Periodic reset of maximum concurrent requests. This guards us against exhausting concurrent
+      // requests if some bug led us to lose a request end event. This will lead to periodically
+      // going above the max concurrent requests. But overall, it should be self-stabilizing. So for
+      // practical purposes, the max concurrent requests is a hint.
+      availableRequests.reset();
+    }
   }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/TaintedObjects.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/TaintedObjects.java
@@ -1,5 +1,6 @@
 package com.datadog.iast.taint;
 
+import com.datadog.iast.IastSystem;
 import com.datadog.iast.model.Range;
 import com.datadog.iast.model.Source;
 import com.datadog.iast.model.json.TaintedObjectEncoding;
@@ -10,74 +11,102 @@ import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TaintedObjects {
-  static final Logger LOGGER = LoggerFactory.getLogger(TaintedObjects.class);
+public interface TaintedObjects {
 
-  static boolean DEBUG = false;
+  TaintedObject taintInputString(@Nonnull String obj, @Nonnull Source source);
 
-  private final TaintedMap map;
-  private final UUID id;
+  TaintedObject taint(@Nonnull Object obj, @Nonnull Range[] ranges);
 
-  public TaintedObjects() {
-    this(new DefaultTaintedMap());
+  TaintedObject get(@Nonnull Object obj);
+
+  void release();
+
+  static TaintedObjects build() {
+    final TaintedObjectsImpl taintedObjects = new TaintedObjectsImpl();
+    return IastSystem.DEBUG ? new TaintedObjectsDebugAdapter(taintedObjects) : taintedObjects;
   }
 
-  public static void setDebug(final boolean newDebugState) {
-    LOGGER.debug("setDebug: newDebugState={}", newDebugState);
-    DEBUG = newDebugState;
+  class TaintedObjectsImpl implements TaintedObjects {
+
+    private final TaintedMap map;
+
+    public TaintedObjectsImpl() {
+      this(new DefaultTaintedMap());
+    }
+
+    public TaintedObjectsImpl(final @Nonnull TaintedMap map) {
+      this.map = map;
+    }
+
+    public TaintedObject taintInputString(final @Nonnull String obj, final @Nonnull Source source) {
+      final TaintedObject tainted =
+          new TaintedObject(obj, Ranges.forString(obj, source), map.getReferenceQueue());
+      map.put(tainted);
+      return tainted;
+    }
+
+    public TaintedObject taint(final @Nonnull Object obj, final @Nonnull Range[] ranges) {
+      final TaintedObject tainted = new TaintedObject(obj, ranges, map.getReferenceQueue());
+      map.put(tainted);
+      return tainted;
+    }
+
+    public TaintedObject get(final @Nonnull Object obj) {
+      return map.get(obj);
+    }
+
+    public void release() {}
   }
 
-  public TaintedObjects(final @Nonnull TaintedMap map) {
-    this.map = map;
-    if (DEBUG) {
+  class TaintedObjectsDebugAdapter implements TaintedObjects {
+    static final Logger LOGGER = LoggerFactory.getLogger(TaintedObjects.class);
+
+    private final TaintedObjectsImpl delegated;
+    private final UUID id;
+
+    public TaintedObjectsDebugAdapter(final TaintedObjectsImpl delegated) {
+      this.delegated = delegated;
       this.id = UUID.randomUUID();
       LOGGER.debug("new: id={}", id);
-    } else {
-      this.id = null;
     }
-  }
 
-  public void taintInputString(final @Nonnull String obj, final @Nonnull Source source) {
-    final TaintedObject tainted =
-        new TaintedObject(obj, Ranges.forString(obj, source), map.getReferenceQueue());
-    map.put(tainted);
-    if (DEBUG) {
+    public TaintedObject taintInputString(final @Nonnull String obj, final @Nonnull Source source) {
+      final TaintedObject tainted = delegated.taintInputString(obj, source);
       logTainted(tainted);
+      return tainted;
     }
-  }
 
-  public void taint(final @Nonnull Object obj, final @Nonnull Range[] ranges) {
-    final TaintedObject tainted = new TaintedObject(obj, ranges, map.getReferenceQueue());
-    map.put(tainted);
-    if (DEBUG) {
+    public TaintedObject taint(final @Nonnull Object obj, final @Nonnull Range[] ranges) {
+      final TaintedObject tainted = delegated.taint(obj, ranges);
       logTainted(tainted);
+      return tainted;
     }
-  }
 
-  public TaintedObject get(final @Nonnull Object obj) {
-    return map.get(obj);
-  }
+    public TaintedObject get(final @Nonnull Object obj) {
+      return delegated.get(obj);
+    }
 
-  public void release() {
-    if (DEBUG && LOGGER.isDebugEnabled()) {
-      try {
-        final List<TaintedObject> entries = new ArrayList<>();
-        for (final TaintedObject to : map) {
-          entries.add(to);
+    public void release() {
+      if (IastSystem.DEBUG && LOGGER.isDebugEnabled()) {
+        try {
+          final List<TaintedObject> entries = new ArrayList<>();
+          for (final TaintedObject to : delegated.map) {
+            entries.add(to);
+          }
+          LOGGER.debug("release {}: map={}", id, TaintedObjectEncoding.toJson(entries));
+        } catch (final Throwable e) {
+          LOGGER.error("Failed to debug tainted objects release", e);
         }
-        LOGGER.debug("release {}: map={}", id, TaintedObjectEncoding.toJson(entries));
-      } catch (final Throwable e) {
-        LOGGER.error("Failed to debug tainted objects release", e);
       }
     }
-  }
 
-  private void logTainted(final TaintedObject tainted) {
-    if (LOGGER.isDebugEnabled()) {
-      try {
-        LOGGER.debug("taint {}: tainted={}", id, TaintedObjectEncoding.toJson(tainted));
-      } catch (final Throwable e) {
-        LOGGER.error("Failed to debug new tainted object", e);
+    private void logTainted(final TaintedObject tainted) {
+      if (LOGGER.isDebugEnabled()) {
+        try {
+          LOGGER.debug("taint {}: tainted={}", id, TaintedObjectEncoding.toJson(tainted));
+        } catch (final Throwable e) {
+          LOGGER.error("Failed to debug new tainted object", e);
+        }
       }
     }
   }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/NonBlockingSemaphore.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/NonBlockingSemaphore.java
@@ -1,0 +1,84 @@
+package com.datadog.iast.util;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public interface NonBlockingSemaphore {
+
+  boolean acquire();
+
+  int release();
+
+  int available();
+
+  void reset();
+
+  static NonBlockingSemaphore withPermitCount(final int permits) {
+    assert permits > 0;
+    return permits == 1 ? new AtomicBooleanSemaphore() : new AtomicIntegerSemaphore(permits);
+  }
+
+  class AtomicBooleanSemaphore implements NonBlockingSemaphore {
+    private final AtomicBoolean available = new AtomicBoolean();
+
+    public AtomicBooleanSemaphore() {
+      reset();
+    }
+
+    @Override
+    public boolean acquire() {
+      return available.compareAndSet(true, false);
+    }
+
+    @Override
+    public int release() {
+      reset();
+      return available();
+    }
+
+    @Override
+    public final void reset() {
+      this.available.set(true);
+    }
+
+    @Override
+    public int available() {
+      return this.available.get() ? 1 : 0;
+    }
+  }
+
+  class AtomicIntegerSemaphore implements NonBlockingSemaphore {
+
+    private final int permits;
+
+    private final AtomicInteger available = new AtomicInteger();
+
+    public AtomicIntegerSemaphore(final int permits) {
+      this.permits = permits;
+      reset();
+    }
+
+    @Override
+    public boolean acquire() {
+      if (available.get() == 0) {
+        return false;
+      }
+      return available.getAndUpdate(x -> x > 0 ? x - 1 : x) > 0;
+    }
+
+    @Override
+    public int release() {
+      return available.updateAndGet(x -> x < permits ? x + 1 : x);
+    }
+
+    @Override
+    public final void reset() {
+      this.available.set(permits);
+    }
+
+    @Override
+    public int available() {
+      return this.available.get();
+    }
+  }
+}

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/overhead/OverheadContextTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/overhead/OverheadContextTest.groovy
@@ -3,13 +3,14 @@ package com.datadog.iast.overhead
 import datadog.trace.api.Config
 import datadog.trace.test.util.DDSpecification
 import datadog.trace.util.AgentTaskScheduler
+import com.datadog.iast.overhead.OverheadController.OverheadControllerImpl
 
 class OverheadContextTest extends DDSpecification {
 
   void 'Can reset global overhead context'() {
     given:
     def taskSchedler = Stub(AgentTaskScheduler)
-    def overheadController = new OverheadController(Config.get(), taskSchedler)
+    def overheadController = new OverheadControllerImpl(Config.get(), taskSchedler)
 
     when:
     overheadController.globalContext.consumeQuota(1)

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/overhead/OverheadControllerLogTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/overhead/OverheadControllerLogTest.groovy
@@ -1,0 +1,119 @@
+package com.datadog.iast.overhead
+
+import ch.qos.logback.classic.Logger
+import com.datadog.iast.IastSystem
+import datadog.trace.api.Config
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import datadog.trace.test.util.DDSpecification
+
+class OverheadControllerLogTest extends DDSpecification {
+
+  private boolean defaultDebug
+  private Logger logger
+
+  def setup() {
+    defaultDebug = IastSystem.DEBUG
+    logger = OverheadController.OverheadControllerDebugAdapter.LOGGER as Logger
+  }
+
+  def cleanup() {
+    IastSystem.DEBUG = defaultDebug
+    OverheadController.OverheadControllerDebugAdapter.LOGGER = logger
+  }
+
+  void 'on acquire request'() {
+    given:
+    IastSystem.DEBUG = true
+    final logger = Mock(org.slf4j.Logger)
+    OverheadController.OverheadControllerDebugAdapter.LOGGER = logger
+    final controller = OverheadController.build(Config.get(), null)
+
+    when:
+    controller.acquireRequest()
+
+    then:
+    noExceptionThrown()
+    1 * logger.isDebugEnabled() >> true
+    1 * logger.debug(_, _)
+
+    when:
+    controller.acquireRequest()
+
+    then:
+    noExceptionThrown()
+    1 * logger.isDebugEnabled() >> false
+    0 * _
+  }
+
+  void 'on reset request'() {
+    given:
+    IastSystem.DEBUG = true
+    final logger = Mock(org.slf4j.Logger)
+    OverheadController.OverheadControllerDebugAdapter.LOGGER = logger
+    final controller = OverheadController.build(Config.get(), null)
+
+    when:
+    controller.releaseRequest()
+
+    then:
+    noExceptionThrown()
+    1 * logger.isDebugEnabled() >> true
+    1 * logger.debug(_, _, _)
+
+    when:
+    controller.releaseRequest()
+
+    then:
+    noExceptionThrown()
+    1 * logger.isDebugEnabled() >> false
+    0 * _
+  }
+
+  void 'on has quota'() {
+    given:
+    IastSystem.DEBUG = true
+    final controller = OverheadController.build(Config.get(), null)
+
+    when:
+    controller.hasQuota(Operations.REPORT_VULNERABILITY, Mock(AgentSpan))
+
+    then:
+    noExceptionThrown()
+
+    when:
+    controller.hasQuota(Operations.REPORT_VULNERABILITY, null)
+
+    then:
+    noExceptionThrown()
+  }
+
+  void 'on consume quota'() {
+    given:
+    IastSystem.DEBUG = true
+    final controller = OverheadController.build(Config.get(), null)
+
+    when:
+    controller.consumeQuota(Operations.REPORT_VULNERABILITY, Mock(AgentSpan))
+
+    then:
+    noExceptionThrown()
+
+    when:
+    controller.consumeQuota(Operations.REPORT_VULNERABILITY, null)
+
+    then:
+    noExceptionThrown()
+  }
+
+  void 'on reset'() {
+    given:
+    IastSystem.DEBUG = true
+    final controller = OverheadController.build(Config.get(), null)
+
+    when:
+    controller.reset()
+
+    then:
+    noExceptionThrown()
+  }
+}

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedObjectsLogTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedObjectsLogTest.groovy
@@ -2,6 +2,7 @@ package com.datadog.iast.taint
 
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
+import com.datadog.iast.IastSystem
 import com.datadog.iast.model.Range
 import com.datadog.iast.model.Source
 import com.datadog.iast.model.SourceType
@@ -14,34 +15,43 @@ class TaintedObjectsLogTest extends DDSpecification {
   private Level defaultLevel
 
   def setup() {
-    defaultDebug = TaintedObjects.DEBUG
-    logger = TaintedObjects.LOGGER as Logger
+    defaultDebug = IastSystem.DEBUG
+    logger = TaintedObjects.TaintedObjectsDebugAdapter.LOGGER as Logger
     defaultLevel = logger.getLevel()
   }
 
   def cleanup() {
-    TaintedObjects.DEBUG = defaultDebug
+    IastSystem.DEBUG = defaultDebug
     logger.setLevel(defaultLevel)
   }
 
   def "test TaintedObjects debug log"() {
     given:
-    TaintedObjects.setDebug(true)
+    IastSystem.DEBUG = true
     logger.setLevel(Level.ALL)
-    TaintedObjects taintedObjects = new TaintedObjects()
+    TaintedObjects taintedObjects = TaintedObjects.build()
+    final value = "A"
 
     when:
-    taintedObjects.taintInputString("A", new Source(SourceType.NONE, null, null))
+    def tainted = taintedObjects.taintInputString(value, new Source(SourceType.NONE, null, null))
 
     then:
     noExceptionThrown()
+    tainted != null
+
+    when:
+    tainted = taintedObjects.get(value)
+
+    then:
+    noExceptionThrown()
+    tainted != null
   }
 
   def "test TaintedObjects debug log on release"() {
     given:
-    TaintedObjects.setDebug(true)
+    IastSystem.DEBUG = true
     logger.setLevel(Level.ALL)
-    TaintedObjects taintedObjects = new TaintedObjects()
+    TaintedObjects taintedObjects = TaintedObjects.build()
     taintedObjects.taint("A", [new Range(0, 1, new Source(SourceType.NONE, null, null))] as Range[])
     taintedObjects.taintInputString("B", new Source(SourceType.REQUEST_PARAMETER_NAME, 'test', 'value'))
 

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/NonBlockingSemaphoreTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/NonBlockingSemaphoreTest.groovy
@@ -1,0 +1,93 @@
+package com.datadog.iast.util
+
+import datadog.trace.test.util.DDSpecification
+
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class NonBlockingSemaphoreTest extends DDSpecification {
+
+  void 'test that the semaphore controls access to a shared resource (#permitCount)'(final int permitCount) {
+    given:
+    final int threads = 100
+    final semaphore = NonBlockingSemaphore.withPermitCount(permitCount)
+    final latch = new CountDownLatch(threads)
+    final executors = Executors.newFixedThreadPool(threads)
+
+    when:
+    final acquired = (1..threads).collect {
+      executors.submit({
+        latch.countDown()
+        if (semaphore.acquire()) {
+          TimeUnit.MILLISECONDS.sleep(100)
+          semaphore.release()
+          return 1
+        }
+        return 0
+      } as Callable<Integer>)
+    }.collect { it.get() }.sum()
+
+    then:
+    acquired >= permitCount
+    acquired < threads
+    semaphore.available() == permitCount
+
+    where:
+    permitCount | _
+    1           | _
+    2           | _
+  }
+
+  void 'there is resource starvation if the semaphore is not released (#permitCount)'(final int permitCount) {
+    given:
+    final int threads = 100
+    final semaphore = NonBlockingSemaphore.withPermitCount(permitCount)
+    final latch = new CountDownLatch(threads)
+    final executors = Executors.newFixedThreadPool(threads)
+
+    when:
+    final acquired = (1..threads).collect {
+      executors.submit ({
+        latch.countDown()
+        if (semaphore.acquire()) {
+          TimeUnit.MILLISECONDS.sleep(100)
+          return 1
+        }
+        return 0
+      } as Callable<Integer>)
+    }.collect { it.get() }.sum()
+
+    then:
+    acquired == permitCount
+    semaphore.available() == 0
+
+    where:
+    permitCount | _
+    1           | _
+    2           | _
+  }
+
+  void 'reset helps recover when there is starvation (#permitCount)'(final int permitCount) {
+    given:
+    final semaphore = NonBlockingSemaphore.withPermitCount(permitCount)
+
+    when:
+    (1..permitCount).each { semaphore.acquire() }
+
+    then:
+    semaphore.available() == 0
+
+    when:
+    semaphore.reset()
+
+    then:
+    semaphore.available() == permitCount
+
+    where:
+    permitCount | _
+    1           | _
+    2           | _
+  }
+}

--- a/dd-java-agent/agent-iast/src/testFixtures/groovy/com/datadog/iast/NoopOverheadController.groovy
+++ b/dd-java-agent/agent-iast/src/testFixtures/groovy/com/datadog/iast/NoopOverheadController.groovy
@@ -1,18 +1,20 @@
 package com.datadog.iast
 
 import com.datadog.iast.overhead.Operation
-import com.datadog.iast.overhead.OverheadContext
 import com.datadog.iast.overhead.OverheadController
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import groovy.transform.CompileStatic
 
-class NoopOverheadController extends OverheadController {
+@CompileStatic
+class NoopOverheadController implements OverheadController {
   @Override
   boolean acquireRequest() {
     true
   }
 
   @Override
-  void releaseRequest() {
+  int releaseRequest() {
+    Integer.MAX_VALUE
   }
 
   @Override
@@ -23,26 +25,6 @@ class NoopOverheadController extends OverheadController {
   @Override
   boolean consumeQuota(Operation operation, AgentSpan span) {
     true
-  }
-
-  @Override
-  OverheadContext getContext(AgentSpan span) {
-    new OverheadContext() {
-        final int availableQuota = Integer.MAX_VALUE
-
-        @Override
-        boolean consumeQuota(int delta) {
-          true
-        }
-
-        @Override
-        void reset() {}
-      }
-  }
-
-  @Override
-  int computeSamplingParameter(float pct) {
-    1
   }
 
   @Override

--- a/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
@@ -8,6 +8,10 @@ import spock.util.concurrent.PollingConditions
 import java.util.function.Function
 import java.util.function.Predicate
 
+import static datadog.trace.api.config.IastConfig.IAST_DEBUG_ENABLED
+import static datadog.trace.api.config.IastConfig.IAST_ENABLED
+import static datadog.trace.api.config.IastConfig.IAST_REQUEST_SAMPLING
+
 class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
 
   private static final String TAG_NAME = '_dd.iast.json'
@@ -30,9 +34,9 @@ class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
     command.add(javaPath())
     command.addAll(defaultJavaProperties)
     command.addAll([
-      "-Ddd.iast.enabled=true",
-      "-Ddd.iast.request-sampling=100",
-      "-Ddd.iast.taint-tracking.debug.enabled=true"
+      withSystemProperty(IAST_ENABLED, true),
+      withSystemProperty(IAST_REQUEST_SAMPLING, 100),
+      withSystemProperty(IAST_DEBUG_ENABLED, true)
     ])
     command.addAll((String[]) ["-jar", springBootShadowJar, "--server.port=${httpPort}"])
     ProcessBuilder processBuilder = new ProcessBuilder(command)
@@ -289,5 +293,9 @@ class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
     return { vul ->
       vul.location.spanId > 0
     }
+  }
+
+  private static String withSystemProperty(final String config, final Object value) {
+    return "-Ddd.${config}=${value}"
   }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -81,7 +81,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_APPSEC_WAF_METRICS = true;
 
   static final boolean DEFAULT_IAST_ENABLED = false;
-  static final boolean DEFAULT_IAST_TAINT_TRACKING_DEBUG_ENABLED = false;
+  static final boolean DEFAULT_IAST_DEBUG_ENABLED = false;
   public static final int DEFAULT_IAST_MAX_CONCURRENT_REQUESTS = 2;
   public static final int DEFAULT_IAST_VULNERABILITIES_PER_REQUEST = 2;
   public static final int DEFAULT_IAST_REQUEST_SAMPLING = 30;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/IastConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/IastConfig.java
@@ -6,7 +6,7 @@ public final class IastConfig {
   public static final String IAST_ENABLED = "iast.enabled";
   public static final String IAST_WEAK_HASH_ALGORITHMS = "iast.weak-hash.algorithms";
   public static final String IAST_WEAK_CIPHER_ALGORITHMS = "iast.weak-cipher.algorithms";
-  public static final String IAST_TAINT_TRAKING_DEBUG_ENABLED = "iast.taint-tracking.debug.enabled";
+  public static final String IAST_DEBUG_ENABLED = "iast.debug.enabled";
   public static final String IAST_MAX_CONCURRENT_REQUESTS = "iast.max-concurrent-requests";
   public static final String IAST_VULNERABILITIES_PER_REQUEST = "iast.vulnerabilities-per-request";
   public static final String IAST_REQUEST_SAMPLING = "iast.request-sampling";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -36,10 +36,10 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_CLIENT_TAG_QUERY_STR
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_ERROR_STATUSES;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_ROUTE_BASED_NAMING;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_TAG_QUERY_STRING;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_DEBUG_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_DEDUPLICATION_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_MAX_CONCURRENT_REQUESTS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_REQUEST_SAMPLING;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_TAINT_TRACKING_DEBUG_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_VULNERABILITIES_PER_REQUEST;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_WEAK_HASH_ALGORITHMS;
@@ -141,10 +141,10 @@ import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_IGNORED_RESO
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_AGGREGATES;
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_PENDING;
 import static datadog.trace.api.config.GeneralConfig.VERSION;
+import static datadog.trace.api.config.IastConfig.IAST_DEBUG_ENABLED;
 import static datadog.trace.api.config.IastConfig.IAST_DEDUPLICATION_ENABLED;
 import static datadog.trace.api.config.IastConfig.IAST_MAX_CONCURRENT_REQUESTS;
 import static datadog.trace.api.config.IastConfig.IAST_REQUEST_SAMPLING;
-import static datadog.trace.api.config.IastConfig.IAST_TAINT_TRAKING_DEBUG_ENABLED;
 import static datadog.trace.api.config.IastConfig.IAST_VULNERABILITIES_PER_REQUEST;
 import static datadog.trace.api.config.IastConfig.IAST_WEAK_CIPHER_ALGORITHMS;
 import static datadog.trace.api.config.IastConfig.IAST_WEAK_HASH_ALGORITHMS;
@@ -503,7 +503,7 @@ public class Config {
   private final int iastMaxConcurrentRequests;
   private final int iastVulnerabilitiesPerRequest;
   private final float iastRequestSampling;
-  private final boolean iastTaintTrackingDebugEnabled;
+  private final boolean iastDebugEnabled;
 
   private final boolean ciVisibilityAgentlessEnabled;
   private final String ciVisibilityAgentlessUrl;
@@ -1072,9 +1072,7 @@ public class Config {
     appSecHttpBlockedTemplateJson =
         configProvider.getString(APPSEC_HTTP_BLOCKED_TEMPLATE_JSON, null);
 
-    iastTaintTrackingDebugEnabled =
-        configProvider.getBoolean(
-            IAST_TAINT_TRAKING_DEBUG_ENABLED, DEFAULT_IAST_TAINT_TRACKING_DEBUG_ENABLED);
+    iastDebugEnabled = configProvider.getBoolean(IAST_DEBUG_ENABLED, DEFAULT_IAST_DEBUG_ENABLED);
 
     iastMaxConcurrentRequests =
         configProvider.getInteger(
@@ -1788,8 +1786,8 @@ public class Config {
     return instrumenterConfig.isIastEnabled();
   }
 
-  public boolean isIastTaintTrackingDebugEnabled() {
-    return iastTaintTrackingDebugEnabled;
+  public boolean isIastDebugEnabled() {
+    return iastDebugEnabled;
   }
 
   public int getIastMaxConcurrentRequests() {


### PR DESCRIPTION
# What Does This Do
Extract atomic semaphores from overhead controller and tainted objects and adds debug information to troubleshoot issues.

# Motivation
We are getting an increased level of flaky tests in system-tests due to the overhead controller.

# Additional Notes
