### PR TITLE
Consider Baggage when creating new root traces

### DIFF
--- a/dd-java-agent/instrumentation/spring-cloud-zuul-2/src/test/groovy/ProxyRequestHelperTest.groovy
+++ b/dd-java-agent/instrumentation/spring-cloud-zuul-2/src/test/groovy/ProxyRequestHelperTest.groovy
@@ -135,7 +135,7 @@ class ProxyRequestHelperTest extends WithHttpServer<ConfigurableApplicationConte
     }
   }
 
-  def "Test baggage headers to be correctly ignored through proxy"() {
+  def "Test baggage headers to be propagated through proxy"() {
     setup:
     def hsBaggageHeader = "Baggage-test"
     def ddBaggageHeader = "ot-baggage-test"
@@ -148,7 +148,7 @@ class ProxyRequestHelperTest extends WithHttpServer<ConfigurableApplicationConte
       .header(PARENT_ID_HEADER, PARENT_ID)
       .header(TRACE_ID_HEADER, TRACE_ID)
       .header(hsBaggageHeader, "shouldnotappear")
-      .header(ddBaggageHeader, "shouldnotappear")
+      .header(ddBaggageHeader, "shouldAppear")
       .header(nonTracerHeader, "shouldAppear")
       .build()
 
@@ -158,7 +158,7 @@ class ProxyRequestHelperTest extends WithHttpServer<ConfigurableApplicationConte
 
     then:
     !receivedHeaders.containsKey(hsBaggageHeader)
-    !receivedHeaders.containsKey(ddBaggageHeader)
+    receivedHeaders.containsKey(ddBaggageHeader)
     receivedHeaders.containsKey(nonTracerHeader)
 
     receivedHeaders.containsKey(defaultParentHeader)

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1291,7 +1291,6 @@ public class CoreTracer implements AgentTracer.TracerAPI {
           parentSpanId = extractedContext.getSpanId();
           samplingPriority = extractedContext.getSamplingPriority();
           endToEndStartTime = extractedContext.getEndToEndStartTime();
-          baggage = extractedContext.getBaggage();
           propagationTags = extractedContext.getPropagationTags();
         } else {
           // Start a new trace
@@ -1299,7 +1298,6 @@ public class CoreTracer implements AgentTracer.TracerAPI {
           parentSpanId = DDSpanId.ZERO;
           samplingPriority = PrioritySampling.UNSET;
           endToEndStartTime = 0;
-          baggage = null;
           propagationTags = propagationTagsFactory.empty();
         }
 
@@ -1308,11 +1306,13 @@ public class CoreTracer implements AgentTracer.TracerAPI {
           TagContext tc = (TagContext) parentContext;
           coreTags = tc.getTags();
           origin = tc.getOrigin();
+          baggage = tc.getBaggage();
           requestContextDataAppSec = tc.getRequestContextDataAppSec();
           requestContextDataIast = tc.getRequestContextDataIast();
         } else {
           coreTags = null;
           origin = null;
+          baggage = null;
           requestContextDataAppSec = null;
           requestContextDataIast = null;
         }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -39,6 +39,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
   protected int samplingPriority;
   protected Map<String, String> tags;
   protected Map<String, String> baggage;
+
   protected String origin;
   protected long endToEndStartTime;
   protected boolean valid;
@@ -257,9 +258,10 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
       } else if (origin != null
           || !tags.isEmpty()
           || httpHeaders != null
+          || !baggage.isEmpty()
           || samplingPriority != PrioritySampling.UNSET) {
         return new TagContext(
-            origin, tags, httpHeaders, samplingPriorityOrDefault(samplingPriority));
+            origin, tags, httpHeaders, baggage, samplingPriorityOrDefault(samplingPriority));
       }
     }
     return null;

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
@@ -11,7 +11,6 @@ public class ExtractedContext extends TagContext {
   private final DDTraceId traceId;
   private final long spanId;
   private final long endToEndStartTime;
-  private final Map<String, String> baggage;
   private final PropagationTags propagationTags;
 
   public ExtractedContext(
@@ -24,17 +23,11 @@ public class ExtractedContext extends TagContext {
       final Map<String, String> tags,
       final HttpHeaders httpHeaders,
       final PropagationTags propagationTags) {
-    super(origin, tags, httpHeaders, samplingPriority);
+    super(origin, tags, httpHeaders, baggage, samplingPriority);
     this.traceId = traceId;
     this.spanId = spanId;
     this.endToEndStartTime = endToEndStartTime;
-    this.baggage = baggage;
     this.propagationTags = propagationTags;
-  }
-
-  @Override
-  public final Iterable<Map.Entry<String, String>> baggageItems() {
-    return baggage.entrySet();
   }
 
   @Override
@@ -49,10 +42,6 @@ public class ExtractedContext extends TagContext {
 
   public final long getEndToEndStartTime() {
     return endToEndStartTime;
-  }
-
-  public final Map<String, String> getBaggage() {
-    return baggage;
   }
 
   public PropagationTags getPropagationTags() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
@@ -1,18 +1,18 @@
 package datadog.trace.core.propagation
 
-import datadog.trace.api.DDSpanId
-import datadog.trace.api.DDTraceId
-import datadog.trace.bootstrap.ActiveSubsystems
-import datadog.trace.bootstrap.instrumentation.api.TagContext
-import datadog.trace.api.sampling.PrioritySampling
-import datadog.trace.bootstrap.instrumentation.api.ContextVisitors
-import datadog.trace.test.util.DDSpecification
-
 import static datadog.trace.api.config.TracerConfig.PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED
 import static datadog.trace.core.CoreTracer.TRACE_ID_MAX
 import static datadog.trace.core.propagation.HaystackHttpCodec.OT_BAGGAGE_PREFIX
 import static datadog.trace.core.propagation.HaystackHttpCodec.SPAN_ID_KEY
 import static datadog.trace.core.propagation.HaystackHttpCodec.TRACE_ID_KEY
+
+import datadog.trace.api.DDSpanId
+import datadog.trace.api.DDTraceId
+import datadog.trace.api.sampling.PrioritySampling
+import datadog.trace.bootstrap.ActiveSubsystems
+import datadog.trace.bootstrap.instrumentation.api.ContextVisitors
+import datadog.trace.bootstrap.instrumentation.api.TagContext
+import datadog.trace.test.util.DDSpecification
 
 class HaystackHttpExtractorTest extends DDSpecification {
 
@@ -207,40 +207,79 @@ class HaystackHttpExtractorTest extends DDSpecification {
     context == null
   }
 
-  def "extract 128 bit id truncates id to 64 bit"() {
+  def "baggage is mapped on context creation"() {
     setup:
     def headers = [
-      (TRACE_ID_KEY.toUpperCase()): traceId,
-      (SPAN_ID_KEY.toUpperCase()) : spanId,
+      (TRACE_ID_KEY.toUpperCase())            : traceId,
+      (SPAN_ID_KEY.toUpperCase())             : spanId,
+      SOME_CUSTOM_BAGGAGE_HEADER              : "mappedBaggageValue",
+      (OT_BAGGAGE_PREFIX.toUpperCase() + "k1"): "v1",
+      (OT_BAGGAGE_PREFIX.toUpperCase() + "k2"): "v2",
+      SOME_ARBITRARY_HEADER                             : "my-interesting-info",
     ]
 
     when:
-    final ExtractedContext context = extractor.extract(headers, ContextVisitors.stringValuesMap())
+    final TagContext context = extractor.extract(headers, ContextVisitors.stringValuesMap())
 
     then:
-    if (expectedTraceId) {
-      assert context.traceId == expectedTraceId
-      assert context.spanId == expectedSpanId
+    if (ctxCreated) {
+      assert context != null
+      assert context.getBaggage() == [
+        "Haystack-Trace-ID": traceId,
+        "Haystack-Span-ID" : spanId,
+        "some-baggage"     : "mappedBaggageValue",
+        "k1"               : "v1",
+        "k2"               : "v2",
+      ]
     } else {
       assert context == null
     }
 
     where:
-    traceId                                | spanId                                 | expectedTraceId                     | expectedSpanId
-    "-1"                                   | "1"                                    | null                                | DDSpanId.ZERO
-    "1"                                    | "-1"                                   | null                                | DDSpanId.ZERO
-    "0"                                    | "1"                                    | null                                | DDSpanId.ZERO
-    "00001"                                | "00001"                                | DDTraceId.ONE                       | 1
-    "463ac35c9f6413ad"                     | "463ac35c9f6413ad"                     | DDTraceId.from(5060571933882717101) | 5060571933882717101
-    "463ac35c9f6413ad48485a3953bb6124"     | "1"                                    | DDTraceId.from(5208512171318403364) | 1
-    "44617461-646f-6721-463a-c35c9f6413ad" | "44617461-646f-6721-463a-c35c9f6413ad" | DDTraceId.from(5060571933882717101) | 5060571933882717101
-    "f" * 16                               | "1"                                    | DDTraceId.MAX                       | 1
-    "a" * 16 + "f" * 16                    | "1"                                    | DDTraceId.MAX                       | 1
-    "1" + "f" * 32                         | "1"                                    | null                                | 1
-    "0" + "f" * 32                         | "1"                                    | null                                | 1
-    "1"                                    | "f" * 16                               | DDTraceId.ONE                       | DDSpanId.MAX
-    "1"                                    | "1" + "f" * 16                         | null                                | DDSpanId.ZERO
-    "1"                                    | "000" + "f" * 16                       | DDTraceId.ONE                       | DDSpanId.MAX
+    ctxCreated     | traceId                                | spanId
+    false          | "-1"                                   | "1"
+    false          | "1"                                    | "-1"
+    true           | "0"                                    | "1"
+    true           | "44617461-646f-6721-463a-c35c9f6413ad" | "44617461-646f-6721-463a-c35c9f6413ad"
+  }
+
+  def "extract 128 bit id truncates id to 64 bit"() {
+    setup:
+    def headers = [
+      (TRACE_ID_KEY.toUpperCase())            : traceId,
+      (SPAN_ID_KEY.toUpperCase())             : spanId,
+    ]
+
+    when:
+    final TagContext context = extractor.extract(headers, ContextVisitors.stringValuesMap())
+
+    then:
+    if (expectedTraceId) {
+      assert context.traceId == expectedTraceId
+      assert context.spanId == expectedSpanId
+    }
+    if (ctxCreated) {
+      assert context != null
+    } else {
+      assert context == null
+    }
+
+    where:
+    ctxCreated     | traceId                                | spanId                                 | expectedTraceId | expectedSpanId
+    false          | "-1"                                   | "1"                                    | null            | DDSpanId.ZERO
+    false          | "1"                                    | "-1"                                   | null            | DDSpanId.ZERO
+    true           | "0"                                    | "1"                                    | null            | DDSpanId.ZERO
+    true           | "00001"                                | "00001"                                | DDTraceId.ONE   | 1
+    true           | "463ac35c9f6413ad"                     | "463ac35c9f6413ad"                     | DDTraceId.from(5060571933882717101) | 5060571933882717101
+    true           | "463ac35c9f6413ad48485a3953bb6124"     | "1"                                    | DDTraceId.from(5208512171318403364) | 1
+    true           | "44617461-646f-6721-463a-c35c9f6413ad" | "44617461-646f-6721-463a-c35c9f6413ad" | DDTraceId.from(5060571933882717101) | 5060571933882717101
+    true           | "f" * 16                               | "1"                                    | DDTraceId.MAX   | 1
+    true           | "a" * 16 + "f" * 16                    | "1"                                    | DDTraceId.MAX   | 1
+    false          | "1" + "f" * 32                         | "1"                                    | null            | 1
+    false          | "0" + "f" * 32                         | "1"                                    | null            | 1
+    true           | "1"                                    | "f" * 16                               | DDTraceId.ONE   | DDSpanId.MAX
+    false          | "1"                                    | "1" + "f" * 16                         | null            | DDSpanId.ZERO
+    true           | "1"                                    | "000" + "f" * 16                       | DDTraceId.ONE   | DDSpanId.MAX
   }
 
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
@@ -19,6 +19,7 @@ public class TagContext implements AgentSpan.Context.Extracted {
   private Object requestContextDataAppSec;
   private Object requestContextDataIast;
   private final HttpHeaders httpHeaders;
+  private final Map<String, String> baggage;
 
   private final int samplingPriority;
 
@@ -27,17 +28,19 @@ public class TagContext implements AgentSpan.Context.Extracted {
   }
 
   public TagContext(final String origin, final Map<String, String> tags) {
-    this(origin, tags, null, PrioritySampling.UNSET);
+    this(origin, tags, null, null, PrioritySampling.UNSET);
   }
 
   public TagContext(
       final String origin,
       final Map<String, String> tags,
       HttpHeaders httpHeaders,
+      final Map<String, String> baggage,
       int samplingPriority) {
     this.origin = origin;
     this.tags = tags;
     this.httpHeaders = httpHeaders == null ? EMPTY_HTTP_HEADERS : httpHeaders;
+    this.baggage = baggage == null ? Collections.emptyMap() : baggage;
     this.samplingPriority = samplingPriority;
   }
 
@@ -123,9 +126,13 @@ public class TagContext implements AgentSpan.Context.Extracted {
     return samplingPriority;
   }
 
+  public final Map<String, String> getBaggage() {
+    return baggage;
+  }
+
   @Override
   public Iterable<Map.Entry<String, String>> baggageItems() {
-    return Collections.emptyList();
+    return baggage.entrySet();
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do
Solves #4516

This PR modifies which extracted information is used when creating a new trace.

# Motivation
Due to Baggage mapping, there now is a possible need to map headers into new created traces.

# Additional Notes
No failing test - If someone can point me to the correct test cases to improve to cover this change please do so.