### PR TITLE
Refactor Datadog propagation tags

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
@@ -2,7 +2,7 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDTags
 import datadog.trace.api.DDTraceId
 import datadog.trace.api.interceptor.MutableSpan
-import datadog.trace.core.propagation.DatadogTags
+import datadog.trace.core.propagation.PropagationTags
 import static datadog.trace.api.sampling.PrioritySampling.*
 import static datadog.trace.api.sampling.SamplingMechanism.*
 import datadog.trace.context.TraceScope
@@ -135,11 +135,11 @@ class OpenTelemetryTest extends AgentTestRunner {
     setup:
     def builder = tracer.spanBuilder("some name")
     if (parentId) {
-      def ctx = new ExtractedContext(DDTraceId.ONE, parentId, SAMPLER_DROP, null, 0, [:], [:], null, DatadogTags.factory().empty())
+      def ctx = new ExtractedContext(DDTraceId.ONE, parentId, SAMPLER_DROP, null, 0, [:], [:], null, PropagationTags.factory().empty())
       builder.setParent(tracer.converter.toSpanContext(ctx))
     }
     if (linkId) {
-      def ctx = new ExtractedContext(DDTraceId.ONE, linkId, SAMPLER_DROP, null, 0, [:], [:], null, DatadogTags.factory().empty())
+      def ctx = new ExtractedContext(DDTraceId.ONE, linkId, SAMPLER_DROP, null, 0, [:], [:], null, PropagationTags.factory().empty())
       builder.addLink(tracer.converter.toSpanContext(ctx))
     }
     def result = builder.startSpan()

--- a/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/TypeConverterTest.groovy
@@ -10,7 +10,7 @@ import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext
 import datadog.trace.core.PendingTrace
 import datadog.trace.core.monitor.HealthMetrics
-import datadog.trace.core.propagation.DatadogTags
+import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.core.scopemanager.ContinuableScopeManager
 import datadog.trace.instrumentation.opentelemetry.TypeConverter
 
@@ -81,7 +81,7 @@ class TypeConverterTest extends AgentTestRunner {
       null,
       NoopPathwayContext.INSTANCE,
       false,
-      DatadogTags.factory().empty()) {
+      PropagationTags.factory().empty()) {
         @Override void setServiceName(final String serviceName) {
           // override this method that is called from the DDSpanContext constructor
           // because it causes NPE when calls trace.getTracer from within setServiceName

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -4,7 +4,7 @@ import datadog.trace.api.DDTags
 import datadog.trace.api.DDTraceId
 import datadog.trace.api.interceptor.MutableSpan
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities
-import datadog.trace.core.propagation.DatadogTags
+import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.instrumentation.opentracing.DefaultLogHandler
 import datadog.trace.instrumentation.opentracing31.OTTracer
 import datadog.trace.instrumentation.opentracing31.TypeConverter
@@ -45,7 +45,7 @@ class OpenTracing31Test extends AgentTestRunner {
         .withTag("boolean", true)
     }
     if (addReference) {
-      def ctx = new ExtractedContext(DDTraceId.ONE, 2, SAMPLER_DROP, null, 0, [:], [:], null, DatadogTags.factory().empty())
+      def ctx = new ExtractedContext(DDTraceId.ONE, 2, SAMPLER_DROP, null, 0, [:], [:], null, PropagationTags.factory().empty())
       builder.addReference(addReference, tracer.tracer.converter.toSpanContext(ctx))
     }
     def result = builder.start()

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/TypeConverterTest.groovy
@@ -10,7 +10,7 @@ import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext
 import datadog.trace.core.PendingTrace
 import datadog.trace.core.monitor.HealthMetrics
-import datadog.trace.core.propagation.DatadogTags
+import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.core.scopemanager.ContinuableScopeManager
 import datadog.trace.instrumentation.opentracing.DefaultLogHandler
 import datadog.trace.instrumentation.opentracing31.TypeConverter
@@ -89,7 +89,7 @@ class TypeConverterTest extends AgentTestRunner {
       null,
       NoopPathwayContext.INSTANCE,
       false,
-      DatadogTags.factory().empty()) {
+      PropagationTags.factory().empty()) {
         @Override void setServiceName(final String serviceName) {
           // override this method that is called from the DDSpanContext constructor
           // because it causes NPE when calls trace.getTracer from within setServiceName

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -6,8 +6,8 @@ import datadog.trace.api.interceptor.MutableSpan
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities
 import datadog.trace.context.TraceScope
 import datadog.trace.core.DDSpan
-import datadog.trace.core.propagation.DatadogTags
 import datadog.trace.core.propagation.ExtractedContext
+import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.instrumentation.opentracing.DefaultLogHandler
 import datadog.trace.instrumentation.opentracing32.OTTracer
 import datadog.trace.instrumentation.opentracing32.TypeConverter
@@ -50,7 +50,7 @@ class OpenTracing32Test extends AgentTestRunner {
         .withTag("boolean", true)
     }
     if (addReference) {
-      def ctx = new ExtractedContext(DDTraceId.ONE, 2, SAMPLER_DROP, null, 0, [:], [:], null, DatadogTags.factory().empty())
+      def ctx = new ExtractedContext(DDTraceId.ONE, 2, SAMPLER_DROP, null, 0, [:], [:], null, PropagationTags.factory().empty())
       builder.addReference(addReference, tracer.tracer.converter.toSpanContext(ctx))
     }
     def result = builder.start()

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/TypeConverterTest.groovy
@@ -10,7 +10,7 @@ import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext
 import datadog.trace.core.PendingTrace
 import datadog.trace.core.monitor.HealthMetrics
-import datadog.trace.core.propagation.DatadogTags
+import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.core.scopemanager.ContinuableScopeManager
 import datadog.trace.instrumentation.opentracing.DefaultLogHandler
 import datadog.trace.instrumentation.opentracing32.TypeConverter
@@ -89,7 +89,7 @@ class TypeConverterTest extends AgentTestRunner {
       null,
       NoopPathwayContext.INSTANCE,
       false,
-      DatadogTags.factory().empty()) {
+      PropagationTags.factory().empty()) {
         @Override void setServiceName(final String serviceName) {
           // override this method that is called from the DDSpanContext constructor
           // because it causes NPE when calls trace.getTracer from within setServiceName

--- a/dd-trace-core/src/jmh/java/datadog/trace/common/writer/ddagent/TraceMapperBenchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/common/writer/ddagent/TraceMapperBenchmark.java
@@ -20,7 +20,7 @@ import datadog.trace.core.DDSpan;
 import datadog.trace.core.DDSpanContext;
 import datadog.trace.core.DDSpanHelper;
 import datadog.trace.core.PendingTrace;
-import datadog.trace.core.propagation.DatadogTags;
+import datadog.trace.core.propagation.PropagationTags;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -60,7 +60,7 @@ public class TraceMapperBenchmark {
 
   @Setup(Level.Trial)
   public void init(Blackhole blackhole) {
-    DatadogTags datadogTags = null;
+    PropagationTags propagationTags = null;
     String[] mapperAndFeatures = mapperName.split(":");
     switch (mapperAndFeatures[0]) {
       case "v04":
@@ -76,8 +76,8 @@ public class TraceMapperBenchmark {
       String feature = mapperAndFeatures[i];
       switch (feature) {
         case "x-dth":
-          datadogTags =
-              DatadogTags.factory().fromHeaderValue("_dd.p.anytag=value,_dd.p.dm=934086a686-4");
+          propagationTags =
+              PropagationTags.factory().fromHeaderValue("_dd.p.anytag=value,_dd.p.dm=934086a686-4");
           break;
         default:
           throw new IllegalArgumentException("Unknown benchmark feature " + feature + ".");
@@ -119,7 +119,7 @@ public class TraceMapperBenchmark {
             null,
             NoopPathwayContext.INSTANCE,
             false,
-            datadogTags);
+            propagationTags);
     DDSpanHelper.setAllTags(rootContext, tags);
     DDSpan root = DDSpanHelper.create(System.currentTimeMillis() * 1000, rootContext);
     root.setResourceName(UTF8BytesString.create("benchmark"));

--- a/dd-trace-core/src/jmh/java/datadog/trace/common/writer/ddagent/TraceMapperBenchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/common/writer/ddagent/TraceMapperBenchmark.java
@@ -77,7 +77,10 @@ public class TraceMapperBenchmark {
       switch (feature) {
         case "x-dth":
           propagationTags =
-              PropagationTags.factory().fromHeaderValue("_dd.p.anytag=value,_dd.p.dm=934086a686-4");
+              PropagationTags.factory()
+                  .fromHeaderValue(
+                      PropagationTags.HeaderType.DATADOG,
+                      "_dd.p.anytag=value,_dd.p.dm=934086a686-4");
           break;
         default:
           throw new IllegalArgumentException("Unknown benchmark feature " + feature + ".");

--- a/dd-trace-core/src/jmh/java/datadog/trace/core/propagation/InjectorBenchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/propagation/InjectorBenchmark.java
@@ -51,7 +51,7 @@ public class InjectorBenchmark {
   long spanId;
   CoreTracer tracer;
   DDSpanContext spanContext;
-  DatadogTags datadogTags;
+  PropagationTags propagationTags;
   boolean modifyDatadogTags = false;
 
   @Setup(Level.Trial)
@@ -72,12 +72,14 @@ public class InjectorBenchmark {
         String feature = propagationAndFeatures[i];
         switch (feature) {
           case "x-dth":
-            datadogTags =
-                DatadogTags.factory().fromHeaderValue("_dd.p.anytag=value,_dd.p.dm=934086a686-4");
+            propagationTags =
+                PropagationTags.factory()
+                    .fromHeaderValue("_dd.p.anytag=value,_dd.p.dm=934086a686-4");
             break;
           case "x-dth-mod":
-            datadogTags =
-                DatadogTags.factory().fromHeaderValue("_dd.p.anytag=value,_dd.p.dm=934086a686-4");
+            propagationTags =
+                PropagationTags.factory()
+                    .fromHeaderValue("_dd.p.anytag=value,_dd.p.dm=934086a686-4");
             modifyDatadogTags = true;
             break;
           default:
@@ -120,7 +122,7 @@ public class InjectorBenchmark {
             null,
             null,
             false,
-            datadogTags);
+            propagationTags);
   }
 
   int mechanism = 0;
@@ -131,7 +133,7 @@ public class InjectorBenchmark {
     blackhole.consume(headers);
     if (modifyDatadogTags) {
       int sm = mechanism = (mechanism + 1) % 4;
-      datadogTags.updateTraceSamplingPriority(1, sm, "service");
+      propagationTags.updateTraceSamplingPriority(1, sm, "service");
     }
   }
 

--- a/dd-trace-core/src/jmh/java/datadog/trace/core/propagation/InjectorBenchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/propagation/InjectorBenchmark.java
@@ -52,7 +52,7 @@ public class InjectorBenchmark {
   CoreTracer tracer;
   DDSpanContext spanContext;
   PropagationTags propagationTags;
-  boolean modifyDatadogTags = false;
+  boolean modifyPropagationTags = false;
 
   @Setup(Level.Trial)
   public void setUp(Blackhole blackhole) {
@@ -84,7 +84,7 @@ public class InjectorBenchmark {
                     .fromHeaderValue(
                         PropagationTags.HeaderType.DATADOG,
                         "_dd.p.anytag=value,_dd.p.dm=934086a686-4");
-            modifyDatadogTags = true;
+            modifyPropagationTags = true;
             break;
           default:
             System.out.println("Unknown benchmark feature " + feature + ". Will be ignored!");
@@ -135,7 +135,7 @@ public class InjectorBenchmark {
   public void injectContext(Blackhole blackhole) {
     injector.inject(spanContext, headers, MAP_SETTER);
     blackhole.consume(headers);
-    if (modifyDatadogTags) {
+    if (modifyPropagationTags) {
       int sm = mechanism = (mechanism + 1) % 4;
       propagationTags.updateTraceSamplingPriority(1, sm, "service");
     }

--- a/dd-trace-core/src/jmh/java/datadog/trace/core/propagation/InjectorBenchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/propagation/InjectorBenchmark.java
@@ -74,12 +74,16 @@ public class InjectorBenchmark {
           case "x-dth":
             propagationTags =
                 PropagationTags.factory()
-                    .fromHeaderValue("_dd.p.anytag=value,_dd.p.dm=934086a686-4");
+                    .fromHeaderValue(
+                        PropagationTags.HeaderType.DATADOG,
+                        "_dd.p.anytag=value,_dd.p.dm=934086a686-4");
             break;
           case "x-dth-mod":
             propagationTags =
                 PropagationTags.factory()
-                    .fromHeaderValue("_dd.p.anytag=value,_dd.p.dm=934086a686-4");
+                    .fromHeaderValue(
+                        PropagationTags.HeaderType.DATADOG,
+                        "_dd.p.anytag=value,_dd.p.dm=934086a686-4");
             modifyDatadogTags = true;
             break;
           default:

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -186,10 +186,10 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   private final CallbackProvider callbackProviderIast;
   private final CallbackProvider universalCallbackProvider;
 
-  private final PropagationTags.Factory datadogTagsFactory;
+  private final PropagationTags.Factory propagationTagsFactory;
 
-  PropagationTags.Factory getDatadogTagsFactory() {
-    return datadogTagsFactory;
+  PropagationTags.Factory getPropagationTagsFactory() {
+    return propagationTagsFactory;
   }
 
   @Override
@@ -585,7 +585,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
     StatusLogger.logStatus(config);
 
-    datadogTagsFactory = PropagationTags.factory(config);
+    propagationTagsFactory = PropagationTags.factory(config);
     this.profilingContextIntegration = profilingContextIntegration;
   }
 
@@ -829,7 +829,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
   @Override
   public AgentSpan.Context notifyExtensionStart(Object event) {
-    return LambdaHandler.notifyStartInvocation(event, datadogTagsFactory);
+    return LambdaHandler.notifyStartInvocation(event, propagationTagsFactory);
   }
 
   @Override
@@ -1280,7 +1280,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
             ddsc.getPathwayContext().isStarted()
                 ? ddsc.getPathwayContext()
                 : dataStreamsCheckpointer.newPathwayContext();
-        propagationTags = datadogTagsFactory.empty();
+        propagationTags = propagationTagsFactory.empty();
       } else {
         long endToEndStartTime;
 
@@ -1292,7 +1292,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
           samplingPriority = extractedContext.getSamplingPriority();
           endToEndStartTime = extractedContext.getEndToEndStartTime();
           baggage = extractedContext.getBaggage();
-          propagationTags = extractedContext.getDatadogTags();
+          propagationTags = extractedContext.getPropagationTags();
         } else {
           // Start a new trace
           traceId = idGenerationStrategy.generateTraceId();
@@ -1300,7 +1300,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
           samplingPriority = PrioritySampling.UNSET;
           endToEndStartTime = 0;
           baggage = null;
-          propagationTags = datadogTagsFactory.empty();
+          propagationTags = propagationTagsFactory.empty();
         }
 
         // Get header tags and set origin whether propagating or not.

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -190,7 +190,7 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext, TraceSe
     this.propagationTags =
         propagationTags != null
             ? propagationTags
-            : trace.getTracer().getDatadogTagsFactory().empty();
+            : trace.getTracer().getPropagationTagsFactory().empty();
 
     if (samplingPriority != PrioritySampling.UNSET) {
       setSamplingPriority(samplingPriority, SamplingMechanism.UNKNOWN);
@@ -586,14 +586,14 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext, TraceSe
 
   public void processTagsAndBaggage(final MetadataConsumer consumer) {
     synchronized (unsafeTags) {
-      Map<String, String> baggageItemsWithDatadogTags = new HashMap<>(baggageItems);
-      propagationTags.fillTagMap(baggageItemsWithDatadogTags);
+      Map<String, String> baggageItemsWithPropagationTags = new HashMap<>(baggageItems);
+      propagationTags.fillTagMap(baggageItemsWithPropagationTags);
       consumer.accept(
           new Metadata(
               threadId,
               threadName,
               postProcessor.processTags(unsafeTags),
-              baggageItemsWithDatadogTags,
+              baggageItemsWithPropagationTags,
               samplingPriority != PrioritySampling.UNSET ? samplingPriority : getSamplingPriority(),
               measured,
               topLevel,
@@ -674,7 +674,7 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext, TraceSe
     return this;
   }
 
-  public PropagationTags getDatadogTags() {
+  public PropagationTags getPropagationTags() {
     return propagationTags;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -19,7 +19,7 @@ import datadog.trace.bootstrap.instrumentation.api.PathwayContext;
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
-import datadog.trace.core.propagation.DatadogTags;
+import datadog.trace.core.propagation.PropagationTags;
 import datadog.trace.core.taginterceptor.TagInterceptor;
 import datadog.trace.core.tagprocessor.QueryObfuscator;
 import datadog.trace.core.tagprocessor.TagsPostProcessor;
@@ -123,7 +123,7 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext, TraceSe
 
   private final boolean disableSamplingMechanismValidation;
 
-  private final DatadogTags datadogTags;
+  private final PropagationTags propagationTags;
 
   private volatile PathwayContext pathwayContext;
 
@@ -146,7 +146,7 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext, TraceSe
       final Object requestContextDataIast,
       final PathwayContext pathwayContext,
       final boolean disableSamplingMechanismValidation,
-      final DatadogTags datadogTags) {
+      final PropagationTags propagationTags) {
 
     assert trace != null;
     this.trace = trace;
@@ -187,8 +187,10 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext, TraceSe
     this.threadName = THREAD_NAMES.computeIfAbsent(current.getName(), Functions.UTF8_ENCODE);
 
     this.disableSamplingMechanismValidation = disableSamplingMechanismValidation;
-    this.datadogTags =
-        datadogTags != null ? datadogTags : trace.getTracer().getDatadogTagsFactory().empty();
+    this.propagationTags =
+        propagationTags != null
+            ? propagationTags
+            : trace.getTracer().getDatadogTagsFactory().empty();
 
     if (samplingPriority != PrioritySampling.UNSET) {
       setSamplingPriority(samplingPriority, SamplingMechanism.UNKNOWN);
@@ -298,7 +300,7 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext, TraceSe
     // even if the old sampling priority and mechanism have already propagated
     if (SAMPLING_PRIORITY_UPDATER.getAndSet(this, PrioritySampling.USER_KEEP)
         == PrioritySampling.UNSET) {
-      datadogTags.updateTraceSamplingPriority(
+      propagationTags.updateTraceSamplingPriority(
           PrioritySampling.USER_KEEP, samplingMechanism, serviceName);
     }
   }
@@ -339,8 +341,8 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext, TraceSe
       }
       return false;
     }
-    // set trace level sampling priority tag datadogTags
-    datadogTags.updateTraceSamplingPriority(newPriority, newMechanism, serviceName);
+    // set trace level sampling priority tag propagationTags
+    propagationTags.updateTraceSamplingPriority(newPriority, newMechanism, serviceName);
     return true;
   }
 
@@ -585,7 +587,7 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext, TraceSe
   public void processTagsAndBaggage(final MetadataConsumer consumer) {
     synchronized (unsafeTags) {
       Map<String, String> baggageItemsWithDatadogTags = new HashMap<>(baggageItems);
-      datadogTags.fillTagMap(baggageItemsWithDatadogTags);
+      propagationTags.fillTagMap(baggageItemsWithDatadogTags);
       consumer.accept(
           new Metadata(
               threadId,
@@ -672,8 +674,8 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext, TraceSe
     return this;
   }
 
-  public DatadogTags getDatadogTags() {
-    return datadogTags;
+  public PropagationTags getDatadogTags() {
+    return propagationTags;
   }
 
   /** TraceSegment Implementation */

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -42,7 +42,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
   protected String origin;
   protected long endToEndStartTime;
   protected boolean valid;
-  protected DatadogTags datadogTags;
+  protected PropagationTags propagationTags;
 
   private TagContext.HttpHeaders httpHeaders;
   private final String customIpHeaderName;
@@ -244,7 +244,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
                 baggage,
                 tags,
                 httpHeaders,
-                datadogTags);
+                propagationTags);
         return context;
       } else if (origin != null
           || !tags.isEmpty()

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
@@ -71,7 +71,7 @@ class DatadogHttpCodec {
       }
 
       // inject x-datadog-tags
-      String datadogTags = context.getDatadogTags().headerValue();
+      String datadogTags = context.getDatadogTags().headerValue(PropagationTags.HeaderType.DATADOG);
       if (datadogTags != null) {
         setter.set(carrier, DATADOG_TAGS_KEY, datadogTags);
       }
@@ -191,7 +191,8 @@ class DatadogHttpCodec {
                 endToEndStartTime = extractEndToEndStartTime(firstHeaderValue(value));
                 break;
               case DD_TAGS:
-                propagationTags = datadogTagsFactory.fromHeaderValue(value);
+                propagationTags =
+                    datadogTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, value);
                 break;
               case OT_BAGGAGE:
                 {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
@@ -111,13 +111,13 @@ class DatadogHttpCodec {
     private static final int IGNORE = -1;
 
     private final boolean isAwsPropagationEnabled;
-    private final DatadogTags.Factory datadogTagsFactory;
+    private final PropagationTags.Factory datadogTagsFactory;
 
     private DatadogContextInterpreter(
         Map<String, String> taggedHeaders, Map<String, String> baggageMapping, Config config) {
       super(taggedHeaders, baggageMapping, config);
       isAwsPropagationEnabled = config.isAwsPropagationEnabled();
-      datadogTagsFactory = DatadogTags.factory(config);
+      datadogTagsFactory = PropagationTags.factory(config);
     }
 
     @Override
@@ -191,7 +191,7 @@ class DatadogHttpCodec {
                 endToEndStartTime = extractEndToEndStartTime(firstHeaderValue(value));
                 break;
               case DD_TAGS:
-                datadogTags = datadogTagsFactory.fromHeaderValue(value);
+                propagationTags = datadogTagsFactory.fromHeaderValue(value);
                 break;
               case OT_BAGGAGE:
                 {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
@@ -71,7 +71,8 @@ class DatadogHttpCodec {
       }
 
       // inject x-datadog-tags
-      String datadogTags = context.getDatadogTags().headerValue(PropagationTags.HeaderType.DATADOG);
+      String datadogTags =
+          context.getPropagationTags().headerValue(PropagationTags.HeaderType.DATADOG);
       if (datadogTags != null) {
         setter.set(carrier, DATADOG_TAGS_KEY, datadogTags);
       }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
@@ -12,7 +12,7 @@ public class ExtractedContext extends TagContext {
   private final long spanId;
   private final long endToEndStartTime;
   private final Map<String, String> baggage;
-  private final DatadogTags datadogTags;
+  private final PropagationTags propagationTags;
 
   public ExtractedContext(
       final DDTraceId traceId,
@@ -23,13 +23,13 @@ public class ExtractedContext extends TagContext {
       final Map<String, String> baggage,
       final Map<String, String> tags,
       final HttpHeaders httpHeaders,
-      final DatadogTags datadogTags) {
+      final PropagationTags propagationTags) {
     super(origin, tags, httpHeaders, samplingPriority);
     this.traceId = traceId;
     this.spanId = spanId;
     this.endToEndStartTime = endToEndStartTime;
     this.baggage = baggage;
-    this.datadogTags = datadogTags;
+    this.propagationTags = propagationTags;
   }
 
   @Override
@@ -55,7 +55,7 @@ public class ExtractedContext extends TagContext {
     return baggage;
   }
 
-  public DatadogTags getDatadogTags() {
-    return datadogTags;
+  public PropagationTags getDatadogTags() {
+    return propagationTags;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
@@ -55,7 +55,7 @@ public class ExtractedContext extends TagContext {
     return baggage;
   }
 
-  public PropagationTags getDatadogTags() {
+  public PropagationTags getPropagationTags() {
     return propagationTags;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
@@ -4,6 +4,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_X_DATADOG_TAGS_MAX_
 
 import datadog.trace.api.Config;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -25,17 +26,21 @@ public abstract class PropagationTags {
   }
 
   public static PropagationTags.Factory factory(int datadogTagsLimit) {
-    return new DatadogPropagationTagsFactory(datadogTagsLimit);
+    return new PropagationTagsFactory(datadogTagsLimit);
   }
 
   public static PropagationTags.Factory factory() {
     return factory(DEFAULT_TRACE_X_DATADOG_TAGS_MAX_LENGTH);
   }
 
+  public enum HeaderType {
+    DATADOG
+  }
+
   public interface Factory {
     PropagationTags empty();
 
-    PropagationTags fromHeaderValue(String value);
+    PropagationTags fromHeaderValue(HeaderType headerType, String value);
   }
 
   /**
@@ -50,7 +55,7 @@ public abstract class PropagationTags {
    * sampling decision tag _dd.p.dm based on the current state. Returns null if the value length
    * exceeds a configured limit or empty.
    */
-  public abstract String headerValue();
+  public abstract String headerValue(HeaderType headerType);
 
   /**
    * Fills a provided tagMap with valid propagated _dd.p.* tags and possibly a new sampling decision
@@ -64,4 +69,13 @@ public abstract class PropagationTags {
     fillTagMap(result);
     return result;
   }
+
+  // Internal methods used by the different HeaderType implementations
+  abstract List<String> tagPairs();
+
+  abstract int tagsSize();
+
+  abstract boolean missingDecisionMaker();
+
+  abstract String decisionMakerTagValue();
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
@@ -18,24 +18,24 @@ import java.util.Map;
  *   - producing meta tags to be sent to the agent
  * </pre>
  */
-public abstract class DatadogTags {
+public abstract class PropagationTags {
 
-  public static DatadogTags.Factory factory(Config config) {
+  public static PropagationTags.Factory factory(Config config) {
     return factory(config.getxDatadogTagsMaxLength());
   }
 
-  public static DatadogTags.Factory factory(int datadogTagsLimit) {
-    return new DatadogTagsFactory(datadogTagsLimit);
+  public static PropagationTags.Factory factory(int datadogTagsLimit) {
+    return new DatadogPropagationTagsFactory(datadogTagsLimit);
   }
 
-  public static DatadogTags.Factory factory() {
+  public static PropagationTags.Factory factory() {
     return factory(DEFAULT_TRACE_X_DATADOG_TAGS_MAX_LENGTH);
   }
 
   public interface Factory {
-    DatadogTags empty();
+    PropagationTags empty();
 
-    DatadogTags fromHeaderValue(String value);
+    PropagationTags fromHeaderValue(String value);
   }
 
   /**

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTagsFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTagsFactory.java
@@ -1,0 +1,146 @@
+package datadog.trace.core.propagation;
+
+import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.core.propagation.PropagationTags.HeaderType;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class PropagationTagsFactory implements PropagationTags.Factory {
+  static final String PROPAGATION_ERROR_TAG_KEY = "_dd.propagation_error";
+
+  private final DatadogPropagationTagsFactory ddFactory;
+
+  PropagationTagsFactory(int xDatadogTagsLimit) {
+    ddFactory = new DatadogPropagationTagsFactory(xDatadogTagsLimit);
+  }
+
+  @Override
+  public final PropagationTags empty() {
+    return new ValidPropagationTags(Collections.<String>emptyList(), 0, false);
+  }
+
+  @Override
+  public final PropagationTags fromHeaderValue(HeaderType headerType, String value) {
+    return ddFactory.fromHeaderValue(this, value);
+  }
+
+  PropagationTags createValid(List<String> tagPairs, int tagSize, boolean hasDecisionMaker) {
+    return new ValidPropagationTags(tagPairs, tagSize, hasDecisionMaker);
+  }
+
+  PropagationTags createInvalid(String error) {
+    return new InvalidPropagationTags(error);
+  }
+
+  // This implementation is used when service propagation is enabled
+  private final class ValidPropagationTags extends PropagationTags {
+    // tags that don't require any modifications and propagated as-is
+    private final List<String> propagatedTagPairs;
+    // pre-calc header size
+    private final int propagatedTagsSize;
+
+    private final boolean isDecisionMakerTagMissing;
+
+    // extracted decision maker tag for easier updates
+    private volatile String decisionMakerTagValue;
+
+    private ValidPropagationTags(List<String> tagPairs, int tagsSize, boolean hasDecisionMaker) {
+      assert tagPairs.size() % 2 == 0;
+      propagatedTagPairs = tagPairs;
+      propagatedTagsSize = tagsSize;
+      isDecisionMakerTagMissing = !hasDecisionMaker;
+    }
+
+    @Override
+    public void updateTraceSamplingPriority(
+        int samplingPriority, int samplingMechanism, String serviceName) {
+
+      if (samplingPriority != PrioritySampling.UNSET && isDecisionMakerTagMissing) {
+        if (samplingPriority > 0) {
+          // protected against possible SamplingMechanism.UNKNOWN (-1) that doesn't comply with the
+          // format
+          if (samplingMechanism >= 0) {
+            decisionMakerTagValue = "-" + samplingMechanism;
+          }
+        } else {
+          // drop decision maker tag
+          decisionMakerTagValue = null;
+        }
+      }
+    }
+
+    @Override
+    public String headerValue(HeaderType headerType) {
+      return ddFactory.headerValue(this);
+    }
+
+    @Override
+    public void fillTagMap(Map<String, String> tagMap) {
+      ddFactory.fillTagMap(this, tagMap);
+    }
+
+    @Override
+    List<String> tagPairs() {
+      return propagatedTagPairs;
+    }
+
+    @Override
+    int tagsSize() {
+      return propagatedTagsSize;
+    }
+
+    @Override
+    boolean missingDecisionMaker() {
+      return isDecisionMakerTagMissing;
+    }
+
+    @Override
+    String decisionMakerTagValue() {
+      return decisionMakerTagValue;
+    }
+  }
+
+  // This implementation is used for errors and doesn't allow any modifications
+  private static final class InvalidPropagationTags extends PropagationTags {
+    private final String error;
+
+    private InvalidPropagationTags(String error) {
+      this.error = error;
+    }
+
+    @Override
+    public void updateTraceSamplingPriority(
+        int samplingPriority, int samplingMechanism, String serviceName) {}
+
+    @Override
+    public String headerValue(HeaderType headerType) {
+      return null;
+    }
+
+    @Override
+    public void fillTagMap(Map<String, String> tagMap) {
+      tagMap.put(PROPAGATION_ERROR_TAG_KEY, error);
+    }
+
+    @Override
+    List<String> tagPairs() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    int tagsSize() {
+      return 0;
+    }
+
+    @Override
+    boolean missingDecisionMaker() {
+      return false;
+    }
+
+    @Override
+    String decisionMakerTagValue() {
+      return null;
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaHandler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaHandler.java
@@ -63,7 +63,7 @@ public class LambdaHandler {
   private static String EXTENSION_BASE_URL = "http://127.0.0.1:8124";
 
   public static AgentSpan.Context notifyStartInvocation(
-      Object event, PropagationTags.Factory datadogTagsFactory) {
+      Object event, PropagationTags.Factory propagationTagsFactory) {
     RequestBody body = RequestBody.create(jsonMediaType, writeValueAsString(event));
     try (Response response =
         HTTP_CLIENT
@@ -89,7 +89,7 @@ public class LambdaHandler {
               traceID,
               samplingPriority);
           PropagationTags propagationTags =
-              datadogTagsFactory.fromHeaderValue(
+              propagationTagsFactory.fromHeaderValue(
                   PropagationTags.HeaderType.DATADOG, response.headers().get(DATADOG_TAGS_KEY));
           return new ExtractedContext(
               DDTraceId.from(traceID),

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaHandler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaHandler.java
@@ -8,8 +8,8 @@ import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.core.propagation.DatadogTags;
 import datadog.trace.core.propagation.ExtractedContext;
+import datadog.trace.core.propagation.PropagationTags;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -63,7 +63,7 @@ public class LambdaHandler {
   private static String EXTENSION_BASE_URL = "http://127.0.0.1:8124";
 
   public static AgentSpan.Context notifyStartInvocation(
-      Object event, DatadogTags.Factory datadogTagsFactory) {
+      Object event, PropagationTags.Factory datadogTagsFactory) {
     RequestBody body = RequestBody.create(jsonMediaType, writeValueAsString(event));
     try (Response response =
         HTTP_CLIENT
@@ -88,7 +88,7 @@ public class LambdaHandler {
               "notifyStartInvocation success, found traceID = {} and samplingPriority = {}",
               traceID,
               samplingPriority);
-          DatadogTags datadogTags =
+          PropagationTags propagationTags =
               datadogTagsFactory.fromHeaderValue(response.headers().get(DATADOG_TAGS_KEY));
           return new ExtractedContext(
               DDTraceId.from(traceID),
@@ -99,7 +99,7 @@ public class LambdaHandler {
               null,
               null,
               null,
-              datadogTags);
+              propagationTags);
         } else {
           log.debug(
               "could not find traceID or sampling priority in notifyStartInvocation, not injecting the context");

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaHandler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaHandler.java
@@ -89,7 +89,8 @@ public class LambdaHandler {
               traceID,
               samplingPriority);
           PropagationTags propagationTags =
-              datadogTagsFactory.fromHeaderValue(response.headers().get(DATADOG_TAGS_KEY));
+              datadogTagsFactory.fromHeaderValue(
+                  PropagationTags.HeaderType.DATADOG, response.headers().get(DATADOG_TAGS_KEY));
           return new ExtractedContext(
               DDTraceId.from(traceID),
               DDSpanId.ZERO,

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
@@ -423,7 +423,7 @@ class DDAgentApiTest extends DDCoreSpecification {
     return [discovery, new DDAgentApi(client, agentUrl, discovery, monitoring, false)]
   }
 
-  DDSpan buildSpan(long timestamp, String tag, String value, PropagationTags datadogTags) {
+  DDSpan buildSpan(long timestamp, String tag, String value, PropagationTags propagationTags) {
     def tracer = tracerBuilder().writer(new ListWriter()).build()
     def context = new DDSpanContext(
       DDTraceId.ONE,
@@ -444,7 +444,7 @@ class DDAgentApiTest extends DDCoreSpecification {
       null,
       NoopPathwayContext.INSTANCE,
       false,
-      datadogTags)
+      propagationTags)
 
     def span = DDSpan.create(timestamp, context)
     span.setTag(tag, value)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
@@ -22,7 +22,7 @@ import datadog.trace.core.monitor.MonitoringImpl
 import datadog.communication.serialization.ByteBufferConsumer
 import datadog.communication.serialization.FlushingBuffer
 import datadog.communication.serialization.msgpack.MsgPackWriter
-import datadog.trace.core.propagation.DatadogTags
+import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.core.test.DDCoreSpecification
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
@@ -138,7 +138,7 @@ class DDAgentApiTest extends DDCoreSpecification {
     traces                                                                                                           | expectedRequestBody
     []                                                                                                               | []
     // service propagation enabled
-    [[buildSpan(1L, "service.name", "my-service", DatadogTags.factory().fromHeaderValue("_dd.p.usr=123"))]]          | [[new TreeMap<>([
+    [[buildSpan(1L, "service.name", "my-service", PropagationTags.factory().fromHeaderValue("_dd.p.usr=123"))]]     | [[new TreeMap<>([
       "duration" : 10,
       "error"    : 0,
       "meta"     : ["thread.name": Thread.currentThread().getName(), "_dd.p.usr": "123", "_dd.p.dm": "-1"],
@@ -158,7 +158,7 @@ class DDAgentApiTest extends DDCoreSpecification {
       "type"     : "fakeType"
     ])]]
     // service propagation disabled
-    [[buildSpan(100L, "resource.name", "my-resource", DatadogTags.factory().fromHeaderValue("_dd.p.usr=123"))]] | [[new TreeMap<>([
+    [[buildSpan(100L, "resource.name", "my-resource", PropagationTags.factory().fromHeaderValue("_dd.p.usr=123"))]] | [[new TreeMap<>([
       "duration" : 10,
       "error"    : 0,
       "meta"     : ["thread.name": Thread.currentThread().getName(), "_dd.p.usr": "123", "_dd.p.dm": "-1"],
@@ -423,7 +423,7 @@ class DDAgentApiTest extends DDCoreSpecification {
     return [discovery, new DDAgentApi(client, agentUrl, discovery, monitoring, false)]
   }
 
-  DDSpan buildSpan(long timestamp, String tag, String value, DatadogTags datadogTags) {
+  DDSpan buildSpan(long timestamp, String tag, String value, PropagationTags datadogTags) {
     def tracer = tracerBuilder().writer(new ListWriter()).build()
     def context = new DDSpanContext(
       DDTraceId.ONE,

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
@@ -138,7 +138,7 @@ class DDAgentApiTest extends DDCoreSpecification {
     traces                                                                                                           | expectedRequestBody
     []                                                                                                               | []
     // service propagation enabled
-    [[buildSpan(1L, "service.name", "my-service", PropagationTags.factory().fromHeaderValue("_dd.p.usr=123"))]]     | [[new TreeMap<>([
+    [[buildSpan(1L, "service.name", "my-service", PropagationTags.factory().fromHeaderValue(PropagationTags.HeaderType.DATADOG, "_dd.p.usr=123"))]] | [[new TreeMap<>([
       "duration" : 10,
       "error"    : 0,
       "meta"     : ["thread.name": Thread.currentThread().getName(), "_dd.p.usr": "123", "_dd.p.dm": "-1"],
@@ -158,7 +158,7 @@ class DDAgentApiTest extends DDCoreSpecification {
       "type"     : "fakeType"
     ])]]
     // service propagation disabled
-    [[buildSpan(100L, "resource.name", "my-resource", PropagationTags.factory().fromHeaderValue("_dd.p.usr=123"))]] | [[new TreeMap<>([
+    [[buildSpan(100L, "resource.name", "my-resource", PropagationTags.factory().fromHeaderValue(PropagationTags.HeaderType.DATADOG, "_dd.p.usr=123"))]] | [[new TreeMap<>([
       "duration" : 10,
       "error"    : 0,
       "meta"     : ["thread.name": Thread.currentThread().getName(), "_dd.p.usr": "123", "_dd.p.dm": "-1"],

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
@@ -21,7 +21,7 @@ import datadog.communication.serialization.FlushingBuffer
 import datadog.communication.serialization.Mapper
 import datadog.communication.serialization.msgpack.MsgPackWriter
 import datadog.trace.core.monitor.TracerHealthMetrics
-import datadog.trace.core.propagation.DatadogTags
+import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.core.test.DDCoreSpecification
 import okhttp3.HttpUrl
 import spock.lang.Retry
@@ -285,7 +285,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
       null,
       NoopPathwayContext.INSTANCE,
       false,
-      DatadogTags.factory().empty())
+      PropagationTags.factory().empty())
   }
 
   def createMinimalTrace() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
@@ -13,7 +13,7 @@ import datadog.trace.core.PendingTrace
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopPathwayContext
 import datadog.trace.core.monitor.HealthMetrics
 import datadog.trace.core.monitor.MonitoringImpl
-import datadog.trace.core.propagation.DatadogTags
+import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.core.test.DDCoreSpecification
 import spock.lang.Subject
 
@@ -213,7 +213,7 @@ class DDAgentWriterTest extends DDCoreSpecification {
       null,
       NoopPathwayContext.INSTANCE,
       false,
-      DatadogTags.factory().empty())
+      PropagationTags.factory().empty())
     return new DDSpan(0, context)
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
@@ -20,7 +20,7 @@ import datadog.trace.core.PendingTrace
 import datadog.trace.core.monitor.HealthMetrics
 import datadog.trace.core.monitor.MonitoringImpl
 import datadog.trace.core.monitor.TracerHealthMetrics
-import datadog.trace.core.propagation.DatadogTags
+import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.core.test.DDCoreSpecification
 import okhttp3.HttpUrl
 import spock.lang.Retry
@@ -752,7 +752,7 @@ class DDIntakeWriterCombinedTest extends DDCoreSpecification {
       null,
       AgentTracer.NoopPathwayContext.INSTANCE,
       false,
-      DatadogTags.factory().empty())
+      PropagationTags.factory().empty())
   }
 
   def createMinimalTrace() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterTest.groovy
@@ -13,7 +13,7 @@ import datadog.trace.core.DDSpanContext
 import datadog.trace.core.PendingTrace
 import datadog.trace.core.monitor.HealthMetrics
 import datadog.trace.core.monitor.MonitoringImpl
-import datadog.trace.core.propagation.DatadogTags
+import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.core.test.DDCoreSpecification
 import spock.lang.Subject
 
@@ -203,7 +203,7 @@ class DDIntakeWriterTest extends DDCoreSpecification{
       null,
       AgentTracer.NoopPathwayContext.INSTANCE,
       false,
-      DatadogTags.factory().empty())
+      PropagationTags.factory().empty())
     return new DDSpan(0, context)
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
@@ -14,7 +14,7 @@ import datadog.trace.core.DDSpanContext
 import datadog.trace.core.PendingTrace
 import datadog.trace.core.monitor.HealthMetrics
 import datadog.trace.core.monitor.MonitoringImpl
-import datadog.trace.core.propagation.DatadogTags
+import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.test.util.DDSpecification
 import spock.lang.Shared
 import spock.lang.Timeout
@@ -173,7 +173,7 @@ class PayloadDispatcherTest extends DDSpecification {
       null,
       NoopPathwayContext.INSTANCE,
       false,
-      DatadogTags.factory().empty())
+      PropagationTags.factory().empty())
     return new DDSpan(0, context)
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDEvpProxyApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDEvpProxyApiTest.groovy
@@ -15,7 +15,7 @@ import datadog.trace.common.writer.ListWriter
 import datadog.trace.common.writer.Payload
 import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext
-import datadog.trace.core.propagation.DatadogTags
+import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.core.test.DDCoreSpecification
 import okhttp3.HttpUrl
 import org.msgpack.jackson.dataformat.MessagePackFactory
@@ -229,7 +229,7 @@ class DDEvpProxyApiTest extends DDCoreSpecification {
       null,
       AgentTracer.NoopPathwayContext.INSTANCE,
       false,
-      DatadogTags.factory().empty())
+      PropagationTags.factory().empty())
 
     def span = DDSpan.create(timestamp, context)
     span.setTag(tag, value)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDIntakeApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDIntakeApiTest.groovy
@@ -15,7 +15,7 @@ import datadog.trace.common.writer.ListWriter
 import datadog.trace.common.writer.Payload
 import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext
-import datadog.trace.core.propagation.DatadogTags
+import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.core.test.DDCoreSpecification
 import okhttp3.HttpUrl
 import org.msgpack.jackson.dataformat.MessagePackFactory
@@ -261,7 +261,7 @@ class DDIntakeApiTest extends DDCoreSpecification {
       null,
       AgentTracer.NoopPathwayContext.INSTANCE,
       false,
-      DatadogTags.factory().empty())
+      PropagationTags.factory().empty())
 
     def span = DDSpan.create(timestamp, context)
     span.setTag(tag, value)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -9,7 +9,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopPathwayContext
 import datadog.trace.bootstrap.instrumentation.api.TagContext
 import datadog.trace.common.writer.ListWriter
-import datadog.trace.core.propagation.DatadogTags
+import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.core.propagation.ExtractedContext
 import datadog.trace.core.test.DDCoreSpecification
 
@@ -329,8 +329,8 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
 
     where:
     extractedContext | _
-    new ExtractedContext(DDTraceId.ONE, 2, PrioritySampling.SAMPLER_DROP, null, 0, [:], [:], null, DatadogTags.factory().fromHeaderValue("_dd.p.dm=934086a686-4,_dd.p.anytag=value"))                 | _
-    new ExtractedContext(DDTraceId.from(3), 4, PrioritySampling.SAMPLER_KEEP, "some-origin", 0, ["asdf": "qwer"], [(ORIGIN_KEY): "some-origin", "zxcv": "1234"], null, DatadogTags.factory().empty()) | _
+    new ExtractedContext(DDTraceId.ONE, 2, PrioritySampling.SAMPLER_DROP, null, 0, [:], [:], null, PropagationTags.factory().fromHeaderValue("_dd.p.dm=934086a686-4,_dd.p.anytag=value"))                 | _
+    new ExtractedContext(DDTraceId.from(3), 4, PrioritySampling.SAMPLER_KEEP, "some-origin", 0, ["asdf": "qwer"], [(ORIGIN_KEY): "some-origin", "zxcv": "1234"], null, PropagationTags.factory().empty()) | _
   }
 
   def "TagContext should populate default span details"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -325,7 +325,7 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
     }
     span.getTag(THREAD_ID) == thread.id
     span.getTag(THREAD_NAME) == thread.name
-    span.context().datadogTags.headerValue(PropagationTags.HeaderType.DATADOG) == extractedContext.datadogTags.headerValue(PropagationTags.HeaderType.DATADOG)
+    span.context().propagationTags.headerValue(PropagationTags.HeaderType.DATADOG) == extractedContext.propagationTags.headerValue(PropagationTags.HeaderType.DATADOG)
 
     where:
     extractedContext | _

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -325,11 +325,11 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
     }
     span.getTag(THREAD_ID) == thread.id
     span.getTag(THREAD_NAME) == thread.name
-    span.context().datadogTags.headerValue() == extractedContext.datadogTags.headerValue()
+    span.context().datadogTags.headerValue(PropagationTags.HeaderType.DATADOG) == extractedContext.datadogTags.headerValue(PropagationTags.HeaderType.DATADOG)
 
     where:
     extractedContext | _
-    new ExtractedContext(DDTraceId.ONE, 2, PrioritySampling.SAMPLER_DROP, null, 0, [:], [:], null, PropagationTags.factory().fromHeaderValue("_dd.p.dm=934086a686-4,_dd.p.anytag=value"))                 | _
+    new ExtractedContext(DDTraceId.ONE, 2, PrioritySampling.SAMPLER_DROP, null, 0, [:], [:], null, PropagationTags.factory().fromHeaderValue(PropagationTags.HeaderType.DATADOG, "_dd.p.dm=934086a686-4,_dd.p.anytag=value")) | _
     new ExtractedContext(DDTraceId.from(3), 4, PrioritySampling.SAMPLER_KEEP, "some-origin", 0, ["asdf": "qwer"], [(ORIGIN_KEY): "some-origin", "zxcv": "1234"], null, PropagationTags.factory().empty()) | _
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextPropagationTagsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextPropagationTagsTest.groovy
@@ -9,7 +9,7 @@ import datadog.trace.core.test.DDCoreSpecification
 import static datadog.trace.api.sampling.PrioritySampling.*
 import static datadog.trace.api.sampling.SamplingMechanism.*
 
-class DDSpanContextDatadogTagsTest extends DDCoreSpecification {
+class DDSpanContextPropagationTagsTest extends DDCoreSpecification {
 
   def writer = new ListWriter()
   def tracer

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextPropagationTagsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextPropagationTagsTest.groovy
@@ -4,6 +4,7 @@ import datadog.trace.api.DDTraceId
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.propagation.ExtractedContext
+import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.core.test.DDCoreSpecification
 
 import static datadog.trace.api.sampling.PrioritySampling.*
@@ -21,7 +22,7 @@ class DDSpanContextPropagationTagsTest extends DDCoreSpecification {
   def "update span DatadogTags"() {
     setup:
     tracer = tracerBuilder().writer(writer).build()
-    def datadogTags = tracer.datadogTagsFactory.fromHeaderValue(header)
+    def datadogTags = tracer.datadogTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, header)
     def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", 0, [:], [:], null, datadogTags)
     .withRequestContextDataAppSec("dummy")
     def span = (DDSpan) tracer.buildSpan("top")
@@ -34,7 +35,7 @@ class DDSpanContextPropagationTagsTest extends DDCoreSpecification {
     span.getSamplingPriority() == newPriority
 
     then:
-    dd.headerValue() == newHeader
+    dd.headerValue(PropagationTags.HeaderType.DATADOG) == newHeader
     dd.createTagMap() == tagMap
 
     where:
@@ -50,7 +51,7 @@ class DDSpanContextPropagationTagsTest extends DDCoreSpecification {
   def "update trace DatadogTags"() {
     setup:
     tracer = tracerBuilder().writer(writer).build()
-    def datadogTags = tracer.datadogTagsFactory.fromHeaderValue(header)
+    def datadogTags = tracer.datadogTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, header)
     def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", 0, [:], [:], null, datadogTags)
     .withRequestContextDataAppSec("dummy")
     def rootSpan = (DDSpan) tracer.buildSpan("top")
@@ -65,9 +66,9 @@ class DDSpanContextPropagationTagsTest extends DDCoreSpecification {
     span.getSamplingPriority() == newPriority
 
     then:
-    dd.headerValue() == null
+    dd.headerValue(PropagationTags.HeaderType.DATADOG) == null
     dd.createTagMap() == spanTagMap
-    ddRoot.headerValue() == rootHeader
+    ddRoot.headerValue(PropagationTags.HeaderType.DATADOG) == rootHeader
     ddRoot.createTagMap() == rootTagMap
 
     where:
@@ -83,7 +84,7 @@ class DDSpanContextPropagationTagsTest extends DDCoreSpecification {
   def "forceKeep span DatadogTags"() {
     setup:
     tracer = tracerBuilder().writer(writer).build()
-    def datadogTags = tracer.datadogTagsFactory.fromHeaderValue(header)
+    def datadogTags = tracer.datadogTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, header)
     def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", 0, [:], [:], null, datadogTags)
     .withRequestContextDataAppSec("dummy")
     def span = (DDSpan) tracer.buildSpan("top")
@@ -96,7 +97,7 @@ class DDSpanContextPropagationTagsTest extends DDCoreSpecification {
     span.getSamplingPriority() == USER_KEEP
 
     then:
-    dd.headerValue() == newHeader
+    dd.headerValue(PropagationTags.HeaderType.DATADOG) == newHeader
     dd.createTagMap() == tagMap
 
     where:
@@ -110,7 +111,7 @@ class DDSpanContextPropagationTagsTest extends DDCoreSpecification {
   def "forceKeep trace DatadogTags"() {
     setup:
     tracer = tracerBuilder().writer(writer).build()
-    def datadogTags = tracer.datadogTagsFactory.fromHeaderValue(header)
+    def datadogTags = tracer.datadogTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, header)
     def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", 0, [:], [:], null, datadogTags)
     .withRequestContextDataAppSec("dummy")
     def rootSpan = (DDSpan) tracer.buildSpan("top")
@@ -125,9 +126,9 @@ class DDSpanContextPropagationTagsTest extends DDCoreSpecification {
     span.getSamplingPriority() == USER_KEEP
 
     then:
-    dd.headerValue() == null
+    dd.headerValue(PropagationTags.HeaderType.DATADOG) == null
     dd.createTagMap() == spanTagMap
-    ddRoot.headerValue() == rootHeader
+    ddRoot.headerValue(PropagationTags.HeaderType.DATADOG) == rootHeader
     ddRoot.createTagMap() == rootTagMap
 
     where:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextPropagationTagsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextPropagationTagsTest.groovy
@@ -19,16 +19,16 @@ class DDSpanContextPropagationTagsTest extends DDCoreSpecification {
     tracer.close()
   }
 
-  def "update span DatadogTags"() {
+  def "update span PropagationTags"() {
     setup:
     tracer = tracerBuilder().writer(writer).build()
-    def datadogTags = tracer.datadogTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, header)
-    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", 0, [:], [:], null, datadogTags)
+    def propagationTags = tracer.propagationTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, header)
+    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", 0, [:], [:], null, propagationTags)
     .withRequestContextDataAppSec("dummy")
     def span = (DDSpan) tracer.buildSpan("top")
       .asChildOf((AgentSpan.Context) extracted)
       .start()
-    def dd = span.context().getDatadogTags()
+    def dd = span.context().getPropagationTags()
 
     when:
     span.setSamplingPriority(newPriority, newMechanism)
@@ -48,18 +48,18 @@ class DDSpanContextPropagationTagsTest extends DDCoreSpecification {
     SAMPLER_KEEP | "_dd.p.usr=123"                       | USER_KEEP    | MANUAL       | "_dd.p.usr=123"                       | ["_dd.p.usr": "123"]
   }
 
-  def "update trace DatadogTags"() {
+  def "update trace PropagationTags"() {
     setup:
     tracer = tracerBuilder().writer(writer).build()
-    def datadogTags = tracer.datadogTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, header)
-    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", 0, [:], [:], null, datadogTags)
+    def propagationTags = tracer.propagationTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, header)
+    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", 0, [:], [:], null, propagationTags)
     .withRequestContextDataAppSec("dummy")
     def rootSpan = (DDSpan) tracer.buildSpan("top")
       .asChildOf((AgentSpan.Context) extracted)
       .start()
-    def ddRoot = rootSpan.context().getDatadogTags()
+    def ddRoot = rootSpan.context().getPropagationTags()
     def span = (DDSpan) tracer.buildSpan("current").asChildOf(rootSpan).start()
-    def dd = span.context().getDatadogTags()
+    def dd = span.context().getPropagationTags()
 
     when:
     span.setSamplingPriority(newPriority, newMechanism)
@@ -81,16 +81,16 @@ class DDSpanContextPropagationTagsTest extends DDCoreSpecification {
     SAMPLER_KEEP | "_dd.p.usr=123"                       | USER_KEEP    | MANUAL       | "_dd.p.usr=123"                       | [:]        | ["_dd.p.usr": "123"]
   }
 
-  def "forceKeep span DatadogTags"() {
+  def "forceKeep span PropagationTags"() {
     setup:
     tracer = tracerBuilder().writer(writer).build()
-    def datadogTags = tracer.datadogTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, header)
-    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", 0, [:], [:], null, datadogTags)
+    def propagationTags = tracer.propagationTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, header)
+    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", 0, [:], [:], null, propagationTags)
     .withRequestContextDataAppSec("dummy")
     def span = (DDSpan) tracer.buildSpan("top")
       .asChildOf((AgentSpan.Context) extracted)
       .start()
-    def dd = span.context().getDatadogTags()
+    def dd = span.context().getPropagationTags()
 
     when:
     span.context().forceKeep()
@@ -108,18 +108,18 @@ class DDSpanContextPropagationTagsTest extends DDCoreSpecification {
     SAMPLER_KEEP | "_dd.p.usr=123"                       | "_dd.p.usr=123"                       | ["_dd.p.usr": "123"]
   }
 
-  def "forceKeep trace DatadogTags"() {
+  def "forceKeep trace PropagationTags"() {
     setup:
     tracer = tracerBuilder().writer(writer).build()
-    def datadogTags = tracer.datadogTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, header)
-    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", 0, [:], [:], null, datadogTags)
+    def propagationTags = tracer.propagationTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, header)
+    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", 0, [:], [:], null, propagationTags)
     .withRequestContextDataAppSec("dummy")
     def rootSpan = (DDSpan) tracer.buildSpan("top")
       .asChildOf((AgentSpan.Context) extracted)
       .start()
-    def ddRoot = rootSpan.context().getDatadogTags()
+    def ddRoot = rootSpan.context().getPropagationTags()
     def span = (DDSpan) tracer.buildSpan("current").asChildOf(rootSpan).start()
-    def dd = span.context().getDatadogTags()
+    def dd = span.context().getPropagationTags()
 
     when:
     span.context().forceKeep()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
@@ -176,7 +176,7 @@ class DDSpanContextTest extends DDCoreSpecification {
 
   def "set TraceSegment tags and data on correct span"() {
     setup:
-    def extracted = new ExtractedContext(DDTraceId.from(123), 456, SAMPLER_KEEP, "789", 0, [:], [:], null, tracer.getDatadogTagsFactory().empty())
+    def extracted = new ExtractedContext(DDTraceId.from(123), 456, SAMPLER_KEEP, "789", 0, [:], [:], null, tracer.getPropagationTagsFactory().empty())
     .withRequestContextDataAppSec("dummy")
 
     def top = tracer.buildSpan("top").asChildOf((AgentSpan.Context) extracted).start()
@@ -226,7 +226,7 @@ class DDSpanContextTest extends DDCoreSpecification {
     context.getTag(SPAN_SAMPLING_RULE_RATE_TAG) == rate
     context.getTag(SPAN_SAMPLING_MAX_PER_SECOND_TAG) == (limit == Integer.MAX_VALUE ? null : limit)
     context.getSamplingPriority() == USER_KEEP
-    context.getDatadogTags().createTagMap() == ["_dd.p.dm":"-" + SPAN_SAMPLING_RATE]
+    context.getPropagationTags().createTagMap() == ["_dd.p.dm":"-" + SPAN_SAMPLING_RATE]
 
     where:
     rate | limit

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -29,7 +29,7 @@ class DDSpanTest extends DDCoreSpecification {
   @Shared def writer = new ListWriter()
   @Shared def sampler = new RateByServiceTraceSampler()
   @Shared def tracer = tracerBuilder().writer(writer).sampler(sampler).build()
-  @Shared def datadogTagsFactory = tracer.getDatadogTagsFactory()
+  @Shared def propagationTagsFactory = tracer.getPropagationTagsFactory()
 
   def cleanup() {
     tracer?.close()
@@ -274,7 +274,7 @@ class DDSpanTest extends DDCoreSpecification {
     where:
     extractedContext                                                                                                                          | _
     new TagContext("some-origin", [:])                                                                                                        | _
-    new ExtractedContext(DDTraceId.ONE, 2, PrioritySampling.SAMPLER_DROP, "some-origin", 0, [:], [:], null, datadogTagsFactory.empty()) | _
+    new ExtractedContext(DDTraceId.ONE, 2, PrioritySampling.SAMPLER_DROP, "some-origin", 0, [:], [:], null, propagationTagsFactory.empty()) | _
   }
 
   def "isRootSpan() in and not in the context of distributed tracing"() {
@@ -293,7 +293,7 @@ class DDSpanTest extends DDCoreSpecification {
     where:
     extractedContext                                                                                                                          | isTraceRootSpan
     null                                                                                                                                      | true
-    new ExtractedContext(DDTraceId.from(123), 456, PrioritySampling.SAMPLER_KEEP, "789", 0, [:], [:], null, datadogTagsFactory.empty()) | false
+    new ExtractedContext(DDTraceId.from(123), 456, PrioritySampling.SAMPLER_KEEP, "789", 0, [:], [:], null, propagationTagsFactory.empty()) | false
   }
 
   def "getApplicationRootSpan() in and not in the context of distributed tracing"() {
@@ -315,7 +315,7 @@ class DDSpanTest extends DDCoreSpecification {
     where:
     extractedContext                                                                                                                          | isTraceRootSpan
     null                                                                                                                                      | true
-    new ExtractedContext(DDTraceId.from(123), 456, PrioritySampling.SAMPLER_KEEP, "789", 0, [:], [:], null, datadogTagsFactory.empty()) | false
+    new ExtractedContext(DDTraceId.from(123), 456, PrioritySampling.SAMPLER_KEEP, "789", 0, [:], [:], null, propagationTagsFactory.empty()) | false
   }
 
   def 'publishing of root span closes the request context data'() {
@@ -344,7 +344,7 @@ class DDSpanTest extends DDCoreSpecification {
 
   def "infer top level from parent service name"() {
     setup:
-    def datadogTagsFactory = tracer.getDatadogTagsFactory()
+    def propagationTagsFactory = tracer.getPropagationTagsFactory()
     when:
     DDSpanContext context =
       new DDSpanContext(
@@ -366,7 +366,7 @@ class DDSpanTest extends DDCoreSpecification {
       null,
       NoopPathwayContext.INSTANCE,
       false,
-      datadogTagsFactory.empty())
+      propagationTagsFactory.empty())
     then:
     context.isTopLevel() == expectTopLevel
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
@@ -11,7 +11,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopPathwayContex
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource
 import datadog.trace.context.TraceScope
 import datadog.trace.core.monitor.HealthMetrics
-import datadog.trace.core.propagation.DatadogTags
+import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.core.scopemanager.ContinuableScopeManager
 import datadog.trace.test.util.DDSpecification
 import spock.lang.Subject
@@ -400,7 +400,7 @@ class PendingTraceBufferTest extends DDSpecification {
       null,
       NoopPathwayContext.INSTANCE,
       false,
-      DatadogTags.factory().empty())
+      PropagationTags.factory().empty())
     return DDSpan.create(0, context)
   }
 
@@ -425,7 +425,7 @@ class PendingTraceBufferTest extends DDSpecification {
       null,
       NoopPathwayContext.INSTANCE,
       false,
-      DatadogTags.factory().empty())
+      PropagationTags.factory().empty())
     return DDSpan.create(0, context)
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
@@ -5,7 +5,7 @@ import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.api.time.TimeSource
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.core.monitor.HealthMetrics
-import datadog.trace.core.propagation.DatadogTags
+import datadog.trace.core.propagation.PropagationTags
 import spock.lang.Timeout
 
 import java.util.concurrent.TimeUnit
@@ -37,7 +37,7 @@ class PendingTraceTest extends PendingTraceTestBase {
       null,
       AgentTracer.NoopPathwayContext.INSTANCE,
       false,
-      DatadogTags.factory().empty()))
+      PropagationTags.factory().empty()))
   }
 
   @Timeout(value = 60, unit = TimeUnit.SECONDS)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpInjectorTest.groovy
@@ -46,7 +46,7 @@ class B3HttpInjectorTest extends DDCoreSpecification {
       null,
       NoopPathwayContext.INSTANCE,
       false,
-      DatadogTags.factory().empty())
+      PropagationTags.factory().empty())
 
     final Map<String, String> carrier = Mock()
 
@@ -108,7 +108,7 @@ class B3HttpInjectorTest extends DDCoreSpecification {
       null,
       NoopPathwayContext.INSTANCE,
       false,
-      DatadogTags.factory().empty())
+      PropagationTags.factory().empty())
     final Map<String, String> carrier = Mock()
 
     when:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpInjectorTest.groovy
@@ -41,7 +41,7 @@ class DatadogHttpInjectorTest extends DDCoreSpecification {
       null,
       NoopPathwayContext.INSTANCE,
       false,
-      DatadogTags.factory().fromHeaderValue("_dd.p.usr=123"))
+      PropagationTags.factory().fromHeaderValue("_dd.p.usr=123"))
 
     final Map<String, String> carrier = Mock()
 
@@ -98,7 +98,7 @@ class DatadogHttpInjectorTest extends DDCoreSpecification {
       null,
       NoopPathwayContext.INSTANCE,
       false,
-      DatadogTags.factory().fromHeaderValue("_dd.p.dm=-4,_dd.p.anytag=value"))
+      PropagationTags.factory().fromHeaderValue("_dd.p.dm=-4,_dd.p.anytag=value"))
 
     mockedContext.beginEndToEnd()
 
@@ -145,7 +145,7 @@ class DatadogHttpInjectorTest extends DDCoreSpecification {
       null,
       NoopPathwayContext.INSTANCE,
       false,
-      DatadogTags.factory().empty())
+      PropagationTags.factory().empty())
 
     mockedContext.setSamplingPriority(USER_KEEP, MANUAL)
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpInjectorTest.groovy
@@ -41,7 +41,7 @@ class DatadogHttpInjectorTest extends DDCoreSpecification {
       null,
       NoopPathwayContext.INSTANCE,
       false,
-      PropagationTags.factory().fromHeaderValue("_dd.p.usr=123"))
+      PropagationTags.factory().fromHeaderValue(PropagationTags.HeaderType.DATADOG, "_dd.p.usr=123"))
 
     final Map<String, String> carrier = Mock()
 
@@ -98,7 +98,7 @@ class DatadogHttpInjectorTest extends DDCoreSpecification {
       null,
       NoopPathwayContext.INSTANCE,
       false,
-      PropagationTags.factory().fromHeaderValue("_dd.p.dm=-4,_dd.p.anytag=value"))
+      PropagationTags.factory().fromHeaderValue(PropagationTags.HeaderType.DATADOG, "_dd.p.dm=-4,_dd.p.anytag=value"))
 
     mockedContext.beginEndToEnd()
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogPropagationTagsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogPropagationTagsTest.groovy
@@ -6,7 +6,7 @@ import datadog.trace.core.test.DDCoreSpecification
 import static datadog.trace.api.sampling.PrioritySampling.*
 import static datadog.trace.api.sampling.SamplingMechanism.*
 
-class PropagationTagsTest extends DDCoreSpecification {
+class DatadogPropagationTagsTest extends DDCoreSpecification {
 
   def createDatadogTagsFromHeaderValue() {
     setup:
@@ -15,10 +15,10 @@ class PropagationTagsTest extends DDCoreSpecification {
     def datadogTagsFactory = PropagationTags.factory(config)
 
     when:
-    def datadogTags = datadogTagsFactory.fromHeaderValue(headerValue)
+    def datadogTags = datadogTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, headerValue)
 
     then:
-    datadogTags.headerValue() == expectedHeaderValue
+    datadogTags.headerValue(PropagationTags.HeaderType.DATADOG) == expectedHeaderValue
     datadogTags.createTagMap() == tags
 
     where:
@@ -72,13 +72,13 @@ class PropagationTagsTest extends DDCoreSpecification {
     def config = Mock(Config)
     config.getxDatadogTagsMaxLength() >> 512
     def datadogTagsFactory = PropagationTags.factory(config)
-    def datadogTags = datadogTagsFactory.fromHeaderValue(originalTagSet)
+    def datadogTags = datadogTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, originalTagSet)
 
     when:
     datadogTags.updateTraceSamplingPriority(priority, mechanism, "service-1")
 
     then:
-    datadogTags.headerValue() == expectedHeaderValue
+    datadogTags.headerValue(PropagationTags.HeaderType.DATADOG) == expectedHeaderValue
     datadogTags.createTagMap() == tags
 
     where:
@@ -112,13 +112,13 @@ class PropagationTagsTest extends DDCoreSpecification {
     setup:
     def tags = "_dd.p.anytag=value"
     def limit = tags.length() - 1
-    def datadogTags = PropagationTags.factory(limit).fromHeaderValue(tags)
+    def datadogTags = PropagationTags.factory(limit).fromHeaderValue(PropagationTags.HeaderType.DATADOG, tags)
 
     when:
     datadogTags.updateTraceSamplingPriority(USER_KEEP, MANUAL, "service-name")
 
     then:
-    datadogTags.headerValue() == null
+    datadogTags.headerValue(PropagationTags.HeaderType.DATADOG) == null
     datadogTags.createTagMap() == ["_dd.propagation_error": "extract_max_size"]
   }
 
@@ -126,25 +126,25 @@ class PropagationTagsTest extends DDCoreSpecification {
     setup:
     def tags = "_dd.p.anytag=value"
     def limit = tags.length()
-    def datadogTags = PropagationTags.factory(limit).fromHeaderValue(tags)
+    def datadogTags = PropagationTags.factory(limit).fromHeaderValue(PropagationTags.HeaderType.DATADOG, tags)
 
     when:
     datadogTags.updateTraceSamplingPriority(USER_KEEP, MANUAL, "service-name")
 
     then:
-    datadogTags.headerValue() == null
+    datadogTags.headerValue(PropagationTags.HeaderType.DATADOG) == null
     datadogTags.createTagMap() == ["_dd.propagation_error": "inject_max_size"]
   }
 
   def injectionLimitExceededLimit0() {
     setup:
-    def datadogTags = PropagationTags.factory(0).fromHeaderValue("")
+    def datadogTags = PropagationTags.factory(0).fromHeaderValue(PropagationTags.HeaderType.DATADOG, "")
 
     when:
     datadogTags.updateTraceSamplingPriority(USER_KEEP, MANUAL, "service-name")
 
     then:
-    datadogTags.headerValue() == null
+    datadogTags.headerValue(PropagationTags.HeaderType.DATADOG) == null
     datadogTags.createTagMap() == ["_dd.propagation_error": "disabled"]
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogPropagationTagsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogPropagationTagsTest.groovy
@@ -8,18 +8,18 @@ import static datadog.trace.api.sampling.SamplingMechanism.*
 
 class DatadogPropagationTagsTest extends DDCoreSpecification {
 
-  def createDatadogTagsFromHeaderValue() {
+  def createPropagationTagsFromHeaderValue() {
     setup:
     def config = Mock(Config)
     config.getxDatadogTagsMaxLength() >> 512
-    def datadogTagsFactory = PropagationTags.factory(config)
+    def propagationTagsFactory = PropagationTags.factory(config)
 
     when:
-    def datadogTags = datadogTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, headerValue)
+    def propagationTags = propagationTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, headerValue)
 
     then:
-    datadogTags.headerValue(PropagationTags.HeaderType.DATADOG) == expectedHeaderValue
-    datadogTags.createTagMap() == tags
+    propagationTags.headerValue(PropagationTags.HeaderType.DATADOG) == expectedHeaderValue
+    propagationTags.createTagMap() == tags
 
     where:
     headerValue                                                                                                                  | expectedHeaderValue                        | tags
@@ -67,19 +67,19 @@ class DatadogPropagationTagsTest extends DDCoreSpecification {
     "_dd.p.dm=934086a665-12b"                                                                                                    | null                                       | ["_dd.propagation_error": "decoding_error"] // invalid dm tag value sampling mechanism contains invalid char
   }
 
-  def updateDatadogTagsSamplingMechanism() {
+  def updatePropagationTagsSamplingMechanism() {
     setup:
     def config = Mock(Config)
     config.getxDatadogTagsMaxLength() >> 512
-    def datadogTagsFactory = PropagationTags.factory(config)
-    def datadogTags = datadogTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, originalTagSet)
+    def propagationTagsFactory = PropagationTags.factory(config)
+    def propagationTags = propagationTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, originalTagSet)
 
     when:
-    datadogTags.updateTraceSamplingPriority(priority, mechanism, "service-1")
+    propagationTags.updateTraceSamplingPriority(priority, mechanism, "service-1")
 
     then:
-    datadogTags.headerValue(PropagationTags.HeaderType.DATADOG) == expectedHeaderValue
-    datadogTags.createTagMap() == tags
+    propagationTags.headerValue(PropagationTags.HeaderType.DATADOG) == expectedHeaderValue
+    propagationTags.createTagMap() == tags
 
     where:
     originalTagSet                                              | priority     | mechanism  | expectedHeaderValue                                         | tags
@@ -112,39 +112,39 @@ class DatadogPropagationTagsTest extends DDCoreSpecification {
     setup:
     def tags = "_dd.p.anytag=value"
     def limit = tags.length() - 1
-    def datadogTags = PropagationTags.factory(limit).fromHeaderValue(PropagationTags.HeaderType.DATADOG, tags)
+    def propagationTags = PropagationTags.factory(limit).fromHeaderValue(PropagationTags.HeaderType.DATADOG, tags)
 
     when:
-    datadogTags.updateTraceSamplingPriority(USER_KEEP, MANUAL, "service-name")
+    propagationTags.updateTraceSamplingPriority(USER_KEEP, MANUAL, "service-name")
 
     then:
-    datadogTags.headerValue(PropagationTags.HeaderType.DATADOG) == null
-    datadogTags.createTagMap() == ["_dd.propagation_error": "extract_max_size"]
+    propagationTags.headerValue(PropagationTags.HeaderType.DATADOG) == null
+    propagationTags.createTagMap() == ["_dd.propagation_error": "extract_max_size"]
   }
 
   def injectionLimitExceeded() {
     setup:
     def tags = "_dd.p.anytag=value"
     def limit = tags.length()
-    def datadogTags = PropagationTags.factory(limit).fromHeaderValue(PropagationTags.HeaderType.DATADOG, tags)
+    def propagationTags = PropagationTags.factory(limit).fromHeaderValue(PropagationTags.HeaderType.DATADOG, tags)
 
     when:
-    datadogTags.updateTraceSamplingPriority(USER_KEEP, MANUAL, "service-name")
+    propagationTags.updateTraceSamplingPriority(USER_KEEP, MANUAL, "service-name")
 
     then:
-    datadogTags.headerValue(PropagationTags.HeaderType.DATADOG) == null
-    datadogTags.createTagMap() == ["_dd.propagation_error": "inject_max_size"]
+    propagationTags.headerValue(PropagationTags.HeaderType.DATADOG) == null
+    propagationTags.createTagMap() == ["_dd.propagation_error": "inject_max_size"]
   }
 
   def injectionLimitExceededLimit0() {
     setup:
-    def datadogTags = PropagationTags.factory(0).fromHeaderValue(PropagationTags.HeaderType.DATADOG, "")
+    def propagationTags = PropagationTags.factory(0).fromHeaderValue(PropagationTags.HeaderType.DATADOG, "")
 
     when:
-    datadogTags.updateTraceSamplingPriority(USER_KEEP, MANUAL, "service-name")
+    propagationTags.updateTraceSamplingPriority(USER_KEEP, MANUAL, "service-name")
 
     then:
-    datadogTags.headerValue(PropagationTags.HeaderType.DATADOG) == null
-    datadogTags.createTagMap() == ["_dd.propagation_error": "disabled"]
+    propagationTags.headerValue(PropagationTags.HeaderType.DATADOG) == null
+    propagationTags.createTagMap() == ["_dd.propagation_error": "disabled"]
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
@@ -50,7 +50,7 @@ class HttpInjectorTest extends DDCoreSpecification {
       null,
       NoopPathwayContext.INSTANCE,
       false,
-      DatadogTags.factory().fromHeaderValue("_dd.p.usr=123"))
+      PropagationTags.factory().fromHeaderValue("_dd.p.usr=123"))
 
     final Map<String, String> carrier = Mock()
 
@@ -137,7 +137,7 @@ class HttpInjectorTest extends DDCoreSpecification {
       null,
       NoopPathwayContext.INSTANCE,
       false,
-      DatadogTags.factory().fromHeaderValue("_dd.p.usr=123"))
+      PropagationTags.factory().fromHeaderValue("_dd.p.usr=123"))
 
     final Map<String, String> carrier = Mock()
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
@@ -50,7 +50,7 @@ class HttpInjectorTest extends DDCoreSpecification {
       null,
       NoopPathwayContext.INSTANCE,
       false,
-      PropagationTags.factory().fromHeaderValue("_dd.p.usr=123"))
+      PropagationTags.factory().fromHeaderValue(PropagationTags.HeaderType.DATADOG, "_dd.p.usr=123"))
 
     final Map<String, String> carrier = Mock()
 
@@ -137,7 +137,7 @@ class HttpInjectorTest extends DDCoreSpecification {
       null,
       NoopPathwayContext.INSTANCE,
       false,
-      PropagationTags.factory().fromHeaderValue("_dd.p.usr=123"))
+      PropagationTags.factory().fromHeaderValue(PropagationTags.HeaderType.DATADOG, "_dd.p.usr=123"))
 
     final Map<String, String> carrier = Mock()
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/PropagationTagsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/PropagationTagsTest.groovy
@@ -6,13 +6,13 @@ import datadog.trace.core.test.DDCoreSpecification
 import static datadog.trace.api.sampling.PrioritySampling.*
 import static datadog.trace.api.sampling.SamplingMechanism.*
 
-class DatadogTagsTest extends DDCoreSpecification {
+class PropagationTagsTest extends DDCoreSpecification {
 
   def createDatadogTagsFromHeaderValue() {
     setup:
     def config = Mock(Config)
     config.getxDatadogTagsMaxLength() >> 512
-    def datadogTagsFactory = DatadogTags.factory(config)
+    def datadogTagsFactory = PropagationTags.factory(config)
 
     when:
     def datadogTags = datadogTagsFactory.fromHeaderValue(headerValue)
@@ -71,7 +71,7 @@ class DatadogTagsTest extends DDCoreSpecification {
     setup:
     def config = Mock(Config)
     config.getxDatadogTagsMaxLength() >> 512
-    def datadogTagsFactory = DatadogTags.factory(config)
+    def datadogTagsFactory = PropagationTags.factory(config)
     def datadogTags = datadogTagsFactory.fromHeaderValue(originalTagSet)
 
     when:
@@ -112,7 +112,7 @@ class DatadogTagsTest extends DDCoreSpecification {
     setup:
     def tags = "_dd.p.anytag=value"
     def limit = tags.length() - 1
-    def datadogTags = DatadogTags.factory(limit).fromHeaderValue(tags)
+    def datadogTags = PropagationTags.factory(limit).fromHeaderValue(tags)
 
     when:
     datadogTags.updateTraceSamplingPriority(USER_KEEP, MANUAL, "service-name")
@@ -126,7 +126,7 @@ class DatadogTagsTest extends DDCoreSpecification {
     setup:
     def tags = "_dd.p.anytag=value"
     def limit = tags.length()
-    def datadogTags = DatadogTags.factory(limit).fromHeaderValue(tags)
+    def datadogTags = PropagationTags.factory(limit).fromHeaderValue(tags)
 
     when:
     datadogTags.updateTraceSamplingPriority(USER_KEEP, MANUAL, "service-name")
@@ -138,7 +138,7 @@ class DatadogTagsTest extends DDCoreSpecification {
 
   def injectionLimitExceededLimit0() {
     setup:
-    def datadogTags = DatadogTags.factory(0).fromHeaderValue("")
+    def datadogTags = PropagationTags.factory(0).fromHeaderValue("")
 
     when:
     datadogTags.updateTraceSamplingPriority(USER_KEEP, MANUAL, "service-name")

--- a/dd-trace-core/src/test/groovy/datadog/trace/lambda/LambdaHandlerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/lambda/LambdaHandlerTest.groovy
@@ -3,7 +3,7 @@ package datadog.trace.lambda
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTraceId
-import datadog.trace.core.propagation.DatadogTags
+import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.core.test.DDCoreSpecification
 import datadog.trace.core.DDSpan
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
@@ -46,7 +46,7 @@ class LambdaHandlerTest extends DDCoreSpecification {
     LambdaHandler.setExtensionBaseUrl(server.address.toString())
 
     when:
-    def objTest = LambdaHandler.notifyStartInvocation(obj, DatadogTags.factory(config))
+    def objTest = LambdaHandler.notifyStartInvocation(obj, PropagationTags.factory(config))
 
     then:
     objTest.getTraceId().toString() == traceId
@@ -77,7 +77,7 @@ class LambdaHandlerTest extends DDCoreSpecification {
     LambdaHandler.setExtensionBaseUrl(server.address.toString())
 
     when:
-    def objTest = LambdaHandler.notifyStartInvocation(obj, DatadogTags.factory(config))
+    def objTest = LambdaHandler.notifyStartInvocation(obj, PropagationTags.factory(config))
 
     then:
     objTest == expected

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/TypeConverterTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/TypeConverterTest.groovy
@@ -11,7 +11,7 @@ import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext
 import datadog.trace.core.PendingTrace
 import datadog.trace.core.monitor.HealthMetrics
-import datadog.trace.core.propagation.DatadogTags
+import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.core.scopemanager.ContinuableScopeManager
 import datadog.trace.test.util.DDSpecification
 
@@ -95,6 +95,6 @@ class TypeConverterTest extends DDSpecification {
       null,
       NoopPathwayContext.INSTANCE,
       false,
-      DatadogTags.factory().empty())
+      PropagationTags.factory().empty())
   }
 }


### PR DESCRIPTION
# What Does This Do

* Renames `DatadogTags` to `PropagationTags`
* Adds a `HeaderType` and moves out the `PropagationTags` classes to a common `PropagationTagsFactory`

# Motivation

We need to support different header types for Datadog and W3C both for extraction and injection

# Additional Notes

Reviewing the two commits separately is probably easier since otherwise the changes show up as deleted and added files instead of renames and changes.