### PR TITLE
Fail process when running in Agentless mode and API key is not set

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -27,6 +27,7 @@ import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration;
 import datadog.trace.bootstrap.instrumentation.jfr.InstrumentationBasedProfiling;
 import datadog.trace.util.AgentTaskScheduler;
 import datadog.trace.util.AgentThreadFactory.AgentThread;
+import datadog.trace.util.throwable.FatalAgentMisconfigurationError;
 import java.lang.instrument.Instrumentation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -477,6 +478,8 @@ public class Agent {
           tracerInstallerClass.getMethod(
               "installGlobalTracer", scoClass, ProfilingContextIntegration.class);
       tracerInstallerMethod.invoke(null, sco, createProfilingContextIntegration());
+    } catch (final FatalAgentMisconfigurationError ex) {
+      throw ex;
     } catch (final Throwable ex) {
       log.error("Throwable thrown while installing the Datadog Tracer", ex);
     }

--- a/dd-java-agent/src/test/groovy/datadog/trace/bootstrap/AgentBootstrapTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/bootstrap/AgentBootstrapTest.groovy
@@ -11,39 +11,39 @@ class AgentBootstrapTest extends Specification {
     major == expected
 
     where:
-    version     | expected
-    null        | 0
-    ''          | 0
-    'a.0.0'     | 0
-    '0.a.0'     | 0
-    '0.0.a'     | 0
-    '1.a.0_0'   | 1
-    '1.8.a_0'   | 8
-    '1.8.0_a'   | 8
-    '1.7'       | 7
-    '1.7.0'     | 7
-    '1.7.0_221' | 7
-    '1.8'       | 8
-    '1.8.0'     | 8
-    '1.8.0_212' | 8
-    '1.8.0_292' | 8
-    '9-ea'      | 9
-    '9.0.4'     | 9
-    '9.1.2'     | 9
-    '10.0.2'    | 10
-    '11'        | 11
-    '11a'       | 11
-    '11.0.6'    | 11
-    '11.0.11'   | 11
-    '12.0.2'    | 12
-    '13.0.2'    | 13
-    '14'        | 14
-    '14.0.2'    | 14
-    '15'        | 15
-    '15.0.2'    | 15
-    '16.0.1'    | 16
-    '11.0.9.1+1'| 11
-    '11.0.6+10' | 11
+    version      | expected
+    null         | 0
+    ''           | 0
+    'a.0.0'      | 0
+    '0.a.0'      | 0
+    '0.0.a'      | 0
+    '1.a.0_0'    | 1
+    '1.8.a_0'    | 8
+    '1.8.0_a'    | 8
+    '1.7'        | 7
+    '1.7.0'      | 7
+    '1.7.0_221'  | 7
+    '1.8'        | 8
+    '1.8.0'      | 8
+    '1.8.0_212'  | 8
+    '1.8.0_292'  | 8
+    '9-ea'       | 9
+    '9.0.4'      | 9
+    '9.1.2'      | 9
+    '10.0.2'     | 10
+    '11'         | 11
+    '11a'        | 11
+    '11.0.6'     | 11
+    '11.0.11'    | 11
+    '12.0.2'     | 12
+    '13.0.2'     | 13
+    '14'         | 14
+    '14.0.2'     | 14
+    '15'         | 15
+    '15.0.2'     | 15
+    '16.0.1'     | 16
+    '11.0.9.1+1' | 11
+    '11.0.6+10'  | 11
   }
 
   def 'log warning message when java version is less than 8'() {
@@ -73,24 +73,69 @@ class AgentBootstrapTest extends Specification {
     }
 
     where:
-    version     | expectedLower
-    null        | true
-    ''          | true
-    'a.0.0'     | true
-    '0.a.0'     | true
-    '0.0.a'     | true
-    '1.a.0_0'   | true
-    '1.8.a_0'   | false
-    '1.8.0_a'   | false
-    '1.7'       | true
-    '1.7.0'     | true
-    '1.7.0_221' | true
-    '1.8'       | false
-    '9.0.4'     | false
-    '10.0.2'    | false
-    '11a'       | false
-    '15'        | false
-    '11.0.9.1+1'| false
+    version      | expectedLower
+    null         | true
+    ''           | true
+    'a.0.0'      | true
+    '0.a.0'      | true
+    '0.0.a'      | true
+    '1.a.0_0'    | true
+    '1.8.a_0'    | false
+    '1.8.0_a'    | false
+    '1.7'        | true
+    '1.7.0'      | true
+    '1.7.0_221'  | true
+    '1.8'        | false
+    '9.0.4'      | false
+    '10.0.2'     | false
+    '11a'        | false
+    '15'         | false
+    '11.0.9.1+1' | false
 
+  }
+
+  def 'return true when first exception in the cause chain is the specified exception'() {
+    setup:
+    def ex = new IOException()
+
+    when:
+    def causeChainContainsException = AgentBootstrap.exceptionCauseChainContains(ex, "java.io.IOException")
+
+    then:
+    causeChainContainsException
+  }
+
+  def 'return false when exception cause chain does not contain specified exception'() {
+    setup:
+    def ex = new NullPointerException()
+
+    when:
+    def causeChainContainsException = AgentBootstrap.exceptionCauseChainContains(ex, "java.io.IOException")
+
+    then:
+    !causeChainContainsException
+  }
+
+  def 'return true when exception cause chain contains specified exception as a cause'() {
+    setup:
+    def ex = new Exception(new IOException())
+
+    when:
+    def causeChainContainsException = AgentBootstrap.exceptionCauseChainContains(ex, "java.io.IOException")
+
+    then:
+    causeChainContainsException
+  }
+
+  def 'return false when exception cause chain has a cycle'() {
+    setup:
+    def ex = Mock(Exception)
+    ex.getCause() >> ex
+
+    when:
+    def causeChainContainsException = AgentBootstrap.exceptionCauseChainContains(ex, "java.io.IOException")
+
+    then:
+    !causeChainContainsException
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
@@ -102,12 +102,6 @@ public class WriterFactory {
                 .trackType(trackType)
                 .build();
       } else {
-        final String apiKey = config.getApiKey();
-        if (apiKey == null || apiKey.isEmpty()) {
-          log.warn("Api Key has not been detected, using PrinterWriter.");
-          return new PrintingWriter(System.out, true);
-        }
-
         HttpUrl hostUrl = null;
         if (config.getCiVisibilityAgentlessUrl() != null) {
           hostUrl = HttpUrl.get(config.getCiVisibilityAgentlessUrl());

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1261,7 +1261,7 @@ public class Config {
         && (apiKey == null || apiKey.isEmpty())) {
       throw new FatalAgentMisconfigurationError(
           "Attempt to start in Agentless mode without API key. "
-              + "Please ensure that either API key is configured, or the tracer is set up to work with Agent");
+              + "Please ensure that either an API key is configured, or the tracer is set up to work with the Agent");
     }
 
     log.debug("New instance: {}", this);

--- a/internal-api/src/main/java/datadog/trace/util/throwable/FatalAgentMisconfigurationError.java
+++ b/internal-api/src/main/java/datadog/trace/util/throwable/FatalAgentMisconfigurationError.java
@@ -1,0 +1,15 @@
+package datadog.trace.util.throwable;
+
+/**
+ * This error represents a critical agent configuration issue that needs to be signalled to the
+ * client in a fail-fast manner. It is reserved for the rare cases when we want to abort the entire
+ * process rather than proceeding to start without the properly initialised agent.
+ *
+ * <p>This class is referred to by name in some parts of the code, so please be cautious when
+ * renaming or moving it.
+ */
+public class FatalAgentMisconfigurationError extends Error {
+  public FatalAgentMisconfigurationError(String message) {
+    super(message);
+  }
+}


### PR DESCRIPTION
# What Does This Do
When in Agentless mode, the Datadog API key is required to send payloads to the intake.
If we detect there’s no API Key, currently we silently continue without sending payloads.
We want to fail the process instead.

# Motivation
It is easy to overlook such misconfiguration, so we want to make it more obvious by failing the process rather than silently continuing.

# Additional Notes
This only applies to scenarios where CI visibility feature is enabled.
If CI visibility is disabled, previous behaviour remains unchanged (proceed with starting the process even if the API key is missing).
