### PR TITLE
Turn off remote-config during field-injection / log-injection smoke tests

### DIFF
--- a/dd-smoke-tests/field-injection/src/test/groovy/datadog/smoketest/FieldInjectionSmokeTest.groovy
+++ b/dd-smoke-tests/field-injection/src/test/groovy/datadog/smoketest/FieldInjectionSmokeTest.groovy
@@ -57,7 +57,10 @@ class FieldInjectionSmokeTest extends Specification {
     command.add("${getMinMemoryArgumentForFork()}" as String)
     command.add("-javaagent:${shadowJarPath}" as String)
     command.add("-XX:ErrorFile=/tmp/hs_err_pid%p.log")
+    // turn off these features as their debug output can break up our expected logging lines on IBM JVMs
+    // causing random test failures (we are not testing these features here so they don't need to be on)
     command.add("-Ddd.instrumentation.telemetry.enabled=false")
+    command.add("-Ddd.remote_config.enabled=false")
     command.add("-Ddd.writer.type=TraceStructureWriter")
     command.add("-Ddd.trace.debug=true")
     command.add("-jar")

--- a/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
+++ b/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
@@ -49,7 +49,10 @@ abstract class LogInjectionSmokeTest extends AbstractSmokeTest {
     List<String> command = new ArrayList<>()
     command.add(javaPath())
     command.addAll(defaultJavaProperties)
+    // turn off these features as their debug output can break up our expected logging lines on IBM JVMs
+    // causing random test failures (we are not testing these features here so they don't need to be on)
     command.add("-Ddd.instrumentation.telemetry.enabled=false")
+    command.add("-Ddd.remote_config.enabled=false")
     command.add("-Ddd.test.logfile=${outputLogFile.absolutePath}" as String)
     command.add("-Ddd.test.jsonlogfile=${outputJsonLogFile.absolutePath}" as String)
     if (noTags) {


### PR DESCRIPTION
as its debug output can interfere with the smoke test's log-file scraping, causing intermittent failures on CI