### PR TITLE
Miscellaneous instrumentation cleanup

### DIFF
--- a/dd-java-agent/agent-tooling/src/jmh/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteBenchmark.java
+++ b/dd-java-agent/agent-tooling/src/jmh/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteBenchmark.java
@@ -62,15 +62,15 @@ public class CallSiteBenchmark {
     CALL_SITE("callSite"),
     CALLEE("callee");
 
-    private final String instrumenter;
+    private final String instrumentation;
 
-    Type(final String instrumenter) {
-      this.instrumenter = instrumenter;
+    Type(final String instrumentation) {
+      this.instrumentation = instrumentation;
     }
 
     public void apply(final Instrumentation instrumentation) {
-      if (instrumenter != null) {
-        System.setProperty("dd.benchmark.instrumentation", instrumenter);
+      if (this.instrumentation != null) {
+        System.setProperty("dd.benchmark.instrumentation", this.instrumentation);
         AgentInstaller.installBytebuddyAgent(instrumentation);
       }
     }
@@ -79,7 +79,7 @@ public class CallSiteBenchmark {
       if (response == null) {
         throw new RuntimeException("Empty response received");
       }
-      String expected = instrumenter == null ? "Hello!" : "Hello! [Transformed]";
+      String expected = instrumentation == null ? "Hello!" : "Hello! [Transformed]";
       if (!expected.equals(response)) {
         throw new RuntimeException(
             String.format("Wrong response, expected '%s' but received '%s'", expected, response));

--- a/dd-java-agent/agent-tooling/src/jmh/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteBenchmarkInstrumentation.java
+++ b/dd-java-agent/agent-tooling/src/jmh/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteBenchmarkInstrumentation.java
@@ -12,10 +12,10 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.jar.asm.Opcodes;
 import net.bytebuddy.matcher.ElementMatcher;
 
-public class CallSiteBenchmarkInstrumenter extends CallSiteInstrumenter
+public class CallSiteBenchmarkInstrumentation extends CallSiteInstrumentation
     implements ElementMatcher<TypeDescription> {
 
-  public CallSiteBenchmarkInstrumenter() {
+  public CallSiteBenchmarkInstrumentation() {
     super(buildCallSites(), "call-site");
   }
 

--- a/dd-java-agent/agent-tooling/src/jmh/java/datadog/trace/agent/tooling/bytebuddy/csi/CalleeBenchmarkInstrumentation.java
+++ b/dd-java-agent/agent-tooling/src/jmh/java/datadog/trace/agent/tooling/bytebuddy/csi/CalleeBenchmarkInstrumentation.java
@@ -8,10 +8,10 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.muzzle.ReferenceMatcher;
 import java.util.Set;
 
-public class CalleeBenchmarkInstrumenter extends Instrumenter.Default
+public class CalleeBenchmarkInstrumentation extends Instrumenter.Default
     implements Instrumenter.ForSingleType {
 
-  public CalleeBenchmarkInstrumenter() {
+  public CalleeBenchmarkInstrumentation() {
     super("callee");
   }
 

--- a/dd-java-agent/agent-tooling/src/jmh/resources/META-INF/services/datadog.trace.agent.tooling.Instrumenter
+++ b/dd-java-agent/agent-tooling/src/jmh/resources/META-INF/services/datadog.trace.agent.tooling.Instrumenter
@@ -1,2 +1,2 @@
-datadog.trace.agent.tooling.bytebuddy.csi.CalleeBenchmarkInstrumenter
-datadog.trace.agent.tooling.bytebuddy.csi.CallSiteBenchmarkInstrumenter
+datadog.trace.agent.tooling.bytebuddy.csi.CalleeBenchmarkInstrumentation
+datadog.trace.agent.tooling.bytebuddy.csi.CallSiteBenchmarkInstrumentation

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import net.bytebuddy.asm.AsmVisitorWrapper;
 import net.bytebuddy.description.ByteCodeElement;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
@@ -382,5 +383,23 @@ public interface Instrumenter {
         ClassLoader classLoader,
         JavaModule module,
         ProtectionDomain pd);
+  }
+
+  final class VisitingTransformer implements AdviceTransformer {
+    private final AsmVisitorWrapper visitor;
+
+    public VisitingTransformer(AsmVisitorWrapper visitor) {
+      this.visitor = visitor;
+    }
+
+    @Override
+    public DynamicType.Builder<?> transform(
+        DynamicType.Builder<?> builder,
+        TypeDescription typeDescription,
+        ClassLoader classLoader,
+        JavaModule module,
+        ProtectionDomain pd) {
+      return builder.visit(visitor);
+    }
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteInstrumentation.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteInstrumentation.java
@@ -13,7 +13,8 @@ import javax.annotation.Nonnull;
 public abstract class CallSiteInstrumentation extends Instrumenter.Default
     implements Instrumenter.ForCallSite {
 
-  private final Advices advices;
+  private final Class<?> spiInterface;
+  private Advices advices;
 
   /**
    * Create a new instance of the instrumenter.
@@ -24,7 +25,9 @@ public abstract class CallSiteInstrumentation extends Instrumenter.Default
       @Nonnull final Class<?> spiInterface,
       @Nonnull final String name,
       @Nonnull final String... additionalNames) {
-    this(fetchAdvicesFromSpi(spiInterface), name, additionalNames);
+    super(name, additionalNames);
+    this.spiInterface = spiInterface;
+    this.advices = null;
   }
 
   protected CallSiteInstrumentation(
@@ -32,6 +35,7 @@ public abstract class CallSiteInstrumentation extends Instrumenter.Default
       @Nonnull final String name,
       @Nonnull final String... additionalNames) {
     super(name, additionalNames);
+    this.spiInterface = null;
     this.advices = Advices.fromCallSites(advices);
   }
 
@@ -44,7 +48,7 @@ public abstract class CallSiteInstrumentation extends Instrumenter.Default
 
   @Override
   public String[] helperClassNames() {
-    return advices.getHelpers();
+    return advices().getHelpers();
   }
 
   @Override
@@ -52,6 +56,13 @@ public abstract class CallSiteInstrumentation extends Instrumenter.Default
 
   @Override
   public AdviceTransformer transformer() {
-    return new CallSiteTransformer(advices);
+    return new CallSiteTransformer(advices());
+  }
+
+  private Advices advices() {
+    if (null == advices) {
+      advices = Advices.fromCallSites(fetchAdvicesFromSpi(spiInterface));
+    }
+    return advices;
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteInstrumentation.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteInstrumentation.java
@@ -10,7 +10,7 @@ import javax.annotation.Nonnull;
  * fetch the instance of the {@link CallSiteAdvice} from SPI according to the specified marker
  * interface.
  */
-public abstract class CallSiteInstrumenter extends Instrumenter.Default
+public abstract class CallSiteInstrumentation extends Instrumenter.Default
     implements Instrumenter.ForCallSite {
 
   private final Advices advices;
@@ -20,14 +20,14 @@ public abstract class CallSiteInstrumenter extends Instrumenter.Default
    *
    * @param spiInterface marker interface implemented by the chosen {@link CallSiteAdvice} instances
    */
-  public CallSiteInstrumenter(
+  public CallSiteInstrumentation(
       @Nonnull final Class<?> spiInterface,
       @Nonnull final String name,
       @Nonnull final String... additionalNames) {
     this(fetchAdvicesFromSpi(spiInterface), name, additionalNames);
   }
 
-  protected CallSiteInstrumenter(
+  protected CallSiteInstrumentation(
       @Nonnull final Iterable<CallSiteAdvice> advices,
       @Nonnull final String name,
       @Nonnull final String... additionalNames) {
@@ -38,7 +38,7 @@ public abstract class CallSiteInstrumenter extends Instrumenter.Default
   @SuppressWarnings("unchecked")
   private static Iterable<CallSiteAdvice> fetchAdvicesFromSpi(
       @Nonnull final Class<?> spiInterface) {
-    final ClassLoader targetClassLoader = CallSiteInstrumenter.class.getClassLoader();
+    final ClassLoader targetClassLoader = CallSiteInstrumentation.class.getClassLoader();
     return (ServiceLoader<CallSiteAdvice>) ServiceLoader.load(spiInterface, targetClassLoader);
   }
 

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/BaseCallSiteTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/BaseCallSiteTest.groovy
@@ -1,7 +1,7 @@
 package datadog.trace.agent.tooling.csi
 
 import datadog.trace.agent.tooling.bytebuddy.csi.Advices
-import datadog.trace.agent.tooling.bytebuddy.csi.CallSiteInstrumenter
+import datadog.trace.agent.tooling.bytebuddy.csi.CallSiteInstrumentation
 import datadog.trace.agent.tooling.bytebuddy.csi.CallSiteTransformer
 import datadog.trace.test.util.DDSpecification
 import net.bytebuddy.agent.builder.AgentBuilder
@@ -162,9 +162,9 @@ class BaseCallSiteTest extends DDSpecification {
       }
   }
 
-  protected static CallSiteInstrumenter buildInstrumenter(final Iterable<CallSiteAdvice> advices,
+  protected static CallSiteInstrumentation buildInstrumentation(final Iterable<CallSiteAdvice> advices,
     final ElementMatcher<TypeDescription> callerType = any()) {
-    return new CallSiteInstrumenter(advices, 'csi') {
+    return new CallSiteInstrumentation(advices, 'csi') {
         @Override
         ElementMatcher<TypeDescription> callerType() {
           return callerType
@@ -172,9 +172,9 @@ class BaseCallSiteTest extends DDSpecification {
       }
   }
 
-  protected static CallSiteInstrumenter buildInstrumenter(final Class<?> spiClass,
+  protected static CallSiteInstrumentation buildInstrumentation(final Class<?> spiClass,
     final ElementMatcher<TypeDescription> callerType = any()) {
-    return new CallSiteInstrumenter(spiClass, 'csi') {
+    return new CallSiteInstrumentation(spiClass, 'csi') {
         @Override
         ElementMatcher<TypeDescription> callerType() {
           return callerType

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteInstrumentationTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteInstrumentationTest.groovy
@@ -5,19 +5,19 @@ import net.bytebuddy.asm.AsmVisitorWrapper
 import net.bytebuddy.description.type.TypeDescription
 import net.bytebuddy.dynamic.DynamicType
 
-class CallSiteInstrumenterTest extends BaseCallSiteTest {
+class CallSiteInstrumentationTest extends BaseCallSiteTest {
 
-  def 'test instrumenter creates transformer'() {
+  def 'test instrumentation creates transformer'() {
     setup:
     final advice = mockInvokeAdvice(stringConcatPointcut())
-    final instrumenter = buildInstrumenter([advice])
+    final instrumentation = buildInstrumentation([advice])
     final builder = Mock(DynamicType.Builder)
     final type = Mock(TypeDescription) {
       getName() >> StringConcatExample.name
     }
 
     when:
-    final transformer = instrumenter.transformer()
+    final transformer = instrumentation.transformer()
     final result = transformer.transform(builder, type, getClass().getClassLoader(), null, null)
 
     then:
@@ -25,14 +25,14 @@ class CallSiteInstrumenterTest extends BaseCallSiteTest {
     1 * builder.visit(_ as AsmVisitorWrapper) >> builder
   }
 
-  def 'test instrumenter adds no transformations'() {
+  def 'test instrumentation adds no transformations'() {
     setup:
     final advice = mockInvokeAdvice(stringConcatPointcut())
-    final instrumenter = buildInstrumenter([advice])
+    final instrumentation = buildInstrumentation([advice])
     final mock = Mock(Instrumenter.AdviceTransformation)
 
     when:
-    instrumenter.adviceTransformations(mock)
+    instrumentation.adviceTransformations(mock)
 
     then:
     0 * mock._
@@ -42,10 +42,10 @@ class CallSiteInstrumenterTest extends BaseCallSiteTest {
     setup:
     final advice1 = mockInvokeAdvice(stringConcatPointcut(), 'foo.bar.Helper1')
     final advice2 = mockInvokeAdvice(messageDigestGetInstancePointcut(), 'foo.bar.Helper1', 'foo.bar.Helper2', 'foo.bar.Helper3')
-    final instrumenter = buildInstrumenter([advice1, advice2])
+    final instrumentation = buildInstrumentation([advice1, advice2])
 
     when:
-    final helpers = instrumenter.helperClassNames()
+    final helpers = instrumentation.helperClassNames()
 
     then:
     helpers.length == 3
@@ -60,8 +60,8 @@ class CallSiteInstrumenterTest extends BaseCallSiteTest {
     }
 
     when:
-    final instrumenter = buildInstrumenter(TestCallSiteAdvice)
-    final transformer = instrumenter.transformer()
+    final instrumentation = buildInstrumentation(TestCallSiteAdvice)
+    final transformer = instrumentation.transformer()
     transformer.transform(builder, type, getClass().getClassLoader(), null, null)
 
     then:
@@ -77,8 +77,8 @@ class CallSiteInstrumenterTest extends BaseCallSiteTest {
     }
 
     when:
-    final instrumenter = buildInstrumenter(CallSiteAdvice)
-    final transformer = instrumenter.transformer()
+    final instrumentation = buildInstrumentation(CallSiteAdvice)
+    final transformer = instrumentation.transformer()
     transformer.transform(builder, type, getClass().getClassLoader(), null, null)
 
     then:

--- a/dd-java-agent/agent-tooling/src/test/resources/META-INF/services/datadog.trace.agent.tooling.csi.TestCallSiteAdvice
+++ b/dd-java-agent/agent-tooling/src/test/resources/META-INF/services/datadog.trace.agent.tooling.csi.TestCallSiteAdvice
@@ -1,1 +1,1 @@
-datadog.trace.agent.tooling.csi.CallSiteInstrumenterTest$StringConcatAdvice
+datadog.trace.agent.tooling.csi.CallSiteInstrumentationTest$StringConcatAdvice

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/AbstractHibernateInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/AbstractHibernateInstrumentation.java
@@ -5,6 +5,8 @@ import datadog.trace.agent.tooling.Instrumenter;
 public abstract class AbstractHibernateInstrumentation extends Instrumenter.Tracing
     implements Instrumenter.CanShortcutTypeMatching {
 
+  static final String SESSION_STATE = "datadog.trace.instrumentation.hibernate.SessionState";
+
   public AbstractHibernateInstrumentation() {
     super("hibernate", "hibernate-core");
   }

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/CriteriaInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/CriteriaInstrumentation.java
@@ -26,7 +26,7 @@ public class CriteriaInstrumentation extends AbstractHibernateInstrumentation {
 
   @Override
   public Map<String, String> contextStore() {
-    return singletonMap("org.hibernate.Criteria", SessionState.class.getName());
+    return singletonMap("org.hibernate.Criteria", SESSION_STATE);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/QueryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/QueryInstrumentation.java
@@ -28,7 +28,7 @@ public class QueryInstrumentation extends AbstractHibernateInstrumentation {
 
   @Override
   public Map<String, String> contextStore() {
-    return singletonMap("org.hibernate.Query", SessionState.class.getName());
+    return singletonMap("org.hibernate.Query", SESSION_STATE);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionFactoryInstrumentation.java
@@ -34,9 +34,9 @@ public class SessionFactoryInstrumentation extends AbstractHibernateInstrumentat
   @Override
   public Map<String, String> contextStore() {
     final Map<String, String> stores = new HashMap<>();
-    stores.put("org.hibernate.Session", SessionState.class.getName());
-    stores.put("org.hibernate.StatelessSession", SessionState.class.getName());
-    stores.put("org.hibernate.SharedSessionContract", SessionState.class.getName());
+    stores.put("org.hibernate.Session", SESSION_STATE);
+    stores.put("org.hibernate.StatelessSession", SESSION_STATE);
+    stores.put("org.hibernate.SharedSessionContract", SESSION_STATE);
     return Collections.unmodifiableMap(stores);
   }
 

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/SessionInstrumentation.java
@@ -39,11 +39,11 @@ public class SessionInstrumentation extends AbstractHibernateInstrumentation {
   @Override
   public Map<String, String> contextStore() {
     final Map<String, String> map = new HashMap<>();
-    map.put("org.hibernate.Session", SessionState.class.getName());
-    map.put("org.hibernate.StatelessSession", SessionState.class.getName());
-    map.put("org.hibernate.Query", SessionState.class.getName());
-    map.put("org.hibernate.Transaction", SessionState.class.getName());
-    map.put("org.hibernate.Criteria", SessionState.class.getName());
+    map.put("org.hibernate.Session", SESSION_STATE);
+    map.put("org.hibernate.StatelessSession", SESSION_STATE);
+    map.put("org.hibernate.Query", SESSION_STATE);
+    map.put("org.hibernate.Transaction", SESSION_STATE);
+    map.put("org.hibernate.Criteria", SESSION_STATE);
     return Collections.unmodifiableMap(map);
   }
 

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/TransactionInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/TransactionInstrumentation.java
@@ -25,7 +25,7 @@ public class TransactionInstrumentation extends AbstractHibernateInstrumentation
 
   @Override
   public Map<String, String> contextStore() {
-    return singletonMap("org.hibernate.Transaction", SessionState.class.getName());
+    return singletonMap("org.hibernate.Transaction", SESSION_STATE);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/AbstractHibernateInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/AbstractHibernateInstrumentation.java
@@ -5,6 +5,8 @@ import datadog.trace.agent.tooling.Instrumenter;
 public abstract class AbstractHibernateInstrumentation extends Instrumenter.Tracing
     implements Instrumenter.CanShortcutTypeMatching {
 
+  static final String SESSION_STATE = "datadog.trace.instrumentation.hibernate.SessionState";
+
   public AbstractHibernateInstrumentation() {
     super("hibernate", "hibernate-core");
   }

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/CriteriaInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/CriteriaInstrumentation.java
@@ -25,7 +25,7 @@ public class CriteriaInstrumentation extends AbstractHibernateInstrumentation {
 
   @Override
   public Map<String, String> contextStore() {
-    return singletonMap("org.hibernate.Criteria", SessionState.class.getName());
+    return singletonMap("org.hibernate.Criteria", SESSION_STATE);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/QueryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/QueryInstrumentation.java
@@ -27,7 +27,7 @@ public class QueryInstrumentation extends AbstractHibernateInstrumentation {
 
   @Override
   public Map<String, String> contextStore() {
-    return singletonMap("org.hibernate.Query", SessionState.class.getName());
+    return singletonMap("org.hibernate.Query", SESSION_STATE);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionFactoryInstrumentation.java
@@ -28,7 +28,7 @@ public class SessionFactoryInstrumentation extends AbstractHibernateInstrumentat
 
   @Override
   public Map<String, String> contextStore() {
-    return singletonMap("org.hibernate.SharedSessionContract", SessionState.class.getName());
+    return singletonMap("org.hibernate.SharedSessionContract", SESSION_STATE);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/SessionInstrumentation.java
@@ -36,10 +36,10 @@ public class SessionInstrumentation extends AbstractHibernateInstrumentation {
   @Override
   public Map<String, String> contextStore() {
     final Map<String, String> map = new HashMap<>();
-    map.put("org.hibernate.SharedSessionContract", SessionState.class.getName());
-    map.put("org.hibernate.Query", SessionState.class.getName());
-    map.put("org.hibernate.Transaction", SessionState.class.getName());
-    map.put("org.hibernate.Criteria", SessionState.class.getName());
+    map.put("org.hibernate.SharedSessionContract", SESSION_STATE);
+    map.put("org.hibernate.Query", SESSION_STATE);
+    map.put("org.hibernate.Transaction", SESSION_STATE);
+    map.put("org.hibernate.Criteria", SESSION_STATE);
     return Collections.unmodifiableMap(map);
   }
 

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/TransactionInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/TransactionInstrumentation.java
@@ -24,7 +24,7 @@ public class TransactionInstrumentation extends AbstractHibernateInstrumentation
 
   @Override
   public Map<String, String> contextStore() {
-    return singletonMap("org.hibernate.Transaction", SessionState.class.getName());
+    return singletonMap("org.hibernate.Transaction", SESSION_STATE);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_3/ProcedureCallInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_3/ProcedureCallInstrumentation.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.hibernate.core.v4_3;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.instrumentation.hibernate.core.v4_3.SessionInstrumentation.SESSION_STATE;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
@@ -27,7 +28,7 @@ public class ProcedureCallInstrumentation extends Instrumenter.Tracing
 
   @Override
   public Map<String, String> contextStore() {
-    return singletonMap("org.hibernate.procedure.ProcedureCall", SessionState.class.getName());
+    return singletonMap("org.hibernate.procedure.ProcedureCall", SESSION_STATE);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_3/SessionInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_3/SessionInstrumentation.java
@@ -25,6 +25,8 @@ import org.hibernate.procedure.ProcedureCall;
 public class SessionInstrumentation extends Instrumenter.Tracing
     implements Instrumenter.CanShortcutTypeMatching {
 
+  static final String SESSION_STATE = "datadog.trace.instrumentation.hibernate.SessionState";
+
   public SessionInstrumentation() {
     super("hibernate", "hibernate-core");
   }
@@ -32,8 +34,8 @@ public class SessionInstrumentation extends Instrumenter.Tracing
   @Override
   public Map<String, String> contextStore() {
     final Map<String, String> map = new HashMap<>();
-    map.put("org.hibernate.SharedSessionContract", SessionState.class.getName());
-    map.put("org.hibernate.procedure.ProcedureCall", SessionState.class.getName());
+    map.put("org.hibernate.SharedSessionContract", SESSION_STATE);
+    map.put("org.hibernate.procedure.ProcedureCall", SESSION_STATE);
     return Collections.unmodifiableMap(map);
   }
 

--- a/dd-java-agent/instrumentation/iast-instrumenter/src/main/java/datadog/trace/instrumentation/iastinstrumenter/IastInstrumentation.java
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/main/java/datadog/trace/instrumentation/iastinstrumenter/IastInstrumentation.java
@@ -2,18 +2,18 @@ package datadog.trace.instrumentation.iastinstrumenter;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.agent.tooling.bytebuddy.csi.CallSiteInstrumenter;
+import datadog.trace.agent.tooling.bytebuddy.csi.CallSiteInstrumentation;
 import datadog.trace.api.iast.IastAdvice;
 import java.util.Set;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(Instrumenter.class)
-public class IastInstrumenter extends CallSiteInstrumenter
+public class IastInstrumentation extends CallSiteInstrumentation
     implements ElementMatcher<TypeDescription> {
 
-  public IastInstrumenter() {
-    super(IastAdvice.class, "IastInstrumenter");
+  public IastInstrumentation() {
+    super(IastAdvice.class, "IastInstrumentation");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/iast-instrumenter/src/test/groovy/IastInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/test/groovy/IastInstrumentationTest.groovy
@@ -1,12 +1,12 @@
 import datadog.trace.agent.tooling.Instrumenter
-import datadog.trace.instrumentation.iastinstrumenter.IastInstrumenter
+import datadog.trace.instrumentation.iastinstrumenter.IastInstrumentation
 import datadog.trace.test.util.DDSpecification
 import net.bytebuddy.description.type.TypeDescription
 
-class IastInstrumenterTest extends DDSpecification{
-  def 'test Iast Instrumenter'(){
+class IastInstrumentationTest extends DDSpecification{
+  def 'test Iast Instrumentation'(){
     given:
-    IastInstrumenter instrumenter = new IastInstrumenter()
+    IastInstrumentation instrumentation = new IastInstrumentation()
     TypeDescription typeDescription1 = Mock (TypeDescription)
     typeDescription1.getName() >> "org.jsantos.Tool"
     TypeDescription typeDescription2 = Mock(TypeDescription)
@@ -14,11 +14,11 @@ class IastInstrumenterTest extends DDSpecification{
     Set<Instrumenter.TargetSystem> enabledSystems = Mock(Set)
 
     when:
-    instrumenter.isEnabled()
-    instrumenter.isApplicable(enabledSystems)
-    instrumenter.callerType()
-    boolean description1Matched = instrumenter.matches(typeDescription1)
-    boolean description2Matched = instrumenter.matches(typeDescription2)
+    instrumentation.isEnabled()
+    instrumentation.isApplicable(enabledSystems)
+    instrumentation.callerType()
+    boolean description1Matched = instrumentation.matches(typeDescription1)
+    boolean description2Matched = instrumentation.matches(typeDescription2)
 
     then:
     description1Matched

--- a/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/FileOutputStreamCallSite.java
+++ b/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/FileOutputStreamCallSite.java
@@ -7,7 +7,7 @@ import datadog.trace.api.iast.sink.PathTraversalModule;
 import javax.annotation.Nullable;
 
 @CallSite(spi = IastAdvice.class)
-public class FIleOutputStreamCallSite {
+public class FileOutputStreamCallSite {
 
   @CallSite.Before("void java.io.FileOutputStream.<init>(java.lang.String)")
   public static void beforeConstructor(@CallSite.Argument @Nullable final String path) {

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceInstrumentation.java
@@ -48,7 +48,8 @@ public final class DataSourceInstrumentation extends Instrumenter.Tracing
 
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
-    transformation.applyAdvice(named("getConnection"), GetConnectionAdvice.class.getName());
+    transformation.applyAdvice(
+        named("getConnection"), DataSourceInstrumentation.class.getName() + "$GetConnectionAdvice");
   }
 
   public static class GetConnectionAdvice {

--- a/dd-java-agent/instrumentation/jetty-11/src/main/java/datadog/trace/instrumentation/jetty11/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-11/src/main/java/datadog/trace/instrumentation/jetty11/JettyServerInstrumentation.java
@@ -14,7 +14,6 @@ import datadog.trace.api.Config;
 import datadog.trace.api.ProductActivation;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
 import datadog.trace.instrumentation.jetty9.HttpChannelHandleVisitor;
-import java.security.ProtectionDomain;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -24,13 +23,11 @@ import net.bytebuddy.description.field.FieldDescription;
 import net.bytebuddy.description.field.FieldList;
 import net.bytebuddy.description.method.MethodList;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.implementation.Implementation;
 import net.bytebuddy.jar.asm.ClassVisitor;
 import net.bytebuddy.jar.asm.ClassWriter;
 import net.bytebuddy.jar.asm.Opcodes;
 import net.bytebuddy.pool.TypePool;
-import net.bytebuddy.utility.JavaModule;
 
 @AutoService(Instrumenter.class)
 public final class JettyServerInstrumentation extends Instrumenter.Tracing
@@ -76,17 +73,7 @@ public final class JettyServerInstrumentation extends Instrumenter.Tracing
   }
 
   public AdviceTransformer transformer() {
-    return new AdviceTransformer() {
-      @Override
-      public DynamicType.Builder<?> transform(
-          DynamicType.Builder<?> builder,
-          TypeDescription typeDescription,
-          ClassLoader classLoader,
-          JavaModule module,
-          ProtectionDomain pd) {
-        return builder.visit(new HttpChannelHandleVisitorWrapper());
-      }
-    };
+    return new VisitingTransformer(new HttpChannelHandleVisitorWrapper());
   }
 
   private static class HttpChannelHandleVisitorWrapper implements AsmVisitorWrapper {

--- a/dd-java-agent/instrumentation/jetty-11/src/main/java/datadog/trace/instrumentation/jetty11/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-11/src/main/java/datadog/trace/instrumentation/jetty11/JettyServerInstrumentation.java
@@ -76,7 +76,7 @@ public final class JettyServerInstrumentation extends Instrumenter.Tracing
     return new VisitingTransformer(new HttpChannelHandleVisitorWrapper());
   }
 
-  private static class HttpChannelHandleVisitorWrapper implements AsmVisitorWrapper {
+  public static class HttpChannelHandleVisitorWrapper implements AsmVisitorWrapper {
 
     @Override
     public int mergeWriter(int flags) {

--- a/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyServerInstrumentation.java
@@ -84,7 +84,7 @@ public final class JettyServerInstrumentation extends Instrumenter.Tracing
     return new VisitingTransformer(new ConnectionHandleRequestVisitorWrapper());
   }
 
-  private static class ConnectionHandleRequestVisitorWrapper implements AsmVisitorWrapper {
+  public static class ConnectionHandleRequestVisitorWrapper implements AsmVisitorWrapper {
 
     @Override
     public int mergeWriter(int flags) {

--- a/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyServerInstrumentation.java
@@ -19,7 +19,6 @@ import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.jetty.ConnectionHandleRequestVisitor;
-import java.security.ProtectionDomain;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.asm.AsmVisitorWrapper;
@@ -27,13 +26,11 @@ import net.bytebuddy.description.field.FieldDescription;
 import net.bytebuddy.description.field.FieldList;
 import net.bytebuddy.description.method.MethodList;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.implementation.Implementation;
 import net.bytebuddy.jar.asm.ClassVisitor;
 import net.bytebuddy.jar.asm.ClassWriter;
 import net.bytebuddy.jar.asm.Opcodes;
 import net.bytebuddy.pool.TypePool;
-import net.bytebuddy.utility.JavaModule;
 import org.eclipse.jetty.http.Generator;
 import org.eclipse.jetty.server.HttpConnection;
 import org.eclipse.jetty.server.Request;
@@ -84,17 +81,7 @@ public final class JettyServerInstrumentation extends Instrumenter.Tracing
 
   @Override
   public AdviceTransformer transformer() {
-    return new AdviceTransformer() {
-      @Override
-      public DynamicType.Builder<?> transform(
-          DynamicType.Builder<?> builder,
-          TypeDescription typeDescription,
-          ClassLoader classLoader,
-          JavaModule module,
-          ProtectionDomain pd) {
-        return builder.visit(new ConnectionHandleRequestVisitorWrapper());
-      }
-    };
+    return new VisitingTransformer(new ConnectionHandleRequestVisitorWrapper());
   }
 
   private static class ConnectionHandleRequestVisitorWrapper implements AsmVisitorWrapper {

--- a/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyServerInstrumentation.java
@@ -83,7 +83,7 @@ public final class JettyServerInstrumentation extends Instrumenter.Tracing
     return new VisitingTransformer(new ConnectionHandleRequestVisitorWrapper());
   }
 
-  private static class ConnectionHandleRequestVisitorWrapper implements AsmVisitorWrapper {
+  public static class ConnectionHandleRequestVisitorWrapper implements AsmVisitorWrapper {
 
     @Override
     public int mergeWriter(int flags) {

--- a/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyServerInstrumentation.java
@@ -18,7 +18,6 @@ import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.jetty.ConnectionHandleRequestVisitor;
-import java.security.ProtectionDomain;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.asm.AsmVisitorWrapper;
@@ -26,13 +25,11 @@ import net.bytebuddy.description.field.FieldDescription;
 import net.bytebuddy.description.field.FieldList;
 import net.bytebuddy.description.method.MethodList;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.implementation.Implementation;
 import net.bytebuddy.jar.asm.ClassVisitor;
 import net.bytebuddy.jar.asm.ClassWriter;
 import net.bytebuddy.jar.asm.Opcodes;
 import net.bytebuddy.pool.TypePool;
-import net.bytebuddy.utility.JavaModule;
 import org.eclipse.jetty.http.Generator;
 import org.eclipse.jetty.server.AbstractHttpConnection;
 import org.eclipse.jetty.server.Request;
@@ -83,17 +80,7 @@ public final class JettyServerInstrumentation extends Instrumenter.Tracing
 
   @Override
   public AdviceTransformer transformer() {
-    return new AdviceTransformer() {
-      @Override
-      public DynamicType.Builder<?> transform(
-          DynamicType.Builder<?> builder,
-          TypeDescription typeDescription,
-          ClassLoader classLoader,
-          JavaModule module,
-          ProtectionDomain pd) {
-        return builder.visit(new ConnectionHandleRequestVisitorWrapper());
-      }
-    };
+    return new VisitingTransformer(new ConnectionHandleRequestVisitorWrapper());
   }
 
   private static class ConnectionHandleRequestVisitorWrapper implements AsmVisitorWrapper {

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyServerInstrumentation.java
@@ -98,7 +98,7 @@ public final class JettyServerInstrumentation extends Instrumenter.Tracing
     return new VisitingTransformer(new HttpChannelHandleVisitorWrapper());
   }
 
-  private static class HttpChannelHandleVisitorWrapper implements AsmVisitorWrapper {
+  public static class HttpChannelHandleVisitorWrapper implements AsmVisitorWrapper {
 
     @Override
     public int mergeWriter(int flags) {

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyServerInstrumentation.java
@@ -21,7 +21,6 @@ import datadog.trace.api.ProductActivation;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
-import java.security.ProtectionDomain;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -32,13 +31,11 @@ import net.bytebuddy.description.field.FieldDescription;
 import net.bytebuddy.description.field.FieldList;
 import net.bytebuddy.description.method.MethodList;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.implementation.Implementation;
 import net.bytebuddy.jar.asm.ClassVisitor;
 import net.bytebuddy.jar.asm.ClassWriter;
 import net.bytebuddy.jar.asm.Opcodes;
 import net.bytebuddy.pool.TypePool;
-import net.bytebuddy.utility.JavaModule;
 import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.Request;
 
@@ -98,17 +95,7 @@ public final class JettyServerInstrumentation extends Instrumenter.Tracing
   }
 
   public AdviceTransformer transformer() {
-    return new AdviceTransformer() {
-      @Override
-      public DynamicType.Builder<?> transform(
-          DynamicType.Builder<?> builder,
-          TypeDescription typeDescription,
-          ClassLoader classLoader,
-          JavaModule module,
-          ProtectionDomain pd) {
-        return builder.visit(new HttpChannelHandleVisitorWrapper());
-      }
-    };
+    return new VisitingTransformer(new HttpChannelHandleVisitorWrapper());
   }
 
   private static class HttpChannelHandleVisitorWrapper implements AsmVisitorWrapper {

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
@@ -72,7 +72,7 @@ public class KafkaStreamTaskInstrumentation extends Instrumenter.Tracing
   public Map<String, String> contextStore() {
     return singletonMap(
         "org.apache.kafka.streams.processor.internals.StreamTask",
-        StreamTaskContext.class.getName());
+        packageName + ".StreamTaskContext");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/NettyChannelInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/NettyChannelInstrumentation.java
@@ -58,7 +58,7 @@ public class NettyChannelInstrumentation extends Instrumenter.Tracing
   @Override
   public Map<String, String> contextStore() {
     return Collections.singletonMap(
-        "org.jboss.netty.channel.Channel", ChannelTraceContext.class.getName());
+        "org.jboss.netty.channel.Channel", packageName + ".ChannelTraceContext");
   }
 
   public static class ChannelConnectAdvice extends AbstractNettyAdvice {

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/NettyChannelPipelineInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/NettyChannelPipelineInstrumentation.java
@@ -82,7 +82,7 @@ public class NettyChannelPipelineInstrumentation extends Instrumenter.Tracing
   @Override
   public Map<String, String> contextStore() {
     return Collections.singletonMap(
-        "org.jboss.netty.channel.Channel", ChannelTraceContext.class.getName());
+        "org.jboss.netty.channel.Channel", packageName + ".ChannelTraceContext");
   }
 
   public static class ChannelPipelineAdd2ArgsAdvice extends AbstractNettyAdvice {

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/DecodedFormParametersInstrumentation.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/DecodedFormParametersInstrumentation.java
@@ -69,7 +69,7 @@ public class DecodedFormParametersInstrumentation extends Instrumenter.AppSec
     return new CustomReferenceProvider();
   }
 
-  static class CustomReferenceProvider implements ReferenceProvider {
+  public static class CustomReferenceProvider implements ReferenceProvider {
     @Override
     public Iterable<Reference> buildReferences(TypePool typePool) {
       List<Reference> references = new ArrayList<>();

--- a/dd-java-agent/instrumentation/scala-promise/scala-promise-2.10/src/main/java/datadog/trace/instrumentation/scala210/concurrent/CallbackRunnableInstrumentation.java
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise-2.10/src/main/java/datadog/trace/instrumentation/scala210/concurrent/CallbackRunnableInstrumentation.java
@@ -1,4 +1,4 @@
-package datadog.trace.instrumentation.scala.concurrent;
+package datadog.trace.instrumentation.scala210.concurrent;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.capture;

--- a/dd-java-agent/instrumentation/scala-promise/scala-promise-2.10/src/main/java/datadog/trace/instrumentation/scala210/concurrent/FutureObjectInstrumentation.java
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise-2.10/src/main/java/datadog/trace/instrumentation/scala210/concurrent/FutureObjectInstrumentation.java
@@ -1,4 +1,4 @@
-package datadog.trace.instrumentation.scala.concurrent;
+package datadog.trace.instrumentation.scala210.concurrent;
 
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isTypeInitializer;
@@ -24,10 +24,10 @@ import scala.util.Try;
  * that context and propagate it forward, which is quite unexpected and not very relevant.
  */
 @AutoService(Instrumenter.class)
-public class FutureObjectInstrumentation210 extends Instrumenter.Tracing
+public class FutureObjectInstrumentation extends Instrumenter.Tracing
     implements Instrumenter.ForSingleType {
 
-  public FutureObjectInstrumentation210() {
+  public FutureObjectInstrumentation() {
     super("scala_future_object", "scala_concurrent");
   }
 

--- a/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/src/main/java/datadog/trace/instrumentation/scala213/concurrent/FutureObjectInstrumentation.java
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/src/main/java/datadog/trace/instrumentation/scala213/concurrent/FutureObjectInstrumentation.java
@@ -1,4 +1,4 @@
-package datadog.trace.instrumentation.scala.concurrent;
+package datadog.trace.instrumentation.scala213.concurrent;
 
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isTypeInitializer;
@@ -20,10 +20,10 @@ import scala.util.Try;
  * that context and propagate it forward, which is quite unexpected and not very relevant.
  */
 @AutoService(Instrumenter.class)
-public class FutureObjectInstrumentation213 extends Instrumenter.Tracing
+public class FutureObjectInstrumentation extends Instrumenter.Tracing
     implements Instrumenter.ForSingleType {
 
-  public FutureObjectInstrumentation213() {
+  public FutureObjectInstrumentation() {
     super("scala_future_object", "scala_concurrent");
   }
 

--- a/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/src/main/java/datadog/trace/instrumentation/scala213/concurrent/PromiseTransformationInstrumentation.java
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/src/main/java/datadog/trace/instrumentation/scala213/concurrent/PromiseTransformationInstrumentation.java
@@ -1,4 +1,4 @@
-package datadog.trace.instrumentation.scala.concurrent;
+package datadog.trace.instrumentation.scala213.concurrent;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.capture;

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/ServletContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/ServletContextInstrumentation.java
@@ -46,7 +46,7 @@ public final class ServletContextInstrumentation extends Instrumenter.Tracing
             // javax.servlet.ServletContext.getRequestDispatcher
             // javax.servlet.ServletContext.getNamedDispatcher
             .and(isPublic()),
-        RequestDispatcherTargetAdvice.class.getName());
+        ServletContextInstrumentation.class.getName() + "$RequestDispatcherTargetAdvice");
   }
 
   public static class RequestDispatcherTargetAdvice {

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
@@ -46,7 +46,9 @@ public final class HttpServletResponseInstrumentation extends Instrumenter.Traci
 
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
-    transformation.applyAdvice(namedOneOf("sendError", "sendRedirect"), SendAdvice.class.getName());
+    transformation.applyAdvice(
+        namedOneOf("sendError", "sendRedirect"),
+        HttpServletResponseInstrumentation.class.getName() + "$SendAdvice");
   }
 
   public static class SendAdvice {

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RequestImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RequestImplInstrumentation.java
@@ -4,21 +4,18 @@ import static net.bytebuddy.matcher.ElementMatchers.none;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import java.security.ProtectionDomain;
 import java.util.Arrays;
 import net.bytebuddy.asm.AsmVisitorWrapper;
 import net.bytebuddy.description.field.FieldDescription;
 import net.bytebuddy.description.field.FieldList;
 import net.bytebuddy.description.method.MethodList;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.implementation.Implementation;
 import net.bytebuddy.jar.asm.ClassVisitor;
 import net.bytebuddy.jar.asm.ClassWriter;
 import net.bytebuddy.jar.asm.MethodVisitor;
 import net.bytebuddy.jar.asm.Opcodes;
 import net.bytebuddy.pool.TypePool;
-import net.bytebuddy.utility.JavaModule;
 
 @AutoService(Instrumenter.class)
 public class RequestImplInstrumentation extends Instrumenter.Tracing
@@ -40,93 +37,78 @@ public class RequestImplInstrumentation extends Instrumenter.Tracing
 
   @Override
   public AdviceTransformer transformer() {
-    return new CustomTransformer();
+    return new VisitingTransformer(new RequestImplVisitorWrapper());
   }
 
   // This Transformer will add the Cloneable interface to RequestImpl, as well
   // as a clone method that calls the protected shallow clone method in Object
-  static class CustomTransformer implements AdviceTransformer {
+  static class RequestImplVisitorWrapper implements AsmVisitorWrapper {
     @Override
-    public DynamicType.Builder<?> transform(
-        DynamicType.Builder<?> builder,
-        TypeDescription typeDescription,
-        ClassLoader classLoader,
-        JavaModule module,
-        ProtectionDomain pd) {
-      return builder.visit(
-          new AsmVisitorWrapper() {
-            @Override
-            public int mergeWriter(int flags) {
-              return flags | ClassWriter.COMPUTE_MAXS;
-            }
+    public int mergeWriter(int flags) {
+      return flags | ClassWriter.COMPUTE_MAXS;
+    }
 
-            @Override
-            public int mergeReader(int flags) {
-              return flags;
-            }
+    @Override
+    public int mergeReader(int flags) {
+      return flags;
+    }
 
-            @Override
-            public ClassVisitor wrap(
-                TypeDescription instrumentedType,
-                ClassVisitor classVisitor,
-                Implementation.Context implementationContext,
-                TypePool typePool,
-                FieldList<FieldDescription.InDefinedShape> fields,
-                MethodList<?> methods,
-                int writerFlags,
-                int readerFlags) {
-              return new ClassVisitor(Opcodes.ASM7, classVisitor) {
+    @Override
+    public ClassVisitor wrap(
+        TypeDescription instrumentedType,
+        ClassVisitor classVisitor,
+        Implementation.Context implementationContext,
+        TypePool typePool,
+        FieldList<FieldDescription.InDefinedShape> fields,
+        MethodList<?> methods,
+        int writerFlags,
+        int readerFlags) {
+      return new ClassVisitor(Opcodes.ASM7, classVisitor) {
 
-                @Override
-                public void visit(
-                    int version,
-                    int access,
-                    String name,
-                    String signature,
-                    String superName,
-                    String[] interfaces) {
-                  // Add the Cloneable interface
-                  if (null == interfaces) {
-                    interfaces = new String[1];
-                  } else {
-                    interfaces = Arrays.copyOf(interfaces, interfaces.length + 1);
-                  }
-                  interfaces[interfaces.length - 1] = "java/lang/Cloneable";
-                  cv.visit(version, access, name, signature, superName, interfaces);
-                }
+        @Override
+        public void visit(
+            int version,
+            int access,
+            String name,
+            String signature,
+            String superName,
+            String[] interfaces) {
+          // Add the Cloneable interface
+          if (null == interfaces) {
+            interfaces = new String[1];
+          } else {
+            interfaces = Arrays.copyOf(interfaces, interfaces.length + 1);
+          }
+          interfaces[interfaces.length - 1] = "java/lang/Cloneable";
+          cv.visit(version, access, name, signature, superName, interfaces);
+        }
 
-                @Override
-                public void visitEnd() {
-                  // Add a clone method that calls the protected shallow clone method in Object
-                  //
-                  // public Object clone() throws CloneNotSupportedException {
-                  //    return super.clone(); // Object is the super class
-                  // }
-                  //
-                  final MethodVisitor mv =
-                      cv.visitMethod(
-                          Opcodes.ACC_PUBLIC,
-                          "clone",
-                          "()Ljava/lang/Object;",
-                          null,
-                          new String[] {"java/lang/CloneNotSupportedException"});
-                  mv.visitCode();
-                  mv.visitIntInsn(Opcodes.ALOAD, 0);
-                  mv.visitMethodInsn(
-                      Opcodes.INVOKESPECIAL,
-                      "java/lang/Object",
-                      "clone",
-                      "()Ljava/lang/Object;",
-                      false);
-                  mv.visitInsn(Opcodes.ARETURN);
-                  mv.visitMaxs(0, 0);
-                  mv.visitEnd();
+        @Override
+        public void visitEnd() {
+          // Add a clone method that calls the protected shallow clone method in Object
+          //
+          // public Object clone() throws CloneNotSupportedException {
+          //    return super.clone(); // Object is the super class
+          // }
+          //
+          final MethodVisitor mv =
+              cv.visitMethod(
+                  Opcodes.ACC_PUBLIC,
+                  "clone",
+                  "()Ljava/lang/Object;",
+                  null,
+                  new String[] {"java/lang/CloneNotSupportedException"});
+          mv.visitCode();
+          mv.visitIntInsn(Opcodes.ALOAD, 0);
+          mv.visitMethodInsn(
+              Opcodes.INVOKESPECIAL, "java/lang/Object", "clone", "()Ljava/lang/Object;", false);
+          mv.visitInsn(Opcodes.ARETURN);
+          mv.visitMaxs(0, 0);
+          mv.visitEnd();
 
-                  cv.visitEnd();
-                }
-              };
-            }
-          });
+          cv.visitEnd();
+        }
+      };
     }
   }
 }

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RequestImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RequestImplInstrumentation.java
@@ -42,7 +42,7 @@ public class RequestImplInstrumentation extends Instrumenter.Tracing
 
   // This Transformer will add the Cloneable interface to RequestImpl, as well
   // as a clone method that calls the protected shallow clone method in Object
-  static class RequestImplVisitorWrapper implements AsmVisitorWrapper {
+  public static class RequestImplVisitorWrapper implements AsmVisitorWrapper {
     @Override
     public int mergeWriter(int flags) {
       return flags | ClassWriter.COMPUTE_MAXS;

--- a/internal-api/src/main/java/datadog/trace/api/iast/IastAdvice.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/IastAdvice.java
@@ -1,5 +1,5 @@
 package datadog.trace.api.iast;
 
 // Interface used to mark advice implementations using @CallSite so they are instrumented by the
-// IastInstrumenter
+// IastInstrumentation
 public interface IastAdvice {}


### PR DESCRIPTION
# What Does This Do

* Consistent naming of instrumentation classes
* Prefer string references to non-bootstrap types when describing advice and context-stores
* Remove more anonymous classes to avoid pinning the instrumentation class
* Lazily load call-site advices when the call-site instrumentation is applied

# Motivation

Preparation for unloading muzzle/instrumentation classes after they've been applied