### PR TITLE
Make PidHelper fallback lazy

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -46,9 +46,9 @@ public class AgentInstaller {
     // register weak map/cache suppliers as early as possible
     WeakMaps.registerAsSupplier();
     WeakCaches.registerAsSupplier();
-    // supply PID fall-back on Java 8 as early as possible
+    // register PID fall-back on Java 8 as early as possible
     if (!Platform.isNativeImageBuilder()) {
-      PidHelper.supplyIfAbsent(new PosixPidSupplier());
+      PidHelper.Fallback.set(new PosixPidSupplier());
     }
   }
 

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/test/java/com/datadog/profiling/uploader/ProfileUploaderTest.java
@@ -106,7 +106,7 @@ public class ProfileUploaderTest {
 
   static {
     // register static PID for testing as we're not running as an agent
-    PidHelper.supplyIfAbsent(() -> 54321L);
+    PidHelper.Fallback.set(() -> "54321");
 
     // Not using Guava's ImmutableMap because we want to test null value
     final Map<String, String> tags = new HashMap<>();

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/PosixPidSupplier.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/PosixPidSupplier.java
@@ -7,17 +7,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Use POSIX API to retrieve PID on Java8. */
-public final class PosixPidSupplier implements Supplier<Long> {
+public final class PosixPidSupplier implements Supplier<String> {
   private static final Logger log = LoggerFactory.getLogger(PosixPidSupplier.class);
 
   @Override
-  public Long get() {
+  public String get() {
     try {
       final POSIX posix = POSIXFactory.getPOSIX();
-      return (long) posix.getpid();
+      return Integer.toString(posix.getpid());
     } catch (Throwable e) {
       log.debug("Cannot get PID through POSIX API", e);
-      return null;
+      return "";
     }
   }
 }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/PidHelperTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/PidHelperTest.groovy
@@ -7,7 +7,7 @@ class PidHelperTest extends DDSpecification {
 
   def "PID is available everywhere we test"() {
     when:
-    PidHelper.supplyIfAbsent(new PosixPidSupplier())
+    PidHelper.Fallback.set(new PosixPidSupplier())
 
     then:
     !PidHelper.getPid().isEmpty()

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -71,6 +71,7 @@ excludedClassesCoverage += [
   "datadog.trace.util.ClassNameTrie.JavaGenerator",
   "datadog.trace.util.CollectionUtils",
   "datadog.trace.util.PidHelper",
+  "datadog.trace.util.PidHelper.Fallback",
   "datadog.trace.api.IntegrationsCollector.Holder",
   "datadog.trace.api.ConfigCollector.Holder",
   "datadog.trace.api.Config.HostNameHolder",

--- a/internal-api/internal-api-9/src/main/java/datadog/trace/util/JDK9PidSupplier.java
+++ b/internal-api/internal-api-9/src/main/java/datadog/trace/util/JDK9PidSupplier.java
@@ -5,16 +5,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Use standard API to retrieve PID on Java9+. */
-public final class JDK9PidSupplier implements Supplier<Long> {
+public final class JDK9PidSupplier implements Supplier<String> {
   private static final Logger log = LoggerFactory.getLogger(JDK9PidSupplier.class);
 
   @Override
-  public Long get() {
+  public String get() {
     try {
-      return ProcessHandle.current().pid();
+      return Long.toString(ProcessHandle.current().pid());
     } catch (Throwable e) {
       log.debug("Cannot get PID through JVM API", e);
-      return null;
+      return "";
     }
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1271,19 +1271,7 @@ public class Config {
   }
 
   public Long getProcessId() {
-    String pid = PidHelper.getPid();
-
-    pid = pid == null ? "" : pid.trim();
-    if (pid.isEmpty()) {
-      return 0L;
-    }
-
-    try {
-      return Long.parseLong(pid);
-    } catch (NumberFormatException e) {
-      log.error("Cannot parse pid properly from string {} to long. Default to 0", pid, e);
-      return 0L;
-    }
+    return PidHelper.getPidAsLong();
   }
 
   public String getRuntimeVersion() {

--- a/internal-api/src/test/java/datadog/trace/util/PidHelperForkedTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/PidHelperForkedTest.java
@@ -4,12 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-public class PidHelperTest {
+public class PidHelperForkedTest {
   @Test
   public void testPidCanBeSupplied() {
-    PidHelper.supplyIfAbsent(() -> 12345L);
+    PidHelper.Fallback.set(() -> "12345");
     assertEquals("12345", PidHelper.getPid(), "Expect PID to match supplied value");
-    PidHelper.supplyIfAbsent(() -> 67890L);
+    PidHelper.Fallback.set(() -> "67890");
     assertEquals("12345", PidHelper.getPid(), "Expect PID to not change once set");
   }
 }


### PR DESCRIPTION
# What Does This Do

Improvement on PR #4393 that only calls the `PidHelper` fallback on Java 8 when something actually uses `PidHelper`, rather than when setting up `AgentInstaller`. This also includes some clean-up of PID parsing.

# Motivation

Services like the tracing and profiling always use the PID, but `PidHelper` may never get called for some configurations of the Java tracer, for example if tracing and profiling are turned off but CI visibility is turned on. This PR means that we only pay the cost of looking up the PID when we actually need it.