### PR TITLE
Do not fail if git info is missing

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
@@ -46,12 +46,17 @@ public class CiVisibilitySystem {
 
     InstrumentationBridge.setMethodLinesResolver(new MethodLinesResolverImpl());
 
-    CodeownersProvider codeownersProvider = new CodeownersProvider();
-    InstrumentationBridge.setCodeowners(codeownersProvider.build(repoRoot));
+    if (repoRoot != null) {
+      CodeownersProvider codeownersProvider = new CodeownersProvider();
+      InstrumentationBridge.setCodeowners(codeownersProvider.build(repoRoot));
 
-    InstrumentationBridge.setSourcePathResolver(
-        new BestEfforSourcePathResolver(
-            new CompilerAidedSourcePathResolver(repoRoot),
-            new RepoIndexSourcePathResolver(repoRoot)));
+      InstrumentationBridge.setSourcePathResolver(
+          new BestEfforSourcePathResolver(
+              new CompilerAidedSourcePathResolver(repoRoot),
+              new RepoIndexSourcePathResolver(repoRoot)));
+    } else {
+      InstrumentationBridge.setCodeowners(path -> null);
+      InstrumentationBridge.setSourcePathResolver(clazz -> null);
+    }
   }
 }


### PR DESCRIPTION
# What Does This Do
This PR changes CI visibility subsystem initialisation so that it does not fail in case the tracer cannot detect customer's Git information.

# Motivation
Some customers use non-standard set ups and run CI visibility in environments where Git info is not available.
While many CI visibility features rely on Git info being there, the core functionality does not require it.
So in case it is missing, we should still do as much as we can, and not fail.
