### PR TITLE
Guard against agent being initialized twice

### DIFF
--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
@@ -44,11 +44,16 @@ import java.util.regex.Pattern;
 public final class AgentBootstrap {
   private static final Class<?> thisClass = AgentBootstrap.class;
 
+  private static boolean initialized = false;
+
   public static void premain(final String agentArgs, final Instrumentation inst) {
     agentmain(agentArgs, inst);
   }
 
   public static void agentmain(final String agentArgs, final Instrumentation inst) {
+    if (checkAndLogIfInitializedTwice(System.out)) {
+      return;
+    }
     if (checkAndLogIfLessThanJava8()) {
       return;
     }
@@ -91,6 +96,16 @@ public final class AgentBootstrap {
           "Please upgrade your Java version to 8+ or use the 0.x version of dd-java-agent in your build tool or download it from https://dtdg.co/java-tracer-v0");
       return true;
     }
+    return false;
+  }
+
+  static boolean checkAndLogIfInitializedTwice(final PrintStream output) {
+    if (initialized) {
+      output.println(
+          "Warning: dd-java-agent is being initialized more than once. Please, check that you are defining -javaagent:dd-java-agent.jar only once.");
+      return true;
+    }
+    initialized = true;
     return false;
   }
 


### PR DESCRIPTION
# What Does This Do

Guard against agent being initialized twice. Instead of producing later errors, it will just print a warning and stop any further work.

# Motivation

Some customers are defining `-javaagent` more than once. This produces later failures, in very non-obvious ways.

# Additional Notes
