### PR TITLE
Fix NotEqual operator

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/JsonToExpressionConverter.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/JsonToExpressionConverter.java
@@ -55,11 +55,12 @@ public class JsonToExpressionConverter {
         }
       case "!=":
       case "neq":
+      case "ne":
         {
           JsonReader.Token token = reader.peek();
           if (token != BEGIN_ARRAY) {
             throw new UnsupportedOperationException(
-                "Operation 'neq' expects the arguments to be defined as array");
+                "Operation 'ne' expects the arguments to be defined as array");
           }
           reader.beginArray();
           expr = DSL.not(createBinaryValuePredicate(reader, DSL::eq));
@@ -222,8 +223,15 @@ public class JsonToExpressionConverter {
     switch (reader.peek()) {
       case NUMBER:
         {
-          // handle int/long?
-          value = DSL.value(reader.nextDouble());
+          // Moshi always consider numbers as decimal. need to parse it as string and detect if dot
+          // is present
+          // or not to determine ints/longs vs doubles
+          String numberStrValue = reader.nextString();
+          if (numberStrValue.indexOf('.') > 0) {
+            value = DSL.value(Double.parseDouble(numberStrValue));
+          } else {
+            value = DSL.value(Long.parseLong(numberStrValue));
+          }
           break;
         }
       case STRING:

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
@@ -58,6 +58,14 @@ public class ProbeConditionTest {
   }
 
   @Test
+  void testComparisonOperators() throws Exception {
+    ProbeCondition probeCondition = load("/test_conditional_05.json");
+    ValueReferenceResolver ctx =
+        RefResolverHelper.createResolver(null, singletonMap("intField1", 42));
+    assertTrue(probeCondition.execute(ctx));
+  }
+
+  @Test
   void testJsonAdapter() throws IOException {
     Moshi moshi =
         new Moshi.Builder()

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_05.json
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_05.json
@@ -1,0 +1,15 @@
+{
+  "dsl": "this.intField1 == 42 && (this.intField1 > 0 || intField1 >= 0 || intField1 < 50 || intField1 <= 42) && intField1 != 0",
+  "json": {
+    "and": [
+      { "eq": [{"ref": "this.intField1"}, 42] },
+      { "or": [
+        {"gt": [{"ref": "this.intField1"}, 0]},
+        {"ge": [{"ref": "intField1"}, 0]},
+        {"lt": [{"ref": "intField1"}, 50]},
+        {"le": [{"ref": "intField1"}, 42]}
+      ]},
+      {"ne": [{"ref": "intField1"}, 0]}
+    ]
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
@@ -45,7 +45,7 @@ public class ConfigurationTest {
     assertEquals(4, metricProbes.size());
     assertEquals("datadog.debugger.calls", metricProbes.get(0).getMetricName());
     assertEquals(
-        "ValueScript{expr=NumericLiteral{value=42.0}, dsl='42'}",
+        "ValueScript{expr=NumericLiteral{value=42}, dsl='42'}",
         metricProbes.get(0).getValue().toString());
     assertEquals("datadog.debugger.gauge_value", metricProbes.get(1).getMetricName());
     assertEquals(


### PR DESCRIPTION
# What Does This Do
add support for `ne` json operator in expression Language as specified (instead of `neq`).
Fix also the way we parse Json numbers for separating integers from decimals


# Motivation

# Additional Notes
