### PR TITLE
Ignore org.bouncycastle.* types

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
+++ b/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
@@ -176,6 +176,7 @@
 2 org.apache.xerces.*
 2 org.apache.xml.*
 2 org.apache.xpath.*
+2 org.bouncycastle.*
 2 org.h2.*
 0 org.h2.Driver
 # Some runnables that get instrumented


### PR DESCRIPTION
# What Does This Do

This avoids a potential deadlock scenario where one thread might be loading a bouncycastle type which triggers type-matching causing a related class file to be fetched from a signed jar. When the JVM verifies the signed jar entry it might need to access the shared X509Factory certificate store.

Meanwhile another thread is checking some SSL certificates when it needs to load a bouncycastle implementation class.

The first thread has acquired a class-loading lock and wants the X509Factory lock.

The second thread has acquired the X509Factory lock and wants a class-loading lock.

I ran the bouncycastle test-suite with the tracer attached and no types of interest matched our existing instrumentations, so it is safe to ignore these classes. This is the simplest solution to avoid the potential deadlock scenario described above.