### PR TITLE
conflate arm64 with aarch64 correctly

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/Arch.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/Arch.java
@@ -9,8 +9,8 @@ import java.util.Set;
 public enum Arch {
   x64("x86_64", "amd64", "k8"),
   x86("x86", "i386", "i486", "i586", "i686"),
-  arm("ARM", "arm64"),
-  aarch64("aarch64"),
+  arm("ARM", "aarch32"),
+  arm64("arm64", "aarch64"),
   unknown();
 
   private final Set<String> identifiers;


### PR DESCRIPTION
# What Does This Do

amr64 and aarch64 are the same thing. This change means we try to load profiler libraries built as "arm64" on aarch64. Really, we should prefer "aarch64" but this would require two coordinated changes and I think we can live with arm64 as our canonical representation.

# Motivation

# Additional Notes
