### PR TITLE
DSM - direction tag is now used to prevent loops / hash explosions

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
@@ -124,7 +124,7 @@ public class DefaultPathwayContext implements PathwayContext {
       // will cause a `cardinality explosion` for hash / parentHash tag values
       if (sortedTags.containsKey(TagsProcessor.DIRECTION_TAG)) {
         String direction = sortedTags.get(TagsProcessor.DIRECTION_TAG);
-        if (direction == previousDirection) {
+        if (direction.equals(previousDirection)) {
           hash = closestOppositeDirectionHash;
         } else {
           previousDirection = direction;

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
@@ -13,7 +13,6 @@ import datadog.trace.bootstrap.instrumentation.api.PathwayContext;
 import datadog.trace.bootstrap.instrumentation.api.StatsPoint;
 import datadog.trace.core.Base64Decoder;
 import datadog.trace.core.Base64Encoder;
-import datadog.trace.core.util.LRUCache;
 import datadog.trace.util.FNV64Hash;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -46,8 +45,10 @@ public class DefaultPathwayContext implements PathwayContext {
   private long edgeStartNanoTicks;
   private long hash;
   private boolean started;
-  // used to detect and prevent loops in case of inaccurate / incomplete instrumentation
-  private final LRUCache<Long, Long> history = new LRUCache<Long, Long>(10000);
+  // state variables used to memoize the pathway hash with
+  // direction != current direction
+  private long closestOppositeDirectionHash;
+  private String previousDirection;
 
   private static final Set<String> hashableTagKeys =
       new HashSet<String>(
@@ -76,6 +77,7 @@ public class DefaultPathwayContext implements PathwayContext {
     this.pathwayStartNanoTicks = pathwayStartNanoTicks;
     this.edgeStartNanoTicks = edgeStartNanoTicks;
     this.hash = hash;
+    this.closestOppositeDirectionHash = hash;
     this.started = true;
   }
 
@@ -118,12 +120,16 @@ public class DefaultPathwayContext implements PathwayContext {
 
       long nodeHash = generateNodeHash(pathwayHashBuilder);
       // loop protection - a node should not be chosen as parent
-      // for an identical node within a single pathway context, as this
+      // for a sequential node with the same direction, as this
       // will cause a `cardinality explosion` for hash / parentHash tag values
-      if (hash != 0 && history.containsKey(nodeHash)) {
-        hash = history.get(nodeHash);
-      } else {
-        history.put(nodeHash, hash);
+      if (sortedTags.containsKey(TagsProcessor.DIRECTION_TAG)) {
+        String direction = sortedTags.get(TagsProcessor.DIRECTION_TAG);
+        if (direction == previousDirection) {
+          hash = closestOppositeDirectionHash;
+        } else {
+          previousDirection = direction;
+          closestOppositeDirectionHash = hash;
+        }
       }
 
       long newHash = generatePathwayHash(nodeHash, hash);

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DefaultPathwayContextTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DefaultPathwayContextTest.groovy
@@ -78,29 +78,29 @@ class DefaultPathwayContextTest extends DDCoreSpecification {
 
     when:
     timeSource.advance(50)
-    context.setCheckpoint(new LinkedHashMap<>(["type": "internal"]), pointConsumer)
+    context.setCheckpoint(new LinkedHashMap<>(["direction": "out", "type": "kafka"]), pointConsumer)
     timeSource.advance(25)
     context.setCheckpoint(
-      new LinkedHashMap<>(["group": "group", "topic": "topic", "type": "kafka"]), pointConsumer)
+      new LinkedHashMap<>(["direction": "in", "group": "group", "topic": "topic", "type": "kafka"]), pointConsumer)
     timeSource.advance(30)
     context.setCheckpoint(
-      new LinkedHashMap<>(["group": "group", "topic": "topic", "type": "kafka"]), pointConsumer)
+      new LinkedHashMap<>(["direction": "in", "group": "group", "topic": "topic", "type": "kafka"]), pointConsumer)
 
     then:
     context.isStarted()
     pointConsumer.points.size() == 3
     verifyFirstPoint(pointConsumer.points[0])
     with(pointConsumer.points[1]) {
-      edgeTags == ["group:group", "topic:topic", "type:kafka"]
-      edgeTags.size() == 3
+      edgeTags == ["direction:in", "group:group", "topic:topic", "type:kafka"]
+      edgeTags.size() == 4
       parentHash == pointConsumer.points[0].hash
       hash != 0
       pathwayLatencyNano == 25
       edgeLatencyNano == 25
     }
     with(pointConsumer.points[2]) {
-      edgeTags == ["group:group", "topic:topic", "type:kafka"]
-      edgeTags.size() == 3
+      edgeTags == ["direction:in", "group:group", "topic:topic", "type:kafka"]
+      edgeTags.size() == 4
       // this point should have the first point as parent,
       // as the loop protection will reset the parent if two identical
       // points (same hash for tag values) are about to form a hierarchy


### PR DESCRIPTION
This change simplifies previous attempt to resolve cycles in DSM context propagation. The main idea behind this change is that two edges going in the same direction within a single context can't be a part of a correct hierarchy / data flow. Hence we will use the direction tag to determine more correct parent for a pathway checkpoint.

One of the scenarios when the old logic would not handle correctly:

The client has Spring Kafka handler, which receives data from topic `Input`. The same handler modifies the data and forwards it to two different topics: `Destination 1` and `Destination 2`. Under the hood, we gonna make 3 different checkpoints:

1. When we receive the message. The pathway context hash will be extracted from message headers or will be 0, if nothing was passed though the queue. (Direction = In)
2. When we produce a message to `Destination 1`. Pathway context hash will use the hash from receive operation as a parent and will produce a correct hash. (Direction = Out). 
3. When we produce a message to `Destination 2`. The current pathway context contains the information from the second checkpoint, so when we produce the hash, we'll use it as a parent. Creating a loop, when 1 produce operation becomes a parent of another produce operation. (Direction = Out)
<img width="525" alt="Screenshot 2023-01-18 at 4 27 17 PM" src="https://user-images.githubusercontent.com/21974069/213308861-52fbb927-54c9-4f5f-a828-c8065a3aa0c6.png">

After the change in this PR the produce operation to `Destination 2` will use the hash of a closes context with a different direction, i.e. consume operation. This will produce a correct hierarchy.
<img width="339" alt="Screenshot 2023-01-18 at 4 27 43 PM" src="https://user-images.githubusercontent.com/21974069/213308905-650ac2a4-e8a1-4254-a17f-d3285718ce56.png"> 
