### PR TITLE
Remove debug log line when handling exception during field extract for JSON serialization

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
@@ -622,11 +622,6 @@ public class MoshiSnapshotHelper {
         BiConsumer<Exception, Field> exHandling =
             (ex, field) -> {
               String fieldName = field.getName();
-              LOG.debug(
-                  "Cannot extract field[{}] from class[{}]",
-                  fieldName,
-                  field.getDeclaringClass().getName(),
-                  ex);
               try {
                 jsonWriter.name(fieldName);
                 jsonWriter.beginObject();


### PR DESCRIPTION
# What Does This Do
Exception is reported in the snapshot anyway

# Motivation

# Additional Notes
