### PR TITLE
Improved logging using placeholders

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -640,7 +640,7 @@ public class Agent {
   private static synchronized void initializeJmxSystemAccessProvider(
       final ClassLoader classLoader) {
     if (log.isDebugEnabled()) {
-      log.debug("Initializing JMX system access provider for " + classLoader.toString());
+      log.debug("Initializing JMX system access provider for {}", classLoader);
     }
     try {
       final Class<?> tracerInstallerClass =
@@ -1036,7 +1036,7 @@ public class Agent {
     }
   }
 
-  /** @see datadog.trace.api.ProductActivationConfig#fromString(String) */
+  /** @see datadog.trace.api.ProductActivation#fromString(String) */
   private static boolean isAppSecFullyDisabled() {
     // must be kept in sync with logic from Config!
     final String featureEnabledSysprop = AgentFeature.APPSEC.systemProp;

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/AgentJarIndex.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/AgentJarIndex.java
@@ -81,7 +81,7 @@ public final class AgentJarIndex {
         return new AgentJarIndex(prefixes, ClassNameTrie.readFrom(in));
       }
     } catch (Throwable e) {
-      log.error("Unable to read " + AGENT_INDEX_FILE_NAME, e);
+      log.error("Unable to read {}", AGENT_INDEX_FILE_NAME, e);
       return null;
     }
   }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParser.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParser.java
@@ -868,7 +868,7 @@ public enum JDBCConnectionUrlParser {
         try {
           builder.port(Integer.parseInt(portNumber));
         } catch (final NumberFormatException e) {
-          ExceptionLogger.LOGGER.debug("Error parsing portnumber property: " + portNumber, e);
+          ExceptionLogger.LOGGER.debug("Error parsing portnumber property: {}", portNumber, e);
         }
       }
 
@@ -877,7 +877,7 @@ public enum JDBCConnectionUrlParser {
         try {
           builder.port(Integer.parseInt(portNumber));
         } catch (final NumberFormatException e) {
-          ExceptionLogger.LOGGER.debug("Error parsing portNumber property: " + portNumber, e);
+          ExceptionLogger.LOGGER.debug("Error parsing portNumber property: {}", portNumber, e);
         }
       }
     }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -121,8 +121,10 @@ public class DebuggerTransformer implements ClassFileTransformer {
                   }
                 });
       } catch (IOException ex) {
-        log.warn("Error reading exclude file '{}' for Instrument-The-World: ", fileName, ex);
-      }
+        log.warn(
+            "Error reading exclude file '{}' for Instrument-The-World. Exception: {}",
+            fileName,
+            ex.getMessage());      }
     }
   }
 
@@ -328,7 +330,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
     try {
       classNode.accept(writer);
     } catch (Throwable t) {
-      log.error("Cannot write classfile for class: {}", classFilePath, t);
+      log.error("Cannot write classfile for class: {} Exception: ", classFilePath, t.getMessage());
     }
     byte[] data = writer.toByteArray();
     dumpInstrumentedClassFile(classFilePath, data);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -1,8 +1,5 @@
 package com.datadog.debugger.agent;
 
-import static java.util.Collections.singletonList;
-import static java.util.stream.Collectors.toList;
-
 import com.datadog.debugger.instrumentation.DiagnosticMessage;
 import com.datadog.debugger.instrumentation.InstrumentationResult;
 import com.datadog.debugger.probe.LogProbe;
@@ -13,6 +10,23 @@ import datadog.trace.agent.tooling.AgentStrategies;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.ProbeId;
 import datadog.trace.bootstrap.debugger.ProbeImplementation;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.pool.TypePool;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.LineNumberNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.analysis.Analyzer;
+import org.objectweb.asm.tree.analysis.AnalyzerException;
+import org.objectweb.asm.tree.analysis.BasicValue;
+import org.objectweb.asm.tree.analysis.BasicVerifier;
+import org.objectweb.asm.util.CheckClassAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -35,22 +49,9 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
-import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.pool.TypePool;
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.tree.AbstractInsnNode;
-import org.objectweb.asm.tree.ClassNode;
-import org.objectweb.asm.tree.LineNumberNode;
-import org.objectweb.asm.tree.MethodNode;
-import org.objectweb.asm.tree.analysis.Analyzer;
-import org.objectweb.asm.tree.analysis.AnalyzerException;
-import org.objectweb.asm.tree.analysis.BasicValue;
-import org.objectweb.asm.tree.analysis.BasicVerifier;
-import org.objectweb.asm.util.CheckClassAdapter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
 
 /**
  * Handles transformations of loading classes matching the probe definitions provided by the
@@ -121,10 +122,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
                   }
                 });
       } catch (IOException ex) {
-        log.warn(
-            "Error reading exclude file '{}' for Instrument-The-World. Exception: {}",
-            fileName,
-            ex.getMessage());
+        log.warn("Error reading exclude file '{}' for Instrument-The-World: ", fileName, ex);
       }
     }
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -124,7 +124,8 @@ public class DebuggerTransformer implements ClassFileTransformer {
         log.warn(
             "Error reading exclude file '{}' for Instrument-The-World. Exception: {}",
             fileName,
-            ex.getMessage());      }
+            ex.getMessage());
+      }
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -1,5 +1,8 @@
 package com.datadog.debugger.agent;
 
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+
 import com.datadog.debugger.instrumentation.DiagnosticMessage;
 import com.datadog.debugger.instrumentation.InstrumentationResult;
 import com.datadog.debugger.probe.LogProbe;
@@ -10,23 +13,6 @@ import datadog.trace.agent.tooling.AgentStrategies;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.ProbeId;
 import datadog.trace.bootstrap.debugger.ProbeImplementation;
-import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.pool.TypePool;
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.tree.AbstractInsnNode;
-import org.objectweb.asm.tree.ClassNode;
-import org.objectweb.asm.tree.LineNumberNode;
-import org.objectweb.asm.tree.MethodNode;
-import org.objectweb.asm.tree.analysis.Analyzer;
-import org.objectweb.asm.tree.analysis.AnalyzerException;
-import org.objectweb.asm.tree.analysis.BasicValue;
-import org.objectweb.asm.tree.analysis.BasicVerifier;
-import org.objectweb.asm.util.CheckClassAdapter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -49,9 +35,22 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
-
-import static java.util.Collections.singletonList;
-import static java.util.stream.Collectors.toList;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.pool.TypePool;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.LineNumberNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.analysis.Analyzer;
+import org.objectweb.asm.tree.analysis.AnalyzerException;
+import org.objectweb.asm.tree.analysis.BasicValue;
+import org.objectweb.asm.tree.analysis.BasicVerifier;
+import org.objectweb.asm.util.CheckClassAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Handles transformations of loading classes matching the probe definitions provided by the

--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
@@ -31,7 +31,7 @@ public class JMXFetch {
   public static final List<String> DEFAULT_CONFIGS =
       Collections.singletonList("jmxfetch-config.yaml");
 
-  private static final int DELAY_BETWEEN_RUN_ATTEMPTS = 5000;
+  private static final int SLEEP_AFTER_JMXFETCH_EXITS = 5000;
 
   public static void run(final StatsDClientManager statsDClientManager) {
     run(statsDClientManager, Config.get());
@@ -95,7 +95,6 @@ public class JMXFetch {
             // App should be run as daemon otherwise CLI apps would not exit once main method exits.
             .daemon(true)
             .embedded(true)
-            .exitWatcher(new TraceConfigExitWatcher())
             .confdDirectory(jmxFetchConfigDir)
             .yamlFileList(jmxFetchConfigs)
             .targetDirectInstances(true)
@@ -109,7 +108,7 @@ public class JMXFetch {
 
     if (config.isJmxFetchMultipleRuntimeServicesEnabled()) {
       ServiceNameCollectingTraceInterceptor serviceNameProvider =
-          ServiceNameCollectingTraceInterceptor.INSTANCE;
+          new ServiceNameCollectingTraceInterceptor();
       GlobalTracer.get().addTraceInterceptor(serviceNameProvider);
 
       configBuilder.serviceNameProvider(serviceNameProvider);
@@ -132,9 +131,10 @@ public class JMXFetch {
                   if (!appConfig.getExitWatcher().shouldExit()) {
                     try {
                       final int result = app.run();
-                      log.error("jmx collector exited with result: " + result);
+                      log.error("jmx collector exited with result: {}", result);
                     } catch (final Exception e) {
                       log.error("Exception in jmx collector thread", e);
+
                     }
                   }
                   // always wait before next attempt

--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
@@ -31,7 +31,7 @@ public class JMXFetch {
   public static final List<String> DEFAULT_CONFIGS =
       Collections.singletonList("jmxfetch-config.yaml");
 
-  private static final int SLEEP_AFTER_JMXFETCH_EXITS = 5000;
+  private static final int DELAY_BETWEEN_RUN_ATTEMPTS = 5000;
 
   public static void run(final StatsDClientManager statsDClientManager) {
     run(statsDClientManager, Config.get());
@@ -108,7 +108,7 @@ public class JMXFetch {
 
     if (config.isJmxFetchMultipleRuntimeServicesEnabled()) {
       ServiceNameCollectingTraceInterceptor serviceNameProvider =
-          new ServiceNameCollectingTraceInterceptor();
+          ServiceNameCollectingTraceInterceptor.INSTANCE;
       GlobalTracer.get().addTraceInterceptor(serviceNameProvider);
 
       configBuilder.serviceNameProvider(serviceNameProvider);
@@ -134,7 +134,6 @@ public class JMXFetch {
                       log.error("jmx collector exited with result: {}", result);
                     } catch (final Exception e) {
                       log.error("Exception in jmx collector thread", e);
-
                     }
                   }
                   // always wait before next attempt

--- a/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
+++ b/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
@@ -159,7 +159,7 @@ public class ProfilingAgent {
         log.warn(e.getMessage());
         log.debug("", e);
       } catch (final ConfigurationException e) {
-        log.warn("Failed to initialize profiling agent! " + e.getMessage());
+        log.warn("Failed to initialize profiling agent! {}", e.getMessage());
         log.debug("Failed to initialize profiling agent!", e);
       }
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentCLI.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentCLI.java
@@ -128,7 +128,7 @@ public final class AgentCLI {
 
   private static void unzipJar(Consumer<File> invoker, File file) throws IOException {
     try (JarFile jar = new JarFile(file)) {
-      log.debug("Finding entries in file:" + file.getName());
+      log.debug("Finding entries in file: {}", file.getName());
 
       jar.stream()
           .forEach(

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/KnownTypesIndex.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/KnownTypesIndex.java
@@ -70,7 +70,7 @@ public final class KnownTypesIndex {
         }
         return new KnownTypesIndex(multipleIdTable, ClassNameTrie.readFrom(in));
       } catch (Throwable e) {
-        log.error("Problem reading " + KNOWN_TYPES_INDEX_NAME, e);
+        log.error("Problem reading {}", KNOWN_TYPES_INDEX_NAME, e);
       }
     }
     return buildIndex(); // fallback to runtime generation when testing

--- a/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/csi/StringConcatExample.java
+++ b/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/csi/StringConcatExample.java
@@ -11,7 +11,7 @@ public class StringConcatExample implements BiFunction<String, String, String> {
   public String apply(final String first, final String second) {
     LOGGER.debug("Before apply");
     final String result = first.concat(second);
-    LOGGER.debug("After apply " + result);
+    LOGGER.debug("After apply {}", result);
     return result;
   }
 }

--- a/dd-java-agent/agent-tooling/src/test/java11/datadog/trace/agent/tooling/csi/StringPlusConstantsExample.java
+++ b/dd-java-agent/agent-tooling/src/test/java11/datadog/trace/agent/tooling/csi/StringPlusConstantsExample.java
@@ -11,7 +11,7 @@ public class StringPlusConstantsExample implements TriFunction<String, String, S
   public String apply(final String first, final String second, final String third) {
     LOGGER.debug("Before apply");
     final String result = first + " " + second + " " + third;
-    LOGGER.debug("After apply " + result);
+    LOGGER.debug("After apply {}", result);
     return result;
   }
 }

--- a/dd-java-agent/agent-tooling/src/test/java11/datadog/trace/agent/tooling/csi/StringPlusExample.java
+++ b/dd-java-agent/agent-tooling/src/test/java11/datadog/trace/agent/tooling/csi/StringPlusExample.java
@@ -11,7 +11,7 @@ public class StringPlusExample implements TriFunction<String, String, String, St
   public String apply(final String first, final String second, final String third) {
     LOGGER.debug("Before apply");
     final String result = first + second + third;
-    LOGGER.debug("After apply " + result);
+    LOGGER.debug("After apply {}", result);
     return result;
   }
 }

--- a/dd-java-agent/agent-tooling/src/test/java11/datadog/trace/agent/tooling/csi/StringPlusLoadWithTagsExample.java
+++ b/dd-java-agent/agent-tooling/src/test/java11/datadog/trace/agent/tooling/csi/StringPlusLoadWithTagsExample.java
@@ -11,7 +11,7 @@ public class StringPlusLoadWithTagsExample implements TriFunction<String, String
   public String apply(final String first, final String second, final String third) {
     LOGGER.debug("Before apply");
     final String result = first + " \u0002 " + second + " \u0001 " + third;
-    LOGGER.debug("After apply " + result);
+    LOGGER.debug("After apply {}", result);
     return result;
   }
 }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
@@ -184,7 +184,7 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
       try {
         listener.onNewSubconfig(newConfig.get(key), reconfiguration);
       } catch (Exception rte) {
-        log.warn("Error updating configuration of app sec module listening on key " + key, rte);
+        log.warn("Error updating configuration of app sec module listening on key {}", key, rte);
       }
     }
   }

--- a/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPDecorator.java
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/main/java/datadog/trace/instrumentation/jsp/JSPDecorator.java
@@ -72,7 +72,7 @@ public class JSPDecorator extends BaseDecorator {
           "jsp.requestURL", (new URI(req.getRequestURL().toString())).normalize().toString());
     } catch (final URISyntaxException uriSE) {
       LoggerFactory.getLogger(HttpJspPage.class)
-          .debug("Failed to get and normalize request URL: " + uriSE.getMessage());
+          .debug("Failed to get and normalize request URL: {}", uriSE.getMessage());
     }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceStructureWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceStructureWriter.java
@@ -64,7 +64,7 @@ public class TraceStructureWriter implements Writer {
             argsDebugLog = true;
             break;
           default:
-            log.warn("Illegal TraceStructureWriter argument '" + args[i] + "'");
+            log.warn("Illegal TraceStructureWriter argument '{}'", args[i]);
             break;
         }
       }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDEvpProxyApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDEvpProxyApi.java
@@ -85,7 +85,7 @@ public class DDEvpProxyApi extends RemoteApi {
 
       final HttpRetryPolicy.Factory retryPolicyFactory = new HttpRetryPolicy.Factory(5, 100, 2.0);
 
-      log.debug("proxiedApiUrl: " + proxiedApiUrl);
+      log.debug("proxiedApiUrl: {}", proxiedApiUrl);
       return new DDEvpProxyApi(client, proxiedApiUrl, subdomain, retryPolicyFactory);
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -736,7 +736,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         addTraceInterceptor(interceptor);
       }
     } catch (final ServiceConfigurationError e) {
-      log.warn("Problem loading TraceInterceptor for classLoader: " + classLoader, e);
+      log.warn("Problem loading TraceInterceptor for classLoader: {}", classLoader, e);
     }
   }
 

--- a/dd-trace-ot/correlation-id-injection/src/main/java/datadog/trace/correlation/CorrelationIdInjectors.java
+++ b/dd-trace-ot/correlation-id-injection/src/main/java/datadog/trace/correlation/CorrelationIdInjectors.java
@@ -38,7 +38,7 @@ public final class CorrelationIdInjectors {
       Class<?> injectorClass = Class.forName(className);
       injectorClass.getConstructor(InternalTracer.class).newInstance(tracer);
     } catch (ReflectiveOperationException e) {
-      log.warn("Failed to enable injector " + className + ".", e);
+      log.warn("Failed to enable injector {}.", className, e);
     }
   }
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -799,7 +799,8 @@ public class Config {
         tmpApiKey =
             new String(Files.readAllBytes(Paths.get(apiKeyFile)), StandardCharsets.UTF_8).trim();
       } catch (final IOException e) {
-        log.error("Cannot read API key from file {}, skipping", apiKeyFile, e);
+        log.error(
+            "Cannot read API key from file {}, skipping. Exception {}", apiKeyFile, e.getMessage());
       }
     }
     site = configProvider.getString(SITE, DEFAULT_SITE);

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
@@ -249,7 +249,7 @@ public final class ConfigProvider {
     try {
       return value == null ? defaultValue : ConfigConverter.parseIntegerRangeSet(value, key);
     } catch (final NumberFormatException e) {
-      log.warn("Invalid configuration for " + key, e);
+      log.warn("Invalid configuration for {}", key, e);
       return defaultValue;
     }
   }

--- a/remote-config/src/main/java/datadog/remoteconfig/state/ProductState.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/state/ProductState.java
@@ -80,7 +80,7 @@ public class ProductState {
       try {
         callListenerCommit(hinter);
       } catch (Exception ex) {
-        log.error("Error committing changes for product" + product, ex);
+        log.error("Error committing changes for product {}", product, ex);
       }
     }
 


### PR DESCRIPTION
# What Does This Do
debug, error and warn logging statements that report both a resource and an exception have been changed so they use placeholders instead of string operations.

# Motivation
Exception reports filed by DDLogger will be sent to our servers using the telemetry API. If the message is composed using placeholders instead of string operations, the placeholders will not be substituted when sending this information over the wire to the telemetry API. This will make sure we don't send any sensitive information to the telemetry service once the telemetry API is merged.

# Additional Notes
This changes are related to the new telemetry functionality implemented by https://github.com/DataDog/dd-trace-java/pull/4521
