### PR TITLE
Record queueing time spent in `SerializingExecutor`

### DIFF
--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/RecordQueueingTimeAdvice.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/RecordQueueingTimeAdvice.java
@@ -1,0 +1,23 @@
+package datadog.trace.instrumentation.grpc;
+
+import datadog.trace.api.experimental.ProfilingContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration;
+import net.bytebuddy.asm.Advice;
+
+/** TODO replace with generic timing logic in core */
+public final class RecordQueueingTimeAdvice {
+  @Advice.OnMethodEnter
+  public static void beforeSchedule(@Advice.Argument(value = 0, readOnly = false) Runnable task) {
+    ProfilingContext context = AgentTracer.get().getProfilingContext();
+    // config doesn't make it easy enough to enable an instrumentation only when a flag is set,
+    // so we'll check here for now and hope the check gets optimised away by the JIT
+    if (context instanceof ProfilingContextIntegration
+        && ((ProfilingContextIntegration) context).isQueuingTimeEnabled()
+        && !(task instanceof TimedRunnable)) {
+      // we know it's safe to wrap here (this will be removed at some point and moved into the
+      // scope manager)
+      task = new TimedRunnable(task);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/SerializingExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/SerializingExecutorInstrumentation.java
@@ -1,0 +1,28 @@
+package datadog.trace.instrumentation.grpc;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+
+@AutoService(Instrumenter.class)
+public class SerializingExecutorInstrumentation extends Instrumenter.Profiling
+    implements Instrumenter.ForSingleType {
+  public SerializingExecutorInstrumentation() {
+    super("grpc", "grpc-queueing-time");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "io.grpc.internal.SerializingExecutor";
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod().and(named("execute").and(takesArguments(Runnable.class))),
+        packageName + ".RecordQueueingTimeAdvice");
+  }
+}

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/SynchronizationContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/SynchronizationContextInstrumentation.java
@@ -6,17 +6,13 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.experimental.ProfilingContext;
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration;
-import net.bytebuddy.asm.Advice;
 
 @AutoService(Instrumenter.class)
 public class SynchronizationContextInstrumentation extends Instrumenter.Profiling
     implements Instrumenter.ForSingleType {
 
   public SynchronizationContextInstrumentation() {
-    super("grpc", "grpc-sync-context");
+    super("grpc", "grpc-queueing-time");
   }
 
   @Override
@@ -34,22 +30,6 @@ public class SynchronizationContextInstrumentation extends Instrumenter.Profilin
     transformation.applyAdvice(
         isMethod()
             .and(namedOneOf("executeLater", "schedule").and(takesArgument(0, Runnable.class))),
-        getClass().getName() + "$Wrap");
-  }
-
-  public static final class Wrap {
-    @Advice.OnMethodEnter
-    public static void executeLater(@Advice.Argument(value = 0, readOnly = false) Runnable task) {
-      ProfilingContext context = AgentTracer.get().getProfilingContext();
-      // config doesn't make it easy enough to enable an instrumentation only when a flag is set,
-      // so we'll check here for now and hope the check gets optimised away by the JIT
-      if (context instanceof ProfilingContextIntegration
-          && ((ProfilingContextIntegration) context).isQueuingTimeEnabled()
-          && !(task instanceof TimedRunnable)) {
-        // we know it's safe to wrap here (this will be removed at some point and moved into the
-        // scope manager)
-        task = new TimedRunnable(task);
-      }
-    }
+        packageName + ".RecordQueueingTimeAdvice");
   }
 }


### PR DESCRIPTION
# What Does This Do

Records time spent queueing in `SerializingExecutor` so that we can explain latency caused by getting stuck behind e.g. parsing a large response.

# Motivation

# Additional Notes
