### PR TITLE
Add partial key cache to enable cache lookup from parts of keys

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/cache/CHMCache.java
+++ b/internal-api/src/main/java/datadog/trace/api/cache/CHMCache.java
@@ -12,13 +12,13 @@ final class CHMCache<K, V> implements DDCache<K, V> {
   }
 
   @Override
-  public V computeIfAbsent(K key, Function<K, ? extends V> func) {
+  public V computeIfAbsent(K key, Function<K, ? extends V> producer) {
     if (null == key) {
       return null;
     }
     V value = chm.get(key);
     if (null == value) {
-      value = func.apply(key);
+      value = producer.apply(key);
       V winner = chm.putIfAbsent(key, value);
       if (null != winner) {
         value = winner;

--- a/internal-api/src/main/java/datadog/trace/api/cache/DDCache.java
+++ b/internal-api/src/main/java/datadog/trace/api/cache/DDCache.java
@@ -3,8 +3,15 @@ package datadog.trace.api.cache;
 import java.util.function.Function;
 
 public interface DDCache<K, V> {
+  /**
+   * Look up or create and store a value in the cache.
+   *
+   * @param key the key to look up
+   * @param producer how to create a cached value base on the key if the lookup fails
+   * @return the cached or created and stored value
+   */
+  V computeIfAbsent(final K key, Function<K, ? extends V> producer);
 
-  V computeIfAbsent(final K key, Function<K, ? extends V> func);
-
+  /** Clear the cache. */
   void clear();
 }

--- a/internal-api/src/main/java/datadog/trace/api/cache/DDCaches.java
+++ b/internal-api/src/main/java/datadog/trace/api/cache/DDCaches.java
@@ -53,4 +53,8 @@ public final class DDCaches {
   public static <K, V> DDCache<K, V> newUnboundedCache(final int initialCapacity) {
     return new CHMCache<>(initialCapacity);
   }
+
+  public static <K, V> DDPartialKeyCache<K, V> newFixedSizePartialKeyCache(final int capacity) {
+    return new FixedSizeCache.FixedSizePartialKeyCache<>(capacity);
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/api/cache/DDPartialKeyCache.java
+++ b/internal-api/src/main/java/datadog/trace/api/cache/DDPartialKeyCache.java
@@ -1,0 +1,49 @@
+package datadog.trace.api.cache;
+
+/**
+ * Cache that can work on parts of a key to look up a value.
+ *
+ * <p>An example would be looking up values from a substring of a string instead of first creating a
+ * string to do the lookup.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+public interface DDPartialKeyCache<K, V> {
+  /**
+   * Look up or create and store a value in the cache.
+   *
+   * @param key the key to look up
+   * @param m extra parameter that is passed along with the key
+   * @param n extra parameter that is passed along with the key
+   * @param hasher how to compute the hash using key, m, and n
+   * @param comparator how to compare the key, m, n, and value
+   * @param producer how to create a cached value base on the key, m, and n if the lookup fails
+   * @return the cached or created and stored value
+   */
+  V computeIfAbsent(
+      final K key,
+      int m,
+      int n,
+      Hasher<K> hasher,
+      Comparator<K, V> comparator,
+      Producer<K, ? extends V> producer);
+
+  /** Clear the cache. */
+  void clear();
+
+  @FunctionalInterface
+  interface Hasher<T> {
+    int apply(T t, int m, int n);
+  }
+
+  @FunctionalInterface
+  interface Comparator<T, U> {
+    boolean test(T t, int m, int n, U u);
+  }
+
+  @FunctionalInterface
+  interface Producer<T, R> {
+    R apply(T t, int m, int n);
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/cache/FixedSizeCache.java
+++ b/internal-api/src/main/java/datadog/trace/api/cache/FixedSizeCache.java
@@ -1,8 +1,13 @@
 package datadog.trace.api.cache;
 
 import datadog.trace.api.Pair;
+import datadog.trace.api.cache.DDPartialKeyCache.Comparator;
+import datadog.trace.api.cache.DDPartialKeyCache.Hasher;
+import datadog.trace.api.cache.DDPartialKeyCache.Producer;
 import java.util.Arrays;
 import java.util.function.Function;
+import java.util.function.IntFunction;
+import javax.annotation.Nullable;
 
 /**
  * This is a fixed size cache that only has one operation <code>computeIfAbsent</code>, that is used
@@ -11,24 +16,28 @@ import java.util.function.Function;
  * <p>If there is a hash collision, the cache uses double hashing two more times to try to find a
  * match or an unused slot.
  *
- * <p>The cache is thread safe, and assumes that the <code>Creator</code> passed into <code>
- * computeIfAbsent</code> is idempotent or otherwise you might not get back the value you expect
+ * <p>The cache is thread safe, and assumes that the <code>Producer</code> passed into <code>
+ * computeIfAbsent</code> is idempotent, or otherwise you might not get back the value you expect
  * from a cache lookup.
  *
+ * @param <E> element type
  * @param <K> key type
  * @param <V> value type
+ * @param <H> hash function type
+ * @param <C> comparison function type
+ * @param <P> producer function type
  */
-abstract class FixedSizeCache<K, V> implements DDCache<K, V> {
+abstract class FixedSizeCache<E, K, V, H, C, P> {
 
   static final int MAXIMUM_CAPACITY = 1 << 30;
 
-  private final int mask;
+  protected final int mask;
   // This is a cache, so there is no need for volatile, atomics or synchronized.
   // All race conditions here are benign since you always read or write a full
-  // Node that can not be modified, and eventually other threads will see it or
-  // write the same information at that position, or other information in the
+  // Element that can not be modified, and eventually other threads will see it
+  // or write the same information at that position, or other information in the
   // case of a collision.
-  private final Pair<K, V>[] elements;
+  protected final E[] elements;
 
   /**
    * Creates a <code>FixedSizeCache</code> that can hold up to <code>capacity</code> elements, if
@@ -36,7 +45,7 @@ abstract class FixedSizeCache<K, V> implements DDCache<K, V> {
    *
    * @param capacity the maximum number of elements that the cache can hold
    */
-  FixedSizeCache(int capacity) {
+  FixedSizeCache(int capacity, IntFunction<E[]> initializer) {
     if (capacity <= 0) {
       throw new IllegalArgumentException("Cache capacity must be > 0");
     }
@@ -46,43 +55,49 @@ abstract class FixedSizeCache<K, V> implements DDCache<K, V> {
     // compute a power of two size for the given capacity
     int n = -1 >>> Integer.numberOfLeadingZeros(capacity - 1);
     n = (n < 0) ? 1 : (n >= MAXIMUM_CAPACITY) ? MAXIMUM_CAPACITY : n + 1;
-    @SuppressWarnings({"rawtype", "unchecked"})
-    Pair<K, V>[] lmnts = (Pair<K, V>[]) new Pair[n];
-    this.elements = lmnts;
+    this.elements = initializer.apply(n);
     this.mask = n - 1;
   }
 
   /**
    * Look up or create and store a value in the cache.
    *
+   * <p>If there is a hash collision, the method uses double hashing two more times to try to find a
+   * match or an unused slot. If there is no match or empty slot, the first slot is overwritten.
+   *
    * @param key the key to look up
-   * @param creator how to create a cached value base on the key if the lookup fails
+   * @param m extra parameter that is passed along with the key
+   * @param n extra parameter that is passed along with the key
+   * @param hasher how to compute the hash using key, m, and n
+   * @param comparator how to compare the key, m, n, and value
+   * @param producer how to create a cached value base on the key, m, and n if the lookup fails
    * @return the cached or created and stored value
    */
-  @Override
-  public final V computeIfAbsent(K key, Function<K, ? extends V> creator) {
+  protected final V internalComputeIfAbsent(
+      K key, int m, int n, H hasher, C comparator, P producer) {
     if (key == null) {
       return null;
     }
 
-    int h = hash(key);
+    int hash = hash(hasher, key, m, n);
+    int h = hash;
     int firstPos = h & mask;
     V value;
     // try to find a slot or a match 3 times
     for (int i = 1; true; i++) {
       int pos = h & mask;
-      Pair<K, V> current = elements[pos];
+      E current = elements[pos];
       if (current == null) {
         // we found an empty slot, so store the value there
-        value = createAndStoreValue(key, creator, pos);
+        value = produceAndStoreValue(producer, hash, key, m, n, pos);
         break;
-      } else if (equals(key, current)) {
+      } else if (equals(comparator, hash, key, m, n, current)) {
         // we found a cached key, so use that value
-        value = current.getRight();
+        value = getValue(current);
         break;
       } else if (i == 3) {
         // all 3 slots have been taken, so overwrite the first one
-        value = createAndStoreValue(key, creator, firstPos);
+        value = produceAndStoreValue(producer, hash, key, m, n, firstPos);
         break;
       }
       // slot was occupied by someone else, so try another slot
@@ -91,28 +106,125 @@ abstract class FixedSizeCache<K, V> implements DDCache<K, V> {
     return value;
   }
 
-  @Override
   public void clear() {
     Arrays.fill(elements, null);
   }
 
-  abstract int hash(K key);
+  /**
+   * Compute the hash code using the hasher function, key, and extra parameters m, n.
+   *
+   * @param hasher hash function
+   * @param key the key to compute the hash for
+   * @param m extra parameter passed along with the key
+   * @param n extra parameter passed along with the key
+   * @return the hash code
+   */
+  protected abstract int hash(H hasher, K key, int m, int n);
 
-  abstract boolean equals(K key, Pair<K, V> current);
+  /**
+   * Compare the key and the current element using the comparator function, key, hash code, and
+   * extra parameters m, n.
+   *
+   * @param comparator compare function
+   * @param hash hash code
+   * @param key the key to compare
+   * @param m extra parameter passed along with the key
+   * @param n extra parameter passed along with the key
+   * @param current the element to compare against
+   * @return true if there is a match, false othervise
+   */
+  protected abstract boolean equals(C comparator, int hash, K key, int m, int n, E current);
 
-  private V createAndStoreValue(K key, Function<K, ? extends V> creator, int pos) {
-    V value = creator.apply(key);
-    elements[pos] = Pair.of(key, value);
+  /**
+   * Produce a new value using the producer function, key, and extra parameters m, n.
+   *
+   * @param producer producer function
+   * @param key the key to create the value from
+   * @param m extra parameter passed along with the key
+   * @param n extra parameter passed along with the key
+   * @return a new value
+   */
+  protected abstract V produceValue(P producer, K key, int m, int n);
+
+  /**
+   * Create an element using the hash code key, and value.
+   *
+   * @param hash hash code
+   * @param key the key to create the element for
+   * @param value the value to create the element for
+   * @return a new element
+   */
+  protected abstract E toElement(int hash, K key, V value);
+
+  /**
+   * Get the value from an existing element.
+   *
+   * @param element
+   * @return the value contained in the element.
+   */
+  protected abstract V getValue(E element);
+
+  private V produceAndStoreValue(P producer, int hash, K key, int m, int n, int pos) {
+    V value = produceValue(producer, key, m, n);
+    elements[pos] = toElement(hash, key, value);
     return value;
   }
 
-  private int rehash(int v) {
+  private static int rehash(int v) {
     int h = v * 0x9e3775cd;
     h = Integer.reverseBytes(h);
     return h * 0x9e3775cd;
   }
 
-  static final class ObjectHash<K, V> extends FixedSizeCache<K, V> {
+  abstract static class FixedSizeKeyValueCache<K, V>
+      extends FixedSizeCache<Pair<K, V>, K, V, Void, Void, Function<K, ? extends V>>
+      implements DDCache<K, V> {
+    public FixedSizeKeyValueCache(int capacity) {
+      super(
+          capacity,
+          n -> {
+            @SuppressWarnings(value = {"rawtype", "unchecked"})
+            Pair<K, V>[] elements = (Pair<K, V>[]) new Pair[n];
+            return elements;
+          });
+    }
+
+    @Override
+    public final V computeIfAbsent(K key, Function<K, ? extends V> producer) {
+      return internalComputeIfAbsent(key, 0, 0, null, null, producer);
+    }
+
+    @Override
+    protected final int hash(Void unused, K key, int m, int n) {
+      return hash(key);
+    }
+
+    @Override
+    protected final boolean equals(Void unused, int hash, K key, int m, int n, Pair<K, V> current) {
+      return equals(key, current);
+    }
+
+    @Override
+    protected final V produceValue(Function<K, ? extends V> producer, K key, int m, int n) {
+      return producer.apply(key);
+    }
+
+    @Override
+    protected final Pair<K, V> toElement(int hash, K key, V value) {
+      return Pair.of(key, value);
+    }
+
+    @Override
+    protected final V getValue(Pair<K, V> element) {
+      return element.getRight();
+    }
+
+    abstract int hash(K key);
+
+    abstract boolean equals(K key, Pair<K, V> current);
+  }
+
+  static final class ObjectHash<K, V> extends FixedSizeKeyValueCache<K, V> {
     ObjectHash(int capacity) {
       super(capacity);
     }
@@ -126,7 +238,7 @@ abstract class FixedSizeCache<K, V> implements DDCache<K, V> {
     }
   }
 
-  static final class IdentityHash<K, V> extends FixedSizeCache<K, V> {
+  static final class IdentityHash<K, V> extends FixedSizeKeyValueCache<K, V> {
     IdentityHash(int capacity) {
       super(capacity);
     }
@@ -140,7 +252,7 @@ abstract class FixedSizeCache<K, V> implements DDCache<K, V> {
     }
   }
 
-  static final class ArrayHash<K, V> extends FixedSizeCache<K[], V> {
+  static final class ArrayHash<K, V> extends FixedSizeKeyValueCache<K[], V> {
     ArrayHash(int capacity) {
       super(capacity);
     }
@@ -151,6 +263,72 @@ abstract class FixedSizeCache<K, V> implements DDCache<K, V> {
 
     boolean equals(K[] key, Pair<K[], V> current) {
       return Arrays.equals(key, current.getLeft());
+    }
+  }
+
+  static final class FixedSizePartialKeyCache<K, V>
+      extends FixedSizeCache<
+          HVElement<V>, K, V, Hasher<K>, Comparator<K, V>, Producer<K, ? extends V>>
+      implements DDPartialKeyCache<K, V> {
+    public FixedSizePartialKeyCache(int capacity) {
+      super(
+          capacity,
+          n -> {
+            @SuppressWarnings(value = {"rawtype", "unchecked"})
+            HVElement<V>[] elements = (HVElement<V>[]) new HVElement[n];
+            return elements;
+          });
+    }
+
+    @Override
+    public V computeIfAbsent(
+        K key,
+        int m,
+        int n,
+        Hasher<K> hasher,
+        Comparator<K, V> comparator,
+        Producer<K, ? extends V> producer) {
+      return internalComputeIfAbsent(key, m, n, hasher, comparator, producer);
+    }
+
+    @Override
+    protected int hash(Hasher<K> hasher, K key, int m, int n) {
+      return hasher.apply(key, m, n);
+    }
+
+    @Override
+    protected boolean equals(
+        Comparator<K, V> comparator, int hash, K key, int m, int n, HVElement<V> current) {
+      return hash == current.hash && comparator.test(key, m, n, current.value);
+    }
+
+    @Override
+    protected V produceValue(Producer<K, ? extends V> producer, K key, int m, int n) {
+      return producer.apply(key, m, n);
+    }
+
+    @Override
+    protected HVElement<V> toElement(int hash, K key, V value) {
+      return HVElement.of(hash, value);
+    }
+
+    @Override
+    protected V getValue(HVElement<V> element) {
+      return element.value;
+    }
+  }
+
+  static final class HVElement<U> {
+    static <U> HVElement<U> of(int hash, U value) {
+      return new HVElement<>(hash, value);
+    }
+
+    final int hash;
+    final U value;
+
+    HVElement(int hash, @Nullable U value) {
+      this.hash = hash;
+      this.value = value;
     }
   }
 }


### PR DESCRIPTION
# What Does This Do

Changes the `FixedSizeCache` implementation to allow for a partial key cache, where two extra integers are provided as arguments to hash, compare and produce functions.

# Motivation

This is in preparation for doing value lookups from of parts of strings while not creating any extra objects (i.e. substring instances or wrappers holding the arguments).

# Additional Notes

Naming is hard.
