### PR TITLE
Fix duplicated probe not instrumented

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerProductChangesListener.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerProductChangesListener.java
@@ -79,7 +79,7 @@ public class DebuggerProductChangesListener implements ProductListener {
       configChunks.put(configId, (builder) -> builder.add(metricProbe));
     } else if (configId.startsWith("logProbe_")) {
       LogProbe logProbe = Adapter.deserializeLogProbe(content);
-      configChunks.put(configId, (builder) -> builder.add(logProbe));
+      configChunks.put(configId, (builder) -> builder.add(logProbe.copy()));
     } else if (IS_UUID.test(configId)) {
       Configuration newConfig = Adapter.deserializeConfiguration(content);
       if (newConfig.getService().equals(serviceName)) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -217,7 +217,7 @@ public class LogProbe extends ProbeDefinition {
         LANGUAGE,
         null,
         true,
-        null,
+        Tag.fromStrings(null),
         null,
         MethodLocation.DEFAULT,
         null,
@@ -241,13 +241,57 @@ public class LogProbe extends ProbeDefinition {
       ProbeCondition probeCondition,
       Capture capture,
       Sampling sampling) {
-    super(language, id, active, tagStrs, where, evaluateAt);
+    this(
+        language,
+        id,
+        active,
+        Tag.fromStrings(tagStrs),
+        where,
+        evaluateAt,
+        template,
+        segments,
+        captureSnapshot,
+        probeCondition,
+        capture,
+        sampling);
+  }
+
+  private LogProbe(
+      String language,
+      String id,
+      boolean active,
+      Tag[] tags,
+      Where where,
+      MethodLocation evaluateAt,
+      String template,
+      List<Segment> segments,
+      boolean captureSnapshot,
+      ProbeCondition probeCondition,
+      Capture capture,
+      Sampling sampling) {
+    super(language, id, active, tags, where, evaluateAt);
     this.template = template;
     this.segments = segments;
     this.captureSnapshot = captureSnapshot;
     this.probeCondition = probeCondition;
     this.capture = capture;
     this.sampling = sampling;
+  }
+
+  public LogProbe copy() {
+    return new LogProbe(
+        language,
+        id,
+        active,
+        tags,
+        where,
+        evaluateAt,
+        template,
+        segments,
+        captureSnapshot,
+        probeCondition,
+        capture,
+        sampling);
   }
 
   public String getTemplate() {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
@@ -65,6 +65,22 @@ public abstract class ProbeDefinition {
     this.evaluateAt = evaluateAt;
   }
 
+  protected ProbeDefinition(
+      String language,
+      String id,
+      boolean active,
+      Tag[] tags,
+      Where where,
+      MethodLocation evaluateAt) {
+    this.language = language;
+    this.id = id;
+    this.active = active;
+    this.tags = tags;
+    initTagMap(tagMap, tags);
+    this.where = where;
+    this.evaluateAt = evaluateAt;
+  }
+
   public String getId() {
     return id;
   }


### PR DESCRIPTION
# What Does This Do
copy a log probe when receive new configuration to detect changes for a duplicated probe

# Motivation
Since we keep the same instance of deserialized probe and for duplicated we add them in the log definition as additional probes, changes are not detected with ConfigurationComparer

# Additional Notes
