### PR TITLE
Prefetch Docker images in tests and reorganize Docker scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,6 @@ commands:
           # But its time to setup (~1min) exceeds the time required to prefetch all images we use.
           docker_layer_caching: true
 
-      # Only needed if docker_layer_caching is enabled.
       - run:
           name: Prepare testcontainers environment
           command: .circleci/prepare_docker_env.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ commands:
       - run:
           name: Testcontainers tunnels
           background: true
-          command: autoforward --port 60906 --remote $FORWARDED_DOCKER_HOST --forward remote-docker --secure --server-key $DOCKER_CERT_PATH/server-key.pem --server-cert $DOCKER_CERT_PATH/server-cert.pem --remote-key $DOCKER_CERT_PATH/remote-key.pem --remote-cert $DOCKER_CERT_PATH/remote-cert.pem --remote-ca $DOCKER_CERT_PATH/remote-ca.pem
+          command: .circleci/start_docker_autoforward.sh
 
       - run:
           name: Prefetch Docker images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,41 +126,24 @@ commands:
     steps:
       - setup_remote_docker:
           version: 20.10.14
+          # DLC shares Docker layers across jobs (at an extra cost).
+          # But its time to setup (~1min) exceeds the time required to prefetch all images we use.
           docker_layer_caching: true
 
+      # Only needed if docker_layer_caching is enabled.
       - run:
-          name: Testcontainers environment variables
-          command: |
-            echo "export FORWARDED_DOCKER_HOST=$DOCKER_HOST" >> $BASH_ENV
-            echo "export DOCKER_HOST=tcp://localhost:60906" >> $BASH_ENV
-            echo "export TESTCONTAINERS_HOST_OVERRIDE=localhost" >> $BASH_ENV
-            echo "export TESTCONTAINERS_RYUK_DISABLED=true" >> $BASH_ENV
+          name: Prepare testcontainers environment
+          command: .circleci/prepare_docker_env.sh
 
       - run:
           name: Testcontainers tunnels
           background: true
-          command: |
-            cd $DOCKER_CERT_PATH
-            mv key.pem remote-key.pem
-            mv cert.pem remote-cert.pem
-            mv ca.pem remote-ca.pem
-            
-            openssl genrsa -out ca-key.pem 4096
-            openssl req -new -x509 -days 365 -key ca-key.pem -sha256 -subj "/C=US/CN=localhost/emailAddress=admin@datadoghq.com" -out ca.pem
-            openssl genrsa -out server-key.pem 4096
-            openssl req -subj "/CN=localhost" -sha256 -new -key server-key.pem -out server.csr
-            echo subjectAltName = DNS:localhost,IP:10.10.10.20,IP:127.0.0.1 >> extfile.cnf
-            echo extendedKeyUsage = serverAuth >> extfile.cnf
-            openssl x509 -req -days 365 -sha256 -in server.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out server-cert.pem -extfile extfile.cnf
-            openssl genrsa -out key.pem 4096
-            openssl req -subj '/CN=client' -new -key key.pem -out client.csr
-            echo extendedKeyUsage = clientAuth > extfile-client.cnf
-            openssl x509 -req -days 365 -sha256 -in client.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out cert.pem -extfile extfile-client.cnf
-            rm -v client.csr server.csr extfile.cnf extfile-client.cnf
-            chmod -v 0400 ca-key.pem key.pem server-key.pem
-            chmod -v 0444 ca.pem server-cert.pem cert.pem
-            
-            autoforward --port 60906 --remote $FORWARDED_DOCKER_HOST --forward remote-docker --secure --server-key $DOCKER_CERT_PATH/server-key.pem --server-cert $DOCKER_CERT_PATH/server-cert.pem --remote-key $DOCKER_CERT_PATH/remote-key.pem --remote-cert $DOCKER_CERT_PATH/remote-cert.pem --remote-ca $DOCKER_CERT_PATH/remote-ca.pem
+          command: autoforward --port 60906 --remote $FORWARDED_DOCKER_HOST --forward remote-docker --secure --server-key $DOCKER_CERT_PATH/server-key.pem --server-cert $DOCKER_CERT_PATH/server-cert.pem --remote-key $DOCKER_CERT_PATH/remote-key.pem --remote-cert $DOCKER_CERT_PATH/remote-cert.pem --remote-ca $DOCKER_CERT_PATH/remote-ca.pem
+
+      - run:
+          name: Prefetch Docker images
+          background: true
+          command: .circleci/fetch_docker_images.sh
 
   early_return_for_forked_pull_requests:
     description: >-
@@ -205,7 +188,8 @@ commands:
     steps:
       - run:
           name: Max Memory Used
-          command: cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
+          # The file does not seem to exist when DLC is disabled
+          command: cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes || true
           when: always
 
 jobs:

--- a/.circleci/fetch_docker_images.sh
+++ b/.circleci/fetch_docker_images.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -eu
+
+# instrumentation
+IMAGES=(
+  aerospike:5.5.0.9
+  cassandra:3
+  cassandra:4
+  couchbase/server:7.1.0
+  memcached:1.6.14-alpine
+  mysql:8.0
+  postgres:11.1
+  rabbitmq:3.9.20-alpine
+)
+# smoke-tests
+IMAGES+=(
+  mongo:4.0.10
+  #rabbitmq:3.9.20-alpine
+)
+
+echo "Waiting for Docker to be available"
+while ! docker system info &>/dev/null; do
+  sleep 1
+done
+
+echo "Docker is avaiable now, pulling images"
+for image in "${IMAGES[@]}"; do
+  docker pull "${image}" || true
+done

--- a/.circleci/fetch_docker_images.sh
+++ b/.circleci/fetch_docker_images.sh
@@ -19,8 +19,16 @@ IMAGES+=(
 )
 
 echo "Waiting for Docker to be available"
+t0=$SECONDS
 while ! docker system info &>/dev/null; do
   sleep 1
+  t1=$SECONDS
+  # Give up after one minute. Even if Docker becomes available,
+  # prefetching is unlikely to help if it kicks in too late.
+  if [[ $((t1 - t0)) -gt 60 ]]; then
+    echo "Waiting for Docker timeout, skipping image prefetch."
+    exit 0
+  fi
 done
 
 echo "Docker is avaiable now, pulling images"

--- a/.circleci/prepare_docker_env.sh
+++ b/.circleci/prepare_docker_env.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eu
+set -eux
 
 {
   echo "export FORWARDED_DOCKER_HOST=${DOCKER_HOST}"

--- a/.circleci/prepare_docker_env.sh
+++ b/.circleci/prepare_docker_env.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -eu
+
+{
+  echo "export FORWARDED_DOCKER_HOST=$DOCKER_HOST"
+  echo "export DOCKER_HOST=tcp://localhost:60906"
+  echo "export TESTCONTAINERS_HOST_OVERRIDE=localhost"
+  echo "export TESTCONTAINERS_RYUK_DISABLED=true"
+} >> "${BASH_ENV}"
+
+source "${BASH_ENV}"
+
+cd "${DOCKER_CERT_PATH}"
+mv key.pem remote-key.pem
+mv cert.pem remote-cert.pem
+mv ca.pem remote-ca.pem
+
+openssl genrsa -out ca-key.pem 4096
+openssl req -new -x509 -days 365 -key ca-key.pem -sha256 -subj "/C=US/CN=localhost/emailAddress=admin@datadoghq.com" -out ca.pem
+openssl genrsa -out server-key.pem 4096
+openssl req -subj "/CN=localhost" -sha256 -new -key server-key.pem -out server.csr
+echo subjectAltName = DNS:localhost,IP:10.10.10.20,IP:127.0.0.1 >> extfile.cnf
+echo extendedKeyUsage = serverAuth >> extfile.cnf
+openssl x509 -req -days 365 -sha256 -in server.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out server-cert.pem -extfile extfile.cnf
+openssl genrsa -out key.pem 4096
+openssl req -subj '/CN=client' -new -key key.pem -out client.csr
+echo extendedKeyUsage = clientAuth > extfile-client.cnf
+openssl x509 -req -days 365 -sha256 -in client.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out cert.pem -extfile extfile-client.cnf
+rm -v client.csr server.csr extfile.cnf extfile-client.cnf
+chmod -v 0400 ca-key.pem key.pem server-key.pem
+chmod -v 0444 ca.pem server-cert.pem cert.pem

--- a/.circleci/prepare_docker_env.sh
+++ b/.circleci/prepare_docker_env.sh
@@ -10,7 +10,6 @@ set -eu
   # DOCKERT_CERT_PATH is provided only if DLC is enabled.
   if [[ -n "${DOCKERT_CERT_PATH:-}" ]]; then
     echo "export DOCKER_CERT_PATH=${DOCKER_CERT_PATH}"
-    echo "export DOCKER_TLS_VERIFY=1"
   else
     echo "export DOCKER_TLS_VERIFY=0"
   fi

--- a/.circleci/prepare_docker_env.sh
+++ b/.circleci/prepare_docker_env.sh
@@ -10,6 +10,7 @@ set -eu
   # DOCKERT_CERT_PATH is provided only if DLC is enabled.
   if [[ -n "${DOCKERT_CERT_PATH:-}" ]]; then
     echo "export DOCKER_CERT_PATH=${DOCKER_CERT_PATH}"
+    echo "export DOCKER_TLS_VERIFY=1"
   else
     echo "export DOCKER_TLS_VERIFY=0"
   fi

--- a/.circleci/prepare_docker_env.sh
+++ b/.circleci/prepare_docker_env.sh
@@ -2,30 +2,39 @@
 set -eu
 
 {
-  echo "export FORWARDED_DOCKER_HOST=$DOCKER_HOST"
+  echo "export FORWARDED_DOCKER_HOST=${DOCKER_HOST}"
   echo "export DOCKER_HOST=tcp://localhost:60906"
   echo "export TESTCONTAINERS_HOST_OVERRIDE=localhost"
   echo "export TESTCONTAINERS_RYUK_DISABLED=true"
+
+  # DOCKERT_CERT_PATH is provided only if DLC is enabled.
+  if [[ -n "${DOCKERT_CERT_PATH:-}" ]]; then
+    echo "export DOCKER_CERT_PATH=${DOCKER_CERT_PATH}"
+    echo "export DOCKER_TLS_VERIFY=1"
+  else
+    echo "export DOCKER_TLS_VERIFY=0"
+  fi
 } >> "${BASH_ENV}"
 
-source "${BASH_ENV}"
+if [[ -n ${DOCKER_CERT_PATH:-} ]]; then
+  cd "${DOCKER_CERT_PATH}"
+  mv key.pem remote-key.pem
+  mv cert.pem remote-cert.pem
+  mv ca.pem remote-ca.pem
 
-cd "${DOCKER_CERT_PATH}"
-mv key.pem remote-key.pem
-mv cert.pem remote-cert.pem
-mv ca.pem remote-ca.pem
-
-openssl genrsa -out ca-key.pem 4096
-openssl req -new -x509 -days 365 -key ca-key.pem -sha256 -subj "/C=US/CN=localhost/emailAddress=admin@datadoghq.com" -out ca.pem
-openssl genrsa -out server-key.pem 4096
-openssl req -subj "/CN=localhost" -sha256 -new -key server-key.pem -out server.csr
-echo subjectAltName = DNS:localhost,IP:10.10.10.20,IP:127.0.0.1 >> extfile.cnf
-echo extendedKeyUsage = serverAuth >> extfile.cnf
-openssl x509 -req -days 365 -sha256 -in server.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out server-cert.pem -extfile extfile.cnf
-openssl genrsa -out key.pem 4096
-openssl req -subj '/CN=client' -new -key key.pem -out client.csr
-echo extendedKeyUsage = clientAuth > extfile-client.cnf
-openssl x509 -req -days 365 -sha256 -in client.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out cert.pem -extfile extfile-client.cnf
-rm -v client.csr server.csr extfile.cnf extfile-client.cnf
-chmod -v 0400 ca-key.pem key.pem server-key.pem
-chmod -v 0444 ca.pem server-cert.pem cert.pem
+  # Generate temporary certificates for our proxy.
+  openssl genrsa -out ca-key.pem 4096
+  openssl req -new -x509 -days 365 -key ca-key.pem -sha256 -subj "/C=US/CN=localhost/emailAddress=admin@datadoghq.com" -out ca.pem
+  openssl genrsa -out server-key.pem 4096
+  openssl req -subj "/CN=localhost" -sha256 -new -key server-key.pem -out server.csr
+  echo subjectAltName = DNS:localhost,IP:10.10.10.20,IP:127.0.0.1 >> extfile.cnf
+  echo extendedKeyUsage = serverAuth >> extfile.cnf
+  openssl x509 -req -days 365 -sha256 -in server.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out server-cert.pem -extfile extfile.cnf
+  openssl genrsa -out key.pem 4096
+  openssl req -subj '/CN=client' -new -key key.pem -out client.csr
+  echo extendedKeyUsage = clientAuth > extfile-client.cnf
+  openssl x509 -req -days 365 -sha256 -in client.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out cert.pem -extfile extfile-client.cnf
+  rm -v client.csr server.csr extfile.cnf extfile-client.cnf
+  chmod -v 0400 ca-key.pem key.pem server-key.pem
+  chmod -v 0444 ca.pem server-cert.pem cert.pem
+fi

--- a/.circleci/prepare_docker_env.sh
+++ b/.circleci/prepare_docker_env.sh
@@ -7,8 +7,8 @@ set -eux
   echo "export TESTCONTAINERS_HOST_OVERRIDE=localhost"
   echo "export TESTCONTAINERS_RYUK_DISABLED=true"
 
-  # DOCKERT_CERT_PATH is provided only if DLC is enabled.
-  if [[ -n "${DOCKERT_CERT_PATH:-}" ]]; then
+  # DOCKER_CERT_PATH is provided only if DLC is enabled.
+  if [[ -n "${DOCKER_CERT_PATH:-}" ]]; then
     echo "export DOCKER_CERT_PATH=${DOCKER_CERT_PATH}"
     echo "export DOCKER_TLS_VERIFY=1"
   else

--- a/.circleci/start_docker_autoforward.sh
+++ b/.circleci/start_docker_autoforward.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-if [[ "${DOCKER_TLS_VERIFY}" = 1 ]]; then
+if [[ -n "${DOCKER_CERT_PATH:-}" ]]; then
     TLS_ARGS="
         --secure
         --server-key ${DOCKER_CERT_PATH}/server-key.pem

--- a/.circleci/start_docker_autoforward.sh
+++ b/.circleci/start_docker_autoforward.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -eu
+
+if [[ "${DOCKER_TLS_VERIFY}" = 1 ]]; then
+    TLS_ARGS="
+        --secure
+        --server-key ${DOCKER_CERT_PATH}/server-key.pem
+        --server-cert ${DOCKER_CERT_PATH}/server-cert.pem
+        --remote-key ${DOCKER_CERT_PATH}/remote-key.pem
+        --remote-cert ${DOCKER_CERT_PATH}/remote-cert.pem
+        --remote-ca ${DOCKER_CERT_PATH}/remote-ca.pem
+    "
+fi
+
+exec autoforward \
+  --port 60906 \
+  --remote "${FORWARDED_DOCKER_HOST}" \
+  --forward remote-docker \
+  ${TLS_ARGS:-}

--- a/.circleci/start_docker_autoforward.sh
+++ b/.circleci/start_docker_autoforward.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eu
+set -eux
 
 if [[ -n "${DOCKER_CERT_PATH:-}" ]]; then
     TLS_ARGS="


### PR DESCRIPTION
# What Does This Do
Prefetch Docker images in tests in a background CI job.

# Motivation
This should speed up container start time by pulling images early in the pipeline, in the background.

# Additional Notes
