### PR TITLE
Fix NPE when the configured log file doesn't have a path (current directory)

### DIFF
--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/simplelogger/SLCompatSettings.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/simplelogger/SLCompatSettings.java
@@ -173,8 +173,10 @@ public class SLCompatSettings {
         FileOutputStream outputStream = null;
         try {
           File outputFile = new File(logFile);
-          outputFile.getParentFile().mkdirs();
-
+          File parentFile = outputFile.getParentFile();
+          if (parentFile != null) {
+            parentFile.mkdirs();
+          }
           outputStream = new FileOutputStream(outputFile);
           PrintStream printStream = new PrintStream(outputStream, true);
           return printStream;


### PR DESCRIPTION
# What Does This Do
Prevent a NPE when the system property datadog.slf4j.simpleLogger.logFile doesn't contain a path, only a filename.

# Motivation


# Additional Notes
