### PR TITLE
Add support for `this` as object reference in Expression Language

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
@@ -666,10 +666,6 @@ public class Snapshot {
         String rawName = name.substring(ValueReferences.SYNTHETIC_PREFIX.length());
         target = tryRetrieveSynthetic(rawName);
         checkUndefined(name, target, rawName, "Cannot find synthetic var: ");
-      } else if (name.startsWith(ValueReferences.FIELD_PREFIX)) {
-        String rawName = name.substring(ValueReferences.FIELD_PREFIX.length());
-        target = tryRetrieveField(rawName);
-        checkUndefined(name, target, rawName, "Cannot find field: ");
       } else {
         target = tryRetrieve(name);
         checkUndefined(name, target, name, "Cannot find symbol: ");

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ValueReferences.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ValueReferences.java
@@ -8,7 +8,7 @@ package datadog.trace.bootstrap.debugger.el;
 public final class ValueReferences {
 
   public static String SYNTHETIC_PREFIX = "@";
-  public static String FIELD_PREFIX = "this.";
+  public static String THIS = "this";
 
   public static String DURATION_EXTENSION_NAME = "duration";
   public static String RETURN_EXTENSION_NAME = "return";
@@ -19,13 +19,5 @@ public final class ValueReferences {
 
   public static String synthetic(String name) {
     return SYNTHETIC_PREFIX + name;
-  }
-
-  public static String field(String name) {
-    return FIELD_PREFIX + name;
-  }
-
-  public static boolean isRefPrefix(String prefix) {
-    return SYNTHETIC_PREFIX.equals(prefix) || FIELD_PREFIX.equals(prefix);
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/Values.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/Values.java
@@ -17,4 +17,12 @@ public final class Values {
           return "NULL";
         }
       };
+
+  public static final Object THIS_OBJECT =
+      new Object() {
+        @Override
+        public String toString() {
+          return "this";
+        }
+      };
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/Value.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/Value.java
@@ -23,6 +23,10 @@ public interface Value<T> {
     return NullValue.INSTANCE;
   }
 
+  static Value<?> thisValue() {
+    return ObjectValue.THIS;
+  }
+
   @SuppressWarnings("unchecked")
   static <T> Value<T> undefined() {
     return (Value<T>) undefinedValue();
@@ -44,6 +48,9 @@ public interface Value<T> {
     }
     if (value == Values.UNDEFINED_OBJECT || value == undefinedValue()) {
       return undefinedValue();
+    }
+    if (value == Values.THIS_OBJECT) {
+      return thisValue();
     }
     if (value instanceof Boolean) {
       return new BooleanValue((Boolean) value);

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ObjectValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ObjectValue.java
@@ -8,6 +8,8 @@ import datadog.trace.bootstrap.debugger.el.Values;
  * other value types: boolean, string, number, collection, null, undefined
  */
 public final class ObjectValue extends Literal<Object> {
+  public static final ObjectValue THIS = new ObjectValue(Values.THIS_OBJECT);
+
   public ObjectValue(Object value) {
     super(value == null ? Values.NULL_OBJECT : value);
   }
@@ -24,6 +26,9 @@ public final class ObjectValue extends Literal<Object> {
     }
     if (value == Values.UNDEFINED_OBJECT) {
       return value.toString();
+    }
+    if (value == Values.THIS_OBJECT) {
+      return "this";
     }
     return value.getClass().getTypeName();
   }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ExpressionTest.java
@@ -64,7 +64,9 @@ class ExpressionTest {
     assertEquals("1 <= 1", le(value(1), value(1)).prettyPrint());
     assertEquals(
         "when(this.strField == \"foo\" && @duration > 0)",
-        when(and(eq(ref("this.strField"), value("foo")), gt(ref("@duration"), value(0))))
+        when(and(
+                eq(getMember(ref("this"), "strField"), value("foo")),
+                gt(ref("@duration"), value(0))))
             .prettyPrint());
     assertEquals(
         "len(list[idx].map)", len(getMember(index(ref("list"), ref("idx")), "map")).prettyPrint());

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
@@ -29,48 +29,61 @@ public class ProbeConditionTest {
     ProbeCondition probeCondition = load("/test_conditional_01.json");
 
     Collection<String> tags = Arrays.asList("hello", "world", "ko");
-    ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, singletonMap("tags", tags));
+    ValueReferenceResolver ctx =
+        RefResolverHelper.createResolver(null, null, singletonMap("tags", tags));
 
     assertTrue(probeCondition.execute(ctx));
 
     Collection<String> tags2 = Arrays.asList("hey", "world", "ko");
     ValueReferenceResolver ctx2 =
-        RefResolverHelper.createResolver(null, singletonMap("tags", tags2));
+        RefResolverHelper.createResolver(null, null, singletonMap("tags", tags2));
     assertFalse(probeCondition.execute(ctx2));
   }
 
   @Test
   void testGetMember() throws Exception {
     ProbeCondition probeCondition = load("/test_conditional_04.json");
-
+    class Obj {
+      Container container = new Container("hello");
+    }
     ValueReferenceResolver ctx =
         RefResolverHelper.createResolver(
+            singletonMap("this", new Obj()),
             singletonMap("container", new Container("world")),
-            singletonMap("container", new Container("hello")));
+            null);
 
     assertTrue(probeCondition.execute(ctx));
-
+    class Obj2 {
+      Container obj = new Container("hello");
+    }
     ValueReferenceResolver ctx2 =
         RefResolverHelper.createResolver(
+            singletonMap("this", new Obj2()),
             singletonMap("container", new Container("world")),
-            singletonMap("obj", new Container("hello")));
+            null);
     assertFalse(probeCondition.execute(ctx2));
   }
 
   @Test
   void testComparisonOperators() throws Exception {
     ProbeCondition probeCondition = load("/test_conditional_05.json");
+    class Obj {
+      int intField1 = 42;
+    }
     ValueReferenceResolver ctx =
-        RefResolverHelper.createResolver(null, singletonMap("intField1", 42));
+        RefResolverHelper.createResolver(singletonMap("this", new Obj()), null, null);
     assertTrue(probeCondition.execute(ctx));
   }
 
   @Test
   void testNullLiteral() throws Exception {
     ProbeCondition probeCondition = load("/test_conditional_06.json");
+    class Obj {
+      Object objField = new Object();
+    }
     ValueReferenceResolver ctx =
         RefResolverHelper.createResolver(
-            singletonMap("nullField", null), singletonMap("objField", new Object()));
+            singletonMap("this", new Obj()), singletonMap("nullField", null), null);
     assertTrue(probeCondition.execute(ctx));
   }
 
@@ -85,7 +98,7 @@ public class ProbeConditionTest {
     strMap.put("bar", "foobar");
     fields.put("strMap", strMap);
     fields.put("idx", 1);
-    ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, fields);
+    ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, null, fields);
     assertTrue(probeCondition.execute(ctx));
   }
 
@@ -94,7 +107,7 @@ public class ProbeConditionTest {
     ProbeCondition probeCondition = load("/test_conditional_08.json");
     Map<String, Object> fields = new HashMap<>();
     fields.put("strField", "foobar");
-    ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, fields);
+    ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, null, fields);
     assertTrue(probeCondition.execute(ctx));
   }
 
@@ -114,7 +127,8 @@ public class ProbeConditionTest {
   void testJsonParsing() throws IOException {
     ProbeCondition probeCondition = load("/test_conditional_02.json");
     Collection<String> vets = Arrays.asList("vet1", "vet2", "vet3");
-    ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, singletonMap("vets", vets));
+    ValueReferenceResolver ctx =
+        RefResolverHelper.createResolver(null, null, singletonMap("vets", vets));
 
     // the condition checks if length of vets > 2
     assertTrue(probeCondition.execute(ctx));

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/RefResolverHelper.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/RefResolverHelper.java
@@ -30,7 +30,12 @@ public class RefResolverHelper {
   }
 
   public static ValueReferenceResolver createResolver(
-      Map<String, Object> locals, Map<String, Object> fields) {
+      Map<String, Object> args, Map<String, Object> locals, Map<String, Object> fields) {
+    Snapshot.CapturedValue[] argValues = null;
+    if (args != null) {
+      argValues = new Snapshot.CapturedValue[args.size()];
+      fillValues(args, argValues);
+    }
     Snapshot.CapturedValue[] localValues = null;
     if (locals != null) {
       localValues = new Snapshot.CapturedValue[locals.size()];
@@ -41,14 +46,18 @@ public class RefResolverHelper {
       fieldValues = new Snapshot.CapturedValue[fields.size()];
       fillValues(fields, fieldValues);
     }
-    return new Snapshot.CapturedContext(null, localValues, null, null, fieldValues);
+    return new Snapshot.CapturedContext(argValues, localValues, null, null, fieldValues);
   }
 
   private static void fillValues(Map<String, Object> fields, Snapshot.CapturedValue[] fieldValues) {
     int index = 0;
     for (Map.Entry<String, Object> entry : fields.entrySet()) {
+      Object value = entry.getValue();
       fieldValues[index++] =
-          Snapshot.CapturedValue.of(entry.getKey(), String.class.getTypeName(), entry.getValue());
+          Snapshot.CapturedValue.of(
+              entry.getKey(),
+              value != null ? value.getClass().getTypeName() : Object.class.getTypeName(),
+              value);
     }
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/HasAllExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/HasAllExpressionTest.java
@@ -145,7 +145,7 @@ class HasAllExpressionTest {
 
   @Test
   void testMapHasAny() {
-    ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, null);
+    ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, null, null);
     Map<String, String> valueMap = new HashMap<>();
     valueMap.put("a", "a");
     valueMap.put("b", "a");

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/HasAnyExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/HasAnyExpressionTest.java
@@ -74,7 +74,7 @@ class HasAnyExpressionTest {
 
   @Test
   void testSingleElementHasAny() {
-    ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, null);
+    ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, null, null);
     ValueExpression<?> targetExpression = new ObjectValue(this);
     HasAnyExpression expression = any(targetExpression, TRUE);
     assertTrue(expression.evaluate(ctx));
@@ -100,7 +100,7 @@ class HasAnyExpressionTest {
 
   @Test
   void testArrayHasAny() {
-    ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, null);
+    ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, null, null);
     ValueExpression<?> targetExpression = DSL.value(new Object[] {this, "hello"});
 
     HasAnyExpression expression = any(targetExpression, TRUE);
@@ -125,7 +125,7 @@ class HasAnyExpressionTest {
 
   @Test
   void testListHasAny() {
-    ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, null);
+    ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, null, null);
     ValueExpression<?> targetExpression = DSL.value(Arrays.asList(this, "hello"));
 
     HasAnyExpression expression = any(targetExpression, TRUE);
@@ -150,7 +150,7 @@ class HasAnyExpressionTest {
 
   @Test
   void testMapHasAny() {
-    ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, null);
+    ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, null, null);
     Map<String, String> valueMap = new HashMap<>();
     valueMap.put("a", "a");
     valueMap.put("b", null);

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ValueRefExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ValueRefExpressionTest.java
@@ -68,7 +68,7 @@ class ValueRefExpressionTest {
     Map<String, Object> exts = new HashMap<>();
     exts.put(ValueReferences.RETURN_EXTENSION_NAME, returnVal);
     exts.put(ValueReferences.DURATION_EXTENSION_NAME, duration);
-    ValueReferenceResolver resolver = RefResolverHelper.createResolver(null, values);
+    ValueReferenceResolver resolver = RefResolverHelper.createResolver(null, null, values);
     resolver = resolver.withExtensions(exts);
 
     ValueRefExpression expression = DSL.ref(ValueReferences.DURATION_REF);

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_01.json
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_01.json
@@ -22,7 +22,7 @@
         {"!=":  [{"ref": "field"}, 0]},
         {"not":  {"==":  [{"ref": "field"}, 0]}},
         {"hasAll":  [{"ref": "field"}, {"eq":  [{"ref": "@it"}, 10]}]},
-        {"isEmpty": {"ref": "this.field2"}}
+        {"isEmpty": {"getmember": [{"ref": "this"}, "field2"]}}
       ]}
     ]
   },

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_04.json
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_04.json
@@ -3,7 +3,9 @@
   "json": {
     "eq": [
       {"getmember": [
-        {"ref": "this.container"},
+        {"getmember": [
+          {"ref": "this"},
+          "container"]},
         "msg"
       ]},
       "hello"

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_05.json
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_05.json
@@ -2,9 +2,9 @@
   "dsl": "this.intField1 == 42 && (this.intField1 > 0 || intField1 >= 0 || intField1 < 50 || intField1 <= 42) && intField1 != 0",
   "json": {
     "and": [
-      { "eq": [{"ref": "this.intField1"}, 42] },
+      { "eq": [{"getmember": [{"ref": "this"}, "intField1"]}, 42] },
       { "or": [
-        {"gt": [{"ref": "this.intField1"}, 0]},
+        {"gt": [{"getmember": [{"ref": "this"}, "intField1"]}, 0]},
         {"ge": [{"ref": "intField1"}, 0]},
         {"lt": [{"ref": "intField1"}, 50]},
         {"le": [{"ref": "intField1"}, 42]}

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_06.json
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_06.json
@@ -2,7 +2,7 @@
   "dsl": "this.objField != null && nullField == null",
   "json": {
     "and": [
-      {"ne": [{"ref": "this.objField"}, null]},
+      {"ne": [{"getmember": [{"ref": "this"}, "objField"]}, null]},
       {"eq": [{"ref": "nullField"}, null]}
     ]
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/LogMessageTemplateSummaryBuilder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/LogMessageTemplateSummaryBuilder.java
@@ -249,7 +249,7 @@ public class LogMessageTemplateSummaryBuilder implements SummaryBuilder {
     }
 
     private void maxFieldCount(Field field) {
-      sb.append("...");
+      sb.append(", ...");
     }
 
     @Override

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
@@ -214,6 +214,10 @@ public class MoshiSnapshotHelper {
       List<Snapshot.CapturedValue> values = new ArrayList<>();
       while (jsonReader.hasNext()) {
         String name = jsonReader.nextName();
+        if (NOT_CAPTURED_REASON.equals(name)) {
+          jsonReader.nextString();
+          continue;
+        }
         Snapshot.CapturedValue capturedValue = valueAdapter.fromJson(jsonReader);
         if (capturedValue != null) {
           capturedValue.setName(name);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CaptureAssertionHelper.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CaptureAssertionHelper.java
@@ -89,6 +89,7 @@ class CaptureAssertionHelper {
       // no entry/exit for line probe
       return;
     }
+    addThis(expectedEntryContext, captures.getEntry());
     assertEquals(expectedEntryContext, captures.getEntry());
     if (exceptionKind != DebuggerTransformerTest.ExceptionKind.UNHANDLED) {
       // no return context is captured for unhandled exceptions
@@ -99,9 +100,16 @@ class CaptureAssertionHelper {
               returnValues.get(exceptionKind),
               null,
               correlationFields);
+      addThis(expectedExitContext, captures.getReturn());
       assertEquals(expectedExitContext, captures.getReturn());
     } else {
       assertNotNull(captures.getReturn().getThrowable());
+    }
+  }
+
+  private void addThis(Snapshot.CapturedContext expected, Snapshot.CapturedContext context) {
+    if (context.getArguments().containsKey("this")) {
+      expected.getArguments().put("this", context.getArguments().get("this"));
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1112,7 +1112,8 @@ public class CapturedSnapshotTest {
     // it's important there is no null key in this map, as Jackson is not happy about it
     // it's means here that argument names are not resolved correctly
     Assert.assertFalse(arguments.containsKey(null));
-    Assert.assertEquals(3, arguments.size());
+    Assert.assertEquals(4, arguments.size());
+    Assert.assertTrue(arguments.containsKey("this"));
     Assert.assertTrue(arguments.containsKey("apiKey"));
     Assert.assertTrue(arguments.containsKey("uriInfo"));
     Assert.assertTrue(arguments.containsKey("value"));

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -239,6 +239,20 @@ public class LogProbesInstrumentationTest {
         "index[10] out of bounds: [0-3]", snapshot.getEvaluationErrors().get(0).getMessage());
   }
 
+  @Test
+  public void lineTemplateThisLog() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot06";
+    DebuggerTransformerTest.TestSnapshotListener listener =
+        installSingleProbe("this is log line for this={this}", CLASS_NAME, null, null, "24");
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "f").get();
+    Assert.assertEquals(42, result);
+    Snapshot snapshot = assertOneSnapshot(listener);
+    assertEquals(
+        "this is log line for this={STATIC_STR=strStatic, intValue=48, doubleValue=3.14, strValue=done, strList=..., ...}",
+        snapshot.getSummary());
+  }
+
   private DebuggerTransformerTest.TestSnapshotListener installSingleProbe(
       String template, String typeName, String methodName, String signature, String... lines) {
     LogProbe logProbe = createProbe(LOG_ID, template, typeName, methodName, signature, lines);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
@@ -385,7 +385,7 @@ public class MetricProbesInstrumentationTest {
             CLASS_NAME,
             "f",
             "()",
-            new ValueScript(DSL.ref("this.intValue"), "this.intValue"));
+            new ValueScript(DSL.getMember(DSL.ref("this"), "intValue"), "this.intValue"));
 
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
@@ -404,7 +404,7 @@ public class MetricProbesInstrumentationTest {
             METRIC_NAME,
             COUNT,
             CLASS_NAME,
-            new ValueScript(DSL.ref("this.intValue"), "intValue"),
+            new ValueScript(DSL.getMember(DSL.ref("this"), "intValue"), "intValue"),
             24);
     MetricForwarderListener listener = installMetricProbes(metricProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);


### PR DESCRIPTION
# What Does This Do
Capture `this` object as arguments for instance method. Then can be resolved as normal object reference and be used in EL

# Motivation
Be able to use `this` as real object reference instead of string field prefix in Expression Language

# Additional Notes
