### PR TITLE
enable wallclock profiler by default, add config flags

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -11,6 +11,8 @@ import static com.datadog.profiling.ddprof.DatadogProfilerConfig.getSafeMode;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.getSchedulingEvent;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.getSchedulingEventInterval;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.getStackDepth;
+import static com.datadog.profiling.ddprof.DatadogProfilerConfig.getWallCollapsing;
+import static com.datadog.profiling.ddprof.DatadogProfilerConfig.getWallContextFilter;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.getWallInterval;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isAllocationProfilingEnabled;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isCpuProfilerEnabled;
@@ -322,9 +324,16 @@ public final class DatadogProfiler {
     }
     if (profilingModes.contains(WALL)) {
       // wall profiling is enabled.
-      cmd.append(",wall=~").append(getWallInterval(configProvider)).append('m').append(",filter=0");
-      cmd.append(",loglevel=").append(getLogLevel(configProvider));
+      cmd.append(",wall=");
+      if (getWallCollapsing(configProvider)) {
+        cmd.append("~");
+      }
+      cmd.append(getWallInterval(configProvider)).append('m');
+      if (getWallContextFilter(configProvider)) {
+        cmd.append(",filter=0");
+      }
     }
+    cmd.append(",loglevel=").append(getLogLevel(configProvider));
     if (profilingModes.contains(ALLOCATION)) {
       // allocation profiling is enabled
       cmd.append(",alloc=").append(getAllocationInterval(configProvider)).append('b');

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
@@ -78,6 +78,20 @@ public class DatadogProfilerConfig {
     return getWallInterval(ConfigProvider.getInstance());
   }
 
+  public static boolean getWallCollapsing(ConfigProvider configProvider) {
+    return getBoolean(
+        configProvider,
+        PROFILING_DATADOG_PROFILER_WALL_COLLAPSING,
+        PROFILING_DATADOG_PROFILER_WALL_COLLAPSING_DEFAULT);
+  }
+
+  public static boolean getWallContextFilter(ConfigProvider configProvider) {
+    return getBoolean(
+        configProvider,
+        PROFILING_DATADOG_PROFILER_WALL_CONTEXT_FILTER,
+        PROFILING_DATADOG_PROFILER_WALL_CONTEXT_FILTER_DEFAULT);
+  }
+
   public static boolean isAllocationProfilingEnabled(ConfigProvider configProvider) {
     return getBoolean(
         configProvider,

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -79,10 +79,18 @@ public final class ProfilingConfig {
   public static final int PROFILING_DATADOG_PROFILER_CPU_INTERVAL_DEFAULT = 10;
   public static final String PROFILING_DATADOG_PROFILER_WALL_ENABLED =
       "profiling.ddprof.wall.enabled";
-  public static final boolean PROFILING_DATADOG_PROFILER_WALL_ENABLED_DEFAULT = false;
+  public static final boolean PROFILING_DATADOG_PROFILER_WALL_ENABLED_DEFAULT = true;
   public static final String PROFILING_DATADOG_PROFILER_WALL_INTERVAL =
       "profiling.ddprof.wall.interval.ms";
   public static final int PROFILING_DATADOG_PROFILER_WALL_INTERVAL_DEFAULT = 10;
+
+  public static final String PROFILING_DATADOG_PROFILER_WALL_COLLAPSING =
+      "profiling.ddprof.wall.collapsing";
+  public static final boolean PROFILING_DATADOG_PROFILER_WALL_COLLAPSING_DEFAULT = false;
+
+  public static final String PROFILING_DATADOG_PROFILER_WALL_CONTEXT_FILTER =
+      "profiling.ddprof.wall.context.filter";
+  public static final boolean PROFILING_DATADOG_PROFILER_WALL_CONTEXT_FILTER_DEFAULT = true;
 
   public static final String PROFILING_DATADOG_PROFILER_SCHEDULING_EVENT =
       "profiling.experimental.ddprof.scheduling.event";


### PR DESCRIPTION
# What Does This Do

Enables the wallclock profiler by default.

# Motivation

# Additional Notes
