### PR TITLE
graphql.field spans: Fix graphql.type tag and add graphql.coordinates tag

### DIFF
--- a/dd-java-agent/instrumentation/graphql-java-14.0/build.gradle
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/build.gradle
@@ -3,13 +3,14 @@ muzzle {
   pass {
     group = "com.graphql-java"
     module = 'graphql-java'
-    versions = '[14.0,2018)' // exclude dates as version numbers
+    //TODO: rename module to graphql-java-13.0 as it now supported
+    versions = '[13.0,2018)' // exclude dates as version numbers
     // earlier versions are missing some classes and will require separate instrumentation
   }
   fail {
     group = "com.graphql-java"
     module = 'graphql-java'
-    versions = '[1.2,14.0)'
+    versions = '[1.2,13.0)'
   }
 }
 
@@ -23,8 +24,8 @@ testSets {
 }
 
 dependencies {
-  compileOnly group: 'com.graphql-java', name: 'graphql-java', version: '14.0'
-  testImplementation group: 'com.graphql-java', name: 'graphql-java', version: '14.0'
+  compileOnly group: 'com.graphql-java', name: 'graphql-java', version: '13.0'
+  testImplementation group: 'com.graphql-java', name: 'graphql-java', version: '13.0'
 
   testImplementation project(':dd-java-agent:instrumentation:trace-annotation')
 

--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/main/java/datadog.trace.instrumentation.graphqljava/GraphQLJavaInstrumentation.java
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/main/java/datadog.trace.instrumentation.graphqljava/GraphQLJavaInstrumentation.java
@@ -7,6 +7,7 @@ import static net.bytebuddy.matcher.ElementMatchers.returns;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import graphql.analysis.QueryTraverser;
 import graphql.execution.instrumentation.Instrumentation;
 import net.bytebuddy.asm.Advice;
 
@@ -57,6 +58,11 @@ public class GraphQLJavaInstrumentation extends Instrumenter.Tracing
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void onExit(@Advice.Return(readOnly = false) Instrumentation instrumentation) {
       instrumentation = GraphQLInstrumentation.install(instrumentation);
+    }
+
+    public static void muzzleCheck(QueryTraverser queryTraverser) {
+      // Class renamed in 13.0
+      queryTraverser.newQueryTraverser();
     }
   }
 }

--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLTest.groovy
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLTest.groovy
@@ -33,6 +33,13 @@ class GraphQLTest extends AgentTestRunner {
             return Book.getById(bookId)
           }
         }))
+        .type(newTypeWiring("Book").dataFetcher("isbn", new DataFetcher<String>() {
+          @Override
+          String get(DataFetchingEnvironment environment) throws Exception {
+            Book book = environment.getSource()
+            return book.getIsbn()
+          }
+        }))
         .type(newTypeWiring("Book").dataFetcher("author", new DataFetcher<Author>() {
           @Override
           Author get(DataFetchingEnvironment environment) throws Exception {
@@ -66,6 +73,7 @@ class GraphQLTest extends AgentTestRunner {
       '      firstName\n' +
       '      lastName\n' +
       '    }\n' +
+      '    isbn\n' +
       '  }\n' +
       '}'
     def expectedQuery = 'query findBookById {\n' +
@@ -77,6 +85,7 @@ class GraphQLTest extends AgentTestRunner {
       '      firstName\n' +
       '      lastName\n' +
       '    }\n' +
+      '    isbn\n' +
       '  }\n' +
       '}\n'
 
@@ -86,7 +95,7 @@ class GraphQLTest extends AgentTestRunner {
     result.getErrors().isEmpty()
 
     assertTraces(1) {
-      trace(6) {
+      trace(7) {
         span {
           operationName "graphql.request"
           resourceName "graphql.request"
@@ -98,6 +107,20 @@ class GraphQLTest extends AgentTestRunner {
             "$Tags.COMPONENT" "graphql-java"
             "graphql.query" expectedQuery
             "graphql.operation.name" "findBookById"
+            defaultTags()
+          }
+        }
+        span {
+          operationName "graphql.field"
+          resourceName "Book.isbn"
+          childOf(span(0))
+          spanType DDSpanTypes.GRAPHQL
+          errored false
+          measured true
+          tags {
+            "$Tags.COMPONENT" "graphql-java"
+            "graphql.type" "ID!"
+            "graphql.coordinates" "Book.isbn"
             defaultTags()
           }
         }
@@ -132,7 +155,7 @@ class GraphQLTest extends AgentTestRunner {
         span {
           operationName "getBookById"
           resourceName "book"
-          childOf(span(2))
+          childOf(span(3))
           spanType null
           errored false
           measured false

--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLTest.groovy
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLTest.groovy
@@ -103,7 +103,7 @@ class GraphQLTest extends AgentTestRunner {
         }
         span {
           operationName "graphql.field"
-          resourceName "graphql.field"
+          resourceName "Book.author"
           childOf(span(0))
           spanType DDSpanTypes.GRAPHQL
           errored false
@@ -111,12 +111,13 @@ class GraphQLTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "graphql-java"
             "graphql.type" "Author"
+            "graphql.coordinates" "Book.author"
             defaultTags()
           }
         }
         span {
           operationName "graphql.field"
-          resourceName "graphql.field"
+          resourceName "Query.bookById"
           childOf(span(0))
           spanType DDSpanTypes.GRAPHQL
           errored false
@@ -124,6 +125,7 @@ class GraphQLTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "graphql-java"
             "graphql.type" "Book"
+            "graphql.coordinates" "Query.bookById"
             defaultTags()
           }
         }
@@ -322,7 +324,7 @@ class GraphQLTest extends AgentTestRunner {
         }
         span {
           operationName "graphql.field"
-          resourceName "graphql.field"
+          resourceName "Book.cover"
           childOf(span(0))
           spanType DDSpanTypes.GRAPHQL
           errored true
@@ -330,6 +332,7 @@ class GraphQLTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "graphql-java"
             "graphql.type" "String"
+            "graphql.coordinates" "Book.cover"
             "error.type" "java.lang.IllegalStateException"
             "error.message" "TEST"
             "error.stack" String
@@ -338,7 +341,7 @@ class GraphQLTest extends AgentTestRunner {
         }
         span {
           operationName "graphql.field"
-          resourceName "graphql.field"
+          resourceName "Query.bookById"
           childOf(span(0))
           spanType DDSpanTypes.GRAPHQL
           errored false
@@ -346,6 +349,7 @@ class GraphQLTest extends AgentTestRunner {
           tags {
             "$Tags.COMPONENT" "graphql-java"
             "graphql.type" "Book"
+            "graphql.coordinates" "Query.bookById"
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/test/java/Book.java
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/test/java/Book.java
@@ -6,19 +6,21 @@ public class Book {
   private String name;
   private int pageCount;
   private String authorId;
+  private String isbn;
 
-  public Book(String id, String name, int pageCount, String authorId) {
+  public Book(String id, String name, int pageCount, String authorId, String isbn) {
     this.id = id;
     this.name = name;
     this.pageCount = pageCount;
     this.authorId = authorId;
+    this.isbn = isbn;
   }
 
   private static List<Book> books =
       Arrays.asList(
-          new Book("book-1", "Harry Potter and the Philosopher's Stone", 223, "author-1"),
-          new Book("book-2", "Moby Dick", 635, "author-2"),
-          new Book("book-3", "Interview with the vampire", 371, "author-3"));
+          new Book("book-1", "Harry Potter and the Philosopher's Stone", 223, "author-1", "isbn1"),
+          new Book("book-2", "Moby Dick", 635, "author-2", "isbn2"),
+          new Book("book-3", "Interview with the vampire", 371, "author-3", "isbn3"));
 
   public static Book getById(String id) {
     return books.stream().filter(book -> book.getId().equals(id)).findFirst().orElse(null);
@@ -30,5 +32,9 @@ public class Book {
 
   public String getAuthorId() {
     return authorId;
+  }
+
+  public String getIsbn() {
+    return isbn;
   }
 }

--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/test/resources/schema.graphqls
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/test/resources/schema.graphqls
@@ -13,6 +13,7 @@ type Book {
   pageCount: Int
   author: Author
   cover: String
+  isbn: ID!
 }
 
 type Author {


### PR DESCRIPTION
# What Does This Do

Addresses https://github.com/DataDog/dd-trace-java/issues/4050

# Motivation
 - Provide significant context pertinent to field retrieval
 - Significantly improve the usability and usefulness of the GraphQL resource view in Datadog APM
 - Always provide the field's type, as it was coded it would only provide the type if it was not wrapped

# Additional Notes
https://github.com/graphql/graphql-wg/blob/main/rfcs/SchemaCoordinates.md felt like the natural solution for the naming of the resource being fetched and providing as its own tag.  Having the resource view in Datadog APM broken down by this will provide immense utility in determining where to dig into.