### PR TITLE
Update IAST overhead rates

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/overhead/OverheadController.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/overhead/OverheadController.java
@@ -108,6 +108,9 @@ public interface OverheadController {
   }
 
   class OverheadControllerImpl implements OverheadController {
+
+    private static final int RESET_PERIOD_SECONDS = 30;
+
     private final int maxConcurrentRequests;
     private final int sampling;
 
@@ -123,7 +126,8 @@ public interface OverheadController {
       availableRequests =
           NonBlockingSemaphore.withPermitCount(config.getIastMaxConcurrentRequests());
       if (taskScheduler != null) {
-        taskScheduler.scheduleAtFixedRate(this::reset, 60, 60, TimeUnit.SECONDS);
+        taskScheduler.scheduleAtFixedRate(
+            this::reset, 2 * RESET_PERIOD_SECONDS, RESET_PERIOD_SECONDS, TimeUnit.SECONDS);
       }
     }
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -80,7 +80,7 @@ public final class ConfigDefaults {
 
   static final boolean DEFAULT_IAST_ENABLED = false;
   static final boolean DEFAULT_IAST_DEBUG_ENABLED = false;
-  public static final int DEFAULT_IAST_MAX_CONCURRENT_REQUESTS = 2;
+  public static final int DEFAULT_IAST_MAX_CONCURRENT_REQUESTS = 4;
   public static final int DEFAULT_IAST_VULNERABILITIES_PER_REQUEST = 2;
   public static final int DEFAULT_IAST_REQUEST_SAMPLING = 30;
   static final Set<String> DEFAULT_IAST_WEAK_HASH_ALGORITHMS =


### PR DESCRIPTION
# What Does This Do
Updates the max concurrent request and reset period of the overhead controller to prevent the agent from skipping to many requests.

# Motivation

# Additional Notes
