### PR TITLE
Move dd-javac-plugin-client dependency to internal-api module

### DIFF
--- a/dd-java-agent/agent-ci-visibility/build.gradle
+++ b/dd-java-agent/agent-ci-visibility/build.gradle
@@ -24,8 +24,6 @@ dependencies {
   implementation deps.asm
   implementation deps.asmcommons
 
-  implementation "com.datadoghq:dd-javac-plugin-client:0.1.0"
-
   implementation project(':internal-api')
   implementation project(':internal-api:internal-api-9')
 

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -102,6 +102,10 @@ dependencies {
   api deps.slf4j
   api project(":utils:time-utils")
 
+  // has to be loaded by system classloader:
+  // it contains annotation that is also present in the instrumented application classes
+  api "com.datadoghq:dd-javac-plugin-client:0.1.0"
+
   testImplementation project(":utils:test-utils")
   testImplementation("org.assertj:assertj-core:2.9.1")
   testImplementation deps.junit5

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -104,7 +104,7 @@ dependencies {
 
   // has to be loaded by system classloader:
   // it contains annotation that is also present in the instrumented application classes
-  api "com.datadoghq:dd-javac-plugin-client:0.1.0"
+  api "com.datadoghq:dd-javac-plugin-client:0.1.1"
 
   testImplementation project(":utils:test-utils")
   testImplementation("org.assertj:assertj-core:2.9.1")


### PR DESCRIPTION
# What Does This Do
Moves `dd-javac-plugin-client` dependency to from `agent-ci-visibility` module to `internal-api` module

# Motivation
`dd-javac-plugin-client` contains `SourcePath` annotation.
Customer classes can be annotated with this annotation in order to inform the runtime about source code location for a specific class (the annotation can be done automatically by the compiler plugin).

In case of customer classes the annotation will be loaded by the system class loader.
While `agent-ci-visibility` module is loaded by the agent's internal classloader, and so the annotation class that it loads is different from the annotation class with which the customer classes are annotated.
On the other hand, `internal-api` module is loaded by the system classloader.
So moving the dependency to that module (and loading it along with it) solves the issue of having two different classloaders to load the same class.