### PR TITLE
Fix support for widening on equals operator

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ComparisonOperator.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ComparisonOperator.java
@@ -10,7 +10,13 @@ public enum ComparisonOperator {
   EQ("==") {
     @Override
     public Boolean apply(Value<?> left, Value<?> right) {
-      return Objects.equals(left.getValue(), right.getValue());
+      if (left.getValue().getClass() == right.getValue().getClass()) {
+        return Objects.equals(left.getValue(), right.getValue());
+      } else if (left instanceof NumericValue && right instanceof NumericValue) {
+        return compare(left, right) == 0;
+      } else {
+        return Boolean.FALSE;
+      }
     }
   },
   GE(">=") {

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ComparisonExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ComparisonExpressionTest.java
@@ -39,6 +39,7 @@ class ComparisonExpressionTest {
         Arguments.of(new NumericValue(1L), new NumericValue(1L), EQ, true, "1 == 1"),
         Arguments.of(new NumericValue(1.0F), new NumericValue(1.0F), EQ, true, "1.0 == 1.0"),
         Arguments.of(new NumericValue(1.0), new NumericValue(1.0), EQ, true, "1.0 == 1.0"),
+        Arguments.of(new NumericValue(1), new NumericValue(1.0), EQ, true, "1 == 1.0"),
         Arguments.of(new NumericValue(1), new NumericValue(2), EQ, false, "1 == 2"),
         Arguments.of(new StringValue("foo"), new NumericValue(2), EQ, false, "\"foo\" == 2"),
         Arguments.of(new NumericValue(1), new StringValue("foo"), EQ, false, "1 == \"foo\""),
@@ -49,6 +50,8 @@ class ComparisonExpressionTest {
         Arguments.of(new NumericValue(1), new NumericValue(2), GT, false, "1 > 2"),
         Arguments.of(new NumericValue(2), new NumericValue(1), GT, true, "2 > 1"),
         Arguments.of(new NumericValue(1.1), new NumericValue(1.0), GT, true, "1.1 > 1.0"),
+        Arguments.of(new NumericValue(1.1), new NumericValue(1), GT, true, "1.1 > 1"),
+        Arguments.of(new NumericValue(1), new NumericValue(0.9), GT, true, "1 > 0.9"),
         Arguments.of(ValueExpression.NULL, new NumericValue(2), GT, false, "null > 2"),
         Arguments.of(new NumericValue(2), ValueExpression.NULL, GT, false, "2 > null"),
         Arguments.of(
@@ -62,6 +65,8 @@ class ComparisonExpressionTest {
         Arguments.of(new NumericValue(1), new NumericValue(2), GE, false, "1 >= 2"),
         Arguments.of(new NumericValue(2), new NumericValue(1), GE, true, "2 >= 1"),
         Arguments.of(new NumericValue(1.1), new NumericValue(1.0), GE, true, "1.1 >= 1.0"),
+        Arguments.of(new NumericValue(1.1), new NumericValue(1), GE, true, "1.1 >= 1"),
+        Arguments.of(new NumericValue(1), new NumericValue(0.9), GE, true, "1 >= 0.9"),
         Arguments.of(ValueExpression.NULL, new NumericValue(2), GE, false, "null >= 2"),
         Arguments.of(
             new NumericValue(Double.NaN), new NumericValue(Double.NaN), GE, true, "NaN >= NaN"),
@@ -75,6 +80,8 @@ class ComparisonExpressionTest {
         Arguments.of(new NumericValue(1), new NumericValue(2), LT, true, "1 < 2"),
         Arguments.of(new NumericValue(2), new NumericValue(1), LT, false, "2 < 1"),
         Arguments.of(new NumericValue(1.0), new NumericValue(1.1), LT, true, "1.0 < 1.1"),
+        Arguments.of(new NumericValue(1), new NumericValue(1.1), LT, true, "1 < 1.1"),
+        Arguments.of(new NumericValue(0.9), new NumericValue(1), LT, true, "0.9 < 1"),
         Arguments.of(ValueExpression.NULL, new NumericValue(2), LT, false, "null < 2"),
         Arguments.of(
             new NumericValue(Double.NaN), new NumericValue(Double.NaN), LT, false, "NaN < NaN"),
@@ -88,6 +95,8 @@ class ComparisonExpressionTest {
         Arguments.of(new NumericValue(1), new NumericValue(2), LE, true, "1 <= 2"),
         Arguments.of(new NumericValue(2), new NumericValue(1), LE, false, "2 <= 1"),
         Arguments.of(new NumericValue(1.0), new NumericValue(1.1), LE, true, "1.0 <= 1.1"),
+        Arguments.of(new NumericValue(1), new NumericValue(1.1), LE, true, "1 <= 1.1"),
+        Arguments.of(new NumericValue(0.9), new NumericValue(1), LE, true, "0.9 <= 1"),
         Arguments.of(ValueExpression.NULL, new NumericValue(2), LE, false, "null <= 2"),
         Arguments.of(
             new NumericValue(Double.NaN), new NumericValue(Double.NaN), LE, true, "NaN <= NaN"),


### PR DESCRIPTION
# What Does This Do
only the equals operator in Expression Language was not supporting mixing integer and float. If the type does not match we are widening to BigDecimal for comparison

# Motivation

# Additional Notes
