### PR TITLE
remove publish task from correlation-id-injection

### DIFF
--- a/dd-trace-ot/correlation-id-injection/build.gradle
+++ b/dd-trace-ot/correlation-id-injection/build.gradle
@@ -1,5 +1,4 @@
 apply from: "$rootDir/gradle/java.gradle"
-apply from: "$rootDir/gradle/publish.gradle"
 
 minimumBranchCoverage = 0.8
 


### PR DESCRIPTION
# What Does This Do
removes the publish task from `correlation-id-injection`, only a select top-level modules should have this task

# Motivation
`correlation-id-injection` is shaded into `dd-trace-ot` and shouldn't be published as a separate artifact
