### PR TITLE
Handle mapped baggage keys as case sensitive

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -77,14 +77,14 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
     protected abstract ContextInterpreter construct(
         Map<String, String> tagsMapping, Map<String, String> baggageMapping);
 
-    protected Map<String, String> cleanMapping(Map<String, String> mapping, boolean lowerCaseKeys) {
+    protected Map<String, String> cleanMapping(Map<String, String> mapping, boolean lowerCaseValues) {
       final Map<String, String> cleanedMapping = new HashMap<>(mapping.size() * 4 / 3);
       for (Map.Entry<String, String> association : mapping.entrySet()) {
-        String key = association.getKey().trim();
-        if (lowerCaseKeys) {
-          key = key.toLowerCase();
+        String value = association.getValue().trim();
+        if (lowerCaseValues) {
+          value = value.toLowerCase();
         }
-        cleanedMapping.put(key, association.getValue().trim().toLowerCase());
+        cleanedMapping.put(association.getKey().trim().toLowerCase(), value);
       }
       return cleanedMapping;
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -71,19 +71,26 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
 
     public ContextInterpreter create(
         Map<String, String> tagsMapping, Map<String, String> baggageMapping) {
-      return construct(cleanMapping(tagsMapping), cleanMapping(baggageMapping));
+      return construct(cleanMapping(tagsMapping), cleanMapping(baggageMapping, true));
     }
 
     protected abstract ContextInterpreter construct(
         Map<String, String> tagsMapping, Map<String, String> baggageMapping);
 
-    protected Map<String, String> cleanMapping(Map<String, String> mapping) {
+    protected Map<String, String> cleanMapping(Map<String, String> mapping, boolean lowerCaseKeys) {
       final Map<String, String> cleanedMapping = new HashMap<>(mapping.size() * 4 / 3);
       for (Map.Entry<String, String> association : mapping.entrySet()) {
-        cleanedMapping.put(
-            association.getKey().trim().toLowerCase(), association.getValue().trim().toLowerCase());
+        String key = association.getKey().trim();
+        if (lowerCaseKeys) {
+          key = key.toLowerCase();
+        }
+        cleanedMapping.put(key, association.getValue().trim().toLowerCase());
       }
       return cleanedMapping;
+    }
+
+    protected Map<String, String> cleanMapping(Map<String, String> mapping) {
+      return cleanMapping(mapping, false);
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -77,7 +77,8 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
     protected abstract ContextInterpreter construct(
         Map<String, String> tagsMapping, Map<String, String> baggageMapping);
 
-    protected Map<String, String> cleanMapping(Map<String, String> mapping, boolean lowerCaseValues) {
+    protected Map<String, String> cleanMapping(
+        Map<String, String> mapping, boolean lowerCaseValues) {
       final Map<String, String> cleanedMapping = new HashMap<>(mapping.size() * 4 / 3);
       for (Map.Entry<String, String> association : mapping.entrySet()) {
         String value = association.getValue().trim();

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -71,7 +71,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
 
     public ContextInterpreter create(
         Map<String, String> tagsMapping, Map<String, String> baggageMapping) {
-      return construct(cleanMapping(tagsMapping), cleanMapping(baggageMapping, true));
+      return construct(cleanMapping(tagsMapping), cleanMapping(baggageMapping, false));
     }
 
     protected abstract ContextInterpreter construct(
@@ -90,7 +90,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
     }
 
     protected Map<String, String> cleanMapping(Map<String, String> mapping) {
-      return cleanMapping(mapping, false);
+      return cleanMapping(mapping, true);
     }
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpExtractorTest.groovy
@@ -23,7 +23,9 @@ class DatadogHttpExtractorTest extends DDSpecification {
 
   private HttpCodec.Extractor getExtractor() {
     _extractor ?: (
-      _extractor = DatadogHttpCodec.newExtractor(["SOME_HEADER": "some-tag"], ["SOME_CUSTOM_BAGGAGE_HEADER": "some-baggage"])
+      _extractor = DatadogHttpCodec.newExtractor(
+      ["SOME_HEADER": "some-tag"],
+      ["SOME_CUSTOM_BAGGAGE_HEADER": "some-baggage", "SOME_CUSTOM_BAGGAGE_HEADER_2": "some-CaseSensitive-baggage"])
       )
   }
 
@@ -50,6 +52,7 @@ class DatadogHttpExtractorTest extends DDSpecification {
       (OT_BAGGAGE_PREFIX.toUpperCase() + "k2"): "v2",
       SOME_HEADER                             : "my-interesting-info",
       SOME_CUSTOM_BAGGAGE_HEADER              : "my-interesting-baggage-info",
+      SOME_CUSTOM_BAGGAGE_HEADER_2            : "my-interesting-baggage-info-2",
     ]
 
     if (samplingPriority != PrioritySampling.UNSET) {
@@ -66,7 +69,10 @@ class DatadogHttpExtractorTest extends DDSpecification {
     then:
     context.traceId == DDTraceId.from(traceId)
     context.spanId == DDSpanId.from(spanId)
-    context.baggage == ["k1": "v1", "k2": "v2", "some-baggage": "my-interesting-baggage-info"]
+    context.baggage == ["k1"                        : "v1",
+      "k2"                        : "v2",
+      "some-baggage"              : "my-interesting-baggage-info",
+      "some-CaseSensitive-baggage": "my-interesting-baggage-info-2"]
     context.tags == ["some-tag": "my-interesting-info"]
     context.samplingPriority == samplingPriority
     context.origin == origin
@@ -315,6 +321,7 @@ class DatadogHttpExtractorTest extends DDSpecification {
       (OT_BAGGAGE_PREFIX.toUpperCase() + "k2"): "v2",
       SOME_HEADER                             : "my-interesting-info",
       SOME_CUSTOM_BAGGAGE_HEADER              : "my-interesting-baggage-info",
+      SOME_CUSTOM_BAGGAGE_HEADER_2            : "my-interesting-baggage-info-2",
     ]
 
     when:
@@ -323,7 +330,10 @@ class DatadogHttpExtractorTest extends DDSpecification {
     then:
     context.traceId == DDTraceId.from(traceId)
     context.spanId == DDSpanId.from(spanId)
-    context.baggage == ["k1": "v1", "k2": "v2", "some-baggage": "my-interesting-baggage-info"]
+    context.baggage == ["k1": "v1",
+      "k2": "v2",
+      "some-baggage": "my-interesting-baggage-info",
+      "some-CaseSensitive-baggage": "my-interesting-baggage-info-2"]
     context.tags == ["some-tag": "my-interesting-info"]
     context.endToEndStartTime == endToEndStartTime * 1000000L
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
@@ -16,7 +16,9 @@ import static datadog.trace.core.propagation.HaystackHttpCodec.TRACE_ID_KEY
 
 class HaystackHttpExtractorTest extends DDSpecification {
 
-  HttpCodec.Extractor extractor = HaystackHttpCodec.newExtractor(["SOME_HEADER": "some-tag"], ["SOME_CUSTOM_BAGGAGE_HEADER": "some-baggage"])
+  HttpCodec.Extractor extractor = HaystackHttpCodec.newExtractor(
+  ["SOME_HEADER": "some-tag"],
+  ["SOME_CUSTOM_BAGGAGE_HEADER": "some-baggage", "SOME_CUSTOM_BAGGAGE_HEADER_2": "some-CaseSensitive-baggage"])
 
   boolean origAppSecActive
 
@@ -42,6 +44,7 @@ class HaystackHttpExtractorTest extends DDSpecification {
       (OT_BAGGAGE_PREFIX.toUpperCase() + "k3"): "%25%37%36%25%33%33", // v3 encoded twice
       SOME_HEADER                             : "my-interesting-info",
       SOME_CUSTOM_BAGGAGE_HEADER              : "my-interesting-baggage-info",
+      SOME_CUSTOM_BAGGAGE_HEADER_2            : "my-interesting-baggage-info-2",
     ]
 
     when:
@@ -53,7 +56,8 @@ class HaystackHttpExtractorTest extends DDSpecification {
     context.baggage == ["k1": "v1", "k2": "v2",
       "k3": "%76%33", // expect value decoded only once
       "Haystack-Trace-ID": traceUuid, "Haystack-Span-ID": spanUuid,
-      "some-baggage": "my-interesting-baggage-info"]
+      "some-baggage": "my-interesting-baggage-info",
+      "some-CaseSensitive-baggage": "my-interesting-baggage-info-2"]
     context.tags == ["some-tag": "my-interesting-info"]
     context.samplingPriority == samplingPriority
     context.origin == origin

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/XRayHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/XRayHttpExtractorTest.groovy
@@ -12,7 +12,7 @@ import static datadog.trace.api.config.TracerConfig.PROPAGATION_EXTRACT_LOG_HEAD
 
 class XRayHttpExtractorTest extends DDSpecification {
 
-  HttpCodec.Extractor extractor = XRayHttpCodec.newExtractor(["SOME_HEADER": "some-tag"], ["SOME_CUSTOM_BAGGAGE_HEADER": "some-baggage"])
+  HttpCodec.Extractor extractor = XRayHttpCodec.newExtractor(["SOME_HEADER": "some-tag"], ["SOME_CUSTOM_BAGGAGE_HEADER": "some-baggage", "SOME_CUSTOM_BAGGAGE_HEADER_2": "some-CaseSensitive-baggage"])
 
   boolean origAppSecActive
 
@@ -34,6 +34,7 @@ class XRayHttpExtractorTest extends DDSpecification {
       "Parent=${spanId.padLeft(16, '0')}${samplingPriority};=empty key;empty value=;=;;",
       SOME_HEADER : "my-interesting-info",
       SOME_CUSTOM_BAGGAGE_HEADER : "my-interesting-baggage-info",
+      SOME_CUSTOM_BAGGAGE_HEADER_2 : "my-interesting-baggage-info-2",
     ]
 
     when:
@@ -44,7 +45,8 @@ class XRayHttpExtractorTest extends DDSpecification {
     context.spanId == DDSpanId.fromHex("$spanId")
     context.baggage == [
       "empty value" : "",
-      "some-baggage": "my-interesting-baggage-info"
+      "some-baggage": "my-interesting-baggage-info",
+      "some-CaseSensitive-baggage": "my-interesting-baggage-info-2"
     ]
     context.tags == [
       "some-tag"    : "my-interesting-info"


### PR DESCRIPTION
# What Does This Do
Solves #4511
During the cleanup of the map, derived from the configuration, the baggage keys were converted to lowercase.
This PR skips the conversion to lowercase strings for baggage keys.

# Motivation
Keep case sensitivity of baggage keys throughout the library.

# Additional Notes
