### PR TITLE
remove unnecessary check when debugger agent bootstraps

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -50,14 +50,6 @@ public class DebuggerAgent {
     ddAgentFeaturesDiscovery.discoverIfOutdated();
     agentVersion = ddAgentFeaturesDiscovery.getVersion();
 
-    if (isSnapshotUploadThroughAgent && !ddAgentFeaturesDiscovery.supportsDebugger()) {
-      log.error(
-          "No endpoint detected to upload snapshots to from datadog agent at "
-              + agentUrl
-              + ". Consider upgrading the datadog agent.");
-      return;
-    }
-
     sink = new DebuggerSink(config);
     sink.start();
     ConfigurationUpdater configurationUpdater =


### PR DESCRIPTION
# What Does This Do

Remove a check in DebuggerAgent bootstrap to ensure DebuggerEndpoint is available on the agent. This is always true as remote config endpoint which is also required was added after the debugger endpoint to the agent.

# Motivation

Simplify the logic

# Additional Notes
