### PR TITLE
Add formatting object values for log lines

### DIFF
--- a/dd-java-agent/agent-debugger/build.gradle
+++ b/dd-java-agent/agent-debugger/build.gradle
@@ -21,7 +21,8 @@ excludedClassesCoverage += [
   'com.datadog.debugger.agent.DebuggerAgent.ShutdownHook',
   'com.datadog.debugger.agent.DebuggerAgent',
   // too old for this coverage (JDK 1.2)
-  'antlr.*'
+  'antlr.*',
+  'com.datadog.debugger.util.MoshiSnapshotHelper' // only static classes
 ]
 
 dependencies {

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
@@ -182,7 +182,15 @@ public class Snapshot {
   }
 
   public String getSummary() {
-    return summaryBuilder.build();
+    String summary = summaryBuilder.build();
+    List<EvaluationError> errors = summaryBuilder.getEvaluationErrors();
+    if (!errors.isEmpty()) {
+      if (evaluationErrors == null) {
+        evaluationErrors = new ArrayList<>();
+      }
+      evaluationErrors.addAll(errors);
+    }
+    return summary;
   }
 
   public void commit() {

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/SnapshotSummaryBuilder.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/SnapshotSummaryBuilder.java
@@ -87,6 +87,11 @@ public class SnapshotSummaryBuilder implements SummaryBuilder {
     return sb.toString();
   }
 
+  @Override
+  public List<Snapshot.EvaluationError> getEvaluationErrors() {
+    return Collections.emptyList();
+  }
+
   private static String formatMethod(List<CapturedStackFrame> stack, ProbeLocation probeLocation) {
     if (stack != null && stack.size() > 0) {
       // we first try to use the top frame on the stacktrace, if available

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/SummaryBuilder.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/SummaryBuilder.java
@@ -12,4 +12,6 @@ public interface SummaryBuilder {
   void addStack(List<CapturedStackFrame> stack);
 
   String build();
+
+  List<Snapshot.EvaluationError> getEvaluationErrors();
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ListValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ListValue.java
@@ -5,7 +5,6 @@ import com.datadog.debugger.el.expressions.ValueExpression;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.Values;
 import java.lang.reflect.Array;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -14,7 +13,7 @@ import java.util.Objects;
  * A list-like {@linkplain Value}.<br>
  * Allows wrapping of arrays as well as {@linkplain List} instances.
  */
-public class ListValue implements CollectionValue<ListValue>, ValueExpression<ListValue> {
+public class ListValue implements CollectionValue<Object>, ValueExpression<ListValue> {
   private final Object listHolder;
   private final Object arrayHolder;
   private final Class<?> arrayType;
@@ -29,7 +28,7 @@ public class ListValue implements CollectionValue<ListValue>, ValueExpression<Li
       arrayHolder = null;
       arrayType = null;
     } else if (object instanceof Collection) {
-      listHolder = new ArrayList<>((Collection<?>) object);
+      listHolder = object;
       arrayHolder = null;
       arrayType = null;
     } else if (object.getClass().isArray()) {
@@ -137,8 +136,11 @@ public class ListValue implements CollectionValue<ListValue>, ValueExpression<Li
   }
 
   @Override
-  public ListValue getValue() {
-    return this;
+  public Object getValue() {
+    if (arrayHolder != null) {
+      return arrayHolder;
+    }
+    return listHolder;
   }
 
   @Override

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/MapValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/MapValue.java
@@ -5,7 +5,6 @@ import com.datadog.debugger.el.expressions.ValueExpression;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.Values;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -16,7 +15,7 @@ import org.slf4j.LoggerFactory;
  * A map-like {@linkplain Value}.<br>
  * Allows wrapping of {@linkplain Map} instances.
  */
-public final class MapValue implements CollectionValue<MapValue>, ValueExpression<MapValue> {
+public final class MapValue implements CollectionValue<Object>, ValueExpression<MapValue> {
   private static final Logger log = LoggerFactory.getLogger(MapValue.class);
 
   public static final class Entry {
@@ -33,7 +32,7 @@ public final class MapValue implements CollectionValue<MapValue>, ValueExpressio
 
   public MapValue(Object object) {
     if (object instanceof Map) {
-      mapHolder = new HashMap<>((Map<?, ?>) object);
+      mapHolder = object;
     } else if (object == null || object == Values.NULL_OBJECT) {
       mapHolder = Value.nullValue();
     } else {
@@ -97,8 +96,8 @@ public final class MapValue implements CollectionValue<MapValue>, ValueExpressio
   }
 
   @Override
-  public MapValue getValue() {
-    return this;
+  public Object getValue() {
+    return mapHolder;
   }
 
   @Override
@@ -108,7 +107,7 @@ public final class MapValue implements CollectionValue<MapValue>, ValueExpressio
 
   @Override
   public String prettyPrint() {
-    if (mapHolder instanceof HashMap) {
+    if (mapHolder instanceof Map) {
       return "Map";
     }
     return "null";

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/LogMessageTemplateSummaryBuilder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/LogMessageTemplateSummaryBuilder.java
@@ -1,14 +1,27 @@
 package com.datadog.debugger.agent;
 
+import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.ValueScript;
 import com.datadog.debugger.probe.LogProbe;
+import com.datadog.debugger.util.ValueSerializer;
 import datadog.trace.bootstrap.debugger.CapturedStackFrame;
+import datadog.trace.bootstrap.debugger.FieldExtractor;
+import datadog.trace.bootstrap.debugger.Fields;
+import datadog.trace.bootstrap.debugger.Limits;
 import datadog.trace.bootstrap.debugger.Snapshot;
 import datadog.trace.bootstrap.debugger.SummaryBuilder;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LogMessageTemplateSummaryBuilder implements SummaryBuilder {
+  private static final Logger LOG = LoggerFactory.getLogger(LogMessageTemplateSummaryBuilder.class);
+
   private final LogProbe logProbe;
+  private final List<Snapshot.EvaluationError> evaluationErrors = new ArrayList<>();
 
   public LogMessageTemplateSummaryBuilder(LogProbe logProbe) {
     this.logProbe = logProbe;
@@ -42,10 +55,23 @@ public class LogMessageTemplateSummaryBuilder implements SummaryBuilder {
       if (segment.getStr() != null) {
         sb.append(segment.getStr());
       } else {
-        sb.append(segment.getParsedExpr().getResult().getValue());
+        Value<?> result = segment.getParsedExpr().getResult();
+        if (result.isUndefined()) {
+          sb.append(result.getValue());
+        } else if (result.isNull()) {
+          sb.append("null");
+        } else {
+          Limits limits = new Limits(1, 3, 255, 5);
+          serializeValue(sb, segment.getParsedExpr().getDsl(), result.getValue(), limits);
+        }
       }
     }
     return sb.toString();
+  }
+
+  @Override
+  public List<Snapshot.EvaluationError> getEvaluationErrors() {
+    return evaluationErrors;
   }
 
   private void executeExpressions(Snapshot.CapturedContext entry) {
@@ -57,6 +83,179 @@ public class LogMessageTemplateSummaryBuilder implements SummaryBuilder {
       if (parsedExr != null) {
         parsedExr.execute(entry);
       }
+    }
+  }
+
+  private void serializeValue(StringBuilder sb, String expr, Object value, Limits limits) {
+    ValueSerializer serializer =
+        new ValueSerializer(new StringTypeSerializer(sb, evaluationErrors));
+    try {
+      serializer.serialize(
+          value, value != null ? value.getClass().getTypeName() : "java.lang.Object", limits);
+    } catch (Exception ex) {
+      evaluationErrors.add(new Snapshot.EvaluationError(expr, ex.toString()));
+    }
+  }
+
+  private static class StringTypeSerializer implements ValueSerializer.TypeSerializer {
+
+    private final StringBuilder sb;
+    private final List<Snapshot.EvaluationError> evalErrors;
+    private boolean initial;
+    private boolean inCollection;
+    private boolean inMapEntry;
+
+    public StringTypeSerializer(StringBuilder sb, List<Snapshot.EvaluationError> evalErrors) {
+      this.sb = sb;
+      this.evalErrors = evalErrors;
+    }
+
+    @Override
+    public void prologue(Object value, String type) throws Exception {
+      if (inMapEntry && !initial) {
+        sb.append("=");
+      } else if (inCollection && !initial) {
+        sb.append(", ");
+      }
+      initial = false;
+    }
+
+    @Override
+    public void epilogue(Object value) throws Exception {}
+
+    @Override
+    public void nullValue() throws Exception {
+      sb.append("null");
+    }
+
+    @Override
+    public void string(String value, boolean isComplete, int originalLength) throws Exception {
+      sb.append(value).append(isComplete ? "" : "...");
+    }
+
+    @Override
+    public void primitiveValue(Object value) throws Exception {
+      sb.append(value);
+    }
+
+    @Override
+    public void arrayPrologue(Object value) throws Exception {
+      sb.append('[');
+      initial = true;
+      inCollection = true;
+    }
+
+    @Override
+    public void arrayEpilogue(Object value, boolean isComplete, int arraySize) throws Exception {
+      sb.append(isComplete ? "]" : ", ...]");
+      inCollection = false;
+    }
+
+    @Override
+    public void primitiveArrayElement(String value, String type) throws Exception {
+      if (inCollection && !initial) {
+        sb.append(", ");
+      }
+      sb.append(value);
+      initial = false;
+    }
+
+    @Override
+    public void collectionPrologue(Object value) throws Exception {
+      sb.append("[");
+      initial = true;
+      inCollection = true;
+    }
+
+    @Override
+    public void collectionEpilogue(Object value, boolean isComplete, int size) throws Exception {
+      sb.append(isComplete ? "]" : ", ...]");
+      inCollection = false;
+    }
+
+    @Override
+    public void mapPrologue(Object value) throws Exception {
+      sb.append("{");
+      initial = true;
+      inCollection = true;
+    }
+
+    @Override
+    public void mapEntryPrologue(Map.Entry<?, ?> entry) throws Exception {
+      if (!initial) {
+        sb.append(", ");
+      }
+      sb.append("[");
+      initial = true;
+      inMapEntry = true;
+    }
+
+    @Override
+    public void mapEntryEpilogue(Map.Entry<?, ?> entry) throws Exception {
+      sb.append("]");
+      inMapEntry = false;
+    }
+
+    @Override
+    public void mapEpilogue(Map<?, ?> map, boolean isComplete) throws Exception {
+      sb.append(isComplete ? "}" : ", ...}");
+      inCollection = false;
+    }
+
+    @Override
+    public void objectValue(Object value, ValueSerializer valueSerializer, Limits limits)
+        throws Exception {
+      sb.append("{");
+      initial = true;
+      Fields.ProcessField onField =
+          (field, val, maxDepth) -> {
+            try {
+              if (!initial) {
+                sb.append(", ");
+              }
+              initial = false;
+              sb.append(field.getName()).append("=");
+              Limits newLimits = Limits.decDepthLimits(maxDepth, limits);
+              String typeName;
+              if (ValueSerializer.isPrimitive(field.getType().getTypeName())) {
+                typeName = field.getType().getTypeName();
+              } else {
+                typeName =
+                    val != null ? val.getClass().getTypeName() : field.getType().getTypeName();
+              }
+              valueSerializer.serialize(
+                  val instanceof Snapshot.CapturedValue
+                      ? ((Snapshot.CapturedValue) val).getValue()
+                      : val,
+                  typeName,
+                  newLimits);
+            } catch (Exception ex) {
+              LOG.debug("Exception when extracting field={}", field.getName(), ex);
+            }
+          };
+      FieldExtractor.extract(
+          value, limits, onField, this::fieldExceptionHandling, this::maxFieldCount);
+      sb.append("}");
+    }
+
+    private void fieldExceptionHandling(Exception ex, Field field) {
+      if (!initial) {
+        sb.append(", ");
+      }
+      initial = false;
+      String fieldName = field.getName();
+      sb.append(fieldName).append('=').append(Value.undefinedValue());
+      evalErrors.add(
+          new Snapshot.EvaluationError(fieldName, "Cannot extract field: " + ex.toString()));
+    }
+
+    private void maxFieldCount(Field field) {
+      sb.append("...");
+    }
+
+    @Override
+    public void reachedMaxDepth() throws Exception {
+      sb.append("...");
     }
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
@@ -16,10 +16,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -31,7 +29,6 @@ import org.slf4j.LoggerFactory;
 
 /** Helper for creating Moshi adapters for (de)serializing snapshots */
 public class MoshiSnapshotHelper {
-  private static final Logger LOG = LoggerFactory.getLogger(MoshiSnapshotHelper.class);
   public static final String CAPTURES = "captures";
   public static final String ENTRY = "entry";
   public static final String RETURN = "return";
@@ -53,31 +50,6 @@ public class MoshiSnapshotHelper {
   public static final String IS_NULL = "isNull";
   public static final String TRUNCATED = "truncated";
   public static final String SIZE = "size";
-
-  public static boolean isPrimitive(String type) {
-    switch (type) {
-      case "byte":
-      case "short":
-      case "char":
-      case "int":
-      case "long":
-      case "boolean":
-      case "float":
-      case "double":
-      case "java.lang.Byte":
-      case "java.lang.Short":
-      case "java.lang.Character":
-      case "java.lang.Integer":
-      case "java.lang.Long":
-      case "java.lang.Boolean":
-      case "java.lang.Float":
-      case "java.lang.Double":
-      case "String":
-      case "java.lang.String":
-        return true;
-    }
-    return false;
-  }
 
   public static class SnapshotJsonFactory implements JsonAdapter.Factory {
     @Override
@@ -382,7 +354,7 @@ public class MoshiSnapshotHelper {
                 value = list;
               } else if (type.endsWith("[]")) {
                 String componentType = type.substring(0, type.indexOf('['));
-                if (isPrimitive(componentType)) {
+                if (ValueSerializer.isPrimitive(componentType)) {
                   value = createPrimitiveArray(componentType, values);
                 } else {
                   value = values.stream().map(Snapshot.CapturedValue::getValue).toArray();
@@ -543,335 +515,11 @@ public class MoshiSnapshotHelper {
 
     private void serializeValue(JsonWriter jsonWriter, Object value, String type, Limits limits)
         throws IOException {
-      jsonWriter.beginObject();
-      jsonWriter.name(TYPE);
-      jsonWriter.value(type);
-      if (value == null) {
-        jsonWriter.name(IS_NULL);
-        jsonWriter.value(true);
-      } else if (isPrimitive(type) || WellKnownClasses.isToStringSafe(type)) {
-        jsonWriter.name(VALUE);
-        writePrimitive(jsonWriter, value, limits);
-      } else if (value.getClass().isArray() && (limits.maxReferenceDepth > 0)) {
-        jsonWriter.name(ELEMENTS);
-        jsonWriter.beginArray();
-        SerializationResult result;
-        if (value.getClass().getComponentType().isPrimitive()) {
-          result = serializePrimitiveArray(jsonWriter, value, limits);
-        } else {
-          result = serializeObjectArray(jsonWriter, (Object[]) value, limits);
-        }
-        jsonWriter.endArray();
-        if (!result.isComplete) {
-          jsonWriter.name(NOT_CAPTURED_REASON);
-          jsonWriter.value(COLLECTION_SIZE_REASON);
-        }
-        jsonWriter.name(SIZE);
-        jsonWriter.value(String.valueOf(result.size));
-      } else if (value instanceof Collection && (limits.maxReferenceDepth > 0)) {
-        Collection<?> col = (Collection<?>) value;
-        jsonWriter.name(ELEMENTS);
-        jsonWriter.beginArray();
-        SerializationResult result = serializeCollection(jsonWriter, col, limits);
-        jsonWriter.endArray();
-        if (!result.isComplete) {
-          jsonWriter.name(NOT_CAPTURED_REASON);
-          jsonWriter.value(COLLECTION_SIZE_REASON);
-        }
-        jsonWriter.name(SIZE);
-        jsonWriter.value(String.valueOf(result.size));
-      } else if (value instanceof Map && (limits.maxReferenceDepth > 0)) {
-        Map<?, ?> map = (Map<?, ?>) value;
-        Set<? extends Map.Entry<?, ?>> entries = map.entrySet();
-        jsonWriter.name(ENTRIES);
-        jsonWriter.beginArray();
-        boolean isComplete = serializeMap(jsonWriter, entries, limits);
-        jsonWriter.endArray();
-        if (!isComplete) {
-          jsonWriter.name(NOT_CAPTURED_REASON);
-          jsonWriter.value(COLLECTION_SIZE_REASON);
-        }
-        jsonWriter.name(SIZE);
-        jsonWriter.value(String.valueOf(map.size()));
-      } else if (limits.maxReferenceDepth > 0) {
-        jsonWriter.name(FIELDS);
-        jsonWriter.beginObject();
-        Fields.ProcessField onField =
-            (field, val, maxDepth) -> {
-              try {
-                jsonWriter.name(field.getName());
-                Limits newLimits = Limits.decDepthLimits(maxDepth, limits);
-                String typeName;
-                if (isPrimitive(field.getType().getTypeName())) {
-                  typeName = field.getType().getTypeName();
-                } else {
-                  typeName =
-                      val != null ? val.getClass().getTypeName() : field.getType().getTypeName();
-                }
-                serializeValue(
-                    jsonWriter,
-                    val instanceof Snapshot.CapturedValue
-                        ? ((Snapshot.CapturedValue) val).getValue()
-                        : val,
-                    typeName,
-                    newLimits);
-              } catch (IOException ex) {
-                LOG.debug("Exception when extracting field={}", field.getName(), ex);
-              }
-            };
-        BiConsumer<Exception, Field> exHandling =
-            (ex, field) -> {
-              String fieldName = field.getName();
-              try {
-                jsonWriter.name(fieldName);
-                jsonWriter.beginObject();
-                jsonWriter.name(TYPE);
-                jsonWriter.value(field.getType().getTypeName());
-                jsonWriter.name(NOT_CAPTURED_REASON);
-                jsonWriter.value(ex.toString());
-                jsonWriter.endObject();
-              } catch (IOException e) {
-                LOG.debug("Error during serializing reason for failed field extraction", e);
-              }
-            };
-        Consumer<Field> maxFieldCount =
-            (field) -> {
-              try {
-                jsonWriter.name(NOT_CAPTURED_REASON);
-                jsonWriter.value(FIELD_COUNT_REASON);
-              } catch (IOException e) {
-                LOG.debug("Error during serializing reason for reaching max field count", e);
-              }
-            };
-        FieldExtractor.extract(value, limits, onField, exHandling, maxFieldCount);
-        jsonWriter.endObject();
-      } else {
-        jsonWriter.name(NOT_CAPTURED_REASON);
-        jsonWriter.value(DEPTH_REASON);
-      }
-      jsonWriter.endObject();
-    }
-
-    private boolean serializeMap(
-        JsonWriter jsonWriter, Set<? extends Map.Entry<?, ?>> entries, Limits limits)
-        throws IOException {
-      int mapSize = entries.size();
-      int maxSize = Math.min(mapSize, limits.maxCollectionSize);
-      Limits newLimits = Limits.decDepthLimits(limits.maxReferenceDepth, limits);
-      int i = 0;
-      Iterator<?> it = entries.iterator();
-      while (i < maxSize && it.hasNext()) {
-        Map.Entry<?, ?> entry = (Map.Entry<?, ?>) it.next();
-        jsonWriter.beginArray();
-        Object keyObj = entry.getKey();
-        Object valObj = entry.getValue();
-        serializeValue(jsonWriter, keyObj, keyObj.getClass().getTypeName(), newLimits);
-        serializeValue(jsonWriter, valObj, valObj.getClass().getTypeName(), newLimits);
-        jsonWriter.endArray();
-        i++;
-      }
-      return maxSize == mapSize;
-    }
-
-    private SerializationResult serializeCollection(
-        JsonWriter jsonWriter, Collection<?> collection, Limits limits) throws IOException {
-      // /!\ here we assume that Collection#Size is O(1) /!\
-      int colSize = collection.size();
-      int maxSize = Math.min(colSize, limits.maxCollectionSize);
-      Limits newLimits = Limits.decDepthLimits(limits.maxReferenceDepth, limits);
-      int i = 0;
-      Iterator<?> it = collection.iterator();
-      while (i < maxSize && it.hasNext()) {
-        Object val = it.next();
-        serializeValue(jsonWriter, val, val.getClass().getTypeName(), newLimits);
-        i++;
-      }
-      return new SerializationResult(colSize, maxSize == colSize);
-    }
-
-    private SerializationResult serializeObjectArray(
-        JsonWriter jsonWriter, Object[] objArray, Limits limits) throws IOException {
-      int maxSize = Math.min(objArray.length, limits.maxCollectionSize);
-      Limits newLimits = Limits.decDepthLimits(limits.maxReferenceDepth, limits);
-      int i = 0;
-      while (i < maxSize) {
-        Object val = objArray[i];
-        serializeValue(
-            jsonWriter,
-            val,
-            val != null ? val.getClass().getTypeName() : "java.lang.Object",
-            newLimits);
-        i++;
-      }
-      return new SerializationResult(objArray.length, maxSize == objArray.length);
-    }
-
-    private SerializationResult serializePrimitiveArray(
-        JsonWriter jsonWriter, Object value, Limits limits) throws IOException {
-      Class<?> componentType = value.getClass().getComponentType();
-      if (componentType == long.class) {
-        return serializeLongArray(jsonWriter, (long[]) value, limits.maxCollectionSize);
-      }
-      if (componentType == int.class) {
-        return serializeIntArray(jsonWriter, (int[]) value, limits.maxCollectionSize);
-      }
-      if (componentType == short.class) {
-        return serializeShortArray(jsonWriter, (short[]) value, limits.maxCollectionSize);
-      }
-      if (componentType == char.class) {
-        return serializeCharArray(jsonWriter, (char[]) value, limits.maxCollectionSize);
-      }
-      if (componentType == byte.class) {
-        return serializeByteArray(jsonWriter, (byte[]) value, limits.maxCollectionSize);
-      }
-      if (componentType == boolean.class) {
-        return serializeBooleanArray(jsonWriter, (boolean[]) value, limits.maxCollectionSize);
-      }
-      if (componentType == float.class) {
-        return serializeFloatArray(jsonWriter, (float[]) value, limits.maxCollectionSize);
-      }
-      if (componentType == double.class) {
-        return serializeDoubleArray(jsonWriter, (double[]) value, limits.maxCollectionSize);
-      }
-      throw new IllegalArgumentException("Unsupported primitive array: " + value.getClass());
-    }
-
-    private static SerializationResult serializeLongArray(
-        JsonWriter jsonWriter, long[] longArray, int maxSize) throws IOException {
-      maxSize = Math.min(longArray.length, maxSize);
-      int i = 0;
-      while (i < maxSize) {
-        long val = longArray[i];
-        String strVal = String.valueOf(val);
-        serializeArrayItem(jsonWriter, "long", strVal);
-        i++;
-      }
-      return new SerializationResult(longArray.length, maxSize == longArray.length);
-    }
-
-    private static SerializationResult serializeIntArray(
-        JsonWriter jsonWriter, int[] intArray, int maxSize) throws IOException {
-      maxSize = Math.min(intArray.length, maxSize);
-      int i = 0;
-      while (i < maxSize) {
-        long val = intArray[i];
-        String strVal = String.valueOf(val);
-        serializeArrayItem(jsonWriter, "int", strVal);
-        i++;
-      }
-      return new SerializationResult(intArray.length, maxSize == intArray.length);
-    }
-
-    private static SerializationResult serializeShortArray(
-        JsonWriter jsonWriter, short[] shortArray, int maxSize) throws IOException {
-      maxSize = Math.min(shortArray.length, maxSize);
-      int i = 0;
-      while (i < maxSize) {
-        short val = shortArray[i];
-        String strVal = String.valueOf(val);
-        serializeArrayItem(jsonWriter, "short", strVal);
-        i++;
-      }
-      return new SerializationResult(shortArray.length, maxSize == shortArray.length);
-    }
-
-    private static SerializationResult serializeCharArray(
-        JsonWriter jsonWriter, char[] charArray, int maxSize) throws IOException {
-      maxSize = Math.min(charArray.length, maxSize);
-      int i = 0;
-      while (i < maxSize) {
-        char val = charArray[i];
-        String strVal = String.valueOf(val);
-        serializeArrayItem(jsonWriter, "char", strVal);
-        i++;
-      }
-      return new SerializationResult(charArray.length, maxSize == charArray.length);
-    }
-
-    private static SerializationResult serializeByteArray(
-        JsonWriter jsonWriter, byte[] byteArray, int maxSize) throws IOException {
-      maxSize = Math.min(byteArray.length, maxSize);
-      int i = 0;
-      while (i < maxSize) {
-        byte val = byteArray[i];
-        String strVal = String.valueOf(val);
-        serializeArrayItem(jsonWriter, "byte", strVal);
-        i++;
-      }
-      return new SerializationResult(byteArray.length, maxSize == byteArray.length);
-    }
-
-    private static SerializationResult serializeBooleanArray(
-        JsonWriter jsonWriter, boolean[] booleanArray, int maxSize) throws IOException {
-      maxSize = Math.min(booleanArray.length, maxSize);
-      int i = 0;
-      while (i < maxSize) {
-        boolean val = booleanArray[i];
-        String strVal = String.valueOf(val);
-        serializeArrayItem(jsonWriter, "boolean", strVal);
-        i++;
-      }
-      return new SerializationResult(booleanArray.length, maxSize == booleanArray.length);
-    }
-
-    private static SerializationResult serializeFloatArray(
-        JsonWriter jsonWriter, float[] floatArray, int maxSize) throws IOException {
-      maxSize = Math.min(floatArray.length, maxSize);
-      int i = 0;
-      while (i < maxSize) {
-        float val = floatArray[i];
-        String strVal = String.valueOf(val);
-        serializeArrayItem(jsonWriter, "float", strVal);
-        i++;
-      }
-      return new SerializationResult(floatArray.length, maxSize == floatArray.length);
-    }
-
-    private static SerializationResult serializeDoubleArray(
-        JsonWriter jsonWriter, double[] doubleArray, int maxSize) throws IOException {
-      maxSize = Math.min(doubleArray.length, maxSize);
-      int i = 0;
-      while (i < maxSize) {
-        double val = doubleArray[i];
-        String strVal = String.valueOf(val);
-        serializeArrayItem(jsonWriter, "double", strVal);
-        i++;
-      }
-      return new SerializationResult(doubleArray.length, maxSize == doubleArray.length);
-    }
-
-    private static void serializeArrayItem(JsonWriter jsonWriter, String type, String value)
-        throws IOException {
-      jsonWriter.beginObject();
-      jsonWriter.name(TYPE);
-      jsonWriter.value(type);
-      jsonWriter.name(VALUE);
-      jsonWriter.value(value);
-      jsonWriter.endObject();
-    }
-
-    private static void writePrimitive(JsonWriter jsonWriter, Object value, Limits limits)
-        throws IOException {
-      // primitive values are stored as String
-      if (value instanceof String) {
-        String strValue = (String) value;
-        int originalLength = strValue.length();
-        boolean isComplete = true;
-        if (originalLength > limits.maxLength) {
-          strValue = strValue.substring(0, limits.maxLength);
-          isComplete = false;
-        }
-        jsonWriter.value(strValue);
-        if (!isComplete) {
-          jsonWriter.name(TRUNCATED);
-          jsonWriter.value(true);
-          jsonWriter.name(SIZE);
-          jsonWriter.value(String.valueOf(originalLength));
-        }
-      } else if (WellKnownClasses.isToStringSafe(value.getClass().getTypeName())) {
-        jsonWriter.value(String.valueOf(value));
-      } else {
-        throw new IOException("Cannot convert value: " + value);
+      ValueSerializer serializer = new ValueSerializer(new JsonTypeSerializer(jsonWriter));
+      try {
+        serializer.serialize(value, type, limits);
+      } catch (Exception ex) {
+        throw new IOException(ex);
       }
     }
 
@@ -911,13 +559,185 @@ public class MoshiSnapshotHelper {
       return null;
     }
 
-    private static class SerializationResult {
-      final int size;
-      final boolean isComplete;
+    private static class JsonTypeSerializer implements ValueSerializer.TypeSerializer {
+      private static final Logger LOG = LoggerFactory.getLogger(JsonTypeSerializer.class);
 
-      public SerializationResult(int size, boolean isComplete) {
-        this.size = size;
-        this.isComplete = isComplete;
+      private final JsonWriter jsonWriter;
+
+      public JsonTypeSerializer(JsonWriter jsonWriter) {
+        this.jsonWriter = jsonWriter;
+      }
+
+      @Override
+      public void prologue(Object value, String type) throws Exception {
+        jsonWriter.beginObject();
+        jsonWriter.name(TYPE);
+        jsonWriter.value(type);
+      }
+
+      @Override
+      public void epilogue(Object value) throws IOException {
+        jsonWriter.endObject();
+      }
+
+      @Override
+      public void nullValue() throws Exception {
+        jsonWriter.name(IS_NULL);
+        jsonWriter.value(true);
+      }
+
+      @Override
+      public void string(String value, boolean isComplete, int originalLength) throws Exception {
+        jsonWriter.name(VALUE);
+        jsonWriter.value(value);
+        if (!isComplete) {
+          jsonWriter.name(TRUNCATED);
+          jsonWriter.value(true);
+          jsonWriter.name(SIZE);
+          jsonWriter.value(String.valueOf(originalLength));
+        }
+      }
+
+      @Override
+      public void primitiveValue(Object value) throws Exception {
+        jsonWriter.name(VALUE);
+        if (WellKnownClasses.isToStringSafe(value.getClass().getTypeName())) {
+          jsonWriter.value(String.valueOf(value));
+        } else {
+          throw new IOException("Cannot convert value: " + value);
+        }
+      }
+
+      @Override
+      public void arrayPrologue(Object value) throws Exception {
+        jsonWriter.name(ELEMENTS);
+        jsonWriter.beginArray();
+      }
+
+      @Override
+      public void arrayEpilogue(Object value, boolean isComplete, int arraySize) throws Exception {
+        jsonWriter.endArray();
+        if (!isComplete) {
+          jsonWriter.name(NOT_CAPTURED_REASON);
+          jsonWriter.value(COLLECTION_SIZE_REASON);
+        }
+        jsonWriter.name(SIZE);
+        jsonWriter.value(String.valueOf(arraySize));
+      }
+
+      @Override
+      public void primitiveArrayElement(String value, String type) throws Exception {
+        jsonWriter.beginObject();
+        jsonWriter.name(TYPE);
+        jsonWriter.value(type);
+        jsonWriter.name(VALUE);
+        jsonWriter.value(value);
+        jsonWriter.endObject();
+      }
+
+      @Override
+      public void collectionPrologue(Object value) throws Exception {
+        jsonWriter.name(ELEMENTS);
+        jsonWriter.beginArray();
+      }
+
+      @Override
+      public void collectionEpilogue(Object value, boolean isComplete, int size) throws Exception {
+        jsonWriter.endArray();
+        if (!isComplete) {
+          jsonWriter.name(NOT_CAPTURED_REASON);
+          jsonWriter.value(COLLECTION_SIZE_REASON);
+        }
+        jsonWriter.name(SIZE);
+        jsonWriter.value(String.valueOf(size));
+      }
+
+      @Override
+      public void mapPrologue(Object value) throws Exception {
+        jsonWriter.name(ENTRIES);
+        jsonWriter.beginArray();
+      }
+
+      @Override
+      public void mapEntryPrologue(Map.Entry<?, ?> entry) throws Exception {
+        jsonWriter.beginArray();
+      }
+
+      @Override
+      public void mapEntryEpilogue(Map.Entry<?, ?> entry) throws Exception {
+        jsonWriter.endArray();
+      }
+
+      @Override
+      public void mapEpilogue(Map<?, ?> map, boolean isComplete) throws Exception {
+        jsonWriter.endArray();
+        if (!isComplete) {
+          jsonWriter.name(NOT_CAPTURED_REASON);
+          jsonWriter.value(COLLECTION_SIZE_REASON);
+        }
+        jsonWriter.name(SIZE);
+        jsonWriter.value(String.valueOf(map.size()));
+      }
+
+      @Override
+      public void objectValue(Object value, ValueSerializer valueSerializer, Limits limits)
+          throws Exception {
+        jsonWriter.name(FIELDS);
+        jsonWriter.beginObject();
+        Fields.ProcessField onField =
+            (field, val, maxDepth) -> {
+              try {
+                jsonWriter.name(field.getName());
+                Limits newLimits = Limits.decDepthLimits(maxDepth, limits);
+                String typeName;
+                if (ValueSerializer.isPrimitive(field.getType().getTypeName())) {
+                  typeName = field.getType().getTypeName();
+                } else {
+                  typeName =
+                      val != null ? val.getClass().getTypeName() : field.getType().getTypeName();
+                }
+                valueSerializer.serialize(
+                    val instanceof Snapshot.CapturedValue
+                        ? ((Snapshot.CapturedValue) val).getValue()
+                        : val,
+                    typeName,
+                    newLimits);
+              } catch (Exception ex) {
+                LOG.debug("Exception when extracting field={}", field.getName(), ex);
+              }
+            };
+        BiConsumer<Exception, Field> exHandling =
+            (ex, field) -> {
+              String fieldName = field.getName();
+              try {
+                jsonWriter.name(fieldName);
+                jsonWriter.beginObject();
+                jsonWriter.name(TYPE);
+                jsonWriter.value(field.getType().getTypeName());
+                jsonWriter.name(NOT_CAPTURED_REASON);
+                jsonWriter.value(ex.toString());
+                jsonWriter.endObject();
+              } catch (IOException e) {
+                LOG.debug("Error during serializing reason for failed field extraction", e);
+              }
+            };
+        Consumer<Field> maxFieldCount =
+            (field) -> {
+              try {
+                jsonWriter.name(NOT_CAPTURED_REASON);
+                jsonWriter.value(FIELD_COUNT_REASON);
+              } catch (IOException e) {
+                LOG.debug("Error during serializing reason for reaching max field count", e);
+              }
+            };
+        FieldExtractor.extract(value, limits, onField, exHandling, maxFieldCount);
+        jsonWriter.endObject();
+      }
+
+      @Override
+      public void reachedMaxDepth() throws Exception {
+        jsonWriter.name(NOT_CAPTURED_REASON);
+        jsonWriter.value(DEPTH_REASON);
       }
     }
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ValueSerializer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ValueSerializer.java
@@ -1,0 +1,290 @@
+package com.datadog.debugger.util;
+
+import datadog.trace.bootstrap.debugger.Limits;
+import java.lang.reflect.Array;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+/** serialize Java Object value with applied {@link Limits} and following references */
+public class ValueSerializer {
+
+  public static boolean isPrimitive(String type) {
+    switch (type) {
+      case "byte":
+      case "short":
+      case "char":
+      case "int":
+      case "long":
+      case "boolean":
+      case "float":
+      case "double":
+      case "java.lang.Byte":
+      case "java.lang.Short":
+      case "java.lang.Character":
+      case "java.lang.Integer":
+      case "java.lang.Long":
+      case "java.lang.Boolean":
+      case "java.lang.Float":
+      case "java.lang.Double":
+      case "String":
+      case "java.lang.String":
+        return true;
+    }
+    return false;
+  }
+
+  public interface TypeSerializer {
+    void prologue(Object value, String type) throws Exception;
+
+    void epilogue(Object value) throws Exception;
+
+    void nullValue() throws Exception;
+
+    void string(String value, boolean isComplete, int originalLength) throws Exception;
+
+    void primitiveValue(Object value) throws Exception;
+
+    void arrayPrologue(Object value) throws Exception;
+
+    void arrayEpilogue(Object value, boolean isComplete, int arraySize) throws Exception;
+
+    void primitiveArrayElement(String value, String type) throws Exception;
+
+    void collectionPrologue(Object value) throws Exception;
+
+    void collectionEpilogue(Object value, boolean isComplete, int size) throws Exception;
+
+    void mapPrologue(Object value) throws Exception;
+
+    void mapEntryPrologue(Map.Entry<?, ?> entry) throws Exception;
+
+    void mapEntryEpilogue(Map.Entry<?, ?> entry) throws Exception;
+
+    void mapEpilogue(Map<?, ?> map, boolean isComplete) throws Exception;
+
+    void objectValue(Object value, ValueSerializer valueSerializer, Limits limits) throws Exception;
+
+    void reachedMaxDepth() throws Exception;
+  }
+
+  private final TypeSerializer typeSerializer;
+
+  public ValueSerializer(TypeSerializer typeSerializer) {
+    this.typeSerializer = typeSerializer;
+  }
+
+  public void serialize(Object value, String type, Limits limits) throws Exception {
+    typeSerializer.prologue(value, type);
+    if (value == null) {
+      typeSerializer.nullValue();
+    } else if (isPrimitive(type) || WellKnownClasses.isToStringSafe(type)) {
+      if (value instanceof String) {
+        String strValue = (String) value;
+        int originalLength = strValue.length();
+        boolean isComplete = true;
+        if (originalLength > limits.maxLength) {
+          strValue = strValue.substring(0, limits.maxLength);
+          isComplete = false;
+        }
+        typeSerializer.string(strValue, isComplete, originalLength);
+      } else {
+        typeSerializer.primitiveValue(value);
+      }
+    } else if (value.getClass().isArray() && (limits.maxReferenceDepth > 0)) {
+      int arraySize = Array.getLength(value);
+      boolean isComplete = true;
+      typeSerializer.arrayPrologue(value);
+      if (value.getClass().getComponentType().isPrimitive()) {
+        Class<?> componentType = value.getClass().getComponentType();
+        if (componentType == long.class) {
+          isComplete = serializeLongArray((long[]) value, limits.maxCollectionSize);
+        }
+        if (componentType == int.class) {
+          isComplete = serializeIntArray((int[]) value, limits.maxCollectionSize);
+        }
+        if (componentType == short.class) {
+          isComplete = serializeShortArray((short[]) value, limits.maxCollectionSize);
+        }
+        if (componentType == char.class) {
+          isComplete = serializeCharArray((char[]) value, limits.maxCollectionSize);
+        }
+        if (componentType == byte.class) {
+          isComplete = serializeByteArray((byte[]) value, limits.maxCollectionSize);
+        }
+        if (componentType == boolean.class) {
+          isComplete = serializeBooleanArray((boolean[]) value, limits.maxCollectionSize);
+        }
+        if (componentType == float.class) {
+          isComplete = serializeFloatArray((float[]) value, limits.maxCollectionSize);
+        }
+        if (componentType == double.class) {
+          isComplete = serializeDoubleArray((double[]) value, limits.maxCollectionSize);
+        }
+      } else {
+        isComplete = serializeObjectArray((Object[]) value, limits);
+      }
+      typeSerializer.arrayEpilogue(value, isComplete, arraySize);
+    } else if (value instanceof Collection && (limits.maxReferenceDepth > 0)) {
+      typeSerializer.collectionPrologue(value);
+      Collection<?> col = (Collection<?>) value;
+      boolean isComplete = serializeCollection(col, limits);
+      typeSerializer.collectionEpilogue(value, isComplete, col.size());
+    } else if (value instanceof Map && (limits.maxReferenceDepth > 0)) {
+      typeSerializer.mapPrologue(value);
+      Map<?, ?> map = (Map<?, ?>) value;
+      Set<? extends Map.Entry<?, ?>> entries = map.entrySet();
+      boolean isComplete = serializeMap(entries, limits);
+      typeSerializer.mapEpilogue(map, isComplete);
+    } else if (limits.maxReferenceDepth > 0) {
+      typeSerializer.objectValue(value, this, limits);
+    } else {
+      typeSerializer.reachedMaxDepth();
+    }
+    typeSerializer.epilogue(value);
+  }
+
+  private boolean serializeLongArray(long[] longArray, int maxSize) throws Exception {
+    maxSize = Math.min(longArray.length, maxSize);
+    int i = 0;
+    while (i < maxSize) {
+      long val = longArray[i];
+      String strVal = String.valueOf(val);
+      typeSerializer.primitiveArrayElement(strVal, "long");
+      i++;
+    }
+    return maxSize == longArray.length;
+  }
+
+  private boolean serializeIntArray(int[] intArray, int maxSize) throws Exception {
+    maxSize = Math.min(intArray.length, maxSize);
+    int i = 0;
+    while (i < maxSize) {
+      long val = intArray[i];
+      String strVal = String.valueOf(val);
+      typeSerializer.primitiveArrayElement(strVal, "int");
+      i++;
+    }
+    return maxSize == intArray.length;
+  }
+
+  private boolean serializeShortArray(short[] shortArray, int maxSize) throws Exception {
+    maxSize = Math.min(shortArray.length, maxSize);
+    int i = 0;
+    while (i < maxSize) {
+      short val = shortArray[i];
+      String strVal = String.valueOf(val);
+      typeSerializer.primitiveArrayElement(strVal, "short");
+      i++;
+    }
+    return maxSize == shortArray.length;
+  }
+
+  private boolean serializeCharArray(char[] charArray, int maxSize) throws Exception {
+    maxSize = Math.min(charArray.length, maxSize);
+    int i = 0;
+    while (i < maxSize) {
+      char val = charArray[i];
+      String strVal = String.valueOf(val);
+      typeSerializer.primitiveArrayElement(strVal, "char");
+      i++;
+    }
+    return maxSize == charArray.length;
+  }
+
+  private boolean serializeByteArray(byte[] byteArray, int maxSize) throws Exception {
+    maxSize = Math.min(byteArray.length, maxSize);
+    int i = 0;
+    while (i < maxSize) {
+      byte val = byteArray[i];
+      String strVal = String.valueOf(val);
+      typeSerializer.primitiveArrayElement(strVal, "byte");
+      i++;
+    }
+    return maxSize == byteArray.length;
+  }
+
+  private boolean serializeBooleanArray(boolean[] booleanArray, int maxSize) throws Exception {
+    maxSize = Math.min(booleanArray.length, maxSize);
+    int i = 0;
+    while (i < maxSize) {
+      boolean val = booleanArray[i];
+      String strVal = String.valueOf(val);
+      typeSerializer.primitiveArrayElement(strVal, "boolean");
+      i++;
+    }
+    return maxSize == booleanArray.length;
+  }
+
+  private boolean serializeFloatArray(float[] floatArray, int maxSize) throws Exception {
+    maxSize = Math.min(floatArray.length, maxSize);
+    int i = 0;
+    while (i < maxSize) {
+      float val = floatArray[i];
+      String strVal = String.valueOf(val);
+      typeSerializer.primitiveArrayElement(strVal, "float");
+      i++;
+    }
+    return maxSize == floatArray.length;
+  }
+
+  private boolean serializeDoubleArray(double[] doubleArray, int maxSize) throws Exception {
+    maxSize = Math.min(doubleArray.length, maxSize);
+    int i = 0;
+    while (i < maxSize) {
+      double val = doubleArray[i];
+      String strVal = String.valueOf(val);
+      typeSerializer.primitiveArrayElement(strVal, "double");
+      i++;
+    }
+    return maxSize == doubleArray.length;
+  }
+
+  private boolean serializeObjectArray(Object[] objArray, Limits limits) throws Exception {
+    int maxSize = Math.min(objArray.length, limits.maxCollectionSize);
+    Limits newLimits = Limits.decDepthLimits(limits.maxReferenceDepth, limits);
+    int i = 0;
+    while (i < maxSize) {
+      Object val = objArray[i];
+      serialize(val, val != null ? val.getClass().getTypeName() : "java.lang.Object", newLimits);
+      i++;
+    }
+    return maxSize == objArray.length;
+  }
+
+  private boolean serializeCollection(Collection<?> collection, Limits limits) throws Exception {
+    // /!\ here we assume that Collection#Size is O(1) /!\
+    int colSize = collection.size();
+    int maxSize = Math.min(colSize, limits.maxCollectionSize);
+    Limits newLimits = Limits.decDepthLimits(limits.maxReferenceDepth, limits);
+    int i = 0;
+    Iterator<?> it = collection.iterator();
+    while (i < maxSize && it.hasNext()) {
+      Object val = it.next();
+      serialize(val, val.getClass().getTypeName(), newLimits);
+      i++;
+    }
+    return maxSize == colSize;
+  }
+
+  private boolean serializeMap(Set<? extends Map.Entry<?, ?>> entries, Limits limits)
+      throws Exception {
+    int mapSize = entries.size();
+    int maxSize = Math.min(mapSize, limits.maxCollectionSize);
+    Limits newLimits = Limits.decDepthLimits(limits.maxReferenceDepth, limits);
+    int i = 0;
+    Iterator<?> it = entries.iterator();
+    while (i < maxSize && it.hasNext()) {
+      Map.Entry<?, ?> entry = (Map.Entry<?, ?>) it.next();
+      typeSerializer.mapEntryPrologue(entry);
+      Object keyObj = entry.getKey();
+      Object valObj = entry.getValue();
+      serialize(keyObj, keyObj.getClass().getTypeName(), newLimits);
+      serialize(valObj, valObj.getClass().getTypeName(), newLimits);
+      typeSerializer.mapEntryEpilogue(entry);
+      i++;
+    }
+    return maxSize == mapSize;
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -20,6 +20,7 @@ import com.datadog.debugger.probe.ProbeDefinition;
 import com.datadog.debugger.probe.Where;
 import com.datadog.debugger.util.MoshiHelper;
 import com.datadog.debugger.util.MoshiSnapshotHelper;
+import com.datadog.debugger.util.ValueSerializer;
 import com.squareup.moshi.JsonAdapter;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.CorrelationAccess;
@@ -1620,7 +1621,7 @@ public class CapturedSnapshotTest {
         if (type == null) {
           Assert.fail("no type for element");
         }
-        if (MoshiSnapshotHelper.isPrimitive(type)) {
+        if (ValueSerializer.isPrimitive(type)) {
           result.add(element.get("value"));
         } else {
           Assert.fail("not implemented");

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogMessageTemplateSummaryBuilderTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogMessageTemplateSummaryBuilderTest.java
@@ -1,10 +1,20 @@
 package com.datadog.debugger.agent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.datadog.debugger.probe.LogProbe;
 import datadog.trace.bootstrap.debugger.Snapshot;
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
 
 class LogMessageTemplateSummaryBuilderTest {
 
@@ -51,5 +61,127 @@ class LogMessageTemplateSummaryBuilderTest {
         });
     summaryBuilder.addEntry(capturedContext);
     assertEquals("foo", summaryBuilder.build());
+  }
+
+  @Test
+  public void argNullTemplate() {
+    LogProbe probe = LogProbe.builder().template("{nullObject}").build();
+    LogMessageTemplateSummaryBuilder summaryBuilder = new LogMessageTemplateSummaryBuilder(probe);
+    Snapshot.CapturedContext capturedContext = new Snapshot.CapturedContext();
+    capturedContext.addArguments(
+        new Snapshot.CapturedValue[] {
+          Snapshot.CapturedValue.of("nullObject", Object.class.getTypeName(), null)
+        });
+    summaryBuilder.addEntry(capturedContext);
+    assertEquals("null", summaryBuilder.build());
+  }
+
+  @Test
+  public void argArrayTemplate() {
+    LogProbe probe = LogProbe.builder().template("{primArray} {strArray}").build();
+    LogMessageTemplateSummaryBuilder summaryBuilder = new LogMessageTemplateSummaryBuilder(probe);
+    Snapshot.CapturedContext capturedContext = new Snapshot.CapturedContext();
+    capturedContext.addArguments(
+        new Snapshot.CapturedValue[] {
+          Snapshot.CapturedValue.of(
+              "primArray", String.class.getTypeName(), new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
+          Snapshot.CapturedValue.of(
+              "strArray",
+              String.class.getTypeName(),
+              new String[] {
+                "foo0", "foo1", "foo2", "foo3", "foo4", "foo5", "foo6", "foo7", "foo8", "foo9"
+              })
+        });
+    summaryBuilder.addEntry(capturedContext);
+    assertEquals("[0, 1, 2, ...] [foo0, foo1, foo2, ...]", summaryBuilder.build());
+  }
+
+  @Test
+  public void argCollectionTemplate() {
+    LogProbe probe = LogProbe.builder().template("{strList} {strSet}").build();
+    LogMessageTemplateSummaryBuilder summaryBuilder = new LogMessageTemplateSummaryBuilder(probe);
+    Snapshot.CapturedContext capturedContext = new Snapshot.CapturedContext();
+    capturedContext.addArguments(
+        new Snapshot.CapturedValue[] {
+          Snapshot.CapturedValue.of(
+              "strList",
+              String.class.getTypeName(),
+              new ArrayList<>(
+                  Arrays.asList(
+                      "foo0", "foo1", "foo2", "foo3", "foo4", "foo5", "foo6", "foo7", "foo8",
+                      "foo9"))),
+          Snapshot.CapturedValue.of(
+              "strSet",
+              String.class.getTypeName(),
+              new LinkedHashSet<>(
+                  Arrays.asList(
+                      "bar0", "bar1", "bar2", "bar3", "bar4", "bar5", "bar6", "bar7", "bar8",
+                      "bar9")))
+        });
+    summaryBuilder.addEntry(capturedContext);
+    assertEquals("[foo0, foo1, foo2, ...] [bar0, bar1, bar2, ...]", summaryBuilder.build());
+  }
+
+  @Test
+  public void argMapTemplate() {
+    LogProbe probe = LogProbe.builder().template("{strMap}").build();
+    LogMessageTemplateSummaryBuilder summaryBuilder = new LogMessageTemplateSummaryBuilder(probe);
+    Snapshot.CapturedContext capturedContext = new Snapshot.CapturedContext();
+    Map<String, String> map = new LinkedHashMap<>();
+    for (int i = 0; i < 10; i++) {
+      map.put("foo" + i, "bar" + i);
+    }
+    capturedContext.addArguments(
+        new Snapshot.CapturedValue[] {
+          Snapshot.CapturedValue.of("strMap", String.class.getTypeName(), map)
+        });
+    summaryBuilder.addEntry(capturedContext);
+    assertEquals("{[foo0=bar0], [foo1=bar1], [foo2=bar2], ...}", summaryBuilder.build());
+  }
+
+  static class Level0 {
+    int intField0 = 0;
+    String strField0 = "foo0";
+    Level1 level1 = new Level1();
+  }
+
+  static class Level1 {
+    int intField1 = 1;
+    String strField1 = "foo1";
+  }
+
+  @Test
+  public void argComplexObjectTemplate() {
+    LogProbe probe = LogProbe.builder().template("{obj}").build();
+    LogMessageTemplateSummaryBuilder summaryBuilder = new LogMessageTemplateSummaryBuilder(probe);
+    Snapshot.CapturedContext capturedContext = new Snapshot.CapturedContext();
+    capturedContext.addArguments(
+        new Snapshot.CapturedValue[] {
+          Snapshot.CapturedValue.of("obj", Level0.class.getTypeName(), new Level0())
+        });
+    summaryBuilder.addEntry(capturedContext);
+    assertEquals("{intField0=0, strField0=foo0, level1=...}", summaryBuilder.build());
+  }
+
+  @Test
+  @EnabledOnJre(JRE.JAVA_17)
+  public void argInaccessibleFieldTemplate() {
+    LogProbe probe = LogProbe.builder().template("{obj}").build();
+    LogMessageTemplateSummaryBuilder summaryBuilder = new LogMessageTemplateSummaryBuilder(probe);
+    Snapshot.CapturedContext capturedContext = new Snapshot.CapturedContext();
+    capturedContext.addArguments(
+        new Snapshot.CapturedValue[] {
+          Snapshot.CapturedValue.of(
+              "obj", Object.class.getTypeName(), ManagementFactory.getOperatingSystemMXBean())
+        });
+    summaryBuilder.addEntry(capturedContext);
+    assertEquals(
+        "{containerMetrics=UNDEFINED, systemLoadTicks=UNDEFINED, processLoadTicks=UNDEFINED, jvm=UNDEFINED, loadavg=UNDEFINED}",
+        summaryBuilder.build());
+    List<Snapshot.EvaluationError> evaluationErrors = summaryBuilder.getEvaluationErrors();
+    assertEquals(5, evaluationErrors.size());
+    for (int i = 0; i < 5; i++) {
+      assertTrue(evaluationErrors.get(i).getMessage().contains("Cannot extract field:"));
+    }
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -165,7 +165,7 @@ public class LogProbesInstrumentationTest {
     Assert.assertEquals(143, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCapturesNull(snapshot);
-    assertEquals("nullObject=NULL sdata=foo cdata=101", snapshot.getSummary());
+    assertEquals("nullObject=null sdata=foo cdata=101", snapshot.getSummary());
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/CapturedValueAdapterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/CapturedValueAdapterTest.java
@@ -1,0 +1,102 @@
+package com.datadog.debugger.util;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+import datadog.trace.bootstrap.debugger.Snapshot;
+import java.io.IOException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class CapturedValueAdapterTest {
+
+  static final String CAPTURED_VALUE_SIMPLE_TEMPLATE = "{\"type\": \"%s\", \"value\": \"%s\"}";
+  private static final String CAPTURED_VALUE_COLLECTION_TEMPLATE =
+      "{\"type\": \"%s\", \"elements\": [%s]}";
+  private static final String CAPTURED_VALUE_MAP_TEMPLATE = "{\"type\": \"%s\", \"entries\": [%s]}";
+  Moshi moshi = new Moshi.Builder().add(new MoshiSnapshotHelper.SnapshotJsonFactory()).build();
+  JsonAdapter<Snapshot.CapturedValue> adapter = moshi.adapter(Snapshot.CapturedValue.class);
+
+  @Test
+  void nullValue() throws IOException {
+    Snapshot.CapturedValue capturedValue =
+        adapter.fromJson("{\"type\": \"String\", \"isNull\": true}");
+    assertNull(capturedValue.getValue());
+  }
+
+  @Test
+  void primitives() throws IOException {
+    Snapshot.CapturedValue value = getSimpleValue(Integer.TYPE.getTypeName(), "42");
+    assertEquals(42, value.getValue());
+    value = getSimpleValue(String.class.getTypeName(), "foobar");
+    assertEquals("foobar", value.getValue());
+    value = getSimpleValue(byte.class.getTypeName(), 42);
+    assertEquals((byte) 42, value.getValue());
+    value = getSimpleValue(char.class.getTypeName(), '*');
+    assertEquals('*', value.getValue());
+    value = getSimpleValue(short.class.getTypeName(), 42);
+    assertEquals((short) 42, value.getValue());
+    value = getSimpleValue(long.class.getTypeName(), 42L);
+    assertEquals(42L, value.getValue());
+    value = getSimpleValue(boolean.class.getTypeName(), true);
+    assertEquals(true, value.getValue());
+    value = getSimpleValue(float.class.getTypeName(), 42.1F);
+    assertEquals(42.1F, value.getValue());
+    value = getSimpleValue(double.class.getTypeName(), 42.1D);
+    assertEquals(42.1D, value.getValue());
+  }
+
+  @Test
+  void collection() throws IOException {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < 10; i++) {
+      if (i > 0) {
+        sb.append(",");
+      }
+      sb.append(String.format(CAPTURED_VALUE_SIMPLE_TEMPLATE, int.class.getTypeName(), i));
+    }
+    Snapshot.CapturedValue value = getCollectionValue(int[].class.getTypeName(), sb.toString());
+    assertArrayEquals(new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, (int[]) value.getValue());
+
+    sb = new StringBuilder();
+    for (int i = 0; i < 10; i++) {
+      if (i > 0) {
+        sb.append(",");
+      }
+      sb.append(
+          String.format(CAPTURED_VALUE_SIMPLE_TEMPLATE, String.class.getTypeName(), "foo" + i));
+    }
+    value = getCollectionValue(String[].class.getTypeName(), sb.toString());
+    assertArrayEquals(
+        new String[] {
+          "foo0", "foo1", "foo2", "foo3", "foo4", "foo5", "foo6", "foo7", "foo8", "foo9"
+        },
+        (String[]) value.getValue());
+  }
+
+  @Test
+  void map() throws IOException {
+    String key = String.format(CAPTURED_VALUE_SIMPLE_TEMPLATE, String.class.getTypeName(), "foo");
+    String value = String.format(CAPTURED_VALUE_SIMPLE_TEMPLATE, String.class.getTypeName(), "bar");
+    Snapshot.CapturedValue capturedValue =
+        getMapValue(int[].class.getTypeName(), "[" + key + "," + value + "]");
+    Map<String, String> stringMap = (Map<String, String>) capturedValue.getValue();
+    assertEquals("bar", stringMap.get("foo"));
+  }
+
+  private Snapshot.CapturedValue getSimpleValue(String type, Object value) throws IOException {
+    return adapter.fromJson(String.format(CAPTURED_VALUE_SIMPLE_TEMPLATE, type, value));
+  }
+
+  private Snapshot.CapturedValue getCollectionValue(String type, String elements)
+      throws IOException {
+    return adapter.fromJson(String.format(CAPTURED_VALUE_COLLECTION_TEMPLATE, type, elements));
+  }
+
+  private Snapshot.CapturedValue getMapValue(String type, String entries) throws IOException {
+    return adapter.fromJson(String.format(CAPTURED_VALUE_MAP_TEMPLATE, type, entries));
+  }
+}


### PR DESCRIPTION
# What Does This Do
Primitives are printed as is,
collections/maps are printed up to 3 elements/entries Complex classes are printed with fields up to 5 and deep level 1. Refactored how we serializew value for sharing with Json snapshot serializations and applied limits

# Motivation
Coherent log line parameter representation

# Additional Notes
