### PR TITLE
Use JDK 11 for spotless

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,6 +285,7 @@ jobs:
       - run:
           name: Run spotless
           command: >-
+            JAVA_HOME=$JAVA_11_HOME
             ./gradlew spotlessCheck -PskipBuildSrcTest
             << pipeline.parameters.gradle_flags >>
             --max-workers=8


### PR DESCRIPTION


# What Does This Do
Use JDK 11 for spotless

# Motivation
spotlessCheck is flaky when using JDK 8. It sometimes gives this error:

```
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':dd-trace-ot:spotlessGroovy'.
        [...]
Caused by: com.diffplug.spotless.ThrowingEx$WrappedAsRuntimeException: java.lang.Exception: You are running Spotless on JVM 8, which limits you to eclipse groovy formatter 4.19.0.
If you upgrade your JVM to 11+, then you can use eclipse groovy formatter 4.21.0, which may have fixed this problem.
       [...]
Caused by: java.lang.Exception: You are running Spotless on JVM 8, which limits you to eclipse groovy formatter 4.19.0.
If you upgrade your JVM to 11+, then you can use eclipse groovy formatter 4.21.0, which may have fixed this problem.
	at com.diffplug.spotless.Jvm$Support$1.apply(Jvm.java:181)
	at com.diffplug.spotless.FormatterStepImpl$Standard.format(FormatterStepImpl.java:82)
	at com.diffplug.spotless.FormatterStep$Strict.format(FormatterStep.java:88)
	at com.diffplug.spotless.Formatter.compute(Formatter.java:230)
	... 151 more
Caused by: java.lang.ArrayIndexOutOfBoundsException
	at com.diffplug.spotless.extra.eclipse.groovy.GrEclipseFormatterStepImpl$GroovyErrorListener.<init>(GrEclipseFormatterStepImpl.java:109)
	at com.diffplug.spotless.extra.eclipse.groovy.GrEclipseFormatterStepImpl.format(GrEclipseFormatterStepImpl.java:83)
	at com.diffplug.spotless.extra.groovy.GrEclipseFormatterStep.lambda$apply$0(GrEclipseFormatterStep.java:57)
	at com.diffplug.spotless.FormatterFunc.apply(FormatterFunc.java:32)
	at com.diffplug.spotless.Jvm$Support$1.apply(Jvm.java:179)
	... 154 more
```

# Additional Notes
* Example of failed build: https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/21510/workflows/cbcd9882-ff4d-4d92-97fc-cfc6911e3b92/jobs/578638