### PR TITLE
Refactor ScopeManager for future scoped context improvements

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/TypeConverterTest.groovy
@@ -1,7 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTraceId
-import datadog.trace.api.StatsDClient
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopPathwayContext
@@ -9,7 +8,6 @@ import datadog.trace.bootstrap.instrumentation.api.ScopeSource
 import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext
 import datadog.trace.core.PendingTrace
-import datadog.trace.core.monitor.HealthMetrics
 import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.core.scopemanager.ContinuableScopeManager
 import datadog.trace.instrumentation.opentelemetry.TypeConverter
@@ -47,7 +45,7 @@ class TypeConverterTest extends AgentTestRunner {
   }
 
   def "should avoid extra allocation for a scope wrapper"() {
-    def scopeManager = new ContinuableScopeManager(0, StatsDClient.NO_OP, false, true, HealthMetrics.NO_OP)
+    def scopeManager = new ContinuableScopeManager(0, false, true)
     def context = createTestSpanContext()
     def span1 = new DDSpan(0, context)
     def span2 = new DDSpan(0, context)

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/TypeConverterTest.groovy
@@ -1,7 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTraceId
-import datadog.trace.api.StatsDClient
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopPathwayContext
@@ -9,7 +8,6 @@ import datadog.trace.bootstrap.instrumentation.api.ScopeSource
 import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext
 import datadog.trace.core.PendingTrace
-import datadog.trace.core.monitor.HealthMetrics
 import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.core.scopemanager.ContinuableScopeManager
 import datadog.trace.instrumentation.opentracing.DefaultLogHandler
@@ -52,7 +50,7 @@ class TypeConverterTest extends AgentTestRunner {
   }
 
   def "should avoid extra allocation for a scope wrapper"() {
-    def scopeManager = new ContinuableScopeManager(0, StatsDClient.NO_OP, false, true, HealthMetrics.NO_OP)
+    def scopeManager = new ContinuableScopeManager(0, false, true)
     def context = createTestSpanContext()
     def span1 = new DDSpan(0, context)
     def span2 = new DDSpan(0, context)

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/TypeConverterTest.groovy
@@ -1,7 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTraceId
-import datadog.trace.api.StatsDClient
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopPathwayContext
@@ -9,7 +8,6 @@ import datadog.trace.bootstrap.instrumentation.api.ScopeSource
 import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext
 import datadog.trace.core.PendingTrace
-import datadog.trace.core.monitor.HealthMetrics
 import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.core.scopemanager.ContinuableScopeManager
 import datadog.trace.instrumentation.opentracing.DefaultLogHandler
@@ -52,7 +50,7 @@ class TypeConverterTest extends AgentTestRunner {
   }
 
   def "should avoid extra allocation for a scope wrapper"() {
-    def scopeManager = new ContinuableScopeManager(0, StatsDClient.NO_OP, false, true, HealthMetrics.NO_OP)
+    def scopeManager = new ContinuableScopeManager(0, false, true)
     def context = createTestSpanContext()
     def span1 = new DDSpan(0, context)
     def span2 = new DDSpan(0, context)

--- a/dd-trace-core/build.gradle
+++ b/dd-trace-core/build.gradle
@@ -20,7 +20,7 @@ excludedClassesCoverage += [
   'datadog.trace.core.PendingTraceBuffer.DelayingPendingTraceBuffer.FlushElement',
   'datadog.trace.core.StatusLogger',
   'datadog.trace.core.scopemanager.ContinuableScopeManager.ScopeStackThreadLocal',
-  'datadog.trace.core.scopemanager.ContinuableScopeManager.SingleContinuation',
+  'datadog.trace.core.scopemanager.SingleContinuation',
   'datadog.trace.core.SpanCorrelationImpl',
   'datadog.trace.core.Base64Encoder',
   'datadog.trace.core.CoreTracer.1',

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -500,16 +500,13 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
     this.traceWriteTimer = performanceMonitoring.newThreadLocalTimer("trace.write");
     if (scopeManager == null) {
-      ContinuableScopeManager csm =
+      this.scopeManager =
           new ContinuableScopeManager(
               config.getScopeDepthLimit(),
               config.isScopeStrictMode(),
               config.isScopeInheritAsyncPropagation(),
-              this.statsDClient,
               profilingContextIntegration,
               this.healthMetrics);
-      this.scopeManager = csm;
-
     } else {
       this.scopeManager = scopeManager;
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -702,8 +702,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   @Override
-  public AgentScope.Continuation captureSpan(final AgentSpan span, ScopeSource source) {
-    return scopeManager.captureSpan(span, source);
+  public AgentScope.Continuation captureSpan(final AgentSpan span) {
+    return scopeManager.captureSpan(span);
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -503,9 +503,9 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       ContinuableScopeManager csm =
           new ContinuableScopeManager(
               config.getScopeDepthLimit(),
-              this.statsDClient,
               config.isScopeStrictMode(),
               config.isScopeInheritAsyncPropagation(),
+              this.statsDClient,
               profilingContextIntegration,
               this.healthMetrics);
       this.scopeManager = csm;

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
@@ -47,7 +47,7 @@ public abstract class HealthMetrics implements AutoCloseable {
 
   public void onCreateManualTrace() {}
 
-  public void onScopeClose(int scopeSource) {}
+  public void onScopeCloseError(int scopeSource) {}
 
   public void onCancelContinuation() {}
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
@@ -17,46 +17,46 @@ import java.util.List;
  * </ul>
  */
 public abstract class HealthMetrics implements AutoCloseable {
-  public static HealthMetrics NO_OP = new NoOpHealthMetrics();
+  public static HealthMetrics NO_OP = new HealthMetrics() {};
 
-  public void start() {};
+  public void start() {}
 
-  public void onStart(final int queueCapacity) {};
+  public void onStart(final int queueCapacity) {}
 
-  public void onShutdown(final boolean flushSuccess) {};
+  public void onShutdown(final boolean flushSuccess) {}
 
-  public void onPublish(final List<DDSpan> trace, final int samplingPriority) {};
+  public void onPublish(final List<DDSpan> trace, final int samplingPriority) {}
 
-  public void onFailedPublish(final int samplingPriority) {};
+  public void onFailedPublish(final int samplingPriority) {}
 
-  public void onPartialPublish(final int numberOfDroppedSpans) {};
+  public void onPartialPublish(final int numberOfDroppedSpans) {}
 
-  public void onScheduleFlush(final boolean previousIncomplete) {};
+  public void onScheduleFlush(final boolean previousIncomplete) {}
 
-  public void onFlush(final boolean early) {};
+  public void onFlush(final boolean early) {}
 
-  public void onPartialFlush(final int sizeInBytes) {};
+  public void onPartialFlush(final int sizeInBytes) {}
 
-  public void onSerialize(final int serializedSizeInBytes) {};
+  public void onSerialize(final int serializedSizeInBytes) {}
 
-  public void onFailedSerialize(final List<DDSpan> trace, final Throwable optionalCause) {};
+  public void onFailedSerialize(final List<DDSpan> trace, final Throwable optionalCause) {}
 
-  public void onCreateSpan() {};
+  public void onCreateSpan() {}
 
-  public void onCreateTrace() {};
+  public void onCreateTrace() {}
 
-  public void onCreateManualTrace() {};
+  public void onCreateManualTrace() {}
 
-  public void onCancelContinuation() {};
+  public void onCancelContinuation() {}
 
-  public void onFinishContinuation() {};
+  public void onFinishContinuation() {}
 
   public void onSend(
-      final int traceCount, final int sizeInBytes, final RemoteApi.Response response) {};
+      final int traceCount, final int sizeInBytes, final RemoteApi.Response response) {}
 
   public void onFailedSend(
-      final int traceCount, final int sizeInBytes, final RemoteApi.Response response) {};
+      final int traceCount, final int sizeInBytes, final RemoteApi.Response response) {}
 
   @Override
-  public void close() {};
+  public void close() {}
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
@@ -47,6 +47,8 @@ public abstract class HealthMetrics implements AutoCloseable {
 
   public void onCreateManualTrace() {}
 
+  public void onScopeClose(int scopeSource) {}
+
   public void onCancelContinuation() {}
 
   public void onFinishContinuation() {}

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/NoOpHealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/NoOpHealthMetrics.java
@@ -1,3 +1,0 @@
-package datadog.trace.core.monitor;
-
-public class NoOpHealthMetrics extends HealthMetrics implements AutoCloseable {}

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
@@ -212,10 +212,10 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
   }
 
   @Override
-  public void onScopeClose(int scopeSource) {
-    statsd.incrementCounter("scope.close.error");
+  public void onScopeCloseError(int scopeSource) {
+    statsd.incrementCounter("scope.close.error", NO_TAGS);
     if (scopeSource == ScopeSource.MANUAL.id()) {
-      statsd.incrementCounter("scope.user.close.error");
+      statsd.incrementCounter("scope.user.close.error", NO_TAGS);
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
@@ -11,6 +11,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import datadog.trace.api.StatsDClient;
 import datadog.trace.api.cache.RadixTreeCache;
+import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.common.writer.RemoteApi;
 import datadog.trace.core.DDSpan;
 import datadog.trace.util.AgentTaskScheduler;
@@ -208,6 +209,14 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
   @Override
   public void onCreateManualTrace() {
     manualTraces.inc();
+  }
+
+  @Override
+  public void onScopeClose(int scopeSource) {
+    statsd.incrementCounter("scope.close.error");
+    if (scopeSource == ScopeSource.MANUAL.id()) {
+      statsd.incrementCounter("scope.user.close.error");
+    }
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/AbstractContinuation.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/AbstractContinuation.java
@@ -1,0 +1,34 @@
+package datadog.trace.core.scopemanager;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTrace;
+
+/**
+ * This class must not be a nested class of ContinuableScope to avoid an unconstrained chain of
+ * references (using too much memory).
+ */
+abstract class AbstractContinuation implements AgentScope.Continuation {
+
+  final ContinuableScopeManager scopeManager;
+  final AgentSpan spanUnderScope;
+  final byte source;
+  final AgentTrace trace;
+
+  public AbstractContinuation(
+      ContinuableScopeManager scopeManager, AgentSpan spanUnderScope, byte source) {
+    this.scopeManager = scopeManager;
+    this.spanUnderScope = spanUnderScope;
+    this.source = source;
+    this.trace = spanUnderScope.context().getTrace();
+  }
+
+  AbstractContinuation register() {
+    trace.registerContinuation(this);
+    return this;
+  }
+
+  // Called by ContinuableScopeManager when a continued scope is closed
+  // Can't use cancel() for SingleContinuation because of the "used" check
+  abstract void cancelFromContinuedScopeClose();
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ConcurrentContinuation.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ConcurrentContinuation.java
@@ -2,7 +2,6 @@ package datadog.trace.core.scopemanager;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 /**
@@ -67,7 +66,8 @@ final class ConcurrentContinuation extends AbstractContinuation {
     if (tryClose()) {
       trace.cancelContinuation(this);
     }
-    ContinuableScopeManager.log.debug("t_id={} -> canceling continuation {}", spanUnderScope.getTraceId(), this);
+    ContinuableScopeManager.log.debug(
+        "t_id={} -> canceling continuation {}", spanUnderScope.getTraceId(), this);
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ConcurrentContinuation.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ConcurrentContinuation.java
@@ -1,0 +1,95 @@
+package datadog.trace.core.scopemanager;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
+/**
+ * This class must not be a nested class of ContinuableScope to avoid an unconstrained chain of
+ * references (using too much memory).
+ *
+ * <p>This {@link AbstractContinuation} differs from the {@link SingleContinuation} in that if it is
+ * activated, it needs to be canceled in addition to the returned {@link AgentScope} being closed.
+ * This is to allow multiple concurrent threads that activate the continuation to race in a safe
+ * way, and close the scopes without fear of closing the related {@link AgentSpan} prematurely.
+ */
+final class ConcurrentContinuation extends AbstractContinuation {
+  private static final int START = 1;
+  private static final int CLOSED = Integer.MIN_VALUE >> 1;
+  private static final int BARRIER = Integer.MIN_VALUE >> 2;
+  private volatile int count = START;
+
+  private static final AtomicIntegerFieldUpdater<ConcurrentContinuation> COUNT =
+      AtomicIntegerFieldUpdater.newUpdater(ConcurrentContinuation.class, "count");
+
+  public ConcurrentContinuation(
+      ContinuableScopeManager scopeManager, AgentSpan spanUnderScope, byte source) {
+    super(scopeManager, spanUnderScope, source);
+  }
+
+  private boolean tryActivate() {
+    int current = COUNT.incrementAndGet(this);
+    if (current < START) {
+      COUNT.decrementAndGet(this);
+    }
+    return current > START;
+  }
+
+  private boolean tryClose() {
+    int current = COUNT.get(this);
+    if (current < BARRIER) {
+      return false;
+    }
+    // Now decrement the counter
+    current = COUNT.decrementAndGet(this);
+    // Try to close this if we are between START and BARRIER
+    while (current < START && current > BARRIER) {
+      if (COUNT.compareAndSet(this, current, CLOSED)) {
+        return true;
+      }
+      current = COUNT.get(this);
+    }
+    return false;
+  }
+
+  @Override
+  public AgentScope activate() {
+    if (tryActivate()) {
+      return scopeManager.continueSpan(this, spanUnderScope, source);
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public void cancel() {
+    if (tryClose()) {
+      trace.cancelContinuation(this);
+    }
+    ContinuableScopeManager.log.debug("t_id={} -> canceling continuation {}", spanUnderScope.getTraceId(), this);
+  }
+
+  @Override
+  public AgentSpan getSpan() {
+    return spanUnderScope;
+  }
+
+  @Override
+  void cancelFromContinuedScopeClose() {
+    cancel();
+  }
+
+  @Override
+  public String toString() {
+    int c = COUNT.get(this);
+    String s = c < BARRIER ? "CANCELED" : String.valueOf(c);
+    return getClass().getSimpleName()
+        + "@"
+        + Integer.toHexString(hashCode())
+        + "("
+        + s
+        + ")->"
+        + spanUnderScope;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
@@ -42,7 +42,7 @@ class ContinuableScope implements AgentScope, AttachableWrapper {
 
   @Override
   public final void close() {
-    final ContinuableScopeManager.ScopeStack scopeStack = scopeManager.scopeStack();
+    final ScopeStack scopeStack = scopeManager.scopeStack();
 
     // fast check first, only perform slower check when there's an inconsistency with the stack
     if (!scopeStack.checkTop(this) && !scopeStack.checkOverdueScopes(this)) {
@@ -68,7 +68,7 @@ class ContinuableScope implements AgentScope, AttachableWrapper {
     }
   }
 
-  void cleanup(final ContinuableScopeManager.ScopeStack scopeStack) {
+  void cleanup(final ScopeStack scopeStack) {
     scopeStack.cleanup();
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
@@ -1,0 +1,199 @@
+package datadog.trace.core.scopemanager;
+
+import datadog.trace.api.scopemanager.ExtendedScopeListener;
+import datadog.trace.api.scopemanager.ScopeListener;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AttachableWrapper;
+import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+class ContinuableScope implements AgentScope, AttachableWrapper {
+  private final ContinuableScopeManager scopeManager;
+
+  final AgentSpan span; // package-private so scopeManager can access it directly
+
+  /**
+   * Flag to propagate this scope across async boundaries.
+   */
+  private boolean isAsyncPropagating;
+
+  private final byte flags;
+
+  private short referenceCount = 1;
+
+  private volatile Object wrapper;
+  private static final AtomicReferenceFieldUpdater<ContinuableScope, Object>
+      WRAPPER_FIELD_UPDATER =
+      AtomicReferenceFieldUpdater.newUpdater(ContinuableScope.class, Object.class, "wrapper");
+
+  ContinuableScope(
+      final ContinuableScopeManager scopeManager,
+      final AgentSpan span,
+      final byte source,
+      final boolean isAsyncPropagating) {
+    this.scopeManager = scopeManager;
+    this.span = span;
+    this.flags = source;
+    this.isAsyncPropagating = isAsyncPropagating;
+  }
+
+  @Override
+  public final void close() {
+    final ContinuableScopeManager.ScopeStack scopeStack = scopeManager.scopeStack();
+
+    // fast check first, only perform slower check when there's an inconsistency with the stack
+    if (!scopeStack.checkTop(this) && !scopeStack.checkOverdueScopes(this)) {
+      if (ContinuableScopeManager.log.isDebugEnabled()) {
+        ContinuableScopeManager.log.debug(
+            "Tried to close {} scope when not on top.  Current top: {}", this, scopeStack.top);
+      }
+
+      scopeManager.statsDClient.incrementCounter("scope.close.error");
+
+      if (source() == ScopeSource.MANUAL.id()) {
+        scopeManager.statsDClient.incrementCounter("scope.user.close.error");
+
+        if (scopeManager.strictMode) {
+          throw new RuntimeException("Tried to close scope when not on top");
+        }
+      }
+    }
+
+    final boolean alive = decrementReferences();
+    if (!alive) {
+      cleanup(scopeStack);
+    }
+  }
+
+  void cleanup(final ContinuableScopeManager.ScopeStack scopeStack) {
+    scopeStack.cleanup();
+  }
+
+  /*
+   * Exists to allow stack unwinding to do a delayed call to close when the close is
+   * finished properly.  e.g. When the scope is back on the top of the stack.
+   *
+   * DQH - If we clean-up the delegation code & notification semantics at later time,
+   * I would hope this becomes unnecessary.
+   */
+  final void onProperClose() {
+    for (final ScopeListener listener : scopeManager.scopeListeners) {
+      try {
+        listener.afterScopeClosed();
+      } catch (Exception e) {
+        ContinuableScopeManager.log.debug("ScopeListener threw exception in close()", e);
+      }
+    }
+
+    for (final ExtendedScopeListener listener : scopeManager.extendedScopeListeners) {
+      try {
+        listener.afterScopeClosed();
+      } catch (Exception e) {
+        ContinuableScopeManager.log.debug("ScopeListener threw exception in close()", e);
+      }
+    }
+  }
+
+  final void incrementReferences() {
+    ++referenceCount;
+  }
+
+  /**
+   * Decrements ref count -- returns true if the scope is still alive
+   */
+  final boolean decrementReferences() {
+    return --referenceCount > 0;
+  }
+
+  final void clearReferences() {
+    referenceCount = 0;
+  }
+
+  /**
+   * Returns true if the scope is still alive (non-zero ref count)
+   */
+  final boolean alive() {
+    return referenceCount > 0;
+  }
+
+  @Override
+  public final boolean isAsyncPropagating() {
+    return isAsyncPropagating;
+  }
+
+  @Override
+  public final AgentSpan span() {
+    return span;
+  }
+
+  @Override
+  public final void setAsyncPropagation(final boolean value) {
+    isAsyncPropagating = value;
+  }
+
+  /**
+   * The continuation returned must be closed or activated or the trace will not finish.
+   *
+   * @return The new continuation, or null if this scope is not async propagating.
+   */
+  @Override
+  public final AbstractContinuation capture() {
+    return isAsyncPropagating
+        ? new SingleContinuation(scopeManager, span, source()).register()
+        : null;
+  }
+
+  /**
+   * The continuation returned must be closed or activated or the trace will not finish.
+   *
+   * @return The new continuation, or null if this scope is not async propagating.
+   */
+  @Override
+  public final AbstractContinuation captureConcurrent() {
+    return isAsyncPropagating
+        ? new ConcurrentContinuation(scopeManager, span, source()).register()
+        : null;
+  }
+
+  @Override
+  public final String toString() {
+    return super.toString() + "->" + span;
+  }
+
+  public final void afterActivated() {
+    for (final ScopeListener listener : scopeManager.scopeListeners) {
+      try {
+        listener.afterScopeActivated();
+      } catch (Throwable e) {
+        ContinuableScopeManager.log.debug("ScopeListener threw exception in afterActivated()", e);
+      }
+    }
+
+    for (final ExtendedScopeListener listener : scopeManager.extendedScopeListeners) {
+      try {
+        listener.afterScopeActivated(
+            span.getTraceId(), span.getLocalRootSpan().getSpanId(), span.context().getSpanId());
+      } catch (Throwable e) {
+        ContinuableScopeManager.log.debug("ExtendedScopeListener threw exception in afterActivated()", e);
+      }
+    }
+  }
+
+  @Override
+  public byte source() {
+    return (byte) (flags & 0x7F);
+  }
+
+  @Override
+  public void attachWrapper(@Nonnull Object wrapper) {
+    WRAPPER_FIELD_UPDATER.set(this, wrapper);
+  }
+
+  @Override
+  public Object getWrapper() {
+    return WRAPPER_FIELD_UPDATER.get(this);
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
@@ -47,14 +47,10 @@ class ContinuableScope implements AgentScope, AttachableWrapper {
             "Tried to close {} scope when not on top.  Current top: {}", this, scopeStack.top);
       }
 
-      scopeManager.statsDClient.incrementCounter("scope.close.error");
-
-      if (source() == ScopeSource.MANUAL.id()) {
-        scopeManager.statsDClient.incrementCounter("scope.user.close.error");
-
-        if (scopeManager.strictMode) {
-          throw new RuntimeException("Tried to close scope when not on top");
-        }
+      byte source = source();
+      scopeManager.healthMetrics.onScopeClose(source);
+      if (source == ScopeSource.MANUAL.id() && scopeManager.strictMode) {
+        throw new RuntimeException("Tried to close scope when not on top");
       }
     }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
@@ -48,7 +48,7 @@ class ContinuableScope implements AgentScope, AttachableWrapper {
       }
 
       byte source = source();
-      scopeManager.healthMetrics.onScopeClose(source);
+      scopeManager.healthMetrics.onScopeCloseError(source);
       if (source == ScopeSource.MANUAL.id() && scopeManager.strictMode) {
         throw new RuntimeException("Tried to close scope when not on top");
       }

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
@@ -6,18 +6,15 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AttachableWrapper;
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
-
-import javax.annotation.Nonnull;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import javax.annotation.Nonnull;
 
 class ContinuableScope implements AgentScope, AttachableWrapper {
   private final ContinuableScopeManager scopeManager;
 
   final AgentSpan span; // package-private so scopeManager can access it directly
 
-  /**
-   * Flag to propagate this scope across async boundaries.
-   */
+  /** Flag to propagate this scope across async boundaries. */
   private boolean isAsyncPropagating;
 
   private final byte flags;
@@ -25,8 +22,7 @@ class ContinuableScope implements AgentScope, AttachableWrapper {
   private short referenceCount = 1;
 
   private volatile Object wrapper;
-  private static final AtomicReferenceFieldUpdater<ContinuableScope, Object>
-      WRAPPER_FIELD_UPDATER =
+  private static final AtomicReferenceFieldUpdater<ContinuableScope, Object> WRAPPER_FIELD_UPDATER =
       AtomicReferenceFieldUpdater.newUpdater(ContinuableScope.class, Object.class, "wrapper");
 
   ContinuableScope(
@@ -101,9 +97,7 @@ class ContinuableScope implements AgentScope, AttachableWrapper {
     ++referenceCount;
   }
 
-  /**
-   * Decrements ref count -- returns true if the scope is still alive
-   */
+  /** Decrements ref count -- returns true if the scope is still alive */
   final boolean decrementReferences() {
     return --referenceCount > 0;
   }
@@ -112,9 +106,7 @@ class ContinuableScope implements AgentScope, AttachableWrapper {
     referenceCount = 0;
   }
 
-  /**
-   * Returns true if the scope is still alive (non-zero ref count)
-   */
+  /** Returns true if the scope is still alive (non-zero ref count) */
   final boolean alive() {
     return referenceCount > 0;
   }
@@ -177,7 +169,8 @@ class ContinuableScope implements AgentScope, AttachableWrapper {
         listener.afterScopeActivated(
             span.getTraceId(), span.getLocalRootSpan().getSpanId(), span.context().getSpanId());
       } catch (Throwable e) {
-        ContinuableScopeManager.log.debug("ExtendedScopeListener threw exception in afterActivated()", e);
+        ContinuableScopeManager.log.debug(
+            "ExtendedScopeListener threw exception in afterActivated()", e);
       }
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -27,7 +27,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
@@ -618,95 +617,6 @@ public final class ContinuableScopeManager implements AgentScopeManager {
     private void onBecomeEmpty() {
       profilingContextIntegration.setContext(0, 0);
       profilingContextIntegration.onDetach();
-    }
-  }
-
-  /**
-   * This class must not be a nested class of ContinuableScope to avoid an unconstrained chain of
-   * references (using too much memory).
-   *
-   * <p>This {@link AbstractContinuation} differs from the {@link SingleContinuation} in that if it is
-   * activated, it needs to be canceled in addition to the returned {@link AgentScope} being closed.
-   * This is to allow multiple concurrent threads that activate the continuation to race in a safe
-   * way, and close the scopes without fear of closing the related {@link AgentSpan} prematurely.
-   */
-  private static final class ConcurrentContinuation extends AbstractContinuation {
-    private static final int START = 1;
-    private static final int CLOSED = Integer.MIN_VALUE >> 1;
-    private static final int BARRIER = Integer.MIN_VALUE >> 2;
-    private volatile int count = START;
-
-    private static final AtomicIntegerFieldUpdater<ConcurrentContinuation> COUNT =
-        AtomicIntegerFieldUpdater.newUpdater(ConcurrentContinuation.class, "count");
-
-    public ConcurrentContinuation(
-        ContinuableScopeManager scopeManager, AgentSpan spanUnderScope, byte source) {
-      super(scopeManager, spanUnderScope, source);
-    }
-
-    private boolean tryActivate() {
-      int current = COUNT.incrementAndGet(this);
-      if (current < START) {
-        COUNT.decrementAndGet(this);
-      }
-      return current > START;
-    }
-
-    private boolean tryClose() {
-      int current = COUNT.get(this);
-      if (current < BARRIER) {
-        return false;
-      }
-      // Now decrement the counter
-      current = COUNT.decrementAndGet(this);
-      // Try to close this if we are between START and BARRIER
-      while (current < START && current > BARRIER) {
-        if (COUNT.compareAndSet(this, current, CLOSED)) {
-          return true;
-        }
-        current = COUNT.get(this);
-      }
-      return false;
-    }
-
-    @Override
-    public AgentScope activate() {
-      if (tryActivate()) {
-        return scopeManager.continueSpan(this, spanUnderScope, source);
-      } else {
-        return null;
-      }
-    }
-
-    @Override
-    public void cancel() {
-      if (tryClose()) {
-        trace.cancelContinuation(this);
-      }
-      log.debug("t_id={} -> canceling continuation {}", spanUnderScope.getTraceId(), this);
-    }
-
-    @Override
-    public AgentSpan getSpan() {
-      return spanUnderScope;
-    }
-
-    @Override
-    void cancelFromContinuedScopeClose() {
-      cancel();
-    }
-
-    @Override
-    public String toString() {
-      int c = COUNT.get(this);
-      String s = c < BARRIER ? "CANCELED" : String.valueOf(c);
-      return getClass().getSimpleName()
-          + "@"
-          + Integer.toHexString(hashCode())
-          + "("
-          + s
-          + ")->"
-          + spanUnderScope;
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -18,7 +18,7 @@ import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.bootstrap.instrumentation.api.ScopeState;
 import datadog.trace.core.monitor.HealthMetrics;
 import datadog.trace.util.AgentTaskScheduler;
-import java.util.ArrayDeque;
+
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -288,129 +288,6 @@ public final class ContinuableScopeManager implements AgentScopeManager {
     @Override
     protected ScopeStack initialValue() {
       return new ScopeStack(profilingContextIntegration);
-    }
-  }
-
-  /**
-   * The invariant is that the top of a non-empty stack is always active. Anytime a scope is closed,
-   * cleanup() is called to ensure the invariant
-   */
-  static final class ScopeStack {
-
-    private final ProfilingContextIntegration profilingContextIntegration;
-    private final ArrayDeque<ContinuableScope> stack = new ArrayDeque<>(); // previous scopes
-
-    ContinuableScope top; // current scope
-
-    // set by background task when a root iteration scope remains unclosed for too long
-    volatile ContinuableScope overdueRootScope;
-
-    ScopeStack(ProfilingContextIntegration profilingContextIntegration) {
-      this.profilingContextIntegration = profilingContextIntegration;
-    }
-
-    ContinuableScope active() {
-      // avoid attaching further spans to the root scope when it's been marked as overdue
-      return top != overdueRootScope ? top : null;
-    }
-
-    /** Removes and closes all scopes up to the nearest live scope */
-    void cleanup() {
-      ContinuableScope curScope = top;
-      boolean changedTop = false;
-      while (curScope != null && !curScope.alive()) {
-        // no longer alive -- trigger listener & null out
-        curScope.onProperClose();
-        changedTop = true;
-        curScope = stack.poll();
-      }
-      if (curScope != null && curScope == overdueRootScope) {
-        // we know this scope is the last on the stack and is overdue
-        curScope.onProperClose();
-        overdueRootScope = null;
-        top = null;
-      } else if (changedTop) {
-        top = curScope;
-        if (curScope != null) {
-          curScope.afterActivated();
-        }
-      }
-      if (top == null) {
-        onBecomeEmpty();
-      } else {
-        onTopChanged(top);
-      }
-    }
-
-    /** Marks a new scope as current, pushing the previous onto the stack */
-    void push(final ContinuableScope scope) {
-      onTopChanged(scope);
-      if (top != null) {
-        stack.push(top);
-      } else {
-        onBecomeNonEmpty();
-      }
-      top = scope;
-      scope.afterActivated();
-    }
-
-    /** Fast check to see if the expectedScope is on top */
-    boolean checkTop(final ContinuableScope expectedScope) {
-      return expectedScope.equals(top);
-    }
-
-    /**
-     * Slower check to see if overdue scopes ahead of the expected scope are all ITERATION scopes.
-     * These represent iterations that are now out-of-scope and can be finished ready for cleanup.
-     */
-    final boolean checkOverdueScopes(final ContinuableScope expectedScope) {
-      // we already know 'top' isn't the expected scope, so just need to check its source
-      if (top == null || top.source() != ScopeSource.ITERATION.id()) {
-        return false;
-      }
-      // avoid calling close() as we're already in that method, instead just clear any
-      // remaining references so the scope gets removed in the subsequent cleanup() call
-      top.clearReferences();
-      top.span.finishWithEndToEnd();
-      // now do the same for any previous iteration scopes ahead of the expected scope
-      for (ContinuableScope scope : stack) {
-        if (scope.source() != ScopeSource.ITERATION.id()) {
-          return expectedScope.equals(scope);
-        } else {
-          scope.clearReferences();
-          scope.span.finishWithEndToEnd();
-        }
-      }
-      return false; // we didn't find the expected scope
-    }
-
-    /** Returns the current depth, including the top scope */
-    int depth() {
-      return top != null ? 1 + stack.size() : 0;
-    }
-
-    // DQH - regrettably needed for pre-existing tests
-    void clear() {
-      stack.clear();
-      top = null;
-    }
-
-    private void onTopChanged(ContinuableScope top) {
-      long spanId = top.span.getSpanId();
-      AgentSpan rootSpan = top.span.getLocalRootSpan();
-      long rootSpanId = rootSpan == null ? spanId : rootSpan.getSpanId();
-      profilingContextIntegration.setContext(rootSpanId, spanId);
-    }
-
-    /** Notifies context thread listeners that this thread has a context now */
-    private void onBecomeNonEmpty() {
-      profilingContextIntegration.onAttach();
-    }
-
-    /** Notifies context thread listeners that this thread no longer has a context */
-    private void onBecomeEmpty() {
-      profilingContextIntegration.setContext(0, 0);
-      profilingContextIntegration.onDetach();
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -6,7 +6,6 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import datadog.trace.api.Config;
-import datadog.trace.api.StatsDClient;
 import datadog.trace.api.scopemanager.ExtendedScopeListener;
 import datadog.trace.api.scopemanager.ScopeListener;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -41,15 +40,14 @@ public final class ContinuableScopeManager implements AgentScopeManager {
   volatile ConcurrentMap<ScopeStack, ContinuableScope> rootIterationScopes;
   final List<ScopeListener> scopeListeners;
   final List<ExtendedScopeListener> extendedScopeListeners;
-  final StatsDClient statsDClient;
   final boolean strictMode;
   private final ScopeStackThreadLocal tlsScopeStack;
   private final int depthLimit;
   private final boolean inheritAsyncPropagation;
-  private final HealthMetrics healthMetrics;
+  final HealthMetrics healthMetrics;
 
   /**
-   * Constructor with NOOP StatsD, Profiling and HealthMetrics implementation.
+   * Constructor with NOOP Profiling and HealthMetrics implementations.
    *
    * @param depthLimit The maximum scope depth limit, <code>0</code> for unlimited.
    * @param strictMode Whether check if the closed spans are the active ones or not.
@@ -62,7 +60,6 @@ public final class ContinuableScopeManager implements AgentScopeManager {
         depthLimit,
         strictMode,
         inheritAsyncPropagation,
-        StatsDClient.NO_OP,
         ProfilingContextIntegration.NoOp.INSTANCE,
         HealthMetrics.NO_OP);
   }
@@ -79,11 +76,9 @@ public final class ContinuableScopeManager implements AgentScopeManager {
       final int depthLimit,
       final boolean strictMode,
       final boolean inheritAsyncPropagation,
-      final StatsDClient statsDClient,
       final ProfilingContextIntegration profilingContextIntegration,
       final HealthMetrics healthMetrics) {
     this.depthLimit = depthLimit == 0 ? Integer.MAX_VALUE : depthLimit;
-    this.statsDClient = statsDClient;
     this.strictMode = strictMode;
     this.inheritAsyncPropagation = inheritAsyncPropagation;
     this.scopeListeners = new CopyOnWriteArrayList<>();

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -104,8 +104,8 @@ public final class ContinuableScopeManager implements AgentScopeManager {
   }
 
   @Override
-  public AgentScope.Continuation captureSpan(final AgentSpan span, final ScopeSource source) {
-    AbstractContinuation continuation = new SingleContinuation(this, span, source.id());
+  public AgentScope.Continuation captureSpan(final AgentSpan span) {
+    AbstractContinuation continuation = new SingleContinuation(this, span, ScopeSource.INSTRUMENTATION.id());
     continuation.register();
     return continuation;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -13,7 +13,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentScopeManager;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.bootstrap.instrumentation.api.AttachableWrapper;
 import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration;
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.bootstrap.instrumentation.api.ScopeState;
@@ -27,8 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import javax.annotation.Nonnull;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,10 +49,10 @@ public final class ContinuableScopeManager implements AgentScopeManager {
   final List<ScopeListener> scopeListeners;
   final List<ExtendedScopeListener> extendedScopeListeners;
   final StatsDClient statsDClient;
+  final boolean strictMode;
   private final HealthMetrics healthMetrics;
 
   private final int depthLimit;
-  private final boolean strictMode;
   private final boolean inheritAsyncPropagation;
 
   public ContinuableScopeManager(
@@ -276,210 +274,6 @@ public final class ContinuableScopeManager implements AgentScopeManager {
     @Override
     public void fetchFromActive() {
       localScopeStack = tlsScopeStack.get();
-    }
-  }
-
-  private static class ContinuableScope implements AgentScope, AttachableWrapper {
-    private final ContinuableScopeManager scopeManager;
-
-    final AgentSpan span; // package-private so scopeManager can access it directly
-
-    /** Flag to propagate this scope across async boundaries. */
-    private boolean isAsyncPropagating;
-
-    private final byte flags;
-
-    private short referenceCount = 1;
-
-    private volatile Object wrapper;
-    private static final AtomicReferenceFieldUpdater<ContinuableScope, Object>
-        WRAPPER_FIELD_UPDATER =
-            AtomicReferenceFieldUpdater.newUpdater(ContinuableScope.class, Object.class, "wrapper");
-
-    ContinuableScope(
-        final ContinuableScopeManager scopeManager,
-        final AgentSpan span,
-        final byte source,
-        final boolean isAsyncPropagating) {
-      this.scopeManager = scopeManager;
-      this.span = span;
-      this.flags = source;
-      this.isAsyncPropagating = isAsyncPropagating;
-    }
-
-    @Override
-    public final void close() {
-      final ScopeStack scopeStack = scopeManager.scopeStack();
-
-      // fast check first, only perform slower check when there's an inconsistency with the stack
-      if (!scopeStack.checkTop(this) && !scopeStack.checkOverdueScopes(this)) {
-        if (log.isDebugEnabled()) {
-          log.debug(
-              "Tried to close {} scope when not on top.  Current top: {}", this, scopeStack.top);
-        }
-
-        scopeManager.statsDClient.incrementCounter("scope.close.error");
-
-        if (source() == ScopeSource.MANUAL.id()) {
-          scopeManager.statsDClient.incrementCounter("scope.user.close.error");
-
-          if (scopeManager.strictMode) {
-            throw new RuntimeException("Tried to close scope when not on top");
-          }
-        }
-      }
-
-      final boolean alive = decrementReferences();
-      if (!alive) {
-        cleanup(scopeStack);
-      }
-    }
-
-    void cleanup(final ScopeStack scopeStack) {
-      scopeStack.cleanup();
-    }
-
-    /*
-     * Exists to allow stack unwinding to do a delayed call to close when the close is
-     * finished properly.  e.g. When the scope is back on the top of the stack.
-     *
-     * DQH - If we clean-up the delegation code & notification semantics at later time,
-     * I would hope this becomes unnecessary.
-     */
-    final void onProperClose() {
-      for (final ScopeListener listener : scopeManager.scopeListeners) {
-        try {
-          listener.afterScopeClosed();
-        } catch (Exception e) {
-          log.debug("ScopeListener threw exception in close()", e);
-        }
-      }
-
-      for (final ExtendedScopeListener listener : scopeManager.extendedScopeListeners) {
-        try {
-          listener.afterScopeClosed();
-        } catch (Exception e) {
-          log.debug("ScopeListener threw exception in close()", e);
-        }
-      }
-    }
-
-    final void incrementReferences() {
-      ++referenceCount;
-    }
-
-    /** Decrements ref count -- returns true if the scope is still alive */
-    final boolean decrementReferences() {
-      return --referenceCount > 0;
-    }
-
-    final void clearReferences() {
-      referenceCount = 0;
-    }
-
-    /** Returns true if the scope is still alive (non-zero ref count) */
-    final boolean alive() {
-      return referenceCount > 0;
-    }
-
-    @Override
-    public final boolean isAsyncPropagating() {
-      return isAsyncPropagating;
-    }
-
-    @Override
-    public final AgentSpan span() {
-      return span;
-    }
-
-    @Override
-    public final void setAsyncPropagation(final boolean value) {
-      isAsyncPropagating = value;
-    }
-
-    /**
-     * The continuation returned must be closed or activated or the trace will not finish.
-     *
-     * @return The new continuation, or null if this scope is not async propagating.
-     */
-    @Override
-    public final AbstractContinuation capture() {
-      return isAsyncPropagating
-          ? new SingleContinuation(scopeManager, span, source()).register()
-          : null;
-    }
-
-    /**
-     * The continuation returned must be closed or activated or the trace will not finish.
-     *
-     * @return The new continuation, or null if this scope is not async propagating.
-     */
-    @Override
-    public final AbstractContinuation captureConcurrent() {
-      return isAsyncPropagating
-          ? new ConcurrentContinuation(scopeManager, span, source()).register()
-          : null;
-    }
-
-    @Override
-    public final String toString() {
-      return super.toString() + "->" + span;
-    }
-
-    public final void afterActivated() {
-      for (final ScopeListener listener : scopeManager.scopeListeners) {
-        try {
-          listener.afterScopeActivated();
-        } catch (Throwable e) {
-          log.debug("ScopeListener threw exception in afterActivated()", e);
-        }
-      }
-
-      for (final ExtendedScopeListener listener : scopeManager.extendedScopeListeners) {
-        try {
-          listener.afterScopeActivated(
-              span.getTraceId(), span.getLocalRootSpan().getSpanId(), span.context().getSpanId());
-        } catch (Throwable e) {
-          log.debug("ExtendedScopeListener threw exception in afterActivated()", e);
-        }
-      }
-    }
-
-    @Override
-    public byte source() {
-      return (byte) (flags & 0x7F);
-    }
-
-    @Override
-    public void attachWrapper(@Nonnull Object wrapper) {
-      WRAPPER_FIELD_UPDATER.set(this, wrapper);
-    }
-
-    @Override
-    public Object getWrapper() {
-      return WRAPPER_FIELD_UPDATER.get(this);
-    }
-  }
-
-  private static final class ContinuingScope extends ContinuableScope {
-    /** Continuation that created this scope. */
-    private final AbstractContinuation continuation;
-
-    ContinuingScope(
-        final ContinuableScopeManager scopeManager,
-        final AgentSpan span,
-        final byte source,
-        final boolean isAsyncPropagating,
-        final AbstractContinuation continuation) {
-      super(scopeManager, span, source, isAsyncPropagating);
-      this.continuation = continuation;
-    }
-
-    @Override
-    void cleanup(final ScopeStack scopeStack) {
-      super.cleanup(scopeStack);
-
-      continuation.cancelFromContinuedScopeClose();
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -105,7 +105,8 @@ public final class ContinuableScopeManager implements AgentScopeManager {
 
   @Override
   public AgentScope.Continuation captureSpan(final AgentSpan span) {
-    AbstractContinuation continuation = new SingleContinuation(this, span, ScopeSource.INSTRUMENTATION.id());
+    AbstractContinuation continuation =
+        new SingleContinuation(this, span, ScopeSource.INSTRUMENTATION.id());
     continuation.register();
     return continuation;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuingScope.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuingScope.java
@@ -1,0 +1,27 @@
+package datadog.trace.core.scopemanager;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+
+final class ContinuingScope extends ContinuableScope {
+  /**
+   * Continuation that created this scope.
+   */
+  private final AbstractContinuation continuation;
+
+  ContinuingScope(
+      final ContinuableScopeManager scopeManager,
+      final AgentSpan span,
+      final byte source,
+      final boolean isAsyncPropagating,
+      final AbstractContinuation continuation) {
+    super(scopeManager, span, source, isAsyncPropagating);
+    this.continuation = continuation;
+  }
+
+  @Override
+  void cleanup(final ContinuableScopeManager.ScopeStack scopeStack) {
+    super.cleanup(scopeStack);
+
+    continuation.cancelFromContinuedScopeClose();
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuingScope.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuingScope.java
@@ -19,7 +19,7 @@ final class ContinuingScope extends ContinuableScope {
   }
 
   @Override
-  void cleanup(final ContinuableScopeManager.ScopeStack scopeStack) {
+  void cleanup(final ScopeStack scopeStack) {
     super.cleanup(scopeStack);
 
     continuation.cancelFromContinuedScopeClose();

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuingScope.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuingScope.java
@@ -3,9 +3,7 @@ package datadog.trace.core.scopemanager;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 
 final class ContinuingScope extends ContinuableScope {
-  /**
-   * Continuation that created this scope.
-   */
+  /** Continuation that created this scope. */
   private final AbstractContinuation continuation;
 
   ContinuingScope(

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeStack.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeStack.java
@@ -3,7 +3,6 @@ package datadog.trace.core.scopemanager;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration;
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
-
 import java.util.ArrayDeque;
 
 /**
@@ -29,9 +28,7 @@ final class ScopeStack {
     return top != overdueRootScope ? top : null;
   }
 
-  /**
-   * Removes and closes all scopes up to the nearest live scope
-   */
+  /** Removes and closes all scopes up to the nearest live scope */
   void cleanup() {
     ContinuableScope curScope = top;
     boolean changedTop = false;
@@ -59,9 +56,7 @@ final class ScopeStack {
     }
   }
 
-  /**
-   * Marks a new scope as current, pushing the previous onto the stack
-   */
+  /** Marks a new scope as current, pushing the previous onto the stack */
   void push(final ContinuableScope scope) {
     onTopChanged(scope);
     if (top != null) {
@@ -73,9 +68,7 @@ final class ScopeStack {
     scope.afterActivated();
   }
 
-  /**
-   * Fast check to see if the expectedScope is on top
-   */
+  /** Fast check to see if the expectedScope is on top */
   boolean checkTop(final ContinuableScope expectedScope) {
     return expectedScope.equals(top);
   }
@@ -105,9 +98,7 @@ final class ScopeStack {
     return false; // we didn't find the expected scope
   }
 
-  /**
-   * Returns the current depth, including the top scope
-   */
+  /** Returns the current depth, including the top scope */
   int depth() {
     return top != null ? 1 + stack.size() : 0;
   }
@@ -125,16 +116,12 @@ final class ScopeStack {
     profilingContextIntegration.setContext(rootSpanId, spanId);
   }
 
-  /**
-   * Notifies context thread listeners that this thread has a context now
-   */
+  /** Notifies context thread listeners that this thread has a context now */
   private void onBecomeNonEmpty() {
     profilingContextIntegration.onAttach();
   }
 
-  /**
-   * Notifies context thread listeners that this thread no longer has a context
-   */
+  /** Notifies context thread listeners that this thread no longer has a context */
   private void onBecomeEmpty() {
     profilingContextIntegration.setContext(0, 0);
     profilingContextIntegration.onDetach();

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeStack.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeStack.java
@@ -1,0 +1,142 @@
+package datadog.trace.core.scopemanager;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration;
+import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
+
+import java.util.ArrayDeque;
+
+/**
+ * The invariant is that the top of a non-empty stack is always active. Anytime a scope is closed,
+ * cleanup() is called to ensure the invariant
+ */
+final class ScopeStack {
+
+  private final ProfilingContextIntegration profilingContextIntegration;
+  private final ArrayDeque<ContinuableScope> stack = new ArrayDeque<>(); // previous scopes
+
+  ContinuableScope top; // current scope
+
+  // set by background task when a root iteration scope remains unclosed for too long
+  volatile ContinuableScope overdueRootScope;
+
+  ScopeStack(ProfilingContextIntegration profilingContextIntegration) {
+    this.profilingContextIntegration = profilingContextIntegration;
+  }
+
+  ContinuableScope active() {
+    // avoid attaching further spans to the root scope when it's been marked as overdue
+    return top != overdueRootScope ? top : null;
+  }
+
+  /**
+   * Removes and closes all scopes up to the nearest live scope
+   */
+  void cleanup() {
+    ContinuableScope curScope = top;
+    boolean changedTop = false;
+    while (curScope != null && !curScope.alive()) {
+      // no longer alive -- trigger listener & null out
+      curScope.onProperClose();
+      changedTop = true;
+      curScope = stack.poll();
+    }
+    if (curScope != null && curScope == overdueRootScope) {
+      // we know this scope is the last on the stack and is overdue
+      curScope.onProperClose();
+      overdueRootScope = null;
+      top = null;
+    } else if (changedTop) {
+      top = curScope;
+      if (curScope != null) {
+        curScope.afterActivated();
+      }
+    }
+    if (top == null) {
+      onBecomeEmpty();
+    } else {
+      onTopChanged(top);
+    }
+  }
+
+  /**
+   * Marks a new scope as current, pushing the previous onto the stack
+   */
+  void push(final ContinuableScope scope) {
+    onTopChanged(scope);
+    if (top != null) {
+      stack.push(top);
+    } else {
+      onBecomeNonEmpty();
+    }
+    top = scope;
+    scope.afterActivated();
+  }
+
+  /**
+   * Fast check to see if the expectedScope is on top
+   */
+  boolean checkTop(final ContinuableScope expectedScope) {
+    return expectedScope.equals(top);
+  }
+
+  /**
+   * Slower check to see if overdue scopes ahead of the expected scope are all ITERATION scopes.
+   * These represent iterations that are now out-of-scope and can be finished ready for cleanup.
+   */
+  final boolean checkOverdueScopes(final ContinuableScope expectedScope) {
+    // we already know 'top' isn't the expected scope, so just need to check its source
+    if (top == null || top.source() != ScopeSource.ITERATION.id()) {
+      return false;
+    }
+    // avoid calling close() as we're already in that method, instead just clear any
+    // remaining references so the scope gets removed in the subsequent cleanup() call
+    top.clearReferences();
+    top.span.finishWithEndToEnd();
+    // now do the same for any previous iteration scopes ahead of the expected scope
+    for (ContinuableScope scope : stack) {
+      if (scope.source() != ScopeSource.ITERATION.id()) {
+        return expectedScope.equals(scope);
+      } else {
+        scope.clearReferences();
+        scope.span.finishWithEndToEnd();
+      }
+    }
+    return false; // we didn't find the expected scope
+  }
+
+  /**
+   * Returns the current depth, including the top scope
+   */
+  int depth() {
+    return top != null ? 1 + stack.size() : 0;
+  }
+
+  // DQH - regrettably needed for pre-existing tests
+  void clear() {
+    stack.clear();
+    top = null;
+  }
+
+  private void onTopChanged(ContinuableScope top) {
+    long spanId = top.span.getSpanId();
+    AgentSpan rootSpan = top.span.getLocalRootSpan();
+    long rootSpanId = rootSpan == null ? spanId : rootSpan.getSpanId();
+    profilingContextIntegration.setContext(rootSpanId, spanId);
+  }
+
+  /**
+   * Notifies context thread listeners that this thread has a context now
+   */
+  private void onBecomeNonEmpty() {
+    profilingContextIntegration.onAttach();
+  }
+
+  /**
+   * Notifies context thread listeners that this thread no longer has a context
+   */
+  private void onBecomeEmpty() {
+    profilingContextIntegration.setContext(0, 0);
+    profilingContextIntegration.onDetach();
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/SingleContinuation.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/SingleContinuation.java
@@ -1,0 +1,62 @@
+package datadog.trace.core.scopemanager;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
+/**
+ * This class must not be a nested class of ContinuableScope to avoid an unconstrained chain of
+ * references (using too much memory).
+ */
+final class SingleContinuation extends AbstractContinuation {
+  private static final AtomicIntegerFieldUpdater<SingleContinuation> USED =
+      AtomicIntegerFieldUpdater.newUpdater(SingleContinuation.class, "used");
+  private volatile int used = 0;
+
+  SingleContinuation(
+      final ContinuableScopeManager scopeManager,
+      final AgentSpan spanUnderScope,
+      final byte source) {
+    super(scopeManager, spanUnderScope, source);
+  }
+
+  @Override
+  public AgentScope activate() {
+    if (USED.compareAndSet(this, 0, 1)) {
+      return scopeManager.continueSpan(this, spanUnderScope, source);
+    } else {
+      ContinuableScopeManager.log.debug(
+          "Failed to activate continuation. Reusing a continuation not allowed. Spans may be reported separately.");
+      return scopeManager.continueSpan(null, spanUnderScope, source);
+    }
+  }
+
+  @Override
+  public void cancel() {
+    if (USED.compareAndSet(this, 0, 1)) {
+      trace.cancelContinuation(this);
+    } else {
+      ContinuableScopeManager.log.debug("Failed to close continuation {}. Already used.", this);
+    }
+  }
+
+  @Override
+  public AgentSpan getSpan() {
+    return spanUnderScope;
+  }
+
+  @Override
+  void cancelFromContinuedScopeClose() {
+    trace.cancelContinuation(this);
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName()
+        + "@"
+        + Integer.toHexString(hashCode())
+        + "->"
+        + spanUnderScope;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/SingleContinuation.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/SingleContinuation.java
@@ -2,7 +2,6 @@ package datadog.trace.core.scopemanager;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 /**

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
@@ -4,7 +4,6 @@ import datadog.communication.monitor.Monitoring
 import datadog.trace.SamplingPriorityMetadataChecker
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTraceId
-import datadog.trace.api.StatsDClient
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.api.time.SystemTimeSource
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopPathwayContext
@@ -30,7 +29,7 @@ class PendingTraceBufferTest extends DDSpecification {
   def bufferSpy = Spy(buffer)
 
   def tracer = Mock(CoreTracer)
-  def scopeManager = new ContinuableScopeManager(10, StatsDClient.NO_OP, true, true, HealthMetrics.NO_OP)
+  def scopeManager = new ContinuableScopeManager(10, true, true)
   def factory = new PendingTrace.Factory(tracer, bufferSpy, SystemTimeSource.INSTANCE, false, HealthMetrics.NO_OP)
   List<TraceScope.Continuation> continuations = []
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeAndContinuationLayoutTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeAndContinuationLayoutTest.groovy
@@ -10,15 +10,15 @@ import spock.lang.Requires
 class ScopeAndContinuationLayoutTest extends DDSpecification {
 
   def "continuable scope layout"() {
-    expect: layoutAcceptable(ContinuableScopeManager.ContinuableScope, 32)
+    expect: layoutAcceptable(ContinuableScope, 32)
   }
 
   def "single continuation layout"() {
-    expect: layoutAcceptable(ContinuableScopeManager.SingleContinuation, 32)
+    expect: layoutAcceptable(SingleContinuation, 32)
   }
 
   def "concurrent continuation layout"() {
-    expect: layoutAcceptable(ContinuableScopeManager.ConcurrentContinuation, 32)
+    expect: layoutAcceptable(ConcurrentContinuation, 32)
   }
 
   def layoutAcceptable(Class<?> klass, int acceptableSize) {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerDepthTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerDepthTest.groovy
@@ -20,7 +20,7 @@ class ScopeManagerDepthTest extends DDCoreSpecification {
     for (int i = 0; i < depth; i++) {
       def span = tracer.buildSpan("test").start()
       scope = tracer.activateSpan(span)
-      assert scope instanceof ContinuableScopeManager.ContinuableScope
+      assert scope instanceof ContinuableScope
     }
 
     then: "last scope is still valid"
@@ -61,7 +61,7 @@ class ScopeManagerDepthTest extends DDCoreSpecification {
     for (int i = 0; i < defaultLimit; i++) {
       def span = tracer.buildSpan("test").start()
       scope = tracer.activateSpan(span)
-      assert scope instanceof ContinuableScopeManager.ContinuableScope
+      assert scope instanceof ContinuableScope
     }
 
     then: "last scope is still valid"

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -161,7 +161,7 @@ class ScopeManagerTest extends DDCoreSpecification {
 
     then:
     scopeManager.active() == scope
-    scope instanceof ContinuableScopeManager.ContinuableScope
+    scope instanceof ContinuableScope
 
     when:
     scope.close()
@@ -189,7 +189,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     scope.span() == span
     !spanFinished(scope.span())
     scopeManager.active() == scope
-    scope instanceof ContinuableScopeManager.ContinuableScope
+    scope instanceof ContinuableScope
     writer.empty
 
     when:
@@ -396,7 +396,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     }
 
     then: "the continued scope becomes active and span state doesnt change"
-    newScope instanceof ContinuableScopeManager.ContinuableScope
+    newScope instanceof ContinuableScope
     newScope.isAsyncPropagating()
     scopeManager.active() == newScope
     newScope != childScope
@@ -446,7 +446,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     }
 
     then: "the continuation sets the active scope"
-    newScope instanceof ContinuableScopeManager.ContinuableScope
+    newScope instanceof ContinuableScope
     newScope != scope
     scopeManager.active() == newScope
     spanFinished(span)
@@ -510,7 +510,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     AgentScope continuableScope = tracer.activateSpan(span)
 
     then:
-    continuableScope instanceof ContinuableScopeManager.ContinuableScope
+    continuableScope instanceof ContinuableScope
     assertEvents([ACTIVATE])
 
     when:
@@ -518,7 +518,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     AgentScope childDDScope = tracer.activateSpan(childSpan)
 
     then:
-    childDDScope instanceof ContinuableScopeManager.ContinuableScope
+    childDDScope instanceof ContinuableScope
     assertEvents([ACTIVATE, ACTIVATE])
 
     when:
@@ -746,7 +746,7 @@ class ScopeManagerTest extends DDCoreSpecification {
       continuation.cancel()
     }
     AgentSpan secondSpan = tracer.buildSpan("test2").start()
-    AgentScope secondScope = (ContinuableScopeManager.ContinuableScope) tracer.activateSpan(secondSpan)
+    AgentScope secondScope = (ContinuableScope) tracer.activateSpan(secondSpan)
 
     then:
     scopeManager.active() == secondScope
@@ -882,7 +882,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test").start()
     def start = System.nanoTime()
-    def scope = (ContinuableScopeManager.ContinuableScope) tracer.activateSpan(span)
+    def scope = (ContinuableScope) tracer.activateSpan(span)
     scope.setAsyncPropagation(true)
     continuation = scope.captureConcurrent()
     scope.close()

--- a/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/CustomScopeManagerWrapper.java
@@ -111,9 +111,9 @@ class CustomScopeManagerWrapper implements AgentScopeManager {
   }
 
   @Override
-  public AgentScope.Continuation captureSpan(final AgentSpan span, ScopeSource source) {
+  public AgentScope.Continuation captureSpan(final AgentSpan span) {
     // I can't see a better way to do this, and I don't know if this even makes sense.
-    try (AgentScope scope = this.activate(span, source)) {
+    try (AgentScope scope = this.activate(span, ScopeSource.INSTRUMENTATION)) {
       return scope.capture();
     }
   }

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/TypeConverterTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/TypeConverterTest.groovy
@@ -2,7 +2,6 @@ package datadog.opentracing
 
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTraceId
-import datadog.trace.api.StatsDClient
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource
@@ -10,7 +9,6 @@ import datadog.trace.core.CoreTracer
 import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext
 import datadog.trace.core.PendingTrace
-import datadog.trace.core.monitor.HealthMetrics
 import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.core.scopemanager.ContinuableScopeManager
 import datadog.trace.test.util.DDSpecification
@@ -54,7 +52,7 @@ class TypeConverterTest extends DDSpecification {
   }
 
   def "should avoid extra allocation for a scope wrapper"() {
-    def scopeManager = new ContinuableScopeManager(0, StatsDClient.NO_OP, false, true, HealthMetrics.NO_OP)
+    def scopeManager = new ContinuableScopeManager(0, false, true)
     def context = createTestSpanContext()
     def span1 = new DDSpan(0, context)
     def span2 = new DDSpan(0, context)

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScopeManager.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScopeManager.java
@@ -13,7 +13,7 @@ public interface AgentScopeManager extends ScopeStateAware {
 
   AgentSpan activeSpan();
 
-  AgentScope.Continuation captureSpan(AgentSpan span, ScopeSource source);
+  AgentScope.Continuation captureSpan(AgentSpan span);
 
   void closePrevious(boolean finishSpan);
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -53,7 +53,7 @@ public class AgentTracer {
   }
 
   public static AgentScope.Continuation captureSpan(final AgentSpan span) {
-    return get().captureSpan(span, ScopeSource.INSTRUMENTATION);
+    return get().captureSpan(span);
   }
 
   /**
@@ -132,7 +132,7 @@ public class AgentTracer {
 
     AgentScope activateSpan(AgentSpan span, ScopeSource source, boolean isAsyncPropagating);
 
-    AgentScope.Continuation captureSpan(AgentSpan span, ScopeSource source);
+    AgentScope.Continuation captureSpan(AgentSpan span);
 
     void closePrevious(boolean finishSpan);
 
@@ -244,7 +244,7 @@ public class AgentTracer {
     }
 
     @Override
-    public AgentScope.Continuation captureSpan(final AgentSpan span, final ScopeSource source) {
+    public AgentScope.Continuation captureSpan(final AgentSpan span) {
       return NoopContinuation.INSTANCE;
     }
 


### PR DESCRIPTION
# What Does This Do

This class splits the `ContinuableScopeManager` to introduce the future changes related to scoped context storage.
It does not change any logic from the original single file.

# Motivation

There will be different scope related changes. Splitting the `ContinuableScopeManager` will make things clearer, and git changes easier to merge.

# Additional Notes

All the commits will be squashed at merge. 