### PR TITLE
DDIntakeWriter: Do not flush after every single trace

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDIntakeWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDIntakeWriter.java
@@ -40,7 +40,7 @@ public class DDIntakeWriter extends RemoteWriter {
     RetryPolicy retryPolicy = RetryPolicy.builder().withMaxRetry(5).withBackoff(100).build();
     private int flushTimeout = 5;
     private TimeUnit flushTimeoutUnit = TimeUnit.SECONDS;
-    private boolean alwaysFlush = true;
+    private boolean alwaysFlush = false;
 
     private RemoteApi intakeApi;
     private String apiKey;

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/Payload.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/Payload.java
@@ -67,6 +67,16 @@ public abstract class Payload {
     }
   }
 
+  protected int msgpackMapHeaderSize(int count) {
+    if (count < 0x10) {
+      return 1;
+    } else if (count < 0x10000) {
+      return 3;
+    } else {
+      return 5;
+    }
+  }
+
   protected ByteBuffer msgpackArrayHeader(int count) {
     if (count < 0x10) {
       return ByteBuffer.allocate(1).put(0, (byte) (FIXARRAY | count));


### PR DESCRIPTION
# What Does This Do
* Change the `DDIntakeWriter` default for `alwaysFlush` so we batch traces together.
* Fixes the `CiTestCycleMapperV1` mapper so it doesn't add N headers when sending N traces. It now generates the header separately and sends it only once at the beginning of every payload.
* Updates the test so we only expect one header followed by any number of traces in a payload.

Generating the header once in the mapper this way is similar to what we do in `TraceMapperV0_4` and `TraceMapperV0_5`.
# Motivation
Using the `DDIntakeWriter` was painfully slow because it was making one request per trace (ie: one per test in CI Visibility).

This only affected CI Visibility users in Agentless mode before, but after #4369 would also affect Agent users.