### PR TITLE
pin buildx version for publishing to GCP

### DIFF
--- a/.github/workflows/lib-injection.yaml
+++ b/.github/workflows/lib-injection.yaml
@@ -27,6 +27,8 @@ jobs:
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # 2.0.0
+      with:
+        version: v0.9.1 # https://github.com/docker/buildx/issues/1533
 
     - name: Set up Docker platforms
       id: buildx-platforms


### PR DESCRIPTION
# What Does This Do

There is a slack thread where lib injection images cannot be pushed to GCR due to changes to buildx

# Motivation

# Additional Notes
