### PR TITLE
Set error in instrumented span on exception

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerSpan.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerSpan.java
@@ -3,11 +3,16 @@ package datadog.trace.bootstrap.debugger;
 public interface DebuggerSpan {
   void finish();
 
+  void setError(Throwable t);
+
   DebuggerSpan NOOP_SPAN = new NoopSpan();
 
   class NoopSpan implements DebuggerSpan {
 
     @Override
     public void finish() {}
+
+    @Override
+    public void setError(Throwable t) {}
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTracer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTracer.java
@@ -42,5 +42,11 @@ public class DebuggerTracer implements DebuggerContext.Tracer {
       currentScope.close();
       underlyingSpan.finish();
     }
+
+    @Override
+    public void setError(Throwable t) {
+      underlyingSpan.setError(true);
+      underlyingSpan.addThrowable(t);
+    }
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/SpanInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/SpanInstrumentor.java
@@ -50,6 +50,16 @@ public class SpanInstrumentor extends Instrumentor {
   private InsnList createCatchHandler(LabelNode handlerLabel) {
     InsnList handler = new InsnList();
     handler.add(handlerLabel);
+    // stack [exception]
+    handler.add(new InsnNode(Opcodes.DUP));
+    // stack [exception, exception]
+    handler.add(new VarInsnNode(Opcodes.ALOAD, spanVar));
+    // stack [exception, exception, span]
+    handler.add(new InsnNode(Opcodes.SWAP));
+    // stack [exception, span, exception]
+    invokeInterface(
+        handler, DEBUGGER_SPAN_TYPE, "setError", Type.VOID_TYPE, Type.getType(Throwable.class));
+    // stack [exception]
     debuggerSpanFinish(handler);
     handler.add(new InsnNode(Opcodes.ATHROW));
     return handler;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTracerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTracerTest.java
@@ -23,4 +23,14 @@ class DebuggerTracerTest {
     span.finish();
     assertNotEquals(0, underlyingSpan.getDurationNano());
   }
+
+  @Test
+  public void setError() {
+    AgentTracer.forceRegister(CoreTracer.builder().build());
+    DebuggerTracer debuggerTracer = new DebuggerTracer();
+    DebuggerSpan span = debuggerTracer.createSpan("a-span", new String[] {"foo:bar"});
+    span.setError(new IllegalArgumentException("oops"));
+    AgentSpan underlyingSpan = ((DebuggerTracer.DebuggerSpanImpl) span).underlyingSpan;
+    assertTrue(underlyingSpan.isError());
+  }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanProbeInstrumentationTest.java
@@ -123,6 +123,7 @@ public class SpanProbeInstrumentationTest extends ProbeInstrumentationTest {
 
   static class MockSpan implements DebuggerSpan {
     boolean finished;
+    Throwable throwable;
     String name;
     String[] tags;
 
@@ -134,6 +135,11 @@ public class SpanProbeInstrumentationTest extends ProbeInstrumentationTest {
     @Override
     public void finish() {
       finished = true;
+    }
+
+    @Override
+    public void setError(Throwable t) {
+      this.throwable = t;
     }
 
     public boolean isFinished() {


### PR DESCRIPTION
# What Does This Do
When exception is thrown during the instrumented span, we store the throwable inside the span for reporting it as error span.

# Motivation

# Additional Notes
