### PR TITLE
Fix log template evaluation

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
@@ -262,7 +262,7 @@ public class Snapshot {
       String currentProbeId = entry.getKey();
       SnapshotStatus status = entry.getValue();
       if (evaluateConditions(status.probeDetails, methodLocation)) {
-        DebuggerScript script = status.probeDetails.getScript();
+        DebuggerScript<Boolean> script = status.probeDetails.getScript();
         if (!executeScript(script, capture, currentProbeId)) {
           status.sending = false;
           status.capturing = false; // force to stop capturing
@@ -298,7 +298,7 @@ public class Snapshot {
   }
 
   private static boolean executeScript(
-      DebuggerScript script, CapturedContext capture, String probeId) {
+      DebuggerScript<Boolean> script, CapturedContext capture, String probeId) {
     if (script == null) {
       return true;
     }
@@ -384,7 +384,7 @@ public class Snapshot {
         ProbeLocation location,
         MethodLocation evaluateAt,
         boolean captureSnapshot,
-        DebuggerScript script,
+        DebuggerScript<Boolean> script,
         String tags,
         SummaryBuilder summaryBuilder) {
       this(
@@ -403,7 +403,7 @@ public class Snapshot {
         ProbeLocation location,
         MethodLocation evaluateAt,
         boolean captureSnapshot,
-        DebuggerScript script,
+        DebuggerScript<Boolean> script,
         String tags,
         SummaryBuilder summaryBuilder,
         List<ProbeDetails> additionalProbes) {
@@ -429,7 +429,7 @@ public class Snapshot {
       return evaluateAt;
     }
 
-    public DebuggerScript getScript() {
+    public DebuggerScript<Boolean> getScript() {
       return script;
     }
 

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/DebuggerScript.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/DebuggerScript.java
@@ -5,6 +5,6 @@ package datadog.trace.bootstrap.debugger.el;
  * debugger EL.<br>
  * Because it must be reachable from the instrumented code it must be placed in bootstrap.
  */
-public interface DebuggerScript {
-  boolean execute(ValueReferenceResolver valueRefResolver);
+public interface DebuggerScript<R> {
+  R execute(ValueReferenceResolver valueRefResolver);
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/ProbeCondition.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/ProbeCondition.java
@@ -13,7 +13,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 
 /** Implements expression language for probe condition */
-public final class ProbeCondition implements DebuggerScript {
+public final class ProbeCondition implements DebuggerScript<Boolean> {
   public static final ProbeCondition NONE = new ProbeCondition(null, "");
 
   private final String dslExpression;
@@ -95,7 +95,7 @@ public final class ProbeCondition implements DebuggerScript {
   }
 
   @Override
-  public boolean execute(ValueReferenceResolver valueRefResolver) {
+  public Boolean execute(ValueReferenceResolver valueRefResolver) {
     if (when == null) {
       return true;
     }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/ValueScript.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/ValueScript.java
@@ -15,12 +15,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /** Implements expression language for capturing values for metric probes */
-public class ValueScript implements DebuggerScript {
+public class ValueScript implements DebuggerScript<Value<?>> {
   private static final Pattern PERIOD_PATTERN = Pattern.compile("\\.");
   private static final Pattern INDEX_PATTERN = Pattern.compile("(.+)\\[([^]]+)]");
   private final ValueExpression<?> expr;
   private final String dsl;
-  private Value<?> result;
 
   public ValueScript(ValueExpression<?> expr, String dsl) {
     this.expr = expr;
@@ -32,13 +31,8 @@ public class ValueScript implements DebuggerScript {
   }
 
   @Override
-  public boolean execute(ValueReferenceResolver valueRefResolver) {
-    result = expr.evaluate(valueRefResolver);
-    return true;
-  }
-
-  public Value<?> getResult() {
-    return result;
+  public Value<?> execute(ValueReferenceResolver valueRefResolver) {
+    return expr.evaluate(valueRefResolver);
   }
 
   @Override

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
@@ -107,15 +107,16 @@ public class MetricInstrumentor extends Instrumentor {
   private InsnList internalCallMetric(
       String metricMethodName, MetricProbe metricProbe, InsnList insnList) {
     InsnList nullBranch = new InsnList();
+    Value<?> result;
     try {
-      metricProbe
-          .getValue()
-          .execute(new CompileToInsnList(classNode, methodNode, Type.LONG_TYPE, nullBranch));
+      result =
+          metricProbe
+              .getValue()
+              .execute(new CompileToInsnList(classNode, methodNode, Type.LONG_TYPE, nullBranch));
     } catch (InvalidValueException ex) {
       reportError(ex.getMessage());
       return EMPTY_INSN_LIST;
     }
-    Value<?> result = metricProbe.getValue().getResult();
     if (result.isNull() || result.isUndefined()) {
       return EMPTY_INSN_LIST;
     }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogMessageTemplateSummaryBuilderTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogMessageTemplateSummaryBuilderTest.java
@@ -64,6 +64,27 @@ class LogMessageTemplateSummaryBuilderTest {
   }
 
   @Test
+  public void argMultipleInFlightTemplate() {
+    LogProbe probe = LogProbe.builder().template("{arg}").build();
+    LogMessageTemplateSummaryBuilder summaryBuilder = new LogMessageTemplateSummaryBuilder(probe);
+    Snapshot.CapturedContext capturedContext = new Snapshot.CapturedContext();
+    capturedContext.addArguments(
+        new Snapshot.CapturedValue[] {
+          Snapshot.CapturedValue.of("arg", String.class.getTypeName(), "foo")
+        });
+    summaryBuilder.addEntry(capturedContext);
+    LogMessageTemplateSummaryBuilder summaryBuilder2 = new LogMessageTemplateSummaryBuilder(probe);
+    Snapshot.CapturedContext capturedContext2 = new Snapshot.CapturedContext();
+    capturedContext2.addArguments(
+        new Snapshot.CapturedValue[] {
+          Snapshot.CapturedValue.of("arg", String.class.getTypeName(), "bar")
+        });
+    summaryBuilder2.addEntry(capturedContext2);
+    assertEquals("foo", summaryBuilder.build());
+    assertEquals("bar", summaryBuilder2.build());
+  }
+
+  @Test
   public void argNullTemplate() {
     LogProbe probe = LogProbe.builder().template("{nullObject}").build();
     LogMessageTemplateSummaryBuilder summaryBuilder = new LogMessageTemplateSummaryBuilder(probe);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
@@ -217,7 +217,7 @@ public class SnapshotSerializationTest {
                 PROBE_LOCATION,
                 Snapshot.MethodLocation.DEFAULT,
                 true,
-                new ProbeCondition(DSL.when(DSL.gt(DSL.ref("^n"), DSL.value(0))), "^n > 0"),
+                new ProbeCondition(DSL.when(DSL.gt(DSL.ref("^n"), DSL.value(0))), "n > 0"),
                 "",
                 new SnapshotSummaryBuilder(PROBE_LOCATION)),
             String.class.getTypeName());
@@ -231,8 +231,7 @@ public class SnapshotSerializationTest {
     Snapshot deserializedSnapshot = adapter.fromJson(buffer);
     Assert.assertTrue(deserializedSnapshot.getProbe().getScript() instanceof ProbeCondition);
     Assert.assertEquals(
-        "^n > 0",
-        ((ProbeCondition) deserializedSnapshot.getProbe().getScript()).getDslExpression());
+        "n > 0", ((ProbeCondition) deserializedSnapshot.getProbe().getScript()).getDslExpression());
   }
 
   static class AnotherClass {


### PR DESCRIPTION
# What Does This Do
ValueScript is storing result value in a field which can be overwritten by another execution. Now the execute method returns directly the result value and ValueScript became effectively stateless regarding execution.

# Motivation
Bug in log template evaluation for concurrent requests

# Additional Notes
