### PR TITLE
Load instrumentation classes in separate classloader so they can be unloaded after use

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
@@ -3,6 +3,7 @@ package datadog.trace.bootstrap;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.ref.WeakReference;
 import java.net.URL;
 import java.security.CodeSource;
 import java.security.SecureClassLoader;
@@ -30,6 +31,9 @@ public final class DatadogClassLoader extends SecureClassLoader {
   private final CodeSource agentCodeSource;
   private final String agentResourcePrefix;
   private final AgentJarIndex agentJarIndex;
+
+  private WeakReference<InstrumentationClassLoader> instrumentationClassLoader =
+      new WeakReference<>(new InstrumentationClassLoader(this));
 
   public DatadogClassLoader(final URL agentJarURL, final ClassLoader parent) throws Exception {
     super(parent);
@@ -86,7 +90,28 @@ public final class DatadogClassLoader extends SecureClassLoader {
   }
 
   @Override
+  protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+    if (name.startsWith("datadog.trace.instrumentation.")
+        && (name.endsWith("$Muzzle") || name.endsWith("Instrumentation"))) {
+      InstrumentationClassLoader cl = instrumentationClassLoader.get();
+      if (null == cl) {
+        // previous instance was unloaded, create fresh one
+        cl = new InstrumentationClassLoader(this);
+        instrumentationClassLoader = new WeakReference<>(cl);
+      }
+      return cl.loadInstrumentationClass(name, agentCodeSource);
+    } else {
+      return super.loadClass(name, resolve);
+    }
+  }
+
+  @Override
   protected Class<?> findClass(String name) throws ClassNotFoundException {
+    byte[] buf = loadClassBytes(name);
+    return defineClass(name, buf, 0, buf.length, agentCodeSource);
+  }
+
+  byte[] loadClassBytes(String name) throws ClassNotFoundException {
     String entryName = agentJarIndex.classEntryName(name);
     if (null != entryName) {
       JarEntry jarEntry = agentJarFile.getJarEntry(entryName);
@@ -102,7 +127,7 @@ public final class DatadogClassLoader extends SecureClassLoader {
             bytesRead += delta;
           }
           if (bytesRead == buf.length) {
-            return defineClass(name, buf, 0, buf.length, agentCodeSource);
+            return buf;
           } else {
             log.warn("Malformed class data at {}", jarEntry);
           }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InstrumentationClassLoader.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InstrumentationClassLoader.java
@@ -1,0 +1,34 @@
+package datadog.trace.bootstrap;
+
+import java.security.CodeSource;
+import java.security.SecureClassLoader;
+
+/** Holds Muzzle and Instrumentation classes, so they can be unloaded separately to the agent. */
+final class InstrumentationClassLoader extends SecureClassLoader {
+  static {
+    ClassLoader.registerAsParallelCapable();
+  }
+
+  InstrumentationClassLoader(DatadogClassLoader parent) {
+    super(parent);
+  }
+
+  Class<?> loadInstrumentationClass(String name, CodeSource agentCodeSource)
+      throws ClassNotFoundException {
+    synchronized (getClassLoadingLock(name)) {
+      Class<?> instrumentationClass = findLoadedClass(name);
+      if (null != instrumentationClass) {
+        return instrumentationClass;
+      } else {
+        // load bytecode from dd-java-agent jar, but define the class locally
+        byte[] buf = ((DatadogClassLoader) getParent()).loadClassBytes(name);
+        return defineClass(name, buf, 0, buf.length, agentCodeSource);
+      }
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "instrumentation";
+  }
+}

--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/NativeImageGeneratorRunnerInstrumentation.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/NativeImageGeneratorRunnerInstrumentation.java
@@ -68,6 +68,7 @@ public final class NativeImageGeneratorRunnerInstrumentation
               + "datadog.trace.bootstrap.BootstrapProxy:build_time,"
               + "datadog.trace.bootstrap.CallDepthThreadLocalMap:build_time,"
               + "datadog.trace.bootstrap.DatadogClassLoader:build_time,"
+              + "datadog.trace.bootstrap.InstrumentationClassLoader:build_time,"
               + "datadog.trace.bootstrap.FieldBackedContextStores:build_time,"
               + "datadog.trace.bootstrap.instrumentation.java.concurrent.ConcurrentState:build_time,"
               + "datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter:build_time,"

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/InstrumenterUnloadTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/InstrumenterUnloadTest.groovy
@@ -1,0 +1,41 @@
+package datadog.trace.agent
+
+import datadog.trace.agent.test.IntegrationTestUtils
+import jvmbootstraptest.UnloadingChecker
+import spock.lang.Specification
+import spock.lang.Timeout
+
+@Timeout(30)
+class InstrumenterUnloadTest extends Specification {
+
+  private static final String DEFAULT_LOG_LEVEL = "debug"
+  private static final String API_KEY = "01234567890abcdef123456789ABCDEF"
+
+  // Run test using forked jvm
+  def "instrumenter and muzzle classes can be unloaded after use"() {
+    setup:
+    def testOutput = new ByteArrayOutputStream()
+
+    when:
+    int returnCode = IntegrationTestUtils.runOnSeparateJvm(UnloadingChecker.getName()
+      , [
+        "-verbose:class",
+        "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL"
+      ] as String[]
+      , "" as String[]
+      , ["DD_API_KEY": API_KEY]
+      , new PrintStream(testOutput))
+
+    int unloadCount = 0
+    new ByteArrayInputStream((testOutput.toByteArray())).eachLine {
+      System.out.println(it)
+      if (it =~ /(?i)unload.* datadog.trace.instrumentation./) {
+        unloadCount++
+      }
+    }
+
+    then:
+    returnCode == 0
+    unloadCount > 0
+  }
+}

--- a/dd-java-agent/src/test/java/jvmbootstraptest/UnloadingChecker.java
+++ b/dd-java-agent/src/test/java/jvmbootstraptest/UnloadingChecker.java
@@ -1,0 +1,13 @@
+package jvmbootstraptest;
+
+import datadog.trace.test.util.GCUtils;
+
+public class UnloadingChecker {
+  public static void main(final String[] args) {
+    try {
+      GCUtils.awaitGC();
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+}


### PR DESCRIPTION
# What Does This Do

Redirects class-loading requests for `...$Muzzle` and `...Instrumentation` classes to a separate class-loader, which is kept in a weak reference. Once the byte-buddy agent has been built these classes are no longer referenced and the `InstrumentationClassLoader` can be unloaded.

For a simple Spring-Web application this results in 400 tracer-related classes being unloaded by the time the application is ready to serve requests  - the majority are `..Instrumentation` classes.

# Motivation

This should reduce the memory (metaspace) overhead of the Java tracer over time.

# Additional Notes

Some instrumentations create instances of statically nested classes that are passed back to the byte-buddy agent installer, typically for custom transformations or custom muzzle checks. These nested classes will continue to be loaded in the main agent class-loader to avoid keeping `InstrumentationClassLoader` alive for the life of the byte-buddy agent.

Since `Instrumentation` classes will now be loaded in a different class-loader to the rest of the Java tracer, any nested classes (and constructors) used by the instrumentation class itself must be marked `public` so they remain accessible.

Lazy loading of `...$Muzzle` classes means additional instances of `InstrumentationClassLoader` may occasionally be created over the life of the application, but each once should eventually be unloaded (at which point a new instance may be created sometime later as/when further muzzle matching is required.)