### PR TITLE
Log JSON sampling rules when failed to parse for easier debugging.

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/SpanSamplingRules.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/SpanSamplingRules.java
@@ -128,7 +128,7 @@ public class SpanSamplingRules {
       List<Rule> rules = LIST_OF_RULES_ADAPTER.fromJson(json);
       return filterOutNullRules(rules);
     } catch (Throwable ex) {
-      log.error("Couldn't parse Span Sampling Rules from JSON", ex);
+      log.error("Couldn't parse Span Sampling Rules from JSON: " + json, ex);
       return null;
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/SpanSamplingRules.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/SpanSamplingRules.java
@@ -128,7 +128,7 @@ public class SpanSamplingRules {
       List<Rule> rules = LIST_OF_RULES_ADAPTER.fromJson(json);
       return filterOutNullRules(rules);
     } catch (Throwable ex) {
-      log.error("Couldn't parse Span Sampling Rules from JSON: " + json, ex);
+      log.error("Couldn't parse Span Sampling Rules from JSON: {}", json, ex);
       return null;
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/TraceSamplingRules.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/TraceSamplingRules.java
@@ -80,7 +80,7 @@ public class TraceSamplingRules {
     try {
       return new TraceSamplingRules(LIST_OF_RULES_ADAPTER.fromJson(json));
     } catch (Throwable ex) {
-      log.error("Couldn't parse Trace Sampling Rules from JSON: " + json, ex);
+      log.error("Couldn't parse Trace Sampling Rules from JSON: {}", json, ex);
       return null;
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/TraceSamplingRules.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/TraceSamplingRules.java
@@ -80,7 +80,7 @@ public class TraceSamplingRules {
     try {
       return new TraceSamplingRules(LIST_OF_RULES_ADAPTER.fromJson(json));
     } catch (Throwable ex) {
-      log.error("Couldn't parse Trace Sampling Rules from JSON", ex);
+      log.error("Couldn't parse Trace Sampling Rules from JSON: " + json, ex);
       return null;
     }
   }


### PR DESCRIPTION
# What Does This Do

Adds logging for JSON sampling rules when failed to parse for easier debugging.

# Motivation

When it couldn't parse provided JSON sampling rules it would be useful the rules logged to simplify debugging.

# Additional Notes

APMS-8472
