### PR TITLE
Ignore org.springframework.web.util.WebUtils from exclusion list

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
+++ b/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
@@ -261,6 +261,7 @@
 0 org.springframework.web.context.support.XmlWebApplicationContext
 0 org.springframework.web.reactive.*
 0 org.springframework.web.servlet.*
+# Included for IAST
 0 org.springframework.web.util.WebUtils
 2 org.xml.*
 2 org.yaml.snakeyaml.*

--- a/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
+++ b/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
@@ -261,6 +261,7 @@
 0 org.springframework.web.context.support.XmlWebApplicationContext
 0 org.springframework.web.reactive.*
 0 org.springframework.web.servlet.*
+0 org.springframework.web.util.WebUtils
 2 org.xml.*
 2 org.yaml.snakeyaml.*
 # saves ~0.5s skipping instrumentation of almost ~470 classes

--- a/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
@@ -173,6 +173,7 @@
 1 org.springframework.*
 0 org.springframework.web.context.request.*
 0 org.springframework.samples.*
+0 org.springframework.web.util.WebUtils
 1 org.synchronoss.*
 1 org.terracotta.*
 1 org.testcontainers.*

--- a/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -1,5 +1,6 @@
 package datadog.smoketest.springboot.controller;
 
+import datadog.smoketest.springboot.model.TestBean;
 import ddtest.client.sources.Hasher;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
@@ -17,7 +18,7 @@ public class IastWebController {
   private final Hasher hasher;
 
   public IastWebController() {
-    this.hasher = new Hasher();
+    hasher = new Hasher();
     hasher.sha1();
   }
 
@@ -80,6 +81,12 @@ public class IastWebController {
   public String pathTraversalPath(final HttpServletRequest request) {
     new File(System.getProperty("user.dir")).toPath().resolve(request.getParameter("path"));
     return "Path Traversal page";
+  }
+
+  @GetMapping("/param_binding/test")
+  public String paramBinding(final TestBean testBean) {
+
+    return "Test bean -> name: " + testBean.getName() + ", value: " + testBean.getValue();
   }
 
   private void withProcess(final Operation<Process> op) {

--- a/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -95,7 +95,7 @@ public class IastWebController {
     return "Header is: " + header;
   }
 
-  @GetMapping("/path_param/{param}")
+  @GetMapping("/path_param")
   public String pathParam(@PathParam("param") String param) {
     return "PathParam is: " + param;
   }

--- a/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -7,7 +7,9 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import javax.servlet.http.HttpServletRequest;
+import javax.websocket.server.PathParam;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -85,8 +87,17 @@ public class IastWebController {
 
   @GetMapping("/param_binding/test")
   public String paramBinding(final TestBean testBean) {
-
     return "Test bean -> name: " + testBean.getName() + ", value: " + testBean.getValue();
+  }
+
+  @GetMapping("/request_header/test")
+  public String requestHeader(@RequestHeader("test-header") String header) {
+    return "Header is: " + header;
+  }
+
+  @GetMapping("/path_param/{param}")
+  public String pathParam(@PathParam("param") String param) {
+    return "PathParam is: " + param;
   }
 
   private void withProcess(final Operation<Process> op) {

--- a/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/model/TestBean.java
+++ b/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/model/TestBean.java
@@ -1,0 +1,23 @@
+package datadog.smoketest.springboot.model;
+
+public class TestBean {
+
+  private String name;
+  private String value;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+}

--- a/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
@@ -265,7 +265,7 @@ class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
 
   def "path param taint string"() {
     setup:
-    String url = "http://localhost:${httpPort}/path_param/test"
+    String url = "http://localhost:${httpPort}/path_param?param=test"
     def request = new Request.Builder().url(url).get().build()
 
     when:

--- a/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
@@ -28,7 +28,6 @@ class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
 
     List<String> command = new ArrayList<>()
     command.add(javaPath())
-    command.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005")
     command.addAll(defaultJavaProperties)
     command.addAll([
       "-Ddd.iast.enabled=true",


### PR DESCRIPTION
# What Does This Do

- Ignore org.springframework.web.util.WebUtils from exclusion list
- Add IAST smoke test for springframework parameter binding

# Motivation

IAST needs to instrument this class to taint source parameters when parameter binding is used in  spring framework 

# Additional Notes
