### PR TITLE
Add ProbeId as metric tag

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
@@ -8,12 +8,14 @@ import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.values.ObjectValue;
 import com.datadog.debugger.el.values.UndefinedValue;
 import com.datadog.debugger.probe.MetricProbe;
+import com.datadog.debugger.probe.ProbeDefinition;
 import com.datadog.debugger.probe.Where;
 import datadog.trace.bootstrap.debugger.DiagnosticMessage;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.ValueReferences;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -36,6 +38,7 @@ import org.slf4j.LoggerFactory;
 public class MetricInstrumentor extends Instrumentor {
   private static final Logger LOGGER = LoggerFactory.getLogger(MetricInstrumentor.class);
   private static final InsnList EMPTY_INSN_LIST = new InsnList();
+  private static final String PROBEID_TAG_NAME = "debugger.probeid";
 
   private final MetricProbe metricProbe;
 
@@ -85,7 +88,9 @@ public class MetricInstrumentor extends Instrumentor {
       // consider the metric as an increment counter one
       insnList.add(new LdcInsnNode(metricProbe.getMetricName()));
       ldc(insnList, 1L); // stack [long]
-      pushTags(insnList, metricProbe.getTags()); // stack [long, array]
+      pushTags(
+          insnList,
+          addProbeIdWithTags(metricProbe.getId(), metricProbe.getTags())); // stack [long, array]
       invokeStatic(
           insnList,
           DEBUGGER_CONTEXT_TYPE,
@@ -146,7 +151,10 @@ public class MetricInstrumentor extends Instrumentor {
     }
     // insert metric name at the beginning of the list
     insnList.insert(new LdcInsnNode(metricProbe.getMetricName())); // stack [string, long]
-    pushTags(insnList, metricProbe.getTags()); // stack [string, long, array]
+    pushTags(
+        insnList,
+        addProbeIdWithTags(
+            metricProbe.getId(), metricProbe.getTags())); // stack [string, long, array]
     invokeStatic(
         insnList,
         DEBUGGER_CONTEXT_TYPE,
@@ -157,6 +165,15 @@ public class MetricInstrumentor extends Instrumentor {
         Types.asArray(STRING_TYPE, 1));
     insnList.add(nullBranch);
     return insnList;
+  }
+
+  private ProbeDefinition.Tag[] addProbeIdWithTags(String probeId, ProbeDefinition.Tag[] tags) {
+    if (tags == null) {
+      return new ProbeDefinition.Tag[] {new ProbeDefinition.Tag(PROBEID_TAG_NAME, probeId)};
+    }
+    ProbeDefinition.Tag[] newTags = Arrays.copyOf(tags, tags.length + 1);
+    newTags[newTags.length - 1] = new ProbeDefinition.Tag(PROBEID_TAG_NAME, probeId);
+    return newTags;
   }
 
   private InsnList callGauge(MetricProbe metricProbe) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
@@ -36,6 +36,8 @@ public class MetricProbesInstrumentationTest {
   private static final String METRIC_ID1 = "beae1807-f3b0-4ea8-a74f-826790c5e6f6";
   private static final String METRIC_ID2 = "beae1807-f3b0-4ea8-a74f-826790c5e6f7";
   private static final String SERVICE_NAME = "service-name";
+  private static final String METRIC_PROBEID_TAG =
+      "debugger.probeid:beae1807-f3b0-4ea8-a74f-826790c5e6f8";
 
   private Instrumentation instr = ByteBuddyAgent.install();
   private ClassFileTransformer currentTransformer;
@@ -59,7 +61,7 @@ public class MetricProbesInstrumentationTest {
     Assert.assertEquals(3, result);
     Assert.assertTrue(listener.counters.containsKey(METRIC_NAME));
     Assert.assertEquals(1, listener.counters.get(METRIC_NAME).longValue());
-    Assert.assertArrayEquals(null, listener.lastTags);
+    Assert.assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
   @Test
@@ -80,7 +82,8 @@ public class MetricProbesInstrumentationTest {
     Assert.assertEquals(3, result);
     Assert.assertTrue(listener.counters.containsKey(METRIC_NAME));
     Assert.assertEquals(1, listener.counters.get(METRIC_NAME).longValue());
-    Assert.assertArrayEquals(new String[] {"tag1:foo1", "tag2:foo2"}, listener.lastTags);
+    Assert.assertArrayEquals(
+        new String[] {"tag1:foo1", "tag2:foo2", METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
   @Test
@@ -179,7 +182,7 @@ public class MetricProbesInstrumentationTest {
     Assert.assertEquals(48, result);
     Assert.assertTrue(listener.counters.containsKey(METRIC_NAME));
     Assert.assertEquals(31, listener.counters.get(METRIC_NAME).longValue());
-    Assert.assertArrayEquals(null, listener.lastTags);
+    Assert.assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
   @Test
@@ -197,7 +200,7 @@ public class MetricProbesInstrumentationTest {
             new String[] {"tag1:foo1"});
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertArrayEquals(new String[] {"tag1:foo1"}, listener.lastTags);
+    Assert.assertArrayEquals(new String[] {"tag1:foo1", METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
   @Test
@@ -217,7 +220,7 @@ public class MetricProbesInstrumentationTest {
     Assert.assertEquals(48, result);
     Assert.assertTrue(listener.counters.containsKey(METRIC_NAME));
     Assert.assertEquals(31, listener.counters.get(METRIC_NAME).longValue());
-    Assert.assertArrayEquals(null, listener.lastTags);
+    Assert.assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
   @Test
@@ -239,7 +242,7 @@ public class MetricProbesInstrumentationTest {
     Assert.assertEquals(48, result);
     Assert.assertTrue(listener.counters.containsKey(METRIC_NAME));
     Assert.assertEquals(31, listener.counters.get(METRIC_NAME).longValue());
-    Assert.assertArrayEquals(new String[] {"tag1:foo1"}, listener.lastTags);
+    Assert.assertArrayEquals(new String[] {"tag1:foo1", METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do
add a tag to the metric with the probe id

# Motivation
Identify metric generated by Dynamic Instrumentation

# Additional Notes
