### PR TITLE
fix IDE error because of ambiguity

### DIFF
--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ProfilingContextIntegration.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ProfilingContextIntegration.java
@@ -13,7 +13,8 @@ public interface ProfilingContextIntegration extends ProfilingContext {
 
   final class NoOp implements ProfilingContextIntegration {
 
-    public static final NoOp INSTANCE = new NoOp();
+    public static final ProfilingContextIntegration INSTANCE =
+        new ProfilingContextIntegration.NoOp();
 
     @Override
     public void onAttach() {}


### PR DESCRIPTION
# What Does This Do

I'm not sure how this compiles at all (@mcculls probably does 😅 ), but IntelliJ finds the type name `NoOp` ambiguous because there are two of them in scope.

# Motivation

# Additional Notes
