### PR TITLE
Improve scope.close.error metric with source tag

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/src/test/groovy/OpenTelemetryTest.groovy
@@ -212,8 +212,7 @@ class OpenTelemetryTest extends AgentTestRunner {
 
     then:
     tracer.currentSpan.delegate == secondScope.delegate.span()
-    1 * STATS_D_CLIENT.incrementCounter("scope.close.error")
-    1 * STATS_D_CLIENT.incrementCounter("scope.user.close.error")
+    1 * STATS_D_CLIENT.incrementCounter("scope.close.error", ['source:manual'])
     _ * TEST_CHECKPOINTER._
     0 * _
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -254,8 +254,7 @@ class OpenTracing31Test extends AgentTestRunner {
 
     then:
     tracer.scopeManager().active().delegate == secondScope.delegate
-    1 * STATS_D_CLIENT.incrementCounter("scope.close.error")
-    1 * STATS_D_CLIENT.incrementCounter("scope.user.close.error")
+    1 * STATS_D_CLIENT.incrementCounter("scope.close.error", ['source:manual'])
     _ * TEST_CHECKPOINTER._
     0 * _
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -269,8 +269,7 @@ class OpenTracing32Test extends AgentTestRunner {
 
     then:
     tracer.scopeManager().active().delegate == secondScope.delegate
-    1 * STATS_D_CLIENT.incrementCounter("scope.close.error")
-    1 * STATS_D_CLIENT.incrementCounter("scope.user.close.error")
+    1 * STATS_D_CLIENT.incrementCounter("scope.close.error", ['source:manual'])
     _ * TEST_CHECKPOINTER._
     0 * _
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -549,7 +549,7 @@ class ScopeManagerTest extends DDCoreSpecification {
 
     then:
     assertEvents([ACTIVATE, ACTIVATE])
-    1 * statsDClient.incrementCounter("scope.close.error")
+    1 * statsDClient.incrementCounter("scope.close.error", _)
     1 * rootSpanCheckpointer.onRootSpanStarted(_)
     3 * listener.setContext(_, _)
     1 * listener.onAttach()
@@ -572,7 +572,7 @@ class ScopeManagerTest extends DDCoreSpecification {
 
     then:
     assertEvents([ACTIVATE, ACTIVATE, CLOSE, CLOSE])
-    1 * statsDClient.incrementCounter("scope.close.error")
+    1 * statsDClient.incrementCounter("scope.close.error", _)
   }
 
   def "closing scope out of order - complex"() {
@@ -626,7 +626,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     tracer.activeSpan() == thirdSpan
     tracer.activeScope() == thirdScope
     assertEvents([ACTIVATE, ACTIVATE, ACTIVATE])
-    1 * statsDClient.incrementCounter("scope.close.error")
+    1 * statsDClient.incrementCounter("scope.close.error", _)
     1 * listener.setContext(_, _)
     0 * _
 
@@ -706,7 +706,7 @@ class ScopeManagerTest extends DDCoreSpecification {
 
     then: 'Closing a scope once that has been activated multiple times does not close'
     assertEvents([ACTIVATE, ACTIVATE])
-    1 * statsDClient.incrementCounter("scope.close.error")
+    1 * statsDClient.incrementCounter("scope.close.error", _)
     0 * _
 
     when:

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
@@ -366,8 +366,7 @@ class OpenTracingAPITest extends DDSpecification {
 
     then:
     2 * scopeListener.afterScopeActivated()
-    1 * statsDClient.incrementCounter("scope.close.error")
-    1 * statsDClient.incrementCounter("scope.user.close.error")
+    1 * statsDClient.incrementCounter("scope.close.error", ['source:manual'])
     0 * _
 
     when:
@@ -384,8 +383,7 @@ class OpenTracingAPITest extends DDSpecification {
     firstScope.close()
 
     then:
-    1 * statsDClient.incrementCounter("scope.close.error")
-    1 * statsDClient.incrementCounter("scope.user.close.error")
+    1 * statsDClient.incrementCounter("scope.close.error", ['source:manual'])
     0 * _
   }
 
@@ -413,8 +411,7 @@ class OpenTracingAPITest extends DDSpecification {
 
     then:
     thrown(RuntimeException)
-    1 * statsDClient.incrementCounter("scope.close.error")
-    1 * statsDClient.incrementCounter("scope.user.close.error")
+    1 * statsDClient.incrementCounter("scope.close.error", ['source:manual'])
     0 * _
 
     when:


### PR DESCRIPTION
# What Does This Do

This improves health metrics by using tags to keep source of the scope.

# Motivation

Only use one metric instead of two and keep all sources.

# Additional Notes

See original discussion: https://github.com/DataDog/dd-trace-java/pull/4710#discussion_r1102728668
