### PR TITLE
Simplify aws-sdk traces [1 of 3]

### DIFF
--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientInstrumentation.java
@@ -188,7 +188,7 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Tracing
       final AgentScope scope = HelperMethods.doMethodEnter(request);
 
       // Wrap the handler so we capture the status code
-      if (handler instanceof ResponseHandler) {
+      if (null != scope && handler instanceof ResponseHandler) {
         handler = new WrappingStatusSettingResponseHandler(scope.span(), (ResponseHandler) handler);
       }
       return scope;
@@ -256,7 +256,7 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Tracing
       }
 
       // Wrap the handler so we capture the status code
-      if (handler instanceof ResponseHandler) {
+      if (null != scope && handler instanceof ResponseHandler) {
         handler = new WrappingStatusSettingResponseHandler(scope.span(), (ResponseHandler) handler);
       }
       return scope;

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
@@ -8,7 +8,6 @@ import static datadog.trace.instrumentation.apachehttpclient.ApacheHttpClientDec
 import static datadog.trace.instrumentation.apachehttpclient.HttpHeadersInjectAdapter.SETTER;
 
 import datadog.trace.api.Config;
-import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -18,12 +17,12 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpUriRequest;
 
 public class HelperMethods {
-  private static final boolean isLegacyAwsTracing =
+  private static final boolean AWS_LEGACY_TRACING =
       Config.get().isLegacyTracingEnabled(false, "aws-sdk");
 
   public static AgentScope doMethodEnter(final HttpUriRequest request) {
     boolean awsClientCall = request.containsHeader("amz-sdk-invocation-id");
-    if (!isLegacyAwsTracing && awsClientCall) {
+    if (!AWS_LEGACY_TRACING && awsClientCall) {
       // avoid creating an extra HTTP client span beneath the AWS client call
       return null;
     }
@@ -40,9 +39,8 @@ public class HelperMethods {
       propagate()
           .injectPathwayContext(
               span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
-    } else if (Config.get().isAwsPropagationEnabled()) {
-      propagate().inject(span, request, SETTER, TracePropagationStyle.XRAY);
     }
+
     return scope;
   }
 

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpClientInstrumentation.java
@@ -173,7 +173,7 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Tracing
           HelperMethods.doMethodEnter(new HostAndRequestAsHttpUriRequest(host, request));
 
       // Wrap the handler so we capture the status code
-      if (handler instanceof HttpClientResponseHandler) {
+      if (null != scope && handler instanceof HttpClientResponseHandler) {
         handler =
             new WrappingStatusSettingResponseHandler(
                 scope.span(), (HttpClientResponseHandler) handler);

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HelperMethods.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HelperMethods.java
@@ -8,7 +8,6 @@ import static datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDe
 import static datadog.trace.instrumentation.apachehttpclient5.HttpHeadersInjectAdapter.SETTER;
 
 import datadog.trace.api.Config;
-import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -18,12 +17,12 @@ import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
 
 public class HelperMethods {
-  private static final boolean isLegacyAwsTracing =
+  private static final boolean AWS_LEGACY_TRACING =
       Config.get().isLegacyTracingEnabled(false, "aws-sdk");
 
   public static AgentScope doMethodEnter(final HttpRequest request) {
     boolean awsClientCall = request.containsHeader("amz-sdk-invocation-id");
-    if (!isLegacyAwsTracing && awsClientCall) {
+    if (!AWS_LEGACY_TRACING && awsClientCall) {
       // avoid creating an extra HTTP client span beneath the AWS client call
       return null;
     }
@@ -40,8 +39,6 @@ public class HelperMethods {
       propagate()
           .injectPathwayContext(
               span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
-    } else if (Config.get().isAwsPropagationEnabled()) {
-      propagate().inject(span, request, SETTER, TracePropagationStyle.XRAY);
     }
 
     return scope;

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HelperMethods.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HelperMethods.java
@@ -7,6 +7,8 @@ import static datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDe
 import static datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator.HTTP_REQUEST;
 import static datadog.trace.instrumentation.apachehttpclient5.HttpHeadersInjectAdapter.SETTER;
 
+import datadog.trace.api.Config;
+import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -16,16 +18,32 @@ import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
 
 public class HelperMethods {
+  private static final boolean isLegacyAwsTracing =
+      Config.get().isLegacyTracingEnabled(false, "aws-sdk");
+
   public static AgentScope doMethodEnter(final HttpRequest request) {
+    boolean awsClientCall = request.containsHeader("amz-sdk-invocation-id");
+    if (!isLegacyAwsTracing && awsClientCall) {
+      // avoid creating an extra HTTP client span beneath the AWS client call
+      return null;
+    }
+
     final AgentSpan span = startSpan(HTTP_REQUEST);
     final AgentScope scope = activateSpan(span);
 
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, request);
 
-    propagate().inject(span, request, SETTER);
-    propagate()
-        .injectPathwayContext(span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
+    // AWS calls are often signed, so we can't add headers without breaking the signature.
+    if (!awsClientCall) {
+      propagate().inject(span, request, SETTER);
+      propagate()
+          .injectPathwayContext(
+              span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
+    } else if (Config.get().isAwsPropagationEnabled()) {
+      propagate().inject(span, request, SETTER, TracePropagationStyle.XRAY);
+    }
+
     return scope;
   }
 

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
@@ -6,6 +6,7 @@ import com.amazonaws.Request;
 import com.amazonaws.Response;
 import datadog.trace.api.Functions;
 import datadog.trace.api.cache.QualifiedClassNameCache;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
@@ -13,7 +14,8 @@ import java.net.URI;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
-public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response> {
+public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response>
+    implements AgentPropagation.Setter<Request<?>> {
   public static final AwsSdkClientDecorator DECORATE = new AwsSdkClientDecorator();
 
   private static final Pattern REQUEST_PATTERN = Pattern.compile("Request", Pattern.LITERAL);
@@ -137,5 +139,10 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
   @Override
   protected int status(final Response response) {
     return response.getHttpResponse().getStatusCode();
+  }
+
+  @Override
+  public void set(Request<?> carrier, String key, String value) {
+    carrier.addHeader(key, value);
   }
 }

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/TracingRequestHandler.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/TracingRequestHandler.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.aws.v0;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateNext;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.closePrevious;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.aws.v0.AwsSdkClientDecorator.DECORATE;
 
@@ -11,6 +12,8 @@ import com.amazonaws.Request;
 import com.amazonaws.Response;
 import com.amazonaws.handlers.HandlerContextKey;
 import com.amazonaws.handlers.RequestHandler2;
+import datadog.trace.api.Config;
+import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -42,6 +45,9 @@ public class TracingRequestHandler extends RequestHandler2 {
       activateNext(span); // this scope will last until next poll
     }
     request.addHandlerContext(SCOPE_CONTEXT_KEY, activateSpan(span));
+    if (Config.get().isAwsPropagationEnabled()) {
+      propagate().inject(span, request, DECORATE, TracePropagationStyle.XRAY);
+    }
   }
 
   @Override

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWS1ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWS1ClientTest.groovy
@@ -34,8 +34,6 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.test.util.Flaky
-import org.apache.http.conn.HttpHostConnectException
-import org.apache.http.impl.execchain.RequestAbortedException
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 
@@ -130,7 +128,7 @@ class AWS1ClientTest extends AgentTestRunner {
     client.requestHandler2s.findAll{ it.getClass().getSimpleName() == "TracingRequestHandler" }.size() == 1
 
     assertTraces(1) {
-      trace(2) {
+      trace(1) {
         span {
           serviceName "$ddService"
           operationName "aws.http"
@@ -154,24 +152,6 @@ class AWS1ClientTest extends AgentTestRunner {
             for (def addedTag : additionalTags) {
               "$addedTag.key" "$addedTag.value"
             }
-            defaultTags()
-          }
-        }
-        span {
-          operationName "http.request"
-          resourceName "$method $path"
-          spanType DDSpanTypes.HTTP_CLIENT
-          errored false
-          measured true
-          childOf(span(0))
-          tags {
-            "$Tags.COMPONENT" "apache-httpclient"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
-            "$Tags.HTTP_URL" "${server.address}${path}"
-            "$Tags.HTTP_METHOD" "$method"
-            "$Tags.HTTP_STATUS" 200
             defaultTags()
           }
         }
@@ -237,7 +217,7 @@ class AWS1ClientTest extends AgentTestRunner {
     thrown SdkClientException
 
     assertTraces(1) {
-      trace(2) {
+      trace(1) {
         span {
           serviceName "java-aws-sdk"
           operationName "aws.http"
@@ -261,24 +241,6 @@ class AWS1ClientTest extends AgentTestRunner {
               "$addedTag.key" "$addedTag.value"
             }
             errorTags SdkClientException, ~/Unable to execute HTTP request/
-            defaultTags()
-          }
-        }
-        span {
-          operationName "http.request"
-          resourceName "$method /$url"
-          spanType DDSpanTypes.HTTP_CLIENT
-          errored true
-          measured true
-          childOf(span(0))
-          tags {
-            "$Tags.COMPONENT" "apache-httpclient"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" UNUSABLE_PORT
-            "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/$url"
-            "$Tags.HTTP_METHOD" "$method"
-            errorTags HttpHostConnectException, ~/Connection refused/
             defaultTags()
           }
         }
@@ -357,7 +319,7 @@ class AWS1ClientTest extends AgentTestRunner {
     thrown AmazonClientException
 
     assertTraces(1) {
-      trace(5) {
+      trace(1) {
         span {
           serviceName "java-aws-sdk"
           operationName "aws.http"
@@ -384,30 +346,6 @@ class AWS1ClientTest extends AgentTestRunner {
               errorTags SdkClientException, "Unable to execute HTTP request: Request did not complete before the request timeout configuration."
             }
             defaultTags()
-          }
-        }
-        (1..4).each {
-          span {
-            operationName "http.request"
-            resourceName "GET /someBucket/someKey"
-            spanType DDSpanTypes.HTTP_CLIENT
-            errored true
-            measured true
-            childOf(span(0))
-            tags {
-              "$Tags.COMPONENT" "apache-httpclient"
-              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-              "$Tags.PEER_HOSTNAME" "localhost"
-              "$Tags.PEER_PORT" server.address.port
-              "$Tags.HTTP_URL" "$server.address/someBucket/someKey"
-              "$Tags.HTTP_METHOD" "GET"
-              try {
-                errorTags SocketException, "Socket closed"
-              } catch (AssertionError e) {
-                errorTags RequestAbortedException, "Request aborted"
-              }
-              defaultTags()
-            }
           }
         }
       }

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/LegacyAWS1ClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/LegacyAWS1ClientForkedTest.groovy
@@ -1,0 +1,425 @@
+import com.amazonaws.AmazonClientException
+import com.amazonaws.AmazonWebServiceClient
+import com.amazonaws.ClientConfiguration
+import com.amazonaws.Request
+import com.amazonaws.SDKGlobalConfiguration
+import com.amazonaws.SdkClientException
+import com.amazonaws.auth.AWSCredentialsProviderChain
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.AnonymousAWSCredentials
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.auth.EnvironmentVariableCredentialsProvider
+import com.amazonaws.auth.InstanceProfileCredentialsProvider
+import com.amazonaws.auth.SystemPropertiesCredentialsProvider
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.handlers.RequestHandler2
+import com.amazonaws.regions.Regions
+import com.amazonaws.retry.PredefinedRetryPolicies
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
+import com.amazonaws.services.dynamodbv2.model.CreateTableRequest
+import com.amazonaws.services.ec2.AmazonEC2ClientBuilder
+import com.amazonaws.services.kinesis.AmazonKinesisClientBuilder
+import com.amazonaws.services.kinesis.model.DeleteStreamRequest
+import com.amazonaws.services.rds.AmazonRDSClientBuilder
+import com.amazonaws.services.rds.model.DeleteOptionGroupRequest
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.amazonaws.services.sns.AmazonSNSClientBuilder
+import com.amazonaws.services.sns.model.PublishRequest
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder
+import com.amazonaws.services.sqs.model.CreateQueueRequest
+import com.amazonaws.services.sqs.model.SendMessageRequest
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.DDSpanTypes
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.test.util.Flaky
+import org.apache.http.conn.HttpHostConnectException
+import org.apache.http.impl.execchain.RequestAbortedException
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+import java.util.concurrent.atomic.AtomicReference
+
+import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
+import static datadog.trace.agent.test.utils.PortUtils.UNUSABLE_PORT
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
+
+class LegacyAWS1ClientForkedTest extends AgentTestRunner {
+
+  @Override
+  void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("aws-sdk.legacy.tracing.enabled", "true")
+  }
+
+  private static final CREDENTIALS_PROVIDER_CHAIN = new AWSCredentialsProviderChain(
+  new EnvironmentVariableCredentialsProvider(),
+  new SystemPropertiesCredentialsProvider(),
+  new ProfileCredentialsProvider(),
+  new InstanceProfileCredentialsProvider())
+
+  def setup() {
+    System.setProperty(SDKGlobalConfiguration.ACCESS_KEY_SYSTEM_PROPERTY, "my-access-key")
+    System.setProperty(SDKGlobalConfiguration.SECRET_KEY_SYSTEM_PROPERTY, "my-secret-key")
+  }
+
+  @Shared
+  def credentialsProvider = new AWSStaticCredentialsProvider(new AnonymousAWSCredentials())
+  @Shared
+  def responseBody = new AtomicReference<String>()
+  @AutoCleanup
+  @Shared
+  def server = httpServer {
+    handlers {
+      all {
+        response.status(200).send(responseBody.get())
+      }
+    }
+  }
+  @Shared
+  def endpoint = new AwsClientBuilder.EndpointConfiguration("http://localhost:$server.address.port", "us-west-2")
+
+  def "request handler is hooked up with builder"() {
+    setup:
+    def builder = AmazonS3ClientBuilder.standard()
+      .withRegion(Regions.US_EAST_1)
+    if (addHandler) {
+      builder.withRequestHandlers(new RequestHandler2() {})
+    }
+    AmazonWebServiceClient client = builder.build()
+
+    expect:
+    client.requestHandler2s != null
+    client.requestHandler2s.size() == size
+    client.requestHandler2s.get(position).getClass().getSimpleName() == "TracingRequestHandler"
+
+    where:
+    addHandler | size | position
+    true       | 2    | 1
+    false      | 1    | 0
+  }
+
+  def "request handler is hooked up with constructor"() {
+    setup:
+    String accessKey = "asdf"
+    String secretKey = "qwerty"
+    def credentials = new BasicAWSCredentials(accessKey, secretKey)
+    def client = new AmazonS3Client(credentials)
+    if (addHandler) {
+      client.addRequestHandler(new RequestHandler2() {})
+    }
+
+    expect:
+    client.requestHandler2s != null
+    client.requestHandler2s.size() == size
+    client.requestHandler2s.get(0).getClass().getSimpleName() == "TracingRequestHandler"
+
+    where:
+    addHandler | size
+    true       | 2
+    false      | 1
+  }
+
+  def "send #operation request with mocked response"() {
+    setup:
+    responseBody.set(body)
+
+    when:
+    def response = call.call(client)
+
+    then:
+    response != null
+
+    client.requestHandler2s != null
+    // check we instrumented with exactly one TracingRequestHandler:
+    client.requestHandler2s.findAll{ it.getClass().getSimpleName() == "TracingRequestHandler" }.size() == 1
+
+    assertTraces(1) {
+      trace(2) {
+        span {
+          serviceName "$ddService"
+          operationName "aws.http"
+          resourceName "$service.$operation"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          parent()
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "$server.address/"
+            "$Tags.HTTP_METHOD" "$method"
+            "$Tags.HTTP_STATUS" 200
+            "$Tags.PEER_PORT" server.address.port
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "aws.service" { it.contains(service) }
+            "aws.endpoint" "$server.address"
+            "aws.operation" "${operation}Request"
+            "aws.agent" "java-aws-sdk"
+            for (def addedTag : additionalTags) {
+              "$addedTag.key" "$addedTag.value"
+            }
+            defaultTags()
+          }
+        }
+        span {
+          operationName "http.request"
+          resourceName "$method $path"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" server.address.port
+            "$Tags.HTTP_URL" "${server.address}${path}"
+            "$Tags.HTTP_METHOD" "$method"
+            "$Tags.HTTP_STATUS" 200
+            defaultTags()
+          }
+        }
+      }
+    }
+    server.lastRequest.headers.get("x-datadog-trace-id") == null
+    server.lastRequest.headers.get("x-datadog-parent-id") == null
+
+    where:
+    service      | operation           | ddService      | method | path                  | client                                                                                                                                             | call                                                                            | additionalTags                    | body
+    "S3"         | "CreateBucket"      | "java-aws-sdk" | "PUT"  | "/testbucket/"        | AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true).withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build() | { client -> client.createBucket("testbucket") }                                 | ["aws.bucket.name": "testbucket"] | ""
+    "S3"         | "GetObject"         | "java-aws-sdk" | "GET"  | "/someBucket/someKey" | AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true).withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build() | { client -> client.getObject("someBucket", "someKey") }                         | ["aws.bucket.name": "someBucket"] | ""
+    "DynamoDBv2" | "CreateTable"       | "java-aws-sdk" | "POST" | "/"                   | AmazonDynamoDBClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                            | { c -> c.createTable(new CreateTableRequest("sometable", null)) }               | ["aws.table.name": "sometable"]   | ""
+    "Kinesis"    | "DeleteStream"      | "java-aws-sdk" | "POST" | "/"                   | AmazonKinesisClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                             | { c -> c.deleteStream(new DeleteStreamRequest().withStreamName("somestream")) } | ["aws.stream.name": "somestream"] | ""
+    "SQS"        | "CreateQueue"       | "java-aws-sdk" | "POST" | "/"                   | AmazonSQSClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                                 | { c -> c.createQueue(new CreateQueueRequest("somequeue")) }                     | ["aws.queue.name": "somequeue"]   | """
+        <CreateQueueResponse>
+            <CreateQueueResult><QueueUrl>https://queue.amazonaws.com/123456789012/MyQueue</QueueUrl></CreateQueueResult>
+            <ResponseMetadata><RequestId>7a62c49f-347e-4fc4-9331-6e8e7a96aa73</RequestId></ResponseMetadata>
+        </CreateQueueResponse>
+      """
+    "SQS"        | "SendMessage"       | "sqs"          | "POST" | "/someurl"            | AmazonSQSClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                                 | { c -> c.sendMessage(new SendMessageRequest("someurl", "")) }                   | ["aws.queue.url": "someurl"]      | """
+        <SendMessageResponse>
+            <SendMessageResult>
+                <MD5OfMessageBody>d41d8cd98f00b204e9800998ecf8427e</MD5OfMessageBody>
+                <MD5OfMessageAttributes>3ae8f24a165a8cedc005670c81a27295</MD5OfMessageAttributes>
+                <MessageId>5fea7756-0ea4-451a-a703-a558b933e274</MessageId>
+            </SendMessageResult>
+            <ResponseMetadata><RequestId>27daac76-34dd-47df-bd01-1f6e873584a0</RequestId></ResponseMetadata>
+        </SendMessageResponse>
+      """
+    "SNS"        | "Publish"           | "sns"          | "POST" | "/"                   | AmazonSNSClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                                 | { c -> c.publish(new PublishRequest("arn:aws:sns::123:some-topic", "")) }       | ["aws.topic.name": "some-topic"]  | """
+        <PublishResponse xmlns="https://sns.amazonaws.com/doc/2010-03-31/">
+            <PublishResult>
+                <MessageId>567910cd-659e-55d4-8ccb-5aaf14679dc0</MessageId>
+            </PublishResult>
+            <ResponseMetadata><RequestId>d74b8436-ae13-5ab4-a9ff-ce54dfea72a0</RequestId></ResponseMetadata>
+        </PublishResponse>
+      """
+    "EC2"        | "AllocateAddress"   | "java-aws-sdk" | "POST" | "/"                   | AmazonEC2ClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                                 | { client -> client.allocateAddress() }                                          | [:]                               | """
+        <AllocateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+           <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
+           <publicIp>192.0.2.1</publicIp>
+           <domain>standard</domain>
+        </AllocateAddressResponse>
+      """
+    "RDS"        | "DeleteOptionGroup" | "java-aws-sdk" | "POST" | "/"                   | AmazonRDSClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                                 | { client -> client.deleteOptionGroup(new DeleteOptionGroupRequest()) }          | [:]                               | """
+        <DeleteOptionGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+          <ResponseMetadata>
+            <RequestId>0ac9cda2-bbf4-11d3-f92b-31fa5e8dbc99</RequestId>
+          </ResponseMetadata>
+        </DeleteOptionGroupResponse>
+      """
+  }
+
+  def "send #operation request to closed port"() {
+    setup:
+    responseBody.set(body)
+
+    when:
+    call.call(client)
+
+    then:
+    thrown SdkClientException
+
+    assertTraces(1) {
+      trace(2) {
+        span {
+          serviceName "java-aws-sdk"
+          operationName "aws.http"
+          resourceName "$service.$operation"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored true
+          measured true
+          parent()
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/"
+            "$Tags.HTTP_METHOD" "$method"
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" 61
+            "aws.service" { it.contains(service) }
+            "aws.endpoint" "http://localhost:${UNUSABLE_PORT}"
+            "aws.operation" "${operation}Request"
+            "aws.agent" "java-aws-sdk"
+            for (def addedTag : additionalTags) {
+              "$addedTag.key" "$addedTag.value"
+            }
+            errorTags SdkClientException, ~/Unable to execute HTTP request/
+            defaultTags()
+          }
+        }
+        span {
+          operationName "http.request"
+          resourceName "$method /$url"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored true
+          measured true
+          childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" UNUSABLE_PORT
+            "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/$url"
+            "$Tags.HTTP_METHOD" "$method"
+            errorTags HttpHostConnectException, ~/Connection refused/
+            defaultTags()
+          }
+        }
+      }
+    }
+
+    where:
+    service | operation   | method | url                  | call                                                    | additionalTags                    | body | client
+    "S3"    | "GetObject" | "GET"  | "someBucket/someKey" | { client -> client.getObject("someBucket", "someKey") } | ["aws.bucket.name": "someBucket"] | ""   | new AmazonS3Client(CREDENTIALS_PROVIDER_CHAIN, new ClientConfiguration().withRetryPolicy(PredefinedRetryPolicies.getDefaultRetryPolicyWithCustomMaxRetries(0))).withEndpoint("http://localhost:${UNUSABLE_PORT}")
+  }
+
+  def "naughty request handler doesn't break the trace"() {
+    setup:
+    def client = new AmazonS3Client(CREDENTIALS_PROVIDER_CHAIN)
+    client.addRequestHandler(new RequestHandler2() {
+        void beforeRequest(Request<?> request) {
+          throw new RuntimeException("bad handler")
+        }
+      })
+
+    when:
+    client.getObject("someBucket", "someKey")
+
+    then:
+    activeSpan() == null
+    thrown RuntimeException
+
+    assertTraces(1) {
+      trace(1) {
+        span {
+          serviceName "java-aws-sdk"
+          operationName "aws.http"
+          resourceName "S3.HeadBucket"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored true
+          measured true
+          parent()
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "https://s3.amazonaws.com/"
+            "$Tags.HTTP_METHOD" "HEAD"
+            "$Tags.PEER_HOSTNAME" "s3.amazonaws.com"
+            "aws.service" "Amazon S3"
+            "aws.endpoint" "https://s3.amazonaws.com"
+            "aws.operation" "HeadBucketRequest"
+            "aws.agent" "java-aws-sdk"
+            "aws.bucket.name" "someBucket"
+            errorTags RuntimeException, "bad handler"
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
+  @Flaky("assertTraces sometimes fails")
+  def "timeout and retry errors captured"() {
+    setup:
+    def server = httpServer {
+      handlers {
+        all {
+          Thread.sleep(500)
+          response.status(200).send()
+        }
+      }
+    }
+    AmazonS3Client client = new AmazonS3Client(new ClientConfiguration().withRequestTimeout(50 /* ms */))
+      .withEndpoint("http://localhost:$server.address.port")
+
+    when:
+    client.getObject("someBucket", "someKey")
+
+    then:
+    activeSpan() == null
+    thrown AmazonClientException
+
+    assertTraces(1) {
+      trace(5) {
+        span {
+          serviceName "java-aws-sdk"
+          operationName "aws.http"
+          resourceName "S3.GetObject"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored true
+          measured true
+          parent()
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "$server.address/"
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.PEER_PORT" server.address.port
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "aws.service" "Amazon S3"
+            "aws.endpoint" "$server.address"
+            "aws.operation" "GetObjectRequest"
+            "aws.agent" "java-aws-sdk"
+            "aws.bucket.name" "someBucket"
+            try {
+              errorTags AmazonClientException, ~/Unable to execute HTTP request/
+            } catch (AssertionError e) {
+              errorTags SdkClientException, "Unable to execute HTTP request: Request did not complete before the request timeout configuration."
+            }
+            defaultTags()
+          }
+        }
+        (1..4).each {
+          span {
+            operationName "http.request"
+            resourceName "GET /someBucket/someKey"
+            spanType DDSpanTypes.HTTP_CLIENT
+            errored true
+            measured true
+            childOf(span(0))
+            tags {
+              "$Tags.COMPONENT" "apache-httpclient"
+              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+              "$Tags.PEER_HOSTNAME" "localhost"
+              "$Tags.PEER_PORT" server.address.port
+              "$Tags.HTTP_URL" "$server.address/someBucket/someKey"
+              "$Tags.HTTP_METHOD" "GET"
+              try {
+                errorTags SocketException, "Socket closed"
+              } catch (AssertionError e) {
+                errorTags RequestAbortedException, "Request aborted"
+              }
+              defaultTags()
+            }
+          }
+        }
+      }
+    }
+
+    cleanup:
+    server.close()
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWS0ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWS0ClientTest.groovy
@@ -18,8 +18,6 @@ import com.amazonaws.services.s3.S3ClientOptions
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import org.apache.http.conn.HttpHostConnectException
-import org.apache.http.impl.execchain.RequestAbortedException
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 
@@ -90,7 +88,7 @@ class AWS0ClientTest extends AgentTestRunner {
     client.requestHandler2s.get(0).getClass().getSimpleName() == "TracingRequestHandler"
 
     assertTraces(1) {
-      trace(2) {
+      trace(1) {
         span {
           serviceName "java-aws-sdk"
           operationName "aws.http"
@@ -114,24 +112,6 @@ class AWS0ClientTest extends AgentTestRunner {
             for (def addedTag : additionalTags) {
               "$addedTag.key" "$addedTag.value"
             }
-            defaultTags()
-          }
-        }
-        span {
-          operationName "http.request"
-          resourceName "$method $path"
-          spanType DDSpanTypes.HTTP_CLIENT
-          errored false
-          measured true
-          childOf(span(0))
-          tags {
-            "$Tags.COMPONENT" "apache-httpclient"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
-            "$Tags.HTTP_URL" "${server.address}${path}"
-            "$Tags.HTTP_METHOD" "$method"
-            "$Tags.HTTP_STATUS" 200
             defaultTags()
           }
         }
@@ -171,7 +151,7 @@ class AWS0ClientTest extends AgentTestRunner {
     thrown AmazonClientException
 
     assertTraces(1) {
-      trace(2) {
+      trace(1) {
         span {
           serviceName "java-aws-sdk"
           operationName "aws.http"
@@ -195,24 +175,6 @@ class AWS0ClientTest extends AgentTestRunner {
               "$addedTag.key" "$addedTag.value"
             }
             errorTags AmazonClientException, ~/Unable to execute HTTP request/
-            defaultTags()
-          }
-        }
-        span {
-          operationName "http.request"
-          resourceName "$method /$url"
-          spanType DDSpanTypes.HTTP_CLIENT
-          errored true
-          measured true
-          childOf(span(0))
-          tags {
-            "$Tags.COMPONENT" "apache-httpclient"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" UNUSABLE_PORT
-            "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/$url"
-            "$Tags.HTTP_METHOD" "$method"
-            errorTags HttpHostConnectException, ~/Connection refused/
             defaultTags()
           }
         }
@@ -290,7 +252,7 @@ class AWS0ClientTest extends AgentTestRunner {
     thrown AmazonClientException
 
     assertTraces(1) {
-      trace(5) {
+      trace(1) {
         span {
           serviceName "java-aws-sdk"
           operationName "aws.http"
@@ -313,30 +275,6 @@ class AWS0ClientTest extends AgentTestRunner {
             "aws.bucket.name" "someBucket"
             errorTags AmazonClientException, ~/Unable to execute HTTP request/
             defaultTags()
-          }
-        }
-        (1..4).each {
-          span {
-            operationName "http.request"
-            resourceName "GET /someBucket/someKey"
-            spanType DDSpanTypes.HTTP_CLIENT
-            errored true
-            measured true
-            childOf(span(0))
-            tags {
-              "$Tags.COMPONENT" "apache-httpclient"
-              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-              "$Tags.PEER_HOSTNAME" "localhost"
-              "$Tags.PEER_PORT" server.address.port
-              "$Tags.HTTP_URL" "$server.address/someBucket/someKey"
-              "$Tags.HTTP_METHOD" "GET"
-              try {
-                errorTags SocketException, "Socket closed"
-              } catch (AssertionError e) {
-                errorTags RequestAbortedException, "Request aborted"
-              }
-              defaultTags()
-            }
           }
         }
       }

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/LegacyAWS0ClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/LegacyAWS0ClientForkedTest.groovy
@@ -1,0 +1,354 @@
+import com.amazonaws.AmazonClientException
+import com.amazonaws.ClientConfiguration
+import com.amazonaws.Request
+import com.amazonaws.SDKGlobalConfiguration
+import com.amazonaws.auth.AWSCredentialsProviderChain
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.auth.EnvironmentVariableCredentialsProvider
+import com.amazonaws.auth.InstanceProfileCredentialsProvider
+import com.amazonaws.auth.SystemPropertiesCredentialsProvider
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.handlers.RequestHandler2
+import com.amazonaws.retry.PredefinedRetryPolicies
+import com.amazonaws.services.ec2.AmazonEC2Client
+import com.amazonaws.services.rds.AmazonRDSClient
+import com.amazonaws.services.rds.model.DeleteOptionGroupRequest
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.S3ClientOptions
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.DDSpanTypes
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import org.apache.http.conn.HttpHostConnectException
+import org.apache.http.impl.execchain.RequestAbortedException
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+import java.util.concurrent.atomic.AtomicReference
+
+import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
+import static datadog.trace.agent.test.utils.PortUtils.UNUSABLE_PORT
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
+
+class LegacyAWS0ClientForkedTest extends AgentTestRunner {
+
+  @Override
+  void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("aws-sdk.legacy.tracing.enabled", "true")
+  }
+
+  private static final CREDENTIALS_PROVIDER_CHAIN = new AWSCredentialsProviderChain(
+  new EnvironmentVariableCredentialsProvider(),
+  new SystemPropertiesCredentialsProvider(),
+  new ProfileCredentialsProvider(),
+  new InstanceProfileCredentialsProvider())
+
+  def setup() {
+    System.setProperty(SDKGlobalConfiguration.ACCESS_KEY_SYSTEM_PROPERTY, "my-access-key")
+    System.setProperty(SDKGlobalConfiguration.SECRET_KEY_SYSTEM_PROPERTY, "my-secret-key")
+  }
+
+  @Shared
+  def responseBody = new AtomicReference<String>()
+  @AutoCleanup
+  @Shared
+  def server = httpServer {
+    handlers {
+      all {
+        response.status(200).send(responseBody.get())
+      }
+    }
+  }
+
+  def "request handler is hooked up with constructor"() {
+    setup:
+    String accessKey = "asdf"
+    String secretKey = "qwerty"
+    def credentials = new BasicAWSCredentials(accessKey, secretKey)
+    def client = new AmazonS3Client(credentials)
+    if (addHandler) {
+      client.addRequestHandler(new RequestHandler2() {})
+    }
+
+    expect:
+    client.requestHandler2s != null
+    client.requestHandler2s.size() == size
+    client.requestHandler2s.get(0).getClass().getSimpleName() == "TracingRequestHandler"
+
+    where:
+    addHandler | size
+    true       | 2
+    false      | 1
+  }
+
+  def "send #operation request with mocked response"() {
+    setup:
+    responseBody.set(body)
+
+    when:
+    def response = call.call(client)
+
+    then:
+    response != null
+
+    client.requestHandler2s != null
+    client.requestHandler2s.size() == handlerCount
+    client.requestHandler2s.get(0).getClass().getSimpleName() == "TracingRequestHandler"
+
+    assertTraces(1) {
+      trace(2) {
+        span {
+          serviceName "java-aws-sdk"
+          operationName "aws.http"
+          resourceName "$service.$operation"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          parent()
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "$server.address/"
+            "$Tags.HTTP_METHOD" "$method"
+            "$Tags.HTTP_STATUS" 200
+            "$Tags.PEER_PORT" server.address.port
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "aws.service" { it.contains(service) }
+            "aws.endpoint" "$server.address"
+            "aws.operation" "${operation}Request"
+            "aws.agent" "java-aws-sdk"
+            for (def addedTag : additionalTags) {
+              "$addedTag.key" "$addedTag.value"
+            }
+            defaultTags()
+          }
+        }
+        span {
+          operationName "http.request"
+          resourceName "$method $path"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" server.address.port
+            "$Tags.HTTP_URL" "${server.address}${path}"
+            "$Tags.HTTP_METHOD" "$method"
+            "$Tags.HTTP_STATUS" 200
+            defaultTags()
+          }
+        }
+      }
+    }
+    server.lastRequest.headers.get("x-datadog-trace-id") == null
+    server.lastRequest.headers.get("x-datadog-parent-id") == null
+
+    where:
+    service | operation           | method | path                  | handlerCount | client                                                                      | additionalTags                    | call                                                                                                                                   | body
+    "S3"    | "CreateBucket"      | "PUT"  | "/testbucket/"        | 1            | new AmazonS3Client().withEndpoint("http://localhost:$server.address.port")  | ["aws.bucket.name": "testbucket"] | { client -> client.setS3ClientOptions(S3ClientOptions.builder().setPathStyleAccess(true).build()); client.createBucket("testbucket") } | ""
+    "S3"    | "GetObject"         | "GET"  | "/someBucket/someKey" | 1            | new AmazonS3Client().withEndpoint("http://localhost:$server.address.port")  | ["aws.bucket.name": "someBucket"] | { client -> client.getObject("someBucket", "someKey") }                                                                                | ""
+    "EC2"   | "AllocateAddress"   | "POST" | "/"                   | 4            | new AmazonEC2Client().withEndpoint("http://localhost:$server.address.port") | [:]                               | { client -> client.allocateAddress() }                                                                                                 | """
+            <AllocateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+               <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+               <publicIp>192.0.2.1</publicIp>
+               <domain>standard</domain>
+            </AllocateAddressResponse>
+            """
+    "RDS"   | "DeleteOptionGroup" | "POST" | "/"                   | 1            | new AmazonRDSClient().withEndpoint("http://localhost:$server.address.port") | [:]                               | { client -> client.deleteOptionGroup(new DeleteOptionGroupRequest()) }                                                                 | """
+        <DeleteOptionGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+          <ResponseMetadata>
+            <RequestId>0ac9cda2-bbf4-11d3-f92b-31fa5e8dbc99</RequestId>
+          </ResponseMetadata>
+        </DeleteOptionGroupResponse>
+      """
+  }
+
+  def "send #operation request to closed port"() {
+    setup:
+    responseBody.set(body)
+
+    when:
+    call.call(client)
+
+    then:
+    thrown AmazonClientException
+
+    assertTraces(1) {
+      trace(2) {
+        span {
+          serviceName "java-aws-sdk"
+          operationName "aws.http"
+          resourceName "$service.$operation"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored true
+          measured true
+          parent()
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/"
+            "$Tags.HTTP_METHOD" "$method"
+            "$Tags.PEER_PORT" 61
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "aws.service" { it.contains(service) }
+            "aws.endpoint" "http://localhost:${UNUSABLE_PORT}"
+            "aws.operation" "${operation}Request"
+            "aws.agent" "java-aws-sdk"
+            for (def addedTag : additionalTags) {
+              "$addedTag.key" "$addedTag.value"
+            }
+            errorTags AmazonClientException, ~/Unable to execute HTTP request/
+            defaultTags()
+          }
+        }
+        span {
+          operationName "http.request"
+          resourceName "$method /$url"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored true
+          measured true
+          childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" UNUSABLE_PORT
+            "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/$url"
+            "$Tags.HTTP_METHOD" "$method"
+            errorTags HttpHostConnectException, ~/Connection refused/
+            defaultTags()
+          }
+        }
+      }
+    }
+
+    where:
+    service | operation   | method | url                  | call                                                    | additionalTags                    | body | client
+    "S3"    | "GetObject" | "GET"  | "someBucket/someKey" | { client -> client.getObject("someBucket", "someKey") } | ["aws.bucket.name": "someBucket"] | ""   | new AmazonS3Client(CREDENTIALS_PROVIDER_CHAIN, new ClientConfiguration().withRetryPolicy(PredefinedRetryPolicies.getDefaultRetryPolicyWithCustomMaxRetries(0))).withEndpoint("http://localhost:${UNUSABLE_PORT}")
+  }
+
+  def "naughty request handler doesn't break the trace"() {
+    setup:
+    def client = new AmazonS3Client(CREDENTIALS_PROVIDER_CHAIN)
+    client.addRequestHandler(new RequestHandler2() {
+        void beforeRequest(Request<?> request) {
+          throw new RuntimeException("bad handler")
+        }
+      })
+
+    when:
+    client.getObject("someBucket", "someKey")
+
+    then:
+    activeSpan() == null
+    thrown RuntimeException
+
+    assertTraces(1) {
+      trace(1) {
+        span {
+          serviceName "java-aws-sdk"
+          operationName "aws.http"
+          resourceName "S3.GetObject"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored true
+          measured true
+          parent()
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "https://s3.amazonaws.com/"
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.PEER_HOSTNAME" "s3.amazonaws.com"
+            "aws.service" "Amazon S3"
+            "aws.endpoint" "https://s3.amazonaws.com"
+            "aws.operation" "GetObjectRequest"
+            "aws.agent" "java-aws-sdk"
+            "aws.bucket.name" "someBucket"
+            errorTags RuntimeException, "bad handler"
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
+  def "timeout and retry errors captured"() {
+    setup:
+    def server = httpServer {
+      handlers {
+        all {
+          Thread.sleep(500)
+          response.status(200).send()
+        }
+      }
+    }
+    AmazonS3Client client = new AmazonS3Client(new ClientConfiguration().withRequestTimeout(50 /* ms */))
+      .withEndpoint("http://localhost:$server.address.port")
+
+    when:
+    client.getObject("someBucket", "someKey")
+
+    then:
+    activeSpan() == null
+    thrown AmazonClientException
+
+    assertTraces(1) {
+      trace(5) {
+        span {
+          serviceName "java-aws-sdk"
+          operationName "aws.http"
+          resourceName "S3.GetObject"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored true
+          measured true
+          parent()
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "$server.address/"
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.PEER_PORT" server.address.port
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "aws.service" "Amazon S3"
+            "aws.endpoint" "http://localhost:$server.address.port"
+            "aws.operation" "GetObjectRequest"
+            "aws.agent" "java-aws-sdk"
+            "aws.bucket.name" "someBucket"
+            errorTags AmazonClientException, ~/Unable to execute HTTP request/
+            defaultTags()
+          }
+        }
+        (1..4).each {
+          span {
+            operationName "http.request"
+            resourceName "GET /someBucket/someKey"
+            spanType DDSpanTypes.HTTP_CLIENT
+            errored true
+            measured true
+            childOf(span(0))
+            tags {
+              "$Tags.COMPONENT" "apache-httpclient"
+              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+              "$Tags.PEER_HOSTNAME" "localhost"
+              "$Tags.PEER_PORT" server.address.port
+              "$Tags.HTTP_URL" "$server.address/someBucket/someKey"
+              "$Tags.HTTP_METHOD" "GET"
+              try {
+                errorTags SocketException, "Socket closed"
+              } catch (AssertionError e) {
+                errorTags RequestAbortedException, "Request aborted"
+              }
+              defaultTags()
+            }
+          }
+        }
+      }
+    }
+
+    cleanup:
+    server.close()
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.aws.v2;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -13,7 +14,8 @@ import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.SdkHttpResponse;
 
-public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, SdkHttpResponse> {
+public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, SdkHttpResponse>
+    implements AgentPropagation.Setter<SdkHttpRequest.Builder> {
   public static final AwsSdkClientDecorator DECORATE = new AwsSdkClientDecorator();
 
   public static final CharSequence AWS_HTTP = UTF8BytesString.create("aws.http");
@@ -115,5 +117,10 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
   @Override
   protected int status(final SdkHttpResponse response) {
     return response.statusCode();
+  }
+
+  @Override
+  public void set(SdkHttpRequest.Builder carrier, String key, String value) {
+    carrier.putHeader(key, value);
   }
 }

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/Aws2ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/Aws2ClientTest.groovy
@@ -96,7 +96,7 @@ class Aws2ClientTest extends AgentTestRunner {
     response.class.simpleName.startsWith(operation) || response instanceof ResponseInputStream
 
     assertTraces(1) {
-      trace(2) {
+      trace(1) {
         span {
           serviceName "$ddService"
           operationName "aws.http"
@@ -133,24 +133,6 @@ class Aws2ClientTest extends AgentTestRunner {
             } else if (service == "Kinesis") {
               "aws.stream.name" "somestream"
             }
-            defaultTags()
-          }
-        }
-        span {
-          operationName "http.request"
-          resourceName "$method $path"
-          spanType DDSpanTypes.HTTP_CLIENT
-          errored false
-          measured true
-          childOf(span(0))
-          tags {
-            "$Tags.COMPONENT" "apache-httpclient"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" server.address.port
-            "$Tags.HTTP_URL" "${server.address}${path}"
-            "$Tags.HTTP_METHOD" "$method"
-            "$Tags.HTTP_STATUS" 200
             defaultTags()
           }
         }
@@ -227,7 +209,7 @@ class Aws2ClientTest extends AgentTestRunner {
     executed
     response != null
 
-    assertTraces(2) {
+    assertTraces(1) {
       trace(1) {
         span {
           serviceName "$ddService"
@@ -262,28 +244,6 @@ class Aws2ClientTest extends AgentTestRunner {
             } else if (service == "Kinesis") {
               "aws.stream.name" "somestream"
             }
-            defaultTags()
-          }
-        }
-      }
-      // TODO: this should be part of the same trace but netty instrumentation doesn't cooperate
-      trace(1) {
-        span {
-          operationName "netty.client.request"
-          resourceName "$method $path"
-          spanType DDSpanTypes.HTTP_CLIENT
-          errored false
-          measured true
-          parent()
-          tags {
-            "$Tags.COMPONENT" "netty-client"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" server.address.port
-            "$Tags.HTTP_URL" "${server.address}${path}"
-            "$Tags.HTTP_METHOD" "$method"
-            "$Tags.HTTP_STATUS" 200
             defaultTags()
           }
         }
@@ -361,7 +321,7 @@ class Aws2ClientTest extends AgentTestRunner {
     thrown SdkClientException
 
     assertTraces(1) {
-      trace(5) {
+      trace(1) {
         span {
           serviceName "java-aws-sdk"
           operationName "aws.http"
@@ -382,25 +342,6 @@ class Aws2ClientTest extends AgentTestRunner {
             "aws.bucket.name" "somebucket"
             errorTags SdkClientException, "Unable to execute HTTP request: Read timed out"
             defaultTags()
-          }
-        }
-        (1..4).each {
-          span {
-            operationName "http.request"
-            resourceName "GET /somebucket/somekey"
-            spanType DDSpanTypes.HTTP_CLIENT
-            errored true
-            childOf(span(0))
-            tags {
-              "$Tags.COMPONENT" "apache-httpclient"
-              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-              "$Tags.PEER_HOSTNAME" "localhost"
-              "$Tags.PEER_PORT" server.address.port
-              "$Tags.HTTP_URL" "$server.address/somebucket/somekey"
-              "$Tags.HTTP_METHOD" "GET"
-              errorTags SocketTimeoutException, "Read timed out"
-              defaultTags()
-            }
           }
         }
       }

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/LegacyAws2ClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/LegacyAws2ClientForkedTest.groovy
@@ -1,0 +1,418 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.DDSpanTypes
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.core.ResponseInputStream
+import software.amazon.awssdk.core.async.AsyncResponseTransformer
+import software.amazon.awssdk.core.exception.SdkClientException
+import software.amazon.awssdk.core.interceptor.Context
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.http.apache.ApacheHttpClient
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest
+import software.amazon.awssdk.services.ec2.Ec2AsyncClient
+import software.amazon.awssdk.services.ec2.Ec2Client
+import software.amazon.awssdk.services.kinesis.KinesisClient
+import software.amazon.awssdk.services.kinesis.model.DeleteStreamRequest
+import software.amazon.awssdk.services.rds.RdsAsyncClient
+import software.amazon.awssdk.services.rds.RdsClient
+import software.amazon.awssdk.services.rds.model.DeleteOptionGroupRequest
+import software.amazon.awssdk.services.s3.S3AsyncClient
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import software.amazon.awssdk.services.s3.model.StorageClass
+import software.amazon.awssdk.services.sns.SnsAsyncClient
+import software.amazon.awssdk.services.sns.SnsClient
+import software.amazon.awssdk.services.sns.model.PublishRequest
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import software.amazon.awssdk.services.sqs.SqsClient
+import software.amazon.awssdk.services.sqs.model.CreateQueueRequest
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+import java.time.Duration
+import java.util.concurrent.Future
+import java.util.concurrent.atomic.AtomicReference
+
+import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
+
+class LegacyAws2ClientForkedTest extends AgentTestRunner {
+
+  @Override
+  void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("aws-sdk.legacy.tracing.enabled", "true")
+  }
+
+  private static final StaticCredentialsProvider CREDENTIALS_PROVIDER = StaticCredentialsProvider
+  .create(AwsBasicCredentials.create("my-access-key", "my-secret-key"))
+
+  @Shared
+  def responseBody = new AtomicReference<String>()
+
+  @AutoCleanup
+  @Shared
+  def server = httpServer {
+    handlers {
+      all {
+        response.status(200).send(responseBody.get())
+      }
+    }
+  }
+
+  def watch(builder, callback) {
+    builder.addExecutionInterceptor(new ExecutionInterceptor() {
+        @Override
+        void afterExecution(Context.AfterExecution context, ExecutionAttributes executionAttributes) {
+          callback.call()
+        }
+      })
+  }
+
+  def "send #operation request with builder {#builder.class.getName()} mocked response"() {
+    setup:
+    boolean executed = false
+    def client = builder
+      // tests that our instrumentation doesn't disturb any overridden configuration
+      .overrideConfiguration({ watch(it, { executed = true }) })
+      .endpointOverride(server.address)
+      .region(Region.AP_NORTHEAST_1)
+      .credentialsProvider(CREDENTIALS_PROVIDER)
+      .build()
+    responseBody.set(body)
+    when:
+    def response = call.call(client)
+
+    if (response instanceof Future) {
+      response = response.get()
+    }
+    TEST_WRITER.waitForTraces(1)
+
+    then:
+    executed
+    response != null
+    response.class.simpleName.startsWith(operation) || response instanceof ResponseInputStream
+
+    assertTraces(1) {
+      trace(2) {
+        span {
+          serviceName "$ddService"
+          operationName "aws.http"
+          resourceName "$service.$operation"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          parent()
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" server.address.port
+            "$Tags.HTTP_URL" "${server.address}${path}"
+            "$Tags.HTTP_METHOD" "$method"
+            "$Tags.HTTP_STATUS" 200
+            "aws.service" "$service"
+            "aws.operation" "${operation}"
+            "aws.agent" "java-aws-sdk"
+            "aws.requestId" "$requestId"
+            if (service == "S3") {
+              "aws.bucket.name" "somebucket"
+              if (operation == "PutObject") {
+                "aws.storage.class" "GLACIER"
+              }
+            } else if (service == "Sqs" && operation == "CreateQueue") {
+              "aws.queue.name" "somequeue"
+            } else if (service == "Sqs" && operation == "SendMessage") {
+              "aws.queue.url" "someurl"
+            } else if (service == "Sns" && operation == "Publish") {
+              "aws.topic.name" "some-topic"
+            } else if (service == "DynamoDb") {
+              "aws.table.name" "sometable"
+            } else if (service == "Kinesis") {
+              "aws.stream.name" "somestream"
+            }
+            defaultTags()
+          }
+        }
+        span {
+          operationName "http.request"
+          resourceName "$method $path"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" server.address.port
+            "$Tags.HTTP_URL" "${server.address}${path}"
+            "$Tags.HTTP_METHOD" "$method"
+            "$Tags.HTTP_STATUS" 200
+            defaultTags()
+          }
+        }
+      }
+    }
+    server.lastRequest.headers.get("x-datadog-trace-id") == null
+    server.lastRequest.headers.get("x-datadog-parent-id") == null
+
+    where:
+    service    | operation           | ddService      | method | path                  | requestId                              | builder                  | call                                                                                                                                                            | body
+    "S3"       | "CreateBucket"      | "java-aws-sdk" | "PUT"  | "/somebucket"         | "UNKNOWN"                              | S3Client.builder()       | { c -> c.createBucket(CreateBucketRequest.builder().bucket("somebucket").build()) }                                                                             | ""
+    "S3"       | "GetObject"         | "java-aws-sdk" | "GET"  | "/somebucket/somekey" | "UNKNOWN"                              | S3Client.builder()       | { c -> c.getObject(GetObjectRequest.builder().bucket("somebucket").key("somekey").build()) }                                                                    | ""
+    "S3"       | "PutObject"         | "java-aws-sdk" | "PUT"  | "/somebucket/somekey" | "UNKNOWN"                              | S3Client.builder()       | { c -> c.putObject(PutObjectRequest.builder().bucket("somebucket").key("somekey").storageClass(StorageClass.GLACIER).build(), RequestBody.fromString("body")) } | "body"
+    "DynamoDb" | "CreateTable"       | "java-aws-sdk" | "POST" | "/"                   | "UNKNOWN"                              | DynamoDbClient.builder() | { c -> c.createTable(CreateTableRequest.builder().tableName("sometable").build()) }                                                                             | ""
+    "Kinesis"  | "DeleteStream"      | "java-aws-sdk" | "POST" | "/"                   | "UNKNOWN"                              | KinesisClient.builder()  | { c -> c.deleteStream(DeleteStreamRequest.builder().streamName("somestream").build()) }                                                                         | ""
+    "Sqs"      | "CreateQueue"       | "java-aws-sdk" | "POST" | "/"                   | "7a62c49f-347e-4fc4-9331-6e8e7a96aa73" | SqsClient.builder()      | { c -> c.createQueue(CreateQueueRequest.builder().queueName("somequeue").build()) }                                                                             | """
+        <CreateQueueResponse>
+            <CreateQueueResult><QueueUrl>https://queue.amazonaws.com/123456789012/MyQueue</QueueUrl></CreateQueueResult>
+            <ResponseMetadata><RequestId>7a62c49f-347e-4fc4-9331-6e8e7a96aa73</RequestId></ResponseMetadata>
+        </CreateQueueResponse>
+        """
+    "Sqs"      | "SendMessage"       | "sqs"          | "POST" | "/"                   | "27daac76-34dd-47df-bd01-1f6e873584a0" | SqsClient.builder()      | { c -> c.sendMessage(SendMessageRequest.builder().queueUrl("someurl").messageBody("").build()) }                                                                | """
+        <SendMessageResponse>
+            <SendMessageResult>
+                <MD5OfMessageBody>d41d8cd98f00b204e9800998ecf8427e</MD5OfMessageBody>
+                <MD5OfMessageAttributes>3ae8f24a165a8cedc005670c81a27295</MD5OfMessageAttributes>
+                <MessageId>5fea7756-0ea4-451a-a703-a558b933e274</MessageId>
+            </SendMessageResult>
+            <ResponseMetadata><RequestId>27daac76-34dd-47df-bd01-1f6e873584a0</RequestId></ResponseMetadata>
+        </SendMessageResponse>
+        """
+    "Sns"      | "Publish"           | "sns"          | "POST" | "/"                   | "d74b8436-ae13-5ab4-a9ff-ce54dfea72a0" | SnsClient.builder()      | { c -> c.publish(PublishRequest.builder().topicArn("arn:aws:sns::123:some-topic").message("").build()) }                                                        | """
+        <PublishResponse xmlns="https://sns.amazonaws.com/doc/2010-03-31/">
+            <PublishResult>
+                <MessageId>567910cd-659e-55d4-8ccb-5aaf14679dc0</MessageId>
+            </PublishResult>
+            <ResponseMetadata><RequestId>d74b8436-ae13-5ab4-a9ff-ce54dfea72a0</RequestId></ResponseMetadata>
+        </PublishResponse>
+        """
+    "Ec2"      | "AllocateAddress"   | "java-aws-sdk" | "POST" | "/"                   | "59dbff89-35bd-4eac-99ed-be587EXAMPLE" | Ec2Client.builder()      | { c -> c.allocateAddress() }                                                                                                                                    | """
+        <AllocateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+           <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+           <publicIp>192.0.2.1</publicIp>
+           <domain>standard</domain>
+        </AllocateAddressResponse>
+        """
+    "Rds"      | "DeleteOptionGroup" | "java-aws-sdk" | "POST" | "/"                   | "0ac9cda2-bbf4-11d3-f92b-31fa5e8dbc99" | RdsClient.builder()      | { c -> c.deleteOptionGroup(DeleteOptionGroupRequest.builder().build()) }                                                                                        | """
+        <DeleteOptionGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+          <ResponseMetadata><RequestId>0ac9cda2-bbf4-11d3-f92b-31fa5e8dbc99</RequestId></ResponseMetadata>
+        </DeleteOptionGroupResponse>
+        """
+  }
+
+  def "send #operation async request with builder {#builder.class.getName()} mocked response"() {
+    setup:
+    boolean executed = false
+    def client = builder
+      // tests that our instrumentation doesn't disturb any overridden configuration
+      .overrideConfiguration({ watch(it, { executed = true }) })
+      .endpointOverride(server.address)
+      .region(Region.AP_NORTHEAST_1)
+      .credentialsProvider(CREDENTIALS_PROVIDER)
+      .build()
+    responseBody.set(body)
+    when:
+    def response = call.call(client)
+
+    if (response instanceof Future) {
+      response = response.get()
+    }
+    TEST_WRITER.waitForTraces(1)
+
+    then:
+    executed
+    response != null
+
+    assertTraces(2) {
+      trace(1) {
+        span {
+          serviceName "$ddService"
+          operationName "aws.http"
+          resourceName "$service.$operation"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          parent()
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" server.address.port
+            "$Tags.HTTP_URL" "${server.address}${path}"
+            "$Tags.HTTP_METHOD" "$method"
+            "$Tags.HTTP_STATUS" 200
+            "aws.service" "$service"
+            "aws.operation" "${operation}"
+            "aws.agent" "java-aws-sdk"
+            "aws.requestId" "$requestId"
+            if (service == "S3") {
+              "aws.bucket.name" "somebucket"
+            } else if (service == "Sqs" && operation == "CreateQueue") {
+              "aws.queue.name" "somequeue"
+            } else if (service == "Sqs" && operation == "SendMessage") {
+              "aws.queue.url" "someurl"
+            } else if (service == "Sns" && operation == "Publish") {
+              "aws.topic.name" "some-topic"
+            } else if (service == "DynamoDb") {
+              "aws.table.name" "sometable"
+            } else if (service == "Kinesis") {
+              "aws.stream.name" "somestream"
+            }
+            defaultTags()
+          }
+        }
+      }
+      // TODO: this should be part of the same trace but netty instrumentation doesn't cooperate
+      trace(1) {
+        span {
+          operationName "netty.client.request"
+          resourceName "$method $path"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          parent()
+          tags {
+            "$Tags.COMPONENT" "netty-client"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+            "$Tags.PEER_PORT" server.address.port
+            "$Tags.HTTP_URL" "${server.address}${path}"
+            "$Tags.HTTP_METHOD" "$method"
+            "$Tags.HTTP_STATUS" 200
+            defaultTags()
+          }
+        }
+      }
+    }
+    server.lastRequest.headers.get("x-datadog-trace-id") == null
+    server.lastRequest.headers.get("x-datadog-parent-id") == null
+
+    where:
+    service    | operation           | ddService      | method | path                  | requestId                              | builder                       | call                                                                                                                             | body
+    "S3"       | "CreateBucket"      | "java-aws-sdk" | "PUT"  | "/somebucket"         | "UNKNOWN"                              | S3AsyncClient.builder()       | { c -> c.createBucket(CreateBucketRequest.builder().bucket("somebucket").build()) }                                              | ""
+    "S3"       | "GetObject"         | "java-aws-sdk" | "GET"  | "/somebucket/somekey" | "UNKNOWN"                              | S3AsyncClient.builder()       | { c -> c.getObject(GetObjectRequest.builder().bucket("somebucket").key("somekey").build(), AsyncResponseTransformer.toBytes()) } | "1234567890"
+    "DynamoDb" | "CreateTable"       | "java-aws-sdk" | "POST" | "/"                   | "UNKNOWN"                              | DynamoDbAsyncClient.builder() | { c -> c.createTable(CreateTableRequest.builder().tableName("sometable").build()) }                                              | ""
+    // Kinesis seems to expect an http2 response which is incompatible with our test server.
+    // "Kinesis"  | "DeleteStream"      | "java-aws-sdk" | "POST" | "/"                   | "UNKNOWN"                              | KinesisAsyncClient.builder()  | { c -> c.deleteStream(DeleteStreamRequest.builder().streamName("somestream").build()) }                                          | ""
+    "Sqs"      | "CreateQueue"       | "java-aws-sdk" | "POST" | "/"                   | "7a62c49f-347e-4fc4-9331-6e8e7a96aa73" | SqsAsyncClient.builder()      | { c -> c.createQueue(CreateQueueRequest.builder().queueName("somequeue").build()) }                                              | """
+        <CreateQueueResponse>
+            <CreateQueueResult><QueueUrl>https://queue.amazonaws.com/123456789012/MyQueue</QueueUrl></CreateQueueResult>
+            <ResponseMetadata><RequestId>7a62c49f-347e-4fc4-9331-6e8e7a96aa73</RequestId></ResponseMetadata>
+        </CreateQueueResponse>
+        """
+    "Sqs"      | "SendMessage"       | "sqs"          | "POST" | "/"                   | "27daac76-34dd-47df-bd01-1f6e873584a0" | SqsAsyncClient.builder()      | { c -> c.sendMessage(SendMessageRequest.builder().queueUrl("someurl").messageBody("").build()) }                                 | """
+        <SendMessageResponse>
+            <SendMessageResult>
+                <MD5OfMessageBody>d41d8cd98f00b204e9800998ecf8427e</MD5OfMessageBody>
+                <MD5OfMessageAttributes>3ae8f24a165a8cedc005670c81a27295</MD5OfMessageAttributes>
+                <MessageId>5fea7756-0ea4-451a-a703-a558b933e274</MessageId>
+            </SendMessageResult>
+            <ResponseMetadata><RequestId>27daac76-34dd-47df-bd01-1f6e873584a0</RequestId></ResponseMetadata>
+        </SendMessageResponse>
+        """
+    "Sns"      | "Publish"           | "sns"          | "POST" | "/"                   | "d74b8436-ae13-5ab4-a9ff-ce54dfea72a0" | SnsAsyncClient.builder()      | { c -> c.publish(PublishRequest.builder().topicArn("arn:aws:sns::123:some-topic").message("").build()) } | """
+        <PublishResponse xmlns="https://sns.amazonaws.com/doc/2010-03-31/">
+            <PublishResult>
+                <MessageId>567910cd-659e-55d4-8ccb-5aaf14679dc0</MessageId>
+            </PublishResult>
+            <ResponseMetadata><RequestId>d74b8436-ae13-5ab4-a9ff-ce54dfea72a0</RequestId></ResponseMetadata>
+        </PublishResponse>
+        """
+    "Ec2"      | "AllocateAddress"   | "java-aws-sdk" | "POST" | "/"                   | "59dbff89-35bd-4eac-99ed-be587EXAMPLE" | Ec2AsyncClient.builder()      | { c -> c.allocateAddress() }                                                                                                     | """
+        <AllocateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+           <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+           <publicIp>192.0.2.1</publicIp>
+           <domain>standard</domain>
+        </AllocateAddressResponse>
+        """
+    "Rds"      | "DeleteOptionGroup" | "java-aws-sdk" | "POST" | "/"                   | "0ac9cda2-bbf4-11d3-f92b-31fa5e8dbc99" | RdsAsyncClient.builder()      | { c -> c.deleteOptionGroup(DeleteOptionGroupRequest.builder().build()) }                                                         | """
+        <DeleteOptionGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+          <ResponseMetadata><RequestId>0ac9cda2-bbf4-11d3-f92b-31fa5e8dbc99</RequestId></ResponseMetadata>
+        </DeleteOptionGroupResponse>
+        """
+  }
+
+  def "timeout and retry errors captured"() {
+    setup:
+    def server = httpServer {
+      handlers {
+        all {
+          Thread.sleep(500)
+          response.status(200).send()
+        }
+      }
+    }
+    def client = S3Client.builder()
+      .endpointOverride(server.address)
+      .region(Region.AP_NORTHEAST_1)
+      .credentialsProvider(CREDENTIALS_PROVIDER)
+      .httpClientBuilder(ApacheHttpClient.builder().socketTimeout(Duration.ofMillis(50)))
+      .build()
+
+    when:
+    client.getObject(GetObjectRequest.builder().bucket("somebucket").key("somekey").build())
+
+    then:
+    thrown SdkClientException
+
+    assertTraces(1) {
+      trace(5) {
+        span {
+          serviceName "java-aws-sdk"
+          operationName "aws.http"
+          resourceName "S3.GetObject"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored true
+          parent()
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" server.address.port
+            "$Tags.HTTP_URL" "$server.address/somebucket/somekey"
+            "$Tags.HTTP_METHOD" "GET"
+            "aws.service" "S3"
+            "aws.operation" "GetObject"
+            "aws.agent" "java-aws-sdk"
+            "aws.bucket.name" "somebucket"
+            errorTags SdkClientException, "Unable to execute HTTP request: Read timed out"
+            defaultTags()
+          }
+        }
+        (1..4).each {
+          span {
+            operationName "http.request"
+            resourceName "GET /somebucket/somekey"
+            spanType DDSpanTypes.HTTP_CLIENT
+            errored true
+            childOf(span(0))
+            tags {
+              "$Tags.COMPONENT" "apache-httpclient"
+              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+              "$Tags.PEER_HOSTNAME" "localhost"
+              "$Tags.PEER_PORT" server.address.port
+              "$Tags.HTTP_URL" "$server.address/somebucket/somekey"
+              "$Tags.HTTP_METHOD" "GET"
+              errorTags SocketTimeoutException, "Read timed out"
+              defaultTags()
+            }
+          }
+        }
+      }
+    }
+
+    cleanup:
+    server.close()
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/LegacySqsClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/LegacySqsClientForkedTest.groovy
@@ -1,0 +1,363 @@
+import com.amazon.sqs.javamessaging.ProviderConfiguration
+import com.amazon.sqs.javamessaging.SQSConnectionFactory
+import com.amazonaws.SDKGlobalConfiguration
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.AnonymousAWSCredentials
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.utils.TraceUtils
+import datadog.trace.api.DDSpanId
+import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.config.GeneralConfig
+import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import org.elasticmq.rest.sqs.SQSRestServerBuilder
+import spock.lang.Shared
+
+import javax.jms.Session
+
+import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
+
+class LegacySqsClientForkedTest extends AgentTestRunner {
+
+  def setup() {
+    System.setProperty(SDKGlobalConfiguration.ACCESS_KEY_SYSTEM_PROPERTY, "my-access-key")
+    System.setProperty(SDKGlobalConfiguration.SECRET_KEY_SYSTEM_PROPERTY, "my-secret-key")
+  }
+
+  @Override
+  void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("aws-sdk.legacy.tracing.enabled", "true")
+
+    // Set a service name that gets sorted early with SORT_BY_NAMES
+    injectSysConfig(GeneralConfig.SERVICE_NAME, "A")
+  }
+
+  @Shared
+  def credentialsProvider = new AWSStaticCredentialsProvider(new AnonymousAWSCredentials())
+  @Shared
+  def server = SQSRestServerBuilder.withInterface("localhost").withDynamicPort().start()
+  @Shared
+  def address = server.waitUntilStarted().localAddress()
+  @Shared
+  def endpoint = new AwsClientBuilder.EndpointConfiguration("http://localhost:${address.port}", "elasticmq")
+
+  def cleanupSpec() {
+    if (server != null) {
+      server.stopAndWait()
+    }
+  }
+
+  def "trace details propagated via SQS system message attributes"() {
+    setup:
+    def client = AmazonSQSClientBuilder.standard()
+      .withEndpointConfiguration(endpoint)
+      .withCredentials(credentialsProvider)
+      .build()
+    def queueUrl = client.createQueue('somequeue').queueUrl
+    TEST_WRITER.clear()
+
+    when:
+    TraceUtils.runUnderTrace('parent', {
+      client.sendMessage(queueUrl, 'sometext')
+    })
+    def messages = client.receiveMessage(queueUrl).messages
+
+    then:
+    def sendSpan
+    assertTraces(2) {
+      trace(3) {
+        basicSpan(it, "parent")
+        span {
+          serviceName "sqs"
+          operationName "aws.http"
+          resourceName "SQS.SendMessage"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            "$Tags.PEER_PORT" address.port
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "aws.service" "AmazonSQS"
+            "aws.endpoint" "http://localhost:${address.port}"
+            "aws.operation" "SendMessageRequest"
+            "aws.agent" "java-aws-sdk"
+            "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            defaultTags()
+          }
+        }
+        span {
+          operationName "http.request"
+          resourceName "POST /?/somequeue"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(1))
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" address.port
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/000000000000/somequeue"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            defaultTags()
+          }
+        }
+        sendSpan = span(1)
+      }
+      trace(2) {
+        span {
+          serviceName "sqs"
+          operationName "aws.http"
+          resourceName "SQS.ReceiveMessage"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          parent()
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            "$Tags.PEER_PORT" address.port
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "aws.service" "AmazonSQS"
+            "aws.endpoint" "http://localhost:${address.port}"
+            "aws.operation" "ReceiveMessageRequest"
+            "aws.agent" "java-aws-sdk"
+            "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            defaultTags()
+          }
+        }
+        span {
+          operationName "http.request"
+          resourceName "POST /?/somequeue"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" address.port
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/000000000000/somequeue"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            defaultTags()
+          }
+        }
+      }
+    }
+
+    assert messages[0].attributes['AWSTraceHeader'] =~
+    /Root=1-[0-9a-f]{8}-00000000${sendSpan.traceId.toHexStringPadded(16)};Parent=${DDSpanId.toHexStringPadded(sendSpan.spanId)};Sampled=1/
+
+    cleanup:
+    client.shutdown()
+  }
+
+  def "trace details propagated from SQS to JMS"() {
+    setup:
+    def client = AmazonSQSClientBuilder.standard()
+      .withEndpointConfiguration(endpoint)
+      .withCredentials(credentialsProvider)
+      .build()
+
+    def connectionFactory = new SQSConnectionFactory(new ProviderConfiguration(), client)
+    def connection = connectionFactory.createConnection()
+    def session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)
+    def queue = session.createQueue('somequeue')
+    def consumer = session.createConsumer(queue)
+
+    TEST_WRITER.clear()
+
+    when:
+    connection.start()
+    TraceUtils.runUnderTrace('parent', {
+      client.sendMessage(queue.queueUrl, 'sometext')
+    })
+    def message = consumer.receive()
+    consumer.receiveNoWait()
+
+    then:
+    def sendSpan
+    // Order has changed in 1.10+ versions of amazon-sqs-java-messaging-lib
+    // so sort by names service/operation/resource
+    assertTraces(4, SORT_TRACES_BY_NAMES) {
+      trace(3) {
+        basicSpan(it, "parent")
+        span {
+          serviceName "sqs"
+          operationName "aws.http"
+          resourceName "SQS.SendMessage"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            "$Tags.PEER_PORT" address.port
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "aws.service" "AmazonSQS"
+            "aws.endpoint" "http://localhost:${address.port}"
+            "aws.operation" "SendMessageRequest"
+            "aws.agent" "java-aws-sdk"
+            "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            defaultTags()
+          }
+        }
+        span {
+          operationName "http.request"
+          resourceName "POST /?/somequeue"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(1))
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" address.port
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/000000000000/somequeue"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            defaultTags()
+          }
+        }
+        sendSpan = span(1)
+      }
+      trace(1) {
+        span {
+          serviceName "jms"
+          operationName "jms.consume"
+          resourceName "Consumed from Queue somequeue"
+          spanType DDSpanTypes.MESSAGE_CONSUMER
+          errored false
+          measured true
+          childOf(sendSpan)
+          tags {
+            "$Tags.COMPONENT" "jms"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+            // This shows up in 1.10+ versions of amazon-sqs-java-messaging-lib
+            if (isLatestDepTest) {
+              "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
+            }
+            defaultTags(true)
+          }
+        }
+      }
+      trace(2) {
+        span {
+          serviceName "sqs"
+          operationName "aws.http"
+          resourceName "SQS.DeleteMessage"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          parent()
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            "$Tags.PEER_PORT" address.port
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "aws.service" "AmazonSQS"
+            "aws.endpoint" "http://localhost:${address.port}"
+            "aws.operation" "DeleteMessageRequest"
+            "aws.agent" "java-aws-sdk"
+            "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            defaultTags()
+          }
+        }
+        span {
+          operationName "http.request"
+          resourceName "POST /?/somequeue"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" address.port
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/000000000000/somequeue"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            defaultTags()
+          }
+        }
+      }
+      trace(2) {
+        span {
+          serviceName "sqs"
+          operationName "aws.http"
+          resourceName "SQS.ReceiveMessage"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          parent()
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            "$Tags.PEER_PORT" address.port
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "aws.service" "AmazonSQS"
+            "aws.endpoint" "http://localhost:${address.port}"
+            "aws.operation" "ReceiveMessageRequest"
+            "aws.agent" "java-aws-sdk"
+            "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            defaultTags()
+          }
+        }
+        span {
+          operationName "http.request"
+          resourceName "POST /?/somequeue"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" address.port
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/000000000000/somequeue"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            defaultTags()
+          }
+        }
+      }
+    }
+
+    def expectedTraceProperty = 'X-Amzn-Trace-Id'.toLowerCase(Locale.ENGLISH).replace('-', '__dash__')
+    assert message.getStringProperty(expectedTraceProperty) =~
+    /Root=1-[0-9a-f]{8}-00000000${sendSpan.traceId.toHexStringPadded(16)};Parent=${DDSpanId.toHexStringPadded(sendSpan.spanId)};Sampled=1/
+
+    cleanup:
+    session.close()
+    connection.stop()
+    client.shutdown()
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/SqsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/SqsClientTest.groovy
@@ -66,7 +66,7 @@ class SqsClientTest extends AgentTestRunner {
     then:
     def sendSpan
     assertTraces(2) {
-      trace(3) {
+      trace(2) {
         basicSpan(it, "parent")
         span {
           serviceName "sqs"
@@ -92,27 +92,9 @@ class SqsClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span {
-          operationName "http.request"
-          resourceName "POST /?/somequeue"
-          spanType DDSpanTypes.HTTP_CLIENT
-          errored false
-          measured true
-          childOf(span(1))
-          tags {
-            "$Tags.COMPONENT" "apache-httpclient"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" address.port
-            "$Tags.HTTP_URL" "http://localhost:${address.port}/000000000000/somequeue"
-            "$Tags.HTTP_METHOD" "POST"
-            "$Tags.HTTP_STATUS" 200
-            defaultTags()
-          }
-        }
-        sendSpan = span(2)
+        sendSpan = span(1)
       }
-      trace(2) {
+      trace(1) {
         span {
           serviceName "sqs"
           operationName "aws.http"
@@ -134,24 +116,6 @@ class SqsClientTest extends AgentTestRunner {
             "aws.operation" "ReceiveMessageRequest"
             "aws.agent" "java-aws-sdk"
             "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
-            defaultTags()
-          }
-        }
-        span {
-          operationName "http.request"
-          resourceName "POST /?/somequeue"
-          spanType DDSpanTypes.HTTP_CLIENT
-          errored false
-          measured true
-          childOf(span(0))
-          tags {
-            "$Tags.COMPONENT" "apache-httpclient"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" address.port
-            "$Tags.HTTP_URL" "http://localhost:${address.port}/000000000000/somequeue"
-            "$Tags.HTTP_METHOD" "POST"
-            "$Tags.HTTP_STATUS" 200
             defaultTags()
           }
         }
@@ -193,7 +157,7 @@ class SqsClientTest extends AgentTestRunner {
     // Order has changed in 1.10+ versions of amazon-sqs-java-messaging-lib
     // so sort by names service/operation/resource
     assertTraces(4, SORT_TRACES_BY_NAMES) {
-      trace(3) {
+      trace(2) {
         basicSpan(it, "parent")
         span {
           serviceName "sqs"
@@ -219,25 +183,7 @@ class SqsClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span {
-          operationName "http.request"
-          resourceName "POST /?/somequeue"
-          spanType DDSpanTypes.HTTP_CLIENT
-          errored false
-          measured true
-          childOf(span(1))
-          tags {
-            "$Tags.COMPONENT" "apache-httpclient"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" address.port
-            "$Tags.HTTP_URL" "http://localhost:${address.port}/000000000000/somequeue"
-            "$Tags.HTTP_METHOD" "POST"
-            "$Tags.HTTP_STATUS" 200
-            defaultTags()
-          }
-        }
-        sendSpan = span(2)
+        sendSpan = span(1)
       }
       trace(1) {
         span {
@@ -259,7 +205,7 @@ class SqsClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(2) {
+      trace(1) {
         span {
           serviceName "sqs"
           operationName "aws.http"
@@ -284,26 +230,8 @@ class SqsClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span {
-          operationName "http.request"
-          resourceName "POST /?/somequeue"
-          spanType DDSpanTypes.HTTP_CLIENT
-          errored false
-          measured true
-          childOf(span(0))
-          tags {
-            "$Tags.COMPONENT" "apache-httpclient"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" address.port
-            "$Tags.HTTP_URL" "http://localhost:${address.port}/000000000000/somequeue"
-            "$Tags.HTTP_METHOD" "POST"
-            "$Tags.HTTP_STATUS" 200
-            defaultTags()
-          }
-        }
       }
-      trace(2) {
+      trace(1) {
         span {
           serviceName "sqs"
           operationName "aws.http"
@@ -325,24 +253,6 @@ class SqsClientTest extends AgentTestRunner {
             "aws.operation" "ReceiveMessageRequest"
             "aws.agent" "java-aws-sdk"
             "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
-            defaultTags()
-          }
-        }
-        span {
-          operationName "http.request"
-          resourceName "POST /?/somequeue"
-          spanType DDSpanTypes.HTTP_CLIENT
-          errored false
-          measured true
-          childOf(span(0))
-          tags {
-            "$Tags.COMPONENT" "apache-httpclient"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" address.port
-            "$Tags.HTTP_URL" "http://localhost:${address.port}/000000000000/somequeue"
-            "$Tags.HTTP_METHOD" "POST"
-            "$Tags.HTTP_STATUS" 200
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/LegacySqsClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/LegacySqsClientForkedTest.groovy
@@ -1,0 +1,362 @@
+import com.amazon.sqs.javamessaging.ProviderConfiguration
+import com.amazon.sqs.javamessaging.SQSConnectionFactory
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.utils.TraceUtils
+import datadog.trace.api.DDSpanId
+import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.config.GeneralConfig
+import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import org.elasticmq.rest.sqs.SQSRestServerBuilder
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
+import software.amazon.awssdk.core.SdkSystemSetting
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.sqs.SqsClient
+import software.amazon.awssdk.services.sqs.model.CreateQueueRequest
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest
+import spock.lang.Shared
+
+import javax.jms.Session
+
+import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
+
+class LegacySqsClientForkedTest extends AgentTestRunner {
+
+  def setup() {
+    System.setProperty(SdkSystemSetting.AWS_ACCESS_KEY_ID.property(), "my-access-key")
+    System.setProperty(SdkSystemSetting.AWS_SECRET_ACCESS_KEY.property(), "my-secret-key")
+  }
+
+  @Override
+  void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("aws-sdk.legacy.tracing.enabled", "true")
+
+    // Set a service name that gets sorted early with SORT_BY_NAMES
+    injectSysConfig(GeneralConfig.SERVICE_NAME, "A")
+  }
+
+  @Shared
+  def credentialsProvider = AnonymousCredentialsProvider.create()
+  @Shared
+  def server = SQSRestServerBuilder.withInterface("localhost").withDynamicPort().start()
+  @Shared
+  def address = server.waitUntilStarted().localAddress()
+  @Shared
+  def endpoint = URI.create("http://localhost:${address.port}")
+
+  def cleanupSpec() {
+    if (server != null) {
+      server.stopAndWait()
+    }
+  }
+
+  def "trace details propagated via SQS system message attributes"() {
+    setup:
+    def client = SqsClient.builder()
+      .region(Region.EU_CENTRAL_1)
+      .endpointOverride(endpoint)
+      .credentialsProvider(credentialsProvider)
+      .build()
+    def queueUrl = client.createQueue(CreateQueueRequest.builder().queueName('somequeue').build()).queueUrl()
+    TEST_WRITER.clear()
+
+    when:
+    TraceUtils.runUnderTrace('parent', {
+      client.sendMessage(SendMessageRequest.builder().queueUrl(queueUrl).messageBody('sometext').build())
+    })
+    def messages = client.receiveMessage(ReceiveMessageRequest.builder().queueUrl(queueUrl).build()).messages()
+
+    then:
+    def sendSpan
+    assertTraces(2) {
+      trace(3) {
+        basicSpan(it, "parent")
+        span {
+          serviceName "sqs"
+          operationName "aws.http"
+          resourceName "Sqs.SendMessage"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            "$Tags.PEER_PORT" address.port
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "aws.service" "Sqs"
+            "aws.operation" "SendMessage"
+            "aws.agent" "java-aws-sdk"
+            "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            "aws.requestId" "00000000-0000-0000-0000-000000000000"
+            defaultTags()
+          }
+        }
+        span {
+          operationName "http.request"
+          resourceName "POST /"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(1))
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" address.port
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            defaultTags()
+          }
+        }
+        sendSpan = span(1)
+      }
+      trace(2) {
+        span {
+          serviceName "sqs"
+          operationName "aws.http"
+          resourceName "Sqs.ReceiveMessage"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          parent()
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            "$Tags.PEER_PORT" address.port
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "aws.service" "Sqs"
+            "aws.operation" "ReceiveMessage"
+            "aws.agent" "java-aws-sdk"
+            "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            "aws.requestId" "00000000-0000-0000-0000-000000000000"
+            defaultTags()
+          }
+        }
+        span {
+          operationName "http.request"
+          resourceName "POST /"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" address.port
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            defaultTags()
+          }
+        }
+      }
+    }
+
+    assert messages[0].attributesAsStrings()['AWSTraceHeader'] =~
+    /Root=1-[0-9a-f]{8}-00000000${sendSpan.traceId.toHexStringPadded(16)};Parent=${DDSpanId.toHexStringPadded(sendSpan.spanId)};Sampled=1/
+
+    cleanup:
+    client.close()
+  }
+
+  def "trace details propagated from SQS to JMS"() {
+    setup:
+    def client = SqsClient.builder()
+      .region(Region.EU_CENTRAL_1)
+      .endpointOverride(endpoint)
+      .credentialsProvider(credentialsProvider)
+      .build()
+
+    def connectionFactory = new SQSConnectionFactory(new ProviderConfiguration(), client)
+    def connection = connectionFactory.createConnection()
+    def session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)
+    def queue = session.createQueue('somequeue')
+    def consumer = session.createConsumer(queue)
+
+    TEST_WRITER.clear()
+
+    when:
+    connection.start()
+    TraceUtils.runUnderTrace('parent', {
+      client.sendMessage(SendMessageRequest.builder().queueUrl(queue.queueUrl).messageBody('sometext').build())
+    })
+    def message = consumer.receive()
+    consumer.receiveNoWait()
+
+    then:
+    def sendSpan
+    assertTraces(4, SORT_TRACES_BY_NAMES) {
+      trace(3) {
+        basicSpan(it, "parent")
+        span {
+          serviceName "sqs"
+          operationName "aws.http"
+          resourceName "Sqs.SendMessage"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            "$Tags.PEER_PORT" address.port
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "aws.service" "Sqs"
+            "aws.operation" "SendMessage"
+            "aws.agent" "java-aws-sdk"
+            "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            "aws.requestId" "00000000-0000-0000-0000-000000000000"
+            defaultTags()
+          }
+        }
+        span {
+          operationName "http.request"
+          resourceName "POST /"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(1))
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" address.port
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            defaultTags()
+          }
+        }
+        sendSpan = span(1)
+      }
+      trace(1) {
+        span {
+          serviceName "jms"
+          operationName "jms.consume"
+          resourceName "Consumed from Queue somequeue"
+          spanType DDSpanTypes.MESSAGE_CONSUMER
+          errored false
+          measured true
+          childOf(sendSpan)
+          tags {
+            "$Tags.COMPONENT" "jms"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+            "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
+            defaultTags(true)
+          }
+        }
+      }
+      trace(2) {
+        span {
+          serviceName "sqs"
+          operationName "aws.http"
+          resourceName "Sqs.DeleteMessage"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          parent()
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            "$Tags.PEER_PORT" address.port
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "aws.service" "Sqs"
+            "aws.operation" "DeleteMessage"
+            "aws.agent" "java-aws-sdk"
+            "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            "aws.requestId" "00000000-0000-0000-0000-000000000000"
+            defaultTags()
+          }
+        }
+        span {
+          operationName "http.request"
+          resourceName "POST /"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" address.port
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            defaultTags()
+          }
+        }
+      }
+      trace(2) {
+        span {
+          serviceName "sqs"
+          operationName "aws.http"
+          resourceName "Sqs.ReceiveMessage"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          parent()
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            "$Tags.PEER_PORT" address.port
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "aws.service" "Sqs"
+            "aws.operation" "ReceiveMessage"
+            "aws.agent" "java-aws-sdk"
+            "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            "aws.requestId" "00000000-0000-0000-0000-000000000000"
+            defaultTags()
+          }
+        }
+        span {
+          operationName "http.request"
+          resourceName "POST /"
+          spanType DDSpanTypes.HTTP_CLIENT
+          errored false
+          measured true
+          childOf(span(0))
+          tags {
+            "$Tags.COMPONENT" "apache-httpclient"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_PORT" address.port
+            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
+            "$Tags.HTTP_METHOD" "POST"
+            "$Tags.HTTP_STATUS" 200
+            defaultTags()
+          }
+        }
+      }
+    }
+
+    def expectedTraceProperty = 'X-Amzn-Trace-Id'.toLowerCase(Locale.ENGLISH).replace('-', '__dash__')
+    assert message.getStringProperty(expectedTraceProperty) =~
+    /Root=1-[0-9a-f]{8}-00000000${sendSpan.traceId.toHexStringPadded(16)};Parent=${DDSpanId.toHexStringPadded(sendSpan.spanId)};Sampled=1/
+
+    cleanup:
+    session.close()
+    connection.stop()
+    client.close()
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/SqsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/SqsClientTest.groovy
@@ -69,7 +69,7 @@ class SqsClientTest extends AgentTestRunner {
     then:
     def sendSpan
     assertTraces(2) {
-      trace(3) {
+      trace(2) {
         basicSpan(it, "parent")
         span {
           serviceName "sqs"
@@ -95,27 +95,9 @@ class SqsClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span {
-          operationName "http.request"
-          resourceName "POST /"
-          spanType DDSpanTypes.HTTP_CLIENT
-          errored false
-          measured true
-          childOf(span(1))
-          tags {
-            "$Tags.COMPONENT" "apache-httpclient"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" address.port
-            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
-            "$Tags.HTTP_METHOD" "POST"
-            "$Tags.HTTP_STATUS" 200
-            defaultTags()
-          }
-        }
-        sendSpan = span(2)
+        sendSpan = span(1)
       }
-      trace(2) {
+      trace(1) {
         span {
           serviceName "sqs"
           operationName "aws.http"
@@ -137,24 +119,6 @@ class SqsClientTest extends AgentTestRunner {
             "aws.agent" "java-aws-sdk"
             "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
             "aws.requestId" "00000000-0000-0000-0000-000000000000"
-            defaultTags()
-          }
-        }
-        span {
-          operationName "http.request"
-          resourceName "POST /"
-          spanType DDSpanTypes.HTTP_CLIENT
-          errored false
-          measured true
-          childOf(span(0))
-          tags {
-            "$Tags.COMPONENT" "apache-httpclient"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" address.port
-            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
-            "$Tags.HTTP_METHOD" "POST"
-            "$Tags.HTTP_STATUS" 200
             defaultTags()
           }
         }
@@ -195,7 +159,7 @@ class SqsClientTest extends AgentTestRunner {
     then:
     def sendSpan
     assertTraces(4, SORT_TRACES_BY_NAMES) {
-      trace(3) {
+      trace(2) {
         basicSpan(it, "parent")
         span {
           serviceName "sqs"
@@ -221,25 +185,7 @@ class SqsClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span {
-          operationName "http.request"
-          resourceName "POST /"
-          spanType DDSpanTypes.HTTP_CLIENT
-          errored false
-          measured true
-          childOf(span(1))
-          tags {
-            "$Tags.COMPONENT" "apache-httpclient"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" address.port
-            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
-            "$Tags.HTTP_METHOD" "POST"
-            "$Tags.HTTP_STATUS" 200
-            defaultTags()
-          }
-        }
-        sendSpan = span(2)
+        sendSpan = span(1)
       }
       trace(1) {
         span {
@@ -258,7 +204,7 @@ class SqsClientTest extends AgentTestRunner {
           }
         }
       }
-      trace(2) {
+      trace(1) {
         span {
           serviceName "sqs"
           operationName "aws.http"
@@ -283,26 +229,8 @@ class SqsClientTest extends AgentTestRunner {
             defaultTags()
           }
         }
-        span {
-          operationName "http.request"
-          resourceName "POST /"
-          spanType DDSpanTypes.HTTP_CLIENT
-          errored false
-          measured true
-          childOf(span(0))
-          tags {
-            "$Tags.COMPONENT" "apache-httpclient"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" address.port
-            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
-            "$Tags.HTTP_METHOD" "POST"
-            "$Tags.HTTP_STATUS" 200
-            defaultTags()
-          }
-        }
       }
-      trace(2) {
+      trace(1) {
         span {
           serviceName "sqs"
           operationName "aws.http"
@@ -324,24 +252,6 @@ class SqsClientTest extends AgentTestRunner {
             "aws.agent" "java-aws-sdk"
             "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
             "aws.requestId" "00000000-0000-0000-0000-000000000000"
-            defaultTags()
-          }
-        }
-        span {
-          operationName "http.request"
-          resourceName "POST /"
-          spanType DDSpanTypes.HTTP_CLIENT
-          errored false
-          measured true
-          childOf(span(0))
-          tags {
-            "$Tags.COMPONENT" "apache-httpclient"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_PORT" address.port
-            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
-            "$Tags.HTTP_METHOD" "POST"
-            "$Tags.HTTP_STATUS" 200
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
@@ -13,7 +13,6 @@ import static datadog.trace.instrumentation.netty40.client.NettyHttpClientDecora
 import static datadog.trace.instrumentation.netty40.client.NettyResponseInjectAdapter.SETTER;
 
 import datadog.trace.api.Config;
-import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
@@ -43,7 +42,7 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
     SSL_HANDLER = (Class<ChannelHandler>) sslHandler;
   }
 
-  private static final boolean isLegacyAwsTracing =
+  private static final boolean AWS_LEGACY_TRACING =
       Config.get().isLegacyTracingEnabled(false, "aws-sdk");
 
   @Override
@@ -62,7 +61,7 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
 
     final HttpRequest request = (HttpRequest) msg;
     boolean awsClientCall = request.headers().contains("amz-sdk-invocation-id");
-    if (!isLegacyAwsTracing && awsClientCall) {
+    if (!AWS_LEGACY_TRACING && awsClientCall) {
       // avoid creating an extra HTTP client span beneath the AWS client call
       try {
         ctx.write(msg, prm);
@@ -94,8 +93,6 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
         propagate()
             .injectPathwayContext(
                 span, request.headers(), SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
-      } else if (Config.get().isAwsPropagationEnabled()) {
-        propagate().inject(span, request.headers(), SETTER, TracePropagationStyle.XRAY);
       }
 
       ctx.channel().attr(SPAN_ATTRIBUTE_KEY).set(span);


### PR DESCRIPTION
# What Does This Do

This PR removes the underlying HTTP client spans beneath AWS-SDK calls. The HTTP client span is an implementation detail of the AWS-SDK call, rather than a request to a different service, and collapsing the trace to just show the AWS-SDK calls makes distributed traces easier to follow.

Users who require the old behaviour can re-enable it with this system property:
```
-Ddd.aws-sdk.legacy.tracing.enabled=true
```
or by setting this environment variable:
```
DD_AWS_SDK_LEGACY_TRACING_ENABLED=true
```

# Motivation

We want to make SQS receive spans more consistent with other messaging integrations. This will involve excluding certain SQS calls from our AWS-SDK instrumentation and adding new SQS specific instrumentation. The new SQS instrumentation will avoid creating spans when no messages are received, but underneath the AWS-SDK is still making an HTTP call to check for new messages. Since we don't know at the time of the underlying HTTP call whether we will actually get any messages we cannot filter out any HTTP span at that point. It is also hard to tell which AWS service is being called without examining the attached entity since AWS-SDK uses POST by default.

The simplest solution was to remove the underlying HTTP client spans beneath AWS-SDK calls.

Before:

![Screenshot 2023-02-08 at 00 31 40](https://user-images.githubusercontent.com/145851/217398442-a295f583-4ad7-4f5f-bbab-e52b39fc5b1c.png)

After:

![Screenshot 2023-02-08 at 00 31 28](https://user-images.githubusercontent.com/145851/217398465-a4c35155-562c-4a64-8725-268ce449f2a7.png)

# Additional Notes

This PR also moves setting of the X-Ray propagation header out from the different low-level HTTP instrumentations and into the AWS-SDK instrumentations where it really belongs. (To avoid adding an extra helper class the propagation setter interface was implemented by the existing AWS-SDK decorators.)
