### PR TITLE
Fix evaluation error reporting for merged probes

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -286,26 +286,13 @@ public class ConfigurationUpdater
     return new Snapshot.ProbeDetails(
         probe.getId(),
         location,
-        convertMethodLocation(probe.getEvaluateAt()),
+        ProbeDefinition.MethodLocation.convert(probe.getEvaluateAt()),
         probeCondition,
         probe.concatTags(),
         summaryBuilder,
         probe.getAdditionalProbes().stream()
             .map(relatedProbe -> convertToProbeDetails(((SnapshotProbe) relatedProbe), location))
             .collect(Collectors.toList()));
-  }
-
-  private Snapshot.MethodLocation convertMethodLocation(
-      ProbeDefinition.MethodLocation methodLocation) {
-    switch (methodLocation) {
-      case DEFAULT:
-        return Snapshot.MethodLocation.DEFAULT;
-      case ENTRY:
-        return Snapshot.MethodLocation.ENTRY;
-      case EXIT:
-        return Snapshot.MethodLocation.EXIT;
-    }
-    return null;
   }
 
   private void applyRateLimiter(ConfigurationComparer changes) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
@@ -5,6 +5,7 @@ import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.JsonWriter;
 import datadog.trace.bootstrap.debugger.DiagnosticMessage;
+import datadog.trace.bootstrap.debugger.Snapshot;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -24,6 +25,18 @@ public abstract class ProbeDefinition {
     DEFAULT,
     ENTRY,
     EXIT;
+
+    public static Snapshot.MethodLocation convert(MethodLocation methodLocation) {
+      switch (methodLocation) {
+        case DEFAULT:
+          return Snapshot.MethodLocation.DEFAULT;
+        case ENTRY:
+          return Snapshot.MethodLocation.ENTRY;
+        case EXIT:
+          return Snapshot.MethodLocation.EXIT;
+      }
+      return null;
+    }
   }
 
   protected final String language;


### PR DESCRIPTION
# What Does This Do
Store each eval errors by probe Ids into Snapshot object Reset CapturedContext's evalErrors before evaluating additional probes copy eval errors by probe Ids for corresponding snapshot evaluate conditions only for entry when evaluateAt is DEFAULT

# Motivation
For duplicated probes eval errors were not reported correctly

# Additional Notes
