### PR TITLE
enable async-profiler by default

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -957,7 +957,7 @@ public class Config {
         configProvider.getBoolean(PROFILING_AGENTLESS, PROFILING_AGENTLESS_DEFAULT);
     isAsyncProfilerEnabled =
         configProvider.getBoolean(
-            PROFILING_ASYNC_ENABLED, false /*isAsyncProfilerSafeInCurrentEnvironment()*/);
+            PROFILING_ASYNC_ENABLED, isAsyncProfilerSafeInCurrentEnvironment());
     profilingUrl = configProvider.getString(PROFILING_URL);
 
     if (tmpApiKey == null) {


### PR DESCRIPTION
# What Does This Do

# Motivation

# Additional Notes
