### PR TITLE
Support combining instrumenter matchers

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AdviceStack.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AdviceStack.java
@@ -1,0 +1,36 @@
+package datadog.trace.agent.tooling;
+
+import java.security.ProtectionDomain;
+import java.util.List;
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.utility.JavaModule;
+
+/** Stack of advice transformations declared by a particular instrumentation. */
+final class AdviceStack implements AgentBuilder.Transformer {
+  private final AgentBuilder.Transformer[] advices;
+
+  AdviceStack(List<AgentBuilder.Transformer> advices) {
+    this.advices = advices.toArray(new AgentBuilder.Transformer[0]);
+  }
+
+  AdviceStack(AgentBuilder.Transformer advice) {
+    this.advices = new AgentBuilder.Transformer[] {advice};
+  }
+
+  @Override
+  public DynamicType.Builder<?> transform(
+      DynamicType.Builder<?> builder,
+      TypeDescription target,
+      ClassLoader classLoader,
+      JavaModule module,
+      ProtectionDomain pd) {
+
+    for (AgentBuilder.Transformer advice : advices) {
+      builder = advice.transform(builder, target, classLoader, module, pd);
+    }
+
+    return builder;
+  }
+}

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -126,9 +126,10 @@ public class AgentInstaller {
     }
 
     Instrumenters instrumenters = Instrumenters.load(AgentInstaller.class.getClassLoader());
+    int maxInstrumentationId = instrumenters.maxInstrumentationId();
 
     // pre-size state before registering instrumentations to reduce number of allocations
-    InstrumenterState.setMaxInstrumentationId(instrumenters.maxInstrumentationId());
+    InstrumenterState.setMaxInstrumentationId(maxInstrumentationId);
 
     // This needs to be a separate loop through all the instrumenters before we start adding
     // advice so that we can exclude field injection, since that will try to check exclusion
@@ -150,7 +151,7 @@ public class AgentInstaller {
     if (InstrumenterConfig.get().isLegacyInstallerEnabled()) {
       transformerBuilder = new LegacyTransformerBuilder(agentBuilder);
     } else {
-      transformerBuilder = null;
+      transformerBuilder = new CombiningTransformerBuilder(agentBuilder, maxInstrumentationId);
     }
 
     int installedCount = 0;

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/CombiningMatcher.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/CombiningMatcher.java
@@ -1,0 +1,58 @@
+package datadog.trace.agent.tooling;
+
+import java.security.ProtectionDomain;
+import java.util.BitSet;
+import java.util.List;
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.utility.JavaModule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Combines separate matcher results into a single bit-set for {@link SplittingTransformer}. */
+final class CombiningMatcher implements AgentBuilder.RawMatcher {
+  private static final Logger log = LoggerFactory.getLogger(CombiningMatcher.class);
+
+  // optimization to avoid repeated allocations inside BitSet as matched ids are set
+  static final int MAX_COMBINED_ID_HINT = 512;
+
+  /** Matcher results shared between {@link CombiningMatcher} and {@link SplittingTransformer} */
+  static final ThreadLocal<BitSet> recordedMatches =
+      ThreadLocal.withInitial(() -> new BitSet(MAX_COMBINED_ID_HINT));
+
+  private final BitSet knownTypesMask;
+  private final MatchRecorder[] matchers;
+
+  private static final KnownTypesIndex knownTypesIndex = KnownTypesIndex.readIndex();
+
+  CombiningMatcher(BitSet knownTypesMask, List<MatchRecorder> matchers) {
+    this.knownTypesMask = knownTypesMask;
+    this.matchers = matchers.toArray(new MatchRecorder[0]);
+  }
+
+  @Override
+  public boolean matches(
+      TypeDescription target,
+      ClassLoader classLoader,
+      JavaModule module,
+      Class<?> classBeingRedefined,
+      ProtectionDomain pd) {
+
+    BitSet ids = recordedMatches.get();
+    ids.clear();
+
+    knownTypesIndex.apply(target.getName(), knownTypesMask, ids);
+
+    for (MatchRecorder matcher : matchers) {
+      try {
+        matcher.record(target, classLoader, classBeingRedefined, ids);
+      } catch (Throwable e) {
+        if (log.isDebugEnabled()) {
+          log.debug("Instrumentation matcher unexpected exception - {}", matcher.describe(), e);
+        }
+      }
+    }
+
+    return !ids.isEmpty();
+  }
+}

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/CombiningTransformerBuilder.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/CombiningTransformerBuilder.java
@@ -1,0 +1,198 @@
+package datadog.trace.agent.tooling;
+
+import static datadog.trace.agent.tooling.bytebuddy.DDTransformers.defaultTransformers;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.ANY_CLASS_LOADER;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isSynthetic;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+
+import datadog.trace.agent.tooling.bytebuddy.ExceptionHandlers;
+import datadog.trace.agent.tooling.context.FieldBackedContextInjector;
+import datadog.trace.agent.tooling.context.FieldBackedContextMatcher;
+import datadog.trace.agent.tooling.context.FieldBackedContextRequestRewriter;
+import datadog.trace.agent.tooling.muzzle.MuzzleCheck;
+import datadog.trace.api.InstrumenterConfig;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.Instrumentation;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.List;
+import java.util.Map;
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+/** Builds multiple instrumentations into a single combining-matcher and splitting-transformer. */
+public final class CombiningTransformerBuilder extends AbstractTransformerBuilder {
+  private final AgentBuilder agentBuilder;
+
+  private final List<MatchRecorder> matchers = new ArrayList<>();
+  private final BitSet knownTypesMask;
+  private AdviceStack[] transformers;
+  private int nextSupplementaryId;
+
+  // temporary buffer for collecting advice; reset for each instrumenter
+  private final List<AgentBuilder.Transformer> advice = new ArrayList<>();
+  private ElementMatcher<? super MethodDescription> ignoredMethods;
+
+  public CombiningTransformerBuilder(AgentBuilder agentBuilder, int maxInstrumentationId) {
+    this.agentBuilder = agentBuilder;
+    int maxInstrumentationCount = maxInstrumentationId + 1;
+    this.knownTypesMask = new BitSet(maxInstrumentationCount);
+    this.transformers = new AdviceStack[maxInstrumentationCount];
+    this.nextSupplementaryId = maxInstrumentationId + 1;
+  }
+
+  @Override
+  protected void buildInstrumentation(Instrumenter.Default instrumenter) {
+    InstrumenterState.registerInstrumentation(instrumenter);
+
+    int id = instrumenter.instrumentationId();
+    if (transformers[id] != null) {
+      // this is an additional "dd.trace.methods" instrumenter configured at runtime
+      // (a separate instance is created for each class listed in "dd.trace.methods")
+      // allocate a distinct id for matching purposes to avoid mixing trace methods
+      id = nextSupplementaryId++;
+      if (transformers.length <= id) {
+        transformers = Arrays.copyOf(transformers, id + 1);
+      }
+    }
+
+    buildInstrumentationMatcher(instrumenter, id);
+    buildInstrumentationAdvice(instrumenter, id);
+  }
+
+  private void buildInstrumentationMatcher(Instrumenter.Default instrumenter, int id) {
+
+    if (instrumenter instanceof Instrumenter.ForSingleType
+        || instrumenter instanceof Instrumenter.ForKnownTypes) {
+      knownTypesMask.set(id);
+    } else if (instrumenter instanceof Instrumenter.ForTypeHierarchy) {
+      matchers.add(
+          new MatchRecorder.ForHierarchy(id, (Instrumenter.ForTypeHierarchy) instrumenter));
+    } else if (instrumenter instanceof Instrumenter.ForCallSite) {
+      matchers.add(
+          new MatchRecorder.ForType(id, ((Instrumenter.ForCallSite) instrumenter).callerType()));
+    }
+
+    if (instrumenter instanceof Instrumenter.ForConfiguredType) {
+      String name = ((Instrumenter.ForConfiguredType) instrumenter).configuredMatchingType();
+      if (null != name && !name.isEmpty()) {
+        matchers.add(new MatchRecorder.ForType(id, named(name)));
+      }
+    }
+
+    if (instrumenter instanceof Instrumenter.CanShortcutTypeMatching
+        && !((Instrumenter.CanShortcutTypeMatching) instrumenter).onlyMatchKnownTypes()) {
+      matchers.add(
+          new MatchRecorder.ForHierarchy(id, (Instrumenter.ForTypeHierarchy) instrumenter));
+    }
+
+    ElementMatcher<ClassLoader> classLoaderMatcher = instrumenter.classLoaderMatcher();
+    if (classLoaderMatcher != ANY_CLASS_LOADER) {
+      matchers.add(new MatchRecorder.NarrowLocation(id, classLoaderMatcher));
+    }
+
+    if (instrumenter instanceof Instrumenter.WithTypeStructure) {
+      matchers.add(
+          new MatchRecorder.NarrowType(
+              id, ((Instrumenter.WithTypeStructure) instrumenter).structureMatcher()));
+    }
+
+    matchers.add(new MatchRecorder.NarrowLocation(id, new MuzzleCheck(instrumenter)));
+  }
+
+  private void buildInstrumentationAdvice(Instrumenter.Default instrumenter, int id) {
+
+    String[] helperClassNames = instrumenter.helperClassNames();
+    if (instrumenter.injectHelperDependencies()) {
+      helperClassNames = HelperScanner.withClassDependencies(helperClassNames);
+    }
+    if (helperClassNames.length > 0) {
+      advice.add(new HelperTransformer(instrumenter.getClass().getSimpleName(), helperClassNames));
+    }
+
+    Map<String, String> contextStore = instrumenter.contextStore();
+    if (!contextStore.isEmpty()) {
+      // rewrite context store access to call FieldBackedContextStores with assigned store-id
+      advice.add(
+          new VisitingTransformer(
+              new FieldBackedContextRequestRewriter(contextStore, instrumenter.name())));
+
+      registerContextStoreInjection(instrumenter, contextStore);
+    }
+
+    Instrumenter.AdviceTransformer customTransformer = instrumenter.transformer();
+    if (customTransformer != null) {
+      advice.add(customTransformer::transform);
+    }
+
+    ignoredMethods = instrumenter.methodIgnoreMatcher();
+    instrumenter.adviceTransformations(this);
+    transformers[id] = new AdviceStack(advice);
+
+    advice.clear();
+  }
+
+  @Override
+  protected void buildSingleAdvice(Instrumenter.ForSingleType instrumenter) {
+
+    // this is a test instrumenter which needs a dynamic id
+    int id = nextSupplementaryId++;
+    if (transformers.length <= id) {
+      transformers = Arrays.copyOf(transformers, id + 1);
+    }
+
+    // can't use known-types index because it doesn't include test instrumenters
+    matchers.add(new MatchRecorder.ForType(id, named(instrumenter.instrumentedType())));
+
+    ignoredMethods = isSynthetic();
+    ((Instrumenter.HasAdvice) instrumenter).adviceTransformations(this);
+    transformers[id] = new AdviceStack(advice);
+
+    advice.clear();
+  }
+
+  @Override
+  public void applyAdvice(ElementMatcher<? super MethodDescription> matcher, String name) {
+    advice.add(
+        new AgentBuilder.Transformer.ForAdvice()
+            .include(Utils.getBootstrapProxy(), Utils.getAgentClassLoader())
+            .withExceptionHandler(ExceptionHandlers.defaultExceptionHandler())
+            .advice(not(ignoredMethods).and(matcher), name));
+  }
+
+  @Override
+  protected void applyContextStoreInjection(
+      Map.Entry<String, String> contextStore, ElementMatcher<ClassLoader> activation) {
+    String keyClassName = contextStore.getKey();
+    String contextClassName = contextStore.getValue();
+
+    FieldBackedContextMatcher contextMatcher =
+        new FieldBackedContextMatcher(keyClassName, contextClassName);
+    FieldBackedContextInjector contextAdvice =
+        new FieldBackedContextInjector(keyClassName, contextClassName);
+
+    int id = nextSupplementaryId++;
+
+    matchers.add(new MatchRecorder.ForContextStore(id, activation, contextMatcher));
+    transformers[id] = new AdviceStack(new VisitingTransformer(contextAdvice));
+  }
+
+  @Override
+  public ClassFileTransformer installOn(Instrumentation instrumentation) {
+    if (InstrumenterConfig.get().isRuntimeContextFieldInjection()) {
+      // expand so we have enough space for a context injecting transformer for each store
+      transformers = Arrays.copyOf(transformers, transformers.length + contextStoreCount());
+      applyContextStoreInjection();
+    }
+
+    return agentBuilder
+        .type(new CombiningMatcher(knownTypesMask, matchers))
+        .and(NOT_DECORATOR_MATCHER)
+        .transform(defaultTransformers())
+        .transform(new SplittingTransformer(transformers))
+        .installOn(instrumentation);
+  }
+}

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/MatchRecorder.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/MatchRecorder.java
@@ -1,0 +1,143 @@
+package datadog.trace.agent.tooling;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.ANY_CLASS_LOADER;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.hasClassNamed;
+
+import datadog.trace.agent.tooling.context.FieldBackedContextMatcher;
+import java.util.BitSet;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+/** Records a single match result in the bit-set. */
+abstract class MatchRecorder {
+  protected final int id;
+
+  MatchRecorder(int id) {
+    this.id = id;
+  }
+
+  public abstract void record(
+      TypeDescription type, ClassLoader classLoader, Class<?> classBeingRedefined, BitSet matches);
+
+  public String describe() {
+    return InstrumenterState.describe(id);
+  }
+
+  /** Selects types based on a simple direct match that doesn't require further lookup. */
+  static final class ForType extends MatchRecorder {
+    private final ElementMatcher<TypeDescription> typeMatcher;
+
+    ForType(int id, ElementMatcher<TypeDescription> typeMatcher) {
+      super(id);
+      this.typeMatcher = typeMatcher;
+    }
+
+    @Override
+    public void record(
+        TypeDescription type,
+        ClassLoader classLoader,
+        Class<?> classBeingRedefined,
+        BitSet matches) {
+      if (typeMatcher.matches(type)) {
+        matches.set(id);
+      }
+    }
+  }
+
+  /** Selects types based on more complex matching against the type's hierarchy. */
+  static final class ForHierarchy extends MatchRecorder {
+    private final ElementMatcher<ClassLoader> hintMatcher;
+    private final ElementMatcher<TypeDescription> typeMatcher;
+
+    ForHierarchy(int id, Instrumenter.ForTypeHierarchy instrumenter) {
+      super(id);
+      String hint = instrumenter.hierarchyMarkerType();
+      this.hintMatcher = null != hint ? hasClassNamed(hint) : ANY_CLASS_LOADER;
+      this.typeMatcher = instrumenter.hierarchyMatcher();
+    }
+
+    @Override
+    public void record(
+        TypeDescription type,
+        ClassLoader classLoader,
+        Class<?> classBeingRedefined,
+        BitSet matches) {
+      // check current state first in case a known-type already matched this instrumentation
+      if (!matches.get(id) && hintMatcher.matches(classLoader) && typeMatcher.matches(type)) {
+        matches.set(id);
+      }
+    }
+  }
+
+  /** Selects types that can and should have a context-store field injected. */
+  static final class ForContextStore extends MatchRecorder {
+    private final ElementMatcher<ClassLoader> activation;
+    private final FieldBackedContextMatcher contextMatcher;
+
+    ForContextStore(
+        int id, ElementMatcher<ClassLoader> activation, FieldBackedContextMatcher contextMatcher) {
+      super(id);
+      this.activation = activation;
+      this.contextMatcher = contextMatcher;
+    }
+
+    @Override
+    public void record(
+        TypeDescription type,
+        ClassLoader classLoader,
+        Class<?> classBeingRedefined,
+        BitSet matches) {
+      if (activation.matches(classLoader) && contextMatcher.matches(type, classBeingRedefined)) {
+        matches.set(id);
+      }
+    }
+
+    @Override
+    public String describe() {
+      // store description is more useful, as stores cut across instrumentations
+      return contextMatcher.describe();
+    }
+  }
+
+  /** Narrows the current match to eliminate incompatible types. */
+  static final class NarrowType extends MatchRecorder {
+    private final ElementMatcher<TypeDescription> matcher;
+
+    NarrowType(int id, ElementMatcher<TypeDescription> matcher) {
+      super(id);
+      this.matcher = matcher;
+    }
+
+    @Override
+    public void record(
+        TypeDescription type,
+        ClassLoader classLoader,
+        Class<?> classBeingRedefined,
+        BitSet matches) {
+      if (matches.get(id) && !matcher.matches(type)) {
+        matches.clear(id);
+      }
+    }
+  }
+
+  /** Narrows the current match to eliminate incompatible class-loaders. */
+  static final class NarrowLocation extends MatchRecorder {
+    private final ElementMatcher<ClassLoader> matcher;
+
+    NarrowLocation(int id, ElementMatcher<ClassLoader> matcher) {
+      super(id);
+      this.matcher = matcher;
+    }
+
+    @Override
+    public void record(
+        TypeDescription type,
+        ClassLoader classLoader,
+        Class<?> classBeingRedefined,
+        BitSet matches) {
+      if (matches.get(id) && !matcher.matches(classLoader)) {
+        matches.clear(id);
+      }
+    }
+  }
+}

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/SplittingTransformer.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/SplittingTransformer.java
@@ -1,0 +1,33 @@
+package datadog.trace.agent.tooling;
+
+import java.security.ProtectionDomain;
+import java.util.BitSet;
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.utility.JavaModule;
+
+/** Splits matches recorded by {@link CombiningMatcher} back into separate transformation steps. */
+final class SplittingTransformer implements AgentBuilder.Transformer {
+  private final AdviceStack[] transformers;
+
+  SplittingTransformer(AdviceStack[] transformers) {
+    this.transformers = transformers;
+  }
+
+  @Override
+  public DynamicType.Builder<?> transform(
+      DynamicType.Builder<?> builder,
+      TypeDescription target,
+      ClassLoader classLoader,
+      JavaModule module,
+      ProtectionDomain pd) {
+
+    BitSet ids = CombiningMatcher.recordedMatches.get();
+    for (int id = ids.nextSetBit(0); id >= 0; id = ids.nextSetBit(id + 1)) {
+      builder = transformers[id].transform(builder, target, classLoader, module, pd);
+    }
+
+    return builder;
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterState.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterState.java
@@ -64,10 +64,10 @@ public final class InstrumenterState {
 
   /** Resets the default instrumentation state so nothing is blocked or applied. */
   public static void resetDefaultState() {
-    int instrumentationCount = instrumentationNames.length;
+    int maxInstrumentationCount = instrumentationNames.length;
 
     int wordsPerClassLoaderState =
-        ((instrumentationCount << 1) + BITS_PER_WORD - 1) >> ADDRESS_BITS_PER_WORD;
+        ((maxInstrumentationCount << 1) + BITS_PER_WORD - 1) >> ADDRESS_BITS_PER_WORD;
 
     if (defaultState.length > 0) { // optimization: skip clear if there's no old state
       classLoaderStates.clear();

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/KnownTypesIndex.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/KnownTypesIndex.java
@@ -1,0 +1,166 @@
+package datadog.trace.agent.tooling;
+
+import datadog.trace.agent.tooling.bytebuddy.SharedTypePools;
+import datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers;
+import datadog.trace.util.ClassNameTrie;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Maintains an index from known instrumented class names to stable {@link Instrumenter} ids. */
+public final class KnownTypesIndex {
+  private static final Logger log = LoggerFactory.getLogger(KnownTypesIndex.class);
+
+  private static final String KNOWN_TYPES_INDEX_NAME = "known-types.index";
+
+  // marks results that match multiple instrumentations
+  private static final int MULTIPLE_ID_MARKER = 0x1000;
+
+  // lookup table of multiple-id results
+  private final int[][] multipleIdTable;
+
+  private final ClassNameTrie knownTypesTrie;
+
+  private KnownTypesIndex(int[][] multipleIdTable, ClassNameTrie knownTypesTrie) {
+    this.multipleIdTable = multipleIdTable;
+    this.knownTypesTrie = knownTypesTrie;
+  }
+
+  public void apply(String name, BitSet mask, BitSet instrumentationIds) {
+    int instrumentationId = knownTypesTrie.apply(name);
+    if (instrumentationId >= 0) {
+      if ((instrumentationId & MULTIPLE_ID_MARKER) != 0) {
+        for (int id : multipleIdTable[instrumentationId & ~MULTIPLE_ID_MARKER]) {
+          if (mask.get(id)) {
+            instrumentationIds.set(id);
+          }
+        }
+      } else if (mask.get(instrumentationId)) {
+        instrumentationIds.set(instrumentationId);
+      }
+    }
+  }
+
+  public static KnownTypesIndex readIndex() {
+    ClassLoader instrumenterClassLoader = Instrumenter.class.getClassLoader();
+    URL indexResource = instrumenterClassLoader.getResource(KNOWN_TYPES_INDEX_NAME);
+    if (null != indexResource) {
+      try (DataInputStream in =
+          new DataInputStream(new BufferedInputStream(indexResource.openStream()))) {
+        int multipleIdCount = in.readInt();
+        int[][] multipleIdTable = new int[multipleIdCount][];
+        for (int i = 0; i < multipleIdCount; i++) {
+          int idCount = in.readInt();
+          int[] ids = new int[idCount];
+          for (int j = 0; j < idCount; j++) {
+            ids[j] = in.readInt();
+          }
+          multipleIdTable[i] = ids;
+        }
+        return new KnownTypesIndex(multipleIdTable, ClassNameTrie.readFrom(in));
+      } catch (Throwable e) {
+        log.error("Problem reading " + KNOWN_TYPES_INDEX_NAME, e);
+      }
+    }
+    return buildIndex(); // fallback to runtime generation when testing
+  }
+
+  public static KnownTypesIndex buildIndex() {
+    IndexGenerator indexGenerator = new IndexGenerator();
+    indexGenerator.buildIndex();
+    // bypass writing to file, convert into structure expected at runtime
+    int[][] multipleIdTable = new int[indexGenerator.multipleIdTable.size()][];
+    for (int i = 0; i < multipleIdTable.length; i++) {
+      multipleIdTable[i] = indexGenerator.multipleIdTable.get(i).stream().toArray();
+    }
+    return new KnownTypesIndex(multipleIdTable, indexGenerator.knownTypesTrie.buildTrie());
+  }
+
+  /** Generates an index from known instrumented types referenced by {@link Instrumenter}s. */
+  static class IndexGenerator {
+    final ClassNameTrie.Builder knownTypesTrie = new ClassNameTrie.Builder();
+    final List<BitSet> multipleIdTable = new ArrayList<>();
+
+    public void buildIndex() {
+      log.debug("Generating KnownTypesIndex");
+      for (Instrumenter instrumenter : Instrumenters.load(Instrumenter.class.getClassLoader())) {
+        int instrumentationId = Instrumenters.currentInstrumentationId();
+        if (instrumenter instanceof Instrumenter.ForSingleType) {
+          String type = ((Instrumenter.ForSingleType) instrumenter).instrumentedType();
+          indexKnownType(instrumenter, type, instrumentationId);
+        } else if (instrumenter instanceof Instrumenter.ForKnownTypes) {
+          for (String type : ((Instrumenter.ForKnownTypes) instrumenter).knownMatchingTypes()) {
+            indexKnownType(instrumenter, type, instrumentationId);
+          }
+        }
+      }
+    }
+
+    /** Indexes a single match from known-type to instrumentation-id. */
+    private void indexKnownType(
+        Instrumenter instrumenter, String knownType, int instrumentationId) {
+      if (null == knownType || knownType.isEmpty()) {
+        throw new IllegalArgumentException(
+            instrumenter.getClass() + " declares a null or empty known-type");
+      }
+      int existingId = knownTypesTrie.apply(knownType);
+      if (existingId < 0) {
+        knownTypesTrie.put(knownType, instrumentationId);
+      } else {
+        BitSet instrumentationIds;
+        if ((existingId & MULTIPLE_ID_MARKER) != 0) {
+          // add new instrumentation-id to existing table entry, no need to update trie
+          instrumentationIds = multipleIdTable.get(existingId & ~MULTIPLE_ID_MARKER);
+        } else {
+          // create new table entry to hold multiple ids and update trie with its offset
+          knownTypesTrie.put(knownType, multipleIdTable.size() | MULTIPLE_ID_MARKER);
+          instrumentationIds = new BitSet();
+          multipleIdTable.add(instrumentationIds);
+          instrumentationIds.set(existingId);
+        }
+        instrumentationIds.set(instrumentationId);
+      }
+    }
+
+    public void writeIndex(Path indexFile) throws IOException {
+      try (DataOutputStream out =
+          new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(indexFile)))) {
+        out.writeInt(multipleIdTable.size());
+        for (BitSet ids : multipleIdTable) {
+          out.writeInt(ids.cardinality());
+          for (int id = ids.nextSetBit(0); id >= 0; id = ids.nextSetBit(id + 1)) {
+            out.writeInt(id);
+          }
+        }
+        knownTypesTrie.writeTo(out);
+      }
+    }
+
+    public static void main(String[] args) throws IOException {
+      if (args.length < 1) {
+        throw new IllegalArgumentException("Expected: resources-dir");
+      }
+
+      Path resourcesDir = Paths.get(args[0]).toAbsolutePath();
+
+      // satisfy some instrumenters that cache matchers in initializers
+      HierarchyMatchers.registerIfAbsent(HierarchyMatchers.simpleChecks());
+      SharedTypePools.registerIfAbsent(SharedTypePools.simpleCache());
+
+      IndexGenerator indexGenerator = new IndexGenerator();
+      indexGenerator.buildIndex();
+      indexGenerator.writeIndex(resourcesDir.resolve(KNOWN_TYPES_INDEX_NAME));
+    }
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/KnownTypesIndex.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/KnownTypesIndex.java
@@ -147,6 +147,9 @@ public final class KnownTypesIndex {
       }
     }
 
+    /**
+     * Called from 'generateKnownTypesIndex' task in 'dd-java-agent/instrumentation/build.gradle'.
+     */
     public static void main(String[] args) throws IOException {
       if (args.length < 1) {
         throw new IllegalArgumentException("Expected: resources-dir");

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextMatcher.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextMatcher.java
@@ -52,6 +52,10 @@ public final class FieldBackedContextMatcher {
     return false;
   }
 
+  public String describe() {
+    return "contextStore(" + keyType + "," + valueType + ")";
+  }
+
   /**
    * Assumes that {@link Class#getInterfaces()} returns list of interfaces defined immediately on a
    * given class, not inherited from its parents.

--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -238,7 +238,7 @@ tasks.register('checkAgentJarSize').configure {
   doLast {
     // Arbitrary limit to prevent unintentional increases to the agent jar size
     // Raise or lower as required
-    def megs = (project.rootProject.hasProperty("agentIncludeCwsTls") && agentIncludeCwsTls) ? 22 : 20
+    def megs = (project.rootProject.hasProperty("agentIncludeCwsTls") && agentIncludeCwsTls) ? 23 : 21
     assert shadowJar.archiveFile.get().getAsFile().length() <= megs * 1024 * 1024
   }
 

--- a/dd-java-agent/instrumentation/build.gradle
+++ b/dd-java-agent/instrumentation/build.gradle
@@ -109,3 +109,25 @@ tasks.named('shadowJar').configure {
   duplicatesStrategy = DuplicatesStrategy.FAIL
   dependencies deps.excludeShared
 }
+
+tasks.register('generateKnownTypesIndex', JavaExec) {
+  // temporary config to add slf4j-simple so we get logging from instrumenters while indexing
+  def slf4jSimple = project.configurations.create('slf4j-simple')
+  project.dependencies.add('slf4j-simple', "org.slf4j:slf4j-simple:${versions.slf4j}")
+
+  def resourcesDir = "${sourceSets.main.output.resourcesDir}"
+  def indexFile = "${resourcesDir}/known-types.index"
+
+  it.group = 'Build'
+  it.description = "Generate known-types.index"
+  it.mainClass = 'datadog.trace.agent.tooling.KnownTypesIndex$IndexGenerator'
+  it.classpath = project.configurations.runtimeClasspath + slf4jSimple
+  it.inputs.files(it.classpath)
+  it.outputs.files(indexFile)
+  it.args = [resourcesDir]
+
+  dependsOn 'processResources'
+}
+
+shadowJar.dependsOn 'generateKnownTypesIndex'
+

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -176,7 +176,7 @@ public class InstrumenterConfig {
 
     internalExitOnFailure = configProvider.getBoolean(INTERNAL_EXIT_ON_FAILURE, false);
 
-    legacyInstallerEnabled = configProvider.getBoolean(LEGACY_INSTALLER_ENABLED, true);
+    legacyInstallerEnabled = configProvider.getBoolean(LEGACY_INSTALLER_ENABLED, false);
   }
 
   public boolean isIntegrationsEnabled() {

--- a/internal-api/src/main/java/datadog/trace/util/ClassNameTrie.java
+++ b/internal-api/src/main/java/datadog/trace/util/ClassNameTrie.java
@@ -258,11 +258,11 @@ public final class ClassNameTrie {
 
     /** Allow querying while the class-name trie is being built. */
     public int apply(String key) {
-      return ClassNameTrie.apply(trieData, longJumps, key);
+      return trieLength > 0 ? ClassNameTrie.apply(trieData, longJumps, key) : -1;
     }
 
     public ClassNameTrie buildTrie() {
-      if (null == trieData) {
+      if (trieLength == 0) {
         return EMPTY_TRIE;
       }
       // avoid unnecessary allocation when compaction isn't required


### PR DESCRIPTION
# What Does This Do

Builds on top of #4552 to merge together matchers and transformers so we only register a single matcher+transformer pair with byte-buddy. A thread-local bitset is used to record which specific matchers actually applied during the matching phase, which is then used to decide which transformers need to apply to the final transformed type. 

This PR also includes generation of a known-types index, which records the instrumentations that apply to specific named types known at build-time.

# Motivation

This simplifies the byte-buddy side of our configuration and also makes it easier to use ahead-of-time indexes, such as the new `known-types.index` which replaces several string matchers with a single trie comparison. It should also make it easier to measure matching time.