### PR TITLE
implement profiler context tagging API

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -746,14 +746,15 @@ public class Agent {
   }
 
   /**
-   * {@see com.datadog.profiling.ddprof.ContextThreadFilter} must not be modified to depend on JFR.
+   * {@see com.datadog.profiling.ddprof.DatadogProfilingIntegration} must not be modified to depend
+   * on JFR.
    */
   private static ProfilingContextIntegration createProfilingContextIntegration() {
     if (Config.get().isProfilingEnabled()) {
       try {
         return (ProfilingContextIntegration)
             AGENT_CLASSLOADER
-                .loadClass("com.datadog.profiling.ddprof.ContextThreadFilter")
+                .loadClass("com.datadog.profiling.ddprof.DatadogProfilingIntegration")
                 .getDeclaredConstructor()
                 .newInstance();
       } catch (Throwable t) {

--- a/dd-java-agent/agent-profiling/profiling-ddprof/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/build.gradle
@@ -17,7 +17,7 @@ excludedClassesCoverage += [
   // enums with no additional functionality
   'com.datadog.profiling.controller.ddprof.Arch',
   'com.datadog.profiling.controller.ddprof.OperatingSystem',
-  'com.datadog.profiling.ddprof.ContextThreadFilter',
+  'com.datadog.profiling.ddprof.DatadogProfilingIntegration',
   'com.datadog.profiling.ddprof.DatadogProfilerConfig',
   // --
   'com.datadog.profiling.ddprof.DatadogProfiler.Singleton',

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
@@ -5,6 +5,8 @@ import static datadog.trace.api.config.ProfilingConfig.*;
 
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import java.lang.management.ManagementFactory;
+import java.util.Collections;
+import java.util.Set;
 
 public class DatadogProfilerConfig {
 
@@ -182,6 +184,10 @@ public class DatadogProfilerConfig {
 
   public static String getLogLevel() {
     return getLogLevel(ConfigProvider.getInstance());
+  }
+
+  public static Set<String> getContextAttributes(ConfigProvider configProvider) {
+    return configProvider.getSet(PROFILING_CONTEXT_ATTRIBUTES, Collections.emptySet());
   }
 
   public static String getString(ConfigProvider configProvider, String key, String defaultValue) {

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilingIntegration.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilingIntegration.java
@@ -6,7 +6,7 @@ import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration;
  * This class must be installed early to be able to see all scope initialisations, which means it
  * must not be modified to depend on JFR, so that it can be installed before tracing starts.
  */
-public class ContextThreadFilter implements ProfilingContextIntegration {
+public class DatadogProfilingIntegration implements ProfilingContextIntegration {
 
   private static final DatadogProfiler DDPROF = DatadogProfiler.getInstance();
   private static final boolean WALLCLOCK_ENABLED =
@@ -29,6 +29,13 @@ public class ContextThreadFilter implements ProfilingContextIntegration {
   @Override
   public void setContext(int tid, long rootSpanId, long spanId) {
     DDPROF.setContext(tid, spanId, rootSpanId);
+  }
+
+  @Override
+  public void setContextValue(String attribute, String value) {
+    // FIXME just move the tid back to the profiler instead of polluting
+    //  the java agent with this implementation detail
+    DDPROF.setContextValue(DDPROF.getNativeThreadId(), attribute, value);
   }
 
   @Override

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilingIntegration.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilingIntegration.java
@@ -13,33 +13,26 @@ public class DatadogProfilingIntegration implements ProfilingContextIntegration 
       DatadogProfilerConfig.isWallClockProfilerEnabled();
 
   @Override
-  public void onAttach(int tid) {
+  public void onAttach() {
     if (WALLCLOCK_ENABLED) {
-      DDPROF.addThread(tid);
+      DDPROF.addThread();
     }
   }
 
   @Override
-  public void onDetach(int tid) {
+  public void onDetach() {
     if (WALLCLOCK_ENABLED) {
-      DDPROF.removeThread(tid);
+      DDPROF.removeThread();
     }
   }
 
   @Override
-  public void setContext(int tid, long rootSpanId, long spanId) {
-    DDPROF.setContext(tid, spanId, rootSpanId);
+  public void setContext(long rootSpanId, long spanId) {
+    DDPROF.setContext(spanId, rootSpanId);
   }
 
   @Override
   public void setContextValue(String attribute, String value) {
-    // FIXME just move the tid back to the profiler instead of polluting
-    //  the java agent with this implementation detail
-    DDPROF.setContextValue(DDPROF.getNativeThreadId(), attribute, value);
-  }
-
-  @Override
-  public int getNativeThreadId() {
-    return DDPROF.getNativeThreadId();
+    DDPROF.setContextValue(attribute, value);
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/test/java/com/datadog/profiling/ddprof/DatadogProfilerTest.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/test/java/com/datadog/profiling/ddprof/DatadogProfilerTest.java
@@ -102,11 +102,10 @@ class DatadogProfilerTest {
     DatadogProfiler profiler =
         new DatadogProfiler(
             configProvider(true, true, true, true), new HashSet<>(Arrays.asList("foo", "bar")));
-    int tid = profiler.getNativeThreadId();
-    assertTrue(profiler.setContextValue(tid, "foo", "abc"));
-    assertTrue(profiler.setContextValue(tid, "bar", "abc"));
-    assertTrue(profiler.setContextValue(tid, "foo", "xyz"));
-    assertFalse(profiler.setContextValue(tid, "xyz", "foo"));
+    assertTrue(profiler.setContextValue("foo", "abc"));
+    assertTrue(profiler.setContextValue("bar", "abc"));
+    assertTrue(profiler.setContextValue("foo", "xyz"));
+    assertFalse(profiler.setContextValue("xyz", "foo"));
   }
 
   private static ConfigProvider configProvider(

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/TestProfilingContextIntegration.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/TestProfilingContextIntegration.groovy
@@ -22,6 +22,10 @@ class TestProfilingContextIntegration implements ProfilingContextIntegration {
   }
 
   @Override
+  void setContextValue(String attribute, String value) {
+  }
+
+  @Override
   int getNativeThreadId() {
     return -1
   }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/TestProfilingContextIntegration.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/TestProfilingContextIntegration.groovy
@@ -8,25 +8,20 @@ class TestProfilingContextIntegration implements ProfilingContextIntegration {
   final AtomicInteger attachments = new AtomicInteger()
   final AtomicInteger detachments = new AtomicInteger()
   @Override
-  void onAttach(int tid) {
+  void onAttach() {
     attachments.incrementAndGet()
   }
 
   @Override
-  void onDetach(int tid) {
+  void onDetach() {
     detachments.incrementAndGet()
   }
 
   @Override
-  void setContext(int tid, long rootSpanId, long spanId) {
+  void setContext(long rootSpanId, long spanId) {
   }
 
   @Override
   void setContextValue(String attribute, String value) {
-  }
-
-  @Override
-  int getNativeThreadId() {
-    return -1
   }
 }

--- a/dd-smoke-tests/profiling-integration-tests/src/main/java/datadog/smoketest/profiling/ProfilingTestApplication.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/main/java/datadog/smoketest/profiling/ProfilingTestApplication.java
@@ -1,6 +1,7 @@
 package datadog.smoketest.profiling;
 
 import datadog.trace.api.Trace;
+import datadog.trace.api.experimental.ProfilingContext;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
@@ -13,17 +14,21 @@ public class ProfilingTestApplication {
   private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
 
   public static void main(final String[] args) throws InterruptedException {
+    ProfilingContext context = ProfilingContext.get();
     long duration = -1;
     if (args.length > 0) {
       duration = TimeUnit.SECONDS.toMillis(Long.parseLong(args[0]));
     }
     setupDeadlock();
     final long startTime = System.currentTimeMillis();
+    int counter = 0;
     while (true) {
+      context.setContextValue("foo", "context" + counter % 10);
       tracedMethod();
       if (duration > 0 && duration + startTime < System.currentTimeMillis()) {
         break;
       }
+      counter++;
     }
     System.out.println("Exiting (" + duration + ")");
   }

--- a/dd-trace-api/build.gradle
+++ b/dd-trace-api/build.gradle
@@ -14,7 +14,8 @@ excludedClassesCoverage += [
   'datadog.trace.api.PropagationStyle',
   'datadog.trace.api.TracePropagationStyle',
   'datadog.trace.api.SpanCorrelation*',
-  'datadog.trace.api.interceptor.MutableSpan'
+  'datadog.trace.api.interceptor.MutableSpan',
+  'datadog.trace.api.experimental.ProfilingContext'
 ]
 
 description = 'dd-trace-api'

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -159,5 +159,8 @@ public final class ProfilingConfig {
 
   public static final String PROFILING_DEBUG_DUMP_PATH = "profiling.debug.dump_path";
 
+  public static final String PROFILING_CONTEXT_ATTRIBUTES =
+      "profiling.experimental.context.attributes";
+
   private ProfilingConfig() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/experimental/ProfilingContext.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/experimental/ProfilingContext.java
@@ -1,0 +1,23 @@
+package datadog.trace.api.experimental;
+
+import datadog.trace.api.GlobalTracer;
+import datadog.trace.api.Tracer;
+
+/** This class is experimental and is subject to change and may be removed. */
+public interface ProfilingContext {
+
+  static ProfilingContext get() {
+    Tracer tracer = GlobalTracer.get();
+    if (tracer instanceof ProfilingContext) {
+      return (ProfilingContext) tracer;
+    }
+    return (attribute, value) -> {};
+  }
+  /**
+   * Sets a context value to be appended to profiling data
+   *
+   * @param attribute the attribute (must have been registered at startup)
+   * @param value the value
+   */
+  void setContextValue(String attribute, String value);
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -209,6 +209,11 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     return endpointCheckpointer.onRootSpanStarted(root);
   }
 
+  @Override
+  public void setContextValue(String attribute, String value) {
+    profilingContextIntegration.setContextValue(attribute, value);
+  }
+
   public static class CoreTracerBuilder {
 
     private Config config;

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -486,8 +486,6 @@ public final class ContinuableScopeManager implements AgentScopeManager {
    */
   static final class ScopeStack {
 
-    private final int nativeThreadId;
-
     private final ProfilingContextIntegration profilingContextIntegration;
     private final ArrayDeque<ContinuableScope> stack = new ArrayDeque<>(); // previous scopes
 
@@ -498,7 +496,6 @@ public final class ContinuableScopeManager implements AgentScopeManager {
 
     ScopeStack(ProfilingContextIntegration profilingContextIntegration) {
       this.profilingContextIntegration = profilingContextIntegration;
-      this.nativeThreadId = profilingContextIntegration.getNativeThreadId();
     }
 
     ContinuableScope active() {
@@ -592,18 +589,18 @@ public final class ContinuableScopeManager implements AgentScopeManager {
       long spanId = top.span.getSpanId();
       AgentSpan rootSpan = top.span.getLocalRootSpan();
       long rootSpanId = rootSpan == null ? spanId : rootSpan.getSpanId();
-      profilingContextIntegration.setContext(nativeThreadId, rootSpanId, spanId);
+      profilingContextIntegration.setContext(rootSpanId, spanId);
     }
 
     /** Notifies context thread listeners that this thread has a context now */
     private void onBecomeNonEmpty() {
-      profilingContextIntegration.onAttach(nativeThreadId);
+      profilingContextIntegration.onAttach();
     }
 
     /** Notifies context thread listeners that this thread no longer has a context */
     private void onBecomeEmpty() {
-      profilingContextIntegration.setContext(nativeThreadId, 0, 0);
-      profilingContextIntegration.onDetach(nativeThreadId);
+      profilingContextIntegration.setContext(0, 0);
+      profilingContextIntegration.onDetach();
     }
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -467,8 +467,8 @@ class ScopeManagerTest extends DDCoreSpecification {
     assertEvents([ACTIVATE, ACTIVATE])
     1 * statsDClient.incrementCounter("scope.close.error")
     1 * rootSpanCheckpointer.onRootSpanStarted(_)
-    3 * listener.setContext(_, _, _)
-    1 * listener.onAttach(_)
+    3 * listener.setContext(_, _)
+    1 * listener.onAttach()
     0 * _
 
     when:
@@ -478,8 +478,8 @@ class ScopeManagerTest extends DDCoreSpecification {
     then:
     1 * rootSpanCheckpointer.onRootSpanFinished(_, _)
     _ * statsDClient.close()
-    1 * listener.setContext(_, 0, 0)
-    1 * listener.onDetach(_)
+    1 * listener.setContext(0, 0)
+    1 * listener.onDetach()
     assertEvents([ACTIVATE, ACTIVATE, CLOSE, CLOSE])
     0 * _
 
@@ -506,8 +506,8 @@ class ScopeManagerTest extends DDCoreSpecification {
     tracer.activeScope() == firstScope
     assertEvents([ACTIVATE])
     1 * rootSpanCheckpointer.onRootSpanStarted(_)
-    1 * listener.onAttach(_)
-    1 * listener.setContext(_, _, _)
+    1 * listener.onAttach()
+    1 * listener.setContext(_, _)
     0 * _
 
     when:
@@ -519,7 +519,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     tracer.activeSpan() == secondSpan
     tracer.activeScope() == secondScope
     assertEvents([ACTIVATE, ACTIVATE])
-    1 * listener.setContext(_, _, _)
+    1 * listener.setContext(_, _)
     0 * _
 
     when:
@@ -531,7 +531,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     tracer.activeSpan() == thirdSpan
     tracer.activeScope() == thirdScope
     assertEvents([ACTIVATE, ACTIVATE, ACTIVATE])
-    1 * listener.setContext(_, _, _)
+    1 * listener.setContext(_, _)
     0 * _
 
     when:
@@ -543,7 +543,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     tracer.activeScope() == thirdScope
     assertEvents([ACTIVATE, ACTIVATE, ACTIVATE])
     1 * statsDClient.incrementCounter("scope.close.error")
-    1 * listener.setContext(_, _, _)
+    1 * listener.setContext(_, _)
     0 * _
 
     when:
@@ -556,7 +556,7 @@ class ScopeManagerTest extends DDCoreSpecification {
 
     assertEvents([ACTIVATE, ACTIVATE, ACTIVATE, CLOSE, CLOSE, ACTIVATE])
     _ * statsDClient.close()
-    1 * listener.setContext(_, _, _)
+    1 * listener.setContext(_, _)
     0 * _
 
     when:
@@ -583,8 +583,8 @@ class ScopeManagerTest extends DDCoreSpecification {
       CLOSE
     ])
     _ * statsDClient.close()
-    1 * listener.setContext(_, 0, 0)
-    1 * listener.onDetach(_)
+    1 * listener.setContext(0, 0)
+    1 * listener.onDetach()
     0 * _
   }
 
@@ -614,7 +614,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     tracer.activeSpan() == thirdSpan
     tracer.activeScope() == thirdScope
     assertEvents([ACTIVATE, ACTIVATE])
-    1 * listener.setContext(_, _, _)
+    1 * listener.setContext(_, _)
     0 * _
 
     when:
@@ -631,7 +631,7 @@ class ScopeManagerTest extends DDCoreSpecification {
 
     then: 'Closing scope above multiple activated scope does not close it'
     assertEvents([ACTIVATE, ACTIVATE, CLOSE, ACTIVATE])
-    1 * listener.setContext(_, _, _)
+    1 * listener.setContext(_, _)
     _ * statsDClient.close()
     0 * _
 
@@ -970,7 +970,7 @@ class ScopeManagerTest extends DDCoreSpecification {
       assert scopeManager.active() == null
     }).get()
     then: "the listener is not notified"
-    0 * listener.onAttach(_)
+    0 * listener.onAttach()
 
     when: "scopes activate on threads"
     AgentSpan span = tracer.buildSpan("foo").start()
@@ -991,7 +991,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     }
 
     then: "the first activation notifies the listener"
-    numThreads * listener.onAttach(_)
+    numThreads * listener.onAttach()
     _ * _
 
     cleanup:

--- a/dd-trace-ot/build.gradle
+++ b/dd-trace-ot/build.gradle
@@ -103,6 +103,7 @@ shadowJar {
     exclude('datadog.opentracing.resolver.*')
     exclude('datadog.trace.api.*')
     exclude('datadog.trace.api.config.*')
+    exclude('datadog.trace.api.experimental.*')
     exclude('datadog.trace.api.interceptor.*')
     exclude('datadog.trace.api.internal.*')
     exclude('datadog.trace.api.sampling.*')

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -4,6 +4,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.GlobalTracer;
 import datadog.trace.api.StatsDClient;
+import datadog.trace.api.experimental.ProfilingContext;
 import datadog.trace.api.interceptor.TraceInterceptor;
 import datadog.trace.api.internal.InternalTracer;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
@@ -37,7 +38,8 @@ import org.slf4j.LoggerFactory;
  * DDTracer implements the <code>io.opentracing.Tracer</code> interface to make it easy to send
  * traces and spans to Datadog using the OpenTracing API.
  */
-public class DDTracer implements Tracer, datadog.trace.api.Tracer, InternalTracer {
+public class DDTracer
+    implements Tracer, datadog.trace.api.Tracer, InternalTracer, ProfilingContext {
 
   private static final Logger log = LoggerFactory.getLogger(DDTracer.class);
 
@@ -71,6 +73,13 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer, InternalTrace
   // each depend on each other so scopeManager can't be final
   // Perhaps the api can change so that CoreTracer doesn't need to implement scope methods directly
   private ScopeManager scopeManager;
+
+  @Override
+  public void setContextValue(String attribute, String value) {
+    if (tracer != null) {
+      tracer.setContextValue(attribute, value);
+    }
+  }
 
   public static class DDTracerBuilder {
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -34,7 +34,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    jplib         : "0.10.0",
+    jplib         : "0.11.0",
     asm           : "9.4"
   ]
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -3,6 +3,7 @@ package datadog.trace.bootstrap.instrumentation.api;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_ASYNC_PROPAGATING;
 
 import datadog.trace.api.*;
+import datadog.trace.api.experimental.ProfilingContext;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
@@ -113,7 +114,11 @@ public class AgentTracer {
   private AgentTracer() {}
 
   public interface TracerAPI
-      extends datadog.trace.api.Tracer, InternalTracer, AgentPropagation, EndpointCheckpointer {
+      extends datadog.trace.api.Tracer,
+          InternalTracer,
+          AgentPropagation,
+          EndpointCheckpointer,
+          ProfilingContext {
     AgentSpan startSpan(CharSequence spanName);
 
     AgentSpan startSpan(CharSequence spanName, long startTimeMicros);
@@ -380,6 +385,9 @@ public class AgentTracer {
 
     @Override
     public void notifyExtensionEnd(AgentSpan span, Object result, boolean isError) {}
+
+    @Override
+    public void setContextValue(String attribute, String value) {}
   }
 
   public static final class NoopAgentSpan implements AgentSpan {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ProfilingContextIntegration.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ProfilingContextIntegration.java
@@ -2,36 +2,29 @@ package datadog.trace.bootstrap.instrumentation.api;
 
 public interface ProfilingContextIntegration {
   /** Invoked when a trace first propagates to a thread */
-  void onAttach(int tid);
+  void onAttach();
 
   /** Invoked when a thread exits */
-  void onDetach(int tid);
+  void onDetach();
 
-  void setContext(int tid, long rootSpanId, long spanId);
+  void setContext(long rootSpanId, long spanId);
 
   void setContextValue(String attribute, String value);
-
-  int getNativeThreadId();
 
   final class NoOp implements ProfilingContextIntegration {
 
     public static final NoOp INSTANCE = new NoOp();
 
     @Override
-    public void onAttach(int tid) {}
+    public void onAttach() {}
 
     @Override
-    public void onDetach(int tid) {}
+    public void onDetach() {}
 
     @Override
-    public void setContext(int tid, long rootSpanId, long spanId) {}
+    public void setContext(long rootSpanId, long spanId) {}
 
     @Override
     public void setContextValue(String attribute, String value) {}
-
-    @Override
-    public int getNativeThreadId() {
-      return -1;
-    }
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ProfilingContextIntegration.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ProfilingContextIntegration.java
@@ -9,6 +9,8 @@ public interface ProfilingContextIntegration {
 
   void setContext(int tid, long rootSpanId, long spanId);
 
+  void setContextValue(String attribute, String value);
+
   int getNativeThreadId();
 
   final class NoOp implements ProfilingContextIntegration {
@@ -23,6 +25,9 @@ public interface ProfilingContextIntegration {
 
     @Override
     public void setContext(int tid, long rootSpanId, long spanId) {}
+
+    @Override
+    public void setContextValue(String attribute, String value) {}
 
     @Override
     public int getNativeThreadId() {


### PR DESCRIPTION
# What Does This Do

Let's a user register arbitrary attributes for profiling context by setting:
`-Ddd.profiling.experimental.context.attributes=foo,bar`
Which then allows the user to call 
`ProfilingContext.get().setContextValue("foo", stringValue);`
and have the tags "foo=`stringValue`" appended to each JFR event emitted.

# Motivation

# Additional Notes
