### PR TITLE
Reduce Telemetry warnings

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolver.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolver.java
@@ -61,7 +61,7 @@ public class DependencyResolver {
    */
   static List<Dependency> extractDependenciesFromJar(File jar) {
     if (!jar.exists()) {
-      log.warn("unable to find dependency {}", jar);
+      log.warn("unable to find dependency {} (path does not exist)", jar);
       return Collections.emptyList();
     } else if (!jar.getName().endsWith(JAR_SUFFIX)) {
       log.debug("unsupported file dependency type : {}", jar);


### PR DESCRIPTION
# What Does This Do

Reduce Telemetry warnings. In particular, log all network and HTTP errors to debug, since there are many scenarios where this is frequent (but not harmful).

# Motivation

These warnings are too alarming for customers, for scenarios that are common and safe.

# Additional Notes

There are still some possible warning messages in the module, but the ones I reviewed seem to be unexpected conditions that we do want customers to notice.