### PR TITLE
Do not serialize captured data for Log Probes

### DIFF
--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1419,6 +1419,7 @@ public class CapturedSnapshotTest {
             id,
             location,
             ProbeDefinition.MethodLocation.convert(probe.getEvaluateAt()),
+            true,
             probe.getProbeCondition(),
             probe.concatTags(),
             new SnapshotSummaryBuilder(location),
@@ -1429,6 +1430,7 @@ public class CapturedSnapshotTest {
                             relatedProbe.getId(),
                             location,
                             ProbeDefinition.MethodLocation.convert(relatedProbe.getEvaluateAt()),
+                            true,
                             ((LogProbe) relatedProbe).getProbeCondition(),
                             relatedProbe.concatTags(),
                             new SnapshotSummaryBuilder(location)))

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -54,6 +54,7 @@ public class LogProbesInstrumentationTest {
     int result = Reflect.on(testClass).call("main", "1").get();
     Assert.assertEquals(3, result);
     Snapshot snapshot = assertOneSnapshot(listener);
+    assertCapturesNull(snapshot);
     assertEquals("this is log line", snapshot.getSummary());
   }
 
@@ -67,19 +68,28 @@ public class LogProbesInstrumentationTest {
     int result = Reflect.on(testClass).call("main", "1").get();
     Assert.assertEquals(3, result);
     Snapshot snapshot = assertOneSnapshot(listener);
+    assertCapturesNull(snapshot);
     assertEquals("this is log line with arg=1", snapshot.getSummary());
   }
 
   @Test
   public void methodTemplateArgLogEvaluateAtExit() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installSingleProbe(
-            "this is log line with return={@return}", CLASS_NAME, "main", "int (java.lang.String)");
+    LogProbe probe =
+        createProbeBuilder(
+                LOG_ID,
+                "this is log line with return={@return}",
+                CLASS_NAME,
+                "main",
+                "int (java.lang.String)")
+            .evaluateAt(ProbeDefinition.MethodLocation.EXIT)
+            .build();
+    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, probe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     Assert.assertEquals(3, result);
     Snapshot snapshot = assertOneSnapshot(listener);
+    assertCapturesNull(snapshot);
     assertEquals("this is log line with return=3", snapshot.getSummary());
   }
 
@@ -107,8 +117,10 @@ public class LogProbesInstrumentationTest {
     Assert.assertEquals(3, result);
     Assert.assertEquals(2, listener.snapshots.size());
     Snapshot snapshot0 = listener.snapshots.get(0);
+    assertCapturesNull(snapshot0);
     assertEquals("this is log line #1 with arg=1", snapshot0.getSummary());
     Snapshot snapshot1 = listener.snapshots.get(1);
+    assertCapturesNull(snapshot1);
     assertEquals("this is log line #2 with arg=1", snapshot1.getSummary());
   }
 
@@ -121,6 +133,7 @@ public class LogProbesInstrumentationTest {
     int result = Reflect.on(testClass).call("main", "1").get();
     Assert.assertEquals(3, result);
     Snapshot snapshot = assertOneSnapshot(listener);
+    assertCapturesNull(snapshot);
     assertEquals("this is log line", snapshot.getSummary());
   }
 
@@ -133,6 +146,7 @@ public class LogProbesInstrumentationTest {
     int result = Reflect.on(testClass).call("main", "1").get();
     Assert.assertEquals(3, result);
     Snapshot snapshot = assertOneSnapshot(listener);
+    assertCapturesNull(snapshot);
     assertEquals("this is log line with local var=3", snapshot.getSummary());
   }
 
@@ -150,6 +164,7 @@ public class LogProbesInstrumentationTest {
     int result = Reflect.on(testClass).call("main", "1").get();
     Assert.assertEquals(143, result);
     Snapshot snapshot = assertOneSnapshot(listener);
+    assertCapturesNull(snapshot);
     assertEquals("nullObject=NULL sdata=foo cdata=101", snapshot.getSummary());
   }
 
@@ -167,6 +182,7 @@ public class LogProbesInstrumentationTest {
     int result = Reflect.on(testClass).call("main", "1").get();
     Assert.assertEquals(3, result);
     Snapshot snapshot = assertOneSnapshot(listener);
+    assertCapturesNull(snapshot);
     assertEquals(
         "this is log line with {curly braces} and with local var={3}", snapshot.getSummary());
   }
@@ -180,6 +196,7 @@ public class LogProbesInstrumentationTest {
     int result = Reflect.on(testClass).call("main", "1").get();
     Assert.assertEquals(3, result);
     Snapshot snapshot = assertOneSnapshot(listener);
+    assertCapturesNull(snapshot);
     assertEquals("this is log line with local var=UNDEFINED", snapshot.getSummary());
     assertEquals(1, snapshot.getEvaluationErrors().size());
     assertEquals("var42", snapshot.getEvaluationErrors().get(0).getExpr());
@@ -196,6 +213,7 @@ public class LogProbesInstrumentationTest {
     int result = Reflect.on(testClass).call("main", "").get();
     Assert.assertEquals(143, result);
     Snapshot snapshot = assertOneSnapshot(listener);
+    assertCapturesNull(snapshot);
     assertEquals("this is log line with field=UNDEFINED", snapshot.getSummary());
     assertEquals(1, snapshot.getEvaluationErrors().size());
     assertEquals("intValue", snapshot.getEvaluationErrors().get(0).getExpr());
@@ -221,7 +239,7 @@ public class LogProbesInstrumentationTest {
             .build());
   }
 
-  private static LogProbe createProbe(
+  private static LogProbe.Builder createProbeBuilder(
       String id,
       String template,
       String typeName,
@@ -233,8 +251,17 @@ public class LogProbesInstrumentationTest {
         .probeId(id)
         .active(true)
         .where(typeName, methodName, signature, lines)
-        .template(template)
-        .build();
+        .template(template);
+  }
+
+  private static LogProbe createProbe(
+      String id,
+      String template,
+      String typeName,
+      String methodName,
+      String signature,
+      String... lines) {
+    return createProbeBuilder(id, template, typeName, methodName, signature, lines).build();
   }
 
   private DebuggerTransformerTest.TestSnapshotListener installProbes(
@@ -296,6 +323,7 @@ public class LogProbesInstrumentationTest {
             id,
             location,
             Snapshot.MethodLocation.DEFAULT,
+            false,
             null,
             probe.concatTags(),
             new LogMessageTemplateSummaryBuilder(probe),
@@ -306,6 +334,7 @@ public class LogProbesInstrumentationTest {
                             relatedProbe.getId(),
                             location,
                             Snapshot.MethodLocation.DEFAULT,
+                            false,
                             relatedProbe instanceof LogProbe
                                 ? ((LogProbe) relatedProbe).getProbeCondition()
                                 : null,
@@ -323,5 +352,12 @@ public class LogProbesInstrumentationTest {
     Snapshot snapshot = listener.snapshots.get(0);
     Assert.assertEquals(LOG_ID, snapshot.getProbe().getId());
     return snapshot;
+  }
+
+  private void assertCapturesNull(Snapshot snapshot) {
+    Assert.assertNull(snapshot.getCaptures().getEntry());
+    Assert.assertNull(snapshot.getCaptures().getReturn());
+    Assert.assertNull(snapshot.getCaptures().getLines());
+    Assert.assertNull(snapshot.getCaptures().getCaughtExceptions());
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
@@ -210,6 +210,7 @@ public class SnapshotSerializationTest {
                 PROBE_ID,
                 PROBE_LOCATION,
                 Snapshot.MethodLocation.DEFAULT,
+                true,
                 new ProbeCondition(DSL.when(DSL.gt(DSL.ref("^n"), DSL.value(0))), "^n > 0"),
                 "",
                 new SnapshotSummaryBuilder(PROBE_LOCATION)),

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotWithCorrelationIdsLineRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotWithCorrelationIdsLineRegex.txt
@@ -1,10 +1,10 @@
 ^\[\{
+"dd.span_id":"456",
+"dd.trace_id":"123",
 "ddsource":"dd_debugger",
 "debugger":\{
 "snapshot":\{
-"captures":\{\},
-"evaluationErrors":\[\{"expr":"obj.field","message":"Cannot dereference obj"\}\],
-"id":"[^"]+",
+"captures":\{"lines":\{"25":\{"arguments":\{\},"locals":\{\}\}\}\},
 "language":"java",
 "probe":\{"evaluateAt":"DEFAULT","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
 "stack":\[\],
@@ -16,7 +16,7 @@
 "logger.thread_id":\d+,
 "logger.thread_name":"Test worker",
 "logger.version":2,
-"message":"DebuggerSinkTest.addSnapshotWithEvalErrors\(\)",
+"message":"String.indexOf\(\)",
 "service":"service-name",
 "timestamp":\d+
 \}\]$

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/DebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/DebuggerIntegrationTest.java
@@ -129,7 +129,11 @@ public class DebuggerIntegrationTest extends BaseIntegrationTest {
   void testFullMethod() throws Exception {
     final String METHOD_NAME = "fullMethod";
     LogProbe probe =
-        LogProbe.builder().probeId(PROBE_ID).where("DebuggerTestApplication", METHOD_NAME).build();
+        LogProbe.builder()
+            .probeId(PROBE_ID)
+            .where("DebuggerTestApplication", METHOD_NAME)
+            .captureSnapshot(true)
+            .build();
     setCurrentConfiguration(createConfig(probe));
     targetProcess = createProcessBuilder(logFilePath, METHOD_NAME, "3").start();
     RecordedRequest request = retrieveSnapshotRequest();

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/TracerDebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/TracerDebuggerIntegrationTest.java
@@ -50,6 +50,7 @@ public class TracerDebuggerIntegrationTest extends BaseIntegrationTest {
                 "org.springframework.web.servlet.DispatcherServlet",
                 "doService",
                 "(HttpServletRequest, HttpServletResponse)")
+            .captureSnapshot(true)
             .build();
     setCurrentConfiguration(createConfig(logProbe));
     String httpPort = String.valueOf(PortUtils.randomOpenPort());


### PR DESCRIPTION
# What Does This Do
when `captureSnapshot=false`, don't freeze data and serialize into the snapshot.
Snapshot handling is also refactored by introducing SnapshotStatus which help to handle all combinations of cases when generating snapshots

# Motivation

# Additional Notes
