### PR TITLE
Add flag to disable collection of exception messages in exception profiling

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionProfiling.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionProfiling.java
@@ -24,14 +24,22 @@ public final class ExceptionProfiling {
 
   private final ExceptionHistogram histogram;
   private final ExceptionSampler sampler;
+  private final boolean recordExceptionMessage;
 
   private ExceptionProfiling(final Config config) {
-    this(new ExceptionSampler(config), new ExceptionHistogram(config));
+    this(
+        new ExceptionSampler(config),
+        new ExceptionHistogram(config),
+        config.isProfilingRecordExceptionMessage());
   }
 
-  ExceptionProfiling(final ExceptionSampler sampler, final ExceptionHistogram histogram) {
+  ExceptionProfiling(
+      final ExceptionSampler sampler,
+      final ExceptionHistogram histogram,
+      boolean recordExceptionMessage) {
     this.sampler = sampler;
     this.histogram = histogram;
+    this.recordExceptionMessage = recordExceptionMessage;
   }
 
   public ExceptionSampleEvent process(final Throwable t) {
@@ -43,5 +51,9 @@ public final class ExceptionProfiling {
       return new ExceptionSampleEvent(t, sampled, firstHit);
     }
     return null;
+  }
+
+  boolean recordExceptionMessage() {
+    return recordExceptionMessage;
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionSampleEvent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionSampleEvent.java
@@ -50,10 +50,12 @@ public class ExceptionSampleEvent extends Event implements ContextualEvent {
   }
 
   private static String getMessage(Throwable t) {
-    try {
-      return t.getMessage();
-    } catch (Throwable ignored) {
-      // apparently there might be exceptions throwing at least NPE when trying to get the message
+    if (ExceptionProfiling.getInstance().recordExceptionMessage()) {
+      try {
+        return t.getMessage();
+      } catch (Throwable ignored) {
+        // apparently there might be exceptions throwing at least NPE when trying to get the message
+      }
     }
     return null;
   }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -42,6 +42,9 @@ public final class ProfilingConfig {
   public static final String PROFILING_PROXY_PASSWORD = "profiling.proxy.password";
   public static final String PROFILING_EXCEPTION_SAMPLE_LIMIT = "profiling.exception.sample.limit";
   public static final int PROFILING_EXCEPTION_SAMPLE_LIMIT_DEFAULT = 10_000;
+  public static final String PROFILING_EXCEPTION_RECORD_MESSAGE =
+      "profiling.exception.record.message";
+  public static final boolean PROFILING_EXCEPTION_RECORD_MESSAGE_DEFAULT = true;
 
   public static final String PROFILING_DIRECT_ALLOCATION_SAMPLE_LIMIT =
       "profiling.direct.allocation.sample.limit";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -176,6 +176,8 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTO
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_HISTOGRAM_TOP_ITEMS_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_RECORD_MESSAGE;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_RECORD_MESSAGE_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCEPTION_SAMPLE_LIMIT_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_EXCLUDE_AGENT_THREADS;
@@ -492,6 +494,7 @@ public class Config {
   private final int profilingExceptionHistogramMaxCollectionSize;
   private final boolean profilingExcludeAgentThreads;
   private final boolean profilingUploadSummaryOn413Enabled;
+  private final boolean profilingRecordExceptionMessage;
 
   private final boolean crashTrackingAgentless;
   private final Map<String, String> crashTrackingTags;
@@ -1118,6 +1121,10 @@ public class Config {
             PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE_DEFAULT);
 
     profilingExcludeAgentThreads = configProvider.getBoolean(PROFILING_EXCLUDE_AGENT_THREADS, true);
+
+    profilingRecordExceptionMessage =
+        configProvider.getBoolean(
+            PROFILING_EXCEPTION_RECORD_MESSAGE, PROFILING_EXCEPTION_RECORD_MESSAGE_DEFAULT);
 
     profilingUploadSummaryOn413Enabled =
         configProvider.getBoolean(
@@ -1794,6 +1801,10 @@ public class Config {
 
   public boolean isProfilingUploadSummaryOn413Enabled() {
     return profilingUploadSummaryOn413Enabled;
+  }
+
+  public boolean isProfilingRecordExceptionMessage() {
+    return profilingRecordExceptionMessage;
   }
 
   public boolean isDatadogProfilerEnabled() {


### PR DESCRIPTION
# What Does This Do

Allows users to opt out of exception message capture by setting `-Ddd.profiling.exception.record.message=false` or `DD_PROFILING_EXCEPTION_RECORD_MESSAGE=false`

# Motivation

# Additional Notes
