### PR TITLE
Limit latest async-http-client used in Netty tests to exclude 3.0.0.Beta1

### DIFF
--- a/dd-java-agent/instrumentation/netty-4.1/build.gradle
+++ b/dd-java-agent/instrumentation/netty-4.1/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 
   // latest async-http-client incompatable with 5.0+ netty
   latestDepTestImplementation group: 'io.netty', name: 'netty-codec-http', version: '(,5.0)'
-  latestDepTestImplementation group: 'org.asynchttpclient', name: 'async-http-client', version: '+'
+  latestDepTestImplementation group: 'org.asynchttpclient', name: 'async-http-client', version: '2.+'
 }
 
 // We need to force the dependency to the earliest supported version because other libraries declare newer versions.


### PR DESCRIPTION
(as the new 3.x beta release requires Java11+)