### PR TITLE
Optimization: assume there is only one version of 'java.*' classes in the JVM process

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
@@ -234,7 +234,7 @@ final class TypeFactory {
 
     // existing info from same classloader?
     SharedTypeInfo<TypeDescription> typeInfo = types.find(name);
-    if (null != typeInfo && typeInfo.sameClassLoader(classLoader)) {
+    if (null != typeInfo && (name.startsWith("java.") || typeInfo.sameClassLoader(classLoader))) {
       return typeInfo.get();
     }
 


### PR DESCRIPTION
# What Does This Do

This lets us skip various location checks and immediately re-use the cached `java.` type description regardless of where it was originally cached from. Otherwise we have to compare the class-file location to be confident that class `Foo` cached while processing a class from class-loader `A` is the same as class `Foo` needed to process a different class from class-loader `B` (The location check is still needed for non `java.` types because `A` and `B` might well end up resolving different versions of `Foo` in modular environments.)

# Motivation

This is especially beneficial on large modular systems where the class-loaders don't follow the classic delegation model. 