### PR TITLE
Refactor BeanFactory advice so we can repair other injected bean definitions

### DIFF
--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/BeanDefinitionRepairer.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/BeanDefinitionRepairer.java
@@ -1,16 +1,14 @@
 package datadog.trace.instrumentation.springweb;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 
 /**
  * Repairs Datadog injected bean definitions by restoring missing class references at resolve time.
  */
 public final class BeanDefinitionRepairer {
-  private static final Map<String, Class<?>> ddBeanClasses =
-      Collections.synchronizedMap(new HashMap<>());
+  private static final Map<String, Class<?>> ddBeanClasses = new ConcurrentHashMap<>();
 
   public static void register(Class<?> beanClass) {
     ddBeanClasses.put(beanClass.getName(), beanClass);
@@ -19,7 +17,7 @@ public final class BeanDefinitionRepairer {
   public static void repair(RootBeanDefinition beanDefinition) {
     if (!beanDefinition.hasBeanClass()) {
       String className = beanDefinition.getBeanClassName();
-      if (null != className && className.startsWith("datadog.trace.instrumentation.")) {
+      if (null != className) {
         Class<?> beanClass = ddBeanClasses.get(className);
         if (null != beanClass) {
           beanDefinition.setBeanClass(beanClass);

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/BeanFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/BeanFactoryInstrumentation.java
@@ -41,13 +41,7 @@ public class BeanFactoryInstrumentation extends Instrumenter.Tracing
 
   @Override
   public String[] helperClassNames() {
-    return new String[] {
-      packageName + ".SpringWebHttpServerDecorator",
-      packageName + ".ServletRequestURIAdapter",
-      packageName + ".HandlerMappingResourceNameFilter",
-      packageName + ".HandlerMappingResourceNameFilter$BeanDefinition",
-      packageName + ".PathMatchingHttpServletRequestWrapper",
-    };
+    return new String[] {packageName + ".BeanDefinitionRepairer"};
   }
 
   @Override
@@ -64,13 +58,12 @@ public class BeanFactoryInstrumentation extends Instrumenter.Tracing
   public static class BeanResolvingAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void onEnter(@Advice.Argument(0) final RootBeanDefinition beanDefinition) {
-      if (!beanDefinition.hasBeanClass()
-          && HandlerMappingResourceNameFilter.class
-              .getName()
-              .equals(beanDefinition.getBeanClassName())) {
-
-        beanDefinition.setBeanClass(HandlerMappingResourceNameFilter.class);
-      }
+      BeanDefinitionRepairer.repair(beanDefinition);
     }
+  }
+
+  @Override
+  public String muzzleDirective() {
+    return "spring-webmvc"; // only check against the main 'spring-webmvc' muzzle directive
   }
 }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerMappingResourceNameFilter.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerMappingResourceNameFilter.java
@@ -90,6 +90,7 @@ public class HandlerMappingResourceNameFilter extends OncePerRequestFilter imple
 
     public BeanDefinition() {
       super(HandlerMappingResourceNameFilter.class);
+      BeanDefinitionRepairer.register(HandlerMappingResourceNameFilter.class);
       setBeanClassName(HandlerMappingResourceNameFilter.class.getName());
       setScope(SCOPE_SINGLETON);
       setLazyInit(true);

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/WebApplicationContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/WebApplicationContextInstrumentation.java
@@ -41,6 +41,7 @@ public class WebApplicationContextInstrumentation extends Instrumenter.Tracing
     return new String[] {
       packageName + ".SpringWebHttpServerDecorator",
       packageName + ".ServletRequestURIAdapter",
+      packageName + ".BeanDefinitionRepairer",
       packageName + ".HandlerMappingResourceNameFilter",
       packageName + ".HandlerMappingResourceNameFilter$BeanDefinition",
       packageName + ".PathMatchingHttpServletRequestWrapper",

--- a/dd-java-agent/instrumentation/spring-webmvc-5.3/build.gradle
+++ b/dd-java-agent/instrumentation/spring-webmvc-5.3/build.gradle
@@ -13,6 +13,8 @@ dependencies {
   compileOnly group: 'org.springframework', name: 'spring-webmvc', version: '5.3.23'
   compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '4.0.1'
 
+  implementation project(':dd-java-agent:instrumentation:spring-webmvc-3.1')
+
   testImplementation(project(':dd-java-agent:testing')) {
     exclude(module: 'jetty-server') // incompatable servlet api
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/OrderedServletPathRequestFilter.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/OrderedServletPathRequestFilter.java
@@ -21,6 +21,7 @@ public class OrderedServletPathRequestFilter extends DelegatingFilterProxy imple
 
     public BeanDefinition() {
       super(OrderedServletPathRequestFilter.class);
+      BeanDefinitionRepairer.register(OrderedServletPathRequestFilter.class);
       setBeanClassName(OrderedServletPathRequestFilter.class.getName());
       setScope(SCOPE_SINGLETON);
       setLazyInit(true);

--- a/dd-java-agent/instrumentation/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/ServletPathRequestFilterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/ServletPathRequestFilterInstrumentation.java
@@ -46,6 +46,7 @@ public class ServletPathRequestFilterInstrumentation extends Instrumenter.Tracin
   @Override
   public String[] helperClassNames() {
     return new String[] {
+      packageName + ".BeanDefinitionRepairer",
       packageName + ".OrderedServletPathRequestFilter",
       packageName + ".OrderedServletPathRequestFilter$BeanDefinition",
     };

--- a/dd-smoke-tests/wildfly/build.gradle
+++ b/dd-smoke-tests/wildfly/build.gradle
@@ -36,7 +36,54 @@ dependencies {
   testImplementation project(':dd-smoke-tests')
 }
 
+def appDir = "$projectDir/spring-ear"
+def appBuildDir = "$buildDir/spring-ear"
+def isWindows = System.getProperty("os.name").toLowerCase().contains("win")
+def gradlewCommand = isWindows ? 'gradlew.bat' : 'gradlew'
+// define the task that builds the quarkus project
+tasks.register('earBuild', Exec) {
+  workingDir "$appDir"
+  environment += ["GRADLE_OPTS": "-Dorg.gradle.jvmargs='-Xmx512M'"]
+  commandLine "$rootDir/${gradlewCommand}", "assemble", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archivePath}"
+
+  outputs.cacheIf { true }
+
+  outputs.dir(appBuildDir)
+    .withPropertyName("applicationEar")
+
+  inputs.files(fileTree(appDir) {
+    include '**/*'
+    exclude '.gradle/**'
+  })
+  .withPropertyName("application")
+  .withPathSensitivity(PathSensitivity.RELATIVE)
+}
+
+earBuild {
+  dependsOn project(':dd-trace-api').tasks.named("jar")
+}
+
+tasks.named("compileTestGroovy").configure {
+  dependsOn tasks.earBuild
+  outputs.upToDateWhen {
+    !earBuild.didWork
+  }
+}
+
+spotless {
+  java {
+    target "**/*.java"
+  }
+
+  groovyGradle {
+    target '*.gradle', "**/*.gradle"
+  }
+}
+
+def wildflyDir="${buildDir}/${serverName}-${serverModule}-${serverVersion}"
+
 tasks.register("unzip", Copy) {
+  dependsOn tasks.earBuild
   def zipFileNamePrefix = "servlet"
   def zipPath = project.configurations.serverFile.find {
     it.name.startsWith(zipFileNamePrefix)
@@ -55,8 +102,14 @@ tasks.register("unzip", Copy) {
   onlyIf { !project.rootProject.hasProperty("skipTests") }
 }
 
-tasks.withType(Test).configureEach {
-  dependsOn "unzip"
-
-  jvmArgs "-Ddatadog.smoketest.wildflyDir=${buildDir}/${serverName}-${serverModule}-${serverVersion}"
+tasks.register("deploy", Copy) {
+  dependsOn tasks.unzip
+  from "${appBuildDir}/libs/wildfly-spring-ear-smoketest.ear"
+  into "${wildflyDir}/standalone/deployments"
 }
+
+tasks.withType(Test).configureEach {
+  dependsOn tasks.deploy
+  jvmArgs "-Ddatadog.smoketest.wildflyDir=${wildflyDir}"
+}
+

--- a/dd-smoke-tests/wildfly/spring-ear/.gitignore
+++ b/dd-smoke-tests/wildfly/spring-ear/.gitignore
@@ -1,0 +1,6 @@
+# Ignore all project specific gradle directories/files
+.gradle
+gradle
+build
+gradlew
+gradlew.bat

--- a/dd-smoke-tests/wildfly/spring-ear/build.gradle
+++ b/dd-smoke-tests/wildfly/spring-ear/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+  id 'java'
+  id 'ear'
+  id "com.diffplug.spotless" version "6.11.0"
+  id 'pl.allegro.tech.build.axion-release' version '1.14.2'
+}
+
+def sharedRootDir = "$rootDir/../../../"
+def sharedConfigDirectory = "$sharedRootDir/gradle"
+rootProject.ext.sharedConfigDirectory = sharedConfigDirectory
+
+apply from: "$sharedConfigDirectory/repositories.gradle"
+apply from: "$sharedConfigDirectory/spotless.gradle"
+apply plugin: 'ear'
+
+if (hasProperty('appBuildDir')) {
+  buildDir = property('appBuildDir')
+}
+
+version = ""
+dependencies {
+  earlib 'org.springframework:spring-webmvc:5.3.0'
+  deploy project(path: ':war', configuration: 'archives')
+
+  if (hasProperty('apiJar')) {
+    implementation files(property('apiJar'))
+  } else {
+    implementation "com.datadoghq:dd-trace-api:1.2.0"
+  }
+}

--- a/dd-smoke-tests/wildfly/spring-ear/settings.gradle
+++ b/dd-smoke-tests/wildfly/spring-ear/settings.gradle
@@ -1,0 +1,24 @@
+pluginManagement {
+  repositories {
+    mavenLocal()
+    mavenCentral()
+    gradlePluginPortal()
+  }
+}
+
+def isCI = System.getenv("CI") != null
+
+// Don't pollute the dependency cache with the build cache
+if (isCI) {
+  def sharedRootDir = "$rootDir/../../../"
+  buildCache {
+    local {
+      // This needs to line up with the code in the outer project settings.gradle
+      directory = "$sharedRootDir/workspace/build-cache"
+    }
+  }
+}
+
+rootProject.name='wildfly-spring-ear-smoketest'
+
+include 'war'

--- a/dd-smoke-tests/wildfly/spring-ear/war/build.gradle
+++ b/dd-smoke-tests/wildfly/spring-ear/war/build.gradle
@@ -1,0 +1,10 @@
+apply plugin: 'java'
+apply plugin: 'war'
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  compileOnly 'org.springframework:spring-webmvc:5.3.0'
+}

--- a/dd-smoke-tests/wildfly/spring-ear/war/src/main/java/com/example/hello/HelloController.java
+++ b/dd-smoke-tests/wildfly/spring-ear/war/src/main/java/com/example/hello/HelloController.java
@@ -1,0 +1,13 @@
+package com.example.hello;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+  @RequestMapping("/hello")
+  public String hello() {
+    return "hello world";
+  }
+}

--- a/dd-smoke-tests/wildfly/spring-ear/war/src/main/webapp/WEB-INF/dispatcher-servlet.xml
+++ b/dd-smoke-tests/wildfly/spring-ear/war/src/main/webapp/WEB-INF/dispatcher-servlet.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:mvc="http://www.springframework.org/schema/mvc"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.2.xsd
+		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.2.xsd">
+
+    <mvc:annotation-driven/>
+
+    <context:component-scan base-package="com.example.hello"/>
+</beans>

--- a/dd-smoke-tests/wildfly/spring-ear/war/src/main/webapp/WEB-INF/web.xml
+++ b/dd-smoke-tests/wildfly/spring-ear/war/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+         http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+
+    <servlet>
+        <servlet-name>dispatcher</servlet-name>
+        <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>dispatcher</servlet-name>
+        <url-pattern>/</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/dd-smoke-tests/wildfly/src/test/groovy/datadog/smoketest/WildflySmokeTest.groovy
+++ b/dd-smoke-tests/wildfly/src/test/groovy/datadog/smoketest/WildflySmokeTest.groovy
@@ -56,4 +56,19 @@ class WildflySmokeTest extends AbstractServerSmokeTest {
     where:
     n << (1..200)
   }
+
+  def "spring context loaded successfully"() {
+    setup:
+    String url = "http://localhost:$httpPort/war/hello"
+    def request = new Request.Builder().url(url).get().build()
+
+    when:
+    def response = client.newCall(request).execute()
+
+    then:
+    def responseBodyStr = response.body().string()
+    responseBodyStr != null
+    responseBodyStr.contentEquals("hello world")
+    response.code() == 200
+  }
 }


### PR DESCRIPTION
# What Does This Do

Introduces `BeanDefinitionRepairer` to help make the existing bean definition repair approach more re-usable. Bean definitions registered by the tracer now just have to register their classes with `BeanDefinitionRepairer` and these will be re-applied to bean definitions with matching names, even if the original bean class has been lost, for example due to the definition being cloned.

# Additional Notes

Includes a new smoke test to verify that bean definition repair works for both old and new spring-webmvc definitions.