### PR TITLE
Deprecate dd.propagaion.style for dd.trace.propagation.style

### DIFF
--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
@@ -8,7 +8,7 @@ import static datadog.trace.instrumentation.apachehttpclient.ApacheHttpClientDec
 import static datadog.trace.instrumentation.apachehttpclient.HttpHeadersInjectAdapter.SETTER;
 
 import datadog.trace.api.Config;
-import datadog.trace.api.PropagationStyle;
+import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -33,7 +33,7 @@ public class HelperMethods {
           .injectPathwayContext(
               span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
     } else if (Config.get().isAwsPropagationEnabled()) {
-      propagate().inject(span, request, SETTER, PropagationStyle.XRAY);
+      propagate().inject(span, request, SETTER, TracePropagationStyle.XRAY);
     }
     return scope;
   }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
@@ -13,7 +13,7 @@ import static datadog.trace.instrumentation.netty40.client.NettyHttpClientDecora
 import static datadog.trace.instrumentation.netty40.client.NettyResponseInjectAdapter.SETTER;
 
 import datadog.trace.api.Config;
-import datadog.trace.api.PropagationStyle;
+import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
@@ -75,7 +75,7 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
             .injectPathwayContext(
                 span, request.headers(), SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
       } else if (Config.get().isAwsPropagationEnabled()) {
-        propagate().inject(span, request.headers(), SETTER, PropagationStyle.XRAY);
+        propagate().inject(span, request.headers(), SETTER, TracePropagationStyle.XRAY);
       }
 
       ctx.channel().attr(SPAN_ATTRIBUTE_KEY).set(span);

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
@@ -13,7 +13,7 @@ import static datadog.trace.instrumentation.netty41.client.NettyHttpClientDecora
 import static datadog.trace.instrumentation.netty41.client.NettyResponseInjectAdapter.SETTER;
 
 import datadog.trace.api.Config;
-import datadog.trace.api.PropagationStyle;
+import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
@@ -75,7 +75,7 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
             .injectPathwayContext(
                 span, request.headers(), SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
       } else if (Config.get().isAwsPropagationEnabled()) {
-        propagate().inject(span, request.headers(), SETTER, PropagationStyle.XRAY);
+        propagate().inject(span, request.headers(), SETTER, TracePropagationStyle.XRAY);
       }
 
       ctx.channel().attr(SPAN_ATTRIBUTE_KEY).set(span);

--- a/dd-trace-api/build.gradle
+++ b/dd-trace-api/build.gradle
@@ -12,6 +12,7 @@ excludedClassesCoverage += [
   'datadog.trace.api.DDTraceApiInfo',
   'datadog.trace.api.GlobalTracer*',
   'datadog.trace.api.PropagationStyle',
+  'datadog.trace.api.TracePropagationStyle',
   'datadog.trace.api.SpanCorrelation*',
   'datadog.trace.api.interceptor.MutableSpan'
 ]

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -55,8 +55,6 @@ public final class ConfigDefaults {
   static final int DEFAULT_SCOPE_ITERATION_KEEP_ALIVE = 30; // in seconds
   static final int DEFAULT_PARTIAL_FLUSH_MIN_SPANS = 1000;
   static final boolean DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED = false;
-  static final String DEFAULT_PROPAGATION_STYLE_EXTRACT = PropagationStyle.DATADOG.name();
-  static final String DEFAULT_PROPAGATION_STYLE_INJECT = PropagationStyle.DATADOG.name();
   static final boolean DEFAULT_JMX_FETCH_ENABLED = true;
   static final boolean DEFAULT_TRACE_AGENT_V05_ENABLED = false;
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/PropagationStyle.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/PropagationStyle.java
@@ -1,8 +1,31 @@
 package datadog.trace.api;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * These are the old propagation styles that have been deprecated in favor of the propagation styles
+ * in {@code TracePropagationStyle}
+ */
+@Deprecated
 public enum PropagationStyle {
-  DATADOG,
-  B3,
-  HAYSTACK,
-  XRAY
+  DATADOG(TracePropagationStyle.DATADOG),
+  B3(TracePropagationStyle.B3, TracePropagationStyle.B3MULTI),
+  HAYSTACK(TracePropagationStyle.HAYSTACK),
+  XRAY(TracePropagationStyle.XRAY);
+
+  private final List<TracePropagationStyle> newStyles;
+
+  PropagationStyle(TracePropagationStyle... newStyles) {
+    this.newStyles = Collections.unmodifiableList(Arrays.asList(newStyles));
+  }
+
+  public List<TracePropagationStyle> getNewStyles() {
+    return newStyles;
+  }
+
+  public static PropagationStyle valueOfConfigName(String configName) {
+    return valueOf(configName.toUpperCase().trim());
+  }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/TracePropagationStyle.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/TracePropagationStyle.java
@@ -1,0 +1,39 @@
+package datadog.trace.api;
+
+/** Trace propagation styles for injecting and extracting trace propagation headers. */
+public enum TracePropagationStyle {
+  // Datadog context propagation style
+  DATADOG,
+  // B3 single header context propagation style
+  // https://github.com/openzipkin/b3-propagation/tree/master#single-header
+  B3,
+  // B3 multi header context propagation style
+  // https://github.com/openzipkin/b3-propagation/tree/master#multiple-headers
+  B3MULTI,
+  // Haystack context propagation style
+  // https://github.com/ExpediaDotCom/haystack
+  HAYSTACK,
+  // Amazon X-Ray context propagation style
+  // https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader
+  XRAY;
+
+  public static TracePropagationStyle valueOfDisplayName(String displayName) {
+    String convertedName = displayName.toUpperCase().replace(' ', '_');
+    // Another name for B3 for cross tracer compatibility
+    if (convertedName.equals("B3_SINGLE_HEADER")) {
+      return B3;
+    }
+    return TracePropagationStyle.valueOf(convertedName);
+  }
+
+  private String displayName;
+
+  @Override
+  public String toString() {
+    String string = displayName;
+    if (displayName == null) {
+      string = displayName = name().toLowerCase().replace('_', ' ');
+    }
+    return string;
+  }
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -71,6 +71,10 @@ public final class TracerConfig {
   public static final String PROPAGATION_STYLE_EXTRACT = "propagation.style.extract";
   public static final String PROPAGATION_STYLE_INJECT = "propagation.style.inject";
 
+  public static final String TRACE_PROPAGATION_STYLE = "trace.propagation.style";
+  public static final String TRACE_PROPAGATION_STYLE_EXTRACT = "trace.propagation.style.extract";
+  public static final String TRACE_PROPAGATION_STYLE_INJECT = "trace.propagation.style.inject";
+
   public static final String ENABLE_TRACE_AGENT_V05 = "trace.agent.v0.5.enabled";
 
   public static final String CLIENT_IP_ENABLED = "trace.client-ip.enabled";

--- a/dd-trace-core/src/jmh/java/datadog/trace/core/propagation/InjectorBenchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/propagation/InjectorBenchmark.java
@@ -89,7 +89,7 @@ public class InjectorBenchmark {
     System.setProperty("dd.propagation.style.extract", propagations.toString());
     injector =
         HttpCodec.createInjector(
-            Config.get().getPropagationStylesToInject(), Collections.emptyMap());
+            Config.get().getTracePropagationStylesToInject(), Collections.emptyMap());
 
     traceId = DDTraceId.from("12345");
     spanId = DDSpanId.from("23456");

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -20,8 +20,8 @@ import datadog.trace.api.DDTraceId;
 import datadog.trace.api.EndpointCheckpointer;
 import datadog.trace.api.EndpointCheckpointerHolder;
 import datadog.trace.api.IdGenerationStrategy;
-import datadog.trace.api.PropagationStyle;
 import datadog.trace.api.StatsDClient;
+import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.api.config.GeneralConfig;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.InstrumentationGateway;
@@ -75,7 +75,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -177,7 +176,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
   private final HttpCodec.Injector injector;
 
-  private final Map<PropagationStyle, HttpCodec.Injector> injectors;
+  private final Map<TracePropagationStyle, HttpCodec.Injector> injectors;
   private final HttpCodec.Extractor extractor;
 
   private final InstrumentationGateway instrumentationGateway;
@@ -371,7 +370,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       instrumentationGateway(new InstrumentationGateway());
       injector(
           HttpCodec.createInjector(
-              config.getPropagationStylesToInject(), invertMap(config.getBaggageMapping())));
+              config.getTracePropagationStylesToInject(), invertMap(config.getBaggageMapping())));
       extractor(
           HttpCodec.createExtractor(
               config, config.getRequestHeaderTags(), config.getBaggageMapping()));
@@ -571,8 +570,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     this.callbackProviderIast = instrumentationGateway.getCallbackProvider(RequestContextSlot.IAST);
     this.universalCallbackProvider = instrumentationGateway.getUniversalCallbackProvider();
 
-    injectors =
-        HttpCodec.createInjectors(EnumSet.allOf(PropagationStyle.class), invertMap(baggageMapping));
+    injectors = HttpCodec.allInjectorsFor(invertMap(baggageMapping));
 
     shutdownCallback = new ShutdownHook(this);
     try {
@@ -753,7 +751,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   @Override
-  public <C> void inject(AgentSpan span, C carrier, Setter<C> setter, PropagationStyle style) {
+  public <C> void inject(AgentSpan span, C carrier, Setter<C> setter, TracePropagationStyle style) {
     inject(span.context(), carrier, setter, style);
   }
 
@@ -791,7 +789,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   private <C> void inject(
-      AgentSpan.Context context, C carrier, Setter<C> setter, PropagationStyle style) {
+      AgentSpan.Context context, C carrier, Setter<C> setter, TracePropagationStyle style) {
     if (!(context instanceof DDSpanContext)) {
       return;
     }
@@ -803,7 +801,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     if (null == style) {
       injector.inject(ddSpanContext, carrier, setter);
     } else {
-      HttpCodec.inject(ddSpanContext, carrier, setter, injectors.get(style));
+      injectors.get(style).inject(ddSpanContext, carrier, setter);
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -1,7 +1,7 @@
 package datadog.trace.core.propagation;
 
 import datadog.trace.api.Config;
-import datadog.trace.api.PropagationStyle;
+import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import datadog.trace.core.DDSpanContext;
@@ -10,6 +10,7 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -45,35 +46,37 @@ public class HttpCodec {
     <C> TagContext extract(final C carrier, final AgentPropagation.ContextVisitor<C> getter);
   }
 
-  public static <C> void inject(
-      DDSpanContext context, C carrier, AgentPropagation.Setter<C> setter, Injector injector) {
-    injector.inject(context, carrier, setter);
-  }
-
   public static Injector createInjector(
-      Set<PropagationStyle> styles, Map<String, String> invertedBaggageMapping) {
+      Set<TracePropagationStyle> styles, Map<String, String> invertedBaggageMapping) {
     ArrayList<Injector> injectors =
         new ArrayList<>(createInjectors(styles, invertedBaggageMapping).values());
     return new CompoundInjector(injectors);
   }
 
-  public static Map<PropagationStyle, Injector> createInjectors(
-      Set<PropagationStyle> propagationStyles, Map<String, String> reverseBaggageMapping) {
-    EnumMap<PropagationStyle, Injector> result = new EnumMap<>(PropagationStyle.class);
-    for (PropagationStyle style : propagationStyles) {
+  public static Map<TracePropagationStyle, Injector> allInjectorsFor(
+      Map<String, String> reverseBaggageMapping) {
+    return createInjectors(EnumSet.allOf(TracePropagationStyle.class), reverseBaggageMapping);
+  }
+
+  private static Map<TracePropagationStyle, Injector> createInjectors(
+      Set<TracePropagationStyle> propagationStyles, Map<String, String> reverseBaggageMapping) {
+    EnumMap<TracePropagationStyle, Injector> result = new EnumMap<>(TracePropagationStyle.class);
+    for (TracePropagationStyle style : propagationStyles) {
       switch (style) {
         case DATADOG:
-          result.put(PropagationStyle.DATADOG, DatadogHttpCodec.newInjector(reverseBaggageMapping));
+          result.put(style, DatadogHttpCodec.newInjector(reverseBaggageMapping));
           break;
         case B3:
-          result.put(PropagationStyle.B3, B3HttpCodec.INJECTOR);
+          result.put(style, B3HttpCodec.SINGLE_INJECTOR);
+          break;
+        case B3MULTI:
+          result.put(style, B3HttpCodec.MULTI_INJECTOR);
           break;
         case HAYSTACK:
-          result.put(
-              PropagationStyle.HAYSTACK, HaystackHttpCodec.newInjector(reverseBaggageMapping));
+          result.put(style, HaystackHttpCodec.newInjector(reverseBaggageMapping));
           break;
         case XRAY:
-          result.put(PropagationStyle.XRAY, XRayHttpCodec.newInjector(reverseBaggageMapping));
+          result.put(style, XRayHttpCodec.newInjector(reverseBaggageMapping));
           break;
         default:
           log.debug("No implementation found to inject propagation style: {}", style);
@@ -88,13 +91,15 @@ public class HttpCodec {
       final Map<String, String> taggedHeaders,
       final Map<String, String> baggageMapping) {
     final List<Extractor> extractors = new ArrayList<>();
-    for (final PropagationStyle style : config.getPropagationStylesToExtract()) {
+    for (final TracePropagationStyle style : config.getTracePropagationStylesToExtract()) {
       switch (style) {
         case DATADOG:
           extractors.add(DatadogHttpCodec.newExtractor(taggedHeaders, baggageMapping, config));
           break;
         case B3:
           extractors.add(B3HttpCodec.newSingleExtractor(taggedHeaders, baggageMapping, config));
+          break;
+        case B3MULTI:
           extractors.add(B3HttpCodec.newMultiExtractor(taggedHeaders, baggageMapping, config));
           break;
         case HAYSTACK:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpExtractorTest.groovy
@@ -8,8 +8,8 @@ import datadog.trace.bootstrap.instrumentation.api.ContextVisitors
 import datadog.trace.test.util.DDSpecification
 import spock.lang.Shared
 
-import static datadog.trace.api.PropagationStyle.B3
-import static datadog.trace.api.PropagationStyle.DATADOG
+import static datadog.trace.api.TracePropagationStyle.B3MULTI
+import static datadog.trace.api.TracePropagationStyle.DATADOG
 import static datadog.trace.core.CoreTracer.TRACE_ID_MAX
 
 class HttpExtractorTest extends DDSpecification {
@@ -17,10 +17,10 @@ class HttpExtractorTest extends DDSpecification {
   @Shared
   String outOfRangeTraceId = (TRACE_ID_MAX + 1).toString()
 
-  def "extract http headers"() {
+  def "extract http headers using #styles"() {
     setup:
     Config config = Mock(Config) {
-      getPropagationStylesToExtract() >> styles
+      getTracePropagationStylesToExtract() >> styles
     }
     HttpCodec.Extractor extractor = HttpCodec.createExtractor(config, ["SOME_HEADER": "some-tag"],[:])
 
@@ -67,22 +67,22 @@ class HttpExtractorTest extends DDSpecification {
 
     where:
     // spotless:off
-    styles        | datadogTraceId    | datadogSpanId     | b3TraceId         | b3SpanId          | expectedTraceId | expectedSpanId | putDatadogFields | expectDatadogFields | tagContext
-    [DATADOG, B3] | "1"               | "2"               | "a"               | "b"               | "1"             | "2"            | true             | true                | false
-    [DATADOG, B3] | null              | null              | "a"               | "b"               | "10"            | "11"           | false            | false               | true
-    [DATADOG, B3] | null              | null              | "a"               | "b"               | null            | null           | true             | true                | true
-    [DATADOG]     | "1"               | "2"               | "a"               | "b"               | "1"             | "2"            | true             | true                | false
-    [B3]          | "1"               | "2"               | "a"               | "b"               | "10"            | "11"           | false            | false               | false
-    [B3, DATADOG] | "1"               | "2"               | "a"               | "b"               | "10"            | "11"           | false            | false               | false
-    []            | "1"               | "2"               | "a"               | "b"               | null            | null           | false            | false               | false
-    [DATADOG, B3] | "abc"             | "2"               | "a"               | "b"               | "10"            | "11"           | false            | false               | false
-    [DATADOG]     | "abc"             | "2"               | "a"               | "b"               | null            | null           | false            | false               | false
-    [DATADOG, B3] | outOfRangeTraceId | "2"               | "a"               | "b"               | "10"            | "11"           | false            | false               | false
-    [DATADOG, B3] | "1"               | outOfRangeTraceId | "a"               | "b"               | "10"            | "11"           | false            | false               | false
-    [DATADOG]     | outOfRangeTraceId | "2"               | "a"               | "b"               | null            | null           | false            | false               | false
-    [DATADOG]     | "1"               | outOfRangeTraceId | "a"               | "b"               | null            | null           | false            | false               | false
-    [DATADOG, B3] | "1"               | "2"               | outOfRangeTraceId | "b"               | "1"             | "2"            | true             | false               | false
-    [DATADOG, B3] | "1"               | "2"               | "a"               | outOfRangeTraceId | "1"             | "2"            | true             | false               | false
+    styles             | datadogTraceId    | datadogSpanId     | b3TraceId         | b3SpanId          | expectedTraceId | expectedSpanId | putDatadogFields | expectDatadogFields | tagContext
+    [DATADOG, B3MULTI] | "1"               | "2"               | "a"               | "b"               | "1"             | "2"            | true             | true                | false
+    [DATADOG, B3MULTI] | null              | null              | "a"               | "b"               | "10"            | "11"           | false            | false               | true
+    [DATADOG, B3MULTI] | null              | null              | "a"               | "b"               | null            | null           | true             | true                | true
+    [DATADOG]          | "1"               | "2"               | "a"               | "b"               | "1"             | "2"            | true             | true                | false
+    [B3MULTI]          | "1"               | "2"               | "a"               | "b"               | "10"            | "11"           | false            | false               | false
+    [B3MULTI, DATADOG] | "1"               | "2"               | "a"               | "b"               | "10"            | "11"           | false            | false               | false
+    []                 | "1"               | "2"               | "a"               | "b"               | null            | null           | false            | false               | false
+    [DATADOG, B3MULTI] | "abc"             | "2"               | "a"               | "b"               | "10"            | "11"           | false            | false               | false
+    [DATADOG]          | "abc"             | "2"               | "a"               | "b"               | null            | null           | false            | false               | false
+    [DATADOG, B3MULTI] | outOfRangeTraceId | "2"               | "a"               | "b"               | "10"            | "11"           | false            | false               | false
+    [DATADOG, B3MULTI] | "1"               | outOfRangeTraceId | "a"               | "b"               | "10"            | "11"           | false            | false               | false
+    [DATADOG]          | outOfRangeTraceId | "2"               | "a"               | "b"               | null            | null           | false            | false               | false
+    [DATADOG]          | "1"               | outOfRangeTraceId | "a"               | "b"               | null            | null           | false            | false               | false
+    [DATADOG, B3MULTI] | "1"               | "2"               | outOfRangeTraceId | "b"               | "1"             | "2"            | true             | false               | false
+    [DATADOG, B3MULTI] | "1"               | "2"               | "a"               | outOfRangeTraceId | "1"             | "2"            | true             | false               | false
     // spotless:on
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -51,8 +51,6 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_PERF_METRICS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PRIORITY_SAMPLING_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PRIORITY_SAMPLING_FORCE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_PROPAGATION_STYLE_EXTRACT;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_PROPAGATION_STYLE_INJECT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_REMOTE_CONFIG_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_REMOTE_CONFIG_INITIAL_POLL_INTERVAL;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED;
@@ -275,6 +273,9 @@ import static datadog.trace.api.config.TracerConfig.TRACE_ANALYTICS_ENABLED;
 import static datadog.trace.api.config.TracerConfig.TRACE_CLIENT_IP_HEADER;
 import static datadog.trace.api.config.TracerConfig.TRACE_CLIENT_IP_RESOLVER_ENABLED;
 import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING;
+import static datadog.trace.api.config.TracerConfig.TRACE_PROPAGATION_STYLE;
+import static datadog.trace.api.config.TracerConfig.TRACE_PROPAGATION_STYLE_EXTRACT;
+import static datadog.trace.api.config.TracerConfig.TRACE_PROPAGATION_STYLE_INJECT;
 import static datadog.trace.api.config.TracerConfig.TRACE_RATE_LIMIT;
 import static datadog.trace.api.config.TracerConfig.TRACE_REPORT_HOSTNAME;
 import static datadog.trace.api.config.TracerConfig.TRACE_RESOLVER_ENABLED;
@@ -325,6 +326,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
@@ -421,6 +423,8 @@ public class Config {
   private final boolean logExtractHeaderNames;
   private final Set<PropagationStyle> propagationStylesToExtract;
   private final Set<PropagationStyle> propagationStylesToInject;
+  private final Set<TracePropagationStyle> tracePropagationStylesToExtract;
+  private final Set<TracePropagationStyle> tracePropagationStylesToInject;
   private final int clockSyncPeriod;
 
   private final String dogStatsDNamedPipe;
@@ -782,10 +786,10 @@ public class Config {
       requestHeaderTags = configProvider.getMergedMap(HEADER_TAGS);
       responseHeaderTags = Collections.emptyMap();
       if (configProvider.isSet(REQUEST_HEADER_TAGS)) {
-        logIngoredSettingWarning(REQUEST_HEADER_TAGS, HEADER_TAGS, ".legacy.parsing.enabled");
+        logIgnoredSettingWarning(REQUEST_HEADER_TAGS, HEADER_TAGS, ".legacy.parsing.enabled");
       }
       if (configProvider.isSet(RESPONSE_HEADER_TAGS)) {
-        logIngoredSettingWarning(RESPONSE_HEADER_TAGS, HEADER_TAGS, ".legacy.parsing.enabled");
+        logIgnoredSettingWarning(RESPONSE_HEADER_TAGS, HEADER_TAGS, ".legacy.parsing.enabled");
       }
     } else {
       requestHeaderTags =
@@ -862,12 +866,92 @@ public class Config {
             PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED,
             DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED);
 
-    propagationStylesToExtract =
-        getPropagationStyleSetSettingFromEnvironmentOrDefault(
-            PROPAGATION_STYLE_EXTRACT, DEFAULT_PROPAGATION_STYLE_EXTRACT);
-    propagationStylesToInject =
-        getPropagationStyleSetSettingFromEnvironmentOrDefault(
-            PROPAGATION_STYLE_INJECT, DEFAULT_PROPAGATION_STYLE_INJECT);
+    {
+      // The dd.propagation.style.(extract|inject) settings have been deprecated in
+      // favor of dd.trace.propagation.style(|.extract|.inject) settings.
+      // The different propagation settings when set will be applied in the following order of
+      // precedence, and warnings will be logged for both deprecation and overrides.
+      // * dd.trace.propagation.style.(extract|inject)
+      // * dd.trace.propagation.style
+      // * dd.propagation.style.(extract|inject)
+      Set<PropagationStyle> deprecatedExtract =
+          getSettingsSetFromEnvironment(
+              PROPAGATION_STYLE_EXTRACT, PropagationStyle::valueOfConfigName);
+      Set<PropagationStyle> deprecatedInject =
+          getSettingsSetFromEnvironment(
+              PROPAGATION_STYLE_INJECT, PropagationStyle::valueOfConfigName);
+      Set<TracePropagationStyle> common =
+          getSettingsSetFromEnvironment(
+              TRACE_PROPAGATION_STYLE, TracePropagationStyle::valueOfDisplayName);
+      Set<TracePropagationStyle> extract =
+          getSettingsSetFromEnvironment(
+              TRACE_PROPAGATION_STYLE_EXTRACT, TracePropagationStyle::valueOfDisplayName);
+      Set<TracePropagationStyle> inject =
+          getSettingsSetFromEnvironment(
+              TRACE_PROPAGATION_STYLE_INJECT, TracePropagationStyle::valueOfDisplayName);
+      String extractOrigin = TRACE_PROPAGATION_STYLE_EXTRACT;
+      String injectOrigin = TRACE_PROPAGATION_STYLE_INJECT;
+      // Check if we should use the common setting for extraction
+      if (extract.isEmpty()) {
+        extract = common;
+        extractOrigin = TRACE_PROPAGATION_STYLE;
+      } else if (!common.isEmpty()) {
+        // The more specific settings will override the common setting, so log a warning
+        logOverriddenSettingWarning(
+            TRACE_PROPAGATION_STYLE, TRACE_PROPAGATION_STYLE_EXTRACT, extract);
+      }
+      // Check if we should use the common setting for injection
+      if (inject.isEmpty()) {
+        inject = common;
+        injectOrigin = TRACE_PROPAGATION_STYLE;
+      } else if (!common.isEmpty()) {
+        // The more specific settings will override the common setting, so log a warning
+        logOverriddenSettingWarning(
+            TRACE_PROPAGATION_STYLE, TRACE_PROPAGATION_STYLE_INJECT, inject);
+      }
+      // Check if we should use the deprecated setting for extraction
+      if (extract.isEmpty()) {
+        // If we don't have a new setting, we convert the deprecated one
+        extract = convertSettingsSet(deprecatedExtract, PropagationStyle::getNewStyles);
+        if (!extract.isEmpty()) {
+          logDeprecatedConvertedSetting(
+              PROPAGATION_STYLE_EXTRACT,
+              deprecatedExtract,
+              TRACE_PROPAGATION_STYLE_EXTRACT,
+              extract);
+        }
+      } else if (!deprecatedExtract.isEmpty()) {
+        // If we have a new setting, we log a warning
+        logOverriddenDeprecatedSettingWarning(PROPAGATION_STYLE_EXTRACT, extractOrigin, extract);
+      }
+      // Check if we should use the deprecated setting for injection
+      if (inject.isEmpty()) {
+        // If we don't have a new setting, we convert the deprecated one
+        inject = convertSettingsSet(deprecatedInject, PropagationStyle::getNewStyles);
+        if (!inject.isEmpty()) {
+          logDeprecatedConvertedSetting(
+              PROPAGATION_STYLE_INJECT, deprecatedInject, TRACE_PROPAGATION_STYLE_INJECT, inject);
+        }
+      } else if (!deprecatedInject.isEmpty()) {
+        // If we have a new setting, we log a warning
+        logOverriddenDeprecatedSettingWarning(PROPAGATION_STYLE_INJECT, injectOrigin, inject);
+      }
+      // Now we can check if we should pick the default injection/extraction
+      tracePropagationStylesToExtract =
+          extract.isEmpty() ? Collections.singleton(TracePropagationStyle.DATADOG) : extract;
+      tracePropagationStylesToInject =
+          inject.isEmpty() ? Collections.singleton(TracePropagationStyle.DATADOG) : inject;
+      // These setting are here for backwards compatibility until they can be removed in a major
+      // release of the tracer
+      propagationStylesToExtract =
+          deprecatedExtract.isEmpty()
+              ? Collections.singleton(PropagationStyle.DATADOG)
+              : deprecatedExtract;
+      propagationStylesToInject =
+          deprecatedInject.isEmpty()
+              ? Collections.singleton(PropagationStyle.DATADOG)
+              : deprecatedInject;
+    }
 
     clockSyncPeriod = configProvider.getInteger(CLOCK_SYNC_PERIOD, DEFAULT_CLOCK_SYNC_PERIOD);
 
@@ -1474,12 +1558,22 @@ public class Config {
     return logExtractHeaderNames;
   }
 
+  @Deprecated
   public Set<PropagationStyle> getPropagationStylesToExtract() {
     return propagationStylesToExtract;
   }
 
+  @Deprecated
   public Set<PropagationStyle> getPropagationStylesToInject() {
     return propagationStylesToInject;
+  }
+
+  public Set<TracePropagationStyle> getTracePropagationStylesToExtract() {
+    return tracePropagationStylesToExtract;
+  }
+
+  public Set<TracePropagationStyle> getTracePropagationStylesToInject() {
+    return tracePropagationStylesToInject;
   }
 
   public int getClockSyncPeriod() {
@@ -2395,13 +2489,40 @@ public class Config {
         Collections.singletonList(settingName), "", settingSuffix, defaultEnabled);
   }
 
-  private void logIngoredSettingWarning(
+  private void logIgnoredSettingWarning(
       String setting, String overridingSetting, String overridingSuffix) {
     log.warn(
         "Setting {} ignored since {}{} is enabled.",
         propertyNameToSystemPropertyName(setting),
         propertyNameToSystemPropertyName(overridingSetting),
         overridingSuffix);
+  }
+
+  private void logOverriddenSettingWarning(String setting, String overridingSetting, Object value) {
+    log.warn(
+        "Setting {} is overridden by setting {} with value {}.",
+        propertyNameToSystemPropertyName(setting),
+        propertyNameToSystemPropertyName(overridingSetting),
+        value);
+  }
+
+  private void logOverriddenDeprecatedSettingWarning(
+      String setting, String overridingSetting, Object value) {
+    log.warn(
+        "Setting {} is deprecated and overridden by setting {} with value {}.",
+        propertyNameToSystemPropertyName(setting),
+        propertyNameToSystemPropertyName(overridingSetting),
+        value);
+  }
+
+  private void logDeprecatedConvertedSetting(
+      String deprecatedSetting, Object oldValue, String newSetting, Object newValue) {
+    log.warn(
+        "Setting {} is deprecated and the value {} has been converted to {} for setting {}.",
+        propertyNameToSystemPropertyName(deprecatedSetting),
+        oldValue,
+        newValue,
+        propertyNameToSystemPropertyName(newSetting));
   }
 
   public boolean isTraceAnalyticsIntegrationEnabled(
@@ -2452,23 +2573,22 @@ public class Config {
     return Config.get().isTraceAnalyticsIntegrationEnabled(integrationNames, defaultEnabled);
   }
 
-  /**
-   * Calls configProvider.getString(String, String) and converts the result to a set of strings
-   * splitting by space or comma.
-   */
-  private Set<PropagationStyle> getPropagationStyleSetSettingFromEnvironmentOrDefault(
-      final String name, final String defaultValue) {
-    final String value = configProvider.getString(name, defaultValue);
-    Set<PropagationStyle> result =
-        convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(value));
+  private <T> Set<T> getSettingsSetFromEnvironment(String name, Function<String, T> mapper) {
+    final String value = configProvider.getString(name, "");
+    return convertStringSetToSet(name, parseStringIntoSetOfNonEmptyStrings(value), mapper);
+  }
 
-    if (result.isEmpty()) {
-      // Treat empty parsing result as no value and use default instead
-      result =
-          convertStringSetToPropagationStyleSet(parseStringIntoSetOfNonEmptyStrings(defaultValue));
+  private <F, T> Set<T> convertSettingsSet(Set<F> fromSet, Function<F, Iterable<T>> mapper) {
+    if (fromSet.isEmpty()) {
+      return Collections.emptySet();
     }
-
-    return result;
+    Set<T> result = new LinkedHashSet<>(fromSet.size());
+    for (F from : fromSet) {
+      for (T to : mapper.apply(from)) {
+        result.add(to);
+      }
+    }
+    return Collections.unmodifiableSet(result);
   }
 
   private static final String PREFIX = "dd.";
@@ -2531,16 +2651,21 @@ public class Config {
     return Collections.unmodifiableSet(result);
   }
 
-  @Nonnull
-  private static Set<PropagationStyle> convertStringSetToPropagationStyleSet(
-      final Set<String> input) {
+  private static <T> Set<T> convertStringSetToSet(
+      String setting, final Set<String> input, Function<String, T> mapper) {
+    if (input.isEmpty()) {
+      return Collections.emptySet();
+    }
     // Using LinkedHashSet to preserve original string order
-    final Set<PropagationStyle> result = new LinkedHashSet<>();
+    final Set<T> result = new LinkedHashSet<>();
     for (final String value : input) {
       try {
-        result.add(PropagationStyle.valueOf(value.toUpperCase()));
+        result.add(mapper.apply(value));
       } catch (final IllegalArgumentException e) {
-        log.debug("Cannot recognize config string value: {}, {}", value, PropagationStyle.class);
+        log.warn(
+            "Cannot recognize config string value {} for setting {}",
+            value,
+            propertyNameToSystemPropertyName(setting));
       }
     }
     return Collections.unmodifiableSet(result);
@@ -2775,10 +2900,10 @@ public class Config {
         + partialFlushMinSpans
         + ", traceStrictWritesEnabled="
         + traceStrictWritesEnabled
-        + ", propagationStylesToExtract="
-        + propagationStylesToExtract
-        + ", propagationStylesToInject="
-        + propagationStylesToInject
+        + ", tracePropagationStylesToExtract="
+        + tracePropagationStylesToExtract
+        + ", tracePropagationStylesToInject="
+        + tracePropagationStylesToInject
         + ", clockSyncPeriod="
         + clockSyncPeriod
         + ", jmxFetchEnabled="

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
@@ -1,6 +1,6 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
-import datadog.trace.api.PropagationStyle;
+import datadog.trace.api.TracePropagationStyle;
 import java.util.LinkedHashMap;
 
 public interface AgentPropagation {
@@ -11,7 +11,7 @@ public interface AgentPropagation {
 
   <C> void inject(AgentSpan.Context context, C carrier, Setter<C> setter);
 
-  <C> void inject(AgentSpan span, C carrier, Setter<C> setter, PropagationStyle style);
+  <C> void inject(AgentSpan span, C carrier, Setter<C> setter, TracePropagationStyle style);
 
   // The input tags should be sorted.
   <C> void injectBinaryPathwayContext(

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -5,7 +5,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_ASYNC_PROPAGATING;
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.EndpointCheckpointer;
-import datadog.trace.api.PropagationStyle;
+import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
@@ -335,7 +335,8 @@ public class AgentTracer {
     public <C> void inject(final Context context, final C carrier, final Setter<C> setter) {}
 
     @Override
-    public <C> void inject(AgentSpan span, C carrier, Setter<C> setter, PropagationStyle style) {}
+    public <C> void inject(
+        AgentSpan span, C carrier, Setter<C> setter, TracePropagationStyle style) {}
 
     @Override
     public <C> void injectBinaryPathwayContext(
@@ -715,7 +716,8 @@ public class AgentTracer {
     public <C> void inject(final Context context, final C carrier, final Setter<C> setter) {}
 
     @Override
-    public <C> void inject(AgentSpan span, C carrier, Setter<C> setter, PropagationStyle style) {}
+    public <C> void inject(
+        AgentSpan span, C carrier, Setter<C> setter, TracePropagationStyle style) {}
 
     @Override
     public <C> void injectBinaryPathwayContext(

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -107,6 +107,7 @@ import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLING_OPERATION_RUL
 import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLING_SERVICE_RULES
 import static datadog.trace.api.config.TracerConfig.WRITER_TYPE
 import static datadog.trace.api.config.TracerConfig.TRACE_X_DATADOG_TAGS_MAX_LENGTH
+import static datadog.trace.api.TracePropagationStyle.*
 
 class ConfigTest extends DDSpecification {
 
@@ -257,6 +258,8 @@ class ConfigTest extends DDSpecification {
     config.reportHostName == true
     config.propagationStylesToExtract.toList() == [PropagationStyle.DATADOG, PropagationStyle.B3]
     config.propagationStylesToInject.toList() == [PropagationStyle.B3, PropagationStyle.DATADOG]
+    config.tracePropagationStylesToExtract.toList() == [DATADOG, B3, B3MULTI]
+    config.tracePropagationStylesToInject.toList() == [B3, B3MULTI, DATADOG]
     config.jmxFetchEnabled == false
     config.jmxFetchMetricsConfigs == ["/foo.yaml", "/bar.yaml"]
     config.jmxFetchCheckPeriod == 100
@@ -426,6 +429,8 @@ class ConfigTest extends DDSpecification {
     config.reportHostName == true
     config.propagationStylesToExtract.toList() == [PropagationStyle.DATADOG, PropagationStyle.B3]
     config.propagationStylesToInject.toList() == [PropagationStyle.B3, PropagationStyle.DATADOG]
+    config.tracePropagationStylesToExtract.toList() == [DATADOG, B3, B3MULTI]
+    config.tracePropagationStylesToInject.toList() == [B3, B3MULTI, DATADOG]
     config.jmxFetchEnabled == false
     config.jmxFetchMetricsConfigs == ["/foo.yaml", "/bar.yaml"]
     config.jmxFetchCheckPeriod == 100
@@ -503,6 +508,8 @@ class ConfigTest extends DDSpecification {
     config.writerType == "LoggingWriter"
     config.propagationStylesToExtract.toList() == [PropagationStyle.B3, PropagationStyle.DATADOG]
     config.propagationStylesToInject.toList() == [PropagationStyle.DATADOG, PropagationStyle.B3]
+    config.tracePropagationStylesToExtract.toList() == [B3, B3MULTI, DATADOG]
+    config.tracePropagationStylesToInject.toList() == [DATADOG, B3, B3MULTI]
     config.jmxFetchMetricsConfigs == ["some/file"]
     config.reportHostName == true
     config.xDatadogTagsMaxLength == 42
@@ -578,6 +585,8 @@ class ConfigTest extends DDSpecification {
     config.splitByTags == [].toSet()
     config.propagationStylesToExtract.toList() == [PropagationStyle.DATADOG]
     config.propagationStylesToInject.toList() == [PropagationStyle.DATADOG]
+    config.tracePropagationStylesToExtract.toList() == [DATADOG]
+    config.tracePropagationStylesToInject.toList() == [DATADOG]
   }
 
   def "sys props and env vars overrides for trace_agent_port and agent_port_legacy as expected"() {
@@ -684,6 +693,8 @@ class ConfigTest extends DDSpecification {
     config.partialFlushMinSpans == 15
     config.propagationStylesToExtract.toList() == [PropagationStyle.B3, PropagationStyle.DATADOG]
     config.propagationStylesToInject.toList() == [PropagationStyle.DATADOG, PropagationStyle.B3]
+    config.tracePropagationStylesToExtract.toList() == [B3, B3MULTI, DATADOG]
+    config.tracePropagationStylesToInject.toList() == [DATADOG, B3, B3MULTI]
     config.jmxFetchMetricsConfigs == ["/foo.yaml", "/bar.yaml"]
     config.jmxFetchCheckPeriod == 100
     config.jmxFetchRefreshBeansPeriod == 200
@@ -2105,5 +2116,50 @@ class ConfigTest extends DDSpecification {
       bs.set(i)
     }
     return bs
+  }
+
+  def "check trace propagation style overrides for "() {
+    setup:
+    if (pse) {
+      environmentVariables.set('DD_PROPAGATION_STYLE_EXTRACT', pse.toString())
+    }
+    if (psi) {
+      environmentVariables.set('DD_PROPAGATION_STYLE_INJECT', psi.toString())
+    }
+    if (tps) {
+      environmentVariables.set('DD_TRACE_PROPAGATION_STYLE', tps.toString())
+    }
+    if (tpse) {
+      environmentVariables.set('DD_TRACE_PROPAGATION_STYLE_EXTRACT', tpse.toString())
+    }
+    if (tpsi) {
+      environmentVariables.set('DD_TRACE_PROPAGATION_STYLE_INJECT', tpsi.toString())
+    }
+    when:
+    Config config = new Config()
+
+    then:
+    config.propagationStylesToExtract.asList() == ePSE
+    config.propagationStylesToInject.asList() == ePSI
+    config.tracePropagationStylesToExtract.asList() == eTPSE
+    config.tracePropagationStylesToInject.asList() == eTPSI
+
+    where:
+    // spotless:off
+    pse                      | psi                      | tps      | tpse               | tpsi    | ePSE                       | ePSI                       | eTPSE         | eTPSI
+    PropagationStyle.DATADOG | PropagationStyle.B3      | null     | null               | null    | [PropagationStyle.DATADOG] | [PropagationStyle.B3]      | [DATADOG]     | [B3, B3MULTI]
+    PropagationStyle.B3      | PropagationStyle.DATADOG | null     | null               | null    | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [B3, B3MULTI] | [DATADOG]
+    PropagationStyle.B3      | PropagationStyle.DATADOG | HAYSTACK | null               | null    | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [HAYSTACK]    | [HAYSTACK]
+    PropagationStyle.B3      | PropagationStyle.DATADOG | HAYSTACK | B3                 | null    | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [B3]          | [HAYSTACK]
+    PropagationStyle.B3      | PropagationStyle.DATADOG | HAYSTACK | null               | B3MULTI | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [HAYSTACK]    | [B3MULTI]
+    PropagationStyle.B3      | PropagationStyle.DATADOG | HAYSTACK | B3                 | B3MULTI | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [B3]          | [B3MULTI]
+    PropagationStyle.B3      | PropagationStyle.DATADOG | null     | B3                 | B3MULTI | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [B3]          | [B3MULTI]
+    null                     | null                     | HAYSTACK | null               | null    | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [HAYSTACK]    | [HAYSTACK]
+    null                     | null                     | HAYSTACK | B3                 | B3MULTI | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [B3]          | [B3MULTI]
+    null                     | null                     | null     | B3                 | B3MULTI | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [B3]          | [B3MULTI]
+    null                     | null                     | null     | null               | null    | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [DATADOG]     | [DATADOG]
+    null                     | null                     | null     | null               | null    | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [DATADOG]     | [DATADOG]
+    null                     | null                     | null     | "b3 single header" | null    | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [B3]          | [DATADOG]
+    // spotless:on
   }
 }


### PR DESCRIPTION
# What Does This Do

This deprecates the `dd.propagation.style.extract` and `dd.propagation.style.inject` settings in favor of the three new settings `dd.trace.propagation.style`, `dd.trace.propagation.style.extract`, and `dd.trace.propagation.style.inject`.

The new `dd.trace.propagation.style*` settings makes a distinction between `B3` which is [single header b3 propagation](https://github.com/openzipkin/b3-propagation/tree/master#single-header) and `B3MULTI` which is [multiple header b3 propagation](https://github.com/openzipkin/b3-propagation/tree/master#multiple-headers).

The change is backwards compatible and using the deprecated settings will only result in a deprecation warning being logged, and the settings being translated into the new ones, including the old `B3` setting being translated into both the new `B3` and `B3MULTI`.

# Motivation

Alignment between tracer implementations and preparation for w3c header propagation.

# Additional Notes
