### PR TITLE
Decouple muzzle matching

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentTransformerBuilder.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentTransformerBuilder.java
@@ -70,8 +70,7 @@ public class AgentTransformerBuilder
   }
 
   private AgentBuilder buildInstrumentation(final Instrumenter.Default instrumenter) {
-    InstrumenterState.registerInstrumentationNames(
-        instrumenter.instrumentationId(), instrumenter.names());
+    InstrumenterState.registerInstrumentation(instrumenter);
 
     ignoreMatcher = instrumenter.methodIgnoreMatcher();
     adviceBuilder =

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/MuzzleMatcher.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/MuzzleMatcher.java
@@ -1,19 +1,17 @@
 package datadog.trace.agent.tooling.bytebuddy.matcher;
 
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.agent.tooling.InstrumenterState;
+import datadog.trace.agent.tooling.muzzle.MuzzleCheck;
 import java.security.ProtectionDomain;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.utility.JavaModule;
 
 public final class MuzzleMatcher implements AgentBuilder.RawMatcher {
-  private final Instrumenter.Default instrumenter;
-  private final int instrumentationId;
+  private final MuzzleCheck muzzleCheck;
 
   public MuzzleMatcher(Instrumenter.Default instrumenter) {
-    this.instrumenter = instrumenter;
-    this.instrumentationId = instrumenter.instrumentationId();
+    this.muzzleCheck = new MuzzleCheck(instrumenter);
   }
 
   @Override
@@ -23,16 +21,6 @@ public final class MuzzleMatcher implements AgentBuilder.RawMatcher {
       JavaModule module,
       Class<?> classBeingRedefined,
       ProtectionDomain protectionDomain) {
-    Boolean applicable = InstrumenterState.isApplicable(classLoader, instrumentationId);
-    if (null != applicable) {
-      return applicable;
-    }
-    boolean muzzleMatches = instrumenter.muzzleMatches(classLoader, classBeingRedefined);
-    if (muzzleMatches) {
-      InstrumenterState.applyInstrumentation(classLoader, instrumentationId);
-    } else {
-      InstrumenterState.blockInstrumentation(classLoader, instrumentationId);
-    }
-    return muzzleMatches;
+    return muzzleCheck.allow(classLoader);
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -179,7 +179,8 @@ public interface Instrumenter {
       try {
         // Muzzle class contains static references captured at build-time
         // see datadog.trace.agent.tooling.muzzle.MuzzleGenerator
-        return (ReferenceMatcher) classLoader.loadClass(muzzleClass).getConstructor().newInstance();
+        return (ReferenceMatcher)
+            classLoader.loadClass(muzzleClass).getMethod("create").invoke(null);
       } catch (Throwable e) {
         log.warn("Failed to load - muzzle.class={}", muzzleClass, e);
         return ReferenceMatcher.NO_REFERENCES;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -168,64 +168,21 @@ public interface Instrumenter {
       }
     }
 
-    /** Matches classes for which instrumentation is not muzzled. */
-    public final boolean muzzleMatches(
-        final ClassLoader classLoader, final Class<?> classBeingRedefined) {
-      // Optimization: we delay calling getInstrumentationMuzzle() until we need the references
-      ReferenceMatcher muzzle = getInstrumentationMuzzle();
-      if (null != muzzle) {
-        final boolean isMatch = muzzle.matches(classLoader);
-        if (!isMatch) {
-          if (log.isDebugEnabled()) {
-            final List<Reference.Mismatch> mismatches =
-                muzzle.getMismatchedReferenceSources(classLoader);
-            log.debug(
-                "Muzzled - instrumentation.names=[{}] instrumentation.class={} instrumentation.target.classloader={}",
-                Strings.join(",", instrumentationNames),
-                getClass().getName(),
-                classLoader);
-            for (final Reference.Mismatch mismatch : mismatches) {
-              log.debug(
-                  "Muzzled mismatch - instrumentation.names=[{}] instrumentation.class={} instrumentation.target.classloader={} muzzle.mismatch=\"{}\"",
-                  Strings.join(",", instrumentationNames),
-                  getClass().getName(),
-                  classLoader,
-                  mismatch);
-            }
-          }
-        } else {
-          if (log.isDebugEnabled()) {
-            log.debug(
-                "Instrumentation applied - instrumentation.names=[{}] instrumentation.class={} instrumentation.target.classloader={} instrumentation.target.class={}",
-                Strings.join(",", instrumentationNames),
-                getClass().getName(),
-                classLoader,
-                classBeingRedefined == null ? "null" : classBeingRedefined.getName());
-          }
-        }
-        return isMatch;
-      }
-      return true;
+    public final ReferenceMatcher getInstrumentationMuzzle() {
+      return loadStaticMuzzleReferences(getClass().getClassLoader(), getClass().getName())
+          .withReferenceProvider(runtimeMuzzleReferences());
     }
 
-    public final ReferenceMatcher getInstrumentationMuzzle() {
-      String muzzleClassName = getClass().getName() + "$Muzzle";
+    public static ReferenceMatcher loadStaticMuzzleReferences(
+        ClassLoader classLoader, String instrumentationClass) {
+      String muzzleClass = instrumentationClass + "$Muzzle";
       try {
         // Muzzle class contains static references captured at build-time
         // see datadog.trace.agent.tooling.muzzle.MuzzleGenerator
-        ReferenceMatcher muzzle =
-            (ReferenceMatcher)
-                getClass()
-                    .getClassLoader()
-                    .loadClass(muzzleClassName)
-                    .getConstructor()
-                    .newInstance();
-        // mix in any additional references captured at runtime
-        muzzle.withReferenceProvider(runtimeMuzzleReferences());
-        return muzzle;
+        return (ReferenceMatcher) classLoader.loadClass(muzzleClass).getConstructor().newInstance();
       } catch (Throwable e) {
-        log.warn("Failed to load - muzzle.class={}", muzzleClassName, e);
-        return null;
+        log.warn("Failed to load - muzzle.class={}", muzzleClass, e);
+        return ReferenceMatcher.NO_REFERENCES;
       }
     }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleCheck.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleCheck.java
@@ -1,0 +1,67 @@
+package datadog.trace.agent.tooling.muzzle;
+
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterState;
+import datadog.trace.util.Strings;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MuzzleCheck {
+  private static final Logger log = LoggerFactory.getLogger(MuzzleCheck.class);
+
+  private final int instrumentationId;
+  private final String instrumentationClass;
+  private final ReferenceProvider runtimeMuzzleReferences;
+  private final Iterable<String> instrumentationNames;
+
+  private ReferenceMatcher muzzle;
+
+  public MuzzleCheck(Instrumenter.Default instrumenter) {
+    this.instrumentationId = instrumenter.instrumentationId();
+    this.instrumentationClass = instrumenter.getClass().getName();
+    this.runtimeMuzzleReferences = instrumenter.runtimeMuzzleReferences();
+    this.instrumentationNames = instrumenter.names();
+  }
+
+  public boolean allow(ClassLoader classLoader) {
+    Boolean applicable = InstrumenterState.isApplicable(classLoader, instrumentationId);
+    if (null != applicable) {
+      return applicable;
+    }
+    boolean muzzleMatches = muzzle().matches(classLoader);
+    if (muzzleMatches) {
+      InstrumenterState.applyInstrumentation(classLoader, instrumentationId);
+    } else {
+      InstrumenterState.blockInstrumentation(classLoader, instrumentationId);
+      if (log.isDebugEnabled()) {
+        final List<Reference.Mismatch> mismatches =
+            muzzle.getMismatchedReferenceSources(classLoader);
+        log.debug(
+            "Muzzled - instrumentation.names=[{}] instrumentation.class={} instrumentation.target.classloader={}",
+            Strings.join(",", instrumentationNames),
+            instrumentationClass,
+            classLoader);
+        for (final Reference.Mismatch mismatch : mismatches) {
+          log.debug(
+              "Muzzled mismatch - instrumentation.names=[{}] instrumentation.class={} instrumentation.target.classloader={} muzzle.mismatch=\"{}\"",
+              Strings.join(",", instrumentationNames),
+              instrumentationClass,
+              classLoader,
+              mismatch);
+        }
+      }
+    }
+    return muzzleMatches;
+  }
+
+  private ReferenceMatcher muzzle() {
+    if (null == muzzle) {
+      muzzle =
+          Instrumenter.Default.loadStaticMuzzleReferences(
+                  getClass().getClassLoader(), instrumentationClass)
+              .withReferenceProvider(runtimeMuzzleReferences);
+    }
+    return muzzle;
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGenerator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGenerator.java
@@ -125,14 +125,22 @@ public class MuzzleGenerator implements AsmVisitorWrapper {
         Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL,
         Type.getInternalName(instrumenter.getClass()) + "$Muzzle",
         null,
-        "datadog/trace/agent/tooling/muzzle/ReferenceMatcher",
+        "java/lang/Object",
         null);
 
-    MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
+    MethodVisitor mv =
+        cw.visitMethod(
+            Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC,
+            "create",
+            "()Ldatadog/trace/agent/tooling/muzzle/ReferenceMatcher;",
+            null,
+            null);
 
     mv.visitCode();
 
-    mv.visitIntInsn(Opcodes.ALOAD, 0);
+    mv.visitTypeInsn(Opcodes.NEW, "datadog/trace/agent/tooling/muzzle/ReferenceMatcher");
+    mv.visitInsn(Opcodes.DUP);
+
     mv.visitLdcInsn(references.size());
     mv.visitTypeInsn(Opcodes.ANEWARRAY, "datadog/trace/agent/tooling/muzzle/Reference");
 
@@ -151,7 +159,7 @@ public class MuzzleGenerator implements AsmVisitorWrapper {
         "([Ldatadog/trace/agent/tooling/muzzle/Reference;)V",
         false);
 
-    mv.visitInsn(Opcodes.RETURN);
+    mv.visitInsn(Opcodes.ARETURN);
 
     mv.visitMaxs(0, 0);
     mv.visitEnd();

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceMatcher.java
@@ -17,6 +17,8 @@ import net.bytebuddy.pool.TypePool;
 
 /** Matches a set of references against a classloader. */
 public class ReferenceMatcher {
+  public static final ReferenceMatcher NO_REFERENCES = new ReferenceMatcher();
+
   private final Reference[] references;
 
   private ReferenceProvider referenceProvider;
@@ -25,8 +27,11 @@ public class ReferenceMatcher {
     this.references = references;
   }
 
-  public void withReferenceProvider(ReferenceProvider referenceProvider) {
-    this.referenceProvider = referenceProvider;
+  public ReferenceMatcher withReferenceProvider(ReferenceProvider referenceProvider) {
+    if (this != NO_REFERENCES) {
+      this.referenceProvider = referenceProvider;
+    }
+    return this;
   }
 
   public Reference[] getReferences() {

--- a/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/muzzle/TestInstrumentationClasses.java
+++ b/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/muzzle/TestInstrumentationClasses.java
@@ -24,7 +24,11 @@ public abstract class TestInstrumentationClasses {
   }
 
   public static class EmptyInst extends BaseInst {
-    public static class Muzzle extends ReferenceMatcher {}
+    public static class Muzzle {
+      public static ReferenceMatcher create() {
+        return ReferenceMatcher.NO_REFERENCES;
+      }
+    }
   }
 
   public static class ValidHelperInst extends BaseInst {
@@ -35,7 +39,11 @@ public abstract class TestInstrumentationClasses {
       };
     }
 
-    public static class Muzzle extends ReferenceMatcher {}
+    public static class Muzzle {
+      public static ReferenceMatcher create() {
+        return ReferenceMatcher.NO_REFERENCES;
+      }
+    }
   }
 
   public static class InvalidOrderHelperInst extends BaseInst {
@@ -46,7 +54,11 @@ public abstract class TestInstrumentationClasses {
       };
     }
 
-    public static class Muzzle extends ReferenceMatcher {}
+    public static class Muzzle {
+      public static ReferenceMatcher create() {
+        return ReferenceMatcher.NO_REFERENCES;
+      }
+    }
   }
 
   public static class InvalidMissingHelperInst extends BaseInst {
@@ -57,13 +69,17 @@ public abstract class TestInstrumentationClasses {
       };
     }
 
-    public static class Muzzle extends ReferenceMatcher {}
+    public static class Muzzle {
+      public static ReferenceMatcher create() {
+        return ReferenceMatcher.NO_REFERENCES;
+      }
+    }
   }
 
   public static class BasicInst extends BaseInst {
-    public static class Muzzle extends ReferenceMatcher {
-      public Muzzle() {
-        super(SOME_ADVICE_REFS);
+    public static class Muzzle {
+      public static ReferenceMatcher create() {
+        return new ReferenceMatcher(SOME_ADVICE_REFS);
       }
     }
   }
@@ -79,9 +95,9 @@ public abstract class TestInstrumentationClasses {
       };
     }
 
-    public static class Muzzle extends ReferenceMatcher {
-      public Muzzle() {
-        super(SOME_ADVICE_REFS);
+    public static class Muzzle {
+      public static ReferenceMatcher create() {
+        return new ReferenceMatcher(SOME_ADVICE_REFS);
       }
     }
   }


### PR DESCRIPTION
# What Does This Do

Moves muzzle matching code to outside of `Instrumenter`.

Also changes the generated `Muzzle` classes to be static factories that create `ReferenceMatcher`s, rather than `ReferenceMatcher`s themselves. This will allow each `Muzzle` class to be unloaded once its `ReferenceMatcher` instance has been created.

# Motivation

Second step towards being able to unload muzzle/instrumentation classes after they've been applied
