### PR TITLE
Fix inner classes matching for line probes

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ClassesToRetransformFinder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ClassesToRetransformFinder.java
@@ -1,0 +1,115 @@
+package com.datadog.debugger.agent;
+
+import static com.datadog.debugger.agent.Trie.reverseStr;
+import static com.datadog.debugger.agent.TypeNameHelper.extractSimpleName;
+import static com.datadog.debugger.util.ClassFileHelper.normalizeFilePath;
+import static com.datadog.debugger.util.ClassFileHelper.removeExtension;
+import static com.datadog.debugger.util.ClassFileHelper.stripPackagePath;
+
+import com.datadog.debugger.instrumentation.InstrumentationResult;
+import com.datadog.debugger.probe.ProbeDefinition;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ClassesToRetransformFinder {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClassesToRetransformFinder.class);
+
+  private final ConcurrentMap<String, List<String>> classNamesBySourceFile =
+      new ConcurrentHashMap<>();
+
+  public void register(String sourceFile, String className) {
+    // store only the class name that are different from SourceFile name
+    // (Inner or non-public Top-Level classes)
+    classNamesBySourceFile.compute(
+        sourceFile,
+        (key, list) -> {
+          if (list == null) {
+            list = new ArrayList<>();
+          }
+          list.add(className);
+          return list;
+        });
+  }
+
+  public List<Class<?>> getAllLoadedChangedClasses(
+      Class<?>[] allLoadedClasses, ConfigurationComparer comparer) {
+    List<Class<?>> classesToBeTransformed = new ArrayList<>();
+    Trie changedClasses = getAllChangedClasses(comparer);
+    for (Class<?> clazz : allLoadedClasses) {
+      if (lookupClass(changedClasses, clazz)) {
+        classesToBeTransformed.add(clazz);
+      }
+    }
+    return classesToBeTransformed;
+  }
+
+  public boolean hasChangedClasses(ConfigurationComparer comparer) {
+    return !getAllChangedClasses(comparer).isEmpty();
+  }
+
+  Trie getAllChangedClasses(ConfigurationComparer comparer) {
+    List<ProbeDefinition> changedDefinitions =
+        Stream.concat(
+                comparer.getRemovedDefinitions().stream(), comparer.getAddedDefinitions().stream())
+            .collect(Collectors.toList());
+    Trie changedClasses = new Trie();
+    for (ProbeDefinition definition : changedDefinitions) {
+      InstrumentationResult instrumentationResult =
+          comparer.getInstrumentationResults().get(definition.getId());
+      String key = instrumentationResult != null ? instrumentationResult.getTypeName() : null;
+      if (key == null || key.equals("")) {
+        key = definition.getWhere().getTypeName();
+        if (key == null || key.equals("")) {
+          key = definition.getWhere().getSourceFile();
+          if (key == null || key.equals("")) {
+            continue;
+          }
+          processAdditionalClasses(key, changedClasses);
+          key = removeExtension(key);
+          key = normalizeFilePath(key);
+        }
+      } else {
+        key = normalizeFilePath(key);
+      }
+      LOGGER.debug(
+          "instrumented class changed: {} for probe ids: {}",
+          key,
+          definition.getAllProbeIds().collect(Collectors.toList()));
+      changedClasses.insert(reverseStr(key));
+    }
+    for (String typeName : comparer.getChangedBlockedTypes()) {
+      LOGGER.debug("blocked class found: {}", typeName);
+      changedClasses.insert(reverseStr(typeName));
+    }
+    return changedClasses;
+  }
+
+  private void processAdditionalClasses(String sourceFile, Trie changedClasses) {
+    sourceFile = stripPackagePath(sourceFile);
+    List<String> additionalClasses = classNamesBySourceFile.get(sourceFile);
+    if (additionalClasses == null) {
+      return;
+    }
+    for (String additionalClass : additionalClasses) {
+      additionalClass = normalizeFilePath(additionalClass);
+      changedClasses.insert(reverseStr(additionalClass));
+    }
+  }
+
+  private static boolean lookupClass(Trie changedClasses, Class<?> clazz) {
+    String reversedTypeName = reverseStr(clazz.getName());
+    // try first with FQN (java.lang.String)
+    if (changedClasses.containsPrefix(reversedTypeName)) {
+      return true;
+    }
+    // fallback to matching on SimpleName (String)
+    String simpleName = extractSimpleName(clazz);
+    return changedClasses.contains(reverseStr(simpleName));
+  }
+}

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationComparer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationComparer.java
@@ -1,8 +1,5 @@
 package com.datadog.debugger.agent;
 
-import static com.datadog.debugger.agent.Trie.reverseStr;
-import static com.datadog.debugger.agent.TypeNameHelper.extractSimpleName;
-
 import com.datadog.debugger.instrumentation.InstrumentationResult;
 import com.datadog.debugger.probe.ProbeDefinition;
 import java.util.ArrayList;
@@ -14,7 +11,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +29,6 @@ public class ConfigurationComparer {
   private final boolean filteredListChanged;
   private final Map<String, InstrumentationResult> instrumentationResults;
   private final List<String> changedBlockedTypes;
-  private Trie allChangedClasses;
 
   public ConfigurationComparer(
       Configuration originalConfiguration,
@@ -75,76 +70,20 @@ public class ConfigurationComparer {
     }
   }
 
-  private Trie buildChangedClasses() {
-    List<ProbeDefinition> changedDefinitions =
-        Stream.concat(removedDefinitions.stream(), addedDefinitions.stream())
-            .collect(Collectors.toList());
-    Trie changedClasses = new Trie();
-    for (ProbeDefinition definition : changedDefinitions) {
-      InstrumentationResult instrumentationResult = instrumentationResults.get(definition.getId());
-      String key = instrumentationResult != null ? instrumentationResult.getTypeName() : null;
-      if (key == null || key.equals("")) {
-        key = definition.getWhere().getTypeName();
-        if (key == null || key.equals("")) {
-          key = definition.getWhere().getSourceFile();
-          if (key == null || key.equals("")) {
-            continue;
-          }
-          processAdditionalClasses(key, changedClasses);
-          key = removeExtension(key);
-          key = normalizeFilePath(key);
-        }
-      } else {
-        key = normalizeFilePath(key);
-      }
-      LOGGER.debug(
-          "instrumented class changed: {} for probe ids: {}",
-          key,
-          definition.getAllProbeIds().collect(Collectors.toList()));
-      changedClasses.insert(reverseStr(key));
-    }
-    for (String typeName : changedBlockedTypes) {
-      LOGGER.debug("blocked class found: {}", typeName);
-      changedClasses.insert(reverseStr(typeName));
-    }
-    return changedClasses;
-  }
-
-  private void processAdditionalClasses(String sourceFile, Trie changedClasses) {
-    int idx = sourceFile.lastIndexOf('/');
-    if (idx != -1) {
-      sourceFile = sourceFile.substring(idx + 1);
-    }
-    List<String> additionalClasses =
-        SourceFileTrackingTransformer.INSTANCE.getClassNameBySourceFile(sourceFile);
-    if (additionalClasses == null) {
-      return;
-    }
-    for (String additionalClass : additionalClasses) {
-      additionalClass = normalizeFilePath(additionalClass);
-      changedClasses.insert(reverseStr(additionalClass));
-    }
-  }
-
-  private String removeExtension(String fileName) {
-    int idx = fileName.lastIndexOf('.');
-    if (idx > -1) {
-      fileName = fileName.substring(0, idx);
-    }
-    return fileName;
-  }
-
-  private String normalizeFilePath(String filePath) {
-    filePath = filePath.replace('/', '.');
-    return filePath;
-  }
-
   public Collection<ProbeDefinition> getAddedDefinitions() {
     return addedDefinitions;
   }
 
   public Collection<ProbeDefinition> getRemovedDefinitions() {
     return removedDefinitions;
+  }
+
+  public Map<String, InstrumentationResult> getInstrumentationResults() {
+    return instrumentationResults;
+  }
+
+  public List<String> getChangedBlockedTypes() {
+    return changedBlockedTypes;
   }
 
   public boolean hasProbeRelatedChanges() {
@@ -155,43 +94,6 @@ public class ConfigurationComparer {
     return originalConfiguration != null
             && originalConfiguration.getSampling() != incomingConfiguration.getSampling()
         || hasProbeRelatedChanges();
-  }
-
-  public boolean hasChangedClasses() {
-    return !getAllChangedClasses().isEmpty();
-  }
-
-  Trie getAllChangedClasses() {
-    if (allChangedClasses == null) {
-      allChangedClasses = buildChangedClasses();
-    }
-    return allChangedClasses;
-  }
-
-  public List<Class<?>> getAllLoadedChangedClasses(Class<?>[] allLoadedClasses) {
-    List<Class<?>> classesToBeTransformed = new ArrayList<>();
-    Trie changedClasses = getAllChangedClasses();
-    for (Class<?> clazz : allLoadedClasses) {
-      if (lookupClass(changedClasses, clazz)) {
-        classesToBeTransformed.add(clazz);
-      }
-    }
-    return classesToBeTransformed;
-  }
-
-  private static boolean lookupClass(Trie changedClasses, Class<?> clazz) {
-    String reversedTypeName = reverseStr(clazz.getName());
-    // try first with FQN (java.lang.String)
-    if (changedClasses.contains(reversedTypeName)) {
-      return true;
-    }
-    // fallback to matching on SimpleName (String)
-    String simpleName = extractSimpleName(clazz);
-    if (changedClasses.contains(reverseStr(simpleName))) {
-      return true;
-    }
-    // prefix match with FQN
-    return changedClasses.containsPrefix(reversedTypeName);
   }
 
   List<String> findChangesInBlockedTypes() {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -40,6 +40,7 @@ public class DebuggerAgent {
       return;
     }
     log.info("Starting Dynamic Instrumentation");
+    setupSourceFileTracking(instrumentation);
     String finalDebuggerSnapshotUrl = config.getFinalDebuggerSnapshotUrl();
     String agentUrl = config.getAgentUrl();
     boolean isSnapshotUploadThroughAgent = Objects.equals(finalDebuggerSnapshotUrl, agentUrl);
@@ -101,6 +102,10 @@ public class DebuggerAgent {
     } else {
       log.debug("No configuration poller available from SharedCommunicationObjects");
     }
+  }
+
+  private static void setupSourceFileTracking(Instrumentation instrumentation) {
+    instrumentation.addTransformer(SourceFileTrackingTransformer.INSTANCE);
   }
 
   private static void loadFromFile(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -349,13 +349,15 @@ public class DebuggerTransformer implements ClassFileTransformer {
 
   private void reportLocationNotFound(
       ProbeDefinition definition, String className, String methodName, String[] lines) {
-    String format = CANNOT_FIND_LINE;
-    String location = "0";
+    String format;
+    String location;
     if (methodName != null) {
       format = CANNOT_FIND_METHOD;
       location = methodName;
-    } else if (lines != null && lines.length > 0) {
-      location = lines[0];
+    } else {
+      // This is a line probe, so we don't report line not found because the line may be found later
+      // on a separate class files because probe was set on an inner/top-level class
+      return;
     }
     String msg = String.format(format, className, location);
     DiagnosticMessage diagnosticMessage = new DiagnosticMessage(DiagnosticMessage.Kind.ERROR, msg);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/SourceFileTrackingTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/SourceFileTrackingTransformer.java
@@ -1,0 +1,60 @@
+package com.datadog.debugger.agent;
+
+import com.datadog.debugger.util.ClassFileHelper;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.IllegalClassFormatException;
+import java.security.ProtectionDomain;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Permanent Transformer to track all Inner or Top-Level classes associated with the same SourceFile
+ * (String.java) Allows to get all classes that are dependent from a source file and be able to
+ * trigger {@link java.lang.instrument.Instrumentation#retransformClasses(Class[])} on them
+ */
+public class SourceFileTrackingTransformer implements ClassFileTransformer {
+  public static final SourceFileTrackingTransformer INSTANCE = new SourceFileTrackingTransformer();
+
+  private final ConcurrentMap<String, List<String>> classNamesBySourceFile =
+      new ConcurrentHashMap<>();
+
+  @Override
+  public byte[] transform(
+      ClassLoader loader,
+      String className,
+      Class<?> classBeingRedefined,
+      ProtectionDomain protectionDomain,
+      byte[] classfileBuffer)
+      throws IllegalClassFormatException {
+    if (className == null) {
+      return null;
+    }
+    String sourceFile = ClassFileHelper.extractSourceFile(classfileBuffer);
+    if (sourceFile == null) {
+      return null;
+    }
+    String simpleClassName = className.substring(className.lastIndexOf('/') + 1);
+    String simpleSourceFile = sourceFile.substring(0, sourceFile.lastIndexOf('.'));
+    if (simpleClassName.equals(simpleSourceFile)) {
+      return null;
+    }
+    // store only the class name that are different from SourceFile name
+    // (Inner or non-public Top-Level classes)
+    classNamesBySourceFile.compute(
+        sourceFile,
+        (key, list) -> {
+          if (list == null) {
+            list = new ArrayList<>();
+          }
+          list.add(className);
+          return list;
+        });
+    return null;
+  }
+
+  public List<String> getClassNameBySourceFile(String sourceFile) {
+    return classNamesBySourceFile.get(sourceFile);
+  }
+}

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/TransformerDefinitionMatcher.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/TransformerDefinitionMatcher.java
@@ -3,14 +3,13 @@ package com.datadog.debugger.agent;
 import static com.datadog.debugger.agent.Trie.reverseStr;
 
 import com.datadog.debugger.probe.ProbeDefinition;
+import com.datadog.debugger.util.ClassFileHelper;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.tree.ClassNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -135,17 +134,12 @@ public class TransformerDefinitionMatcher {
   private List<ProbeDefinition> matchProbeDefinitionsBySourceFile(
       String className, byte[] classfileBuffer) {
     // try to match filename, need to retrieve the source filename from classfile
-    // first we try match the package name to determine if it makes sense to parse byte code
     String reversedClassName = reverseStr(className);
     int idx = reversedClassName.indexOf('/');
     boolean hasPackageName = idx > -1;
     String reversedPackageName = reversedClassName.substring(idx + 1);
     // Retrieve the actual source file name
-    // TODO maybe by scanning the byte array directly we can avoid doing an expensive parsing
-    ClassReader reader = new ClassReader(classfileBuffer);
-    ClassNode classNode = new ClassNode();
-    reader.accept(classNode, ClassReader.SKIP_FRAMES);
-    String sourceFileName = classNode.sourceFile;
+    String sourceFileName = ClassFileHelper.extractSourceFile(classfileBuffer);
     if (sourceFileName == null) {
       return Collections.emptyList();
     }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ClassFileHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ClassFileHelper.java
@@ -1,0 +1,15 @@
+package com.datadog.debugger.util;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.tree.ClassNode;
+
+/** Helper class for extracting information of a class file */
+public class ClassFileHelper {
+  public static String extractSourceFile(byte[] classFileBuffer) {
+    // TODO maybe by scanning the byte array directly we can avoid doing an expensive parsing
+    ClassReader classReader = new ClassReader(classFileBuffer);
+    ClassNode classNode = new ClassNode();
+    classReader.accept(classNode, ClassReader.SKIP_FRAMES);
+    return classNode.sourceFile;
+  }
+}

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ClassFileHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ClassFileHelper.java
@@ -12,4 +12,25 @@ public class ClassFileHelper {
     classReader.accept(classNode, ClassReader.SKIP_FRAMES);
     return classNode.sourceFile;
   }
+
+  public static String removeExtension(String fileName) {
+    int idx = fileName.lastIndexOf('.');
+    if (idx > -1) {
+      fileName = fileName.substring(0, idx);
+    }
+    return fileName;
+  }
+
+  public static String normalizeFilePath(String filePath) {
+    filePath = filePath.replace('/', '.');
+    return filePath;
+  }
+
+  public static String stripPackagePath(String classPath) {
+    int idx = classPath.lastIndexOf('/');
+    if (idx != -1) {
+      classPath = classPath.substring(idx + 1);
+    }
+    return classPath;
+  }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -105,19 +105,6 @@ public class CapturedSnapshotTest {
   }
 
   @Test
-  public void lineNotFound() throws IOException, URISyntaxException {
-    final String CLASS_NAME = "CapturedSnapshot01";
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, CLASS_NAME + ".java", 42));
-    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
-    int result = Reflect.on(testClass).call("main", "2").get();
-    Assert.assertEquals(2, result);
-    Assert.assertEquals(
-        "No executable code was found at CapturedSnapshot01:L42",
-        listener.errors.get(PROBE_ID).get(0).getMessage());
-  }
-
-  @Test
   public void methodProbe() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
     DebuggerTransformerTest.TestSnapshotListener listener =

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
@@ -75,7 +75,12 @@ public class ConfigurationUpdaterTest {
   @Test
   public void acceptNoProbes() {
     ConfigurationUpdater configurationUpdater =
-        new ConfigurationUpdater(inst, this::createTransformer, tracerConfig, debuggerSink);
+        new ConfigurationUpdater(
+            inst,
+            this::createTransformer,
+            tracerConfig,
+            debuggerSink,
+            new ClassesToRetransformFinder());
     configurationUpdater.accept(null);
     verify(inst, never()).addTransformer(any(), eq(true));
     verifyNoInteractions(debuggerSink);
@@ -86,7 +91,11 @@ public class ConfigurationUpdaterTest {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
     ConfigurationUpdater configurationUpdater =
         new ConfigurationUpdater(
-            inst, this::createTransformer, tracerConfig, debuggerSinkWithMockStatusSink);
+            inst,
+            this::createTransformer,
+            tracerConfig,
+            debuggerSinkWithMockStatusSink,
+            new ClassesToRetransformFinder());
     List<LogProbe> logProbes =
         Collections.singletonList(
             LogProbe.builder().probeId(PROBE_ID).where("java.lang.String", "concat").build());
@@ -114,7 +123,11 @@ public class ConfigurationUpdaterTest {
     when(inst.getAllLoadedClasses()).thenReturn(classes);
     ConfigurationUpdater configurationUpdater =
         new ConfigurationUpdater(
-            inst, this::createTransformer, tracerConfig, debuggerSinkWithMockStatusSink);
+            inst,
+            this::createTransformer,
+            tracerConfig,
+            debuggerSinkWithMockStatusSink,
+            new ClassesToRetransformFinder());
     List<LogProbe> logProbes =
         Arrays.stream(classes)
             .map(getClassName)
@@ -134,7 +147,11 @@ public class ConfigurationUpdaterTest {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
     ConfigurationUpdater configurationUpdater =
         new ConfigurationUpdater(
-            inst, this::createTransformer, tracerConfig, debuggerSinkWithMockStatusSink);
+            inst,
+            this::createTransformer,
+            tracerConfig,
+            debuggerSinkWithMockStatusSink,
+            new ClassesToRetransformFinder());
     List<LogProbe> logProbes =
         Arrays.asList(
             LogProbe.builder().probeId(PROBE_ID).where("java.lang.String", "concat").build(),
@@ -156,7 +173,11 @@ public class ConfigurationUpdaterTest {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
     ConfigurationUpdater configurationUpdater =
         new ConfigurationUpdater(
-            inst, this::createTransformer, tracerConfig, debuggerSinkWithMockStatusSink);
+            inst,
+            this::createTransformer,
+            tracerConfig,
+            debuggerSinkWithMockStatusSink,
+            new ClassesToRetransformFinder());
     // phase 1: single probe definition
     List<LogProbe> logProbes =
         Arrays.asList(
@@ -186,7 +207,11 @@ public class ConfigurationUpdaterTest {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
     ConfigurationUpdater configurationUpdater =
         new ConfigurationUpdater(
-            inst, this::createTransformer, tracerConfig, debuggerSinkWithMockStatusSink);
+            inst,
+            this::createTransformer,
+            tracerConfig,
+            debuggerSinkWithMockStatusSink,
+            new ClassesToRetransformFinder());
     // phase 1: duplicated probe definition
     List<LogProbe> logProbes =
         Arrays.asList(
@@ -218,7 +243,11 @@ public class ConfigurationUpdaterTest {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
     ConfigurationUpdater configurationUpdater =
         new ConfigurationUpdater(
-            inst, this::createTransformer, tracerConfig, debuggerSinkWithMockStatusSink);
+            inst,
+            this::createTransformer,
+            tracerConfig,
+            debuggerSinkWithMockStatusSink,
+            new ClassesToRetransformFinder());
     List<LogProbe> logProbes =
         Arrays.asList(
             LogProbe.builder().probeId(PROBE_ID).where("java.lang.String", "concat").build());
@@ -240,7 +269,8 @@ public class ConfigurationUpdaterTest {
   public void acceptSourceFileLineNumber() throws UnmodifiableClassException {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
     ConfigurationUpdater configurationUpdater =
-        new ConfigurationUpdater(inst, this::createTransformer, tracerConfig);
+        new ConfigurationUpdater(
+            inst, this::createTransformer, tracerConfig, new ClassesToRetransformFinder());
     List<LogProbe> logProbes =
         Collections.singletonList(
             LogProbe.builder()
@@ -266,7 +296,8 @@ public class ConfigurationUpdaterTest {
         };
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class, runnable.getClass()});
     ConfigurationUpdater configurationUpdater =
-        new ConfigurationUpdater(inst, this::createTransformer, tracerConfig);
+        new ConfigurationUpdater(
+            inst, this::createTransformer, tracerConfig, new ClassesToRetransformFinder());
     List<LogProbe> logProbes =
         Collections.singletonList(
             LogProbe.builder()
@@ -291,7 +322,8 @@ public class ConfigurationUpdaterTest {
         };
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class, runnable.getClass()});
     ConfigurationUpdater configurationUpdater =
-        new ConfigurationUpdater(inst, this::createTransformer, tracerConfig);
+        new ConfigurationUpdater(
+            inst, this::createTransformer, tracerConfig, new ClassesToRetransformFinder());
     List<LogProbe> logProbes =
         Collections.singletonList(
             LogProbe.builder()
@@ -316,7 +348,8 @@ public class ConfigurationUpdaterTest {
               assertEquals(0, configuration.getDefinitions().size());
               return transformer;
             },
-            tracerConfig);
+            tracerConfig,
+            new ClassesToRetransformFinder());
     List<LogProbe> logProbes =
         Arrays.asList(
             LogProbe.builder()
@@ -349,7 +382,8 @@ public class ConfigurationUpdaterTest {
               assertEquals(expectedDefinitions.get(), configuration.getDefinitions().size());
               return transformer;
             },
-            tracerConfig);
+            tracerConfig,
+            new ClassesToRetransformFinder());
     List<LogProbe> logProbes =
         Collections.singletonList(
             LogProbe.builder().probeId(PROBE_ID).where("java.lang.String", "concat").build());
@@ -375,7 +409,11 @@ public class ConfigurationUpdaterTest {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class, HashMap.class});
     ConfigurationUpdater configurationUpdater =
         new ConfigurationUpdater(
-            inst, this::createTransformer, tracerConfig, debuggerSinkWithMockStatusSink);
+            inst,
+            this::createTransformer,
+            tracerConfig,
+            debuggerSinkWithMockStatusSink,
+            new ClassesToRetransformFinder());
     LogProbe probe1 =
         LogProbe.builder()
             .language(LANGUAGE)
@@ -419,7 +457,8 @@ public class ConfigurationUpdaterTest {
               return transformer;
             },
             tracerConfig,
-            debuggerSinkWithMockStatusSink);
+            debuggerSinkWithMockStatusSink,
+            new ClassesToRetransformFinder());
     LogProbe probe1 =
         LogProbe.builder()
             .language(LANGUAGE)
@@ -456,7 +495,11 @@ public class ConfigurationUpdaterTest {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
     ConfigurationUpdater configurationUpdater =
         new ConfigurationUpdater(
-            inst, this::createTransformer, tracerConfig, debuggerSinkWithMockStatusSink);
+            inst,
+            this::createTransformer,
+            tracerConfig,
+            debuggerSinkWithMockStatusSink,
+            new ClassesToRetransformFinder());
     List<LogProbe> logProbes =
         Collections.singletonList(
             LogProbe.builder().probeId(PROBE_ID).where("java.lang.String", "concat").build());
@@ -473,7 +516,8 @@ public class ConfigurationUpdaterTest {
   public void resolve() {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
     ConfigurationUpdater configurationUpdater =
-        new ConfigurationUpdater(inst, this::createTransformer, tracerConfig);
+        new ConfigurationUpdater(
+            inst, this::createTransformer, tracerConfig, new ClassesToRetransformFinder());
     List<LogProbe> logProbes =
         Collections.singletonList(
             LogProbe.builder()
@@ -495,7 +539,8 @@ public class ConfigurationUpdaterTest {
   public void resolveFails() throws UnmodifiableClassException {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
     ConfigurationUpdater configurationUpdater =
-        new ConfigurationUpdater(inst, this::createTransformer, tracerConfig);
+        new ConfigurationUpdater(
+            inst, this::createTransformer, tracerConfig, new ClassesToRetransformFinder());
     List<LogProbe> logProbes =
         Collections.singletonList(
             LogProbe.builder().probeId(PROBE_ID).where("java.lang.String", "concat").build());
@@ -519,7 +564,8 @@ public class ConfigurationUpdaterTest {
               .build());
     }
     ConfigurationUpdater configurationUpdater =
-        new ConfigurationUpdater(inst, this::createTransformer, tracerConfig);
+        new ConfigurationUpdater(
+            inst, this::createTransformer, tracerConfig, new ClassesToRetransformFinder());
     configurationUpdater.accept(createApp(logProbes));
     Assertions.assertEquals(
         ConfigurationUpdater.MAX_ALLOWED_LOG_PROBES,
@@ -554,7 +600,8 @@ public class ConfigurationUpdaterTest {
     logProbes.add(
         LogProbe.builder().probeId("foo").tags(tags).where("java.lang.String", "concat").build());
     ConfigurationUpdater configurationUpdater =
-        new ConfigurationUpdater(inst, this::createTransformer, tracerConfig);
+        new ConfigurationUpdater(
+            inst, this::createTransformer, tracerConfig, new ClassesToRetransformFinder());
     configurationUpdater.accept(createApp(logProbes));
     Assertions.assertEquals(
         expectation ? 1 : 0, configurationUpdater.getAppliedDefinitions().size());
@@ -564,7 +611,8 @@ public class ConfigurationUpdaterTest {
   public void acceptNewMetric() {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
     ConfigurationUpdater configurationUpdater =
-        new ConfigurationUpdater(inst, this::createTransformer, tracerConfig);
+        new ConfigurationUpdater(
+            inst, this::createTransformer, tracerConfig, new ClassesToRetransformFinder());
     List<MetricProbe> metricProbes =
         Collections.singletonList(
             MetricProbe.builder().probeId(METRIC_ID).where("java.lang.String", "concat").build());
@@ -580,7 +628,8 @@ public class ConfigurationUpdaterTest {
   public void acceptNewLog() {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
     ConfigurationUpdater configurationUpdater =
-        new ConfigurationUpdater(inst, this::createTransformer, tracerConfig);
+        new ConfigurationUpdater(
+            inst, this::createTransformer, tracerConfig, new ClassesToRetransformFinder());
     List<LogProbe> logProbes =
         Collections.singletonList(
             LogProbe.builder().probeId(LOG_ID).where("java.lang.String", "concat").build());
@@ -596,7 +645,8 @@ public class ConfigurationUpdaterTest {
   public void acceptDeleteMetric() throws UnmodifiableClassException {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class, HashMap.class});
     ConfigurationUpdater configurationUpdater =
-        new ConfigurationUpdater(inst, this::createTransformer, tracerConfig);
+        new ConfigurationUpdater(
+            inst, this::createTransformer, tracerConfig, new ClassesToRetransformFinder());
     MetricProbe metricProbe1 =
         MetricProbe.builder()
             .language(LANGUAGE)
@@ -629,7 +679,8 @@ public class ConfigurationUpdaterTest {
   public void acceptDeleteLog() throws UnmodifiableClassException {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class, HashMap.class});
     ConfigurationUpdater configurationUpdater =
-        new ConfigurationUpdater(inst, this::createTransformer, tracerConfig);
+        new ConfigurationUpdater(
+            inst, this::createTransformer, tracerConfig, new ClassesToRetransformFinder());
     LogProbe logProbe1 =
         LogProbe.builder()
             .language(LANGUAGE)
@@ -662,7 +713,8 @@ public class ConfigurationUpdaterTest {
   public void acceptClearMetrics() throws UnmodifiableClassException {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
     ConfigurationUpdater configurationUpdater =
-        new ConfigurationUpdater(inst, this::createTransformer, tracerConfig);
+        new ConfigurationUpdater(
+            inst, this::createTransformer, tracerConfig, new ClassesToRetransformFinder());
     List<MetricProbe> metricProbes =
         Collections.singletonList(
             MetricProbe.builder().probeId(METRIC_ID).where("java.lang.String", "concat").build());
@@ -677,7 +729,8 @@ public class ConfigurationUpdaterTest {
   public void acceptClearLogs() throws UnmodifiableClassException {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
     ConfigurationUpdater configurationUpdater =
-        new ConfigurationUpdater(inst, this::createTransformer, tracerConfig);
+        new ConfigurationUpdater(
+            inst, this::createTransformer, tracerConfig, new ClassesToRetransformFinder());
     List<LogProbe> logProbes =
         Collections.singletonList(
             LogProbe.builder().probeId(LOG_ID).where("java.lang.String", "concat").build());
@@ -693,7 +746,8 @@ public class ConfigurationUpdaterTest {
     when(inst.getAllLoadedClasses())
         .thenReturn(new Class[] {String.class, HashMap.class, StringBuilder.class});
     ConfigurationUpdater configurationUpdater =
-        new ConfigurationUpdater(inst, this::createTransformer, tracerConfig);
+        new ConfigurationUpdater(
+            inst, this::createTransformer, tracerConfig, new ClassesToRetransformFinder());
     List<LogProbe> logProbes =
         Arrays.asList(
             LogProbe.builder()

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.agent;
 
+import static com.datadog.debugger.util.ClassFileHelperTest.getClassFileBytes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -25,10 +26,8 @@ import datadog.trace.bootstrap.debugger.Snapshot;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
 import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.io.StringReader;
@@ -37,7 +36,6 @@ import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 import java.lang.instrument.Instrumentation;
 import java.lang.reflect.Field;
-import java.net.URL;
 import java.security.ProtectionDomain;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -208,21 +206,6 @@ public class DebuggerTransformerTest {
   @BeforeEach
   void setup() {
     DebuggerContext.init(null, null, null);
-  }
-
-  private byte[] getClassFileBytes(Class<?> clazz) {
-    URL resource = clazz.getResource(clazz.getSimpleName() + ".class");
-    byte[] buffer = new byte[4096];
-    ByteArrayOutputStream os = new ByteArrayOutputStream();
-    try (InputStream is = resource.openStream()) {
-      int readBytes;
-      while ((readBytes = is.read(buffer)) != -1) {
-        os.write(buffer, 0, readBytes);
-      }
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
-    return os.toByteArray();
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/InnerHelper.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/InnerHelper.java
@@ -1,0 +1,6 @@
+package com.datadog.debugger.agent;
+
+public class InnerHelper {
+
+  public static class MyInner {}
+}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SourceFileTrackingTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SourceFileTrackingTransformerTest.java
@@ -1,0 +1,57 @@
+package com.datadog.debugger.agent;
+
+import static com.datadog.debugger.util.ClassFileHelperTest.getClassFileBytes;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.lang.instrument.IllegalClassFormatException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SourceFileTrackingTransformerTest {
+  @Test
+  void transformTopLevel() throws IllegalClassFormatException {
+    SourceFileTrackingTransformer sourceFileTrackingTransformer =
+        new SourceFileTrackingTransformer();
+    sourceFileTrackingTransformer.transform(
+        null,
+        getInternalName(TopLevelHelper.class),
+        null,
+        null,
+        getClassFileBytes(TopLevelHelper.class));
+    assertNull(sourceFileTrackingTransformer.getClassNameBySourceFile("TopLevelHelper.java"));
+    sourceFileTrackingTransformer.transform(
+        null,
+        getInternalName(MyTopLevelClass.class),
+        null,
+        null,
+        getClassFileBytes(MyTopLevelClass.class));
+    List<String> classNameBySourceFile =
+        sourceFileTrackingTransformer.getClassNameBySourceFile("TopLevelHelper.java");
+    assertEquals(1, classNameBySourceFile.size());
+    assertEquals(getInternalName(MyTopLevelClass.class), classNameBySourceFile.get(0));
+  }
+
+  @Test
+  void transformInner() throws IllegalClassFormatException {
+    SourceFileTrackingTransformer sourceFileTrackingTransformer =
+        new SourceFileTrackingTransformer();
+    sourceFileTrackingTransformer.transform(
+        null, getInternalName(InnerHelper.class), null, null, getClassFileBytes(InnerHelper.class));
+    assertNull(sourceFileTrackingTransformer.getClassNameBySourceFile("TopLevelHelper.java"));
+    sourceFileTrackingTransformer.transform(
+        null,
+        getInternalName(InnerHelper.MyInner.class),
+        null,
+        null,
+        getClassFileBytes(InnerHelper.MyInner.class));
+    List<String> classNameBySourceFile =
+        sourceFileTrackingTransformer.getClassNameBySourceFile("InnerHelper.java");
+    assertEquals(1, classNameBySourceFile.size());
+    assertEquals(getInternalName(InnerHelper.MyInner.class), classNameBySourceFile.get(0));
+  }
+
+  private String getInternalName(Class<?> clazz) {
+    return clazz.getName().replace('.', '/');
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SourceFileTrackingTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SourceFileTrackingTransformerTest.java
@@ -2,53 +2,78 @@ package com.datadog.debugger.agent;
 
 import static com.datadog.debugger.util.ClassFileHelperTest.getClassFileBytes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
+import com.datadog.debugger.probe.LogProbe;
 import java.lang.instrument.IllegalClassFormatException;
+import java.util.HashMap;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class SourceFileTrackingTransformerTest {
   @Test
   void transformTopLevel() throws IllegalClassFormatException {
+    ClassesToRetransformFinder finder = new ClassesToRetransformFinder();
     SourceFileTrackingTransformer sourceFileTrackingTransformer =
-        new SourceFileTrackingTransformer();
+        new SourceFileTrackingTransformer(finder);
+    ConfigurationComparer comparer = createComparer("TopLevelHelper.java");
     sourceFileTrackingTransformer.transform(
         null,
         getInternalName(TopLevelHelper.class),
         null,
         null,
         getClassFileBytes(TopLevelHelper.class));
-    assertNull(sourceFileTrackingTransformer.getClassNameBySourceFile("TopLevelHelper.java"));
+    List<Class<?>> changedClasses =
+        finder.getAllLoadedChangedClasses(new Class[] {TopLevelHelper.class}, comparer);
+    assertEquals(1, changedClasses.size());
+    assertEquals(TopLevelHelper.class, changedClasses.get(0));
     sourceFileTrackingTransformer.transform(
         null,
         getInternalName(MyTopLevelClass.class),
         null,
         null,
         getClassFileBytes(MyTopLevelClass.class));
-    List<String> classNameBySourceFile =
-        sourceFileTrackingTransformer.getClassNameBySourceFile("TopLevelHelper.java");
-    assertEquals(1, classNameBySourceFile.size());
-    assertEquals(getInternalName(MyTopLevelClass.class), classNameBySourceFile.get(0));
+    changedClasses =
+        finder.getAllLoadedChangedClasses(
+            new Class[] {TopLevelHelper.class, MyTopLevelClass.class}, comparer);
+    assertEquals(2, changedClasses.size());
+    assertEquals(TopLevelHelper.class, changedClasses.get(0));
+    assertEquals(MyTopLevelClass.class, changedClasses.get(1));
   }
 
   @Test
   void transformInner() throws IllegalClassFormatException {
+    ClassesToRetransformFinder finder = new ClassesToRetransformFinder();
     SourceFileTrackingTransformer sourceFileTrackingTransformer =
-        new SourceFileTrackingTransformer();
+        new SourceFileTrackingTransformer(finder);
+    ConfigurationComparer comparer = createComparer("InnerHelper.java");
     sourceFileTrackingTransformer.transform(
         null, getInternalName(InnerHelper.class), null, null, getClassFileBytes(InnerHelper.class));
-    assertNull(sourceFileTrackingTransformer.getClassNameBySourceFile("TopLevelHelper.java"));
+    List<Class<?>> changedClasses =
+        finder.getAllLoadedChangedClasses(new Class[] {InnerHelper.class}, comparer);
+    assertEquals(1, changedClasses.size());
+    assertEquals(InnerHelper.class, changedClasses.get(0));
     sourceFileTrackingTransformer.transform(
         null,
         getInternalName(InnerHelper.MyInner.class),
         null,
         null,
         getClassFileBytes(InnerHelper.MyInner.class));
-    List<String> classNameBySourceFile =
-        sourceFileTrackingTransformer.getClassNameBySourceFile("InnerHelper.java");
-    assertEquals(1, classNameBySourceFile.size());
-    assertEquals(getInternalName(InnerHelper.MyInner.class), classNameBySourceFile.get(0));
+    changedClasses =
+        finder.getAllLoadedChangedClasses(
+            new Class[] {InnerHelper.class, InnerHelper.MyInner.class}, comparer);
+    assertEquals(2, changedClasses.size());
+    assertEquals(InnerHelper.class, changedClasses.get(0));
+    assertEquals(InnerHelper.MyInner.class, changedClasses.get(1));
+  }
+
+  private ConfigurationComparer createComparer(String sourceFile) {
+    Configuration emptyConfig = Configuration.builder().setService("service-name").build();
+    Configuration newConfig =
+        Configuration.builder()
+            .setService("service-name")
+            .add(new LogProbe.Builder().where(sourceFile, 42).build())
+            .build();
+    return new ConfigurationComparer(emptyConfig, newConfig, new HashMap<>());
   }
 
   private String getInternalName(Class<?> clazz) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/TransformerDefinitionMatcherTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/TransformerDefinitionMatcherTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.agent;
 
+import static com.datadog.debugger.util.ClassFileHelperTest.getClassFileBytes;
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -7,10 +8,6 @@ import com.datadog.debugger.probe.LogProbe;
 import com.datadog.debugger.probe.MetricProbe;
 import com.datadog.debugger.probe.ProbeDefinition;
 import com.datadog.debugger.probe.SpanProbe;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -196,20 +193,5 @@ public class TransformerDefinitionMatcherTest {
 
   private static String getClassPath(Class<?> clazz) {
     return clazz.getName().replace('.', '/');
-  }
-
-  private static byte[] getClassFileBytes(Class<?> clazz) {
-    URL resource = clazz.getResource(clazz.getSimpleName() + ".class");
-    byte[] buffer = new byte[4096];
-    ByteArrayOutputStream os = new ByteArrayOutputStream();
-    try (InputStream is = resource.openStream()) {
-      int readBytes;
-      while ((readBytes = is.read(buffer)) != -1) {
-        os.write(buffer, 0, readBytes);
-      }
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
-    return os.toByteArray();
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ClassFileHelperTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ClassFileHelperTest.java
@@ -1,0 +1,25 @@
+package com.datadog.debugger.util;
+
+import static datadog.trace.util.Strings.getResourceName;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+public class ClassFileHelperTest {
+  public static byte[] getClassFileBytes(Class<?> clazz) {
+    URL resource = clazz.getResource("/" + getResourceName(clazz.getTypeName()));
+    byte[] buffer = new byte[4096];
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    try (InputStream is = resource.openStream()) {
+      int readBytes;
+      while ((readBytes = is.read(buffer)) != -1) {
+        os.write(buffer, 0, readBytes);
+      }
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return os.toByteArray();
+  }
+}


### PR DESCRIPTION
# What Does This Do
Allows the DebuggerTransformer to find inner classes when using file+line probe definitions.
Reporting of line not found was removed because it can be found latter by loading inner/top-level class.

# Background
When class are already loaded, we need to retransform them for passing through the `DebuggerTransformer`.
But to detect which class need to be retransformed, we rely on the naming. However inner classes or Top-Level classes are independent class files and the only way to associate them is the sourcefile attribute in each class file.

# Solution
Track all dependent classes by their source file, so it easier to find all related class given a filename.
This avoids scanning all loaded classes to parse their sourcefile and try to match with actual probe definitions.

# Motivation
Support line probe in inner/top-level classes or Kotlin lambdas

# Additional Notes
