### PR TITLE
Add javac compiler plugin to inject source path into classes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,7 @@ dd-trace-core/src/main/java/datadog/trace/civisibility/                @DataDog/
 dd-java-agent/instrumentation/junit-4.10/                              @DataDog/ci-app-libraries-java
 dd-java-agent/instrumentation/junit-5.3/                               @DataDog/ci-app-libraries-java
 dd-java-agent/instrumentation/testng-6.4/                              @DataDog/ci-app-libraries-java
+dd-java-compiler-plugin/                                               @DataDog/ci-app-libraries-java
 
 # @DataDog/debugger-java (Live Debugger)
 dd-java-agent/agent-debugger/ @DataDog/debugger-java

--- a/dd-java-compiler-plugin/README.md
+++ b/dd-java-compiler-plugin/README.md
@@ -1,0 +1,126 @@
+# Datadog Java Compiler Plugin
+
+This is a Java compiler (`javac`) [plugin](https://openjdk.org/groups/compiler/processing-code.html#plugin) that
+augments compiled classes with some additional data used by Datadog products.
+
+List of things that the plugin does:
+
+- Inject into every class a `private static final` field with the path to the class' source code
+  (this data is being used by [Datadog's CI Visibility](https://www.datadoghq.com/product/ci-cd-monitoring/)).
+
+## Configuration
+
+The following conditions need to be satisfied in order for the plugin to work:
+
+- the plugin JAR needs to be added to the compiler's annotation processor path
+- `-Xplugin:DatadogCompilerPlugin` argument needs to be provided to the compiler
+- for JDK 16 and newer versions, additional `--add-exports` flags are required due
+  to [JEP 396: Strongly Encapsulate JDK Internals by Default](https://openjdk.org/jeps/396) (see below sections for more
+  details)
+
+If the configuration is successful, you should see the line `DatadogCompilerPlugin initialized` in your compiler's
+output
+
+> For now the augmentation is only useful in test classes, so you can limit configuration to javac invocations that
+> compile test sources.
+
+### Maven
+
+Below is an example of how to specify annotation processor path and compiler arguments for maven compiler plugin.
+
+```xml
+
+<plugins>
+  <plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-compiler-plugin</artifactId>
+    <version>3.5</version>
+    <configuration>
+      <annotationProcessorPaths>
+        <annotationProcessorPath>
+          <groupId>com.datadoghq</groupId>
+          <artifactId>dd-java-compiler-plugin</artifactId>
+          <version>1.3.0</version>
+        </annotationProcessorPath>
+      </annotationProcessorPaths>
+      <testCompilerArgument>
+        -Xplugin:DatadogCompilerPlugin
+      </testCompilerArgument>
+    </configuration>
+  </plugin>
+  <plugins>
+```
+
+> Maven compiler plugin supports
+> [annotationProcessorPaths](https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#annotationProcessorPaths)
+> property starting with version 3.5.
+> If you absolutely must use an older version, declare Datadog compiler plugin as a regular dependency in your project.
+
+Additionally, if you are using JDK 16 or newer, add the following flags
+to [.mvn/jvm.config](https://maven.apache.org/configure.html#mvn-jvm-config-file) in your project base directory:
+
+```
+--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+```
+
+### Gradle
+
+Below is an example of how to configure the plugin for compiling test classes:
+
+```groovy
+dependencies {
+  testAnnotationProcessor 'com.datadoghq:dd-java-compiler-plugin:1.3.0'
+}
+
+compileTestJava {
+  options.compilerArgs << '-Xplugin:DatadogCompilerPlugin'
+}
+```
+
+Additionally, if you are using JDK 16 or newer, add the following flags to your
+[gradle.properties](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties)
+file:
+
+```
+org.gradle.jvmargs=\
+--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED  \
+--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+```
+
+### Other
+
+If you're using any other build system, just make sure to set the annotation processor path and the compiler arguments.
+Below is an example for direct compiler invocation:
+
+```shell
+javac \
+    -processorpath <PATH>/dd-java-compiler-plugin-1.3.0.jar \
+    -Xplugin:DatadogCompilerPlugin \
+    <PATH_TO_SOURCES>
+```
+
+If you are using JDK 16 or newer, additional `--add-exports` flags should be provided:
+
+```shell
+$JAVA_17_HOME/bin/javac \
+  -J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  -J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+  -J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  -J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
+  -processorpath <PATH>/dd-java-compiler-plugin-1.3.0.jar \
+  -Xplugin:DatadogCompilerPlugin \
+  <PATH_TO_SOURCES>
+```
+
+## Limitations
+
+- Support is limited to `javac` (or any other compiler that knows how to work
+  with [com.sun.source.util.Plugin](https://docs.oracle.com/javase/8/docs/jdk/api/javac/tree/com/sun/source/util/Plugin.html)).
+  Eclipse JDT compiler support is [pending](https://bugs.eclipse.org/bugs/show_bug.cgi?id=574899).
+
+- The plugin requires `javac` that comes with java 1.8 or above.

--- a/dd-java-compiler-plugin/build.gradle
+++ b/dd-java-compiler-plugin/build.gradle
@@ -10,6 +10,8 @@ dependencies {
   implementation files(Jvm.current().toolsJar)
 }
 
+excludedClassesCoverage = ['datadog.compiler.*']
+
 project.afterEvaluate {
 
   tasks.withType(Test).configureEach {

--- a/dd-java-compiler-plugin/build.gradle
+++ b/dd-java-compiler-plugin/build.gradle
@@ -1,0 +1,31 @@
+import org.gradle.internal.jvm.Jvm
+
+apply from: "$rootDir/gradle/java.gradle"
+apply from: "$rootDir/gradle/publish.gradle"
+
+description = 'dd-java-compiler-plugin'
+
+dependencies {
+  implementation project(':dd-java-compiler-plugin:client')
+  implementation files(Jvm.current().toolsJar)
+}
+
+project.afterEvaluate {
+
+  tasks.withType(Test).configureEach {
+    if (javaLauncher.isPresent() && javaLauncher.get().metadata.languageVersion.asInt() >= 16) {
+      // in JDK 16 module access checks have been upgraded by JEP 396: Strongly Encapsulate JDK Internals by Default
+      jvmArgs += [
+        '--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED',
+        '--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED',
+        '--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED',
+        '--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED'
+      ]
+    }
+  }
+}
+
+
+
+
+

--- a/dd-java-compiler-plugin/client/build.gradle
+++ b/dd-java-compiler-plugin/client/build.gradle
@@ -1,0 +1,4 @@
+apply from: "$rootDir/gradle/java.gradle"
+apply from: "$rootDir/gradle/publish.gradle"
+
+description = 'dd-java-compiler-plugin-client'

--- a/dd-java-compiler-plugin/client/src/main/java/datadog/compiler/CompilerUtils.java
+++ b/dd-java-compiler-plugin/client/src/main/java/datadog/compiler/CompilerUtils.java
@@ -1,0 +1,19 @@
+package datadog.compiler;
+
+import java.lang.reflect.Field;
+import javax.annotation.Nullable;
+
+public class CompilerUtils {
+  static final String SOURCE_PATH_INJECTED_FIELD_NAME = "__datadog_sourcePath";
+
+  /** Returns path to class source file (injected by Datadog Java compiler plugin) */
+  public static @Nullable String getSourcePath(Class<?> c) {
+    try {
+      Field sourcePathField = c.getDeclaredField(CompilerUtils.SOURCE_PATH_INJECTED_FIELD_NAME);
+      sourcePathField.setAccessible(true);
+      return (String) sourcePathField.get(c);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      return null;
+    }
+  }
+}

--- a/dd-java-compiler-plugin/src/main/java/datadog/compiler/DatadogCompilerPlugin.java
+++ b/dd-java-compiler-plugin/src/main/java/datadog/compiler/DatadogCompilerPlugin.java
@@ -1,0 +1,110 @@
+package datadog.compiler;
+
+import com.sun.source.tree.ClassTree;
+import com.sun.source.util.JavacTask;
+import com.sun.source.util.Plugin;
+import com.sun.source.util.TaskEvent;
+import com.sun.source.util.TaskListener;
+import com.sun.source.util.TreeScanner;
+import com.sun.tools.javac.api.BasicJavacTask;
+import com.sun.tools.javac.code.Flags;
+import com.sun.tools.javac.code.Symtab;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.TreeMaker;
+import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.Log;
+import com.sun.tools.javac.util.Name;
+import com.sun.tools.javac.util.Names;
+import java.io.PrintWriter;
+import java.net.URI;
+import javax.tools.JavaFileObject;
+
+public class DatadogCompilerPlugin implements Plugin {
+
+  static final String NAME = "DatadogCompilerPlugin";
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public void init(JavacTask task, String... strings) {
+    if (task instanceof BasicJavacTask) {
+      BasicJavacTask basicJavacTask = (BasicJavacTask) task;
+      Context context = basicJavacTask.getContext();
+
+      task.addTaskListener(new DatadogCompilerPluginTaskListener(context));
+      Log.instance(context).printRawLines(Log.WriterKind.NOTICE, NAME + " initialized");
+    }
+  }
+
+  private static final class DatadogCompilerPluginTaskListener implements TaskListener {
+    private final Context context;
+
+    private DatadogCompilerPluginTaskListener(Context context) {
+      this.context = context;
+    }
+
+    @Override
+    public void started(TaskEvent e) {}
+
+    @Override
+    public void finished(TaskEvent e) {
+      if (e.getKind() != TaskEvent.Kind.PARSE) {
+        return;
+      }
+
+      try {
+        JavaFileObject sourceFile = e.getSourceFile();
+        URI sourceUri = sourceFile.toUri();
+        String sourcePath = sourceUri.getPath();
+
+        SourcePathInjectingClassVisitor treeVisitor =
+            new SourcePathInjectingClassVisitor(context, sourcePath);
+        e.getCompilationUnit().accept(treeVisitor, null);
+
+      } catch (Throwable t) {
+        Log log = Log.instance(context);
+        log.printRawLines(
+            Log.WriterKind.WARNING,
+            "Could not inject source path field into "
+                + log.currentSourceFile().toUri()
+                + ": "
+                + t.getMessage());
+
+        PrintWriter logWriter = log.getWriter(Log.WriterKind.WARNING);
+        t.printStackTrace(logWriter);
+      }
+    }
+  }
+
+  private static final class SourcePathInjectingClassVisitor extends TreeScanner<Void, Void> {
+
+    private final Context context;
+    private final String sourcePath;
+
+    private SourcePathInjectingClassVisitor(Context context, String sourcePath) {
+      this.context = context;
+      this.sourcePath = sourcePath;
+    }
+
+    @Override
+    public Void visitClass(ClassTree node, Void aVoid) {
+      TreeMaker maker = TreeMaker.instance(context);
+      Names names = Names.instance(context);
+      Symtab symtab = Symtab.instance(context);
+
+      JCTree.JCModifiers modifiers = maker.Modifiers(Flags.PRIVATE | Flags.STATIC | Flags.FINAL);
+      Name name = names.fromString(CompilerUtils.SOURCE_PATH_INJECTED_FIELD_NAME);
+      JCTree.JCExpression type = maker.Type(symtab.stringType);
+      JCTree.JCLiteral value = maker.Literal(sourcePath);
+
+      JCTree.JCVariableDecl sourcePathField = maker.VarDef(modifiers, name, type, value);
+      JCTree.JCClassDecl classDeclaration = (JCTree.JCClassDecl) node;
+      classDeclaration.defs = classDeclaration.defs.prepend(sourcePathField);
+
+      return super.visitClass(node, aVoid);
+    }
+  }
+}

--- a/dd-java-compiler-plugin/src/main/resources/META-INF/services/com.sun.source.util.Plugin
+++ b/dd-java-compiler-plugin/src/main/resources/META-INF/services/com.sun.source.util.Plugin
@@ -1,0 +1,1 @@
+datadog.compiler.DatadogCompilerPlugin

--- a/dd-java-compiler-plugin/src/test/java/datadog/compiler/DatadogCompilerPluginTest.java
+++ b/dd-java-compiler-plugin/src/test/java/datadog/compiler/DatadogCompilerPluginTest.java
@@ -1,0 +1,59 @@
+package datadog.compiler;
+
+import static java.util.Collections.singletonList;
+
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.List;
+import javax.tools.JavaCompiler;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DatadogCompilerPluginTest {
+
+  @Test
+  public void testSourcePathInjection() throws Exception {
+    String testClassName = "datadog.compiler.Test";
+    String testClassSource = "package datadog.compiler; public class Test {}";
+    try (InMemoryFileManager fileManager = compile(testClassName, testClassSource)) {
+      Class<?> clazz = fileManager.loadCompiledClass(testClassName);
+      String sourcePath = CompilerUtils.getSourcePath(clazz);
+      Assert.assertEquals(InMemorySourceFile.sourcePath(testClassName), sourcePath);
+    }
+  }
+
+  @Test
+  public void testInnerClassSourcePathInjection() throws Exception {
+    String testClassName = "datadog.compiler.Test";
+    String testClassSource =
+        "package datadog.compiler; public class Test { public static final class Inner {} }";
+    try (InMemoryFileManager fileManager = compile(testClassName, testClassSource)) {
+      Class<?> innerClazz = fileManager.loadCompiledClass(testClassName + "$Inner");
+      String sourcePath = CompilerUtils.getSourcePath(innerClazz);
+      Assert.assertEquals(InMemorySourceFile.sourcePath(testClassName), sourcePath);
+    }
+  }
+
+  private InMemoryFileManager compile(String className, String classSource) {
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    StandardJavaFileManager standardFileManager = compiler.getStandardFileManager(null, null, null);
+    InMemoryFileManager fileManager = new InMemoryFileManager(standardFileManager);
+
+    StringWriter output = new StringWriter();
+    List<String> arguments =
+        Arrays.asList(
+            "-classpath",
+            System.getProperty("java.class.path"),
+            "-Xplugin:" + DatadogCompilerPlugin.NAME);
+    List<InMemorySourceFile> compilationUnits =
+        singletonList(new InMemorySourceFile(className, classSource));
+
+    JavaCompiler.CompilationTask task =
+        compiler.getTask(output, fileManager, null, arguments, null, compilationUnits);
+    task.call();
+
+    return fileManager;
+  }
+}

--- a/dd-java-compiler-plugin/src/test/java/datadog/compiler/InMemoryClassFile.java
+++ b/dd-java-compiler-plugin/src/test/java/datadog/compiler/InMemoryClassFile.java
@@ -1,0 +1,24 @@
+package datadog.compiler;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import javax.tools.SimpleJavaFileObject;
+
+public class InMemoryClassFile extends SimpleJavaFileObject {
+
+  private ByteArrayOutputStream out;
+
+  public InMemoryClassFile(URI uri) {
+    super(uri, Kind.CLASS);
+  }
+
+  @Override
+  public OutputStream openOutputStream() {
+    return out = new ByteArrayOutputStream();
+  }
+
+  public byte[] getCompiledBinaries() {
+    return out.toByteArray();
+  }
+}

--- a/dd-java-compiler-plugin/src/test/java/datadog/compiler/InMemoryFileManager.java
+++ b/dd-java-compiler-plugin/src/test/java/datadog/compiler/InMemoryFileManager.java
@@ -1,0 +1,39 @@
+package datadog.compiler;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import javax.tools.FileObject;
+import javax.tools.ForwardingJavaFileManager;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+
+public class InMemoryFileManager extends ForwardingJavaFileManager<StandardJavaFileManager> {
+
+  private final Map<String, InMemoryClassFile> compiledClasses = new HashMap<>();
+
+  private final ClassLoader classLoader =
+      new ClassLoader() {
+        @Override
+        protected Class<?> findClass(String name) {
+          byte[] byteCode = compiledClasses.get(name).getCompiledBinaries();
+          return defineClass(name, byteCode, 0, byteCode.length);
+        }
+      };
+
+  protected InMemoryFileManager(StandardJavaFileManager fileManager) {
+    super(fileManager);
+  }
+
+  @Override
+  public JavaFileObject getJavaFileForOutput(
+      Location location, String className, JavaFileObject.Kind kind, FileObject sibling) {
+    InMemoryClassFile result = new InMemoryClassFile(URI.create("string://" + className));
+    compiledClasses.put(className, result);
+    return result;
+  }
+
+  public Class<?> loadCompiledClass(String className) throws ClassNotFoundException {
+    return classLoader.loadClass(className);
+  }
+}

--- a/dd-java-compiler-plugin/src/test/java/datadog/compiler/InMemorySourceFile.java
+++ b/dd-java-compiler-plugin/src/test/java/datadog/compiler/InMemorySourceFile.java
@@ -1,0 +1,26 @@
+package datadog.compiler;
+
+import java.net.URI;
+import javax.tools.SimpleJavaFileObject;
+
+public class InMemorySourceFile extends SimpleJavaFileObject {
+  private static final String FILE_PROTOCOL = "file://";
+  private static final String FAKE_REPO_ROOT = "/repo/src/";
+
+  private final String content;
+
+  public InMemorySourceFile(String qualifiedClassName, String testSource) {
+    super(URI.create(FILE_PROTOCOL + sourcePath(qualifiedClassName)), Kind.SOURCE);
+    content = testSource;
+  }
+
+  @Override
+  public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+    return content;
+  }
+
+  public static String sourcePath(String qualifiedClassName) {
+    return String.format(
+        FAKE_REPO_ROOT + "%s%s", qualifiedClassName.replaceAll("\\.", "/"), Kind.SOURCE.extension);
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -80,6 +80,8 @@ include ':dd-java-agent:cws-tls'
 
 // misc
 include ':dd-java-agent:testing'
+include ':dd-java-compiler-plugin'
+include ':dd-java-compiler-plugin:client'
 include ':utils:container-utils'
 include ':utils:socket-utils'
 include ':utils:test-agent-utils:decoder'


### PR DESCRIPTION
# What Does This Do
This change adds a javac compiler plugin that is supposed to be used by CI visibility clients in combination with the java tracer.
The plugin injects into every compiled class the path to that class' source code (the injection is done by adding a private static field).

# Motivation
CI visibility logic needs to establish correspondence between a test class and its source code file.
For now this is needed in order to determine owners of specific tests (by consulting the CODEOWNERS file), but later it might be used for other purposes, such as determining code coverage per test-case.

# Additional Notes
* This change only adds the plugin. The tracer logic that uses injected data will be added as a separate PR.
* Eclipse JDT compiler does not support plugins, so a separate fallback solution will be developed for the clients who use it

