### PR TITLE
Fix incorrect arg name for already traced methods

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
@@ -6,6 +6,8 @@ import com.datadog.debugger.probe.ProbeDefinition;
 import com.datadog.debugger.probe.Where;
 import datadog.trace.bootstrap.debugger.DiagnosticMessage;
 import datadog.trace.bootstrap.debugger.DiagnosticMessage.Kind;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -38,7 +40,7 @@ public class Instrumentor {
   protected final LabelNode methodEnterLabel;
   protected int localVarBaseOffset;
   protected int argOffset;
-  protected final String[] argumentNames;
+  protected final LocalVariableNode[] localVarsBySlot;
   protected LabelNode returnHandlerLabel;
 
   public Instrumentor(
@@ -61,7 +63,35 @@ public class Instrumentor {
     for (Type t : argTypes) {
       argOffset += t.getSize();
     }
-    argumentNames = extractArgumentNames(argTypes);
+    localVarsBySlot = extractLocalVariables(argTypes);
+  }
+
+  private LocalVariableNode[] extractLocalVariables(Type[] argTypes) {
+    if (methodNode.localVariables == null || methodNode.localVariables.isEmpty()) {
+      return new LocalVariableNode[0];
+    }
+    List<LocalVariableNode> sortedLocalVars = new ArrayList<>(methodNode.localVariables);
+    sortedLocalVars.sort(Comparator.comparingInt(o -> o.index));
+    int maxIndex = sortedLocalVars.get(sortedLocalVars.size() - 1).index;
+    LocalVariableNode[] localVars = new LocalVariableNode[maxIndex + 1];
+    localVarBaseOffset = sortedLocalVars.get(0).index;
+    for (LocalVariableNode localVariableNode : sortedLocalVars) {
+      localVars[localVariableNode.index] = localVariableNode;
+    }
+    // assume that first local variables matches method arguments
+    // as stated into the JVM spec:
+    // https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-2.html#jvms-2.6.1
+    // so we reassigned local var in arg slots if they are empty
+    int slot = isStatic ? 0 : 1;
+    int localVarTableIdx = slot;
+    for (Type t : argTypes) {
+      if (localVars[slot] == null) {
+        localVars[slot] = sortedLocalVars.get(localVarTableIdx);
+      }
+      slot += t.getSize();
+      localVarTableIdx++;
+    }
+    return localVars;
   }
 
   private String[] extractArgumentNames(Type[] argTypes) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/LogInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/LogInstrumentor.java
@@ -261,7 +261,11 @@ public final class LogInstrumentor extends Instrumentor {
     int counter = 0;
     int slot = isStatic ? 0 : 1;
     for (Type argType : argTypes) {
-      String currentArgName = argumentNames[slot];
+      String currentArgName = null;
+      if (localVarsBySlot.length > 0) {
+        LocalVariableNode localVarNode = localVarsBySlot[slot];
+        currentArgName = localVarNode != null ? localVarNode.name : null;
+      }
       if (currentArgName == null) {
         // if argument names are not resolved correctly let's assign p+arg_index
         currentArgName = "p" + counter;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
@@ -348,7 +348,11 @@ public class MetricInstrumentor extends Instrumentor {
       int counter = 0;
       int slot = isStatic ? 0 : 1;
       for (Type argType : argTypes) {
-        String currentArgName = argumentNames[slot];
+        String currentArgName = null;
+        if (localVarsBySlot.length > 0) {
+          LocalVariableNode localVarNode = localVarsBySlot[slot];
+          currentArgName = localVarNode != null ? localVarNode.name : null;
+        }
         if (currentArgName == null) {
           // if argument names are not resolved correctly let's assign p+arg_index
           currentArgName = "p" + counter;

--- a/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/controller/WebController.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/controller/WebController.java
@@ -7,6 +7,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class WebController {
   @RequestMapping("/greeting")
   public String greeting() {
+    processWithArg(42);
     return "Sup Dawg";
+  }
+
+  private void processWithArg(int argInt) {
+    System.out.println(argInt);
   }
 }


### PR DESCRIPTION
# What Does This Do
The fix consists to reassigned local var information to arg slot. 
Added smoke tests for this case.

# Motivation
When instrumenting a method with a debugger probe that contains also tracer instrumentation (using @trace annotation or `trace.methods` property) argument names was not mapped correctly and p0, p1, appears in the snapshot.
This is due to ByteBuddy transformation messing up the LocalVariableTable that helps to maps local vars with names. Args are also local vars and following the JVM spec, the first local vars must match the methods args.
LocalVariableTable is optional and only used for debugger so it does not prevent the actual execution of the method.

# Additional Notes
Example with petclinic:

`VetController.processWithArg` method:
```
      LocalVariableTable:
        Start  Length  Slot  Name   Signature
            0       8     0  this   Lorg/springframework/samples/petclinic/vet/VetController;
            0       8     1   obj   Ljava/lang/Object;
```
When we start with -Ddd.trace.methods=org.springframework.samples.petclinic.vet.VetController[processWithArg]
```
      LocalVariableTable:
        Start  Length  Slot  Name   Signature
          186      11     0  this   Lorg/springframework/samples/petclinic/vet/VetController;
          186      11     4   obj   Ljava/lang/Object;
```
This case works beside the [JVM specification](https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-2.html#jvms-2.6.1), because the slot 1 is still assigned to the parameter, instrumented bytcode do some dance with it to conform with the new `LocalVariableTable`:
```
       220: aload_1
       221: astore        4
       223: nop
       224: getstatic     #16                 // Field java/lang/System.out:Ljava/io/PrintStream;
       227: aload         4
       229: invokevirtual #52                 // Method java/io/PrintStream.println:(Ljava/lang/Object;)V
```
Before calling the original code `System.out.println(obj)`
we load from slot 1 the actual parameter of the method (obj) into the stack and store it back into slot 4 to match the `LocalVariableTable`