### PR TITLE
fix and log async-profiler activation

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-auxiliary/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/build.gradle
@@ -8,6 +8,7 @@ excludedClassesCoverage += []
 
 dependencies {
   api deps.slf4j
+  api project(':internal-api')
   api project(':dd-java-agent:agent-profiling:profiling-controller')
   api project(':dd-java-agent:agent-profiling:profiling-utils')
 

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/AuxiliaryProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/main/java/com/datadog/profiling/auxiliary/AuxiliaryProfiler.java
@@ -1,5 +1,7 @@
 package com.datadog.profiling.auxiliary;
 
+import static datadog.trace.api.Config.isAsyncProfilerSafeInCurrentEnvironment;
+
 import com.datadog.profiling.controller.OngoingRecording;
 import com.datadog.profiling.utils.ProfilingMode;
 import datadog.trace.api.Platform;
@@ -41,7 +43,7 @@ public final class AuxiliaryProfiler {
         Platform.isLinux()
                 && configProvider.getBoolean(
                     ProfilingConfig.PROFILING_ASYNC_ENABLED,
-                    ProfilingConfig.PROFILING_ASYNC_ENABLED_DEFAULT)
+                    isAsyncProfilerSafeInCurrentEnvironment())
             ? "async"
             : configProvider.getString(
                 ProfilingConfig.PROFILING_AUXILIARY_TYPE,
@@ -61,7 +63,7 @@ public final class AuxiliaryProfiler {
         break;
       }
     }
-    this.implementation = impl != null ? impl : AuxiliaryImplementation.NULL;
+    this.implementation = impl;
   }
 
   AuxiliaryProfiler(AuxiliaryImplementation impl) {

--- a/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/java/com/datadog/profiling/auxiliary/AuxiliaryProfilerTest.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary/src/test/java/com/datadog/profiling/auxiliary/AuxiliaryProfilerTest.java
@@ -36,6 +36,7 @@ class AuxiliaryProfilerTest {
   @Test
   void testAuxiliaryFromServiceLoader() {
     Properties props = new Properties();
+    props.put(ProfilingConfig.PROFILING_ASYNC_ENABLED, "false");
     props.put(ProfilingConfig.PROFILING_AUXILIARY_TYPE, TestAuxiliaryProfilerImplementation.TYPE);
     ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(props);
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
@@ -1,5 +1,6 @@
 package datadog.trace.core;
 
+import static datadog.trace.api.Config.isAsyncProfilerSafeInCurrentEnvironment;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import com.squareup.moshi.JsonAdapter;
@@ -125,6 +126,10 @@ public final class StatusLogger extends JsonAdapter<Config>
     writer.value(config.isCwsEnabled());
     writer.name("cws_tls_refresh");
     writer.value(config.getCwsTlsRefresh());
+    writer.name("async_profiler_enabled");
+    writer.value(config.isAsyncProfilerEnabled());
+    writer.name("async_profiler_safe");
+    writer.value(isAsyncProfilerSafeInCurrentEnvironment());
     writer.endObject();
   }
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1792,13 +1792,12 @@ public class Config {
     return isAsyncProfilerEnabled;
   }
 
-  private static boolean isAsyncProfilerSafeInCurrentEnvironment() {
+  public static boolean isAsyncProfilerSafeInCurrentEnvironment() {
     // don't want to put this logic (which will evolve) in the public ProfilingConfig, and can't
     // access Platform there
-    if (Platform.isJ9()) {
-      return true;
-    }
-    return Platform.isJavaVersionAtLeast(18)
+    // don't want to put this logic (which will evolve) in the public ProfilingConfig, and can't
+    // access Platform there
+    return Platform.isJ9()
         || Platform.isJavaVersionAtLeast(17, 0, 5)
         || (Platform.isJavaVersion(11) && Platform.isJavaVersionAtLeast(11, 0, 17))
         || (Platform.isJavaVersion(8) && Platform.isJavaVersionAtLeast(8, 0, 352));


### PR DESCRIPTION
# What Does This Do

Owing to complexities in configuring the profiler, we haven't been actually enabling async-profiler when we could have been since 1.3.0. This really activates it.

# Motivation

# Additional Notes
