### PR TITLE
String constructor instrumentation for IAST propagation

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/StringModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/StringModuleImpl.java
@@ -402,4 +402,21 @@ public class StringModuleImpl extends IastModuleBase implements StringModule {
       taintedObjects.taint(result, newRanges);
     }
   }
+
+  @Override
+  public void onStringConstructor(@Nonnull String self, @Nonnull String result) {
+    if (!canBeTainted(self)) {
+      return;
+    }
+    final IastRequestContext ctx = IastRequestContext.get();
+    if (ctx == null) {
+      return;
+    }
+    final TaintedObjects taintedObjects = ctx.getTaintedObjects();
+    final Range[] selfRanges = getRanges(taintedObjects.get(self));
+    if (selfRanges.length == 0) {
+      return;
+    }
+    taintedObjects.taint(result, selfRanges);
+  }
 }

--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringCallSite.java
@@ -197,4 +197,18 @@ public class StringCallSite {
     }
     return result;
   }
+
+  @CallSite.After("void java.lang.String.<init>(java.lang.String)")
+  public static String afterConstructor(
+      @CallSite.This final String self, @CallSite.Argument final String originalString) {
+    final StringModule module = InstrumentationBridge.STRING;
+    try {
+      if (module != null) {
+        module.onStringConstructor(originalString, self);
+      }
+    } catch (final Throwable e) {
+      module.onUnexpectedException("afterSubstring threw", e);
+    }
+    return self;
+  }
 }

--- a/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/StringCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/StringCallSiteTest.groovy
@@ -165,4 +165,18 @@ class StringCallSiteTest extends AgentTestRunner {
     1 * module.onStringTrim(' hello ', 'hello')
     0 * _
   }
+
+  def 'test string Constructor call site'() {
+    setup:
+    final module = Mock(StringModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    final result = TestStringSuite.stringConstructor("hello")
+
+    then:
+    result == 'hello'
+    1 * module.onStringConstructor(_,_)
+    0 * _
+  }
 }

--- a/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringSuite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringSuite.java
@@ -82,4 +82,11 @@ public class TestStringSuite {
     LOGGER.debug("After string trim {}", result);
     return result;
   }
+
+  public static String stringConstructor(String self) {
+    LOGGER.debug("Before string stringConstructor {} from {}", self);
+    final String result = new String(self);
+    LOGGER.debug("After string stringConstructor {}", result);
+    return result;
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/propagation/StringModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/propagation/StringModule.java
@@ -34,4 +34,6 @@ public interface StringModule extends IastModule {
   void onStringTrim(@Nonnull String self, @Nullable String result);
 
   void onStringRepeat(@Nonnull String self, int count, @Nonnull String result);
+
+  void onStringConstructor(@Nonnull String self, @Nonnull String result);
 }


### PR DESCRIPTION
# What Does This Do
Instrument the String constructor

# Motivation
This is needed so tainted strings are propagated when the String constructor is called. 

# Additional Notes
