### PR TITLE
Move parseTemplate for log probes to tests part

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -10,11 +10,8 @@ import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.JsonWriter;
 import datadog.trace.bootstrap.debugger.DiagnosticMessage;
 import datadog.trace.bootstrap.debugger.Limits;
-import datadog.trace.util.Strings;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.objectweb.asm.tree.ClassNode;
@@ -421,9 +418,9 @@ public class LogProbe extends ProbeDefinition {
     private Capture capture;
     private Sampling sampling;
 
-    public Builder template(String template) {
+    public Builder template(String template, List<Segment> segments) {
       this.template = template;
-      this.segments = parseTemplate(template);
+      this.segments = segments;
       return this;
     }
 
@@ -470,48 +467,6 @@ public class LogProbe extends ProbeDefinition {
           probeCondition,
           capture,
           sampling);
-    }
-
-    private static List<Segment> parseTemplate(String template) {
-      if (template == null) {
-        return Collections.emptyList();
-      }
-      List<Segment> result = new ArrayList<>();
-      int currentIdx = 0;
-      int startStrIdx = 0;
-      do {
-        int startIdx = template.indexOf('{', currentIdx);
-        if (startIdx == -1) {
-          addStrSegment(result, template.substring(startStrIdx));
-          return result;
-        }
-        if (startIdx + 1 < template.length() && template.charAt(startIdx + 1) == '{') {
-          currentIdx = startIdx + 2;
-          continue;
-        }
-        int endIdx = template.indexOf('}', startIdx);
-        if (endIdx == -1) {
-          addStrSegment(result, template.substring(startStrIdx));
-          currentIdx = startIdx + 1;
-          startStrIdx = currentIdx;
-        } else {
-          if (startStrIdx != startIdx) {
-            addStrSegment(result, template.substring(startStrIdx, startIdx));
-          }
-          String expr = template.substring(startIdx + 1, endIdx);
-
-          result.add(new Segment(new ValueScript(ValueScript.parseRefPath(expr), expr)));
-          currentIdx = endIdx + 1;
-          startStrIdx = currentIdx;
-        }
-      } while (currentIdx < template.length());
-      return result;
-    }
-
-    private static void addStrSegment(List<Segment> segments, String str) {
-      str = Strings.replace(str, "{{", "{");
-      str = Strings.replace(str, "}}", "}");
-      segments.add(new Segment(str));
     }
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
@@ -2,6 +2,7 @@ package com.datadog.debugger.agent;
 
 import static com.datadog.debugger.probe.MetricProbe.MetricKind.COUNT;
 import static com.datadog.debugger.probe.MetricProbe.MetricKind.GAUGE;
+import static com.datadog.debugger.util.LogProbeTestHelper.parseTemplate;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -293,7 +294,7 @@ public class ConfigurationTest {
         .captureSnapshot(false)
         .where(typeName, methodName, signature)
         .evaluateAt(ProbeDefinition.MethodLocation.ENTRY)
-        .template(template)
+        .template(template, parseTemplate(template))
         .tags("tag1:value1", "tag2:value2")
         .build();
   }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerProductChangesListenerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerProductChangesListenerTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.agent;
 
+import static com.datadog.debugger.util.LogProbeTestHelper.parseTemplate;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -264,10 +265,11 @@ public class DebuggerProductChangesListenerTest {
   }
 
   LogProbe createLogProbe(String id) {
+    final String LOG_LINE = "hello {world}";
     return LogProbe.builder()
         .probeId(id)
         .where(null, null, null, 1966, "src/main/java/java/lang/String.java")
-        .template("hello {world}")
+        .template(LOG_LINE, parseTemplate(LOG_LINE))
         .build();
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogMessageTemplateSummaryBuilderTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogMessageTemplateSummaryBuilderTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.agent;
 
+import static com.datadog.debugger.util.LogProbeTestHelper.parseTemplate;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -28,7 +29,7 @@ class LogMessageTemplateSummaryBuilderTest {
 
   @Test
   public void emptyTemplate() {
-    LogProbe probe = LogProbe.builder().template("").build();
+    LogProbe probe = createLogProbe("");
     LogMessageTemplateSummaryBuilder summaryBuilder = new LogMessageTemplateSummaryBuilder(probe);
     summaryBuilder.addEntry(new Snapshot.CapturedContext());
     assertEquals("", summaryBuilder.build());
@@ -36,7 +37,7 @@ class LogMessageTemplateSummaryBuilderTest {
 
   @Test
   public void onlyStringTemplate() {
-    LogProbe probe = LogProbe.builder().template("this is a simple string").build();
+    LogProbe probe = createLogProbe("this is a simple string");
     LogMessageTemplateSummaryBuilder summaryBuilder = new LogMessageTemplateSummaryBuilder(probe);
     summaryBuilder.addEntry(new Snapshot.CapturedContext());
     assertEquals("this is a simple string", summaryBuilder.build());
@@ -44,7 +45,7 @@ class LogMessageTemplateSummaryBuilderTest {
 
   @Test
   public void undefinedArgTemplate() {
-    LogProbe probe = LogProbe.builder().template("{arg}").build();
+    LogProbe probe = createLogProbe("{arg}");
     LogMessageTemplateSummaryBuilder summaryBuilder = new LogMessageTemplateSummaryBuilder(probe);
     summaryBuilder.addEntry(new Snapshot.CapturedContext());
     assertEquals("UNDEFINED", summaryBuilder.build());
@@ -52,7 +53,7 @@ class LogMessageTemplateSummaryBuilderTest {
 
   @Test
   public void argTemplate() {
-    LogProbe probe = LogProbe.builder().template("{arg}").build();
+    LogProbe probe = createLogProbe("{arg}");
     LogMessageTemplateSummaryBuilder summaryBuilder = new LogMessageTemplateSummaryBuilder(probe);
     Snapshot.CapturedContext capturedContext = new Snapshot.CapturedContext();
     capturedContext.addArguments(
@@ -65,7 +66,7 @@ class LogMessageTemplateSummaryBuilderTest {
 
   @Test
   public void argMultipleInFlightTemplate() {
-    LogProbe probe = LogProbe.builder().template("{arg}").build();
+    LogProbe probe = createLogProbe("{arg}");
     LogMessageTemplateSummaryBuilder summaryBuilder = new LogMessageTemplateSummaryBuilder(probe);
     Snapshot.CapturedContext capturedContext = new Snapshot.CapturedContext();
     capturedContext.addArguments(
@@ -86,7 +87,7 @@ class LogMessageTemplateSummaryBuilderTest {
 
   @Test
   public void argNullTemplate() {
-    LogProbe probe = LogProbe.builder().template("{nullObject}").build();
+    LogProbe probe = createLogProbe("{nullObject}");
     LogMessageTemplateSummaryBuilder summaryBuilder = new LogMessageTemplateSummaryBuilder(probe);
     Snapshot.CapturedContext capturedContext = new Snapshot.CapturedContext();
     capturedContext.addArguments(
@@ -99,7 +100,7 @@ class LogMessageTemplateSummaryBuilderTest {
 
   @Test
   public void argArrayTemplate() {
-    LogProbe probe = LogProbe.builder().template("{primArray} {strArray}").build();
+    LogProbe probe = createLogProbe("{primArray} {strArray}");
     LogMessageTemplateSummaryBuilder summaryBuilder = new LogMessageTemplateSummaryBuilder(probe);
     Snapshot.CapturedContext capturedContext = new Snapshot.CapturedContext();
     capturedContext.addArguments(
@@ -119,7 +120,7 @@ class LogMessageTemplateSummaryBuilderTest {
 
   @Test
   public void argCollectionTemplate() {
-    LogProbe probe = LogProbe.builder().template("{strList} {strSet}").build();
+    LogProbe probe = createLogProbe("{strList} {strSet}");
     LogMessageTemplateSummaryBuilder summaryBuilder = new LogMessageTemplateSummaryBuilder(probe);
     Snapshot.CapturedContext capturedContext = new Snapshot.CapturedContext();
     capturedContext.addArguments(
@@ -145,7 +146,7 @@ class LogMessageTemplateSummaryBuilderTest {
 
   @Test
   public void argMapTemplate() {
-    LogProbe probe = LogProbe.builder().template("{strMap}").build();
+    LogProbe probe = createLogProbe("{strMap}");
     LogMessageTemplateSummaryBuilder summaryBuilder = new LogMessageTemplateSummaryBuilder(probe);
     Snapshot.CapturedContext capturedContext = new Snapshot.CapturedContext();
     Map<String, String> map = new LinkedHashMap<>();
@@ -173,7 +174,7 @@ class LogMessageTemplateSummaryBuilderTest {
 
   @Test
   public void argComplexObjectTemplate() {
-    LogProbe probe = LogProbe.builder().template("{obj}").build();
+    LogProbe probe = createLogProbe("{obj}");
     LogMessageTemplateSummaryBuilder summaryBuilder = new LogMessageTemplateSummaryBuilder(probe);
     Snapshot.CapturedContext capturedContext = new Snapshot.CapturedContext();
     capturedContext.addArguments(
@@ -186,7 +187,7 @@ class LogMessageTemplateSummaryBuilderTest {
 
   @Test
   public void argComplexObjectArrayTemplate() {
-    LogProbe probe = LogProbe.builder().template("{array}").build();
+    LogProbe probe = createLogProbe("{array}");
     LogMessageTemplateSummaryBuilder summaryBuilder = new LogMessageTemplateSummaryBuilder(probe);
     Snapshot.CapturedContext capturedContext = new Snapshot.CapturedContext();
     capturedContext.addArguments(
@@ -201,7 +202,7 @@ class LogMessageTemplateSummaryBuilderTest {
   @Test
   @EnabledOnJre(JRE.JAVA_17)
   public void argInaccessibleFieldTemplate() {
-    LogProbe probe = LogProbe.builder().template("{obj}").build();
+    LogProbe probe = createLogProbe("{obj}");
     LogMessageTemplateSummaryBuilder summaryBuilder = new LogMessageTemplateSummaryBuilder(probe);
     Snapshot.CapturedContext capturedContext = new Snapshot.CapturedContext();
     capturedContext.addArguments(
@@ -218,5 +219,9 @@ class LogMessageTemplateSummaryBuilderTest {
     for (int i = 0; i < 5; i++) {
       assertTrue(evaluationErrors.get(i).getMessage().contains("Cannot extract field:"));
     }
+  }
+
+  private LogProbe createLogProbe(String template) {
+    return LogProbe.builder().template(template, parseTemplate(template)).build();
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.agent;
 
+import static com.datadog.debugger.util.LogProbeTestHelper.parseTemplate;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
@@ -343,7 +344,7 @@ public class LogProbesInstrumentationTest {
         .probeId(id)
         .active(true)
         .where(typeName, methodName, signature, lines)
-        .template(template);
+        .template(template, parseTemplate(template));
   }
 
   private static LogProbe createProbe(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.probe;
 
+import static com.datadog.debugger.util.LogProbeTestHelper.parseTemplate;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.Assert;
@@ -11,7 +12,7 @@ public class LogProbeTest {
 
   @Test
   public void testCapture() {
-    LogProbe.Builder builder = createLog();
+    LogProbe.Builder builder = createLog(null);
     LogProbe snapshotProbe = builder.capture(1, 420, 255, 20).build();
     Assert.assertEquals(1, snapshotProbe.getCapture().getMaxReferenceDepth());
     Assert.assertEquals(420, snapshotProbe.getCapture().getMaxCollectionSize());
@@ -20,28 +21,28 @@ public class LogProbeTest {
 
   @Test
   public void testSampling() {
-    LogProbe.Builder builder = createLog();
+    LogProbe.Builder builder = createLog(null);
     LogProbe snapshotProbe = builder.sampling(0.25).build();
     Assert.assertEquals(0.25, snapshotProbe.getSampling().getSnapshotsPerSecond(), 0.01);
   }
 
   @Test
   public void log() {
-    LogProbe logProbe = createLog().template(null).build();
+    LogProbe logProbe = createLog(null).build();
     assertNull(logProbe.getTemplate());
     assertTrue(logProbe.getSegments().isEmpty());
-    logProbe = createLog().template("plain log line").build();
+    logProbe = createLog("plain log line").build();
     assertEquals("plain log line", logProbe.getTemplate());
     assertEquals(1, logProbe.getSegments().size());
     assertEquals("plain log line", logProbe.getSegments().get(0).getStr());
     assertNull(logProbe.getSegments().get(0).getExpr());
     assertNull(logProbe.getSegments().get(0).getParsedExpr());
-    logProbe = createLog().template("simple template log line {arg}").build();
+    logProbe = createLog("simple template log line {arg}").build();
     assertEquals("simple template log line {arg}", logProbe.getTemplate());
     assertEquals(2, logProbe.getSegments().size());
     assertEquals("simple template log line ", logProbe.getSegments().get(0).getStr());
     assertEquals("arg", logProbe.getSegments().get(1).getExpr());
-    logProbe = createLog().template("{arg1}={arg2} {{{count(array)}}}").build();
+    logProbe = createLog("{arg1}={arg2} {{{count(array)}}}").build();
     assertEquals("{arg1}={arg2} {{{count(array)}}}", logProbe.getTemplate());
     assertEquals(6, logProbe.getSegments().size());
     assertEquals("arg1", logProbe.getSegments().get(0).getExpr());
@@ -52,7 +53,10 @@ public class LogProbeTest {
     assertEquals("}", logProbe.getSegments().get(5).getStr());
   }
 
-  private LogProbe.Builder createLog() {
-    return LogProbe.builder().language(LANGUAGE).probeId(PROBE_ID);
+  private LogProbe.Builder createLog(String template) {
+    return LogProbe.builder()
+        .language(LANGUAGE)
+        .probeId(PROBE_ID)
+        .template(template, parseTemplate(template));
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/LogProbeTestHelper.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/LogProbeTestHelper.java
@@ -1,0 +1,53 @@
+package com.datadog.debugger.util;
+
+import com.datadog.debugger.el.ValueScript;
+import com.datadog.debugger.probe.LogProbe;
+import datadog.trace.util.Strings;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class LogProbeTestHelper {
+
+  public static List<LogProbe.Segment> parseTemplate(String template) {
+    if (template == null) {
+      return Collections.emptyList();
+    }
+    List<LogProbe.Segment> result = new ArrayList<>();
+    int currentIdx = 0;
+    int startStrIdx = 0;
+    do {
+      int startIdx = template.indexOf('{', currentIdx);
+      if (startIdx == -1) {
+        addStrSegment(result, template.substring(startStrIdx));
+        return result;
+      }
+      if (startIdx + 1 < template.length() && template.charAt(startIdx + 1) == '{') {
+        currentIdx = startIdx + 2;
+        continue;
+      }
+      int endIdx = template.indexOf('}', startIdx);
+      if (endIdx == -1) {
+        addStrSegment(result, template.substring(startStrIdx));
+        currentIdx = startIdx + 1;
+        startStrIdx = currentIdx;
+      } else {
+        if (startStrIdx != startIdx) {
+          addStrSegment(result, template.substring(startStrIdx, startIdx));
+        }
+        String expr = template.substring(startIdx + 1, endIdx);
+
+        result.add(new LogProbe.Segment(new ValueScript(ValueScript.parseRefPath(expr), expr)));
+        currentIdx = endIdx + 1;
+        startStrIdx = currentIdx;
+      }
+    } while (currentIdx < template.length());
+    return result;
+  }
+
+  private static void addStrSegment(List<LogProbe.Segment> segments, String str) {
+    str = Strings.replace(str, "{{", "{");
+    str = Strings.replace(str, "}}", "}");
+    segments.add(new LogProbe.Segment(str));
+  }
+}


### PR DESCRIPTION
only used for tests

# What Does This Do

# Motivation
code cleanup

# Additional Notes
