### PR TITLE
Set servlet.context & servlet.path for Undertow Servlet Request

### DIFF
--- a/dd-java-agent/instrumentation/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/ServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/ServletInstrumentation.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.undertow;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.SERVLET_CONTEXT;
+import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.SERVLET_PATH;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
 import static datadog.trace.instrumentation.undertow.UndertowDecorator.DD_UNDERTOW_SPAN;
 import static datadog.trace.instrumentation.undertow.UndertowDecorator.SERVLET_REQUEST;
@@ -54,6 +56,9 @@ public final class ServletInstrumentation extends Instrumenter.Tracing
         ServletRequest request = servletRequestContext.getServletRequest();
         request.setAttribute(DD_SPAN_ATTRIBUTE, undertow_span);
         undertow_span.setSpanName(SERVLET_REQUEST);
+
+        undertow_span.setTag(SERVLET_CONTEXT, request.getServletContext().getContextPath());
+        undertow_span.setTag(SERVLET_PATH, exchange.getRelativePath());
       }
     }
   }


### PR DESCRIPTION
# What Does This Do

Set servlet.context & servlet.path for Undertow Servlet Request

# Motivation

UndertowDecorator doesn't set servlet.context as opposed to Servlet2Decorator that sets servlet.context tag used by TagInterceptor to set the span’s service name.

# Additional Notes

APMS-8274