### PR TITLE
remove debugger check for config endpoint at bootstrap

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -57,13 +57,6 @@ public class DebuggerAgent {
               + ". Consider upgrading the datadog agent.");
       return;
     }
-    if (ddAgentFeaturesDiscovery.getConfigEndpoint() == null) {
-      log.error(
-          "No endpoint detected to read probe config from datadog agent at "
-              + agentUrl
-              + ". Consider upgrading the datadog agent.");
-      return;
-    }
 
     sink = new DebuggerSink(config);
     sink.start();


### PR DESCRIPTION
# What Does This Do

remove disabling the DebugerAgent if datadog agent config was not found at boot time. 
Unlike other endpoints, configEndpoint get attached after datadog agent [remote config client started](https://github.com/DataDog/datadog-agent/blob/7b816420a1774438524b392342f8fa3f94880473/cmd/trace-agent/run.go#L204).

The solution is to remove this check and let configurationPoller discovery that endpoint at later point in time.

# Motivation

Our customer have setup that start both library and datadog-agent almost at the same time.
That causes DebuggerAgent to cancel it boot sequence because config endpoint was not found. 
On the other hand, ASM products doesn't check for config endpoint and register itself.
Therefore, configurationPoller retried agent discovery until it find the configEndpoint and start getting configurations.

# Additional Notes

We might also want to disable the check for debuggerProxy endpoint. And we should delay this discovery until we get a snapshot to send and drop the snapshot buffer if no endpoint was discovered. 
