### PR TITLE
allow specification and setting of context attributes with an enum class

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilingIntegration.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilingIntegration.java
@@ -35,4 +35,19 @@ public class DatadogProfilingIntegration implements ProfilingContextIntegration 
   public void setContextValue(String attribute, String value) {
     DDPROF.setContextValue(attribute, value);
   }
+
+  @Override
+  public void clearContextValue(String attribute) {
+    DDPROF.clearContextValue(attribute);
+  }
+
+  @Override
+  public <T extends Enum<T>> void setContextValue(T attribute, String value) {
+    DDPROF.setContextValue(attribute, value);
+  }
+
+  @Override
+  public <T extends Enum<T>> void clearContextValue(T attribute) {
+    DDPROF.clearContextValue(attribute);
+  }
 }

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/test/java/com/datadog/profiling/ddprof/ContextEnum.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/test/java/com/datadog/profiling/ddprof/ContextEnum.java
@@ -1,0 +1,11 @@
+package com.datadog.profiling.ddprof;
+
+public enum ContextEnum {
+  FOO,
+  BAR;
+
+  @Override
+  public String toString() {
+    return name().toLowerCase();
+  }
+}

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/TestProfilingContextIntegration.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/TestProfilingContextIntegration.groovy
@@ -24,4 +24,16 @@ class TestProfilingContextIntegration implements ProfilingContextIntegration {
   @Override
   void setContextValue(String attribute, String value) {
   }
+
+  @Override
+  void clearContextValue(String attribute) {
+  }
+
+  @Override
+  <T extends Enum<T>> void setContextValue(T attribute, String value) {
+  }
+
+  @Override
+  <T extends Enum<T>> void clearContextValue(T attribute) {
+  }
 }

--- a/dd-smoke-tests/profiling-integration-tests/src/main/java/datadog/smoketest/profiling/ContextEnum.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/main/java/datadog/smoketest/profiling/ContextEnum.java
@@ -1,0 +1,11 @@
+package datadog.smoketest.profiling;
+
+public enum ContextEnum {
+  FOO,
+  BAR;
+
+  @Override
+  public String toString() {
+    return name().toLowerCase();
+  }
+}

--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/JFRBasedProfilingIntegrationTest.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/JFRBasedProfilingIntegrationTest.java
@@ -1,9 +1,6 @@
 package datadog.smoketest;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openjdk.jmc.common.item.Attribute.attr;
 import static org.openjdk.jmc.common.unit.UnitLookup.NUMBER;
 import static org.openjdk.jmc.common.unit.UnitLookup.PLAIN_TEXT;
@@ -93,8 +90,9 @@ class JFRBasedProfilingIntegrationTest {
       attr("localRootSpanId", "localRootSpanId", "localRootSpanId", NUMBER);
   public static final IAttribute<IQuantity> SPAN_ID = attr("spanId", "spanId", "spanId", NUMBER);
 
-  public static final IAttribute<String> ATTR_1 = attr("attribute1", "", "", PLAIN_TEXT);
-  public static final IAttribute<String> VALUE_1 = attr("value1", "", "", PLAIN_TEXT);
+  // FIXME use these instead after profiler update
+  public static final IAttribute<String> FOO = attr("foo", "", "", PLAIN_TEXT);
+  public static final IAttribute<String> BAR = attr("bar", "", "", PLAIN_TEXT);
 
   private MockWebServer profilingServer;
   private MockWebServer tracingServer;
@@ -141,25 +139,39 @@ class JFRBasedProfilingIntegrationTest {
   @Test
   @DisplayName("Test continuous recording - no jmx delay")
   public void testContinuousRecording_no_jmx_delay(final TestInfo testInfo) throws Exception {
-    testWithRetry(() -> testContinuousRecording(0, ENDPOINT_COLLECTION_ENABLED, true), testInfo, 5);
+    testWithRetry(
+        () -> testContinuousRecording(0, ENDPOINT_COLLECTION_ENABLED, true, false), testInfo, 5);
+  }
+
+  @Test
+  @DisplayName("Test continuous recording - no jmx delay")
+  public void testContinuousRecording_context_enum(final TestInfo testInfo) throws Exception {
+    testWithRetry(
+        () -> testContinuousRecording(0, ENDPOINT_COLLECTION_ENABLED, true, true), testInfo, 5);
   }
 
   @Test
   @DisplayName("Test continuous recording - 1 sec jmx delay")
   public void testContinuousRecording(final TestInfo testInfo) throws Exception {
-    testWithRetry(() -> testContinuousRecording(1, ENDPOINT_COLLECTION_ENABLED, true), testInfo, 5);
+    testWithRetry(
+        () -> testContinuousRecording(1, ENDPOINT_COLLECTION_ENABLED, true, false), testInfo, 5);
   }
 
   private void testContinuousRecording(
       final int jmxFetchDelay,
       final boolean endpointCollectionEnabled,
-      final boolean asyncProfilerEnabled)
+      final boolean asyncProfilerEnabled,
+      final boolean useContextEnum)
       throws Exception {
     final ObjectMapper mapper = new ObjectMapper();
     try {
       targetProcess =
           createDefaultProcessBuilder(
-                  jmxFetchDelay, endpointCollectionEnabled, asyncProfilerEnabled, logFilePath)
+                  jmxFetchDelay,
+                  endpointCollectionEnabled,
+                  asyncProfilerEnabled,
+                  logFilePath,
+                  useContextEnum)
               .start();
 
       Assumptions.assumeFalse(Platform.isJ9());
@@ -381,7 +393,8 @@ class JFRBasedProfilingIntegrationTest {
                         ENDPOINT_COLLECTION_ENABLED,
                         true,
                         exitDelay,
-                        logFilePath)
+                        logFilePath,
+                        false)
                     .start();
 
             /* API key of an incorrect format will cause profiling to get disabled.
@@ -437,7 +450,8 @@ class JFRBasedProfilingIntegrationTest {
                         ENDPOINT_COLLECTION_ENABLED,
                         true,
                         duration,
-                        logFilePath)
+                        logFilePath,
+                        false)
                     .start();
 
             final RecordedRequest request = retrieveRequest();
@@ -516,25 +530,21 @@ class JFRBasedProfilingIntegrationTest {
         IItemCollection executionSamples =
             events.apply(ItemFilters.type("datadog.ExecutionSample"));
         Set<Long> rootSpanIds = new HashSet<>();
-        Set<String> tags = new HashSet<>();
         Set<String> values = new HashSet<>();
         for (IItemIterable executionSampleEvents : executionSamples) {
           IMemberAccessor<IQuantity, IItem> rootSpanIdAccessor =
               LOCAL_ROOT_SPAN_ID.getAccessor(executionSampleEvents.getType());
-          IMemberAccessor<String, IItem> tagAttributeAccessor =
-              ATTR_1.getAccessor(executionSampleEvents.getType());
-          IMemberAccessor<String, IItem> tagValueAccessor =
-              VALUE_1.getAccessor(executionSampleEvents.getType());
+          IMemberAccessor<String, IItem> fooAccessor =
+              FOO.getAccessor(executionSampleEvents.getType());
+          IMemberAccessor<String, IItem> barAccessor =
+              BAR.getAccessor(executionSampleEvents.getType());
           for (IItem executionSample : executionSampleEvents) {
             rootSpanIds.add(rootSpanIdAccessor.getMember(executionSample).longValue());
-            String attribute = tagAttributeAccessor.getMember(executionSample);
-            if (attribute != null) {
-              tags.add(attribute);
+            String foo = fooAccessor.getMember(executionSample);
+            if (foo != null) {
+              values.add(foo);
             }
-            String value = tagValueAccessor.getMember(executionSample);
-            if (value != null) {
-              values.add(value);
-            }
+            assertNull(barAccessor.getMember(executionSample));
           }
         }
         int matches = 0;
@@ -548,8 +558,6 @@ class JFRBasedProfilingIntegrationTest {
         }
         // we expect a rough correspondence between these events
         assertTrue(matches > 0);
-        assertEquals(1, tags.size());
-        assertEquals("foo", tags.iterator().next());
         assertFalse(values.isEmpty());
         for (String value : values) {
           assertTrue(value.startsWith("context"));
@@ -584,11 +592,6 @@ class JFRBasedProfilingIntegrationTest {
     assertTrue(events.apply(ItemFilters.type("datadog.ProfilerSetting")).hasItems());
   }
 
-  private static String getStringParameter(
-      final String name, final Multimap<String, Object> parameters) {
-    return getParameter(name, String.class, parameters);
-  }
-
   private static <T> T getParameter(
       final String name, final Class<T> type, final Multimap<String, Object> parameters) {
     final List<?> vals = (List<?>) parameters.get(name);
@@ -599,7 +602,8 @@ class JFRBasedProfilingIntegrationTest {
       final int jmxFetchDelay,
       final boolean endpointCollectionEnabled,
       final boolean asyncProfilerEnabled,
-      final Path logFilePath) {
+      final Path logFilePath,
+      final boolean useContextEnum) {
     return createProcessBuilder(
         VALID_API_KEY,
         jmxFetchDelay,
@@ -608,7 +612,8 @@ class JFRBasedProfilingIntegrationTest {
         endpointCollectionEnabled,
         asyncProfilerEnabled,
         0,
-        logFilePath);
+        logFilePath,
+        useContextEnum);
   }
 
   private ProcessBuilder createProcessBuilder(
@@ -619,7 +624,8 @@ class JFRBasedProfilingIntegrationTest {
       final boolean endpointCollectionEnabled,
       final boolean asyncProfilerEnabled,
       final int exitDelay,
-      final Path logFilePath) {
+      final Path logFilePath,
+      final boolean useContextEnum) {
     return createProcessBuilder(
         profilingServer.getPort(),
         tracingServer.getPort(),
@@ -630,7 +636,8 @@ class JFRBasedProfilingIntegrationTest {
         endpointCollectionEnabled,
         asyncProfilerEnabled,
         exitDelay,
-        logFilePath);
+        logFilePath,
+        useContextEnum);
   }
 
   private static ProcessBuilder createProcessBuilder(
@@ -643,7 +650,8 @@ class JFRBasedProfilingIntegrationTest {
       final boolean endpointCollectionEnabled,
       final boolean asyncProfilerEnabled,
       final int exitDelay,
-      final Path logFilePath) {
+      final Path logFilePath,
+      final boolean useContextEnum) {
     final String templateOverride =
         JFRBasedProfilingIntegrationTest.class
             .getClassLoader()
@@ -672,7 +680,9 @@ class JFRBasedProfilingIntegrationTest {
             "-Ddd.profiling.upload.timeout=" + PROFILING_UPLOAD_TIMEOUT_SECONDS,
             "-Ddd.profiling.debug.dump_path=/tmp/dd-profiler",
             "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug",
-            "-Ddd.profiling.experimental.context.attributes=foo",
+            useContextEnum
+                ? "-Ddd.profiling.experimental.context.enum=datadog.smoketest.profiling.ContextEnum"
+                : "-Ddd.profiling.experimental.context.attributes=foo,bar",
             "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug",
             "-XX:+IgnoreUnrecognizedVMOptions",
             "-XX:+UnlockCommercialFeatures",

--- a/dd-trace-api/build.gradle
+++ b/dd-trace-api/build.gradle
@@ -15,7 +15,8 @@ excludedClassesCoverage += [
   'datadog.trace.api.TracePropagationStyle',
   'datadog.trace.api.SpanCorrelation*',
   'datadog.trace.api.interceptor.MutableSpan',
-  'datadog.trace.api.experimental.ProfilingContext'
+  'datadog.trace.api.experimental.ProfilingContext',
+  'datadog.trace.api.experimental.ProfilingContext.NoOp'
 ]
 
 description = 'dd-trace-api'

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -162,5 +162,7 @@ public final class ProfilingConfig {
   public static final String PROFILING_CONTEXT_ATTRIBUTES =
       "profiling.experimental.context.attributes";
 
+  public static final String PROFILING_CONTEXT_ENUM = "profiling.experimental.context.enum";
+
   private ProfilingConfig() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/experimental/ProfilingContext.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/experimental/ProfilingContext.java
@@ -2,17 +2,19 @@ package datadog.trace.api.experimental;
 
 import datadog.trace.api.GlobalTracer;
 import datadog.trace.api.Tracer;
+import datadog.trace.api.internal.InternalTracer;
 
 /** This class is experimental and is subject to change and may be removed. */
 public interface ProfilingContext {
 
   static ProfilingContext get() {
     Tracer tracer = GlobalTracer.get();
-    if (tracer instanceof ProfilingContext) {
-      return (ProfilingContext) tracer;
+    if (tracer instanceof InternalTracer) {
+      return ((InternalTracer) tracer).getProfilingContext();
     }
-    return (attribute, value) -> {};
+    return NoOp.INSTANCE;
   }
+
   /**
    * Sets a context value to be appended to profiling data
    *
@@ -20,4 +22,32 @@ public interface ProfilingContext {
    * @param value the value
    */
   void setContextValue(String attribute, String value);
+
+  /**
+   * Clears a context value
+   *
+   * @param attribute the attribute (must have been registered at startup)
+   */
+  void clearContextValue(String attribute);
+
+  <T extends Enum<T>> void setContextValue(T attribute, String value);
+
+  <T extends Enum<T>> void clearContextValue(T attribute);
+
+  final class NoOp implements ProfilingContext {
+
+    public static final NoOp INSTANCE = new NoOp();
+
+    @Override
+    public void setContextValue(String attribute, String value) {}
+
+    @Override
+    public void clearContextValue(String attribute) {}
+
+    @Override
+    public <T extends Enum<T>> void setContextValue(T attribute, String value) {}
+
+    @Override
+    public <T extends Enum<T>> void clearContextValue(T attribute) {}
+  }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/internal/InternalTracer.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/internal/InternalTracer.java
@@ -1,5 +1,7 @@
 package datadog.trace.api.internal;
 
+import datadog.trace.api.experimental.ProfilingContext;
+
 /**
  * Tracer internal features. Those features are not part of public API and can change or be removed
  * at any time.
@@ -16,4 +18,6 @@ public interface InternalTracer {
   void flush();
 
   void flushMetrics();
+
+  ProfilingContext getProfilingContext();
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -24,6 +24,7 @@ import datadog.trace.api.IdGenerationStrategy;
 import datadog.trace.api.StatsDClient;
 import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.api.config.GeneralConfig;
+import datadog.trace.api.experimental.ProfilingContext;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.InstrumentationGateway;
 import datadog.trace.api.gateway.RequestContext;
@@ -207,11 +208,6 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   @Override
   public EndpointTracker onRootSpanStarted(AgentSpan root) {
     return endpointCheckpointer.onRootSpanStarted(root);
-  }
-
-  @Override
-  public void setContextValue(String attribute, String value) {
-    profilingContextIntegration.setContextValue(attribute, value);
   }
 
   public static class CoreTracerBuilder {
@@ -1027,6 +1023,11 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
       log.debug("Failed to wait for metrics flush.", e);
     }
+  }
+
+  @Override
+  public ProfilingContext getProfilingContext() {
+    return profilingContextIntegration;
   }
 
   private static StatsDClient createStatsDClient(final Config config) {

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -38,8 +38,7 @@ import org.slf4j.LoggerFactory;
  * DDTracer implements the <code>io.opentracing.Tracer</code> interface to make it easy to send
  * traces and spans to Datadog using the OpenTracing API.
  */
-public class DDTracer
-    implements Tracer, datadog.trace.api.Tracer, InternalTracer, ProfilingContext {
+public class DDTracer implements Tracer, datadog.trace.api.Tracer, InternalTracer {
 
   private static final Logger log = LoggerFactory.getLogger(DDTracer.class);
 
@@ -73,13 +72,6 @@ public class DDTracer
   // each depend on each other so scopeManager can't be final
   // Perhaps the api can change so that CoreTracer doesn't need to implement scope methods directly
   private ScopeManager scopeManager;
-
-  @Override
-  public void setContextValue(String attribute, String value) {
-    if (tracer != null) {
-      tracer.setContextValue(attribute, value);
-    }
-  }
 
   public static class DDTracerBuilder {
 
@@ -502,6 +494,11 @@ public class DDTracer
   @Override
   public void flushMetrics() {
     tracer.flushMetrics();
+  }
+
+  @Override
+  public ProfilingContext getProfilingContext() {
+    return tracer != null ? tracer.getProfilingContext() : ProfilingContext.NoOp.INSTANCE;
   }
 
   @Override

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -34,7 +34,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    jplib         : "0.11.0",
+    jplib         : "0.12.0",
     asm           : "9.4"
   ]
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -114,11 +114,7 @@ public class AgentTracer {
   private AgentTracer() {}
 
   public interface TracerAPI
-      extends datadog.trace.api.Tracer,
-          InternalTracer,
-          AgentPropagation,
-          EndpointCheckpointer,
-          ProfilingContext {
+      extends datadog.trace.api.Tracer, InternalTracer, AgentPropagation, EndpointCheckpointer {
     AgentSpan startSpan(CharSequence spanName);
 
     AgentSpan startSpan(CharSequence spanName, long startTimeMicros);
@@ -290,6 +286,11 @@ public class AgentTracer {
     public void flushMetrics() {}
 
     @Override
+    public ProfilingContext getProfilingContext() {
+      return ProfilingContext.NoOp.INSTANCE;
+    }
+
+    @Override
     public String getTraceId() {
       return null;
     }
@@ -385,9 +386,6 @@ public class AgentTracer {
 
     @Override
     public void notifyExtensionEnd(AgentSpan span, Object result, boolean isError) {}
-
-    @Override
-    public void setContextValue(String attribute, String value) {}
   }
 
   public static final class NoopAgentSpan implements AgentSpan {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ProfilingContextIntegration.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ProfilingContextIntegration.java
@@ -1,6 +1,8 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
-public interface ProfilingContextIntegration {
+import datadog.trace.api.experimental.ProfilingContext;
+
+public interface ProfilingContextIntegration extends ProfilingContext {
   /** Invoked when a trace first propagates to a thread */
   void onAttach();
 
@@ -8,8 +10,6 @@ public interface ProfilingContextIntegration {
   void onDetach();
 
   void setContext(long rootSpanId, long spanId);
-
-  void setContextValue(String attribute, String value);
 
   final class NoOp implements ProfilingContextIntegration {
 
@@ -26,5 +26,14 @@ public interface ProfilingContextIntegration {
 
     @Override
     public void setContextValue(String attribute, String value) {}
+
+    @Override
+    public void clearContextValue(String attribute) {}
+
+    @Override
+    public <T extends Enum<T>> void setContextValue(T attribute, String value) {}
+
+    @Override
+    public <T extends Enum<T>> void clearContextValue(T attribute) {}
   }
 }


### PR DESCRIPTION
# What Does This Do

Allows users to set `-Ddd.profiling.context.enum=<fully qualified enum class name>` and we'll create a profiling context attribute for each element of that enum, and allow the user to set tags using enum keys.

# Motivation

# Additional Notes
