### PR TITLE
Add test suite start/finish notifications to JUnit 4

### DIFF
--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
@@ -51,12 +51,35 @@ public abstract class JUnit4Utils {
 
         return innerListener.get(listener) instanceof TracingListener;
       } catch (final Throwable e) {
-        log.debug("Could not get inner listener from SynchronizedRunListener for JUnit4Advice", e);
-        return false;
+        log.debug("Could not get inner listener from SynchronizedRunListener", e);
       }
     }
 
     return false;
+  }
+
+  public static TracingListener toTracingListener(final RunListener listener) {
+    if (listener instanceof TracingListener) {
+      return (TracingListener) listener;
+    }
+
+    // Since JUnit 4.12, the RunListener are wrapped by a SynchronizedRunListener object.
+    if (SYNCHRONIZED_LISTENER.equals(listener.getClass().getName())) {
+      try {
+        // There is no public accessor to the inner listener.
+        final Field innerListenerField = listener.getClass().getDeclaredField("listener");
+        innerListenerField.setAccessible(true);
+
+        Object innerListener = innerListenerField.get(listener);
+        if (innerListener instanceof TracingListener) {
+          return (TracingListener) innerListener;
+        }
+      } catch (final Throwable e) {
+        log.debug("Could not get inner listener from SynchronizedRunListener", e);
+      }
+    }
+
+    return null;
   }
 
   /**

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
+import org.junit.runners.model.TestClass;
 
 public class TracingListener extends RunListener {
 
@@ -23,6 +24,14 @@ public class TracingListener extends RunListener {
 
   public TracingListener() {
     version = Version.id();
+  }
+
+  public void testSuiteStarted(final TestClass testClass) {
+    // TODO implement test-suite level visibility
+  }
+
+  public void testSuiteFinished(final TestClass testClass) {
+    // TODO implement test-suite level visibility
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do
This PR modifies `junit-4` instrumentation so that it injects our custom code before/after `org.junit.runners.ParentRunner#run()` method.
The injected code examines registered JUnit listeners, and if Datadog CI Visibility listener is found, its custom event hooks are executed:
* `testSuiteStarted()`
* `testSuiteFinished()`

# Motivation
The event hooks will be used by CI Visibility logic to support test suites instrumentation and reporting.

# Additional Notes
Latest version of JUnit 4 (.13) has similar hooks, but we have to support older versions as well so custom hooks were introduced.
The custom hooks are invoked from the same places as the standard JUnit 4.13 hooks.
