### PR TITLE
track gRPC scheduling time in SynchronizationContext

### DIFF
--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/SynchronizationContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/SynchronizationContextInstrumentation.java
@@ -1,0 +1,55 @@
+package datadog.trace.instrumentation.grpc;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.experimental.ProfilingContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration;
+import net.bytebuddy.asm.Advice;
+
+@AutoService(Instrumenter.class)
+public class SynchronizationContextInstrumentation extends Instrumenter.Profiling
+    implements Instrumenter.ForSingleType {
+
+  public SynchronizationContextInstrumentation() {
+    super("grpc", "grpc-sync-context");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {packageName + ".TimedRunnable"};
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "io.grpc.SynchronizationContext";
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod()
+            .and(namedOneOf("executeLater", "schedule").and(takesArgument(0, Runnable.class))),
+        getClass().getName() + "$Wrap");
+  }
+
+  public static final class Wrap {
+    @Advice.OnMethodEnter
+    public static void executeLater(@Advice.Argument(value = 0, readOnly = false) Runnable task) {
+      ProfilingContext context = AgentTracer.get().getProfilingContext();
+      // config doesn't make it easy enough to enable an instrumentation only when a flag is set,
+      // so we'll check here for now and hope the check gets optimised away by the JIT
+      if (context instanceof ProfilingContextIntegration
+          && ((ProfilingContextIntegration) context).isQueuingTimeEnabled()
+          && !(task instanceof TimedRunnable)) {
+        // we know it's safe to wrap here (this will be removed at some point and moved into the
+        // scope manager)
+        task = new TimedRunnable(task);
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/TimedRunnable.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/TimedRunnable.java
@@ -1,0 +1,26 @@
+package datadog.trace.instrumentation.grpc;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration;
+
+/**
+ * Runnable which records how long it waited to execute. Don't use this except when wrapping can be
+ * shown to be safe TODO: generalise this behaviour in the scope manager, then delete this class.
+ */
+public final class TimedRunnable implements Runnable {
+
+  private final long creationTime;
+  private final Runnable delegate;
+
+  public TimedRunnable(Runnable delegate) {
+    this.delegate = delegate;
+    this.creationTime = System.currentTimeMillis();
+  }
+
+  @Override
+  public void run() {
+    ((ProfilingContextIntegration) AgentTracer.get().getProfilingContext())
+        .recordQueueingTime(System.currentTimeMillis() - creationTime);
+    delegate.run();
+  }
+}

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
@@ -23,6 +23,9 @@ class GrpcStreamingTest extends AgentTestRunner {
     super.configurePreAgent()
     injectSysConfig("dd.trace.grpc.ignored.inbound.methods", "example.Greeter/IgnoreInbound")
     injectSysConfig("dd.trace.grpc.ignored.outbound.methods", "example.Greeter/Ignore")
+    // here to trigger wrapping to record scheduling time - the logic is trivial so it's enough to verify
+    // that ClassCastExceptions do not arise from the wrapping
+    injectSysConfig("dd.profiling.enabled", "true")
   }
 
   def "test conversation #name"() {

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -51,6 +51,9 @@ abstract class GrpcTest extends AgentTestRunner {
     super.configurePreAgent()
     injectSysConfig("dd.trace.grpc.ignored.inbound.methods", "example.Greeter/IgnoreInbound")
     injectSysConfig("dd.trace.grpc.ignored.outbound.methods", "example.Greeter/Ignore")
+    // here to trigger wrapping to record scheduling time - the logic is trivial so it's enough to verify
+    // that ClassCastExceptions do not arise from the wrapping
+    injectSysConfig("dd.profiling.enabled", "true")
   }
 
   def setupSpec() {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/TestProfilingContextIntegration.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/TestProfilingContextIntegration.groovy
@@ -23,7 +23,7 @@ class TestProfilingContextIntegration implements ProfilingContextIntegration {
 
   @Override
   boolean isQueuingTimeEnabled() {
-    return false
+    return true
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

Tells the profiler how long gRPC requests spend scheduled in the `SynchronizationContext`. This work is temporary and will eventually be superseded by a generic implementation that will support any kind of asynchronous scheduling.

# Motivation

# Additional Notes
