### PR TITLE
Split check job out of the critical path

### DIFF
--- a/.circleci/cancel_workflow.sh
+++ b/.circleci/cancel_workflow.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -eu
-echo "Canceliing workflow ${CIRCLE_WORKFLOW_ID}"
+echo "Cancelling workflow ${CIRCLE_WORKFLOW_ID}"
 curl --request POST --url https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/cancel --header "Circle-Token: ${CIRCLE_TOKEN}"

--- a/.circleci/cancel_workflow.sh
+++ b/.circleci/cancel_workflow.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eu
+echo "Canceliing workflow ${CIRCLE_WORKFLOW_ID}"
+curl --request POST --url https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/cancel --header "Circle-Token: ${CIRCLE_TOKEN}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -947,6 +947,7 @@ build_test_jobs: &build_test_jobs
   # and it will be simpler to require different JVM versions for different branches and old releases
   - fan_in:
       requires:
+        - check
         - test_published_artifacts
         - agent_integration_tests
         - test_8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,7 @@ jobs:
           command: >-
             MAVEN_OPTS="-Xms64M -Xmx256M"
             GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms2G -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
-            ./gradlew clean compile shadowJar test -PskipTests
+            ./gradlew clean compile shadowJar test -PskipTests -PskipBuildSrcTest
             << pipeline.parameters.gradle_flags >>
             --max-workers=8
             --rerun-tasks
@@ -435,6 +435,7 @@ jobs:
             MAVEN_OPTS="-Xms64M -Xmx512M"
             GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xms<< parameters.maxDaemonHeapSize >> -Xmx<< parameters.maxDaemonHeapSize >> $PROFILER_COMMAND -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp' -Ddatadog.forkedMaxHeapSize=768M -Ddatadog.forkedMinHeapSize=128M"
             ./gradlew <<# parameters.gradleTarget >><< parameters.gradleTarget >>:<</ parameters.gradleTarget >><< parameters.testTask >> << parameters.gradleParameters >>
+            -PskipBuildSrcTest
             <<# parameters.testJvm >>-PtestJvm=<< parameters.testJvm >><</ parameters.testJvm >>
             << pipeline.parameters.gradle_flags >>
             --max-workers=<< parameters.maxWorkers >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,7 @@ jobs:
           command: >-
             MAVEN_OPTS="-Xms64M -Xmx256M"
             GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms2G -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
-            ./gradlew clean compile shadowJar check -PskipTests
+            ./gradlew clean compile shadowJar test -PskipTests
             << pipeline.parameters.gradle_flags >>
             --max-workers=8
             --rerun-tasks
@@ -274,6 +274,47 @@ jobs:
           <<: *build_cache_paths
 
       - display_memory_usage
+
+  spotless:
+    <<: *defaults
+    resource_class: large
+
+    steps:
+      - setup_code
+
+      - run:
+          name: Run spotless
+          command: >-
+            ./gradlew spotlessCheck -PskipBuildSrcTest
+            << pipeline.parameters.gradle_flags >>
+            --max-workers=8
+
+  check:
+    <<: *defaults
+    resource_class: xlarge
+
+    steps:
+      - setup_code
+
+      - restore_cache:
+          <<: *dependency_cache_keys
+
+      - restore_cache:
+          <<: *build_cache_keys
+
+      - run:
+          name: Check Project
+          command: >-
+            MAVEN_OPTS="-Xms64M -Xmx256M"
+            GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms2G -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
+            ./gradlew check -PskipTests
+            << pipeline.parameters.gradle_flags >>
+            --max-workers=8
+
+      - run:
+          name: Cancel workflow
+          when: on_fail
+          command: .circleci/cancel_workflow.sh
 
   build_clean_cache:
     <<: *defaults
@@ -645,10 +686,17 @@ jobs:
 
 build_test_jobs: &build_test_jobs
   - build
+  - spotless
+
+  - check:
+      requires:
+        - build
+        - spotless
 
   - xlarge_tests:
       requires:
         - build
+        - spotless
       name: z_test_<< matrix.testJvm >>_base
       triggeredBy: *core_modules
       gradleParameters: "-PskipFlakyTests -PskipInstTests -PskipSmokeTests -PskipProfilingTests"
@@ -660,6 +708,7 @@ build_test_jobs: &build_test_jobs
   - xlarge_tests:
       requires:
         - build
+        - spotless
       name: z_test_8_base
       triggeredBy: *core_modules
       gradleParameters: "-PskipFlakyTests -PskipInstTests -PskipSmokeTests -PskipProfilingTests"
@@ -671,6 +720,7 @@ build_test_jobs: &build_test_jobs
   - xlarge_tests:
       requires:
         - build
+        - spotless
       name: z_test_<< matrix.testJvm >>_inst
       gradleTarget: ":dd-java-agent:instrumentation"
       gradleParameters: "-PskipFlakyTests"
@@ -683,6 +733,7 @@ build_test_jobs: &build_test_jobs
   - xlarge_tests:
       requires:
         - build
+        - spotless
       name: z_test_8_inst
       gradleTarget: ":dd-java-agent:instrumentation"
       gradleParameters: "-PskipFlakyTests"
@@ -694,6 +745,7 @@ build_test_jobs: &build_test_jobs
   - xlarge_tests:
       requires:
         - build
+        - spotless
       name: test_8_inst_latest
       testTask: latestDepTest
       gradleTarget: ":dd-java-agent:instrumentation"
@@ -717,6 +769,7 @@ build_test_jobs: &build_test_jobs
   - tests:
       requires:
         - build
+        - spotless
       maxWorkers: 4
       gradleTarget: ":dd-java-agent:agent-profiling"
       gradleParameters: "-PskipFlakyTests"
@@ -729,6 +782,7 @@ build_test_jobs: &build_test_jobs
   - tests:
       requires:
         - build
+        - spotless
       maxWorkers: 4
       name: test_<< matrix.testJvm >>_iast
       gradleTarget: ":dd-java-agent:agent-iast"
@@ -741,6 +795,7 @@ build_test_jobs: &build_test_jobs
   - tests:
       requires:
         - build
+        - spotless
       name: test_<< matrix.testJvm >>_debugger
       maxWorkers: 4
       gradleTarget: ":dd-java-agent:agent-debugger"
@@ -753,6 +808,7 @@ build_test_jobs: &build_test_jobs
   - huge_tests:
       requires:
         - build
+        - spotless
       name: z_test_<< matrix.testJvm >>_smoke
       gradleTarget: "stageMainDist :dd-smoke-test"
       gradleParameters: "-PskipFlakyTests"
@@ -764,6 +820,7 @@ build_test_jobs: &build_test_jobs
   - huge_tests:
       requires:
         - build
+        - spotless
       name: test_IBM11_smoke
       gradleTarget: "stageMainDist :dd-smoke-test"
       gradleParameters: "-PskipFlakyTests"
@@ -774,6 +831,7 @@ build_test_jobs: &build_test_jobs
   - huge_tests:
       requires:
         - build
+        - spotless
       name: test_IBM17_smoke
       gradleTarget: "stageMainDist :dd-smoke-test"
       gradleParameters: "-PskipFlakyTests"
@@ -784,6 +842,7 @@ build_test_jobs: &build_test_jobs
   - xlarge_tests:
       requires:
         - build
+        - spotless
       name: test_GRAALVM11_smoke
       gradleTarget: "stageMainDist :dd-smoke-test:spring-native"
       stage: smoke
@@ -792,6 +851,7 @@ build_test_jobs: &build_test_jobs
   - xlarge_tests:
       requires:
         - build
+        - spotless
       name: test_GRAALVM17_smoke
       gradleTarget: "stageMainDist :dd-smoke-test:spring-native"
       stage: smoke
@@ -801,6 +861,7 @@ build_test_jobs: &build_test_jobs
   - huge_tests:
       requires:
         - build
+        - spotless
       name: z_test_8_smoke
       gradleTarget: "stageMainDist :dd-smoke-test"
       gradleParameters: "-PskipFlakyTests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -689,15 +689,20 @@ build_test_jobs: &build_test_jobs
   - build
   - spotless
 
-  - check:
+  - fan_in:
       requires:
         - build
         - spotless
+      name: ok_to_test
+      stage: ok_to_test
+
+  - check:
+      requires:
+        - ok_to_test
 
   - xlarge_tests:
       requires:
-        - build
-        - spotless
+        - ok_to_test
       name: z_test_<< matrix.testJvm >>_base
       triggeredBy: *core_modules
       gradleParameters: "-PskipFlakyTests -PskipInstTests -PskipSmokeTests -PskipProfilingTests"
@@ -708,8 +713,7 @@ build_test_jobs: &build_test_jobs
 
   - xlarge_tests:
       requires:
-        - build
-        - spotless
+        - ok_to_test
       name: z_test_8_base
       triggeredBy: *core_modules
       gradleParameters: "-PskipFlakyTests -PskipInstTests -PskipSmokeTests -PskipProfilingTests"
@@ -720,8 +724,7 @@ build_test_jobs: &build_test_jobs
 
   - xlarge_tests:
       requires:
-        - build
-        - spotless
+        - ok_to_test
       name: z_test_<< matrix.testJvm >>_inst
       gradleTarget: ":dd-java-agent:instrumentation"
       gradleParameters: "-PskipFlakyTests"
@@ -733,8 +736,7 @@ build_test_jobs: &build_test_jobs
 
   - xlarge_tests:
       requires:
-        - build
-        - spotless
+        - ok_to_test
       name: z_test_8_inst
       gradleTarget: ":dd-java-agent:instrumentation"
       gradleParameters: "-PskipFlakyTests"
@@ -745,8 +747,7 @@ build_test_jobs: &build_test_jobs
 
   - xlarge_tests:
       requires:
-        - build
-        - spotless
+        - ok_to_test
       name: test_8_inst_latest
       testTask: latestDepTest
       gradleTarget: ":dd-java-agent:instrumentation"
@@ -758,7 +759,7 @@ build_test_jobs: &build_test_jobs
 
   - huge_tests:
       requires:
-        - build
+        - ok_to_test
       name: z_test_8_flaky
       gradleParameters: "-PrunFlakyTests"
       continueOnFailure: true
@@ -769,8 +770,7 @@ build_test_jobs: &build_test_jobs
 
   - tests:
       requires:
-        - build
-        - spotless
+        - ok_to_test
       maxWorkers: 4
       gradleTarget: ":dd-java-agent:agent-profiling"
       gradleParameters: "-PskipFlakyTests"
@@ -782,8 +782,7 @@ build_test_jobs: &build_test_jobs
 
   - tests:
       requires:
-        - build
-        - spotless
+        - ok_to_test
       maxWorkers: 4
       name: test_<< matrix.testJvm >>_iast
       gradleTarget: ":dd-java-agent:agent-iast"
@@ -795,8 +794,7 @@ build_test_jobs: &build_test_jobs
 
   - tests:
       requires:
-        - build
-        - spotless
+        - ok_to_test
       name: test_<< matrix.testJvm >>_debugger
       maxWorkers: 4
       gradleTarget: ":dd-java-agent:agent-debugger"
@@ -808,8 +806,7 @@ build_test_jobs: &build_test_jobs
 
   - huge_tests:
       requires:
-        - build
-        - spotless
+        - ok_to_test
       name: z_test_<< matrix.testJvm >>_smoke
       gradleTarget: "stageMainDist :dd-smoke-test"
       gradleParameters: "-PskipFlakyTests"
@@ -820,8 +817,7 @@ build_test_jobs: &build_test_jobs
 
   - huge_tests:
       requires:
-        - build
-        - spotless
+        - ok_to_test
       name: test_IBM11_smoke
       gradleTarget: "stageMainDist :dd-smoke-test"
       gradleParameters: "-PskipFlakyTests"
@@ -831,8 +827,7 @@ build_test_jobs: &build_test_jobs
 
   - huge_tests:
       requires:
-        - build
-        - spotless
+        - ok_to_test
       name: test_IBM17_smoke
       gradleTarget: "stageMainDist :dd-smoke-test"
       gradleParameters: "-PskipFlakyTests"
@@ -842,8 +837,7 @@ build_test_jobs: &build_test_jobs
 
   - xlarge_tests:
       requires:
-        - build
-        - spotless
+        - ok_to_test
       name: test_GRAALVM11_smoke
       gradleTarget: "stageMainDist :dd-smoke-test:spring-native"
       stage: smoke
@@ -851,8 +845,7 @@ build_test_jobs: &build_test_jobs
 
   - xlarge_tests:
       requires:
-        - build
-        - spotless
+        - ok_to_test
       name: test_GRAALVM17_smoke
       gradleTarget: "stageMainDist :dd-smoke-test:spring-native"
       stage: smoke
@@ -861,8 +854,7 @@ build_test_jobs: &build_test_jobs
 
   - huge_tests:
       requires:
-        - build
-        - spotless
+        - ok_to_test
       name: z_test_8_smoke
       gradleTarget: "stageMainDist :dd-smoke-test"
       gradleParameters: "-PskipFlakyTests"
@@ -891,18 +883,18 @@ build_test_jobs: &build_test_jobs
 
   - agent_integration_tests:
       requires:
-        - build
+        - ok_to_test
       triggeredBy: *agent_integration_tests_modules
       testTask: traceAgentTest
       testJvm: "8"
 
   - test_published_artifacts:
       requires:
-        - build
+        - ok_to_test
 
   - muzzle:
       requires:
-        - build
+        - ok_to_test
       filters:
         branches:
           ignore:
@@ -912,7 +904,7 @@ build_test_jobs: &build_test_jobs
 
   - system-tests:
       requires:
-        - build
+        - ok_to_test
       matrix:
           <<: *system_test_matrix
   - fan_in:

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -48,4 +48,5 @@ dependencies {
 tasks.test {
   useJUnitPlatform()
   dependsOn(":call-site-instrumentation-plugin:build")
+  enabled = !project.hasProperty("skipBuildSrcTest")
 }

--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -92,4 +92,5 @@ tasks.build {
 
 tasks.test {
   useJUnitPlatform()
+  enabled = !project.hasProperty("skipBuildSrcTest")
 }


### PR DESCRIPTION
# What Does This Do
* Split `check` job out of the critical path. If it fails, it cancels the whole workflow.
* Add a `spotless` job that runs early in the pipeline. No tests are run if formatting fails.
* Skip `buildSrc` tests in every job except in `check`.

# Motivation
So we don't delay starting tests, but if check fails, we still cancel the whole workflow.

# Additional Notes
