### PR TITLE
Cleanup IAST Instrumenters

### DIFF
--- a/dd-java-agent/agent-tooling/src/jmh/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteBenchmarkInstrumentation.java
+++ b/dd-java-agent/agent-tooling/src/jmh/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteBenchmarkInstrumentation.java
@@ -12,8 +12,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.jar.asm.Opcodes;
 import net.bytebuddy.matcher.ElementMatcher;
 
-public class CallSiteBenchmarkInstrumentation extends CallSiteInstrumentation
-    implements ElementMatcher<TypeDescription> {
+public class CallSiteBenchmarkInstrumentation extends CallSiteInstrumentation {
 
   public CallSiteBenchmarkInstrumentation() {
     super(buildCallSites(), "call-site");
@@ -21,12 +20,7 @@ public class CallSiteBenchmarkInstrumentation extends CallSiteInstrumentation
 
   @Override
   public ElementMatcher<TypeDescription> callerType() {
-    return this;
-  }
-
-  @Override
-  public boolean matches(final TypeDescription target) {
-    return CallSiteTrie.apply(target.getName()) != 1;
+    return CallSiteMatcher.INSTANCE;
   }
 
   @Override
@@ -41,6 +35,16 @@ public class CallSiteBenchmarkInstrumentation extends CallSiteInstrumentation
 
   private static List<CallSiteAdvice> buildCallSites() {
     return Collections.<CallSiteAdvice>singletonList(new GetParameterCallSite());
+  }
+
+  public static final class CallSiteMatcher
+      extends ElementMatcher.Junction.ForNonNullValues<TypeDescription> {
+    public static final CallSiteMatcher INSTANCE = new CallSiteMatcher();
+
+    @Override
+    protected boolean doMatch(TypeDescription target) {
+      return CallSiteTrie.apply(target.getName()) != 1;
+    }
   }
 
   private static class GetParameterCallSite implements InvokeAdvice, HasHelpers, Pointcut {

--- a/dd-java-agent/instrumentation/iast-instrumenter/src/main/java/datadog/trace/instrumentation/iastinstrumenter/IastInstrumentation.java
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/main/java/datadog/trace/instrumentation/iastinstrumenter/IastInstrumentation.java
@@ -9,8 +9,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(Instrumenter.class)
-public class IastInstrumentation extends CallSiteInstrumentation
-    implements ElementMatcher<TypeDescription> {
+public class IastInstrumentation extends CallSiteInstrumentation {
 
   public IastInstrumentation() {
     super(IastAdvice.class, "IastInstrumentation");
@@ -18,16 +17,21 @@ public class IastInstrumentation extends CallSiteInstrumentation
 
   @Override
   public ElementMatcher<TypeDescription> callerType() {
-    return this;
-  }
-
-  @Override
-  public boolean matches(final TypeDescription target) {
-    return IastExclusionTrie.apply(target.getName()) != 1;
+    return IastMatcher.INSTANCE;
   }
 
   @Override
   public boolean isApplicable(final Set<TargetSystem> enabledSystems) {
     return enabledSystems.contains(TargetSystem.IAST);
+  }
+
+  public static final class IastMatcher
+      extends ElementMatcher.Junction.ForNonNullValues<TypeDescription> {
+    public static final IastMatcher INSTANCE = new IastMatcher();
+
+    @Override
+    protected boolean doMatch(TypeDescription target) {
+      return IastExclusionTrie.apply(target.getName()) != 1;
+    }
   }
 }

--- a/dd-java-agent/instrumentation/iast-instrumenter/src/test/groovy/IastInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/test/groovy/IastInstrumentationTest.groovy
@@ -17,8 +17,8 @@ class IastInstrumentationTest extends DDSpecification{
     instrumentation.isEnabled()
     instrumentation.isApplicable(enabledSystems)
     instrumentation.callerType()
-    boolean description1Matched = instrumentation.matches(typeDescription1)
-    boolean description2Matched = instrumentation.matches(typeDescription2)
+    boolean description1Matched = instrumentation.callerType().matches(typeDescription1)
+    boolean description2Matched = instrumentation.callerType().matches(typeDescription2)
 
     then:
     description1Matched


### PR DESCRIPTION
Don't mix concerns - `Instrumenter`s should be declarative and shouldn't implement other APIs with different lifecycles