### PR TITLE
Support Jakarta servlet in IAST

### DIFF
--- a/dd-java-agent/instrumentation/servlet/request-5/build.gradle
+++ b/dd-java-agent/instrumentation/servlet/request-5/build.gradle
@@ -10,6 +10,9 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
+apply plugin: 'org.unbroken-dome.test-sets'
+apply plugin: 'call-site-instrumentation'
+
 // jakarta.servlet-api dependencies are compiled with Java 11 and
 // the gradle muzzle tasks uses the JVM gradle is running with
 if (!JavaVersion.current().java11Compatible) {
@@ -48,6 +51,8 @@ task relocatedJavaxJar(type: ShadowJar) {
 dependencies {
   implementation files(relocatedJavaxJar.outputs.files)
   compileOnly group: 'jakarta.servlet', name: 'jakarta.servlet-api', version: '5.0.0'
+  testImplementation group: 'jakarta.servlet', name: 'jakarta.servlet-api', version: '5.0.0'
+  testRuntimeOnly project(':dd-java-agent:instrumentation:iast-instrumenter')
 
   javaxClassesToRelocate project(':dd-java-agent:instrumentation:servlet-common'), {
     transitive = false

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaServletRequestCallSite.java
@@ -1,0 +1,131 @@
+package datadog.trace.instrumentation.servlet5;
+
+import datadog.trace.agent.tooling.csi.CallSite;
+import datadog.trace.api.iast.IastAdvice;
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.source.WebModule;
+import datadog.trace.util.stacktrace.StackUtils;
+import jakarta.servlet.ServletRequest;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+
+@CallSite(spi = IastAdvice.class)
+public class JakartaServletRequestCallSite {
+
+  @CallSite.AfterArray({
+    @CallSite.After(
+        "java.lang.String jakarta.servlet.ServletRequest.getParameter(java.lang.String)"),
+    @CallSite.After(
+        "java.lang.String jakarta.servlet.http.HttpServletRequest.getParameter(java.lang.String)"),
+    @CallSite.After(
+        "java.lang.String jakarta.servlet.http.HttpServletRequestWrapper.getParameter(java.lang.String)"),
+    @CallSite.After(
+        "java.lang.String jakarta.servlet.ServletRequestWrapper.getParameter(java.lang.String)")
+  })
+  public static String afterGetParameter(
+      @CallSite.This final ServletRequest self,
+      @CallSite.Argument final String paramName,
+      @CallSite.Return final String paramValue) {
+    final WebModule module = InstrumentationBridge.WEB;
+    if (module != null) {
+      try {
+        module.onParameterValue(paramName, paramValue);
+      } catch (final Throwable e) {
+        module.onUnexpectedException("afterGetParameter threw", e);
+      }
+    }
+    return paramValue;
+  }
+
+  @CallSite.AfterArray({
+    @CallSite.After("java.util.Enumeration jakarta.servlet.ServletRequest.getParameterNames()"),
+    @CallSite.After(
+        "java.util.Enumeration jakarta.servlet.http.HttpServletRequest.getParameterNames()"),
+    @CallSite.After(
+        "java.util.Enumeration jakarta.servlet.http.HttpServletRequestWrapper.getParameterNames()"),
+    @CallSite.After(
+        "java.util.Enumeration jakarta.servlet.ServletRequestWrapper.getParameterNames()")
+  })
+  public static Enumeration<?> afterGetParameterNames(
+      @CallSite.This final ServletRequest self, @CallSite.Return final Enumeration<?> enumeration)
+      throws Throwable {
+    final WebModule module = InstrumentationBridge.WEB;
+    if (module == null) {
+      return enumeration;
+    }
+    try {
+      final List<Object> parameterNames = new ArrayList<>();
+      while (enumeration.hasMoreElements()) {
+        final Object paramName = enumeration.nextElement();
+        parameterNames.add(paramName);
+        try {
+          module.onParameterName((String) paramName);
+        } catch (final Throwable e) {
+          module.onUnexpectedException("afterGetParameterNames threw", e);
+        }
+      }
+      return Collections.enumeration(parameterNames);
+    } catch (final Throwable e) {
+      module.onUnexpectedException(
+          "afterGetParameterNames threw while iterating parameter names", e);
+      throw StackUtils.filterFirstDatadog(e);
+    }
+  }
+
+  @CallSite.AfterArray({
+    @CallSite.After(
+        "java.lang.String[] jakarta.servlet.ServletRequest.getParameterValues(java.lang.String)"),
+    @CallSite.After(
+        "java.lang.String[] jakarta.servlet.http.HttpServletRequest.getParameterValues(java.lang.String)"),
+    @CallSite.After(
+        "java.lang.String[] jakarta.servlet.http.HttpServletRequestWrapper.getParameterValues(java.lang.String)"),
+    @CallSite.After(
+        "java.lang.String[] jakarta.servlet.ServletRequestWrapper.getParameterValues(java.lang.String)")
+  })
+  public static String[] afterGetParameterValues(
+      @CallSite.This final ServletRequest self,
+      @CallSite.Argument final String paramName,
+      @CallSite.Return final String[] parameterValues) {
+    if (null != parameterValues) {
+      final WebModule module = InstrumentationBridge.WEB;
+      if (module != null) {
+        for (String paramValue : parameterValues) {
+          try {
+            module.onParameterValue(paramName, paramValue);
+          } catch (final Throwable e) {
+            module.onUnexpectedException("afterGetParameterValues threw", e);
+          }
+        }
+      }
+    }
+    return parameterValues;
+  }
+
+  @CallSite.AfterArray({
+    @CallSite.After("java.util.Map jakarta.servlet.ServletRequest.getParameterMap()"),
+    @CallSite.After("java.util.Map jakarta.servlet.http.HttpServletRequest.getParameterMap()"),
+    @CallSite.After(
+        "java.util.Map jakarta.servlet.http.HttpServletRequestWrapper.getParameterMap()"),
+    @CallSite.After("java.util.Map jakarta.servlet.ServletRequestWrapper.getParameterMap()")
+  })
+  public static java.util.Map<java.lang.String, java.lang.String[]> afterGetParameterMap(
+      @CallSite.This final ServletRequest self, @CallSite.Return final Map<String, String[]> map) {
+    final WebModule module = InstrumentationBridge.WEB;
+    if (module != null) {
+      try {
+        for (Map.Entry<String, String[]> entry : map.entrySet()) {
+          module.onParameterName(entry.getKey());
+          for (String value : entry.getValue()) {
+            module.onParameterValue(entry.getKey(), value);
+          }
+        }
+      } catch (final Throwable e) {
+        module.onUnexpectedException("afterGetParameter threw", e);
+      }
+    }
+    return map;
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaCallSiteTest.groovy
@@ -1,0 +1,71 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.config.TracerConfig
+import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.source.WebModule
+import foo.bar.smoketest.JakartaTestSuite
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequestWrapper
+
+class JakartaCallSiteTest extends AgentTestRunner {
+
+  @Override
+  protected void configurePreAgent() {
+    injectSysConfig(TracerConfig.SCOPE_ITERATION_KEEP_ALIVE, "1") // don't let iteration spans linger
+    injectSysConfig("dd.iast.enabled", "true")
+  }
+
+  def 'test getParameter map'() {
+
+    setup:
+    WebModule iastModule = Mock(WebModule)
+    InstrumentationBridge.registerIastModule(iastModule)
+    HashMap<String, String[]> map = new HashMap<>()
+    map.put("param1", ["value1", "value2"] as String[])
+    final servletRequest = Mock(HttpServletRequest)
+    servletRequest.getParameterMap() >> map
+    final wrapper = new HttpServletRequestWrapper(servletRequest)
+    final testSuite = new JakartaTestSuite(wrapper)
+
+
+    when:
+    Map<String, String[]> returnedMap = testSuite.getParameterMap()
+
+    then:
+    returnedMap != null
+    returnedMap.get("param1")[0] == "value1"
+    returnedMap.get("param1")[1] == "value2"
+    2 * iastModule.onParameterValue(_,_)
+    1 * iastModule.onParameterName(_)
+  }
+
+  def 'test getParameterValues and getParameterNames'() {
+
+    setup:
+    WebModule iastModule = Mock(WebModule)
+    InstrumentationBridge.registerIastModule(iastModule)
+    final List arrayList = new ArrayList()
+    arrayList.add("A")
+    arrayList.add("B")
+    final servletRequest = Mock(HttpServletRequest)
+    servletRequest.getParameter("param") >> "value"
+    servletRequest.getParameterValues("param1") >> ["value1", "value2"]
+    servletRequest.getParameterNames() >> {return Collections.enumeration(arrayList)}
+    final wrapper = new HttpServletRequestWrapper(servletRequest)
+    final JakartaTestSuite testSuite = new JakartaTestSuite(wrapper)
+
+
+    when:
+    testSuite.getParameter("param")
+    String[] resultValues = testSuite.getParameterValues("param1")
+    List<String> paramNames = testSuite.getParameterNames().toList()
+
+    then:
+    resultValues.size() == 2
+    paramNames.size() == 2
+    1 * iastModule.onParameterValue("param","value")
+    1 * iastModule.onParameterValue("param1", "value1")
+    1 * iastModule.onParameterValue("param1", "value2")
+    1 * iastModule.onParameterName("A")
+    1 * iastModule.onParameterName("B")
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaCallSiteTest.groovy
@@ -1,5 +1,4 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.api.config.TracerConfig
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.source.WebModule
 import foo.bar.smoketest.JakartaTestSuite
@@ -10,7 +9,6 @@ class JakartaCallSiteTest extends AgentTestRunner {
 
   @Override
   protected void configurePreAgent() {
-    injectSysConfig(TracerConfig.SCOPE_ITERATION_KEEP_ALIVE, "1") // don't let iteration spans linger
     injectSysConfig("dd.iast.enabled", "true")
   }
 

--- a/dd-java-agent/instrumentation/servlet/request-5/src/test/java/foo/bar/smoketest/JakartaTestSuite.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/test/java/foo/bar/smoketest/JakartaTestSuite.java
@@ -1,0 +1,28 @@
+package foo.bar.smoketest;
+
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import java.util.Enumeration;
+
+public class JakartaTestSuite {
+  HttpServletRequestWrapper request;
+
+  public JakartaTestSuite(HttpServletRequestWrapper request) {
+    this.request = request;
+  }
+
+  public java.util.Map<String, String[]> getParameterMap() {
+    return request.getParameterMap();
+  }
+
+  public String getParameter(String paramName) {
+    return request.getParameter(paramName);
+  }
+
+  public String[] getParameterValues(String paramName) {
+    return request.getParameterValues(paramName);
+  }
+
+  public Enumeration getParameterNames() {
+    return request.getParameterNames();
+  }
+}


### PR DESCRIPTION
# What Does This Do

Instrument the jakarta servlet API

# Motivation
This API is used in a number of frameworks (spring) and web servers. We need to instrument it so we can taint the API output for IAST use.

# Additional Notes
