### PR TITLE
Fix issue resolving dependency with empty artifactId

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/dependency/Dependency.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/Dependency.java
@@ -253,7 +253,7 @@ public final class Dependency {
 
   /** Check is string is valid artifactId. Should be a non-capital single word. */
   private static boolean isValidArtifactId(String artifactId) {
-    return artifactId != null
+    return hasText(artifactId)
         && !artifactId.contains(" ")
         && !artifactId.contains(".")
         && !Character.isUpperCase(artifactId.charAt(0));
@@ -261,10 +261,14 @@ public final class Dependency {
 
   /** Check is string is valid groupId. Should be a non-capital plural-word separated with dot. */
   private static boolean isValidGroupId(String group) {
-    return group != null
+    return hasText(group)
         && !group.contains(" ")
         && group.contains(".")
         && !Character.isUpperCase(group.charAt(0));
+  }
+
+  private static boolean hasText(final String value) {
+    return value != null && !value.isEmpty();
   }
 
   private static boolean equalsNonNull(String s1, String s2) {

--- a/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolver.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolver.java
@@ -44,7 +44,7 @@ public class DependencyResolver {
         }
       }
     } catch (RuntimeException rte) {
-      log.warn("Failed to determine dependency for uri {}", uri, rte);
+      log.debug("Failed to determine dependency for uri {}", uri, rte);
     }
     // TODO : moving jboss vfs here is probably a idea
     // it might however require to do somme checks to make sure it's only applied to jboss
@@ -61,7 +61,7 @@ public class DependencyResolver {
    */
   static List<Dependency> extractDependenciesFromJar(File jar) {
     if (!jar.exists()) {
-      log.warn("unable to find dependency {} (path does not exist)", jar);
+      log.debug("unable to find dependency {} (path does not exist)", jar);
       return Collections.emptyList();
     } else if (!jar.getName().endsWith(JAR_SUFFIX)) {
       log.debug("unsupported file dependency type : {}", jar);
@@ -103,7 +103,7 @@ public class DependencyResolver {
       String jarFileName = jarFile.getName();
       int posSep = jarFileName.indexOf("!/");
       if (posSep == -1) {
-        log.warn("Unable to guess nested dependency for uri '{}': '!/' not found", uri);
+        log.debug("Unable to guess nested dependency for uri '{}': '!/' not found", uri);
         return null;
       }
       lastPart = jarFileName.substring(posSep + 1);
@@ -113,7 +113,7 @@ public class DependencyResolver {
     } catch (IOException e) {
       log.debug("unable to open nested jar manifest for {}", uri, e);
     }
-    log.info(
+    log.debug(
         "Unable to guess nested dependency for uri '{}', lastPart: '{}', fileName: '{}'",
         uri,
         lastPart,

--- a/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencySpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencySpecification.groovy
@@ -1,0 +1,32 @@
+package datadog.telemetry.dependency
+
+import datadog.trace.test.util.DDSpecification
+
+import java.util.jar.Attributes
+import java.util.jar.Manifest
+
+class DependencySpecification extends DDSpecification {
+
+  void 'test guessFallbackNoPom with bundle-symbolicname = #bundleSymbolicName'() {
+    given:
+    final attributes = Mock(Attributes) {
+      getValue('bundle-symbolicname') >> bundleSymbolicName
+    }
+    final manifest = Mock(Manifest) {
+      getMainAttributes() >> attributes
+    }
+    final stream = Mock(InputStream)
+
+    when:
+    Dependency.guessFallbackNoPom(manifest, "abc", stream)
+
+    then:
+    noExceptionThrown()
+
+    where:
+    bundleSymbolicName              | _
+    null                            | _
+    ''                              | _
+    'org.osgi.framework.bsnversion' | _
+  }
+}


### PR DESCRIPTION
# What Does This Do
Fixes issue in dependency resolution when artifactId is empty

# Motivation

# Additional Notes
See https://github.com/DataDog/dd-trace-java/issues/4527
