### PR TITLE
avoid noisy error message on Mac OS or Windows

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -61,16 +61,17 @@ public final class DatadogProfiler {
   }
 
   private static void logFailedInstantiation(Throwable error) {
-    if (log.isDebugEnabled()) {
+    OperatingSystem os = OperatingSystem.current();
+    if (os != OperatingSystem.linux) {
+      log.debug("Datadog profiler only supported on Linux", error);
+    } else if (log.isDebugEnabled()) {
       log.warn(
-          String.format(
-              "failed to instantiate Datadog profiler on %s %s",
-              OperatingSystem.current(), Arch.current()),
+          String.format("failed to instantiate Datadog profiler on %s %s", os, Arch.current()),
           error);
     } else {
       log.warn(
           "failed to instantiate Datadog profiler on {} {} because: {}",
-          OperatingSystem.current(),
+          os,
           Arch.current(),
           error.getMessage());
     }


### PR DESCRIPTION
# What Does This Do

We don't support Mac OS or Windows so we shouldn't log a frightening message if we can't load the profiler and fall back to JFR

# Motivation

# Additional Notes
