### PR TITLE
Update muzzle to run on Gradle's WorkerExecutor

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
@@ -32,7 +32,7 @@ public class MuzzleVersionScanPlugin {
 
   public static void assertInstrumentationMuzzled(
       final ClassLoader instrumentationLoader,
-      final ClassLoader userClassLoader,
+      final ClassLoader testApplicationLoader,
       final boolean assertPass,
       final String muzzleDirective)
       throws Exception {
@@ -42,13 +42,14 @@ public class MuzzleVersionScanPlugin {
       // verify muzzle result matches expectation
       final ReferenceMatcher muzzle = instrumenter.getInstrumentationMuzzle();
       final List<Reference.Mismatch> mismatches =
-          muzzle.getMismatchedReferenceSources(userClassLoader);
+          muzzle.getMismatchedReferenceSources(testApplicationLoader);
 
       ClassLoaderMatchers.reset();
 
-      final boolean classLoaderMatch = instrumenter.classLoaderMatcher().matches(userClassLoader);
-      final boolean passed = mismatches.isEmpty() && classLoaderMatch;
+      final boolean classLoaderMatch =
+          instrumenter.classLoaderMatcher().matches(testApplicationLoader);
 
+      final boolean passed = mismatches.isEmpty() && classLoaderMatch;
       if (passed && !assertPass) {
         System.err.println(
             "MUZZLE PASSED "
@@ -76,7 +77,7 @@ public class MuzzleVersionScanPlugin {
           if (helperClassNames.length > 0) {
             new HelperInjector(
                     MuzzleVersionScanPlugin.class.getSimpleName(), createHelperMap(instrumenter))
-                .transform(null, null, userClassLoader, null, null);
+                .transform(null, null, testApplicationLoader, null, null);
           }
         } catch (final Exception e) {
           System.err.println(

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPluginTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPluginTest.groovy
@@ -26,15 +26,15 @@ class MuzzleVersionScanPluginTest extends DDSpecification {
     instrumentationLoader.addClass(TestInstrumentationClasses)
     instrumentationLoader.addClass(BaseInst)
     instCP.each { instrumentationLoader.addClass(it) }
-    def userClassLoader = new AddableClassLoader(TestInstrumentationClasses)
-    userCP.each { userClassLoader.addClass(it) }
+    def testApplicationLoader = new AddableClassLoader(TestInstrumentationClasses)
+    testCP.each { testApplicationLoader.addClass(it) }
 
     expect:
-    MuzzleVersionScanPlugin.assertInstrumentationMuzzled(instrumentationLoader, userClassLoader, assertPass, null)
+    MuzzleVersionScanPlugin.assertInstrumentationMuzzled(instrumentationLoader, testApplicationLoader, assertPass, null)
 
     where:
     // spotless:off
-    assertPass | instCP                                                                              | userCP
+    assertPass | instCP                                                                              | testCP
     true       | [EmptyInst, EmptyInst.Muzzle]                                                       | []
     false      | [BasicInst, BasicInst.Muzzle, SomeAdvice]                                           | []
     false      | [BasicInst, BasicInst.Muzzle, SomeAdvice]                                           | [AdviceParameter, AdviceStaticReference]
@@ -52,10 +52,10 @@ class MuzzleVersionScanPluginTest extends DDSpecification {
     instrumentationLoader.addClass(TestInstrumentationClasses)
     instrumentationLoader.addClass(BaseInst)
     instCP.each { instrumentationLoader.addClass(it) }
-    def userClassLoader = new AddableClassLoader(TestInstrumentationClasses)
+    def testApplicationLoader = new AddableClassLoader(TestInstrumentationClasses)
 
     when:
-    MuzzleVersionScanPlugin.assertInstrumentationMuzzled(instrumentationLoader, userClassLoader, true, null)
+    MuzzleVersionScanPlugin.assertInstrumentationMuzzled(instrumentationLoader, testApplicationLoader, true, null)
 
     then:
     def ex = thrown(RuntimeException)
@@ -73,12 +73,12 @@ class MuzzleVersionScanPluginTest extends DDSpecification {
     def instrumentationLoader = new ServiceEnabledClassLoader(Instrumenter, Instrumenter.Default, BaseInst,
       ElementMatcher, ReferenceMatcher, Reference, ReferenceCreator, inst, muzzle)
     helpers.each { instrumentationLoader.addClass(it) }
-    def userClassLoader = new AddableClassLoader()
+    def testApplicationLoader = new AddableClassLoader()
 
     expect:
-    MuzzleVersionScanPlugin.assertInstrumentationMuzzled(instrumentationLoader, userClassLoader, true, null)
+    MuzzleVersionScanPlugin.assertInstrumentationMuzzled(instrumentationLoader, testApplicationLoader, true, null)
     !helpers.findAll {
-      userClassLoader.loadClass(it.name) != null
+      testApplicationLoader.loadClass(it.name) != null
     }.isEmpty()
 
     where:
@@ -94,10 +94,10 @@ class MuzzleVersionScanPluginTest extends DDSpecification {
     def instrumentationLoader = new ServiceEnabledClassLoader(Instrumenter, Instrumenter.Default, BaseInst,
       ElementMatcher, ReferenceMatcher, Reference, ReferenceCreator, inst, muzzle)
     helpers.each { instrumentationLoader.addClass(it) }
-    def userClassLoader = new AddableClassLoader()
+    def testApplicationLoader = new AddableClassLoader()
 
     when:
-    MuzzleVersionScanPlugin.assertInstrumentationMuzzled(instrumentationLoader, userClassLoader, true, null)
+    MuzzleVersionScanPlugin.assertInstrumentationMuzzled(instrumentationLoader, testApplicationLoader, true, null)
 
     then:
     def ex = thrown(IllegalArgumentException)


### PR DESCRIPTION
# What Does This Do

Updates the generated `muzzle` tasks to execute via Gradle's `WorkerExecutor` and `WorkQueue`. This enables us to run these tasks on different processes based on the required Java version. (For this first step the tasks still run without any process isolation, but I have verified that they still behave as expected when process isolation is selected.)
