### PR TITLE
Implement CODEOWNERS parsing and matching

### DIFF
--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/Codeowners.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/Codeowners.java
@@ -1,0 +1,64 @@
+package datadog.trace.bootstrap.instrumentation.ci.codeowners;
+
+import datadog.trace.bootstrap.instrumentation.ci.codeowners.matcher.CharacterMatcher;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+
+/**
+ * @see <a
+ *     href="https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners">CODEOWNERS
+ *     file description</a>
+ */
+public class Codeowners {
+
+  private final String repoRoot;
+  private final Iterable<Entry> entries;
+
+  private Codeowners(String repoRoot, Iterable<Entry> entries) {
+    this.repoRoot = repoRoot + (repoRoot.endsWith("/") ? "" : "/");
+    this.entries = entries;
+  }
+
+  /**
+   * @param path <b>Absolute</b> path to a file/folder inside the repository
+   * @return the list of teams/people who own the provided path
+   */
+  public Collection<String> getOwners(String path) {
+    if (!path.startsWith(repoRoot)) {
+      return Collections.emptyList();
+    }
+
+    char[] relativePath = new char[path.length() - repoRoot.length()];
+    path.getChars(repoRoot.length(), path.length(), relativePath, 0);
+
+    for (Entry entry : entries) {
+      if (entry.getMatcher().consume(relativePath, 0) >= 0) {
+        return entry.getOwners();
+      }
+    }
+    return Collections.emptyList();
+  }
+
+  public static Codeowners parse(String repoRoot, Reader r) throws IOException {
+    Deque<Entry> entries = new ArrayDeque<>();
+
+    CharacterMatcher.Factory characterMatcherFactory = new CharacterMatcher.Factory();
+    BufferedReader br = new BufferedReader(r);
+    String s;
+    while ((s = br.readLine()) != null) {
+      EntryBuilder entryBuilder = new EntryBuilder(characterMatcherFactory, s);
+      Entry entry = entryBuilder.parse();
+      if (entry != null) {
+        // place last parsed entry in the beginning of the list, since it has the highest priority
+        entries.offerFirst(entry);
+      }
+    }
+
+    return new Codeowners(repoRoot, entries);
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/Entry.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/Entry.java
@@ -1,0 +1,23 @@
+package datadog.trace.bootstrap.instrumentation.ci.codeowners;
+
+import datadog.trace.bootstrap.instrumentation.ci.codeowners.matcher.Matcher;
+import java.util.Collection;
+
+public class Entry {
+
+  private final Matcher matcher;
+  private final Collection<String> owners;
+
+  public Entry(Matcher matcher, Collection<String> owners) {
+    this.matcher = matcher;
+    this.owners = owners;
+  }
+
+  public Matcher getMatcher() {
+    return matcher;
+  }
+
+  public Collection<String> getOwners() {
+    return owners;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/EntryBuilder.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/EntryBuilder.java
@@ -1,0 +1,221 @@
+package datadog.trace.bootstrap.instrumentation.ci.codeowners;
+
+import datadog.trace.bootstrap.instrumentation.ci.codeowners.matcher.AsteriskMatcher;
+import datadog.trace.bootstrap.instrumentation.ci.codeowners.matcher.CharacterMatcher;
+import datadog.trace.bootstrap.instrumentation.ci.codeowners.matcher.CompositeMatcher;
+import datadog.trace.bootstrap.instrumentation.ci.codeowners.matcher.DoubleAsteriskMatcher;
+import datadog.trace.bootstrap.instrumentation.ci.codeowners.matcher.EndOfLineMatcher;
+import datadog.trace.bootstrap.instrumentation.ci.codeowners.matcher.EndOfSegmentMatcher;
+import datadog.trace.bootstrap.instrumentation.ci.codeowners.matcher.Matcher;
+import datadog.trace.bootstrap.instrumentation.ci.codeowners.matcher.NegatingMatcher;
+import datadog.trace.bootstrap.instrumentation.ci.codeowners.matcher.QuestionMarkMatcher;
+import datadog.trace.bootstrap.instrumentation.ci.codeowners.matcher.RangeMatcher;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Deque;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A builder for parsing CODEOWNERS file entries. A parsed entry contains two main components:
+ *
+ * <ul>
+ *   <li>a matcher that can be used to test if the entry applies to a file/directory
+ *   <li>a list of teams/people who own the matched files
+ * </ul>
+ *
+ * @see <a href="https://git-scm.com/docs/gitignore#_pattern_format">.gitignore pattern format</a>
+ * @see <a
+ *     href="https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners">CODEOWNERS
+ *     file description</a>
+ */
+public class EntryBuilder {
+
+  private static final Logger log = LoggerFactory.getLogger(EntryBuilder.class);
+
+  private final CharacterMatcher.Factory characterMatcherFactory;
+  private final char[] c;
+  private int offset;
+
+  public EntryBuilder(CharacterMatcher.Factory characterMatcherFactory, String s) {
+    this.characterMatcherFactory = characterMatcherFactory;
+    c = s.toCharArray();
+  }
+
+  public @Nullable Entry parse() {
+    try {
+      if (c.length == 0 || c[0] == '#') {
+        return null;
+      }
+
+      Matcher matcher = parseMatcher();
+      Collection<String> owners = parseOwners();
+      return new Entry(matcher, owners);
+
+    } catch (Exception e) {
+      log.error("error parsing CODEOWNERS pattern: {}", Arrays.toString(c), e);
+      return null;
+    }
+  }
+
+  private Matcher parseMatcher() {
+    if (c[offset] == '!') {
+      offset++;
+      return new NegatingMatcher(parseMatcher());
+    }
+
+    boolean patternContainsSlashes = false;
+    if (c[offset] == '/') {
+      // opening slash gets special treatment
+      offset++;
+      patternContainsSlashes = true;
+    }
+
+    Deque<Matcher> characterMatchers = new ArrayDeque<>();
+    for (; offset < c.length; offset++) {
+      if (isPatternTerminator(c[offset])) {
+        break;
+
+      } else if (consumeDoubleAsterisk()) {
+        characterMatchers.offerLast(DoubleAsteriskMatcher.INSTANCE);
+        patternContainsSlashes = true;
+
+      } else if (c[offset] == '/') {
+        // closing slash gets special treatment
+        if (offset + 1 < c.length && !isPatternTerminator(c[offset + 1])) {
+          characterMatchers.offerLast(characterMatcherFactory.create('/'));
+          patternContainsSlashes = true;
+        }
+
+      } else if (c[offset] == '*') {
+        characterMatchers.offerLast(AsteriskMatcher.INSTANCE);
+
+      } else if (c[offset] == '?') {
+        characterMatchers.offerLast(QuestionMarkMatcher.INSTANCE);
+
+      } else if (c[offset] == '[') {
+        characterMatchers.offerLast(parseRangeCharacterMatcher());
+
+      } else if (c[offset] == '\\') {
+        characterMatchers.offerLast(characterMatcherFactory.create(c[++offset]));
+
+      } else {
+        characterMatchers.offerLast(characterMatcherFactory.create(c[offset]));
+      }
+    }
+
+    if (characterMatchers.isEmpty()) {
+      throw new IllegalArgumentException("No matchers found");
+    }
+
+    boolean patternEndsWithSlash = c[offset - 1] == '/';
+    if (!patternEndsWithSlash) { // pattern should match the end of the string
+      if (c[offset - 1] == '*') {
+        characterMatchers.offerLast(EndOfLineMatcher.INSTANCE);
+      } else {
+        characterMatchers.offerLast(EndOfSegmentMatcher.INSTANCE);
+      }
+    }
+
+    if (!patternContainsSlashes) {
+      // pattern does not have to match the beginning of the string
+      characterMatchers.offerFirst(DoubleAsteriskMatcher.INSTANCE);
+    }
+
+    return new CompositeMatcher(characterMatchers.toArray(new Matcher[0]));
+  }
+
+  private boolean consumeDoubleAsterisk() {
+    int position = offset;
+
+    if (c[offset] == '/') {
+      // consuming first '/'
+      position++;
+    } else if (position > 0 && c[position - 1] != '!') {
+      // pattern does not start with a '/', valid alternatives are beginning of the string or '!'
+      return false;
+    }
+
+    if (position == c.length || c[position++] != '*') {
+      // failed to consume first '*'
+      return false;
+    }
+    if (position == c.length || c[position++] != '*') {
+      // failed to consume second '*'
+      return false;
+    }
+
+    if (position == c.length || isPatternTerminator(c[position])) {
+      // there is no last '/', releasing last character
+      offset = position - 1;
+      return true;
+
+    } else if (c[position] == '/') {
+      // consuming last '/'
+      offset = position;
+      return true;
+
+    } else {
+      return false;
+    }
+  }
+
+  private boolean isPatternTerminator(char c) {
+    return c == '#' || Character.isWhitespace(c);
+  }
+
+  private Matcher parseRangeCharacterMatcher() {
+    offset++; // consume opening '['
+
+    Collection<RangeMatcher.Range> ranges = new ArrayList<>();
+    for (; offset < c.length; offset++) {
+      if (c[offset] == ']') {
+        if (!ranges.isEmpty()) {
+          return new RangeMatcher(ranges.toArray(new RangeMatcher.Range[0]));
+        } else {
+          throw new IllegalArgumentException("Empty character range");
+        }
+
+      } else {
+        ranges.add(parseRange());
+      }
+    }
+    throw new IllegalArgumentException("Unterminated character range");
+  }
+
+  private RangeMatcher.Range parseRange() {
+    if (offset + 2 >= c.length) {
+      throw new IllegalArgumentException("Unterminated character range");
+    }
+    if (c[offset + 1] != '-') {
+      throw new IllegalArgumentException("Malformed character range");
+    }
+    offset += 2;
+    return new RangeMatcher.Range(c[offset - 2], c[offset]);
+  }
+
+  private Collection<String> parseOwners() {
+    Collection<String> owners = new ArrayList<>();
+    for (; offset < c.length; offset++) {
+      // skip whitespace until the next token
+      while (offset < c.length && Character.isWhitespace(c[offset])) {
+        offset++;
+      }
+
+      if (offset == c.length || c[offset] == '#') {
+        break; // anything that goes after # is a comment, stop parsing
+      }
+
+      int ownerIdx = offset;
+      while (ownerIdx < c.length && !isPatternTerminator(c[ownerIdx])) {
+        ownerIdx++;
+      }
+      owners.add(new String(c, offset, ownerIdx - offset));
+      offset = ownerIdx;
+    }
+    return owners;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/matcher/AsteriskMatcher.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/matcher/AsteriskMatcher.java
@@ -1,0 +1,18 @@
+package datadog.trace.bootstrap.instrumentation.ci.codeowners.matcher;
+
+public class AsteriskMatcher implements Matcher {
+
+  public static final Matcher INSTANCE = new AsteriskMatcher();
+
+  private AsteriskMatcher() {}
+
+  @Override
+  public int consume(char[] line, int offset) {
+    return offset < line.length && line[offset] != '/' ? 1 : -1;
+  }
+
+  @Override
+  public boolean multi() {
+    return true;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/matcher/CharacterMatcher.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/matcher/CharacterMatcher.java
@@ -1,0 +1,31 @@
+package datadog.trace.bootstrap.instrumentation.ci.codeowners.matcher;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CharacterMatcher implements Matcher {
+
+  private final char character;
+
+  private CharacterMatcher(char character) {
+    this.character = character;
+  }
+
+  @Override
+  public int consume(char[] line, int offset) {
+    return offset < line.length && line[offset] == character ? 1 : -1;
+  }
+
+  @Override
+  public boolean multi() {
+    return false;
+  }
+
+  public static final class Factory {
+    private final Map<Character, CharacterMatcher> canonical = new HashMap<>();
+
+    public Matcher create(char c) {
+      return canonical.computeIfAbsent(c, CharacterMatcher::new);
+    }
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/matcher/CompositeMatcher.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/matcher/CompositeMatcher.java
@@ -1,0 +1,45 @@
+package datadog.trace.bootstrap.instrumentation.ci.codeowners.matcher;
+
+public class CompositeMatcher implements Matcher {
+
+  private final Matcher[] delegates;
+
+  public CompositeMatcher(Matcher[] delegates) {
+    this.delegates = delegates;
+  }
+
+  @Override
+  public int consume(char[] line, int offset) {
+    return consume(line, offset, 0);
+  }
+
+  private int consume(char[] line, int offset, int matcherOffset) {
+    int position = offset;
+    while (matcherOffset < delegates.length) {
+      Matcher delegate = delegates[matcherOffset];
+      if (delegate.multi()) {
+        int consumed = consume(line, position, matcherOffset + 1);
+        if (consumed >= 0) {
+          return position - offset + consumed;
+        }
+      }
+
+      int consumed = delegate.consume(line, position);
+      if (consumed < 0) {
+        return consumed;
+      } else {
+        position += consumed;
+      }
+
+      if (!delegate.multi()) {
+        matcherOffset++;
+      }
+    }
+    return position - offset;
+  }
+
+  @Override
+  public boolean multi() {
+    return false;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/matcher/DoubleAsteriskMatcher.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/matcher/DoubleAsteriskMatcher.java
@@ -1,0 +1,24 @@
+package datadog.trace.bootstrap.instrumentation.ci.codeowners.matcher;
+
+public class DoubleAsteriskMatcher implements Matcher {
+
+  public static final Matcher INSTANCE = new DoubleAsteriskMatcher();
+
+  private DoubleAsteriskMatcher() {}
+
+  @Override
+  public int consume(char[] line, int offset) {
+    if (offset == line.length) {
+      return -1;
+    }
+
+    int position = offset;
+    while (position < line.length && line[position++] != '/') {}
+    return position - offset;
+  }
+
+  @Override
+  public boolean multi() {
+    return true;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/matcher/EndOfLineMatcher.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/matcher/EndOfLineMatcher.java
@@ -1,0 +1,16 @@
+package datadog.trace.bootstrap.instrumentation.ci.codeowners.matcher;
+
+public class EndOfLineMatcher implements Matcher {
+
+  public static final Matcher INSTANCE = new EndOfLineMatcher();
+
+  @Override
+  public int consume(char[] line, int offset) {
+    return offset == line.length ? 0 : -1;
+  }
+
+  @Override
+  public boolean multi() {
+    return false;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/matcher/EndOfSegmentMatcher.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/matcher/EndOfSegmentMatcher.java
@@ -1,0 +1,16 @@
+package datadog.trace.bootstrap.instrumentation.ci.codeowners.matcher;
+
+public class EndOfSegmentMatcher implements Matcher {
+
+  public static final Matcher INSTANCE = new EndOfSegmentMatcher();
+
+  @Override
+  public int consume(char[] line, int offset) {
+    return offset == line.length || line[offset] == '/' ? 0 : -1;
+  }
+
+  @Override
+  public boolean multi() {
+    return false;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/matcher/Matcher.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/matcher/Matcher.java
@@ -1,0 +1,16 @@
+package datadog.trace.bootstrap.instrumentation.ci.codeowners.matcher;
+
+public interface Matcher {
+
+  /**
+   * @return the number of characters matched from the line starting with the offset. Negative value
+   *     means matching failed
+   */
+  int consume(char[] line, int offset);
+
+  /**
+   * @return {@code true} if this matcher can be used [0..*] times. {@code false} if the matcher
+   *     should be used exactly once
+   */
+  boolean multi();
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/matcher/NegatingMatcher.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/matcher/NegatingMatcher.java
@@ -1,0 +1,20 @@
+package datadog.trace.bootstrap.instrumentation.ci.codeowners.matcher;
+
+public class NegatingMatcher implements Matcher {
+
+  private final Matcher delegate;
+
+  public NegatingMatcher(Matcher delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public int consume(char[] line, int offset) {
+    return -delegate.consume(line, offset) - 1;
+  }
+
+  @Override
+  public boolean multi() {
+    return false;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/matcher/QuestionMarkMatcher.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/matcher/QuestionMarkMatcher.java
@@ -1,0 +1,18 @@
+package datadog.trace.bootstrap.instrumentation.ci.codeowners.matcher;
+
+public class QuestionMarkMatcher implements Matcher {
+
+  public static final Matcher INSTANCE = new QuestionMarkMatcher();
+
+  private QuestionMarkMatcher() {}
+
+  @Override
+  public int consume(char[] line, int offset) {
+    return offset < line.length && line[offset] != '/' ? 1 : -1;
+  }
+
+  @Override
+  public boolean multi() {
+    return false;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/matcher/RangeMatcher.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/ci/codeowners/matcher/RangeMatcher.java
@@ -1,0 +1,44 @@
+package datadog.trace.bootstrap.instrumentation.ci.codeowners.matcher;
+
+public class RangeMatcher implements Matcher {
+
+  public static final class Range {
+    private final char from;
+    private final char to;
+
+    public Range(char from, char to) {
+      if (to < from) {
+        throw new IllegalArgumentException("Range is invalid: [" + from + "-" + to + "]");
+      }
+      this.from = from;
+      this.to = to;
+    }
+
+    boolean matches(char c) {
+      return c >= from && c <= to;
+    }
+  }
+
+  private final Range[] ranges;
+
+  public RangeMatcher(Range... ranges) {
+    this.ranges = ranges;
+  }
+
+  @Override
+  public int consume(char[] line, int offset) {
+    if (offset < line.length) {
+      for (Range range : ranges) {
+        if (range.matches(line[offset])) {
+          return 1;
+        }
+      }
+    }
+    return -1;
+  }
+
+  @Override
+  public boolean multi() {
+    return false;
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/ci/codeowners/CodeownersTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/ci/codeowners/CodeownersTest.groovy
@@ -1,0 +1,44 @@
+package datadog.trace.bootstrap.instrumentation.ci.codeowners
+
+import com.google.common.base.Charsets
+import spock.lang.Specification
+
+class CodeownersTest extends Specification {
+
+  def "test codeowners matching: #path"() {
+    setup:
+    def codeowners = new InputStreamReader(CodeownersTest.getClassLoader().getResourceAsStream("ci/codeowners/CODEOWNERS"), Charsets.UTF_8).withCloseable { reader ->
+      Codeowners.parse("/repo/root", reader)
+    }
+
+    when:
+    def owners = codeowners.getOwners(path)
+
+    then:
+    owners == expectedOwners
+
+    where:
+    path                                               | expectedOwners
+    "/outside/MyClass.java"                            | []
+    "/repo/root/MyClass.java"                          | ["@global-owner1", "@global-owner2"]
+    "/repo/root/folder/MyClass.java"                   | ["@global-owner1", "@global-owner2"]
+    "/repo/root/script.js"                             | ["@js-owner"]
+    "/repo/root/inner/folder/script.js"                | ["@js-owner"]
+    "/repo/root/scripts/script.js"                     | ["@doctocat", "@octocat"]
+    "/repo/root/scripts/inner/script.js"               | ["@doctocat", "@octocat"]
+    "/repo/root/build/logs/current.log"                | ["@doctocat"]
+    "/repo/root/build/logs/inner/current.log"          | ["@doctocat"]
+    "/repo/root/module/build/logs/current.log"         | ["@global-owner1", "@global-owner2"]
+    "/repo/root/apps/app1.exe"                         | ["@octocat"]
+    "/repo/root/apps/inner/app2.exe"                   | ["@octocat"]
+    "/repo/root/module/apps/app3.exe"                  | ["@octocat"]
+    "/repo/root/docs/intro.doc"                        | ["@doctocat"]
+    "/repo/root/docs/important/doc.doc"                | ["@doctocat"]
+    "/repo/root/applications/application"              | ["@appowner"]
+    "/repo/root/applications/module/application"       | ["@appowner"]
+    "/repo/root/applications/github/githubApplication" | []
+    "/repo/root/documentation/doc.md"                  | ["docs@example.com"]
+    "/repo/root/documentation/inner/doc.md"            | ["@global-owner1", "@global-owner2"]
+    "/repo/root/documentation/inner/doc.txt"           | ["@octo-org/octocats"]
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/ci/codeowners/EntryBuilderTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/ci/codeowners/EntryBuilderTest.groovy
@@ -117,6 +117,10 @@ class EntryBuilderTest extends Specification {
     "*"                   | ["owner"]                 | "parent/someToken"                              | true
     "*"                   | ["owner"]                 | "parent/someToken/child"                        | true
     "*"                   | ["owner"]                 | "someFile.java"                                 | true
+    "**"                  | ["owner"]                 | "someToken"                                     | true
+    "**"                  | ["owner"]                 | "parent/someToken"                              | true
+    "**"                  | ["owner"]                 | "parent/someToken/child"                        | true
+    "**"                  | ["owner"]                 | "someFile.java"                                 | true
     "*.java"              | ["owner"]                 | "someFile.java"                                 | true
     "*.java"              | ["owner"]                 | "parent/someFile.java"                          | true
     "*.java"              | ["owner"]                 | "grandparent/parent/someFile.java"              | true

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/ci/codeowners/EntryBuilderTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/ci/codeowners/EntryBuilderTest.groovy
@@ -1,0 +1,149 @@
+package datadog.trace.bootstrap.instrumentation.ci.codeowners
+
+import datadog.trace.bootstrap.instrumentation.ci.codeowners.matcher.CharacterMatcher
+import spock.lang.Specification
+
+class EntryBuilderTest extends Specification {
+
+  def "test entry #pattern match against #path is #expectedResult"() {
+    setup:
+    def matcherFactory = new CharacterMatcher.Factory()
+    def entry = new EntryBuilder(matcherFactory, pattern + " " + ownersToString(owners)).parse()
+    def negatedEntry = new EntryBuilder(matcherFactory, "!" + pattern + " " + ownersToString(owners)).parse()
+
+    when:
+    def result = entry.matcher.consume(path.toCharArray(), 0) >= 0
+    def negatedResult = negatedEntry.matcher.consume(path.toCharArray(), 0) >= 0
+
+    then:
+    entry.owners == owners
+    result == expectedResult
+    negatedResult == !expectedResult
+
+    where:
+    pattern               | owners                    | path                                            | expectedResult
+    "someToken"           | ["owner"]                 | "someToken"                                     | true
+    "someToken"           | ["owner"]                 | "sometoken"                                     | false
+    "someToken"           | ["owner"]                 | "anotherToken"                                  | false
+    "someToken"           | ["owner"]                 | "parent/someToken"                              | true
+    "someToken"           | ["owner"]                 | "grandparent/parent/someToken"                  | true
+    "/someToken"          | ["owner"]                 | "someToken"                                     | true
+    "/someToken"          | ["owner"]                 | "sometoken"                                     | false
+    "/someToken"          | ["owner"]                 | "anotherToken"                                  | false
+    "/someToken"          | ["owner"]                 | "parent/someToken"                              | false
+    "/someToken"          | ["owner"]                 | "grandparent/parent/someToken"                  | false
+    "someTok?n"           | ["owner"]                 | "someTokkn"                                     | true
+    "someTok?n"           | ["owner"]                 | "someTok/n"                                     | false
+    "someTok?n"           | ["owner"]                 | "parent/someTokkn"                              | true
+    "someTok?n"           | ["owner"]                 | "grandparent/parent/someTokkn"                  | true
+    "/someTok?n"          | ["owner"]                 | "someTokkn"                                     | true
+    "someTok*n"           | ["owner"]                 | "someTokkn"                                     | true
+    "someTok*n"           | ["owner"]                 | "someTok/n"                                     | false
+    "someTok*n"           | ["owner"]                 | "someTokkkkn"                                   | true
+    "someTok*n"           | ["owner"]                 | "someTokenToken"                                | true
+    "someTok*n"           | ["owner"]                 | "someTokenTokkk"                                | false
+    "s*meTok*n"           | ["owner"]                 | "someToken"                                     | true
+    "s*meTok*n"           | ["owner"]                 | "sabcdefghmeTokabcdefgn"                        | true
+    "s*meTok*n"           | ["owner"]                 | "sabcdefghmeTokabcdefg"                         | false
+    "someTok*n"           | ["owner"]                 | "parent/someTokkn"                              | true
+    "someTok*n"           | ["owner"]                 | "grandparent/parent/someTokkn"                  | true
+    "/someTok*n"          | ["owner"]                 | "someTokkn"                                     | true
+    "someTok[a-z]n"       | ["owner"]                 | "someToken"                                     | true
+    "someTok[a-z]n"       | ["owner"]                 | "someTokEn"                                     | false
+    "someTok[a-z]n"       | ["owner"]                 | "someTok9n"                                     | false
+    "someTok[a-zA-Z]n"    | ["owner"]                 | "someToken"                                     | true
+    "someTok[a-zA-Z]n"    | ["owner"]                 | "someTokEn"                                     | true
+    "someTok[a-zA-Z]n"    | ["owner"]                 | "someTok9n"                                     | false
+    "someTok[a-zA-Z0-9]n" | ["owner"]                 | "someToken"                                     | true
+    "someTok[a-zA-Z0-9]n" | ["owner"]                 | "someTokEn"                                     | true
+    "someTok[a-zA-Z0-9]n" | ["owner"]                 | "someTok9n"                                     | true
+    "s*meTok[a-zA-Z0-9]n" | ["owner"]                 | "smeToken"                                      | true
+    "s*meTok[a-zA-Z0-9]n" | ["owner"]                 | "smeTokEn"                                      | true
+    "s*meTok[a-zA-Z0-9]n" | ["owner"]                 | "smeTok9n"                                      | true
+    "s*meTok[a-zA-Z0-9]n" | ["owner"]                 | "sabcdmeToken"                                  | true
+    "s*meTok[a-zA-Z0-9]n" | ["owner"]                 | "sabcdmeTokEn"                                  | true
+    "s*meTok[a-zA-Z0-9]n" | ["owner"]                 | "sabcdmeTok9n"                                  | true
+    "someToken/"          | ["owner"]                 | "someToken"                                     | true
+    "someToken/"          | ["owner"]                 | "someToken/child"                               | true
+    "someToken/"          | ["owner"]                 | "someToken/child/grandChild"                    | true
+    "someToken/"          | ["owner"]                 | "parent/someToken"                              | true
+    "someToken/"          | ["owner"]                 | "parent/someToken/child"                        | true
+    "someToken/"          | ["owner"]                 | "parent/grandParent/someToken/child/grandChild" | true
+    "/someToken/"         | ["owner"]                 | "someToken"                                     | true
+    "/someToken/"         | ["owner"]                 | "someToken/child"                               | true
+    "/someToken/"         | ["owner"]                 | "someToken/child/grandChild"                    | true
+    "/someToken/"         | ["owner"]                 | "parent/someToken"                              | false
+    "/someToken/"         | ["owner"]                 | "parent/someToken/child"                        | false
+    "/someToken/"         | ["owner"]                 | "parent/grandParent/someToken/child/grandChild" | false
+    "some/token"          | ["owner"]                 | "some/token"                                    | true
+    "some/token"          | ["owner"]                 | "parent/some/token"                             | false
+    "some/token"          | ["owner"]                 | "some/token/child"                              | true
+    "some/token"          | ["owner"]                 | "some/tokenSuffix"                              | false
+    "some/token/"         | ["owner"]                 | "some/token/child"                              | true
+    "some/token/"         | ["owner"]                 | "parent/some/token/child"                       | false
+    "some\\ Token"        | ["owner"]                 | "some Token"                                    | true
+    "\\#someToken"        | ["owner"]                 | "#someToken"                                    | true
+    "**/someToken"        | ["owner"]                 | "someToken"                                     | true
+    "**/someToken"        | ["owner"]                 | "parent/someToken"                              | true
+    "**/someToken"        | ["owner"]                 | "grandparent/parent/someToken"                  | true
+    "**/someToken"        | ["owner"]                 | "anotherToken"                                  | false
+    "**/some/token"       | ["owner"]                 | "some/token"                                    | true
+    "**/some/token"       | ["owner"]                 | "parent/some/token"                             | true
+    "**/some/token"       | ["owner"]                 | "grandparent/parent/some/token"                 | true
+    "**/some/token/"      | ["owner"]                 | "some/token"                                    | true
+    "**/some/token/"      | ["owner"]                 | "some/token/child"                              | true
+    "**/some/token/"      | ["owner"]                 | "some/token/child/grandchild"                   | true
+    "**/some/token/"      | ["owner"]                 | "parent/some/token/child"                       | true
+    "**/some/token/"      | ["owner"]                 | "parent/some/different/token"                   | false
+    "someToken/**"        | ["owner"]                 | "someToken"                                     | true
+    "someToken/**"        | ["owner"]                 | "someToken/child"                               | true
+    "someToken/**"        | ["owner"]                 | "someToken/child/grandChild"                    | true
+    "someToken/**"        | ["owner"]                 | "parent/someToken"                              | false
+    "someToken/**"        | ["owner"]                 | "parent/someToken/child"                        | false
+    "someToken/**"        | ["owner"]                 | "parent/grandParent/someToken/child/grandChild" | false
+    "/someToken/**"       | ["owner"]                 | "someToken"                                     | true
+    "/someToken/**"       | ["owner"]                 | "someToken/child"                               | true
+    "/someToken/**"       | ["owner"]                 | "someToken/child/grandChild"                    | true
+    "/someToken/**"       | ["owner"]                 | "parent/someToken"                              | false
+    "/someToken/**"       | ["owner"]                 | "parent/someToken/child"                        | false
+    "/someToken/**"       | ["owner"]                 | "parent/grandParent/someToken/child/grandChild" | false
+    "some/**/token"       | ["owner"]                 | "some/token"                                    | true
+    "some/**/token"       | ["owner"]                 | "some/other/token"                              | true
+    "some/**/token"       | ["owner"]                 | "some/yet/another/token"                        | true
+    "some/**/token"       | ["owner"]                 | "some/yet/another"                              | false
+    "some/**/token"       | ["owner"]                 | "yet/another/token"                             | false
+    "someToken"           | ["owner", "anotherOwner"] | "someToken"                                     | true
+    "*"                   | ["owner"]                 | "someToken"                                     | true
+    "*"                   | ["owner"]                 | "parent/someToken"                              | true
+    "*"                   | ["owner"]                 | "parent/someToken/child"                        | true
+    "*"                   | ["owner"]                 | "someFile.java"                                 | true
+    "*.java"              | ["owner"]                 | "someFile.java"                                 | true
+    "*.java"              | ["owner"]                 | "parent/someFile.java"                          | true
+    "*.java"              | ["owner"]                 | "grandparent/parent/someFile.java"              | true
+    "*.java"              | ["owner"]                 | "someFile.js"                                   | false
+    "*.java"              | ["owner"]                 | "someFile.java17"                               | false
+    "readme.md"           | ["owner"]                 | "readme.md"                                     | true
+    "readme.md"           | ["owner"]                 | "parent/readme.md"                              | true
+    "readme.md"           | ["owner"]                 | "readme.md5"                                    | false
+    "some/*"              | ["owner"]                 | "some/token"                                    | true
+    "some/*"              | ["owner"]                 | "some/other/token"                              | false
+    "some/*"              | ["owner"]                 | "parent/some/token"                             | false
+    "some/*"              | ["owner"]                 | "parent/some/other/token"                       | false
+    "**/test*.java"       | ["owner"]                 | "test.java"                                     | true
+    "**/test*.java"       | ["owner"]                 | "testFile.java"                                 | true
+    "**/test*.java"       | ["owner"]                 | "parent/test.java"                              | true
+    "**/test*.java"       | ["owner"]                 | "parent/testFile.java"                          | true
+    "**/test*.java"       | ["owner"]                 | "grandparent/parent/test.java"                  | true
+    "**/test*.java"       | ["owner"]                 | "grandparent/parent/testFile.java"              | true
+  }
+
+  private static String ownersToString(Collection<String> owners) {
+    def result = new StringBuilder()
+
+    for (String owner : owners) {
+      result += owner + " " // trailing spaces will be ignored by the matcher
+    }
+
+    return result.toString()
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/ci/codeowners/EntryBuilderTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/ci/codeowners/EntryBuilderTest.groovy
@@ -48,6 +48,7 @@ class EntryBuilderTest extends Specification {
     "someTok*n"           | ["owner"]                 | "parent/someTokkn"                              | true
     "someTok*n"           | ["owner"]                 | "grandparent/parent/someTokkn"                  | true
     "/someTok*n"          | ["owner"]                 | "someTokkn"                                     | true
+    "someTok[a-b]n"       | ["owner"]                 | "someToken"                                     | false
     "someTok[a-z]n"       | ["owner"]                 | "someToken"                                     | true
     "someTok[a-z]n"       | ["owner"]                 | "someTokEn"                                     | false
     "someTok[a-z]n"       | ["owner"]                 | "someTok9n"                                     | false
@@ -139,6 +140,7 @@ class EntryBuilderTest extends Specification {
     "**/test*.java"       | ["owner"]                 | "parent/testFile.java"                          | true
     "**/test*.java"       | ["owner"]                 | "grandparent/parent/test.java"                  | true
     "**/test*.java"       | ["owner"]                 | "grandparent/parent/testFile.java"              | true
+    "\\#someToken"        | ["owner"]                 | "#someToken"                                    | true
   }
 
   private static String ownersToString(Collection<String> owners) {
@@ -149,5 +151,16 @@ class EntryBuilderTest extends Specification {
     }
 
     return result.toString()
+  }
+
+  def "test invalid range parsing"() {
+    setup:
+    def matcherFactory = new CharacterMatcher.Factory()
+
+    when:
+    def entry = new EntryBuilder(matcherFactory, "token[z-a] owner").parse()
+
+    then:
+    entry == null
   }
 }

--- a/internal-api/src/test/resources/ci/codeowners/CODEOWNERS
+++ b/internal-api/src/test/resources/ci/codeowners/CODEOWNERS
@@ -1,0 +1,54 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @global-owner1 @global-owner2
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies JS files, only @js-owner and not the global
+# owner(s) will be requested for a review.
+*.js    @js-owner #This is an inline comment.
+
+# You can also use email addresses if you prefer. They'll be
+# used to look up users just like we do for commit author
+# emails.
+*.go docs@example.com
+
+# Teams can be specified as code owners as well. Teams should
+# be identified in the format @org/team-name. Teams must have
+# explicit write access to the repository. In this example,
+# the octocats team in the octo-org organization owns all .txt files.
+*.txt @octo-org/octocats
+
+# In this example, @doctocat owns any files in the build/logs
+# directory at the root of the repository and any of its
+# subdirectories.
+/build/logs/ @doctocat
+
+# The `documentation/*` pattern will match files like
+# `documentation/getting-started.md` but not further nested files like
+# `documentation/build-app/troubleshooting.md`.
+documentation/*  docs@example.com
+
+# In this example, @octocat owns any file in an apps directory
+# anywhere in your repository.
+apps/ @octocat
+
+# In this example, @doctocat owns any file in the `/docs`
+# directory in the root of your repository and any of its
+# subdirectories.
+/docs/ @doctocat
+
+# In this example, any change inside the `/scripts` directory
+# will require approval from @doctocat or @octocat.
+/scripts/ @doctocat @octocat
+
+# In this example, @octocat owns any file in the `/apps`
+# directory in the root of your repository except for the `/apps/github`
+# subdirectory, as its owners are left empty.
+/applications/ @appowner
+/applications/github


### PR DESCRIPTION
# What Does This Do
This change adds a parser for [github's CODEOWNERS files](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).

# Motivation
We want CI visibility to report code owners for each executed test case.
The goal is to search for a CODEOWNERS file in the client's repo, parse it and use the data to determine which teams or people own specific tests.

# Additional Notes
This change only contains the parsing logic. The rest will follow in a separate PR, to keep the review scope small.
