### PR TITLE
Fix log probe conditions

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -267,8 +267,9 @@ public class ConfigurationUpdater
     SummaryBuilder summaryBuilder;
     ProbeCondition probeCondition;
     if (probe instanceof LogProbe) {
-      summaryBuilder = new LogMessageTemplateSummaryBuilder((LogProbe) probe);
-      probeCondition = null;
+      LogProbe logProbe = (LogProbe) probe;
+      summaryBuilder = new LogMessageTemplateSummaryBuilder(logProbe);
+      probeCondition = logProbe.getProbeCondition();
     } else {
       log.warn("definition id={} has unsupported probe type: {}", probe.getId(), probe.getClass());
       return null;


### PR DESCRIPTION
# What Does This Do
conditions for log probes were not passed to resolved ProbeDetails in snapshot, so no evaluation of the condition.

# Motivation
No condition evaluation for Log Probes

# Additional Notes
A smoke test for condition evaluation should be added to avoid regression on this part but requires a significant effort to implement (Json serialization of the condition configuration). Will do in a next PR.