### PR TITLE
byte-buddy 1.12.22

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
   implementation(gradleApi())
   implementation(localGroovy())
 
-  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.12.20")
+  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.12.22")
 
   implementation("org.eclipse.aether", "aether-connector-basic", "1.1.0")
   implementation("org.eclipse.aether", "aether-transport-http", "1.1.0")

--- a/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
+++ b/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
@@ -12,7 +12,7 @@ class InstrumentPluginTest extends Specification {
   def buildGradle = '''
     plugins {
       id 'java'
-      id 'net.bytebuddy.byte-buddy-gradle-plugin'
+      id 'instrument'
     }
     
     sourceCompatibility = JavaVersion.VERSION_1_8
@@ -23,7 +23,7 @@ class InstrumentPluginTest extends Specification {
     }
 
     dependencies {
-      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.12.20' // just to build TestPlugin
+      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.12.22' // just to build TestPlugin
     }
 
     apply plugin: 'instrument'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -15,7 +15,7 @@ final class CachedData {
     junit4        : "4.13.2",
     junit5        : "5.8.1",
     logback       : "1.2.3",
-    bytebuddy     : "1.12.20",
+    bytebuddy     : "1.12.22",
     scala         : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)
     scala210      : "2.10.7",
     scala211      : "2.11.12",


### PR DESCRIPTION
Main change of interest to us between 1.12.20 and 1.12.22:
> Support `MethodHandle` and `MethodType` in `Advice.Origin` annotation.
> Support `MethodHandles.Lookup` in `Origin` and `Advice.Origin` annotations.

https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.12.21
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.12.22