### PR TITLE
Improve graphql sanitizer to only sanitize value types that are neces…

### DIFF
--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/main/java/datadog/trace/instrumentation/graphqljava/GraphQLQuerySanitizer.java
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/main/java/datadog/trace/instrumentation/graphqljava/GraphQLQuerySanitizer.java
@@ -42,5 +42,4 @@ public final class GraphQLQuerySanitizer extends NodeVisitorStub {
   public TraversalControl visitStringValue(StringValue node, TraverserContext<Node> context) {
     return TreeTransformerUtil.changeNode(context, new EnumValue("{String}"));
   }
-
 }

--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/main/java/datadog/trace/instrumentation/graphqljava/GraphQLQuerySanitizer.java
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/main/java/datadog/trace/instrumentation/graphqljava/GraphQLQuerySanitizer.java
@@ -1,18 +1,21 @@
 package datadog.trace.instrumentation.graphqljava;
 
+import graphql.language.ArrayValue;
 import graphql.language.AstPrinter;
 import graphql.language.AstTransformer;
-import graphql.language.BooleanValue;
-import graphql.language.EnumValue;
+import graphql.language.FloatValue;
+import graphql.language.IntValue;
 import graphql.language.Node;
 import graphql.language.NodeVisitor;
 import graphql.language.NodeVisitorStub;
-import graphql.language.NullValue;
-import graphql.language.Value;
-import graphql.language.VariableReference;
+import graphql.language.ObjectValue;
+import graphql.language.StringValue;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 import graphql.util.TreeTransformerUtil;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Collections;
 
 public final class GraphQLQuerySanitizer extends NodeVisitorStub {
   private static final NodeVisitor REPLACE_VALUES_VISITOR = new GraphQLQuerySanitizer();
@@ -23,25 +26,34 @@ public final class GraphQLQuerySanitizer extends NodeVisitorStub {
     return AstPrinter.printAst(sanitizedQuery);
   }
 
+  private static final IntValue sanitizedIntValue = new IntValue(BigInteger.ZERO);
+  private static final FloatValue sanitizedFloatValue = new FloatValue(BigDecimal.ZERO);
+  private static final StringValue sanitizedStringValue = new StringValue("");
+  private static final ObjectValue sanitizedObjectValue = new ObjectValue(Collections.EMPTY_LIST);
+  private static final ArrayValue santitizedArrayValue = new ArrayValue(Collections.EMPTY_LIST);
+
   @Override
-  protected TraversalControl visitValue(Value<?> node, TraverserContext<Node> context) {
-    EnumValue newValue = new EnumValue("?");
-    return TreeTransformerUtil.changeNode(context, newValue);
+  public TraversalControl visitIntValue(IntValue node, TraverserContext<Node> context) {
+    return TreeTransformerUtil.changeNode(context, sanitizedIntValue);
   }
 
   @Override
-  public TraversalControl visitVariableReference(
-      VariableReference node, TraverserContext<Node> context) {
-    return super.visitValue(node, context);
+  public TraversalControl visitFloatValue(FloatValue node, TraverserContext<Node> context) {
+    return TreeTransformerUtil.changeNode(context, sanitizedFloatValue);
   }
 
   @Override
-  public TraversalControl visitBooleanValue(BooleanValue node, TraverserContext<Node> context) {
-    return super.visitValue(node, context);
+  public TraversalControl visitStringValue(StringValue node, TraverserContext<Node> context) {
+    return TreeTransformerUtil.changeNode(context, sanitizedStringValue);
   }
 
   @Override
-  public TraversalControl visitNullValue(NullValue node, TraverserContext<Node> context) {
-    return super.visitValue(node, context);
+  public TraversalControl visitObjectValue(ObjectValue node, TraverserContext<Node> context) {
+    return TreeTransformerUtil.changeNode(context, sanitizedObjectValue);
+  }
+
+  @Override
+  public TraversalControl visitArrayValue(ArrayValue node, TraverserContext<Node> context) {
+    return TreeTransformerUtil.changeNode(context, santitizedArrayValue);
   }
 }

--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/main/java/datadog/trace/instrumentation/graphqljava/GraphQLQuerySanitizer.java
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/main/java/datadog/trace/instrumentation/graphqljava/GraphQLQuerySanitizer.java
@@ -1,59 +1,50 @@
 package datadog.trace.instrumentation.graphqljava;
 
-import graphql.language.ArrayValue;
 import graphql.language.AstPrinter;
 import graphql.language.AstTransformer;
+import graphql.language.BooleanValue;
+import graphql.language.EnumValue;
 import graphql.language.FloatValue;
 import graphql.language.IntValue;
 import graphql.language.Node;
 import graphql.language.NodeVisitor;
 import graphql.language.NodeVisitorStub;
-import graphql.language.ObjectValue;
 import graphql.language.StringValue;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 import graphql.util.TreeTransformerUtil;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.Collections;
 
 public final class GraphQLQuerySanitizer extends NodeVisitorStub {
   private static final NodeVisitor REPLACE_VALUES_VISITOR = new GraphQLQuerySanitizer();
   private static final AstTransformer AST_TRANSFORMER = new AstTransformer();
+  private static final EnumValue enumValueInt = new EnumValue("{Int}");
+  private static final EnumValue enumValueString = new EnumValue("{String}");
+  private static final EnumValue enumValueFloat = new EnumValue("{Float}");
+  private static final EnumValue enumValueBoolean = new EnumValue("{Boolean}");
 
   public static String sanitizeQuery(Node<?> node) {
     Node sanitizedQuery = AST_TRANSFORMER.transform(node, REPLACE_VALUES_VISITOR);
     return AstPrinter.printAst(sanitizedQuery);
   }
 
-  private static final IntValue sanitizedIntValue = new IntValue(BigInteger.ZERO);
-  private static final FloatValue sanitizedFloatValue = new FloatValue(BigDecimal.ZERO);
-  private static final StringValue sanitizedStringValue = new StringValue("");
-  private static final ObjectValue sanitizedObjectValue = new ObjectValue(Collections.EMPTY_LIST);
-  private static final ArrayValue santitizedArrayValue = new ArrayValue(Collections.EMPTY_LIST);
-
   @Override
   public TraversalControl visitIntValue(IntValue node, TraverserContext<Node> context) {
-    return TreeTransformerUtil.changeNode(context, sanitizedIntValue);
+    return TreeTransformerUtil.changeNode(context, enumValueInt);
+  }
+
+  @Override
+  public TraversalControl visitBooleanValue(BooleanValue node, TraverserContext<Node> context) {
+    return TreeTransformerUtil.changeNode(context, enumValueBoolean);
   }
 
   @Override
   public TraversalControl visitFloatValue(FloatValue node, TraverserContext<Node> context) {
-    return TreeTransformerUtil.changeNode(context, sanitizedFloatValue);
+    return TreeTransformerUtil.changeNode(context, enumValueFloat);
   }
 
   @Override
   public TraversalControl visitStringValue(StringValue node, TraverserContext<Node> context) {
-    return TreeTransformerUtil.changeNode(context, sanitizedStringValue);
+    return TreeTransformerUtil.changeNode(context, enumValueString);
   }
 
-  @Override
-  public TraversalControl visitObjectValue(ObjectValue node, TraverserContext<Node> context) {
-    return TreeTransformerUtil.changeNode(context, sanitizedObjectValue);
-  }
-
-  @Override
-  public TraversalControl visitArrayValue(ArrayValue node, TraverserContext<Node> context) {
-    return TreeTransformerUtil.changeNode(context, santitizedArrayValue);
-  }
 }

--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/main/java/datadog/trace/instrumentation/graphqljava/GraphQLQuerySanitizer.java
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/main/java/datadog/trace/instrumentation/graphqljava/GraphQLQuerySanitizer.java
@@ -17,10 +17,6 @@ import graphql.util.TreeTransformerUtil;
 public final class GraphQLQuerySanitizer extends NodeVisitorStub {
   private static final NodeVisitor REPLACE_VALUES_VISITOR = new GraphQLQuerySanitizer();
   private static final AstTransformer AST_TRANSFORMER = new AstTransformer();
-  private static final EnumValue enumValueInt = new EnumValue("{Int}");
-  private static final EnumValue enumValueString = new EnumValue("{String}");
-  private static final EnumValue enumValueFloat = new EnumValue("{Float}");
-  private static final EnumValue enumValueBoolean = new EnumValue("{Boolean}");
 
   public static String sanitizeQuery(Node<?> node) {
     Node sanitizedQuery = AST_TRANSFORMER.transform(node, REPLACE_VALUES_VISITOR);
@@ -29,22 +25,22 @@ public final class GraphQLQuerySanitizer extends NodeVisitorStub {
 
   @Override
   public TraversalControl visitIntValue(IntValue node, TraverserContext<Node> context) {
-    return TreeTransformerUtil.changeNode(context, enumValueInt);
+    return TreeTransformerUtil.changeNode(context, new EnumValue("{Int}"));
   }
 
   @Override
   public TraversalControl visitBooleanValue(BooleanValue node, TraverserContext<Node> context) {
-    return TreeTransformerUtil.changeNode(context, enumValueBoolean);
+    return TreeTransformerUtil.changeNode(context, new EnumValue("{Boolean}"));
   }
 
   @Override
   public TraversalControl visitFloatValue(FloatValue node, TraverserContext<Node> context) {
-    return TreeTransformerUtil.changeNode(context, enumValueFloat);
+    return TreeTransformerUtil.changeNode(context, new EnumValue("{Float}"));
   }
 
   @Override
   public TraversalControl visitStringValue(StringValue node, TraverserContext<Node> context) {
-    return TreeTransformerUtil.changeNode(context, enumValueString);
+    return TreeTransformerUtil.changeNode(context, new EnumValue("{String}"));
   }
 
 }

--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLQuerySanitizerTest.groovy
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLQuerySanitizerTest.groovy
@@ -1,0 +1,213 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.instrumentation.graphqljava.GraphQLQuerySanitizer
+import graphql.parser.Parser
+
+class GraphQLQuerySanitizerTest extends AgentTestRunner {
+  private Parser parser = new Parser();
+
+  def "sanitizes the use of a String literal in query"() {
+    when:
+    def parsedDoc = parser.parse(
+      'query findBookById {\n' +
+        '  bookById(id: "book-1") {\n' +
+        '    id #test\n' +
+        '    name\n' +
+        '    pageCount\n' +
+        '    author {\n' +
+        '      firstName\n' +
+        '      lastName\n' +
+        '    }\n' +
+        '  }\n' +
+        '}'
+    );
+
+    then:
+    GraphQLQuerySanitizer.sanitizeQuery(parsedDoc) ==
+      'query findBookById {\n' +
+      '  bookById(id: {String}) {\n' +
+      '    id\n' +
+      '    name\n' +
+      '    pageCount\n' +
+      '    author {\n' +
+      '      firstName\n' +
+      '      lastName\n' +
+      '    }\n' +
+      '  }\n' +
+      '}\n'
+  }
+
+  def "sanitizes the use of an array of String literals in query"() {
+    when:
+    def parsedDoc = parser.parse(
+      'query findBooksByIds {\n' +
+        '  booksByIds(ids: ["book-1","book-2","book-3"]) {\n' +
+        '    id #test\n' +
+        '    name\n' +
+        '    pageCount\n' +
+        '    author {\n' +
+        '      firstName\n' +
+        '      lastName\n' +
+        '    }\n' +
+        '  }\n' +
+        '}'
+    );
+
+    then:
+    GraphQLQuerySanitizer.sanitizeQuery(parsedDoc) ==
+      'query findBooksByIds {\n' +
+      '  booksByIds(ids: [{String}, {String}, {String}]) {\n' +
+      '    id\n' +
+      '    name\n' +
+      '    pageCount\n' +
+      '    author {\n' +
+      '      firstName\n' +
+      '      lastName\n' +
+      '    }\n' +
+      '  }\n' +
+      '}\n'
+  }
+
+  def "sanitizes the use of a Int literal in query"() {
+    when:
+    def parsedDoc = parser.parse(
+      'query findBookById {\n' +
+        '  bookById(id: 5) {\n' +
+        '    id #test\n' +
+        '    name\n' +
+        '    pageCount\n' +
+        '    author {\n' +
+        '      firstName\n' +
+        '      lastName\n' +
+        '    }\n' +
+        '  }\n' +
+        '}'
+    );
+
+    then:
+    GraphQLQuerySanitizer.sanitizeQuery(parsedDoc) ==
+      'query findBookById {\n' +
+      '  bookById(id: {Int}) {\n' +
+      '    id\n' +
+      '    name\n' +
+      '    pageCount\n' +
+      '    author {\n' +
+      '      firstName\n' +
+      '      lastName\n' +
+      '    }\n' +
+      '  }\n' +
+      '}\n'
+  }
+
+  def "sanitizes the use of a Float literal in query"() {
+    when:
+    def parsedDoc = parser.parse(
+      'query findCheapBooks {\n' +
+        '  booksCheaperThan(price: 15.99) {\n' +
+        '    id #test\n' +
+        '    name\n' +
+        '    pageCount\n' +
+        '    author {\n' +
+        '      firstName\n' +
+        '      lastName\n' +
+        '    }\n' +
+        '  }\n' +
+        '}'
+    );
+
+    then:
+    GraphQLQuerySanitizer.sanitizeQuery(parsedDoc) ==
+      'query findCheapBooks {\n' +
+      '  booksCheaperThan(price: {Float}) {\n' +
+      '    id\n' +
+      '    name\n' +
+      '    pageCount\n' +
+      '    author {\n' +
+      '      firstName\n' +
+      '      lastName\n' +
+      '    }\n' +
+      '  }\n' +
+      '}\n'
+  }
+
+  def "sanitizes the use of a Boolean literal in query"() {
+    when:
+    def parsedDoc = parser.parse(
+      'query findCheapBooks {\n' +
+        '  findBooks(isCheap: true) {\n' +
+        '    id #test\n' +
+        '    name\n' +
+        '    pageCount\n' +
+        '    author {\n' +
+        '      firstName\n' +
+        '      lastName\n' +
+        '    }\n' +
+        '  }\n' +
+        '}'
+    );
+
+    then:
+    GraphQLQuerySanitizer.sanitizeQuery(parsedDoc) ==
+      'query findCheapBooks {\n' +
+      '  findBooks(isCheap: {Boolean}) {\n' +
+      '    id\n' +
+      '    name\n' +
+      '    pageCount\n' +
+      '    author {\n' +
+      '      firstName\n' +
+      '      lastName\n' +
+      '    }\n' +
+      '  }\n' +
+      '}\n'
+  }
+
+  def "sanitizes literals in mutation nested input"() {
+    when:
+    def parsedDoc = parser.parse(
+      'mutation testUpdateBookAuthor{\n' +
+        '  updateBookAuthor(input: {bookId:2, author:{firstName: "Irma", lastName: "K"}}) {\n' +
+        '    author {\n' +
+        '      firstName\n' +
+        '      lastName\n' +
+        '    }\n' +
+        '  }\n' +
+        '}'
+    );
+
+    then:
+    GraphQLQuerySanitizer.sanitizeQuery(parsedDoc) ==
+      'mutation testUpdateBookAuthor {\n' +
+      '  updateBookAuthor(input: {bookId : {Int}, author : {firstName : {String}, lastName : {String}}}) {\n' +
+      '    author {\n' +
+      '      firstName\n' +
+      '      lastName\n' +
+      '    }\n' +
+      '  }\n' +
+      '}\n'
+  }
+
+  def "sanitization leaves mutation variable reference alone"() {
+    when:
+    def parsedDoc = parser.parse(
+      'mutation testUpdateBookAuthor($id: ID!, $authorFirst: String!, $authorLast: String!) {\n' +
+        '  updateBookAuthor(input: {bookId:$id, author:{firstName: $authorFirst, lastName: $authorLast}}) {\n' +
+        '    author {\n' +
+        '      firstName\n' +
+        '      lastName\n' +
+        '    }\n' +
+        '  }\n' +
+        '}'
+    );
+
+    then:
+    GraphQLQuerySanitizer.sanitizeQuery(parsedDoc) ==
+      'mutation testUpdateBookAuthor($id: ID!, $authorFirst: String!, $authorLast: String!) {\n' +
+      '  updateBookAuthor(input: {bookId : $id, author : {firstName : $authorFirst, lastName : $authorLast}}) {\n' +
+      '    author {\n' +
+      '      firstName\n' +
+      '      lastName\n' +
+      '    }\n' +
+      '  }\n' +
+      '}\n'
+  }
+
+}

--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLQuerySanitizerTest.groovy
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLQuerySanitizerTest.groovy
@@ -3,23 +3,23 @@ import datadog.trace.instrumentation.graphqljava.GraphQLQuerySanitizer
 import graphql.parser.Parser
 
 class GraphQLQuerySanitizerTest extends AgentTestRunner {
-  private Parser parser = new Parser();
+  private Parser parser = new Parser()
 
   def "sanitizes the use of a String literal in query"() {
     when:
     def parsedDoc = parser.parse(
       'query findBookById {\n' +
-        '  bookById(id: "book-1") {\n' +
-        '    id #test\n' +
-        '    name\n' +
-        '    pageCount\n' +
-        '    author {\n' +
-        '      firstName\n' +
-        '      lastName\n' +
-        '    }\n' +
-        '  }\n' +
-        '}'
-    );
+      '  bookById(id: "book-1") {\n' +
+      '    id #test\n' +
+      '    name\n' +
+      '    pageCount\n' +
+      '    author {\n' +
+      '      firstName\n' +
+      '      lastName\n' +
+      '    }\n' +
+      '  }\n' +
+      '}'
+      )
 
     then:
     GraphQLQuerySanitizer.sanitizeQuery(parsedDoc) ==
@@ -40,17 +40,17 @@ class GraphQLQuerySanitizerTest extends AgentTestRunner {
     when:
     def parsedDoc = parser.parse(
       'query findBooksByIds {\n' +
-        '  booksByIds(ids: ["book-1","book-2","book-3"]) {\n' +
-        '    id #test\n' +
-        '    name\n' +
-        '    pageCount\n' +
-        '    author {\n' +
-        '      firstName\n' +
-        '      lastName\n' +
-        '    }\n' +
-        '  }\n' +
-        '}'
-    );
+      '  booksByIds(ids: ["book-1","book-2","book-3"]) {\n' +
+      '    id #test\n' +
+      '    name\n' +
+      '    pageCount\n' +
+      '    author {\n' +
+      '      firstName\n' +
+      '      lastName\n' +
+      '    }\n' +
+      '  }\n' +
+      '}'
+      )
 
     then:
     GraphQLQuerySanitizer.sanitizeQuery(parsedDoc) ==
@@ -71,17 +71,17 @@ class GraphQLQuerySanitizerTest extends AgentTestRunner {
     when:
     def parsedDoc = parser.parse(
       'query findBookById {\n' +
-        '  bookById(id: 5) {\n' +
-        '    id #test\n' +
-        '    name\n' +
-        '    pageCount\n' +
-        '    author {\n' +
-        '      firstName\n' +
-        '      lastName\n' +
-        '    }\n' +
-        '  }\n' +
-        '}'
-    );
+      '  bookById(id: 5) {\n' +
+      '    id #test\n' +
+      '    name\n' +
+      '    pageCount\n' +
+      '    author {\n' +
+      '      firstName\n' +
+      '      lastName\n' +
+      '    }\n' +
+      '  }\n' +
+      '}'
+      )
 
     then:
     GraphQLQuerySanitizer.sanitizeQuery(parsedDoc) ==
@@ -102,17 +102,17 @@ class GraphQLQuerySanitizerTest extends AgentTestRunner {
     when:
     def parsedDoc = parser.parse(
       'query findCheapBooks {\n' +
-        '  booksCheaperThan(price: 15.99) {\n' +
-        '    id #test\n' +
-        '    name\n' +
-        '    pageCount\n' +
-        '    author {\n' +
-        '      firstName\n' +
-        '      lastName\n' +
-        '    }\n' +
-        '  }\n' +
-        '}'
-    );
+      '  booksCheaperThan(price: 15.99) {\n' +
+      '    id #test\n' +
+      '    name\n' +
+      '    pageCount\n' +
+      '    author {\n' +
+      '      firstName\n' +
+      '      lastName\n' +
+      '    }\n' +
+      '  }\n' +
+      '}'
+      )
 
     then:
     GraphQLQuerySanitizer.sanitizeQuery(parsedDoc) ==
@@ -133,17 +133,17 @@ class GraphQLQuerySanitizerTest extends AgentTestRunner {
     when:
     def parsedDoc = parser.parse(
       'query findCheapBooks {\n' +
-        '  findBooks(isCheap: true) {\n' +
-        '    id #test\n' +
-        '    name\n' +
-        '    pageCount\n' +
-        '    author {\n' +
-        '      firstName\n' +
-        '      lastName\n' +
-        '    }\n' +
-        '  }\n' +
-        '}'
-    );
+      '  findBooks(isCheap: true) {\n' +
+      '    id #test\n' +
+      '    name\n' +
+      '    pageCount\n' +
+      '    author {\n' +
+      '      firstName\n' +
+      '      lastName\n' +
+      '    }\n' +
+      '  }\n' +
+      '}'
+      )
 
     then:
     GraphQLQuerySanitizer.sanitizeQuery(parsedDoc) ==
@@ -164,14 +164,14 @@ class GraphQLQuerySanitizerTest extends AgentTestRunner {
     when:
     def parsedDoc = parser.parse(
       'mutation testUpdateBookAuthor{\n' +
-        '  updateBookAuthor(input: {bookId:2, author:{firstName: "Irma", lastName: "K"}}) {\n' +
-        '    author {\n' +
-        '      firstName\n' +
-        '      lastName\n' +
-        '    }\n' +
-        '  }\n' +
-        '}'
-    );
+      '  updateBookAuthor(input: {bookId:2, author:{firstName: "Irma", lastName: "K"}}) {\n' +
+      '    author {\n' +
+      '      firstName\n' +
+      '      lastName\n' +
+      '    }\n' +
+      '  }\n' +
+      '}'
+      )
 
     then:
     GraphQLQuerySanitizer.sanitizeQuery(parsedDoc) ==
@@ -189,14 +189,14 @@ class GraphQLQuerySanitizerTest extends AgentTestRunner {
     when:
     def parsedDoc = parser.parse(
       'mutation testUpdateBookAuthor($id: ID!, $authorFirst: String!, $authorLast: String!) {\n' +
-        '  updateBookAuthor(input: {bookId:$id, author:{firstName: $authorFirst, lastName: $authorLast}}) {\n' +
-        '    author {\n' +
-        '      firstName\n' +
-        '      lastName\n' +
-        '    }\n' +
-        '  }\n' +
-        '}'
-    );
+      '  updateBookAuthor(input: {bookId:$id, author:{firstName: $authorFirst, lastName: $authorLast}}) {\n' +
+      '    author {\n' +
+      '      firstName\n' +
+      '      lastName\n' +
+      '    }\n' +
+      '  }\n' +
+      '}'
+      )
 
     then:
     GraphQLQuerySanitizer.sanitizeQuery(parsedDoc) ==
@@ -209,5 +209,4 @@ class GraphQLQuerySanitizerTest extends AgentTestRunner {
       '  }\n' +
       '}\n'
   }
-
 }

--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLTest.groovy
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLTest.groovy
@@ -179,7 +179,7 @@ class GraphQLTest extends AgentTestRunner {
       '  }\n' +
       '}'
     def expectedQuery = 'query findBookById {\n' +
-      '  bookById(id: "") {\n' +
+      '  bookById(id: {String}) {\n' +
       '    id\n' +
       '    title\n' +
       '    color\n' +
@@ -295,7 +295,7 @@ class GraphQLTest extends AgentTestRunner {
       '  }\n' +
       '}'
     def expectedQuery = 'query findBookById {\n' +
-      '  bookById(id: "") {\n' +
+      '  bookById(id: {String}) {\n' +
       '    id\n' +
       '    cover\n' +
       '  }\n' +

--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLTest.groovy
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLTest.groovy
@@ -2,6 +2,7 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.Trace
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import graphql.ExecutionInput
 import graphql.ExecutionResult
 import graphql.GraphQL
 import graphql.schema.DataFetcher
@@ -57,8 +58,8 @@ class GraphQLTest extends AgentTestRunner {
 
   def "successful query produces spans"() {
     setup:
-    def query = 'query findBookById {\n' +
-      '  bookById(id: "book-1") {\n' +
+    def query = 'query findBookById($id: ID) {\n' +
+      '  bookById(id: $id) {\n' +
       '    id #test\n' +
       '    name\n' +
       '    pageCount\n' +
@@ -68,8 +69,8 @@ class GraphQLTest extends AgentTestRunner {
       '    }\n' +
       '  }\n' +
       '}'
-    def expectedQuery = 'query findBookById {\n' +
-      '  bookById(id: ?) {\n' +
+    def expectedQuery = 'query findBookById($id: ID) {\n' +
+      '  bookById(id: $id) {\n' +
       '    id\n' +
       '    name\n' +
       '    pageCount\n' +
@@ -80,7 +81,8 @@ class GraphQLTest extends AgentTestRunner {
       '  }\n' +
       '}\n'
 
-    ExecutionResult result = graphql.execute(query)
+    ExecutionInput input = ExecutionInput.newExecutionInput().query(query).variables([id: "book-1"]).build()
+    ExecutionResult result = graphql.execute(input)
 
     expect:
     result.getErrors().isEmpty()
@@ -177,7 +179,7 @@ class GraphQLTest extends AgentTestRunner {
       '  }\n' +
       '}'
     def expectedQuery = 'query findBookById {\n' +
-      '  bookById(id: ?) {\n' +
+      '  bookById(id: "") {\n' +
       '    id\n' +
       '    title\n' +
       '    color\n' +
@@ -293,7 +295,7 @@ class GraphQLTest extends AgentTestRunner {
       '  }\n' +
       '}'
     def expectedQuery = 'query findBookById {\n' +
-      '  bookById(id: ?) {\n' +
+      '  bookById(id: "") {\n' +
       '    id\n' +
       '    cover\n' +
       '  }\n' +

--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLTest.groovy
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLTest.groovy
@@ -2,7 +2,6 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.Trace
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import graphql.ExecutionInput
 import graphql.ExecutionResult
 import graphql.GraphQL
 import graphql.schema.DataFetcher
@@ -58,8 +57,8 @@ class GraphQLTest extends AgentTestRunner {
 
   def "successful query produces spans"() {
     setup:
-    def query = 'query findBookById($id: ID) {\n' +
-      '  bookById(id: $id) {\n' +
+    def query = 'query findBookById {\n' +
+      '  bookById(id: "book-1") {\n' +
       '    id #test\n' +
       '    name\n' +
       '    pageCount\n' +
@@ -69,8 +68,8 @@ class GraphQLTest extends AgentTestRunner {
       '    }\n' +
       '  }\n' +
       '}'
-    def expectedQuery = 'query findBookById($id: ID) {\n' +
-      '  bookById(id: $id) {\n' +
+    def expectedQuery = 'query findBookById {\n' +
+      '  bookById(id: {String}) {\n' +
       '    id\n' +
       '    name\n' +
       '    pageCount\n' +
@@ -81,8 +80,7 @@ class GraphQLTest extends AgentTestRunner {
       '  }\n' +
       '}\n'
 
-    ExecutionInput input = ExecutionInput.newExecutionInput().query(query).variables([id: "book-1"]).build()
-    ExecutionResult result = graphql.execute(input)
+    ExecutionResult result = graphql.execute(query)
 
     expect:
     result.getErrors().isEmpty()


### PR DESCRIPTION
…sary/could contain sensitive info

# What Does This Do

Fixes https://github.com/DataDog/dd-trace-java/issues/4661

# Motivation

Currently the GraphQL sanitization implementation changes too much/wipes out useful information that would not be considered sensitive/needing sanitization, such as variable references and use of Enums.

# Additional Notes

dd-trace-js provides a good implementation which was borrowed from Apollo.  Visitors in this MR align with what visitors are used in it:

https://github.com/DataDog/dd-trace-js/blob/7b27059fe3b9de6788c0517a2b499ff6b78da5ff/packages/datadog-plugin-graphql/src/tools/transforms.js#L13
