### PR TITLE
Rename remote config poll interval environment variable

### DIFF
--- a/dd-smoke-tests/appsec/src/main/groovy/datadog/smoketest/appsec/AbstractAppSecServerSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/src/main/groovy/datadog/smoketest/appsec/AbstractAppSecServerSmokeTest.groovy
@@ -48,7 +48,7 @@ abstract class AbstractAppSecServerSmokeTest extends AbstractServerSmokeTest {
   // enable remote config so that appsec is partially enabled (rc is now enabled by default)
   [
     '-Ddd.remote_config.url=https://127.0.0.1:54670/invalid_endpoint',
-    '-Ddd.remote_config.initial.poll.interval=3600'
+    '-Ddd.remote_config.poll_interval.seconds=3600'
   ]:
   ['-Ddd.remote_config.enabled=false']
   )

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
@@ -110,7 +110,7 @@ public abstract class BaseIntegrationTest {
             "-Ddd.jmxfetch.enabled=false",
             "-Ddd.dynamic.instrumentation.enabled=true",
             // "-Ddd.remote_config.enabled=true", // default
-            "-Ddd.remote_config.initial.poll.interval=1",
+            "-Ddd.remote_config.poll_interval.seconds=1",
             /*"-Ddd.remote_config.integrity_check.enabled=false",
             "-Ddd.dynamic.instrumentation.probe.url=http://localhost:"
                 + probeServer.getPort()

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -102,7 +102,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_REMOTE_CONFIG_ENABLED = true;
   static final boolean DEFAULT_REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED = false;
   static final int DEFAULT_REMOTE_CONFIG_MAX_PAYLOAD_SIZE = 1024; // KiB
-  static final int DEFAULT_REMOTE_CONFIG_INITIAL_POLL_INTERVAL = 5; // s
+  static final int DEFAULT_REMOTE_CONFIG_POLL_INTERVAL_SECONDS = 5;
   static final String DEFAULT_REMOTE_CONFIG_TARGETS_KEY_ID =
       "5c4ece41241a1bb513f6e3e5df74ab7d5183dfffbd71bfd43127920d880569fd";
   static final String DEFAULT_REMOTE_CONFIG_TARGETS_KEY =

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/RemoteConfigConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/RemoteConfigConfig.java
@@ -5,8 +5,8 @@ public class RemoteConfigConfig {
   public static final String REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED =
       "remote_config.integrity_check.enabled";
   public static final String REMOTE_CONFIG_URL = "remote_config.url";
-  public static final String REMOTE_CONFIG_INITIAL_POLL_INTERVAL =
-      "remote_config.initial.poll.interval"; // s
+  public static final String REMOTE_CONFIG_POLL_INTERVAL_SECONDS =
+      "remote_config.poll_interval.seconds";
   public static final String REMOTE_CONFIG_MAX_PAYLOAD_SIZE =
       "remote_config.max.payload.size"; // kb
   // these two are specified in RCTE1

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -54,9 +54,9 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_PRIORITY_SAMPLING_ENABLED
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PRIORITY_SAMPLING_FORCE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_REMOTE_CONFIG_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_REMOTE_CONFIG_INITIAL_POLL_INTERVAL;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_REMOTE_CONFIG_MAX_PAYLOAD_SIZE;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_REMOTE_CONFIG_POLL_INTERVAL_SECONDS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_REMOTE_CONFIG_TARGETS_KEY;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_REMOTE_CONFIG_TARGETS_KEY_ID;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SCOPE_DEPTH_LIMIT;
@@ -206,9 +206,9 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_TIMEOUT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_TIMEOUT_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_URL;
 import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_ENABLED;
-import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_INITIAL_POLL_INTERVAL;
 import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED;
 import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_MAX_PAYLOAD_SIZE;
+import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_POLL_INTERVAL_SECONDS;
 import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_TARGETS_KEY;
 import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_TARGETS_KEY_ID;
 import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_URL;
@@ -537,7 +537,7 @@ public class Config {
   private final boolean remoteConfigEnabled;
   private final boolean remoteConfigIntegrityCheckEnabled;
   private final String remoteConfigUrl;
-  private final int remoteConfigInitialPollInterval;
+  private final int remoteConfigPollIntervalSeconds;
   private final long remoteConfigMaxPayloadSize;
   private final String remoteConfigTargetsKeyId;
   private final String remoteConfigTargetsKey;
@@ -1244,9 +1244,9 @@ public class Config {
         configProvider.getBoolean(
             REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED, DEFAULT_REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED);
     remoteConfigUrl = configProvider.getString(REMOTE_CONFIG_URL);
-    remoteConfigInitialPollInterval =
+    remoteConfigPollIntervalSeconds =
         configProvider.getInteger(
-            REMOTE_CONFIG_INITIAL_POLL_INTERVAL, DEFAULT_REMOTE_CONFIG_INITIAL_POLL_INTERVAL);
+            REMOTE_CONFIG_POLL_INTERVAL_SECONDS, DEFAULT_REMOTE_CONFIG_POLL_INTERVAL_SECONDS);
     remoteConfigMaxPayloadSize =
         configProvider.getInteger(
                 REMOTE_CONFIG_MAX_PAYLOAD_SIZE, DEFAULT_REMOTE_CONFIG_MAX_PAYLOAD_SIZE)
@@ -1972,8 +1972,8 @@ public class Config {
     return remoteConfigUrl;
   }
 
-  public int getRemoteConfigInitialPollInterval() {
-    return remoteConfigInitialPollInterval;
+  public int getRemoteConfigPollIntervalSeconds() {
+    return remoteConfigPollIntervalSeconds;
   }
 
   public String getRemoteConfigTargetsKeyId() {
@@ -3087,8 +3087,8 @@ public class Config {
         + remoteConfigEnabled
         + ", remoteConfigUrl="
         + remoteConfigUrl
-        + ", remoteConfigInitialPollInterval="
-        + remoteConfigInitialPollInterval
+        + ", remoteConfigPollIntervalSeconds="
+        + remoteConfigPollIntervalSeconds
         + ", remoteConfigMaxPayloadSize="
         + remoteConfigMaxPayloadSize
         + ", remoteConfigIntegrityCheckEnabled="

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -74,7 +74,7 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_PERIOD
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_TIMEOUT
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_URL
 import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_ENABLED
-import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_INITIAL_POLL_INTERVAL
+import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_POLL_INTERVAL_SECONDS
 import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_MAX_PAYLOAD_SIZE
 import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_URL
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
@@ -212,7 +212,7 @@ class ConfigTest extends DDSpecification {
 
     prop.setProperty(REMOTE_CONFIG_ENABLED, "true")
     prop.setProperty(REMOTE_CONFIG_URL, "remote config url")
-    prop.setProperty(REMOTE_CONFIG_INITIAL_POLL_INTERVAL, "3")
+    prop.setProperty(REMOTE_CONFIG_POLL_INTERVAL_SECONDS, "3")
     prop.setProperty(REMOTE_CONFIG_MAX_PAYLOAD_SIZE, "2")
 
     prop.setProperty(DEBUGGER_ENABLED, "true")
@@ -298,7 +298,7 @@ class ConfigTest extends DDSpecification {
 
     config.remoteConfigEnabled == true
     config.finalRemoteConfigUrl == 'remote config url'
-    config.remoteConfigInitialPollInterval == 3
+    config.remoteConfigPollIntervalSeconds == 3
     config.remoteConfigMaxPayloadSizeBytes == 2048
 
     config.debuggerEnabled == true
@@ -383,7 +383,7 @@ class ConfigTest extends DDSpecification {
 
     System.setProperty(PREFIX + REMOTE_CONFIG_ENABLED, "true")
     System.setProperty(PREFIX + REMOTE_CONFIG_URL, "remote config url")
-    System.setProperty(PREFIX + REMOTE_CONFIG_INITIAL_POLL_INTERVAL, "3")
+    System.setProperty(PREFIX + REMOTE_CONFIG_POLL_INTERVAL_SECONDS, "3")
     System.setProperty(PREFIX + REMOTE_CONFIG_MAX_PAYLOAD_SIZE, "2")
 
     System.setProperty(PREFIX + DEBUGGER_ENABLED, "true")
@@ -469,7 +469,7 @@ class ConfigTest extends DDSpecification {
 
     config.remoteConfigEnabled == true
     config.finalRemoteConfigUrl == 'remote config url'
-    config.remoteConfigInitialPollInterval == 3
+    config.remoteConfigPollIntervalSeconds == 3
     config.remoteConfigMaxPayloadSizeBytes == 2 * 1024
 
     config.debuggerEnabled == true

--- a/remote-config/src/main/java/datadog/remoteconfig/PollerScheduler.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/PollerScheduler.java
@@ -10,11 +10,9 @@ import org.slf4j.LoggerFactory;
 /** Handles scheduling scheme for polling configuration */
 class PollerScheduler {
   private static final Logger LOGGER = LoggerFactory.getLogger(PollerScheduler.class);
-  static final long MAX_POLL_INTERVAL_MS = Duration.ofSeconds(25).toMillis();
 
   private final long initialPollInterval;
   private long currentPollInterval;
-  private final long maxPollInterval = MAX_POLL_INTERVAL_MS;
   private final ConfigurationPoller poller;
   private final AgentTaskScheduler taskScheduler;
   private volatile AgentTaskScheduler.Scheduled<ConfigurationPoller> scheduled;
@@ -23,7 +21,7 @@ class PollerScheduler {
       Config config, ConfigurationPoller poller, AgentTaskScheduler taskScheduler) {
     // TODO add a jitter to avoid herd issue
     this.initialPollInterval =
-        Duration.ofSeconds(config.getRemoteConfigInitialPollInterval()).toMillis();
+        Duration.ofSeconds(config.getRemoteConfigPollIntervalSeconds()).toMillis();
     this.poller = poller;
     this.taskScheduler = taskScheduler;
   }


### PR DESCRIPTION
# What Does This Do
Renames the environment variable used to configure the remote config polling interval.

After this change, remote config polling interval (default: 5 seconds) can be set with `DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS`.

# Motivation
The main motivation for this PR is to align all remote config implementations in the tracers to use the same env variable (name and default value) to configure the polling interval.

# Additional Notes
