### PR TITLE
Disable Docker layer caching in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ commands:
           version: 20.10.18
           # DLC shares Docker layers across jobs (at an extra cost).
           # But its time to setup (~1min) exceeds the time required to prefetch all images we use.
-          docker_layer_caching: true
+          docker_layer_caching: false
 
       - run:
           name: Prepare testcontainers environment


### PR DESCRIPTION
# What Does This Do
Disable Docker layer caching in Circle CI

# Motivation
Setting up the remote Docker with DLC enabled has about 1 minute of extra time. Also it has an extra cost for every job using it, and I don't think we're leveraging it.

# Additional Notes
* This PR is currently on top of https://github.com/DataDog/dd-trace-java/pull/4651
