### PR TITLE
Add null literal support

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/DSL.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/DSL.java
@@ -25,6 +25,7 @@ import com.datadog.debugger.el.predicates.OrPredicate;
 import com.datadog.debugger.el.values.BooleanValue;
 import com.datadog.debugger.el.values.ListValue;
 import com.datadog.debugger.el.values.MapValue;
+import com.datadog.debugger.el.values.NullValue;
 import com.datadog.debugger.el.values.NumericValue;
 import com.datadog.debugger.el.values.ObjectValue;
 import com.datadog.debugger.el.values.StringValue;
@@ -126,6 +127,10 @@ public class DSL {
 
   public static ListValue value(Collection<?> value) {
     return new ListValue(value);
+  }
+
+  public static NullValue nullValue() {
+    return NullValue.INSTANCE;
   }
 
   public static MapValue value(Map<?, ?> value) {

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/JsonToExpressionConverter.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/JsonToExpressionConverter.java
@@ -297,6 +297,12 @@ public class JsonToExpressionConverter {
             reader.endObject();
           }
         }
+      case NULL:
+        {
+          reader.nextNull();
+          value = DSL.nullValue();
+          break;
+        }
       default:
         throw new UnsupportedOperationException("Invalid value definition: ");
     }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
@@ -66,6 +66,15 @@ public class ProbeConditionTest {
   }
 
   @Test
+  void testNullLiteral() throws Exception {
+    ProbeCondition probeCondition = load("/test_conditional_06.json");
+    ValueReferenceResolver ctx =
+        RefResolverHelper.createResolver(
+            singletonMap("nullField", null), singletonMap("objField", new Object()));
+    assertTrue(probeCondition.execute(ctx));
+  }
+
+  @Test
   void testJsonAdapter() throws IOException {
     Moshi moshi =
         new Moshi.Builder()

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_06.json
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_06.json
@@ -1,0 +1,9 @@
+{
+  "dsl": "this.objField != null && nullField == null",
+  "json": {
+    "and": [
+      {"ne": [{"ref": "this.objField"}, null]},
+      {"eq": [{"ref": "nullField"}, null]}
+    ]
+  }
+}


### PR DESCRIPTION
# What Does This Do
Can check accessing reference against null

# Motivation
Able to write `field != null` in expression language

# Additional Notes
