### PR TITLE
Add well known classes as primitive-like objects

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
@@ -549,7 +549,7 @@ public class MoshiSnapshotHelper {
       if (value == null) {
         jsonWriter.name(IS_NULL);
         jsonWriter.value(true);
-      } else if (isPrimitive(type)) {
+      } else if (isPrimitive(type) || WellKnownClasses.isToStringSafe(type)) {
         jsonWriter.name(VALUE);
         writePrimitive(jsonWriter, value, limits);
       } else if (value.getClass().isArray() && (limits.maxReferenceDepth > 0)) {
@@ -868,14 +868,7 @@ public class MoshiSnapshotHelper {
           jsonWriter.name(SIZE);
           jsonWriter.value(String.valueOf(originalLength));
         }
-      } else if (value instanceof Long
-          || value instanceof Integer
-          || value instanceof Double
-          || value instanceof Boolean
-          || value instanceof Byte
-          || value instanceof Short
-          || value instanceof Float
-          || value instanceof Character) {
+      } else if (WellKnownClasses.isToStringSafe(value.getClass().getTypeName())) {
         jsonWriter.value(String.valueOf(value));
       } else {
         throw new IOException("Cannot convert value: " + value);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/WellKnownClasses.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/WellKnownClasses.java
@@ -1,0 +1,60 @@
+package com.datadog.debugger.util;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class WellKnownClasses {
+
+  /** Set of class names which have a toString side effect free and class final */
+  private static Set<String> toStringFinalSafeClasses =
+      new HashSet<>(
+          Arrays.asList(
+              "java.lang.Class",
+              "java.lang.String",
+              "java.lang.Boolean",
+              "java.lang.Integer",
+              "java.lang.Long",
+              "java.lang.Double",
+              "java.lang.Character",
+              "java.lang.Byte",
+              "java.lang.Float",
+              "java.lang.Short",
+              "java.math.BigDecimal",
+              "java.math.BigInteger",
+              "java.time.Duration",
+              "java.time.Instant",
+              "java.time.LocalTime",
+              "java.time.LocalDate",
+              "java.time.LocalDateTime",
+              "java.util.UUID",
+              "java.net.URI"));
+
+  private static Set<String> toStringSafeClasses = new HashSet<>();
+
+  static {
+    toStringSafeClasses.addAll(toStringFinalSafeClasses);
+    toStringSafeClasses.addAll(
+        Arrays.asList(
+            "java.util.concurrent.atomic.AtomicBoolean",
+            "java.util.concurrent.atomic.AtomicInteger",
+            "java.util.concurrent.atomic.AtomicLong"));
+  }
+
+  /**
+   * @return true if type is a final class and toString implementation is well known and side effect
+   *     free
+   */
+  public static boolean isToStringFinalSafe(String type) {
+    return toStringFinalSafeClasses.contains(type);
+  }
+
+  /**
+   * @return true if type is a class with a toString implementation is well known and side effect
+   *     free, but input type name should be a dynamic/concrete type and not a declared type. some
+   *     classes are not final and could be overridden toString
+   */
+  public static boolean isToStringSafe(String concreteType) {
+    return toStringSafeClasses.contains(concreteType);
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
@@ -32,12 +32,18 @@ import datadog.trace.bootstrap.debugger.SnapshotSummaryBuilder;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
+import java.math.BigDecimal;
+import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -229,18 +235,18 @@ public class SnapshotSerializationTest {
         ((ProbeCondition) deserializedSnapshot.getProbe().getScript()).getDslExpression());
   }
 
-  class AnotherClass {
+  static class AnotherClass {
     int anotherIntField = 11;
     String anotherStrField = "foobar";
   }
 
-  class ComplexClass {
+  static class ComplexClass {
     int complexIntField = 21;
     String complexStrField = "bar";
     AnotherClass complexObjField = new AnotherClass();
   }
 
-  class AllPrimitives {
+  static class AllPrimitives {
     long l = 42_000_000_000L;
     int i = 42_000;
     byte b = 42;
@@ -262,12 +268,7 @@ public class SnapshotSerializationTest {
     snapshot.setExit(context);
     String buffer = adapter.toJson(snapshot);
     System.out.println(buffer);
-    Map<String, Object> json = MoshiHelper.createGenericAdapter().fromJson(buffer);
-    Map<String, Object> capturesJson = (Map<String, Object>) json.get(CAPTURES);
-    Map<String, Object> returnJson = (Map<String, Object>) capturesJson.get(RETURN);
-    Map<String, Object> arguments = (Map<String, Object>) returnJson.get(ARGUMENTS);
-    Map<String, Object> thisArg = (Map<String, Object>) arguments.get(THIS);
-    Map<String, Object> thisFields = (Map<String, Object>) thisArg.get(FIELDS);
+    Map<String, Object> thisFields = getFieldsFromJson(buffer);
     Map<String, Object> objFieldJson = (Map<String, Object>) thisFields.get("objField");
     Map<String, Object> objFieldFields = (Map<String, Object>) objFieldJson.get(FIELDS);
     assertPrimitiveValue(objFieldFields, "l", "long", "42000000000");
@@ -278,6 +279,52 @@ public class SnapshotSerializationTest {
     assertPrimitiveValue(objFieldFields, "f", "float", "3.14");
     assertPrimitiveValue(objFieldFields, "d", "double", "2.612");
     assertPrimitiveValue(objFieldFields, "bool", "boolean", "true");
+  }
+
+  static class WellKnownClasses {
+    Class<?> clazz = WellKnownClasses.class;
+    Boolean bool = Boolean.TRUE;
+    Long l = Long.valueOf(42L);
+    BigDecimal bigDecimal = new BigDecimal("3.1415926");
+    Duration duration = Duration.ofMillis(1234567890);
+    LocalDateTime localDateTime = LocalDateTime.of(2023, 1, 17, 13, 31);
+    UUID uuid = UUID.nameUUIDFromBytes("foobar".getBytes());
+    AtomicLong atomicLong = new AtomicLong(123);
+    URI uri = URI.create("https://www.datadoghq.com");
+  }
+
+  @Test
+  public void wellKnownClasses() throws IOException {
+    JsonAdapter<Snapshot> adapter = MoshiHelper.createMoshiSnapshot().adapter(Snapshot.class);
+    Snapshot snapshot = createSnapshot();
+    Snapshot.CapturedContext context = new Snapshot.CapturedContext();
+    Snapshot.CapturedValue objField =
+        capturedValueDepth(
+            "objField", WellKnownClasses.class.getTypeName(), new WellKnownClasses(), 3);
+    context.addFields(new Snapshot.CapturedValue[] {objField});
+    snapshot.setExit(context);
+    String buffer = adapter.toJson(snapshot);
+    System.out.println(buffer);
+    Map<String, Object> thisFields = getFieldsFromJson(buffer);
+    Map<String, Object> objFieldJson = (Map<String, Object>) thisFields.get("objField");
+    Map<String, Object> objFieldFields = (Map<String, Object>) objFieldJson.get(FIELDS);
+    assertPrimitiveValue(
+        objFieldFields,
+        "clazz",
+        Class.class.getTypeName(),
+        "class com.datadog.debugger.agent.SnapshotSerializationTest$WellKnownClasses");
+    assertPrimitiveValue(objFieldFields, "bool", Boolean.class.getTypeName(), "true");
+    assertPrimitiveValue(objFieldFields, "l", Long.class.getTypeName(), "42");
+    assertPrimitiveValue(objFieldFields, "bigDecimal", BigDecimal.class.getTypeName(), "3.1415926");
+    assertPrimitiveValue(
+        objFieldFields, "duration", Duration.class.getTypeName(), "PT342H56M7.89S");
+    assertPrimitiveValue(
+        objFieldFields, "localDateTime", LocalDateTime.class.getTypeName(), "2023-01-17T13:31");
+    assertPrimitiveValue(
+        objFieldFields, "uuid", UUID.class.getTypeName(), "3858f622-30ac-3c91-9f30-0c664312c63f");
+    assertPrimitiveValue(objFieldFields, "atomicLong", AtomicLong.class.getTypeName(), "123");
+    assertPrimitiveValue(
+        objFieldFields, "uri", URI.class.getTypeName(), "https://www.datadoghq.com");
   }
 
   @Test
@@ -292,14 +339,11 @@ public class SnapshotSerializationTest {
     snapshot.setExit(context);
     String buffer = adapter.toJson(snapshot);
     System.out.println(buffer);
-    Map<String, Object> json = MoshiHelper.createGenericAdapter().fromJson(buffer);
-    Map<String, Object> capturesJson = (Map<String, Object>) json.get(CAPTURES);
-    Map<String, Object> returnJson = (Map<String, Object>) capturesJson.get(RETURN);
-    Map<String, Object> locals = (Map<String, Object>) returnJson.get(LOCALS);
+    Map<String, Object> locals = getLocalsFromJson(buffer);
     assertArrayItem(locals, "localObjArray", "foo", null, "42");
   }
 
-  class ObjetArrayClass {
+  static class ObjetArrayClass {
     ComplexClass[] complexClasses = new ComplexClass[3];
   }
 
@@ -315,10 +359,7 @@ public class SnapshotSerializationTest {
     snapshot.setExit(context);
     String buffer = adapter.toJson(snapshot);
     System.out.println(buffer);
-    Map<String, Object> json = MoshiHelper.createGenericAdapter().fromJson(buffer);
-    Map<String, Object> capturesJson = (Map<String, Object>) json.get(CAPTURES);
-    Map<String, Object> returnJson = (Map<String, Object>) capturesJson.get(RETURN);
-    Map<String, Object> locals = (Map<String, Object>) returnJson.get(LOCALS);
+    Map<String, Object> locals = getLocalsFromJson(buffer);
     Map<String, Object> localObjMap = (Map<String, Object>) locals.get("localObj");
     Map<String, Object> localObjFieldsMap = (Map<String, Object>) localObjMap.get(FIELDS);
     Map<String, Object> complexClasses =
@@ -328,7 +369,7 @@ public class SnapshotSerializationTest {
         complexClasses.get(TYPE));
   }
 
-  class PrimitiveArrayClass {
+  static class PrimitiveArrayClass {
     byte[] byteArray = new byte[] {1, 2, 3};
     short[] shortArray = new short[] {128, 129, 130};
     char[] charArray = new char[] {'a', 'b', 'c'};
@@ -351,10 +392,7 @@ public class SnapshotSerializationTest {
     snapshot.setExit(context);
     String buffer = adapter.toJson(snapshot);
     System.out.println(buffer);
-    Map<String, Object> json = MoshiHelper.createGenericAdapter().fromJson(buffer);
-    Map<String, Object> capturesJson = (Map<String, Object>) json.get(CAPTURES);
-    Map<String, Object> returnJson = (Map<String, Object>) capturesJson.get(RETURN);
-    Map<String, Object> locals = (Map<String, Object>) returnJson.get(LOCALS);
+    Map<String, Object> locals = getLocalsFromJson(buffer);
     Map<String, Object> localObjMap = (Map<String, Object>) locals.get("localObj");
     Map<String, Object> localObjFieldsMap = (Map<String, Object>) localObjMap.get(FIELDS);
     assertArrayItem(localObjFieldsMap, "byteArray", "1", "2", "3");
@@ -403,11 +441,6 @@ public class SnapshotSerializationTest {
         objFieldFields, "complexObjField", AnotherClass.class.getTypeName(), DEPTH_REASON);
     assertNotCaptured(
         objFieldFields, "complexObjField", AnotherClass.class.getTypeName(), DEPTH_REASON);
-    assertNotCaptured(
-        objFieldFields,
-        "this$0",
-        "com.datadog.debugger.agent.SnapshotSerializationTest",
-        DEPTH_REASON);
     assertPrimitiveValue(arguments, "strArg", String.class.getTypeName(), null);
     assertPrimitiveValue(arguments, "intArg", "int", "0");
     assertPrimitiveValue(arguments, "objArg", ComplexClass.class.getTypeName(), null);
@@ -422,11 +455,6 @@ public class SnapshotSerializationTest {
         objLocalFields, "complexObjField", AnotherClass.class.getTypeName(), DEPTH_REASON);
     assertNotCaptured(
         objLocalFields, "complexObjField", AnotherClass.class.getTypeName(), DEPTH_REASON);
-    assertNotCaptured(
-        objLocalFields,
-        "this$0",
-        "com.datadog.debugger.agent.SnapshotSerializationTest",
-        DEPTH_REASON);
   }
 
   @Test
@@ -450,11 +478,6 @@ public class SnapshotSerializationTest {
     assertPrimitiveValue(complexObjFieldFields, "anotherIntField", "int", "11");
     assertPrimitiveValue(
         complexObjFieldFields, "anotherStrField", String.class.getTypeName(), "foobar");
-    assertNotCaptured(
-        complexObjFieldFields,
-        "this$0",
-        "com.datadog.debugger.agent.SnapshotSerializationTest",
-        DEPTH_REASON);
     assertPrimitiveValue(arguments, "strArg", String.class.getTypeName(), null);
     assertPrimitiveValue(arguments, "intArg", "int", "0");
     assertPrimitiveValue(arguments, "objArg", ComplexClass.class.getTypeName(), null);
@@ -473,11 +496,6 @@ public class SnapshotSerializationTest {
     assertPrimitiveValue(localComplexObjFieldFields, "anotherIntField", "int", "11");
     assertPrimitiveValue(
         localComplexObjFieldFields, "anotherStrField", String.class.getTypeName(), "foobar");
-    assertNotCaptured(
-        localComplexObjFieldFields,
-        "this$0",
-        "com.datadog.debugger.agent.SnapshotSerializationTest",
-        DEPTH_REASON);
   }
 
   private Map<String, Object> doRefDepth(int maxRefDepth) throws IOException {
@@ -813,6 +831,13 @@ public class SnapshotSerializationTest {
     } else {
       Assert.assertEquals(true, prim.get(IS_NULL));
     }
+  }
+
+  private Map<String, Object> getLocalsFromJson(String buffer) throws IOException {
+    Map<String, Object> json = MoshiHelper.createGenericAdapter().fromJson(buffer);
+    Map<String, Object> capturesJson = (Map<String, Object>) json.get(CAPTURES);
+    Map<String, Object> returnJson = (Map<String, Object>) capturesJson.get(RETURN);
+    return (Map<String, Object>) returnJson.get(LOCALS);
   }
 
   private Map<String, Object> getFieldsFromJson(String buffer) throws IOException {


### PR DESCRIPTION
# What Does This Do
We add two sets of well known classes on which we can safely toString for String representation/serialization.

# Motivation
Having a better string representation than extract fields for classes like `Duration` or `UUID`

<img width="674" alt="Screenshot 2023-01-23 at 11 04 53" src="https://user-images.githubusercontent.com/4610701/214016802-9ea2601d-4790-4311-9b7d-34b64d6f267d.png">

<img width="703" alt="Screenshot 2023-01-23 at 11 20 46" src="https://user-images.githubusercontent.com/4610701/214016824-7ea65fbe-5b22-4bef-8bc6-5e5073e18c9c.png">


# Additional Notes
