### PR TITLE
Clean up Single Span Sampling logic. It shouldn't change trace sampling priority.

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -114,13 +114,6 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext, TraceSe
 
   private volatile int samplingPriority = PrioritySampling.UNSET;
 
-  // A flag that this span has been kept by the Single Span Sampling mechanism. This is needed for
-  // when it's a root span that is set to be dropped by the trace sampling, but kept by the single
-  // span sampling. In this case, we should NOT override the original samplingPriority that is used
-  // by the child spans that don't have an explicitly set trace sampling priority and gets it from
-  // the root span.
-  private volatile boolean isSelectedBySingleSpanSampling = false;
-
   /** The origin of the trace. (eg. Synthetics, CI App) */
   private volatile CharSequence origin;
 
@@ -393,7 +386,6 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext, TraceSe
       if (limit != Integer.MAX_VALUE) {
         unsafeSetTag(SPAN_SAMPLING_MAX_PER_SECOND_TAG, limit);
       }
-      isSelectedBySingleSpanSampling = true;
     }
   }
 
@@ -603,26 +595,13 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext, TraceSe
               threadName,
               postProcessor.processTags(unsafeTags),
               baggageItemsWithPropagationTags,
-              getEffectiveSamplingPriority(),
+              samplingPriority != PrioritySampling.UNSET ? samplingPriority : getSamplingPriority(),
               measured,
               topLevel,
               httpStatusCode == 0 ? null : HTTP_STATUSES.get(httpStatusCode),
               // Get origin from rootSpan.context
               getOrigin()));
     }
-  }
-
-  // used in tests
-  int getEffectiveSamplingPriority() {
-    if (isSelectedBySingleSpanSampling) {
-      // use span sampling priority if this span has been selected by the single span sampler
-      return PrioritySampling.USER_KEEP;
-    } else if (samplingPriority != PrioritySampling.UNSET) {
-      // use trace sampling priority, if it's been set
-      return samplingPriority;
-    }
-    // otherwise get sampling priority from the root span
-    return getSamplingPriority();
   }
 
   @Override

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/SingleSpanSamplerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/SingleSpanSamplerTest.groovy
@@ -10,7 +10,6 @@ import static datadog.trace.api.config.TracerConfig.SPAN_SAMPLING_RULES_FILE
 import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLE_RATE
 import static datadog.trace.api.sampling.SamplingMechanism.DEFAULT
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP
-import static datadog.trace.api.sampling.PrioritySampling.USER_KEEP
 import static datadog.trace.api.sampling.SamplingMechanism.SPAN_SAMPLING_RATE
 
 class SingleSpanSamplerTest extends DDCoreSpecification {
@@ -104,9 +103,6 @@ class SingleSpanSamplerTest extends DDCoreSpecification {
     // set spans sampling priority
     sampler.setSamplingPriority(rootSpan) == sampleRoot
     sampler.setSamplingPriority(childSpan) == sampleChild
-
-    rootSpan.context().effectiveSamplingPriority == (sampleRoot ? USER_KEEP : SAMPLER_DROP)
-    childSpan.context().effectiveSamplingPriority == (sampleChild ? USER_KEEP : SAMPLER_DROP)
 
     expect:
     rootSpan.getTag("_dd.span_sampling.mechanism") == rootMechanism

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
@@ -217,7 +217,6 @@ class DDSpanContextTest extends DDCoreSpecification {
 
     expect:
     context.getSamplingPriority() == UNSET
-    context.effectiveSamplingPriority == UNSET
 
     when:
     context.setSpanSamplingPriority(rate, limit)
@@ -228,7 +227,6 @@ class DDSpanContextTest extends DDCoreSpecification {
     context.getTag(SPAN_SAMPLING_MAX_PER_SECOND_TAG) == (limit == Integer.MAX_VALUE ? null : limit)
     // single span sampling should not change the trace sampling priority
     context.getSamplingPriority() == UNSET
-    context.effectiveSamplingPriority == USER_KEEP
     // make sure the `_dd.p.dm` tag has not been set by single span sampling
     context.getPropagationTags().createTagMap() == [:]
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -425,7 +425,6 @@ class DDSpanTest extends DDCoreSpecification {
     span.getTag(SPAN_SAMPLING_MAX_PER_SECOND_TAG) == (limit == Integer.MAX_VALUE ? null : limit)
     // single span sampling should not change the trace sampling priority
     span.samplingPriority() == UNSET
-    span.context.effectiveSamplingPriority == USER_KEEP
 
     where:
     rate | limit


### PR DESCRIPTION
# What Does This Do

Cleans up Single Span Sampling logic to avoid changing the trace sampling priority.

# Motivation

The Agent doesn't care about the effective trace sampling priority and accepts single sampled spans anyway. So, this PR cleans this up to keep the original trace sampling priority.

# Additional Notes
https://github.com/DataDog/system-tests/pull/848#discussion_r1100563935