### PR TITLE
Exclude com.trimgroup.statsd from IAST

### DIFF
--- a/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
@@ -34,6 +34,7 @@
 0 com.datadog.demo.*
 1 datadog.*
 0 datadog.smoketest.*
+1 com.timgroup.statsd.*
 
 # -------- Libraries --------
 1 antlr.*


### PR DESCRIPTION


# What Does This Do

Exclude com.trimgroup.statsd from IAST

# Motivation

This is the package for https://github.com/DataDog/java-dogstatsd-client/tree/master/src/main/java/com/timgroup/statsd

# Additional Notes
