### PR TITLE
add 10 ms threshold to datadog.EndpointEvent

### DIFF
--- a/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/EndpointEvent.java
+++ b/dd-trace-core/jfr-openjdk/src/main/java/datadog/trace/core/jfr/openjdk/EndpointEvent.java
@@ -2,6 +2,7 @@ package datadog.trace.core.jfr.openjdk;
 
 import datadog.trace.core.DDSpan;
 import datadog.trace.core.EndpointTracker;
+import java.util.concurrent.TimeUnit;
 import jdk.jfr.Category;
 import jdk.jfr.Description;
 import jdk.jfr.Event;
@@ -16,6 +17,8 @@ import jdk.jfr.StackTrace;
 @StackTrace(false)
 public class EndpointEvent extends Event implements EndpointTracker {
 
+  private static final long TEN_MILLISECONDS = TimeUnit.MILLISECONDS.toNanos(10);
+
   @Label("Endpoint")
   private String endpoint = "unknown";
 
@@ -29,7 +32,7 @@ public class EndpointEvent extends Event implements EndpointTracker {
 
   @Override
   public void endpointWritten(DDSpan span, boolean traceSampled, boolean checkpointsSampled) {
-    if (shouldCommit()) {
+    if (span.getDurationNano() >= TEN_MILLISECONDS && shouldCommit()) {
       end();
       this.endpoint = span.getResourceName().toString();
       commit();


### PR DESCRIPTION
# What Does This Do

This adds a 10ms threshold to datadog.EndpointEvent, which prevents emission of these events for very short traces, where we are unlikely to have sampled any CPU or walltime, which keeps recording sizes small.

# Motivation

# Additional Notes
