### PR TITLE
Add configuration timeout for the WAF

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -79,6 +79,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_APPSEC_REPORTING_INBAND = false;
   static final int DEFAULT_APPSEC_TRACE_RATE_LIMIT = 100;
   static final boolean DEFAULT_APPSEC_WAF_METRICS = true;
+  static final int DEFAULT_APPSEC_WAF_TIMEOUT = 100000; // 0.1 s
 
   static final boolean DEFAULT_IAST_ENABLED = false;
   static final boolean DEFAULT_IAST_DEBUG_ENABLED = false;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/AppSecConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/AppSecConfig.java
@@ -10,6 +10,7 @@ public final class AppSecConfig {
   public static final String APPSEC_IP_ADDR_HEADER = "appsec.ipheader";
   public static final String APPSEC_TRACE_RATE_LIMIT = "appsec.trace.rate.limit";
   public static final String APPSEC_WAF_METRICS = "appsec.waf.metrics";
+  public static final String APPSEC_WAF_TIMEOUT = "appsec.waf.timeout";
   public static final String APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP =
       "appsec.obfuscation.parameter_key_regexp";
   public static final String APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP =

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -7,6 +7,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_ANALYTICS_SAMPLE_RATE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_REPORTING_INBAND;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_TRACE_RATE_LIMIT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_WAF_METRICS;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_WAF_TIMEOUT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CIVISIBILITY_AGENTLESS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CLIENT_IP_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CLOCK_SYNC_PERIOD;
@@ -92,6 +93,7 @@ import static datadog.trace.api.config.AppSecConfig.APPSEC_REPORT_TIMEOUT_SEC;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_RULES_FILE;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_TRACE_RATE_LIMIT;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_WAF_METRICS;
+import static datadog.trace.api.config.AppSecConfig.APPSEC_WAF_TIMEOUT;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_AGENTLESS_ENABLED;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_AGENTLESS_URL;
 import static datadog.trace.api.config.CrashTrackingConfig.CRASH_TRACKING_AGENTLESS;
@@ -496,6 +498,7 @@ public class Config {
   private final int appSecReportMaxTimeout;
   private final int appSecTraceRateLimit;
   private final boolean appSecWafMetrics;
+  private final int appSecWafTimeout;
   private final String appSecObfuscationParameterKeyRegexp;
   private final String appSecObfuscationParameterValueRegexp;
   private final String appSecHttpBlockedTemplateHtml;
@@ -1062,6 +1065,8 @@ public class Config {
         configProvider.getInteger(APPSEC_TRACE_RATE_LIMIT, DEFAULT_APPSEC_TRACE_RATE_LIMIT);
 
     appSecWafMetrics = configProvider.getBoolean(APPSEC_WAF_METRICS, DEFAULT_APPSEC_WAF_METRICS);
+
+    appSecWafTimeout = configProvider.getInteger(APPSEC_WAF_TIMEOUT, DEFAULT_APPSEC_WAF_TIMEOUT);
 
     appSecObfuscationParameterKeyRegexp =
         configProvider.getString(APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP, null);
@@ -1761,6 +1766,11 @@ public class Config {
 
   public boolean isAppSecWafMetrics() {
     return appSecWafMetrics;
+  }
+
+  // in microseconds
+  public int getAppSecWafTimeout() {
+    return appSecWafTimeout;
   }
 
   public String getAppSecObfuscationParameterKeyRegexp() {
@@ -2980,7 +2990,9 @@ public class Config {
         + "'"
         + ", appSecHttpBlockedTemplateHtml="
         + appSecHttpBlockedTemplateHtml
-        + ", appSecHttpBlockedTemplateJson="
+        + ", appSecWafTimeout="
+        + appSecWafTimeout
+        + " us, appSecHttpBlockedTemplateJson="
         + appSecHttpBlockedTemplateJson
         + ", cwsEnabled="
         + cwsEnabled


### PR DESCRIPTION
Allows configuring the max time any single run of the WAF can take. This also changes the default from an effectively infinite value down to 100 ms (defined in microseconds).

* Envronment variable: `DD_APPSEC_WAF_TIMEOUT`
* System property: `dd.appsec.waf.timeout`