### PR TITLE
profiler availability check

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-auxiliary-ddprof/src/main/java/com/datadog/profiling/auxiliary/ddprof/AuxiliaryDatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-ddprof/src/main/java/com/datadog/profiling/auxiliary/ddprof/AuxiliaryDatadogProfiler.java
@@ -56,12 +56,13 @@ final class AuxiliaryDatadogProfiler implements AuxiliaryImplementation {
       instance = null;
     }
     datadogProfiler = instance;
-    if (datadogProfiler != null) {
+    if (datadogProfiler != null && datadogProfiler.isAvailable()) {
       FlightRecorder.addPeriodicEvent(DatadogProfilerConfigEvent.class, this::emitConfiguration);
     }
   }
 
   private void emitConfiguration() {
+    assert datadogProfiler.isAvailable();
     try {
       new DatadogProfilerConfigEvent(
               datadogProfiler.getVersion(),
@@ -79,7 +80,6 @@ final class AuxiliaryDatadogProfiler implements AuxiliaryImplementation {
       } else {
         log.warn("Exception occurred while attempting to emit config event: {}", t.toString());
       }
-      throw t;
     }
   }
 
@@ -91,7 +91,7 @@ final class AuxiliaryDatadogProfiler implements AuxiliaryImplementation {
   @Override
   @Nullable
   public OngoingRecording start() {
-    if (datadogProfiler != null) {
+    if (datadogProfiler != null && datadogProfiler.isAvailable()) {
       return datadogProfiler.start();
     }
     return null;

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -60,11 +60,28 @@ public final class DatadogProfiler {
     private static final DatadogProfiler INSTANCE = newInstance();
   }
 
+  private static void logFailedInstantiation(Throwable error) {
+    if (log.isDebugEnabled()) {
+      log.warn(
+          String.format(
+              "failed to instantiate Datadog profiler on %s %s",
+              OperatingSystem.current(), Arch.current()),
+          error);
+    } else {
+      log.warn(
+          "failed to instantiate Datadog profiler on {} {} because: {}",
+          OperatingSystem.current(),
+          Arch.current(),
+          error.getMessage());
+    }
+  }
+
   static DatadogProfiler newInstance() {
     DatadogProfiler instance = null;
     try {
       instance = new DatadogProfiler();
     } catch (Throwable t) {
+      logFailedInstantiation(t);
       instance = new DatadogProfiler((Void) null);
     }
     return instance;
@@ -75,6 +92,7 @@ public final class DatadogProfiler {
     try {
       instance = new DatadogProfiler(configProvider);
     } catch (Throwable t) {
+      logFailedInstantiation(t);
       instance = new DatadogProfiler((Void) null);
     }
     return instance;


### PR DESCRIPTION
# What Does This Do

* We should be checking if the auxiliary profiler is available before registering the periodic event, not just that the instance isn't null
* We should make a bit more noise in the logs if the user has installed the profiler and we can't instantiate the profiler, so issues can be resolved faster
* We don't need to rethrow exceptions from the periodic event once they have been logged

# Motivation

# Additional Notes
