### PR TITLE
Add metric for serialization failure

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
@@ -61,6 +61,8 @@ public class HealthMetrics implements AutoCloseable {
       CountersFactory.createFixedSizeStripedCounter(8);
   private final FixedSizeStripedLongCounter samplerKeepDroppedTraces =
       CountersFactory.createFixedSizeStripedCounter(8);
+  private final FixedSizeStripedLongCounter serialFailedDroppedTraces =
+      CountersFactory.createFixedSizeStripedCounter(8);
   private final FixedSizeStripedLongCounter unsetPriorityDroppedTraces =
       CountersFactory.createFixedSizeStripedCounter(8);
 
@@ -174,8 +176,7 @@ public class HealthMetrics implements AutoCloseable {
   }
 
   public void onFailedSerialize(final List<DDSpan> trace, final Throwable optionalCause) {
-    // TODO - DQH - make a new stat for serialization failure -- or maybe count this towards
-    // api.errors???
+    serialFailedDroppedTraces.inc();
   }
 
   public void onCreateSpan() {
@@ -239,6 +240,7 @@ public class HealthMetrics implements AutoCloseable {
     private static final String[] USER_KEEP_TAG = new String[] {"priority:user_keep"};
     private static final String[] SAMPLER_DROP_TAG = new String[] {"priority:sampler_drop"};
     private static final String[] SAMPLER_KEEP_TAG = new String[] {"priority:sampler_keep"};
+    private static final String[] SERIAL_FAILED_TAG = new String[] {"failure:serial"};
     private static final String[] UNSET_TAG = new String[] {"priority:unset"};
 
     @Override
@@ -267,6 +269,11 @@ public class HealthMetrics implements AutoCloseable {
           target.statsd, "queue.dropped.traces", target.samplerDropDroppedTraces, SAMPLER_DROP_TAG);
       reportIfChanged(
           target.statsd, "queue.dropped.traces", target.samplerKeepDroppedTraces, SAMPLER_KEEP_TAG);
+      reportIfChanged(
+          target.statsd,
+          "queue.dropped.traces",
+          target.serialFailedDroppedTraces,
+          SERIAL_FAILED_TAG);
       reportIfChanged(
           target.statsd, "queue.dropped.traces", target.unsetPriorityDroppedTraces, UNSET_TAG);
       reportIfChanged(target.statsd, "queue.enqueued.spans", target.enqueuedSpans, NO_TAGS);


### PR DESCRIPTION
# What Does This Do

Count the number of dropped traces by serialization failure.

# Motivation

Where a trace is sampled, it can be lost if something unexpected happens during serialization and it was not counted as a dropped trace.

# Additional Notes
