### PR TITLE
Reuse TaintedMap instances in IAST

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastRequestContext.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastRequestContext.java
@@ -21,7 +21,7 @@ public class IastRequestContext {
     this.vulnerabilityBatch = new VulnerabilityBatch();
     this.spanDataIsSet = new AtomicBoolean(false);
     this.overheadContext = new OverheadContext();
-    this.taintedObjects = TaintedObjects.build();
+    this.taintedObjects = TaintedObjects.acquire();
   }
 
   public VulnerabilityBatch getVulnerabilityBatch() {

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedObjectsLogTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedObjectsLogTest.groovy
@@ -29,7 +29,7 @@ class TaintedObjectsLogTest extends DDSpecification {
     given:
     IastSystem.DEBUG = true
     logger.setLevel(Level.ALL)
-    TaintedObjects taintedObjects = TaintedObjects.build()
+    TaintedObjects taintedObjects = TaintedObjects.acquire()
     final value = "A"
 
     when:
@@ -51,7 +51,7 @@ class TaintedObjectsLogTest extends DDSpecification {
     given:
     IastSystem.DEBUG = true
     logger.setLevel(Level.ALL)
-    TaintedObjects taintedObjects = TaintedObjects.build()
+    TaintedObjects taintedObjects = TaintedObjects.acquire()
     taintedObjects.taint("A", [new Range(0, 1, new Source(SourceType.NONE, null, null))] as Range[])
     taintedObjects.taintInputString("B", new Source(SourceType.REQUEST_PARAMETER_NAME, 'test', 'value'))
 


### PR DESCRIPTION
# What Does This Do
Use an object pool for `TaintedObject` instances.

# Motivation

Allocating 16k TaintedObject[] tables within TaintedMap creates a considerable GC churn. We use a small object pool for TaintedObjets instead, and use it to reuse instances between requests.

Note that, with asynchronous processing, there might be cases where a request gets a TaintedObject instance that is already being used by next request. This should be no problem: usually get calls will find nothing.

This change means that TaintedMap.clear needs to be thread-safe, so added tests checking that.

# Additional Notes
