### PR TITLE
disable jdk.FileWrite on OpenJDK versions where durations are incorrect

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -90,6 +90,10 @@ public final class OpenJdkController implements Controller {
       disableEvent(recordingSettings, "jdk.ClassLoaderStatistics", EXPENSIVE_ON_CURRENT_JVM);
     }
 
+    if (!isFileWriteDurationCorrect()) {
+      disableEvent(recordingSettings, "jdk.FileWrite", EXPENSIVE_ON_CURRENT_JVM);
+    }
+
     // Toggle settings from override file
 
     try {

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSupport.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSupport.java
@@ -33,4 +33,11 @@ public class ProfilingSupport {
 
     return (isJavaVersion(8) && isJavaVersionAtLeast(8, 0, 302)) || isJavaVersionAtLeast(11);
   }
+
+  public static boolean isFileWriteDurationCorrect() {
+    return isJavaVersion(8)
+        || isJavaVersion(11)
+        || isJavaVersionAtLeast(17, 0, 6)
+        || isJavaVersionAtLeast(19);
+  }
 }


### PR DESCRIPTION
# What Does This Do

Disables this event for version where there was a [bug in calculating the duration](https://bugs.openjdk.org/browse/JDK-8296733) introduced in JDK15. We only put LTS versions and the known fix version in these checks, so erroneously disable on JDK12-14, because we don't expect these unsupported non-LTS JDKs to still be in use.

# Motivation

# Additional Notes
