### PR TITLE
ignore null resource name

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -245,6 +245,9 @@ public class DDSpanContext implements AgentSpan.Context, RequestContext, TraceSe
   }
 
   public void setResourceName(final CharSequence resourceName, byte priority) {
+    if (null == resourceName) {
+      return;
+    }
     if (priority >= this.resourceNamePriority) {
       this.resourceNamePriority = priority;
       this.resourceName = resourceName;

--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/TagInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/TagInterceptor.java
@@ -101,6 +101,9 @@ public class TagInterceptor {
 
   private boolean interceptResourceName(DDSpanContext span, Object value) {
     if (ruleFlags.isEnabled(RESOURCE_NAME)) {
+      if (null == value) {
+        return false;
+      }
       if (value instanceof CharSequence) {
         span.setResourceName((CharSequence) value, ResourceNamePriorities.TAG_INTERCEPTOR);
       } else {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
@@ -239,6 +239,20 @@ class DDSpanContextTest extends DDCoreSpecification {
     0.25 | Integer.MAX_VALUE
   }
 
+  def "setting resource name to null is ignored"() {
+    setup:
+    def span = tracer.buildSpan("fakeOperation")
+      .withServiceName("fakeService")
+      .withResourceName("fakeResource")
+      .start()
+
+    when:
+    span.setResourceName(null)
+
+    then:
+    span.resourceName == "fakeResource"
+  }
+
   private static String dataTag(String tag) {
     "_dd.${tag}.json"
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/taginterceptor/TagInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/taginterceptor/TagInterceptorTest.groovy
@@ -299,6 +299,23 @@ class TagInterceptorTest extends DDCoreSpecification {
     name = "my resource name"
   }
 
+  def "set resource name ignores null"() {
+    when:
+    def writer = new ListWriter()
+    def tracer = tracerBuilder().writer(writer).build()
+
+    def span = tracer.buildSpan("test").withResourceName("keep").start()
+    span.setTag(DDTags.RESOURCE_NAME, null)
+    span.finish()
+    writer.waitForTraces(1)
+
+    then:
+    span.getResourceName() == "keep"
+
+    cleanup:
+    tracer.close()
+  }
+
   def "set span type"() {
     when:
     def tracer = tracerBuilder().writer(new ListWriter()).build()


### PR DESCRIPTION
# What Does This Do

Ignores when a customer uses a null resource name, either through APIs of the tag interceptor

# Motivation

A customer was overwriting a resource name when trying to set it to null. We decided ignoring the call is the best fix
