### PR TITLE
Mark some more tests as flaky

### DIFF
--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpAsyncClient5Test.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpAsyncClient5Test.groovy
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit
 
 import static org.apache.hc.core5.reactor.IOReactorConfig.custom
 
-class ApacheHttpAsyncClientTest<T extends HttpRequest> extends HttpClientTest {
+class ApacheHttpAsyncClient5Test<T extends HttpRequest> extends HttpClientTest {
 
   @Shared
   def ioReactorConfig = custom()

--- a/dd-java-agent/instrumentation/mule-4/src/test/groovy/mule4/MuleForkedTest.groovy
+++ b/dd-java-agent/instrumentation/mule-4/src/test/groovy/mule4/MuleForkedTest.groovy
@@ -81,7 +81,7 @@ class MuleForkedTest extends WithHttpServer<MuleTestContainer> {
     container.stop()
   }
 
-  @Flaky("SocketTimeoutException")
+  @Flaky("SocketTimeoutException / https://github.com/DataDog/dd-trace-java/issues/4690")
   def "test mule client remote request"() {
     setup:
     def url = HttpUrl.get(address.resolve("/client-request")).newBuilder().build()
@@ -133,7 +133,7 @@ class MuleForkedTest extends WithHttpServer<MuleTestContainer> {
     }
   }
 
-  @Flaky("assert trace.size() == expectedSize")
+  @Flaky("assert trace.size() == expectedSize / https://github.com/DataDog/dd-trace-java/issues/4690")
   def "test parallel for each"() {
     setup:
     def names = ["Alyssa", "Ben", "Cy", "Eva", "Lem", "Louis"]

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/test/groovy/VertxRedisAPITestBase.groovy
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/test/groovy/VertxRedisAPITestBase.groovy
@@ -61,7 +61,6 @@ abstract class VertxRedisAPITestBase extends VertxRedisTestBase {
     }
   }
 
-  @Flaky("flaky in VertxRedisAPIRedisConnectionForkedTest")
   def "decrby (3 args)"() {
     when:
     def set = runWithParentAndHandler({ Handler<AsyncResult<Response>> h ->
@@ -81,7 +80,6 @@ abstract class VertxRedisAPITestBase extends VertxRedisTestBase {
     }
   }
 
-  @Flaky("flaky in VertxRedisAPIRedisConnectionForkedTest")
   def "setbit (4 args)"() {
     when:
     def res = runWithParentAndHandler({ Handler<AsyncResult<Response>> h ->
@@ -137,13 +135,14 @@ abstract class VertxRedisAPITestBase extends VertxRedisTestBase {
   }
 }
 
-@Flaky("linsert is flaky https://github.com/DataDog/dd-trace-java/issues/3874")
+@Flaky("all test cases are flaky https://github.com/DataDog/dd-trace-java/issues/3874")
 class VertxRedisAPIRedisForkedTest extends VertxRedisAPITestBase {
   def setupSpec() {
     redisAPI = RedisAPI.api(redis)
   }
 }
 
+@Flaky("all test cases are flaky https://github.com/DataDog/dd-trace-java/issues/3874")
 class VertxRedisAPIRedisConnectionForkedTest extends VertxRedisAPITestBase {
   def setupSpec() {
     def latch = new CountDownLatch(1)

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -287,7 +287,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     body = (1..10000).join(" ")
   }
 
-  @Flaky(suites = ["ApacheHttpAsyncClientTest"])
+  @Flaky(suites = ["ApacheHttpAsyncClient5Test"])
   def "server error request with parent"() {
     setup:
     def uri = server.address.resolve("/error")
@@ -325,7 +325,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     "POST" | _
   }
 
-  @Flaky(suites = ["ApacheHttpAsyncClientTest"])
+  @Flaky(suites = ["ApacheHttpAsyncClient5Test"])
   def "client error request with parent"() {
     setup:
     def uri = server.address.resolve("/secured")
@@ -395,6 +395,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     method = "HEAD"
   }
 
+  @Flaky(suites = ["ApacheHttpAsyncClient5Test"])
   def "trace request without propagation"() {
     when:
     injectSysConfig(HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "$renameService")

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -1326,6 +1326,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     }
   }
 
+  @Flaky(value = "https://github.com/DataDog/dd-trace-java/issues/4681", suites = ["GrizzlyAsyncTest"])
   def 'test blocking of request with auto and accept=#acceptHeader'(boolean expectedJson, String acceptHeader) {
     // Note: this does not actually test that the handler for SUCCESS is never called,
     //       only that the response is the expected one (insofar as invoking the handler
@@ -1379,7 +1380,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     true         | 'text/html;q=0.8, application/json;q=0.9'
   }
 
-  @Flaky(value = "flaky on some tests from grizzly-2 module", suites = ["GrizzlyAsyncTest"])
+  @Flaky(value = "https://github.com/DataDog/dd-trace-java/issues/4681", suites = ["GrizzlyAsyncTest"])
   def 'test blocking of request with json response'() {
     setup:
     assumeTrue(testBlocking())

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -1327,7 +1327,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     }
   }
 
-  @Flaky(value = "https://github.com/DataDog/dd-trace-java/issues/4681", suites = ["GrizzlyAsyncTest"])
+  @Flaky(value = "https://github.com/DataDog/dd-trace-java/issues/4681", suites = ["GrizzlyAsyncTest", "GrizzlyTest"])
   def 'test blocking of request with auto and accept=#acceptHeader'(boolean expectedJson, String acceptHeader) {
     // Note: this does not actually test that the handler for SUCCESS is never called,
     //       only that the response is the expected one (insofar as invoking the handler
@@ -1381,7 +1381,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     true         | 'text/html;q=0.8, application/json;q=0.9'
   }
 
-  @Flaky(value = "https://github.com/DataDog/dd-trace-java/issues/4681", suites = ["GrizzlyAsyncTest"])
+  @Flaky(value = "https://github.com/DataDog/dd-trace-java/issues/4681", suites = ["GrizzlyAsyncTest", "GrizzlyTest"])
   def 'test blocking of request with json response'() {
     setup:
     assumeTrue(testBlocking())

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -469,6 +469,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     count << [1, 4, 50] // make multiple requests.
   }
 
+  @Flaky(value = "https://github.com/DataDog/dd-trace-java/issues/4690", suites = ["MuleHttpServerForkedTest"])
   def "test forwarded request"() {
     setup:
     assumeTrue(testForwarded())


### PR DESCRIPTION
# What Does This Do
* Mark more tests as flaky, see issues below.
* Rename `ApacheHttpAsyncClientTest` to `ApacheHttpAsyncClient5Test` in `apache-httpclient-5` to distinguish it in test results, IDE, and make it easier to use flaky test selectors.

# Motivation

# Additional Notes
* https://github.com/DataDog/dd-trace-java/issues/3874
* https://github.com/DataDog/dd-trace-java/issues/4681
* https://github.com/DataDog/dd-trace-java/issues/4689
* https://github.com/DataDog/dd-trace-java/issues/4690