### PR TITLE
Fix mixing capturing and non-capturing log probes

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
@@ -216,31 +216,26 @@ public class Snapshot {
        * - Snapshot.commit()
        */
       recordStackTrace(3);
-      if (currentProbeId.equals(probe.id)) {
-        if (status.hasErrors) {
-          evaluationErrors = errorsByProbeIds.get(currentProbeId);
-        }
-      }
-      DebuggerContext.addSnapshot(copy(status.probeDetails, UUID.randomUUID().toString()));
+      DebuggerContext.addSnapshot(duplicateSnapshotForProbe(status.probeDetails));
     }
   }
 
-  private Snapshot copy(ProbeDetails additionalProbe, String newSnapshotId) {
+  private Snapshot duplicateSnapshotForProbe(ProbeDetails probe) {
     Snapshot snapshot =
         new Snapshot(
-            newSnapshotId,
+            UUID.randomUUID().toString(),
             version,
             timestamp,
             duration,
             stack,
-            additionalProbe.captureSnapshot ? captures : new Captures(),
-            additionalProbe,
+            probe.captureSnapshot ? captures : new Captures(),
+            probe,
             language,
             thread,
             thisClassName,
             traceId,
             spanId);
-    List<EvaluationError> evalErrors = errorsByProbeIds.get(additionalProbe.id);
+    List<EvaluationError> evalErrors = errorsByProbeIds.get(probe.id);
     if (evalErrors != null) {
       snapshot.evaluationErrors = new ArrayList<>(evalErrors);
     }

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
@@ -208,8 +208,6 @@ public class Snapshot {
           continue;
         }
       }
-      // generates id only when effectively committing
-      this.id = UUID.randomUUID().toString();
       /*
        * Record stack trace having the caller of this method as 'top' frame.
        * For this it is necessary to discard:
@@ -222,10 +220,8 @@ public class Snapshot {
         if (status.hasErrors) {
           evaluationErrors = errorsByProbeIds.get(currentProbeId);
         }
-        DebuggerContext.addSnapshot(this);
-      } else {
-        DebuggerContext.addSnapshot(copy(status.probeDetails, UUID.randomUUID().toString()));
       }
+      DebuggerContext.addSnapshot(copy(status.probeDetails, UUID.randomUUID().toString()));
     }
   }
 
@@ -237,7 +233,7 @@ public class Snapshot {
             timestamp,
             duration,
             stack,
-            captures,
+            additionalProbe.captureSnapshot ? captures : new Captures(),
             additionalProbe,
             language,
             thread,

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
@@ -346,6 +346,7 @@ public class DebuggerSinkTest {
   @Test
   public void addSnapshotWithEvalErrors() throws URISyntaxException, IOException {
     DebuggerSink sink = new DebuggerSink(config, batchUploader);
+    DebuggerContext.init(sink, null, null);
     Snapshot.CapturedContext entry = new Snapshot.CapturedContext();
     entry.addEvaluationError("obj.field", "Cannot dereference obj");
     Snapshot snapshot =
@@ -356,7 +357,6 @@ public class DebuggerSinkTest {
     snapshot.setEntry(entry);
     snapshot.commit();
     snapshot.getStack().clear();
-    sink.addSnapshot(snapshot);
     String fixtureContent =
         getFixtureContent(SINK_FIXTURE_PREFIX + "/snapshotWithEvalErrorRegex.txt");
     String regex = fixtureContent.replaceAll("\\n", "");

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotWithEvalErrorRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotWithEvalErrorRegex.txt
@@ -4,7 +4,6 @@
 "snapshot":\{
 "captures":\{\},
 "evaluationErrors":\[\{"expr":"obj.field","message":"Cannot dereference obj"\}\],
-"id":"[^"]+",
 "language":"java",
 "probe":\{"evaluateAt":"DEFAULT","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
 "stack":\[\],

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotWithEvalErrorRegex.txt
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/sink/snapshotWithEvalErrorRegex.txt
@@ -4,9 +4,10 @@
 "snapshot":\{
 "captures":\{\},
 "evaluationErrors":\[\{"expr":"obj.field","message":"Cannot dereference obj"\}\],
+"id":"[^"]+",
 "language":"java",
 "probe":\{"evaluateAt":"DEFAULT","id":"12fd-8490-c111-4374-ffde","location":\{"method":"indexOf","type":"java.lang.String"\}\},
-"stack":\[\],
+"stack":\[[^\]]+\],
 "timestamp":\d+
 \}\},
 "duration":0,


### PR DESCRIPTION
# What Does This Do
Creates a copy of the current snapshot and depending of the probe definition indicates capturing or not, includes the captured data (`Captures` object)

# Motivation
When creating 2 log probes on the same method (duplicated), one is capturing the other not, snapshots with captured data included are sent in both cases.

# Additional Notes
