### PR TITLE
(rcm) fix configuration path parsing

### DIFF
--- a/remote-config/src/main/java/datadog/remoteconfig/state/ParsedConfigKey.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/state/ParsedConfigKey.java
@@ -10,7 +10,7 @@ import java.util.regex.Pattern;
 public class ParsedConfigKey {
 
   private static final Pattern EXTRACT_PRODUCT_REGEX =
-      Pattern.compile("([^/]+)(/\\d+)?/([^/]+)/([^/]+)/config");
+      Pattern.compile("([^/]+)(/\\d+)?/([^/]+)/([^/]+)/[^/]+");
 
   private final String orginalKey;
   private final String org;

--- a/remote-config/src/test/groovy/datadog/remoteconfig/state/ParsedConfigKeyTests.groovy
+++ b/remote-config/src/test/groovy/datadog/remoteconfig/state/ParsedConfigKeyTests.groovy
@@ -21,9 +21,9 @@ class ParsedConfigKeyTests extends Specification {
 
     "employee/ASM_DD/1.recommended.json/config" | "employee" | null| Product.ASM_DD | "1.recommended.json"
 
-    "datadog/2/LIVE_DEBUGGING/Snapshot_1ba66cc9-146a-3479-9e66-2b63fd580f48/config" | "datadog" | 2 | Product.LIVE_DEBUGGING | "Snapshot_1ba66cc9-146a-3479-9e66-2b63fd580f48"
+    "datadog/2/LIVE_DEBUGGING/Snapshot_1ba66cc9-146a-3479-9e66-2b63fd580f48/dog" | "datadog" | 2 | Product.LIVE_DEBUGGING | "Snapshot_1ba66cc9-146a-3479-9e66-2b63fd580f48"
 
-    "datadog/2/NOT_REAL_PRODUCT/123/config" | "datadog" | 2 | Product._UNKNOWN | "123"
+    "datadog/2/NOT_REAL_PRODUCT/123/dogoz" | "datadog" | 2 | Product._UNKNOWN | "123"
   }
 
   void 'wrong format configKey fails'() {


### PR DESCRIPTION
# What Does This Do

The Java tracer incorrectly parses the configuration path as it checks it ends with `/config`. This suffix is not guaranteed and should be ignored by the tracer.

Example from .NET: https://github.com/DataDog/dd-trace-dotnet/blob/8c965716755179efa64fbef4543251c0dc100e8d/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationPath.cs#L13.

# Additional Notes

System tests are on the way to test this behavior.