### PR TITLE
fix profiler version when the profiler hasn't  loaded

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -217,7 +217,10 @@ public final class DatadogProfiler {
   }
 
   public String getVersion() {
-    return profiler.getVersion();
+    if (profiler != null) {
+      return profiler.getVersion();
+    }
+    return "profiler not loaded";
   }
 
   @Nullable


### PR DESCRIPTION
# What Does This Do

This can happen when the profiler runs on an unsupported architecture and produces a stack trace:

```
[dd-profiler-recording-scheduler] WARN com.datadog.profiling.auxiliary.ddprof.AuxiliaryDatadogProfiler - Exception occurred while attempting to emit config event
java.lang.NullPointerException
	at com.datadog.profiling.ddprof.DatadogProfiler.getVersion(DatadogProfiler.java:183)
	at com.datadog.profiling.auxiliary.ddprof.AuxiliaryDatadogProfiler.emitConfiguration(AuxiliaryDatadogProfiler.java:67)
	at jdk.jfr/jdk.jfr.internal.RequestEngine$RequestHook$1.run(RequestEngine.java:85)
	at jdk.jfr/jdk.jfr.internal.RequestEngine$RequestHook$1.run(RequestEngine.java:81)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at jdk.jfr/jdk.jfr.internal.RequestEngine$RequestHook.executeSecure(RequestEngine.java:81)
	at jdk.jfr/jdk.jfr.internal.RequestEngine$RequestHook.execute(RequestEngine.java:72)
	at jdk.jfr/jdk.jfr.internal.RequestEngine.doChunk(RequestEngine.java:177)
	at jdk.jfr/jdk.jfr.internal.RequestEngine.doChunkEnd(RequestEngine.java:166)
	at jdk.jfr/jdk.jfr.internal.PlatformRecorder.rotateDisk(PlatformRecorder.java:344)
	at jdk.jfr/jdk.jfr.internal.PlatformRecorder.fillWithRecordedData(PlatformRecorder.java:510)
	at jdk.jfr/jdk.jfr.FlightRecorder.takeSnapshot(FlightRecorder.java:116)
	at com.datadog.profiling.controller.openjdk.OpenJdkOngoingRecording.snapshot(OpenJdkOngoingRecording.java:143)
	at com.datadog.profiling.controller.ProfilingSystem$SnapshotRecording.snapshot(ProfilingSystem.java:245)
	at com.datadog.profiling.controller.ProfilingSystem$SnapshotRecording.snapshot(ProfilingSystem.java:237)
	at datadog.trace.util.AgentTaskScheduler$PeriodicTask.run(AgentTaskScheduler.java:299)
	at datadog.trace.util.AgentTaskScheduler$Worker.run(AgentTaskScheduler.java:254)
	at java.base/java.lang.Thread.run(Thread.java:829)
[411.528s][warning][jfr,event] Exception occured during execution of period hook for datadog.DatadogProfilerConfig(14384)
```

# Motivation

# Additional Notes
