### PR TITLE
Add report of index expression error

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
@@ -659,7 +659,7 @@ public class Snapshot {
 
     private void checkUndefined(String expr, Object target, String name, String msg) {
       if (target == Values.UNDEFINED_OBJECT) {
-        addEvalError(expr, msg + name);
+        addEvaluationError(expr, msg + name);
       }
     }
 
@@ -788,7 +788,7 @@ public class Snapshot {
       }
     }
 
-    public void addEvalError(String expr, String message) {
+    public void addEvaluationError(String expr, String message) {
       if (evaluationErrors == null) {
         evaluationErrors = new ArrayList<>();
       }

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ValueReferenceResolver.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ValueReferenceResolver.java
@@ -4,10 +4,11 @@ import java.util.Map;
 
 /** Debugger EL specific value reference resolver. */
 public interface ValueReferenceResolver {
-
   Object lookup(String name);
 
   Object getMember(Object target, String name);
+
+  void addEvaluationError(String expr, String message);
 
   default ValueReferenceResolver withExtensions(Map<String, Object> extensions) {
     return this;

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/ValueScript.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/ValueScript.java
@@ -11,11 +11,13 @@ import datadog.trace.bootstrap.debugger.el.DebuggerScript;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import java.io.IOException;
 import java.util.Objects;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /** Implements expression language for capturing values for metric probes */
 public class ValueScript implements DebuggerScript {
   private static final Pattern PERIOD_PATTERN = Pattern.compile("\\.");
+  private static final Pattern INDEX_PATTERN = Pattern.compile("(.+)\\[([^]]+)]");
   private final ValueExpression<?> expr;
   private final String dsl;
   private Value<?> result;
@@ -67,7 +69,16 @@ public class ValueScript implements DebuggerScript {
     } else {
       head = parts[0];
     }
-    ValueExpression<?> current = DSL.ref(head);
+    ValueExpression<?> current;
+    Matcher matcher = INDEX_PATTERN.matcher(head);
+    if (matcher.matches()) {
+      String key = matcher.group(2);
+      ValueExpression<?> keyExpr =
+          key.matches("[0-9]+") ? DSL.value(Integer.parseInt(key)) : DSL.value(key);
+      current = DSL.index(DSL.ref(matcher.group(1)), keyExpr);
+    } else {
+      current = DSL.ref(head);
+    }
     for (int i = startIdx; i < parts.length; i++) {
       current = DSL.getMember(current, parts[i]);
     }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IndexExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IndexExpression.java
@@ -28,12 +28,17 @@ public class IndexExpression implements ValueExpression {
     if (keyValue == Value.undefined()) {
       return result;
     }
-    if (targetValue instanceof MapValue) {
-      result = ((MapValue) targetValue).get(keyValue.getValue());
+    try {
+      if (targetValue instanceof MapValue) {
+        result = ((MapValue) targetValue).get(keyValue.getValue());
+      }
+      if (targetValue instanceof ListValue) {
+        result = ((ListValue) targetValue).get(keyValue.getValue());
+      }
+    } catch (IllegalArgumentException ex) {
+      valueRefResolver.addEvaluationError(prettyPrint(), ex.getMessage());
     }
-    if (targetValue instanceof ListValue) {
-      result = ((ListValue) targetValue).get(keyValue.getValue());
-    }
+
     return result;
   }
 

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ComparisonExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ComparisonExpressionTest.java
@@ -146,5 +146,8 @@ class ComparisonExpressionTest {
     public Object getMember(Object target, String name) {
       return Value.undefinedValue();
     }
+
+    @Override
+    public void addEvaluationError(String expr, String message) {}
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
@@ -292,6 +292,9 @@ public class MetricInstrumentor extends Instrumentor {
       return UndefinedValue.INSTANCE;
     }
 
+    @Override
+    public void addEvaluationError(String expr, String message) {}
+
     private Type followReferences(Type currentType, String name, InsnList insnList) {
       Class<?> clazz;
       try {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -204,6 +204,23 @@ public class LogProbesInstrumentationTest {
         snapshot.getEvaluationErrors().get(0).getMessage());
   }
 
+  @Test
+  public void lineTemplateIndexOutOfBoundsLog() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot06";
+    DebuggerTransformerTest.TestSnapshotListener listener =
+        installSingleProbe(
+            "this is log line with element of list={strList[10]}", CLASS_NAME, null, null, "24");
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "f").get();
+    Assert.assertEquals(42, result);
+    Snapshot snapshot = assertOneSnapshot(listener);
+    assertEquals("this is log line with element of list=UNDEFINED", snapshot.getSummary());
+    assertEquals(1, snapshot.getEvaluationErrors().size());
+    assertEquals("strList[10]", snapshot.getEvaluationErrors().get(0).getExpr());
+    assertEquals(
+        "index[10] out of bounds: [0-3]", snapshot.getEvaluationErrors().get(0).getMessage());
+  }
+
   private DebuggerTransformerTest.TestSnapshotListener installSingleProbe(
       String template, String typeName, String methodName, String signature, String... lines) {
     LogProbe logProbe = createProbe(LOG_ID, template, typeName, methodName, signature, lines);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
@@ -322,7 +322,7 @@ public class DebuggerSinkTest {
   public void addSnapshotWithEvalErrors() throws URISyntaxException, IOException {
     DebuggerSink sink = new DebuggerSink(config, batchUploader);
     Snapshot.CapturedContext entry = new Snapshot.CapturedContext();
-    entry.addEvalError("obj.field", "Cannot dereference obj");
+    entry.addEvaluationError("obj.field", "Cannot dereference obj");
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),


### PR DESCRIPTION
# What Does This Do
When accessing collection through index expression, we can now report runtime error like index out of bounds with an explicit expression that failed to be resolved.
example:
`index[10] out of bounds: [0-3]`

# Motivation
Gives explicit feedback in case of runtime error evaluating conditions

# Additional Notes
