### PR TITLE
Refactor Json deserialization for test code only

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
@@ -622,6 +622,8 @@ public class Snapshot {
     private Limits limits = Limits.DEFAULT;
     private String thisClassName;
     private List<EvaluationError> evaluationErrors;
+    private String traceId;
+    private String spanId;
 
     public CapturedContext() {}
 
@@ -694,14 +696,6 @@ public class Snapshot {
       }
       checkUndefined(memberName, target, memberName, "Cannot dereference to field: ");
       return target;
-    }
-
-    private Object tryRetrieveField(String name) {
-      if (fields == null) {
-        return Values.UNDEFINED_OBJECT;
-      }
-      Object field = fields.get(name);
-      return field != null ? field : Values.UNDEFINED_OBJECT;
     }
 
     private Object tryRetrieveSynthetic(String name) {
@@ -793,6 +787,17 @@ public class Snapshot {
       for (CapturedValue value : values) {
         fields.put(value.name, value);
       }
+      traceId = extractSpecialId("dd.trace_id");
+      spanId = extractSpecialId("dd.span_id");
+    }
+
+    private String extractSpecialId(String idName) {
+      CapturedValue capturedValue = fields.get(idName);
+      if (capturedValue == null) {
+        return null;
+      }
+      Object value = capturedValue.getValue();
+      return value instanceof String ? (String) value : null;
     }
 
     public void addEvaluationError(String expr, String message) {
@@ -840,6 +845,14 @@ public class Snapshot {
 
     public String getThisClassName() {
       return thisClassName;
+    }
+
+    public String getTraceId() {
+      return traceId;
+    }
+
+    public String getSpanId() {
+      return spanId;
     }
 
     /**

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/JsonSnapshotSerializer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/JsonSnapshotSerializer.java
@@ -7,12 +7,9 @@ import com.squareup.moshi.JsonAdapter;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.debugger.Snapshot;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Serializes snapshots in Json using Moshi */
 public class JsonSnapshotSerializer implements DebuggerContext.SnapshotSerializer {
-  private static final Logger LOG = LoggerFactory.getLogger(JsonSnapshotSerializer.class);
   private static final String DD_TRACE_ID = "dd.trace_id";
   private static final String DD_SPAN_ID = "dd.span_id";
   private static final JsonAdapter<IntakeRequest> ADAPTER =
@@ -74,34 +71,8 @@ public class JsonSnapshotSerializer implements DebuggerContext.SnapshotSerialize
   }
 
   private void addTraceSpanId(Snapshot.CapturedContext context, IntakeRequest request) {
-    Map<String, Snapshot.CapturedValue> fields = context.getFields();
-    if (fields == null) {
-      return;
-    }
-    request.traceId = extractCorrelationField(fields, DD_TRACE_ID);
-    request.spanId = extractCorrelationField(fields, DD_SPAN_ID);
-  }
-
-  private String extractCorrelationField(
-      Map<String, Snapshot.CapturedValue> fields, String fieldName) {
-    Snapshot.CapturedValue fieldValue = fields.get(fieldName);
-    if (fieldValue != null) {
-      return getValue(fieldValue, fieldName);
-    }
-    return null;
-  }
-
-  public static String getValue(Snapshot.CapturedValue capturedValue, String name) {
-    if (capturedValue != null) {
-      try {
-        Snapshot.CapturedValue deserializedValue =
-            VALUE_ADAPTER.fromJson(capturedValue.getStrValue());
-        return String.valueOf(deserializedValue.getValue());
-      } catch (Exception e) {
-        LOG.warn("Cannot deserialize " + name, e);
-      }
-    }
-    return null;
+    request.traceId = context.getTraceId();
+    request.spanId = context.getSpanId();
   }
 
   public static class IntakeRequest {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
@@ -13,9 +13,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -51,62 +48,32 @@ public class MoshiSnapshotHelper {
     @Override
     public JsonAdapter<?> create(Type type, Set<? extends Annotation> set, Moshi moshi) {
       if (Types.equals(type, Snapshot.Captures.class)) {
-        return new CapturesAdapter(moshi);
+        return new CapturesAdapter(
+            moshi, new CapturedContextAdapter(moshi, new CapturedValueAdapter()));
       }
       if (Types.equals(type, Snapshot.CapturedValue.class)) {
         return new CapturedValueAdapter();
       }
       if (Types.equals(type, Snapshot.CapturedContext.class)) {
-        return new CapturedContextAdapter(moshi);
+        return new CapturedContextAdapter(moshi, new CapturedValueAdapter());
       }
       return null;
     }
   }
 
-  private static class CapturesAdapter extends JsonAdapter<Snapshot.Captures> {
-    private final JsonAdapter<Snapshot.CapturedContext> capturedContextAdapter;
-    private final JsonAdapter<Map<Integer, Snapshot.CapturedContext>> linesAdapter;
-    private final JsonAdapter<List<Snapshot.CapturedThrowable>> caughtExceptionsAdapter;
+  public static class CapturesAdapter extends JsonAdapter<Snapshot.Captures> {
+    protected final JsonAdapter<Snapshot.CapturedContext> capturedContextAdapter;
+    protected final JsonAdapter<Map<Integer, Snapshot.CapturedContext>> linesAdapter;
+    protected final JsonAdapter<List<Snapshot.CapturedThrowable>> caughtExceptionsAdapter;
 
-    public CapturesAdapter(Moshi moshi) {
-      capturedContextAdapter = new CapturedContextAdapter(moshi);
+    public CapturesAdapter(
+        Moshi moshi, JsonAdapter<Snapshot.CapturedContext> capturedContextAdapter) {
+      this.capturedContextAdapter = capturedContextAdapter;
       linesAdapter =
           moshi.adapter(
               Types.newParameterizedType(Map.class, Integer.class, Snapshot.CapturedContext.class));
       caughtExceptionsAdapter =
           moshi.adapter(Types.newParameterizedType(List.class, Snapshot.CapturedThrowable.class));
-    }
-
-    @Override
-    public Snapshot.Captures fromJson(JsonReader jsonReader) throws IOException {
-      jsonReader.beginObject();
-      Snapshot.Captures captures = new Snapshot.Captures();
-      while (jsonReader.hasNext()) {
-        String name = jsonReader.nextName();
-        switch (name) {
-          case ENTRY:
-            captures.setEntry(capturedContextAdapter.fromJson(jsonReader));
-            break;
-          case RETURN:
-            captures.setReturn(capturedContextAdapter.fromJson(jsonReader));
-            break;
-          case LINES:
-            Map<Integer, Snapshot.CapturedContext> map = linesAdapter.fromJson(jsonReader);
-            if (map != null) {
-              map.forEach(captures::addLine);
-            }
-            break;
-          case CAUGHT_EXCEPTIONS:
-            List<Snapshot.CapturedThrowable> capturedThrowables =
-                caughtExceptionsAdapter.fromJson(jsonReader);
-            capturedThrowables.forEach(captures::addCaughtException);
-            break;
-          default:
-            throw new IllegalArgumentException("Unknown field name for Captures object: " + name);
-        }
-      }
-      jsonReader.endObject();
-      return captures;
     }
 
     @Override
@@ -126,102 +93,21 @@ public class MoshiSnapshotHelper {
       caughtExceptionsAdapter.toJson(jsonWriter, captures.getCaughtExceptions());
       jsonWriter.endObject();
     }
-  }
-
-  private static class CapturedContextAdapter extends JsonAdapter<Snapshot.CapturedContext> {
-    private static final Snapshot.CapturedValue[] EMPTY_VALUES_ARRAY =
-        new Snapshot.CapturedValue[0];
-
-    private final JsonAdapter<Snapshot.CapturedThrowable> throwableAdapter;
-    private final JsonAdapter<Snapshot.CapturedValue> valueAdapter;
-
-    public CapturedContextAdapter(Moshi moshi) {
-      valueAdapter = new CapturedValueAdapter();
-      throwableAdapter = moshi.adapter(Snapshot.CapturedThrowable.class);
-    }
 
     @Override
-    public Snapshot.CapturedContext fromJson(JsonReader jsonReader) throws IOException {
-      jsonReader.beginObject();
-      Snapshot.CapturedContext capturedContext = new Snapshot.CapturedContext();
-      while (jsonReader.hasNext()) {
-        String name = jsonReader.nextName();
-        switch (name) {
-          case ARGUMENTS:
-            jsonReader.beginObject();
-            List<Snapshot.CapturedValue> argValues = new ArrayList<>();
-            while (jsonReader.hasNext()) {
-              String argName = jsonReader.peekJson().nextName();
-              if ("this".equals(argName)) {
-                jsonReader.nextName(); // consume "this"
-                fromJsonFields(jsonReader, capturedContext);
-                continue;
-              }
-              argName = jsonReader.nextName();
-              Snapshot.CapturedValue capturedValue = valueAdapter.fromJson(jsonReader);
-              if (capturedValue != null) {
-                capturedValue.setName(argName);
-                argValues.add(capturedValue);
-              }
-            }
-            jsonReader.endObject();
-            capturedContext.addArguments(argValues.toArray(EMPTY_VALUES_ARRAY));
-            break;
-          case LOCALS:
-            capturedContext.addLocals(fromJsonCapturedValues(jsonReader));
-            break;
-          case THROWABLE:
-            capturedContext.addThrowable(throwableAdapter.fromJson(jsonReader));
-            break;
-          default:
-            throw new IllegalArgumentException("Unknown field name for Captures object: " + name);
-        }
-      }
-      jsonReader.endObject();
-      return capturedContext;
+    public Snapshot.Captures fromJson(JsonReader reader) throws IOException {
+      // Only used in test, see MoshiSnapshotTestHelper
+      throw new IllegalStateException("Should not reach this code.");
     }
+  }
 
-    private void fromJsonFields(JsonReader jsonReader, Snapshot.CapturedContext capturedContext)
-        throws IOException {
-      jsonReader.beginObject();
-      while (jsonReader.hasNext()) {
-        String name = jsonReader.nextName();
-        switch (name) {
-          case TYPE:
-            {
-              jsonReader.nextString();
-              break;
-            }
-          case FIELDS:
-            {
-              capturedContext.addFields(fromJsonCapturedValues(jsonReader));
-              break;
-            }
-          default:
-            throw new IllegalArgumentException("Unknown field name for 'this' object: " + name);
-        }
-      }
-      jsonReader.endObject();
-    }
+  public static class CapturedContextAdapter extends JsonAdapter<Snapshot.CapturedContext> {
+    protected final JsonAdapter<Snapshot.CapturedThrowable> throwableAdapter;
+    protected final JsonAdapter<Snapshot.CapturedValue> valueAdapter;
 
-    private Snapshot.CapturedValue[] fromJsonCapturedValues(JsonReader jsonReader)
-        throws IOException {
-      jsonReader.beginObject();
-      List<Snapshot.CapturedValue> values = new ArrayList<>();
-      while (jsonReader.hasNext()) {
-        String name = jsonReader.nextName();
-        if (NOT_CAPTURED_REASON.equals(name)) {
-          jsonReader.nextString();
-          continue;
-        }
-        Snapshot.CapturedValue capturedValue = valueAdapter.fromJson(jsonReader);
-        if (capturedValue != null) {
-          capturedValue.setName(name);
-          values.add(capturedValue);
-        }
-      }
-      jsonReader.endObject();
-      return values.toArray(EMPTY_VALUES_ARRAY);
+    public CapturedContextAdapter(Moshi moshi, JsonAdapter<Snapshot.CapturedValue> valueAdapter) {
+      this.valueAdapter = valueAdapter;
+      this.throwableAdapter = moshi.adapter(Snapshot.CapturedThrowable.class);
     }
 
     @Override
@@ -297,217 +183,22 @@ public class MoshiSnapshotHelper {
       }
       return true;
     }
+
+    @Override
+    public Snapshot.CapturedContext fromJson(JsonReader reader) throws IOException {
+      // Only used in test, see MoshiSnapshotTestHelper
+      throw new IllegalStateException("Should not reach this code.");
+    }
   }
 
   public static class CapturedValueAdapter extends JsonAdapter<Snapshot.CapturedValue> {
-
-    @Override
-    public Snapshot.CapturedValue fromJson(JsonReader jsonReader) throws IOException {
-      jsonReader.beginObject();
-      String type = null;
-      Object value = null;
-      String notCapturedReason = null;
-      while (jsonReader.hasNext()) {
-        String name = jsonReader.nextName();
-        switch (name) {
-          case TYPE:
-            type = jsonReader.nextString();
-            break;
-          case VALUE:
-            String strValue = jsonReader.nextString();
-            value = convertPrimitive(strValue, type);
-            break;
-          case FIELDS:
-            jsonReader.beginObject();
-            Map<String, Snapshot.CapturedValue> fields = new HashMap<>();
-            while (jsonReader.hasNext()) {
-              String fieldName = jsonReader.nextName();
-              if (NOT_CAPTURED_REASON.equals(fieldName)) {
-                notCapturedReason = jsonReader.nextString();
-                continue;
-              }
-              Snapshot.CapturedValue fieldValue = fromJson(jsonReader);
-              fields.put(fieldName, fieldValue);
-            }
-            jsonReader.endObject();
-            value = fields;
-            break;
-          case ELEMENTS:
-            {
-              if (type == null) {
-                throw new RuntimeException("type is null");
-              }
-              jsonReader.beginArray();
-              List<Snapshot.CapturedValue> values = new ArrayList<>();
-              while (jsonReader.hasNext()) {
-                Snapshot.CapturedValue elementValue = fromJson(jsonReader);
-                values.add(elementValue);
-              }
-              jsonReader.endArray();
-              if (type.equals(List.class.getTypeName())
-                  || type.equals(ArrayList.class.getTypeName())
-                  || type.equals("java.util.Collections$UnmodifiableRandomAccessList")) {
-                List<Object> list = new ArrayList<>();
-                for (Snapshot.CapturedValue cValue : values) {
-                  list.add(cValue.getValue());
-                }
-                value = list;
-              } else if (type.endsWith("[]")) {
-                String componentType = type.substring(0, type.indexOf('['));
-                if (SerializerWithLimits.isPrimitive(componentType)) {
-                  value = createPrimitiveArray(componentType, values);
-                } else {
-                  value = values.stream().map(Snapshot.CapturedValue::getValue).toArray();
-                }
-              } else if (type.equals("java.util.Collections$EmptyList")) {
-                value = Collections.emptyList();
-              } else {
-                throw new RuntimeException("Cannot deserialize type: " + type);
-              }
-              break;
-            }
-          case ENTRIES:
-            {
-              jsonReader.beginArray();
-              List<Snapshot.CapturedValue> values = new ArrayList<>();
-              while (jsonReader.hasNext()) {
-                jsonReader.beginArray();
-                Snapshot.CapturedValue elementValue = fromJson(jsonReader);
-                values.add(elementValue);
-                elementValue = fromJson(jsonReader);
-                values.add(elementValue);
-                jsonReader.endArray();
-              }
-              jsonReader.endArray();
-              Map<Object, Object> entries = new HashMap<>();
-              for (int i = 0; i < values.size(); i += 2) {
-                Object entryKey = values.get(i).getValue();
-                if (i + 1 >= values.size()) {
-                  break;
-                }
-                Object entryValue = values.get(i + 1).getValue();
-                entries.put(entryKey, entryValue);
-              }
-              value = entries;
-              break;
-            }
-          case IS_NULL:
-            jsonReader.nextBoolean();
-            value = null;
-            break;
-          case NOT_CAPTURED_REASON:
-            notCapturedReason = jsonReader.nextString();
-            break;
-          case TRUNCATED:
-            boolean truncated = jsonReader.nextBoolean();
-            if (truncated) {
-              notCapturedReason = "truncated";
-            }
-            break;
-          case SIZE:
-            jsonReader.nextString(); // consume size value
-            break;
-          default:
-            throw new RuntimeException("Unknown attribute: " + name);
-        }
-      }
-      jsonReader.endObject();
-      return Snapshot.CapturedValue.raw(type, value, notCapturedReason);
-    }
-
-    private Object createPrimitiveArray(String componentType, List<Snapshot.CapturedValue> values) {
-      switch (componentType) {
-        case "byte":
-          {
-            byte[] bytes = new byte[values.size()];
-            int i = 0;
-            for (Snapshot.CapturedValue capturedValue : values) {
-              bytes[i++] = (Byte) capturedValue.getValue();
-            }
-            return bytes;
-          }
-        case "boolean":
-          {
-            boolean[] booleans = new boolean[values.size()];
-            int i = 0;
-            for (Snapshot.CapturedValue capturedValue : values) {
-              booleans[i++] = (Boolean) capturedValue.getValue();
-            }
-            return booleans;
-          }
-        case "short":
-          {
-            short[] shorts = new short[values.size()];
-            int i = 0;
-            for (Snapshot.CapturedValue capturedValue : values) {
-              shorts[i++] = (Short) capturedValue.getValue();
-            }
-            return shorts;
-          }
-        case "char":
-          {
-            char[] chars = new char[values.size()];
-            int i = 0;
-            for (Snapshot.CapturedValue capturedValue : values) {
-              chars[i++] = (Character) capturedValue.getValue();
-            }
-            return chars;
-          }
-        case "int":
-          {
-            int[] ints = new int[values.size()];
-            int i = 0;
-            for (Snapshot.CapturedValue capturedValue : values) {
-              ints[i++] = (Integer) capturedValue.getValue();
-            }
-            return ints;
-          }
-        case "long":
-          {
-            long[] longs = new long[values.size()];
-            int i = 0;
-            for (Snapshot.CapturedValue capturedValue : values) {
-              longs[i++] = (Long) capturedValue.getValue();
-            }
-            return longs;
-          }
-        case "float":
-          {
-            float[] floats = new float[values.size()];
-            int i = 0;
-            for (Snapshot.CapturedValue capturedValue : values) {
-              floats[i++] = (Float) capturedValue.getValue();
-            }
-            return floats;
-          }
-        case "double":
-          {
-            double[] doubles = new double[values.size()];
-            int i = 0;
-            for (Snapshot.CapturedValue capturedValue : values) {
-              doubles[i++] = (Double) capturedValue.getValue();
-            }
-            return doubles;
-          }
-        case "java.lang.String":
-          {
-            String[] strings = new String[values.size()];
-            int i = 0;
-            for (Snapshot.CapturedValue capturedValue : values) {
-              strings[i++] = (String) capturedValue.getValue();
-            }
-            return strings;
-          }
-        default:
-          throw new RuntimeException("unsupported primitive type: " + componentType);
-      }
-    }
 
     @Override
     public void toJson(JsonWriter jsonWriter, Snapshot.CapturedValue capturedValue)
         throws IOException {
       if (capturedValue == null) {
         jsonWriter.nullValue();
+        return;
       }
       serializeValue(
           jsonWriter, capturedValue.getValue(), capturedValue.getType(), capturedValue.getLimits());
@@ -523,40 +214,10 @@ public class MoshiSnapshotHelper {
       }
     }
 
-    private static Object convertPrimitive(String strValue, String type) {
-      if (type == null) {
-        return null;
-      }
-      switch (type) {
-        case "byte":
-        case "java.lang.Byte":
-          return Byte.parseByte(strValue);
-        case "short":
-        case "java.lang.Short":
-          return Short.parseShort(strValue);
-        case "char":
-        case "java.lang.Character":
-          return strValue.charAt(0);
-        case "int":
-        case "java.lang.Integer":
-          return Integer.parseInt(strValue);
-        case "long":
-        case "java.lang.Long":
-          return Long.parseLong(strValue);
-        case "boolean":
-        case "java.lang.Boolean":
-          return Boolean.parseBoolean(strValue);
-        case "float":
-        case "java.lang.Float":
-          return Float.parseFloat(strValue);
-        case "double":
-        case "java.lang.Double":
-          return Double.parseDouble(strValue);
-        case "String":
-        case "java.lang.String":
-          return strValue;
-      }
-      return null;
+    @Override
+    public Snapshot.CapturedValue fromJson(JsonReader reader) throws IOException {
+      // Only used in test, see MoshiSnapshotTestHelper
+      throw new IllegalStateException("Should not reach this code.");
     }
 
     private static class JsonTokenWriter implements SerializerWithLimits.TokenWriter {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -19,7 +19,7 @@ import com.datadog.debugger.probe.LogProbe;
 import com.datadog.debugger.probe.ProbeDefinition;
 import com.datadog.debugger.probe.Where;
 import com.datadog.debugger.util.MoshiHelper;
-import com.datadog.debugger.util.MoshiSnapshotHelper;
+import com.datadog.debugger.util.MoshiSnapshotTestHelper;
 import com.datadog.debugger.util.SerializerWithLimits;
 import com.squareup.moshi.JsonAdapter;
 import datadog.trace.api.Config;
@@ -76,7 +76,7 @@ public class CapturedSnapshotTest {
   private static final String PROBE_ID2 = "beae1807-f3b0-4ea8-a74f-826790c5e6f7";
   private static final String SERVICE_NAME = "service-name";
   private static final JsonAdapter<Snapshot.CapturedValue> VALUE_ADAPTER =
-      new MoshiSnapshotHelper.CapturedValueAdapter();
+      new MoshiSnapshotTestHelper.CapturedValueAdapter();
   private static final JsonAdapter<Map<String, Object>> GENERIC_ADAPTER =
       MoshiHelper.createGenericAdapter();
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
@@ -23,7 +23,10 @@ import static utils.TestHelper.getFixtureContent;
 import com.datadog.debugger.el.DSL;
 import com.datadog.debugger.el.ProbeCondition;
 import com.datadog.debugger.util.MoshiHelper;
+import com.datadog.debugger.util.MoshiSnapshotHelper;
+import com.datadog.debugger.util.MoshiSnapshotTestHelper;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
 import datadog.trace.bootstrap.debugger.CapturedStackFrame;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.debugger.Limits;
@@ -65,7 +68,7 @@ public class SnapshotSerializationTest {
 
   @Test
   public void roundTripProbeLocation() throws IOException {
-    JsonAdapter<Snapshot> adapter = MoshiHelper.createMoshiSnapshot().adapter(Snapshot.class);
+    JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
     Snapshot snapshot = createSnapshot();
     String buffer = adapter.toJson(snapshot);
 
@@ -80,7 +83,7 @@ public class SnapshotSerializationTest {
   @Test
   @EnabledOnJre(JRE.JAVA_17)
   public void roundTripCapturedValue() throws IOException, URISyntaxException {
-    JsonAdapter<Snapshot> adapter = MoshiHelper.createMoshiSnapshot().adapter(Snapshot.class);
+    JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
     Snapshot snapshot = createSnapshot();
     Snapshot.CapturedContext context = new Snapshot.CapturedContext();
     Snapshot.CapturedValue normalValuedField =
@@ -138,7 +141,7 @@ public class SnapshotSerializationTest {
 
   @Test
   public void roundTripCaughtException() throws IOException {
-    JsonAdapter<Snapshot> adapter = MoshiHelper.createMoshiSnapshot().adapter(Snapshot.class);
+    JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
     Snapshot snapshot = createSnapshot();
     Snapshot.Captures captures = snapshot.getCaptures();
     captures.addCaughtException(
@@ -162,7 +165,7 @@ public class SnapshotSerializationTest {
 
   @Test
   public void roundtripEntryReturn() throws IOException {
-    JsonAdapter<Snapshot> adapter = MoshiHelper.createMoshiSnapshot().adapter(Snapshot.class);
+    JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
     Snapshot snapshot = createSnapshot();
     Snapshot.Captures captures = snapshot.getCaptures();
     Snapshot.CapturedContext entryCapturedContext = new Snapshot.CapturedContext();
@@ -189,7 +192,7 @@ public class SnapshotSerializationTest {
 
   @Test
   public void roundtripLines() throws IOException {
-    JsonAdapter<Snapshot> adapter = MoshiHelper.createMoshiSnapshot().adapter(Snapshot.class);
+    JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
     Snapshot snapshot = createSnapshot();
     Snapshot.Captures captures = snapshot.getCaptures();
     Snapshot.CapturedContext lineCapturedContext = new Snapshot.CapturedContext();
@@ -208,7 +211,7 @@ public class SnapshotSerializationTest {
 
   @Test
   public void roundtripCondition() throws IOException {
-    JsonAdapter<Snapshot> adapter = MoshiHelper.createMoshiSnapshot().adapter(Snapshot.class);
+    JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
     Snapshot snapshot =
         new Snapshot(
             Thread.currentThread(),
@@ -258,7 +261,7 @@ public class SnapshotSerializationTest {
 
   @Test
   public void primitives() throws IOException {
-    JsonAdapter<Snapshot> adapter = MoshiHelper.createMoshiSnapshot().adapter(Snapshot.class);
+    JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
     Snapshot snapshot = createSnapshot();
     Snapshot.CapturedContext context = new Snapshot.CapturedContext();
     Snapshot.CapturedValue objField =
@@ -294,7 +297,7 @@ public class SnapshotSerializationTest {
 
   @Test
   public void wellKnownClasses() throws IOException {
-    JsonAdapter<Snapshot> adapter = MoshiHelper.createMoshiSnapshot().adapter(Snapshot.class);
+    JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
     Snapshot snapshot = createSnapshot();
     Snapshot.CapturedContext context = new Snapshot.CapturedContext();
     Snapshot.CapturedValue objField =
@@ -328,7 +331,7 @@ public class SnapshotSerializationTest {
 
   @Test
   public void objectArray() throws IOException {
-    JsonAdapter<Snapshot> adapter = MoshiHelper.createMoshiSnapshot().adapter(Snapshot.class);
+    JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
     Snapshot snapshot = createSnapshot();
     Snapshot.CapturedContext context = new Snapshot.CapturedContext();
     Snapshot.CapturedValue localObjArray =
@@ -348,7 +351,7 @@ public class SnapshotSerializationTest {
 
   @Test
   public void fieldObjectArray() throws IOException {
-    JsonAdapter<Snapshot> adapter = MoshiHelper.createMoshiSnapshot().adapter(Snapshot.class);
+    JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
     Snapshot snapshot = createSnapshot();
     Snapshot.CapturedContext context = new Snapshot.CapturedContext();
     Snapshot.CapturedValue localObj =
@@ -381,7 +384,7 @@ public class SnapshotSerializationTest {
 
   @Test
   public void fieldPrimitiveArray() throws IOException {
-    JsonAdapter<Snapshot> adapter = MoshiHelper.createMoshiSnapshot().adapter(Snapshot.class);
+    JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
     Snapshot snapshot = createSnapshot();
     Snapshot.CapturedContext context = new Snapshot.CapturedContext();
     Snapshot.CapturedValue localObj =
@@ -498,7 +501,7 @@ public class SnapshotSerializationTest {
   }
 
   private Map<String, Object> doRefDepth(int maxRefDepth) throws IOException {
-    JsonAdapter<Snapshot> adapter = MoshiHelper.createMoshiSnapshot().adapter(Snapshot.class);
+    JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
     Snapshot snapshot = createSnapshotForRefDepth(maxRefDepth);
     String buffer = adapter.toJson(snapshot);
     System.out.println(buffer);
@@ -623,7 +626,7 @@ public class SnapshotSerializationTest {
   }
 
   private Map<String, Object> doCollectionSize(int maxColSize) throws IOException {
-    JsonAdapter<Snapshot> adapter = MoshiHelper.createMoshiSnapshot().adapter(Snapshot.class);
+    JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
     Snapshot snapshot = createSnapshotForCollectionSize(maxColSize);
     String buffer = adapter.toJson(snapshot);
     System.out.println(buffer);
@@ -679,7 +682,7 @@ public class SnapshotSerializationTest {
   }
 
   private Map<String, Object> doMapSize(int maxColSize) throws IOException {
-    JsonAdapter<Snapshot> adapter = MoshiHelper.createMoshiSnapshot().adapter(Snapshot.class);
+    JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
     Snapshot snapshot = createSnapshotForMapSize(maxColSize);
     String buffer = adapter.toJson(snapshot);
     System.out.println(buffer);
@@ -710,8 +713,22 @@ public class SnapshotSerializationTest {
     assertSize(thisArgFields, "strField", "null"); // no size field if no truncation
   }
 
+  @Test
+  public void capturesAdapterNull() {
+    MoshiSnapshotHelper.CapturesAdapter capturesAdapter =
+        new MoshiSnapshotHelper.CapturesAdapter(new Moshi.Builder().build(), null);
+    Assert.assertEquals("null", capturesAdapter.toJson(null));
+  }
+
+  @Test
+  public void capturedValueAdapterNull() {
+    MoshiSnapshotHelper.CapturedValueAdapter capturedValueAdapter =
+        new MoshiSnapshotHelper.CapturedValueAdapter();
+    Assert.assertEquals("null", capturedValueAdapter.toJson(null));
+  }
+
   private Map<String, Object> doLength(int maxLength) throws IOException {
-    JsonAdapter<Snapshot> adapter = MoshiHelper.createMoshiSnapshot().adapter(Snapshot.class);
+    JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
     Snapshot snapshot = createSnapshotForLength(maxLength);
     String buffer = adapter.toJson(snapshot);
     System.out.println(buffer);
@@ -740,7 +757,7 @@ public class SnapshotSerializationTest {
   }
 
   private Map<String, Object> doFieldCount(int maxFieldCount) throws IOException {
-    JsonAdapter<Snapshot> adapter = MoshiHelper.createMoshiSnapshot().adapter(Snapshot.class);
+    JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
     Snapshot snapshot = createSnapshotForFieldCount(maxFieldCount);
     String buffer = adapter.toJson(snapshot);
     System.out.println(buffer);
@@ -1058,5 +1075,9 @@ public class SnapshotSerializationTest {
         Thread.currentThread(),
         new Snapshot.ProbeDetails(PROBE_ID, PROBE_LOCATION),
         String.class.getTypeName());
+  }
+
+  private static JsonAdapter<Snapshot> createSnapshotAdapter() {
+    return MoshiSnapshotTestHelper.createMoshiSnapshot().adapter(Snapshot.class);
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/CapturedValueAdapterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/CapturedValueAdapterTest.java
@@ -17,7 +17,7 @@ public class CapturedValueAdapterTest {
   private static final String CAPTURED_VALUE_COLLECTION_TEMPLATE =
       "{\"type\": \"%s\", \"elements\": [%s]}";
   private static final String CAPTURED_VALUE_MAP_TEMPLATE = "{\"type\": \"%s\", \"entries\": [%s]}";
-  Moshi moshi = new Moshi.Builder().add(new MoshiSnapshotHelper.SnapshotJsonFactory()).build();
+  Moshi moshi = MoshiSnapshotTestHelper.createMoshiSnapshot();
   JsonAdapter<Snapshot.CapturedValue> adapter = moshi.adapter(Snapshot.CapturedValue.class);
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/MoshiSnapshotTestHelper.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/MoshiSnapshotTestHelper.java
@@ -1,0 +1,438 @@
+package com.datadog.debugger.util;
+
+import static com.datadog.debugger.util.MoshiSnapshotHelper.ARGUMENTS;
+import static com.datadog.debugger.util.MoshiSnapshotHelper.CAUGHT_EXCEPTIONS;
+import static com.datadog.debugger.util.MoshiSnapshotHelper.ELEMENTS;
+import static com.datadog.debugger.util.MoshiSnapshotHelper.ENTRIES;
+import static com.datadog.debugger.util.MoshiSnapshotHelper.ENTRY;
+import static com.datadog.debugger.util.MoshiSnapshotHelper.FIELDS;
+import static com.datadog.debugger.util.MoshiSnapshotHelper.IS_NULL;
+import static com.datadog.debugger.util.MoshiSnapshotHelper.LINES;
+import static com.datadog.debugger.util.MoshiSnapshotHelper.LOCALS;
+import static com.datadog.debugger.util.MoshiSnapshotHelper.NOT_CAPTURED_REASON;
+import static com.datadog.debugger.util.MoshiSnapshotHelper.RETURN;
+import static com.datadog.debugger.util.MoshiSnapshotHelper.SIZE;
+import static com.datadog.debugger.util.MoshiSnapshotHelper.THROWABLE;
+import static com.datadog.debugger.util.MoshiSnapshotHelper.TRUNCATED;
+import static com.datadog.debugger.util.MoshiSnapshotHelper.TYPE;
+import static com.datadog.debugger.util.MoshiSnapshotHelper.VALUE;
+
+import com.datadog.debugger.el.ProbeCondition;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.Moshi;
+import com.squareup.moshi.Types;
+import datadog.trace.bootstrap.debugger.Snapshot;
+import datadog.trace.bootstrap.debugger.el.DebuggerScript;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class MoshiSnapshotTestHelper {
+
+  public static class SnapshotJsonFactory implements JsonAdapter.Factory {
+    @Override
+    public JsonAdapter<?> create(Type type, Set<? extends Annotation> set, Moshi moshi) {
+      if (Types.equals(type, Snapshot.Captures.class)) {
+        return new MoshiSnapshotTestHelper.CapturesAdapter(
+            moshi, new CapturedContextAdapter(moshi, new CapturedValueAdapter()));
+      }
+      if (Types.equals(type, Snapshot.CapturedValue.class)) {
+        return new MoshiSnapshotTestHelper.CapturedValueAdapter();
+      }
+      if (Types.equals(type, Snapshot.CapturedContext.class)) {
+        return new MoshiSnapshotTestHelper.CapturedContextAdapter(
+            moshi, new CapturedValueAdapter());
+      }
+      return null;
+    }
+  }
+
+  public static Moshi createMoshiSnapshot() {
+    return new Moshi.Builder()
+        .add(new MoshiSnapshotTestHelper.SnapshotJsonFactory())
+        .add(
+            DebuggerScript.class,
+            new ProbeCondition.ProbeConditionJsonAdapter()) // ProbeDetails in Snapshot
+        .build();
+  }
+
+  private static class CapturesAdapter extends MoshiSnapshotHelper.CapturesAdapter {
+
+    public CapturesAdapter(
+        Moshi moshi, JsonAdapter<Snapshot.CapturedContext> capturedContextAdapter) {
+      super(moshi, capturedContextAdapter);
+    }
+
+    @Override
+    public Snapshot.Captures fromJson(JsonReader jsonReader) throws IOException {
+      jsonReader.beginObject();
+      Snapshot.Captures captures = new Snapshot.Captures();
+      while (jsonReader.hasNext()) {
+        String name = jsonReader.nextName();
+        switch (name) {
+          case ENTRY:
+            captures.setEntry(capturedContextAdapter.fromJson(jsonReader));
+            break;
+          case RETURN:
+            captures.setReturn(capturedContextAdapter.fromJson(jsonReader));
+            break;
+          case LINES:
+            Map<Integer, Snapshot.CapturedContext> map = linesAdapter.fromJson(jsonReader);
+            if (map != null) {
+              map.forEach(captures::addLine);
+            }
+            break;
+          case CAUGHT_EXCEPTIONS:
+            List<Snapshot.CapturedThrowable> capturedThrowables =
+                caughtExceptionsAdapter.fromJson(jsonReader);
+            capturedThrowables.forEach(captures::addCaughtException);
+            break;
+          default:
+            throw new IllegalArgumentException("Unknown field name for Captures object: " + name);
+        }
+      }
+      jsonReader.endObject();
+      return captures;
+    }
+  }
+
+  public static class CapturedContextAdapter extends MoshiSnapshotHelper.CapturedContextAdapter {
+    private static final Snapshot.CapturedValue[] EMPTY_VALUES_ARRAY =
+        new Snapshot.CapturedValue[0];
+
+    public CapturedContextAdapter(Moshi moshi, JsonAdapter<Snapshot.CapturedValue> valueAdapter) {
+      super(moshi, valueAdapter);
+    }
+
+    @Override
+    public Snapshot.CapturedContext fromJson(JsonReader jsonReader) throws IOException {
+      jsonReader.beginObject();
+      Snapshot.CapturedContext capturedContext = new Snapshot.CapturedContext();
+      while (jsonReader.hasNext()) {
+        String name = jsonReader.nextName();
+        switch (name) {
+          case ARGUMENTS:
+            jsonReader.beginObject();
+            List<Snapshot.CapturedValue> argValues = new ArrayList<>();
+            while (jsonReader.hasNext()) {
+              String argName = jsonReader.peekJson().nextName();
+              if ("this".equals(argName)) {
+                jsonReader.nextName(); // consume "this"
+                fromJsonFields(jsonReader, capturedContext);
+                continue;
+              }
+              argName = jsonReader.nextName();
+              Snapshot.CapturedValue capturedValue = valueAdapter.fromJson(jsonReader);
+              if (capturedValue != null) {
+                capturedValue.setName(argName);
+                argValues.add(capturedValue);
+              }
+            }
+            jsonReader.endObject();
+            capturedContext.addArguments(argValues.toArray(EMPTY_VALUES_ARRAY));
+            break;
+          case LOCALS:
+            capturedContext.addLocals(fromJsonCapturedValues(jsonReader));
+            break;
+          case THROWABLE:
+            capturedContext.addThrowable(throwableAdapter.fromJson(jsonReader));
+            break;
+          default:
+            throw new IllegalArgumentException("Unknown field name for Captures object: " + name);
+        }
+      }
+      jsonReader.endObject();
+      return capturedContext;
+    }
+
+    private void fromJsonFields(JsonReader jsonReader, Snapshot.CapturedContext capturedContext)
+        throws IOException {
+      jsonReader.beginObject();
+      while (jsonReader.hasNext()) {
+        String name = jsonReader.nextName();
+        switch (name) {
+          case TYPE:
+            {
+              jsonReader.nextString();
+              break;
+            }
+          case FIELDS:
+            {
+              capturedContext.addFields(fromJsonCapturedValues(jsonReader));
+              break;
+            }
+          default:
+            throw new IllegalArgumentException("Unknown field name for 'this' object: " + name);
+        }
+      }
+      jsonReader.endObject();
+    }
+
+    private Snapshot.CapturedValue[] fromJsonCapturedValues(JsonReader jsonReader)
+        throws IOException {
+      jsonReader.beginObject();
+      List<Snapshot.CapturedValue> values = new ArrayList<>();
+      while (jsonReader.hasNext()) {
+        String name = jsonReader.nextName();
+        if (NOT_CAPTURED_REASON.equals(name)) {
+          jsonReader.nextString();
+          continue;
+        }
+        Snapshot.CapturedValue capturedValue = valueAdapter.fromJson(jsonReader);
+        if (capturedValue != null) {
+          capturedValue.setName(name);
+          values.add(capturedValue);
+        }
+      }
+      jsonReader.endObject();
+      return values.toArray(EMPTY_VALUES_ARRAY);
+    }
+  }
+
+  public static class CapturedValueAdapter extends MoshiSnapshotHelper.CapturedValueAdapter {
+    @Override
+    public Snapshot.CapturedValue fromJson(JsonReader jsonReader) throws IOException {
+      jsonReader.beginObject();
+      String type = null;
+      Object value = null;
+      String notCapturedReason = null;
+      while (jsonReader.hasNext()) {
+        String name = jsonReader.nextName();
+        switch (name) {
+          case TYPE:
+            type = jsonReader.nextString();
+            break;
+          case VALUE:
+            String strValue = jsonReader.nextString();
+            value = convertPrimitive(strValue, type);
+            break;
+          case FIELDS:
+            jsonReader.beginObject();
+            Map<String, Snapshot.CapturedValue> fields = new HashMap<>();
+            while (jsonReader.hasNext()) {
+              String fieldName = jsonReader.nextName();
+              if (NOT_CAPTURED_REASON.equals(fieldName)) {
+                notCapturedReason = jsonReader.nextString();
+                continue;
+              }
+              Snapshot.CapturedValue fieldValue = fromJson(jsonReader);
+              fields.put(fieldName, fieldValue);
+            }
+            jsonReader.endObject();
+            value = fields;
+            break;
+          case ELEMENTS:
+            {
+              if (type == null) {
+                throw new RuntimeException("type is null");
+              }
+              jsonReader.beginArray();
+              List<Snapshot.CapturedValue> values = new ArrayList<>();
+              while (jsonReader.hasNext()) {
+                Snapshot.CapturedValue elementValue = fromJson(jsonReader);
+                values.add(elementValue);
+              }
+              jsonReader.endArray();
+              if (type.equals(List.class.getTypeName())
+                  || type.equals(ArrayList.class.getTypeName())
+                  || type.equals("java.util.Collections$UnmodifiableRandomAccessList")) {
+                List<Object> list = new ArrayList<>();
+                for (Snapshot.CapturedValue cValue : values) {
+                  list.add(cValue.getValue());
+                }
+                value = list;
+              } else if (type.endsWith("[]")) {
+                String componentType = type.substring(0, type.indexOf('['));
+                if (SerializerWithLimits.isPrimitive(componentType)) {
+                  value = createPrimitiveArray(componentType, values);
+                } else {
+                  value = values.stream().map(Snapshot.CapturedValue::getValue).toArray();
+                }
+              } else if (type.equals("java.util.Collections$EmptyList")) {
+                value = Collections.emptyList();
+              } else {
+                throw new RuntimeException("Cannot deserialize type: " + type);
+              }
+              break;
+            }
+          case ENTRIES:
+            {
+              jsonReader.beginArray();
+              List<Snapshot.CapturedValue> values = new ArrayList<>();
+              while (jsonReader.hasNext()) {
+                jsonReader.beginArray();
+                Snapshot.CapturedValue elementValue = fromJson(jsonReader);
+                values.add(elementValue);
+                elementValue = fromJson(jsonReader);
+                values.add(elementValue);
+                jsonReader.endArray();
+              }
+              jsonReader.endArray();
+              Map<Object, Object> entries = new HashMap<>();
+              for (int i = 0; i < values.size(); i += 2) {
+                Object entryKey = values.get(i).getValue();
+                if (i + 1 >= values.size()) {
+                  break;
+                }
+                Object entryValue = values.get(i + 1).getValue();
+                entries.put(entryKey, entryValue);
+              }
+              value = entries;
+              break;
+            }
+          case IS_NULL:
+            jsonReader.nextBoolean();
+            value = null;
+            break;
+          case NOT_CAPTURED_REASON:
+            notCapturedReason = jsonReader.nextString();
+            break;
+          case TRUNCATED:
+            boolean truncated = jsonReader.nextBoolean();
+            if (truncated) {
+              notCapturedReason = "truncated";
+            }
+            break;
+          case SIZE:
+            jsonReader.nextString(); // consume size value
+            break;
+          default:
+            throw new RuntimeException("Unknown attribute: " + name);
+        }
+      }
+      jsonReader.endObject();
+      return Snapshot.CapturedValue.raw(type, value, notCapturedReason);
+    }
+
+    private Object createPrimitiveArray(String componentType, List<Snapshot.CapturedValue> values) {
+      switch (componentType) {
+        case "byte":
+          {
+            byte[] bytes = new byte[values.size()];
+            int i = 0;
+            for (Snapshot.CapturedValue capturedValue : values) {
+              bytes[i++] = (Byte) capturedValue.getValue();
+            }
+            return bytes;
+          }
+        case "boolean":
+          {
+            boolean[] booleans = new boolean[values.size()];
+            int i = 0;
+            for (Snapshot.CapturedValue capturedValue : values) {
+              booleans[i++] = (Boolean) capturedValue.getValue();
+            }
+            return booleans;
+          }
+        case "short":
+          {
+            short[] shorts = new short[values.size()];
+            int i = 0;
+            for (Snapshot.CapturedValue capturedValue : values) {
+              shorts[i++] = (Short) capturedValue.getValue();
+            }
+            return shorts;
+          }
+        case "char":
+          {
+            char[] chars = new char[values.size()];
+            int i = 0;
+            for (Snapshot.CapturedValue capturedValue : values) {
+              chars[i++] = (Character) capturedValue.getValue();
+            }
+            return chars;
+          }
+        case "int":
+          {
+            int[] ints = new int[values.size()];
+            int i = 0;
+            for (Snapshot.CapturedValue capturedValue : values) {
+              ints[i++] = (Integer) capturedValue.getValue();
+            }
+            return ints;
+          }
+        case "long":
+          {
+            long[] longs = new long[values.size()];
+            int i = 0;
+            for (Snapshot.CapturedValue capturedValue : values) {
+              longs[i++] = (Long) capturedValue.getValue();
+            }
+            return longs;
+          }
+        case "float":
+          {
+            float[] floats = new float[values.size()];
+            int i = 0;
+            for (Snapshot.CapturedValue capturedValue : values) {
+              floats[i++] = (Float) capturedValue.getValue();
+            }
+            return floats;
+          }
+        case "double":
+          {
+            double[] doubles = new double[values.size()];
+            int i = 0;
+            for (Snapshot.CapturedValue capturedValue : values) {
+              doubles[i++] = (Double) capturedValue.getValue();
+            }
+            return doubles;
+          }
+        case "java.lang.String":
+          {
+            String[] strings = new String[values.size()];
+            int i = 0;
+            for (Snapshot.CapturedValue capturedValue : values) {
+              strings[i++] = (String) capturedValue.getValue();
+            }
+            return strings;
+          }
+        default:
+          throw new RuntimeException("unsupported primitive type: " + componentType);
+      }
+    }
+
+    private static Object convertPrimitive(String strValue, String type) {
+      if (type == null) {
+        return null;
+      }
+      switch (type) {
+        case "byte":
+        case "java.lang.Byte":
+          return Byte.parseByte(strValue);
+        case "short":
+        case "java.lang.Short":
+          return Short.parseShort(strValue);
+        case "char":
+        case "java.lang.Character":
+          return strValue.charAt(0);
+        case "int":
+        case "java.lang.Integer":
+          return Integer.parseInt(strValue);
+        case "long":
+        case "java.lang.Long":
+          return Long.parseLong(strValue);
+        case "boolean":
+        case "java.lang.Boolean":
+          return Boolean.parseBoolean(strValue);
+        case "float":
+        case "java.lang.Float":
+          return Float.parseFloat(strValue);
+        case "double":
+        case "java.lang.Double":
+          return Double.parseDouble(strValue);
+        case "String":
+        case "java.lang.String":
+          return strValue;
+      }
+      return null;
+    }
+  }
+}

--- a/dd-smoke-tests/debugger-integration-tests/build.gradle
+++ b/dd-smoke-tests/debugger-integration-tests/build.gradle
@@ -18,6 +18,8 @@ dependencies {
   testImplementation project(':dd-smoke-tests')
   testImplementation project(':dd-java-agent:agent-debugger')
   testImplementation project(':dd-java-agent:agent-debugger:debugger-bootstrap')
+  // dependency on some helper classes made only for tests
+  testImplementation project(':dd-java-agent:agent-debugger').sourceSets.test.output
   testImplementation deps.junit5
   testImplementation deps.mockito
 }

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
@@ -9,6 +9,7 @@ import com.datadog.debugger.agent.JsonSnapshotSerializer;
 import com.datadog.debugger.agent.ProbeStatus;
 import com.datadog.debugger.probe.LogProbe;
 import com.datadog.debugger.util.MoshiHelper;
+import com.datadog.debugger.util.MoshiSnapshotTestHelper;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Types;
 import datadog.trace.bootstrap.debugger.Snapshot;
@@ -203,7 +204,7 @@ public abstract class BaseIntegrationTest {
   }
 
   protected JsonAdapter<List<JsonSnapshotSerializer.IntakeRequest>> createAdapterForSnapshot() {
-    return MoshiHelper.createMoshiSnapshot()
+    return MoshiSnapshotTestHelper.createMoshiSnapshot()
         .adapter(
             Types.newParameterizedType(List.class, JsonSnapshotSerializer.IntakeRequest.class));
   }


### PR DESCRIPTION
# What Does This Do
Snapshot deserialization is only used for test code. Isolate deserialization code from Moshi adapters to test helper class and share it also for smoke tests

# Motivation
Isolate snapshot deserialization code into test only

# Additional Notes
