### PR TITLE
Do not add the `_dd.p.dm` tag for spans selected by SSS

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -392,8 +392,6 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext, TraceSe
       if (limit != Integer.MAX_VALUE) {
         unsafeSetTag(SPAN_SAMPLING_MAX_PER_SECOND_TAG, limit);
       }
-      propagationTags.updateTraceSamplingPriority(
-          PrioritySampling.USER_KEEP, SamplingMechanism.SPAN_SAMPLING_RATE);
       isSelectedBySingleSpanSampling = true;
     }
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
@@ -229,7 +229,8 @@ class DDSpanContextTest extends DDCoreSpecification {
     // single span sampling should not change the trace sampling priority
     context.getSamplingPriority() == UNSET
     context.effectiveSamplingPriority == USER_KEEP
-    context.getPropagationTags().createTagMap() == ["_dd.p.dm":"-" + SPAN_SAMPLING_RATE]
+    // make sure the `_dd.p.dm` tag has not been set by single span sampling
+    context.getPropagationTags().createTagMap() == [:]
 
     where:
     rate | limit


### PR DESCRIPTION
# What Does This Do

Removes adding `_dd.p.dm` for spans selected by Single Span Sampling.

# Motivation

This tag should only be added for the trace, not individual spans.

# Additional Notes

Related to the recent fix: #4674
