### PR TITLE
Build lib injection image from tags too, so the jar doesn't have a snapshot version

### DIFF
--- a/.github/workflows/lib-injection.yaml
+++ b/.github/workflows/lib-injection.yaml
@@ -4,6 +4,8 @@ on:
     branches:
       - master
       - 'release/*'
+    tags:
+      - '*'
   pull_request:
     branches:
       - master


### PR DESCRIPTION
# What Does This Do

# Motivation

# Additional Notes
