### PR TITLE
Introduced Visitor in Expression Language

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/Expression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/Expression.java
@@ -7,11 +7,7 @@ import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 public interface Expression<ReturnType> {
   ReturnType evaluate(ValueReferenceResolver valueRefResolver);
 
-  default String prettyPrint() {
-    return this.toString();
-  }
-
-  static String nullSafePrettyPrint(Expression expr) {
-    return expr != null ? expr.prettyPrint() : "null";
+  default <R> R accept(Visitor<R> visitor) {
+    return null;
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/PrettyPrintVisitor.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/PrettyPrintVisitor.java
@@ -1,0 +1,277 @@
+package com.datadog.debugger.el;
+
+import com.datadog.debugger.el.expressions.BinaryExpression;
+import com.datadog.debugger.el.expressions.BinaryOperator;
+import com.datadog.debugger.el.expressions.BooleanExpression;
+import com.datadog.debugger.el.expressions.ComparisonExpression;
+import com.datadog.debugger.el.expressions.ComparisonOperator;
+import com.datadog.debugger.el.expressions.ContainsExpression;
+import com.datadog.debugger.el.expressions.EndsWithExpression;
+import com.datadog.debugger.el.expressions.FilterCollectionExpression;
+import com.datadog.debugger.el.expressions.GetMemberExpression;
+import com.datadog.debugger.el.expressions.HasAllExpression;
+import com.datadog.debugger.el.expressions.HasAnyExpression;
+import com.datadog.debugger.el.expressions.IfElseExpression;
+import com.datadog.debugger.el.expressions.IfExpression;
+import com.datadog.debugger.el.expressions.IndexExpression;
+import com.datadog.debugger.el.expressions.IsEmptyExpression;
+import com.datadog.debugger.el.expressions.IsUndefinedExpression;
+import com.datadog.debugger.el.expressions.LenExpression;
+import com.datadog.debugger.el.expressions.MatchesExpression;
+import com.datadog.debugger.el.expressions.NotExpression;
+import com.datadog.debugger.el.expressions.StartsWithExpression;
+import com.datadog.debugger.el.expressions.StringPredicateExpression;
+import com.datadog.debugger.el.expressions.SubStringExpression;
+import com.datadog.debugger.el.expressions.ValueRefExpression;
+import com.datadog.debugger.el.expressions.WhenExpression;
+import com.datadog.debugger.el.values.BooleanValue;
+import com.datadog.debugger.el.values.ListValue;
+import com.datadog.debugger.el.values.MapValue;
+import com.datadog.debugger.el.values.NumericValue;
+import com.datadog.debugger.el.values.ObjectValue;
+import com.datadog.debugger.el.values.StringValue;
+import datadog.trace.bootstrap.debugger.el.Values;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PrettyPrintVisitor implements Visitor<String> {
+
+  public static String print(Expression<?> expr) {
+    return expr.accept(new PrettyPrintVisitor());
+  }
+
+  @Override
+  public String visit(BinaryExpression binaryExpression) {
+    return nullSafeAccept(binaryExpression.getLeft())
+        + " "
+        + binaryExpression.getOperator().accept(this)
+        + " "
+        + nullSafeAccept(binaryExpression.getRight());
+  }
+
+  @Override
+  public String visit(BinaryOperator operator) {
+    return operator.getSymbol();
+  }
+
+  @Override
+  public String visit(ComparisonExpression comparisonExpression) {
+    return nullSafeAccept(comparisonExpression.getLeft())
+        + " "
+        + comparisonExpression.getOperator().accept(this)
+        + " "
+        + nullSafeAccept(comparisonExpression.getRight());
+  }
+
+  @Override
+  public String visit(ComparisonOperator operator) {
+    return operator.getSymbol();
+  }
+
+  @Override
+  public String visit(ContainsExpression containsExpression) {
+    return stringPredicateExpression(containsExpression);
+  }
+
+  @Override
+  public String visit(EndsWithExpression endsWithExpression) {
+    return stringPredicateExpression(endsWithExpression);
+  }
+
+  @Override
+  public String visit(FilterCollectionExpression filterCollectionExpression) {
+    return "filter("
+        + nullSafeAccept(filterCollectionExpression.getSource())
+        + ", "
+        + nullSafeAccept(filterCollectionExpression.getFilterExpression())
+        + ")";
+  }
+
+  @Override
+  public String visit(HasAllExpression hasAllExpression) {
+    return "hasAll("
+        + nullSafeAccept(hasAllExpression.getValueExpression())
+        + ", "
+        + nullSafeAccept(hasAllExpression.getFilterPredicateExpression())
+        + ")";
+  }
+
+  @Override
+  public String visit(HasAnyExpression hasAnyExpression) {
+    return "hasAny("
+        + nullSafeAccept(hasAnyExpression.getValueExpression())
+        + ", "
+        + nullSafeAccept(hasAnyExpression.getFilterPredicateExpression())
+        + ")";
+  }
+
+  @Override
+  public String visit(IfElseExpression ifElseExpression) {
+    return "if "
+        + nullSafeAccept(ifElseExpression.getTest())
+        + " then "
+        + nullSafeAccept(ifElseExpression.getThenExpression())
+        + " else "
+        + nullSafeAccept(ifElseExpression.getElseExpression());
+  }
+
+  @Override
+  public String visit(IfExpression ifExpression) {
+    return "if "
+        + nullSafeAccept(ifExpression.getTest())
+        + " then "
+        + nullSafeAccept(ifExpression.getExpression());
+  }
+
+  @Override
+  public String visit(IsEmptyExpression isEmptyExpression) {
+    return "isEmpty(" + nullSafeAccept(isEmptyExpression.getValueExpression()) + ")";
+  }
+
+  @Override
+  public String visit(IsUndefinedExpression isUndefinedExpression) {
+    return "isUndefined(" + nullSafeAccept(isUndefinedExpression.getValueExpression()) + ")";
+  }
+
+  @Override
+  public String visit(LenExpression lenExpression) {
+    return "len(" + nullSafeAccept(lenExpression.getSource()) + ")";
+  }
+
+  @Override
+  public String visit(MatchesExpression matchesExpression) {
+    return stringPredicateExpression(matchesExpression);
+  }
+
+  @Override
+  public String visit(NotExpression notExpression) {
+    return "not(" + nullSafeAccept(notExpression.getPredicate()) + ")";
+  }
+
+  @Override
+  public String visit(StartsWithExpression startsWithExpression) {
+    return stringPredicateExpression(startsWithExpression);
+  }
+
+  @Override
+  public String visit(SubStringExpression subStringExpression) {
+    return "substring("
+        + nullSafeAccept(subStringExpression.getSource())
+        + ", "
+        + subStringExpression.getStartIndex()
+        + ", "
+        + subStringExpression.getEndIndex()
+        + ")";
+  }
+
+  @Override
+  public String visit(ValueRefExpression valueRefExpression) {
+    return valueRefExpression.getSymbolName();
+  }
+
+  @Override
+  public String visit(GetMemberExpression getMemberExpression) {
+    return nullSafeAccept(getMemberExpression.getTarget())
+        + "."
+        + getMemberExpression.getMemberName();
+  }
+
+  @Override
+  public String visit(IndexExpression indexExpression) {
+    return nullSafeAccept(indexExpression.getTarget())
+        + "["
+        + nullSafeAccept(indexExpression.getKey())
+        + "]";
+  }
+
+  @Override
+  public String visit(WhenExpression whenExpression) {
+    return "when(" + nullSafeAccept(whenExpression.getExpression()) + ")";
+  }
+
+  @Override
+  public String visit(BooleanExpression booleanExpression) {
+    return booleanExpression.toString();
+  }
+
+  @Override
+  public String visit(StringValue stringValue) {
+    return "\"" + stringValue.value + "\"";
+  }
+
+  @Override
+  public String visit(ObjectValue objectValue) {
+    Object value = objectValue.value;
+    if (value == null || value == Values.NULL_OBJECT) {
+      return "null";
+    }
+    if (value == Values.UNDEFINED_OBJECT) {
+      return value.toString();
+    }
+    if (value == Values.THIS_OBJECT) {
+      return "this";
+    }
+    return value.getClass().getTypeName();
+  }
+
+  @Override
+  public String visit(NumericValue numericValue) {
+    Number value = numericValue.value;
+    if (value instanceof Double) {
+      return String.valueOf(value.doubleValue());
+    }
+    if (value instanceof Long) {
+      return String.valueOf(value.longValue());
+    }
+    if (value instanceof BigDecimal || value instanceof BigInteger) {
+      return value.toString();
+    }
+    return "null";
+  }
+
+  @Override
+  public String visit(BooleanValue booleanValue) {
+    if (booleanValue.value == null) {
+      return "null";
+    }
+    return String.valueOf(booleanValue.value.booleanValue());
+  }
+
+  @Override
+  public String visit(ListValue listValue) {
+    if (listValue.getArrayHolder() != null) {
+      return listValue.getArrayType().getTypeName() + "[]";
+    }
+    if (listValue.getListHolder() instanceof List) {
+      return "List";
+    }
+    if (listValue.getListHolder() instanceof Set) {
+      return "Set";
+    }
+    return "null";
+  }
+
+  @Override
+  public String visit(MapValue mapValue) {
+    if (mapValue.getMapHolder() instanceof Map) {
+      return "Map";
+    }
+    return "null";
+  }
+
+  private String stringPredicateExpression(StringPredicateExpression stringPredicateExpression) {
+    return stringPredicateExpression.getName()
+        + "("
+        + nullSafeAccept(stringPredicateExpression.getSourceString())
+        + ", "
+        + nullSafeAccept(stringPredicateExpression.getStr())
+        + ")";
+  }
+
+  private String nullSafeAccept(Expression<?> expr) {
+    return expr != null ? expr.accept(this) : "null";
+  }
+}

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/ProbeCondition.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/ProbeCondition.java
@@ -105,4 +105,8 @@ public final class ProbeCondition implements DebuggerScript<Boolean> {
     }
     return false;
   }
+
+  public void accept(Visitor visitor) {
+    when.accept(visitor);
+  }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/Visitor.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/Visitor.java
@@ -1,0 +1,69 @@
+package com.datadog.debugger.el;
+
+import com.datadog.debugger.el.expressions.*;
+import com.datadog.debugger.el.values.BooleanValue;
+import com.datadog.debugger.el.values.ListValue;
+import com.datadog.debugger.el.values.MapValue;
+import com.datadog.debugger.el.values.NumericValue;
+import com.datadog.debugger.el.values.ObjectValue;
+import com.datadog.debugger.el.values.StringValue;
+
+public interface Visitor<R> {
+  R visit(BinaryExpression binaryExpression);
+
+  R visit(BinaryOperator operator);
+
+  R visit(ComparisonExpression comparisonExpression);
+
+  R visit(ComparisonOperator operator);
+
+  R visit(ContainsExpression containsExpression);
+
+  R visit(EndsWithExpression endsWithExpression);
+
+  R visit(FilterCollectionExpression filterCollectionExpression);
+
+  R visit(HasAllExpression hasAllExpression);
+
+  R visit(HasAnyExpression hasAnyExpression);
+
+  R visit(IfElseExpression ifElseExpression);
+
+  R visit(IfExpression ifExpression);
+
+  R visit(IsEmptyExpression isEmptyExpression);
+
+  R visit(IsUndefinedExpression isUndefinedExpression);
+
+  R visit(LenExpression lenExpression);
+
+  R visit(MatchesExpression matchesExpression);
+
+  R visit(NotExpression notExpression);
+
+  R visit(StartsWithExpression startsWithExpression);
+
+  R visit(SubStringExpression subStringExpression);
+
+  R visit(ValueRefExpression valueRefExpression);
+
+  R visit(GetMemberExpression getMemberExpression);
+
+  R visit(IndexExpression indexExpression);
+
+  R visit(WhenExpression whenExpression);
+
+  R visit(BooleanExpression booleanExpression);
+
+  R visit(ObjectValue objectValue);
+
+  R visit(StringValue stringValue);
+
+  R visit(NumericValue numericValue);
+
+  R visit(BooleanValue booleanValue);
+
+  R visit(ListValue listValue);
+
+  R visit(MapValue mapValue);
+}

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/BinaryExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/BinaryExpression.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.expressions;
 
+import com.datadog.debugger.el.Visitor;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 
 /**
@@ -36,7 +37,19 @@ public final class BinaryExpression implements BooleanExpression {
   }
 
   @Override
-  public String prettyPrint() {
-    return left.prettyPrint() + " " + operator.prettyPrint() + " " + right.prettyPrint();
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
+  }
+
+  public BooleanExpression getLeft() {
+    return left;
+  }
+
+  public BooleanExpression getRight() {
+    return right;
+  }
+
+  public BinaryOperator getOperator() {
+    return operator;
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/BinaryOperator.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/BinaryOperator.java
@@ -1,5 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
+import com.datadog.debugger.el.Visitor;
+
 public enum BinaryOperator {
   AND("&&") {
     @Override
@@ -22,7 +24,11 @@ public enum BinaryOperator {
 
   public abstract Boolean apply(Boolean left, Boolean right);
 
-  public String prettyPrint() {
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
+  }
+
+  public String getSymbol() {
     return symbol;
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/BooleanExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/BooleanExpression.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
 import com.datadog.debugger.el.Expression;
+import com.datadog.debugger.el.Visitor;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 
 /** A generic interface for expressions resolving to {@linkplain Boolean} */
@@ -16,6 +17,11 @@ public interface BooleanExpression extends Expression<Boolean> {
         public String toString() {
           return "true";
         }
+
+        @Override
+        public <R> R accept(Visitor<R> visitor) {
+          return visitor.visit(this);
+        }
       };
   BooleanExpression FALSE =
       new BooleanExpression() {
@@ -27,6 +33,11 @@ public interface BooleanExpression extends Expression<Boolean> {
         @Override
         public String toString() {
           return "false";
+        }
+
+        @Override
+        public <R> R accept(Visitor<R> visitor) {
+          return visitor.visit(this);
         }
       };
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ComparisonExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ComparisonExpression.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.Visitor;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 
 /**
@@ -33,7 +34,19 @@ public class ComparisonExpression implements BooleanExpression {
   }
 
   @Override
-  public String prettyPrint() {
-    return left.prettyPrint() + " " + operator.prettyPrint() + " " + right.prettyPrint();
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
+  }
+
+  public ValueExpression<?> getLeft() {
+    return left;
+  }
+
+  public ValueExpression<?> getRight() {
+    return right;
+  }
+
+  public ComparisonOperator getOperator() {
+    return operator;
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ComparisonOperator.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ComparisonOperator.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.values.NumericValue;
 import com.datadog.debugger.el.values.StringValue;
 import java.math.BigDecimal;
@@ -74,8 +75,12 @@ public enum ComparisonOperator {
 
   public abstract Boolean apply(Value<?> left, Value<?> right);
 
-  public String prettyPrint() {
+  public String getSymbol() {
     return symbol;
+  }
+
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
   }
 
   protected static boolean isNan(Number... numbers) {

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ContainsExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ContainsExpression.java
@@ -1,9 +1,15 @@
 package com.datadog.debugger.el.expressions;
 
+import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.values.StringValue;
 
 public class ContainsExpression extends StringPredicateExpression {
   public ContainsExpression(ValueExpression<?> sourceString, StringValue str) {
     super(sourceString, str, String::contains, "contains");
+  }
+
+  @Override
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/EndsWithExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/EndsWithExpression.java
@@ -1,9 +1,15 @@
 package com.datadog.debugger.el.expressions;
 
+import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.values.StringValue;
 
 public class EndsWithExpression extends StringPredicateExpression {
   public EndsWithExpression(ValueExpression<?> sourceString, StringValue str) {
     super(sourceString, str, String::endsWith, "endsWith");
+  }
+
+  @Override
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/FilterCollectionExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/FilterCollectionExpression.java
@@ -1,8 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
-import static com.datadog.debugger.el.Expression.nullSafePrettyPrint;
-
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.values.CollectionValue;
 import com.datadog.debugger.el.values.ListValue;
 import com.datadog.debugger.el.values.MapValue;
@@ -76,11 +75,15 @@ public final class FilterCollectionExpression implements ValueExpression<Collect
   }
 
   @Override
-  public String prettyPrint() {
-    return "filter("
-        + nullSafePrettyPrint(source)
-        + ", "
-        + nullSafePrettyPrint(filterExpression)
-        + ")";
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
+  }
+
+  public ValueExpression<?> getSource() {
+    return source;
+  }
+
+  public BooleanExpression getFilterExpression() {
+    return filterExpression;
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/GetMemberExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/GetMemberExpression.java
@@ -1,13 +1,12 @@
 package com.datadog.debugger.el.expressions;
 
-import static com.datadog.debugger.el.Expression.nullSafePrettyPrint;
-
 import com.datadog.debugger.el.Generated;
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.Visitor;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import java.util.Objects;
 
-public class GetMemberExpression implements ValueExpression {
+public class GetMemberExpression implements ValueExpression<Value<?>> {
   private final ValueExpression<?> target;
   private final String memberName;
 
@@ -55,7 +54,7 @@ public class GetMemberExpression implements ValueExpression {
   }
 
   @Override
-  public String prettyPrint() {
-    return nullSafePrettyPrint(target) + "." + memberName;
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/HasAllExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/HasAllExpression.java
@@ -1,8 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
-import static com.datadog.debugger.el.Expression.nullSafePrettyPrint;
-
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.values.ListValue;
 import com.datadog.debugger.el.values.MapValue;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
@@ -71,11 +70,7 @@ public final class HasAllExpression extends MatchingExpression {
   }
 
   @Override
-  public String prettyPrint() {
-    return "hasAll("
-        + nullSafePrettyPrint(valueExpression)
-        + ", "
-        + nullSafePrettyPrint(filterPredicateExpression)
-        + ")";
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/HasAnyExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/HasAnyExpression.java
@@ -1,8 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
-import static com.datadog.debugger.el.Expression.nullSafePrettyPrint;
-
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.values.ListValue;
 import com.datadog.debugger.el.values.MapValue;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
@@ -75,11 +74,7 @@ public final class HasAnyExpression extends MatchingExpression {
   }
 
   @Override
-  public String prettyPrint() {
-    return "hasAny("
-        + nullSafePrettyPrint(valueExpression)
-        + ", "
-        + nullSafePrettyPrint(filterPredicateExpression)
-        + ")";
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IfElseExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IfElseExpression.java
@@ -1,8 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
-import static com.datadog.debugger.el.Expression.nullSafePrettyPrint;
-
 import com.datadog.debugger.el.Expression;
+import com.datadog.debugger.el.Visitor;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 
 /** TODO: Primordial support for 'debugger watches' support */
@@ -29,12 +28,19 @@ public final class IfElseExpression implements Expression<Void> {
   }
 
   @Override
-  public String prettyPrint() {
-    return "if "
-        + nullSafePrettyPrint(test)
-        + " then "
-        + nullSafePrettyPrint(thenExpression)
-        + " else "
-        + nullSafePrettyPrint(elseExpression);
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
+  }
+
+  public BooleanExpression getTest() {
+    return test;
+  }
+
+  public Expression<?> getThenExpression() {
+    return thenExpression;
+  }
+
+  public Expression<?> getElseExpression() {
+    return elseExpression;
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IfExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IfExpression.java
@@ -1,8 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
-import static com.datadog.debugger.el.Expression.nullSafePrettyPrint;
-
 import com.datadog.debugger.el.Expression;
+import com.datadog.debugger.el.Visitor;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 
 /** TODO: Primordial support for 'debugger watches' support */
@@ -24,7 +23,15 @@ public final class IfExpression implements Expression<Void> {
   }
 
   @Override
-  public String prettyPrint() {
-    return "if " + nullSafePrettyPrint(test) + " then " + nullSafePrettyPrint(expression);
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
+  }
+
+  public BooleanExpression getTest() {
+    return test;
+  }
+
+  public Expression<?> getExpression() {
+    return expression;
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IsEmptyExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IsEmptyExpression.java
@@ -1,8 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
-import static com.datadog.debugger.el.Expression.nullSafePrettyPrint;
-
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.values.CollectionValue;
 import com.datadog.debugger.el.values.StringValue;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
@@ -33,7 +32,11 @@ public final class IsEmptyExpression implements BooleanExpression {
   }
 
   @Override
-  public String prettyPrint() {
-    return "isEmpty(" + nullSafePrettyPrint(valueExpression) + ")";
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
+  }
+
+  public ValueExpression<?> getValueExpression() {
+    return valueExpression;
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IsUndefinedExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IsUndefinedExpression.java
@@ -1,8 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
-import static com.datadog.debugger.el.Expression.nullSafePrettyPrint;
-
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.Visitor;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 
 /**
@@ -27,7 +26,11 @@ public final class IsUndefinedExpression implements BooleanExpression {
   }
 
   @Override
-  public String prettyPrint() {
-    return "isUndefined(" + nullSafePrettyPrint(valueExpression) + ")";
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
+  }
+
+  public ValueExpression<?> getValueExpression() {
+    return valueExpression;
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/LenExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/LenExpression.java
@@ -1,7 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
-import com.datadog.debugger.el.Expression;
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.values.CollectionValue;
 import com.datadog.debugger.el.values.NumericValue;
 import com.datadog.debugger.el.values.StringValue;
@@ -45,7 +45,7 @@ public final class LenExpression implements ValueExpression<Value<? extends Numb
   }
 
   @Override
-  public String prettyPrint() {
-    return "len(" + Expression.nullSafePrettyPrint(source) + ")";
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/MatchesExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/MatchesExpression.java
@@ -1,9 +1,15 @@
 package com.datadog.debugger.el.expressions;
 
+import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.values.StringValue;
 
 public class MatchesExpression extends StringPredicateExpression {
   public MatchesExpression(ValueExpression<?> sourceString, StringValue str) {
     super(sourceString, str, String::matches, "matches");
+  }
+
+  @Override
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/MatchingExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/MatchingExpression.java
@@ -11,4 +11,12 @@ abstract class MatchingExpression implements BooleanExpression {
     this.filterPredicateExpression =
         filterPredicateExpression == null ? BooleanExpression.TRUE : filterPredicateExpression;
   }
+
+  public ValueExpression<?> getValueExpression() {
+    return valueExpression;
+  }
+
+  public BooleanExpression getFilterPredicateExpression() {
+    return filterPredicateExpression;
+  }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/NotExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/NotExpression.java
@@ -1,7 +1,6 @@
 package com.datadog.debugger.el.expressions;
 
-import static com.datadog.debugger.el.Expression.nullSafePrettyPrint;
-
+import com.datadog.debugger.el.Visitor;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 
 /** Will negate the resolved {@linkplain BooleanExpression} */
@@ -18,7 +17,11 @@ public final class NotExpression implements BooleanExpression {
   }
 
   @Override
-  public String prettyPrint() {
-    return "not(" + nullSafePrettyPrint(predicate) + ")";
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
+  }
+
+  public BooleanExpression getPredicate() {
+    return predicate;
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/StartsWithExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/StartsWithExpression.java
@@ -1,9 +1,15 @@
 package com.datadog.debugger.el.expressions;
 
+import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.values.StringValue;
 
 public class StartsWithExpression extends StringPredicateExpression {
   public StartsWithExpression(ValueExpression<?> sourceString, StringValue str) {
     super(sourceString, str, String::startsWith, "startsWith");
+  }
+
+  @Override
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/StringPredicateExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/StringPredicateExpression.java
@@ -1,7 +1,5 @@
 package com.datadog.debugger.el.expressions;
 
-import static com.datadog.debugger.el.Expression.nullSafePrettyPrint;
-
 import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.values.StringValue;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
@@ -35,8 +33,19 @@ public class StringPredicateExpression implements BooleanExpression {
     return Boolean.FALSE;
   }
 
-  @Override
-  public String prettyPrint() {
-    return name + "(" + nullSafePrettyPrint(sourceString) + ", " + nullSafePrettyPrint(str) + ")";
+  public ValueExpression<?> getSourceString() {
+    return sourceString;
+  }
+
+  public StringValue getStr() {
+    return str;
+  }
+
+  public BiPredicate<String, String> getPredicate() {
+    return predicate;
+  }
+
+  public String getName() {
+    return name;
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/SubStringExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/SubStringExpression.java
@@ -1,8 +1,8 @@
 package com.datadog.debugger.el.expressions;
 
-import static com.datadog.debugger.el.Expression.nullSafePrettyPrint;
-
+import com.datadog.debugger.el.PrettyPrintVisitor;
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.Visitor;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 
 public class SubStringExpression implements ValueExpression<Value<String>> {
@@ -24,14 +24,26 @@ public class SubStringExpression implements ValueExpression<Value<String>> {
       try {
         return (Value<String>) Value.of(sourceStr.substring(startIndex, endIndex));
       } catch (StringIndexOutOfBoundsException ex) {
-        valueRefResolver.addEvaluationError(prettyPrint(), ex.getMessage());
+        valueRefResolver.addEvaluationError(PrettyPrintVisitor.print(this), ex.getMessage());
       }
     }
     return Value.undefined();
   }
 
   @Override
-  public String prettyPrint() {
-    return "substring(" + nullSafePrettyPrint(source) + ", " + startIndex + ", " + endIndex + ")";
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
+  }
+
+  public ValueExpression<?> getSource() {
+    return source;
+  }
+
+  public int getStartIndex() {
+    return startIndex;
+  }
+
+  public int getEndIndex() {
+    return endIndex;
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ValueRefExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ValueRefExpression.java
@@ -2,12 +2,12 @@ package com.datadog.debugger.el.expressions;
 
 import com.datadog.debugger.el.Generated;
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.Visitor;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import java.util.Objects;
 
 /** An expression taking a reference path and resolving to {@linkplain Value} */
-@SuppressWarnings("rawtypes")
-public final class ValueRefExpression implements ValueExpression {
+public final class ValueRefExpression implements ValueExpression<Value<?>> {
   private final String symbolName;
 
   public ValueRefExpression(String symbolName) {
@@ -45,7 +45,7 @@ public final class ValueRefExpression implements ValueExpression {
   }
 
   @Override
-  public String prettyPrint() {
-    return symbolName;
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/WhenExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/WhenExpression.java
@@ -1,6 +1,6 @@
 package com.datadog.debugger.el.expressions;
 
-import com.datadog.debugger.el.Expression;
+import com.datadog.debugger.el.Visitor;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 
 /** The entry-point expression for the debugger EL */
@@ -17,7 +17,11 @@ public final class WhenExpression implements BooleanExpression {
   }
 
   @Override
-  public String prettyPrint() {
-    return "when(" + Expression.nullSafePrettyPrint(expression) + ")";
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
+  }
+
+  public BooleanExpression getExpression() {
+    return expression;
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/BooleanValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/BooleanValue.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.el.values;
 
 import com.datadog.debugger.el.Literal;
+import com.datadog.debugger.el.Visitor;
 
 /** Constant boolean value */
 public final class BooleanValue extends Literal<Boolean> {
@@ -17,10 +18,7 @@ public final class BooleanValue extends Literal<Boolean> {
   }
 
   @Override
-  public String prettyPrint() {
-    if (value == null) {
-      return "null";
-    }
-    return String.valueOf(value.booleanValue());
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ListValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ListValue.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.el.values;
 
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.expressions.ValueExpression;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.Values;
@@ -152,16 +153,19 @@ public class ListValue implements CollectionValue<Object>, ValueExpression<ListV
   }
 
   @Override
-  public String prettyPrint() {
-    if (arrayHolder != null) {
-      return arrayType.getTypeName() + "[]";
-    }
-    if (listHolder instanceof List) {
-      return "List";
-    }
-    if (listHolder instanceof Set) {
-      return "Set";
-    }
-    return "null";
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
+  }
+
+  public Object getListHolder() {
+    return listHolder;
+  }
+
+  public Object getArrayHolder() {
+    return arrayHolder;
+  }
+
+  public Class<?> getArrayType() {
+    return arrayType;
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/MapValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/MapValue.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.el.values;
 
 import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.expressions.ValueExpression;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.Values;
@@ -106,10 +107,11 @@ public final class MapValue implements CollectionValue<Object>, ValueExpression<
   }
 
   @Override
-  public String prettyPrint() {
-    if (mapHolder instanceof Map) {
-      return "Map";
-    }
-    return "null";
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
+  }
+
+  public Object getMapHolder() {
+    return mapHolder;
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/NullValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/NullValue.java
@@ -31,9 +31,4 @@ public final class NullValue extends Literal<Object> {
   public String toString() {
     return "null";
   }
-
-  @Override
-  public String prettyPrint() {
-    return "null";
-  }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/NumericValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/NumericValue.java
@@ -1,8 +1,7 @@
 package com.datadog.debugger.el.values;
 
 import com.datadog.debugger.el.Literal;
-import java.math.BigDecimal;
-import java.math.BigInteger;
+import com.datadog.debugger.el.Visitor;
 
 /** A numeric {@linkplain com.datadog.debugger.el.Value} */
 public final class NumericValue extends Literal<Number> {
@@ -26,16 +25,7 @@ public final class NumericValue extends Literal<Number> {
   }
 
   @Override
-  public String prettyPrint() {
-    if (value instanceof Double) {
-      return String.valueOf(value.doubleValue());
-    }
-    if (value instanceof Long) {
-      return String.valueOf(value.longValue());
-    }
-    if (value instanceof BigDecimal || value instanceof BigInteger) {
-      return value.toString();
-    }
-    return "null";
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ObjectValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ObjectValue.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.el.values;
 
 import com.datadog.debugger.el.Literal;
+import com.datadog.debugger.el.Visitor;
 import datadog.trace.bootstrap.debugger.el.Values;
 
 /**
@@ -20,16 +21,7 @@ public final class ObjectValue extends Literal<Object> {
   }
 
   @Override
-  public String prettyPrint() {
-    if (value == null || value == Values.NULL_OBJECT) {
-      return "null";
-    }
-    if (value == Values.UNDEFINED_OBJECT) {
-      return value.toString();
-    }
-    if (value == Values.THIS_OBJECT) {
-      return "this";
-    }
-    return value.getClass().getTypeName();
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/StringValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/StringValue.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.el.values;
 
 import com.datadog.debugger.el.Literal;
+import com.datadog.debugger.el.Visitor;
 
 /** A string {@linkplain com.datadog.debugger.el.Value} */
 public final class StringValue extends Literal<String> {
@@ -27,7 +28,7 @@ public final class StringValue extends Literal<String> {
   }
 
   @Override
-  public String prettyPrint() {
-    return "\"" + value + "\"";
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/UndefinedValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/UndefinedValue.java
@@ -37,9 +37,4 @@ public final class UndefinedValue extends Literal<Object> {
   public String toString() {
     return "UNDEFINED";
   }
-
-  @Override
-  public String prettyPrint() {
-    return "undefined";
-  }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ExpressionTest.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.el;
 
 import static com.datadog.debugger.el.DSL.*;
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.el.expressions.IsEmptyExpression;
@@ -56,28 +57,20 @@ class ExpressionTest {
 
   @Test
   void testPrettyPrint() {
-    assertEquals("\"foo\" == \"bar\"", eq(value("foo"), value("bar")).prettyPrint());
-    assertEquals("1 == 1", eq(value(1), value(1)).prettyPrint());
-    assertEquals("1 > 1", gt(value(1), value(1)).prettyPrint());
-    assertEquals("1 >= 1", ge(value(1), value(1)).prettyPrint());
-    assertEquals("1 < 1", lt(value(1), value(1)).prettyPrint());
-    assertEquals("1 <= 1", le(value(1), value(1)).prettyPrint());
+    assertEquals("\"foo\" == \"bar\"", print(eq(value("foo"), value("bar"))));
+    assertEquals("1 == 1", print(eq(value(1), value(1))));
+    assertEquals("1 > 1", print(gt(value(1), value(1))));
+    assertEquals("1 >= 1", print(ge(value(1), value(1))));
+    assertEquals("1 < 1", print(lt(value(1), value(1))));
+    assertEquals("1 <= 1", print(le(value(1), value(1))));
     assertEquals(
         "when(this.strField == \"foo\" && @duration > 0)",
-        when(and(
-                eq(getMember(ref("this"), "strField"), value("foo")),
-                gt(ref("@duration"), value(0))))
-            .prettyPrint());
+        print(
+            when(
+                and(
+                    eq(getMember(ref("this"), "strField"), value("foo")),
+                    gt(ref("@duration"), value(0))))));
     assertEquals(
-        "len(list[idx].map)", len(getMember(index(ref("list"), ref("idx")), "map")).prettyPrint());
-    assertTrue(new MyExpression().prettyPrint().contains("MyExpression"));
-  }
-
-  static class MyExpression implements Expression {
-
-    @Override
-    public Object evaluate(ValueReferenceResolver valueRefResolver) {
-      return null;
-    }
+        "len(list[idx].map)", print(len(getMember(index(ref("list"), ref("idx")), "map"))));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/BinaryExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/BinaryExpressionTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.expressions;
 
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -12,7 +13,7 @@ class BinaryExpressionTest {
     BinaryExpression expression =
         new BinaryExpression(null, BooleanExpression.TRUE, BinaryOperator.AND);
     assertFalse(expression.evaluate(RefResolverHelper.createResolver(this)));
-    assertEquals("false && true", expression.prettyPrint());
+    assertEquals("false && true", print(expression));
   }
 
   @Test
@@ -20,6 +21,6 @@ class BinaryExpressionTest {
     BinaryExpression expression =
         new BinaryExpression(BooleanExpression.TRUE, null, BinaryOperator.AND);
     assertFalse(expression.evaluate(RefResolverHelper.createResolver(this)));
-    assertEquals("true && false", expression.prettyPrint());
+    assertEquals("true && false", print(expression));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ComparisonExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ComparisonExpressionTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.expressions;
 
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static com.datadog.debugger.el.expressions.ComparisonOperator.EQ;
 import static com.datadog.debugger.el.expressions.ComparisonOperator.GE;
 import static com.datadog.debugger.el.expressions.ComparisonOperator.GT;
@@ -30,7 +31,7 @@ class ComparisonExpressionTest {
       String prettyPrint) {
     ComparisonExpression expression = new ComparisonExpression(left, right, operator);
     assertEquals(expected, expression.evaluate(NoopResolver.INSTANCE));
-    assertEquals(prettyPrint, expression.prettyPrint());
+    assertEquals(prettyPrint, print(expression));
   }
 
   private static Stream<Arguments> expressions() {
@@ -123,7 +124,7 @@ class ComparisonExpressionTest {
       String prettyPrint) {
     ComparisonExpression expression = new ComparisonExpression(left, right, operator);
     assertEquals(expected, expression.evaluate(NoopResolver.INSTANCE));
-    assertEquals(prettyPrint, expression.prettyPrint());
+    assertEquals(prettyPrint, print(expression));
   }
 
   private static Stream<Arguments> expressionStrs() {

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ContainsExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ContainsExpressionTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.expressions;
 
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.el.DSL;
@@ -16,7 +17,7 @@ class ContainsExpressionTest {
   void nullExpression() {
     ContainsExpression expression = new ContainsExpression(null, null);
     assertFalse(expression.evaluate(resolver));
-    assertEquals("contains(null, null)", expression.prettyPrint());
+    assertEquals("contains(null, null)", print(expression));
   }
 
   @Test
@@ -24,7 +25,7 @@ class ContainsExpressionTest {
     ContainsExpression expression =
         new ContainsExpression(DSL.value(Values.UNDEFINED_OBJECT), new StringValue(null));
     assertFalse(expression.evaluate(resolver));
-    assertEquals("contains(UNDEFINED, \"null\")", expression.prettyPrint());
+    assertEquals("contains(UNDEFINED, \"null\")", print(expression));
   }
 
   @Test
@@ -32,10 +33,10 @@ class ContainsExpressionTest {
     ContainsExpression expression =
         new ContainsExpression(DSL.value("abcd"), new StringValue("bc"));
     assertTrue(expression.evaluate(resolver));
-    assertEquals("contains(\"abcd\", \"bc\")", expression.prettyPrint());
+    assertEquals("contains(\"abcd\", \"bc\")", print(expression));
 
     expression = new ContainsExpression(DSL.value("abc"), new StringValue("dc"));
     assertFalse(expression.evaluate(resolver));
-    assertEquals("contains(\"abc\", \"dc\")", expression.prettyPrint());
+    assertEquals("contains(\"abc\", \"dc\")", print(expression));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/EndsWithExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/EndsWithExpressionTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.expressions;
 
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -18,7 +19,7 @@ class EndsWithExpressionTest {
   void nullExpression() {
     EndsWithExpression expression = new EndsWithExpression(null, null);
     assertFalse(expression.evaluate(resolver));
-    assertEquals("endsWith(null, null)", expression.prettyPrint());
+    assertEquals("endsWith(null, null)", print(expression));
   }
 
   @Test
@@ -26,17 +27,17 @@ class EndsWithExpressionTest {
     EndsWithExpression expression =
         new EndsWithExpression(DSL.value(Values.UNDEFINED_OBJECT), new StringValue(null));
     assertFalse(expression.evaluate(resolver));
-    assertEquals("endsWith(UNDEFINED, \"null\")", expression.prettyPrint());
+    assertEquals("endsWith(UNDEFINED, \"null\")", print(expression));
   }
 
   @Test
   void stringExpression() {
     EndsWithExpression expression = new EndsWithExpression(DSL.value("abc"), new StringValue("bc"));
     assertTrue(expression.evaluate(resolver));
-    assertEquals("endsWith(\"abc\", \"bc\")", expression.prettyPrint());
+    assertEquals("endsWith(\"abc\", \"bc\")", print(expression));
 
     expression = new EndsWithExpression(DSL.value("abc"), new StringValue("ab"));
     assertFalse(expression.evaluate(resolver));
-    assertEquals("endsWith(\"abc\", \"ab\")", expression.prettyPrint());
+    assertEquals("endsWith(\"abc\", \"ab\")", print(expression));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/FilterCollectionExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/FilterCollectionExpressionTest.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
 import static com.datadog.debugger.el.DSL.*;
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.el.RefResolverHelper;
@@ -27,7 +28,7 @@ class FilterCollectionExpressionTest {
     assertFalse(filtered.isEmpty());
     assertFalse(filtered.isNull());
     assertFalse(filtered.isUndefined());
-    assertEquals("filter(int[], @it < 2)", expression.prettyPrint());
+    assertEquals("filter(int[], @it < 2)", print(expression));
   }
 
   @Test
@@ -40,7 +41,7 @@ class FilterCollectionExpressionTest {
     assertTrue(filtered.isEmpty());
     assertFalse(filtered.isNull());
     assertFalse(filtered.isUndefined());
-    assertEquals("filter(int[], @it < 2)", expression.prettyPrint());
+    assertEquals("filter(int[], @it < 2)", print(expression));
   }
 
   @Test
@@ -51,7 +52,7 @@ class FilterCollectionExpressionTest {
     CollectionValue<?> filtered = expression.evaluate(RefResolverHelper.createResolver(this));
     assertEquals(collection, filtered);
     assertTrue(filtered.isNull());
-    assertEquals("filter(null, @it < 2)", expression.prettyPrint());
+    assertEquals("filter(null, @it < 2)", print(expression));
   }
 
   @Test
@@ -62,7 +63,7 @@ class FilterCollectionExpressionTest {
     CollectionValue<?> filtered = expression.evaluate(RefResolverHelper.createResolver(this));
     assertEquals(collection, filtered);
     assertTrue(filtered.isNull());
-    assertEquals("filter(null, @it < 2)", expression.prettyPrint());
+    assertEquals("filter(null, @it < 2)", print(expression));
   }
 
   @Test
@@ -73,7 +74,7 @@ class FilterCollectionExpressionTest {
     CollectionValue<?> filtered = expression.evaluate(RefResolverHelper.createResolver(this));
     assertEquals(collection, filtered);
     assertTrue(filtered.isUndefined());
-    assertEquals("filter(null, @it < 2)", expression.prettyPrint());
+    assertEquals("filter(null, @it < 2)", print(expression));
   }
 
   @Test
@@ -103,7 +104,7 @@ class FilterCollectionExpressionTest {
     assertFalse(filtered.isEmpty());
     assertFalse(filtered.isNull());
     assertFalse(filtered.isUndefined());
-    assertEquals("filter(Map, @it.value < 2)", expression.prettyPrint());
+    assertEquals("filter(Map, @it.value < 2)", print(expression));
   }
 
   @Test
@@ -116,7 +117,7 @@ class FilterCollectionExpressionTest {
     assertTrue(filtered.isEmpty());
     assertFalse(filtered.isNull());
     assertFalse(filtered.isUndefined());
-    assertEquals("filter(Map, @it < 2)", expression.prettyPrint());
+    assertEquals("filter(Map, @it < 2)", print(expression));
   }
 
   @Test
@@ -127,7 +128,7 @@ class FilterCollectionExpressionTest {
     CollectionValue<?> filtered = expression.evaluate(RefResolverHelper.createResolver(this));
     assertEquals(collection, filtered);
     assertTrue(filtered.isNull());
-    assertEquals("filter(null, @it < 2)", expression.prettyPrint());
+    assertEquals("filter(null, @it < 2)", print(expression));
   }
 
   @Test
@@ -138,7 +139,7 @@ class FilterCollectionExpressionTest {
     CollectionValue<?> filtered = expression.evaluate(RefResolverHelper.createResolver(this));
     assertEquals(collection, filtered);
     assertTrue(filtered.isNull());
-    assertEquals("filter(null, @it < 2)", expression.prettyPrint());
+    assertEquals("filter(null, @it < 2)", print(expression));
   }
 
   @Test
@@ -149,6 +150,6 @@ class FilterCollectionExpressionTest {
     CollectionValue<?> filtered = expression.evaluate(RefResolverHelper.createResolver(this));
     assertEquals(collection, filtered);
     assertTrue(filtered.isUndefined());
-    assertEquals("filter(null, @it < 2)", expression.prettyPrint());
+    assertEquals("filter(null, @it < 2)", print(expression));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/GetMemberExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/GetMemberExpressionTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.expressions;
 
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -19,7 +20,7 @@ class GetMemberExpressionTest {
     assertNotNull(val);
     assertFalse(val.isUndefined());
     assertEquals(parent.getB(), val.getValue());
-    assertEquals("ref.b", expr.prettyPrint());
+    assertEquals("ref.b", print(expr));
   }
 
   @Test
@@ -34,6 +35,6 @@ class GetMemberExpressionTest {
     assertNotNull(val);
     assertFalse(val.isUndefined());
     assertEquals(root.getB(), val.getValue());
-    assertEquals("ref.ref.b", expr.prettyPrint());
+    assertEquals("ref.ref.b", print(expr));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/HasAllExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/HasAllExpressionTest.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
 import static com.datadog.debugger.el.DSL.*;
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -23,21 +24,21 @@ class HasAllExpressionTest {
     ValueReferenceResolver resolver = RefResolverHelper.createResolver(this);
     HasAllExpression expression = new HasAllExpression(null, null);
     assertFalse(expression.evaluate(resolver));
-    assertEquals("hasAll(null, true)", expression.prettyPrint());
+    assertEquals("hasAll(null, true)", print(expression));
     expression = new HasAllExpression(value(Values.UNDEFINED_OBJECT), null);
     assertFalse(expression.evaluate(resolver));
-    assertEquals("hasAll(UNDEFINED, true)", expression.prettyPrint());
+    assertEquals("hasAll(UNDEFINED, true)", print(expression));
     expression = new HasAllExpression(value(this), null);
     assertTrue(expression.evaluate(resolver));
     assertEquals(
         "hasAll(com.datadog.debugger.el.expressions.HasAllExpressionTest, true)",
-        expression.prettyPrint());
+        print(expression));
     expression = new HasAllExpression(value(Collections.singletonList(this)), null);
     assertTrue(expression.evaluate(resolver));
-    assertEquals("hasAll(List, true)", expression.prettyPrint());
+    assertEquals("hasAll(List, true)", print(expression));
     expression = new HasAllExpression(value(Collections.singletonMap(this, this)), null);
     assertTrue(expression.evaluate(resolver));
-    assertEquals("hasAll(Map, true)", expression.prettyPrint());
+    assertEquals("hasAll(Map, true)", print(expression));
   }
 
   @Test
@@ -45,15 +46,15 @@ class HasAllExpressionTest {
     ValueReferenceResolver ctx = RefResolverHelper.createResolver(this);
     HasAllExpression expression = all(null, TRUE);
     assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAll(null, true)", expression.prettyPrint());
+    assertEquals("hasAll(null, true)", print(expression));
 
     expression = all(null, FALSE);
     assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAll(null, false)", expression.prettyPrint());
+    assertEquals("hasAll(null, false)", print(expression));
 
     expression = all(null, eq(ref("testField"), value(10)));
     assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAll(null, testField == 10)", expression.prettyPrint());
+    assertEquals("hasAll(null, testField == 10)", print(expression));
   }
 
   @Test
@@ -61,15 +62,15 @@ class HasAllExpressionTest {
     ValueReferenceResolver ctx = RefResolverHelper.createResolver(this);
     HasAllExpression expression = all(value(Values.UNDEFINED_OBJECT), TRUE);
     assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAll(UNDEFINED, true)", expression.prettyPrint());
+    assertEquals("hasAll(UNDEFINED, true)", print(expression));
 
     expression = all(null, FALSE);
     assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAll(null, false)", expression.prettyPrint());
+    assertEquals("hasAll(null, false)", print(expression));
 
     expression = all(value(Values.UNDEFINED_OBJECT), eq(ref("testField"), value(10)));
     assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAll(UNDEFINED, testField == 10)", expression.prettyPrint());
+    assertEquals("hasAll(UNDEFINED, testField == 10)", print(expression));
   }
 
   @Test
@@ -80,19 +81,19 @@ class HasAllExpressionTest {
     assertTrue(expression.evaluate(ctx));
     assertEquals(
         "hasAll(com.datadog.debugger.el.expressions.HasAllExpressionTest, true)",
-        expression.prettyPrint());
+        print(expression));
 
     expression = all(targetExpression, FALSE);
     assertFalse(expression.evaluate(ctx));
     assertEquals(
         "hasAll(com.datadog.debugger.el.expressions.HasAllExpressionTest, false)",
-        expression.prettyPrint());
+        print(expression));
 
     expression = all(targetExpression, eq(ref("testField"), value(10)));
     assertTrue(expression.evaluate(ctx));
     assertEquals(
         "hasAll(com.datadog.debugger.el.expressions.HasAllExpressionTest, testField == 10)",
-        expression.prettyPrint());
+        print(expression));
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/HasAnyExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/HasAnyExpressionTest.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
 import static com.datadog.debugger.el.DSL.*;
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.el.DSL;
@@ -23,21 +24,21 @@ class HasAnyExpressionTest {
     ValueReferenceResolver resolver = RefResolverHelper.createResolver(this);
     HasAnyExpression expression = new HasAnyExpression(null, null);
     assertFalse(expression.evaluate(resolver));
-    assertEquals("hasAny(null, true)", expression.prettyPrint());
+    assertEquals("hasAny(null, true)", print(expression));
     expression = new HasAnyExpression(value(Values.UNDEFINED_OBJECT), null);
     assertFalse(expression.evaluate(resolver));
-    assertEquals("hasAny(UNDEFINED, true)", expression.prettyPrint());
+    assertEquals("hasAny(UNDEFINED, true)", print(expression));
     expression = new HasAnyExpression(value(this), null);
     assertTrue(expression.evaluate(resolver));
     assertEquals(
         "hasAny(com.datadog.debugger.el.expressions.HasAnyExpressionTest, true)",
-        expression.prettyPrint());
+        print(expression));
     expression = new HasAnyExpression(value(Collections.singletonList(this)), null);
     assertTrue(expression.evaluate(resolver));
-    assertEquals("hasAny(List, true)", expression.prettyPrint());
+    assertEquals("hasAny(List, true)", print(expression));
     expression = new HasAnyExpression(value(Collections.singletonMap(this, this)), null);
     assertTrue(expression.evaluate(resolver));
-    assertEquals("hasAny(Map, true)", expression.prettyPrint());
+    assertEquals("hasAny(Map, true)", print(expression));
   }
 
   @Test
@@ -45,15 +46,15 @@ class HasAnyExpressionTest {
     ValueReferenceResolver ctx = RefResolverHelper.createResolver(this);
     HasAnyExpression expression = any(null, BooleanExpression.TRUE);
     assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAny(null, true)", expression.prettyPrint());
+    assertEquals("hasAny(null, true)", print(expression));
 
     expression = any(null, BooleanExpression.FALSE);
     assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAny(null, false)", expression.prettyPrint());
+    assertEquals("hasAny(null, false)", print(expression));
 
     expression = any(null, eq(ref("testField"), value(10)));
     assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAny(null, testField == 10)", expression.prettyPrint());
+    assertEquals("hasAny(null, testField == 10)", print(expression));
   }
 
   @Test
@@ -61,15 +62,15 @@ class HasAnyExpressionTest {
     ValueReferenceResolver ctx = RefResolverHelper.createResolver(this);
     HasAnyExpression expression = any(value(Values.UNDEFINED_OBJECT), TRUE);
     assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAny(UNDEFINED, true)", expression.prettyPrint());
+    assertEquals("hasAny(UNDEFINED, true)", print(expression));
 
     expression = any(null, FALSE);
     assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAny(null, false)", expression.prettyPrint());
+    assertEquals("hasAny(null, false)", print(expression));
 
     expression = any(value(Values.UNDEFINED_OBJECT), eq(ref("testField"), value(10)));
     assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAny(UNDEFINED, testField == 10)", expression.prettyPrint());
+    assertEquals("hasAny(UNDEFINED, testField == 10)", print(expression));
   }
 
   @Test
@@ -80,13 +81,13 @@ class HasAnyExpressionTest {
     assertTrue(expression.evaluate(ctx));
     assertEquals(
         "hasAny(com.datadog.debugger.el.expressions.HasAnyExpressionTest, true)",
-        expression.prettyPrint());
+        print(expression));
 
     expression = any(targetExpression, FALSE);
     assertFalse(expression.evaluate(ctx));
     assertEquals(
         "hasAny(com.datadog.debugger.el.expressions.HasAnyExpressionTest, false)",
-        expression.prettyPrint());
+        print(expression));
 
     expression =
         any(
@@ -95,7 +96,7 @@ class HasAnyExpressionTest {
     assertTrue(expression.evaluate(ctx));
     assertEquals(
         "hasAny(com.datadog.debugger.el.expressions.HasAnyExpressionTest, @it.testField == 10)",
-        expression.prettyPrint());
+        print(expression));
   }
 
   @Test
@@ -105,22 +106,22 @@ class HasAnyExpressionTest {
 
     HasAnyExpression expression = any(targetExpression, TRUE);
     assertTrue(expression.evaluate(ctx));
-    assertEquals("hasAny(java.lang.Object[], true)", expression.prettyPrint());
+    assertEquals("hasAny(java.lang.Object[], true)", print(expression));
 
     expression = any(targetExpression, FALSE);
     assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAny(java.lang.Object[], false)", expression.prettyPrint());
+    assertEquals("hasAny(java.lang.Object[], false)", print(expression));
 
     expression =
         any(
             targetExpression,
             eq(getMember(ref(ValueReferences.ITERATOR_REF), "testField"), value(10)));
     assertTrue(expression.evaluate(ctx));
-    assertEquals("hasAny(java.lang.Object[], @it.testField == 10)", expression.prettyPrint());
+    assertEquals("hasAny(java.lang.Object[], @it.testField == 10)", print(expression));
 
     expression = any(targetExpression, eq(ref(ValueReferences.ITERATOR_REF), value("hello")));
     assertTrue(expression.evaluate(ctx));
-    assertEquals("hasAny(java.lang.Object[], @it == \"hello\")", expression.prettyPrint());
+    assertEquals("hasAny(java.lang.Object[], @it == \"hello\")", print(expression));
   }
 
   @Test
@@ -130,22 +131,22 @@ class HasAnyExpressionTest {
 
     HasAnyExpression expression = any(targetExpression, TRUE);
     assertTrue(expression.evaluate(ctx));
-    assertEquals("hasAny(List, true)", expression.prettyPrint());
+    assertEquals("hasAny(List, true)", print(expression));
 
     expression = any(targetExpression, FALSE);
     assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAny(List, false)", expression.prettyPrint());
+    assertEquals("hasAny(List, false)", print(expression));
 
     expression =
         any(
             targetExpression,
             eq(getMember(ref(ValueReferences.ITERATOR_REF), "testField"), value(10)));
     assertTrue(expression.evaluate(ctx));
-    assertEquals("hasAny(List, @it.testField == 10)", expression.prettyPrint());
+    assertEquals("hasAny(List, @it.testField == 10)", print(expression));
 
     expression = any(targetExpression, eq(ref(ValueReferences.ITERATOR_REF), value("hello")));
     assertTrue(expression.evaluate(ctx));
-    assertEquals("hasAny(List, @it == \"hello\")", expression.prettyPrint());
+    assertEquals("hasAny(List, @it == \"hello\")", print(expression));
   }
 
   @Test
@@ -159,34 +160,34 @@ class HasAnyExpressionTest {
 
     HasAnyExpression expression = any(targetExpression, TRUE);
     assertTrue(expression.evaluate(ctx));
-    assertEquals("hasAny(Map, true)", expression.prettyPrint());
+    assertEquals("hasAny(Map, true)", print(expression));
 
     expression = any(targetExpression, FALSE);
     assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAny(Map, false)", expression.prettyPrint());
+    assertEquals("hasAny(Map, false)", print(expression));
 
     expression =
         any(targetExpression, eq(getMember(ref(ValueReferences.ITERATOR_REF), "key"), value("b")));
     assertTrue(expression.evaluate(ctx));
-    assertEquals("hasAny(Map, @it.key == \"b\")", expression.prettyPrint());
+    assertEquals("hasAny(Map, @it.key == \"b\")", print(expression));
 
     expression =
         any(
             targetExpression,
             eq(getMember(ref(ValueReferences.ITERATOR_REF), "value"), value("a")));
     assertTrue(expression.evaluate(ctx));
-    assertEquals("hasAny(Map, @it.value == \"a\")", expression.prettyPrint());
+    assertEquals("hasAny(Map, @it.value == \"a\")", print(expression));
 
     expression =
         any(targetExpression, eq(getMember(ref(ValueReferences.ITERATOR_REF), "key"), value("c")));
     assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAny(Map, @it.key == \"c\")", expression.prettyPrint());
+    assertEquals("hasAny(Map, @it.key == \"c\")", print(expression));
 
     expression =
         any(
             targetExpression,
             eq(getMember(ref(ValueReferences.ITERATOR_REF), "value"), value("c")));
     assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAny(Map, @it.value == \"c\")", expression.prettyPrint());
+    assertEquals("hasAny(Map, @it.value == \"c\")", print(expression));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/IsEmptyExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/IsEmptyExpressionTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.expressions;
 
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.el.DSL;
@@ -23,13 +24,13 @@ class IsEmptyExpressionTest {
     ValueReferenceResolver resolver = RefResolverHelper.createResolver(this);
     IsEmptyExpression expression = new IsEmptyExpression(null);
     assertTrue(expression.evaluate(resolver));
-    assertEquals("isEmpty(null)", expression.prettyPrint());
+    assertEquals("isEmpty(null)", print(expression));
     expression = new IsEmptyExpression(DSL.value(Values.NULL_OBJECT));
     assertTrue(expression.evaluate(resolver));
-    assertEquals("isEmpty(null)", expression.prettyPrint());
+    assertEquals("isEmpty(null)", print(expression));
     expression = new IsEmptyExpression(DSL.value(Value.nullValue()));
     assertTrue(expression.evaluate(resolver));
-    assertEquals("isEmpty(com.datadog.debugger.el.values.NullValue)", expression.prettyPrint());
+    assertEquals("isEmpty(com.datadog.debugger.el.values.NullValue)", print(expression));
   }
 
   @Test
@@ -37,7 +38,7 @@ class IsEmptyExpressionTest {
     ValueReferenceResolver resolver = RefResolverHelper.createResolver(this);
     IsEmptyExpression expression = new IsEmptyExpression(DSL.value(Values.UNDEFINED_OBJECT));
     assertTrue(expression.evaluate(resolver));
-    assertEquals("isEmpty(UNDEFINED)", expression.prettyPrint());
+    assertEquals("isEmpty(UNDEFINED)", print(expression));
   }
 
   @Test
@@ -49,13 +50,13 @@ class IsEmptyExpressionTest {
     ValueReferenceResolver resolver = RefResolverHelper.createResolver(this);
     IsEmptyExpression expression = new IsEmptyExpression(zero);
     assertFalse(expression.evaluate(resolver));
-    assertEquals("isEmpty(0)", expression.prettyPrint());
+    assertEquals("isEmpty(0)", print(expression));
     expression = new IsEmptyExpression(one);
     assertFalse(expression.evaluate(resolver));
-    assertEquals("isEmpty(1)", expression.prettyPrint());
+    assertEquals("isEmpty(1)", print(expression));
     expression = new IsEmptyExpression(none);
     assertTrue(expression.evaluate(resolver));
-    assertEquals("isEmpty(null)", expression.prettyPrint());
+    assertEquals("isEmpty(null)", print(expression));
   }
 
   @Test
@@ -67,13 +68,13 @@ class IsEmptyExpressionTest {
     ValueReferenceResolver resolver = RefResolverHelper.createResolver(this);
     IsEmptyExpression expression = new IsEmptyExpression(yes);
     assertFalse(expression.evaluate(resolver));
-    assertEquals("isEmpty(true)", expression.prettyPrint());
+    assertEquals("isEmpty(true)", print(expression));
     expression = new IsEmptyExpression(no);
     assertFalse(expression.evaluate(resolver));
-    assertEquals("isEmpty(false)", expression.prettyPrint());
+    assertEquals("isEmpty(false)", print(expression));
     expression = new IsEmptyExpression(none);
     assertTrue(expression.evaluate(resolver));
-    assertEquals("isEmpty(null)", expression.prettyPrint());
+    assertEquals("isEmpty(null)", print(expression));
   }
 
   @Test
@@ -88,11 +89,11 @@ class IsEmptyExpressionTest {
     IsEmptyExpression isEmpty3 = new IsEmptyExpression(nullString);
 
     assertFalse(isEmpty1.evaluate(resolver));
-    assertEquals("isEmpty(\"Hello World\")", isEmpty1.prettyPrint());
+    assertEquals("isEmpty(\"Hello World\")", print(isEmpty1));
     assertTrue(isEmpty2.evaluate(resolver));
-    assertEquals("isEmpty(\"\")", isEmpty2.prettyPrint());
+    assertEquals("isEmpty(\"\")", print(isEmpty2));
     assertTrue(isEmpty3.evaluate(resolver));
-    assertEquals("isEmpty(\"null\")", isEmpty3.prettyPrint());
+    assertEquals("isEmpty(\"null\")", print(isEmpty3));
   }
 
   @Test
@@ -113,17 +114,17 @@ class IsEmptyExpressionTest {
     IsEmptyExpression isEmpty6 = new IsEmptyExpression(emptySet);
 
     assertFalse(isEmpty1.evaluate(resolver));
-    assertEquals("isEmpty(List)", isEmpty1.prettyPrint());
+    assertEquals("isEmpty(List)", print(isEmpty1));
     assertTrue(isEmpty2.evaluate(resolver));
-    assertEquals("isEmpty(List)", isEmpty2.prettyPrint());
+    assertEquals("isEmpty(List)", print(isEmpty2));
     assertTrue(isEmpty3.evaluate(resolver));
-    assertEquals("isEmpty(null)", isEmpty3.prettyPrint());
+    assertEquals("isEmpty(null)", print(isEmpty3));
     assertTrue(isEmpty4.evaluate(resolver));
-    assertEquals("isEmpty(null)", isEmpty4.prettyPrint());
+    assertEquals("isEmpty(null)", print(isEmpty4));
     assertFalse(isEmpty5.evaluate(resolver));
-    assertEquals("isEmpty(Set)", isEmpty5.prettyPrint());
+    assertEquals("isEmpty(Set)", print(isEmpty5));
     assertTrue(isEmpty6.evaluate(resolver));
-    assertEquals("isEmpty(Set)", isEmpty6.prettyPrint());
+    assertEquals("isEmpty(Set)", print(isEmpty6));
   }
 
   @Test
@@ -140,12 +141,12 @@ class IsEmptyExpressionTest {
     IsEmptyExpression isEmpty4 = new IsEmptyExpression(undefinedMap);
 
     assertFalse(isEmpty1.evaluate(resolver));
-    assertEquals("isEmpty(Map)", isEmpty1.prettyPrint());
+    assertEquals("isEmpty(Map)", print(isEmpty1));
     assertTrue(isEmpty2.evaluate(resolver));
-    assertEquals("isEmpty(Map)", isEmpty2.prettyPrint());
+    assertEquals("isEmpty(Map)", print(isEmpty2));
     assertTrue(isEmpty3.evaluate(resolver));
-    assertEquals("isEmpty(null)", isEmpty3.prettyPrint());
+    assertEquals("isEmpty(null)", print(isEmpty3));
     assertTrue(isEmpty4.evaluate(resolver));
-    assertEquals("isEmpty(null)", isEmpty4.prettyPrint());
+    assertEquals("isEmpty(null)", print(isEmpty4));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/IsUndefinedExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/IsUndefinedExpressionTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.expressions;
 
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -25,13 +26,13 @@ class IsUndefinedExpressionTest {
   void testNullValue() {
     IsUndefinedExpression expression = new IsUndefinedExpression(null);
     assertFalse(expression.evaluate(resolver));
-    assertEquals("isUndefined(null)", expression.prettyPrint());
+    assertEquals("isUndefined(null)", print(expression));
     expression = new IsUndefinedExpression(DSL.value(Values.NULL_OBJECT));
     assertFalse(expression.evaluate(resolver));
-    assertEquals("isUndefined(null)", expression.prettyPrint());
+    assertEquals("isUndefined(null)", print(expression));
     expression = new IsUndefinedExpression(DSL.value(Value.nullValue()));
     assertFalse(expression.evaluate(resolver));
-    assertEquals("isUndefined(com.datadog.debugger.el.values.NullValue)", expression.prettyPrint());
+    assertEquals("isUndefined(com.datadog.debugger.el.values.NullValue)", print(expression));
   }
 
   @Test
@@ -39,7 +40,7 @@ class IsUndefinedExpressionTest {
     IsUndefinedExpression expression =
         new IsUndefinedExpression(DSL.value(Values.UNDEFINED_OBJECT));
     assertTrue(expression.evaluate(resolver));
-    assertEquals("isUndefined(UNDEFINED)", expression.prettyPrint());
+    assertEquals("isUndefined(UNDEFINED)", print(expression));
   }
 
   @Test
@@ -50,13 +51,13 @@ class IsUndefinedExpressionTest {
 
     IsUndefinedExpression expression = new IsUndefinedExpression(zero);
     assertFalse(expression.evaluate(resolver));
-    assertEquals("isUndefined(0)", expression.prettyPrint());
+    assertEquals("isUndefined(0)", print(expression));
     expression = new IsUndefinedExpression(one);
     assertFalse(expression.evaluate(resolver));
-    assertEquals("isUndefined(1)", expression.prettyPrint());
+    assertEquals("isUndefined(1)", print(expression));
     expression = new IsUndefinedExpression(none);
     assertFalse(expression.evaluate(resolver));
-    assertEquals("isUndefined(null)", expression.prettyPrint());
+    assertEquals("isUndefined(null)", print(expression));
   }
 
   @Test
@@ -67,13 +68,13 @@ class IsUndefinedExpressionTest {
 
     IsUndefinedExpression expression = new IsUndefinedExpression(yes);
     assertFalse(expression.evaluate(resolver));
-    assertEquals("isUndefined(true)", expression.prettyPrint());
+    assertEquals("isUndefined(true)", print(expression));
     expression = new IsUndefinedExpression(no);
     assertFalse(expression.evaluate(resolver));
-    assertEquals("isUndefined(false)", expression.prettyPrint());
+    assertEquals("isUndefined(false)", print(expression));
     expression = new IsUndefinedExpression(none);
     assertFalse(expression.evaluate(resolver));
-    assertEquals("isUndefined(null)", expression.prettyPrint());
+    assertEquals("isUndefined(null)", print(expression));
   }
 
   @Test
@@ -87,11 +88,11 @@ class IsUndefinedExpressionTest {
     IsUndefinedExpression isUndefined3 = new IsUndefinedExpression(nullString);
 
     assertFalse(isUndefined1.evaluate(resolver));
-    assertEquals("isUndefined(\"Hello World\")", isUndefined1.prettyPrint());
+    assertEquals("isUndefined(\"Hello World\")", print(isUndefined1));
     assertFalse(isUndefined2.evaluate(resolver));
-    assertEquals("isUndefined(\"\")", isUndefined2.prettyPrint());
+    assertEquals("isUndefined(\"\")", print(isUndefined2));
     assertFalse(isUndefined3.evaluate(resolver));
-    assertEquals("isUndefined(\"null\")", isUndefined3.prettyPrint());
+    assertEquals("isUndefined(\"null\")", print(isUndefined3));
   }
 
   @Test
@@ -107,13 +108,13 @@ class IsUndefinedExpressionTest {
     IsUndefinedExpression isUndefined4 = new IsUndefinedExpression(undefinedList);
 
     assertFalse(isUndefined1.evaluate(resolver));
-    assertEquals("isUndefined(List)", isUndefined1.prettyPrint());
+    assertEquals("isUndefined(List)", print(isUndefined1));
     assertFalse(isUndefined2.evaluate(resolver));
-    assertEquals("isUndefined(List)", isUndefined2.prettyPrint());
+    assertEquals("isUndefined(List)", print(isUndefined2));
     assertFalse(isUndefined3.evaluate(resolver));
-    assertEquals("isUndefined(null)", isUndefined3.prettyPrint());
+    assertEquals("isUndefined(null)", print(isUndefined3));
     assertTrue(isUndefined4.evaluate(resolver));
-    assertEquals("isUndefined(null)", isUndefined4.prettyPrint());
+    assertEquals("isUndefined(null)", print(isUndefined4));
   }
 
   @Test
@@ -130,12 +131,12 @@ class IsUndefinedExpressionTest {
     IsUndefinedExpression isUndefined4 = new IsUndefinedExpression(undefinedMap);
 
     assertFalse(isUndefined1.evaluate(resolver));
-    assertEquals("isUndefined(Map)", isUndefined1.prettyPrint());
+    assertEquals("isUndefined(Map)", print(isUndefined1));
     assertFalse(isUndefined2.evaluate(resolver));
-    assertEquals("isUndefined(Map)", isUndefined2.prettyPrint());
+    assertEquals("isUndefined(Map)", print(isUndefined2));
     assertFalse(isUndefined3.evaluate(resolver));
-    assertEquals("isUndefined(null)", isUndefined3.prettyPrint());
+    assertEquals("isUndefined(null)", print(isUndefined3));
     assertTrue(isUndefined4.evaluate(resolver));
-    assertEquals("isUndefined(null)", isUndefined4.prettyPrint());
+    assertEquals("isUndefined(null)", print(isUndefined4));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/LenExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/LenExpressionTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.expressions;
 
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.el.DSL;
@@ -18,37 +19,37 @@ class LenExpressionTest {
   void nullExpression() {
     LenExpression expression = new LenExpression(null);
     assertEquals(-1L, expression.evaluate(resolver).getValue());
-    assertEquals("len(null)", expression.prettyPrint());
+    assertEquals("len(null)", print(expression));
   }
 
   @Test
   void undefinedExpression() {
     LenExpression expression = new LenExpression(DSL.value(Values.UNDEFINED_OBJECT));
     assertEquals(0L, expression.evaluate(resolver).getValue());
-    assertEquals("len(UNDEFINED)", expression.prettyPrint());
+    assertEquals("len(UNDEFINED)", print(expression));
   }
 
   @Test
   void stringExpression() {
     LenExpression expression = new LenExpression(DSL.value("a"));
     assertEquals(1L, expression.evaluate(resolver).getValue());
-    assertEquals("len(\"a\")", expression.prettyPrint());
+    assertEquals("len(\"a\")", print(expression));
   }
 
   @Test
   void collectionExpression() {
     LenExpression expression = new LenExpression(DSL.value(Arrays.asList("a", "b")));
     assertEquals(2L, expression.evaluate(resolver).getValue());
-    assertEquals("len(List)", expression.prettyPrint());
+    assertEquals("len(List)", print(expression));
     expression = new LenExpression(DSL.value(new HashSet<>(Arrays.asList("a", "b"))));
     assertEquals(2L, expression.evaluate(resolver).getValue());
-    assertEquals("len(Set)", expression.prettyPrint());
+    assertEquals("len(Set)", print(expression));
   }
 
   @Test
   void mapExpression() {
     LenExpression expression = new LenExpression(DSL.value(Collections.singletonMap("a", "b")));
     assertEquals(1L, expression.evaluate(resolver).getValue());
-    assertEquals("len(Map)", expression.prettyPrint());
+    assertEquals("len(Map)", print(expression));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/MatchesExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/MatchesExpressionTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.expressions;
 
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.el.DSL;
@@ -16,7 +17,7 @@ class MatchesExpressionTest {
   void nullExpression() {
     MatchesExpression expression = new MatchesExpression(null, null);
     assertFalse(expression.evaluate(resolver));
-    assertEquals("matches(null, null)", expression.prettyPrint());
+    assertEquals("matches(null, null)", print(expression));
   }
 
   @Test
@@ -24,23 +25,23 @@ class MatchesExpressionTest {
     MatchesExpression expression =
         new MatchesExpression(DSL.value(Values.UNDEFINED_OBJECT), new StringValue(null));
     assertFalse(expression.evaluate(resolver));
-    assertEquals("matches(UNDEFINED, \"null\")", expression.prettyPrint());
+    assertEquals("matches(UNDEFINED, \"null\")", print(expression));
   }
 
   @Test
   void stringExpression() {
     MatchesExpression expression = new MatchesExpression(DSL.value("abc"), new StringValue("abc"));
     assertTrue(expression.evaluate(resolver));
-    assertEquals("matches(\"abc\", \"abc\")", expression.prettyPrint());
+    assertEquals("matches(\"abc\", \"abc\")", print(expression));
     expression = new MatchesExpression(DSL.value("abc"), new StringValue("^ab.*"));
     assertTrue(expression.evaluate(resolver));
-    assertEquals("matches(\"abc\", \"^ab.*\")", expression.prettyPrint());
+    assertEquals("matches(\"abc\", \"^ab.*\")", print(expression));
 
     expression = new MatchesExpression(DSL.value("abc"), new StringValue("bc"));
     assertFalse(expression.evaluate(resolver));
-    assertEquals("matches(\"abc\", \"bc\")", expression.prettyPrint());
+    assertEquals("matches(\"abc\", \"bc\")", print(expression));
     expression = new MatchesExpression(DSL.value("abc"), new StringValue("[def]+"));
     assertFalse(expression.evaluate(resolver));
-    assertEquals("matches(\"abc\", \"[def]+\")", expression.prettyPrint());
+    assertEquals("matches(\"abc\", \"[def]+\")", print(expression));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/NotExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/NotExpressionTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.expressions;
 
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.el.RefResolverHelper;
@@ -14,7 +15,7 @@ class NotExpressionTest {
   void testNullPredicate(BooleanExpression expression, boolean expected, String prettyPrint) {
     NotExpression expr = new NotExpression(expression);
     assertEquals(expected, expr.evaluate(RefResolverHelper.createResolver(this)));
-    assertEquals(prettyPrint, expr.prettyPrint());
+    assertEquals(prettyPrint, print(expr));
   }
 
   private static Stream<Arguments> expressions() {

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/StartsWithExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/StartsWithExpressionTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.expressions;
 
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.el.DSL;
@@ -16,7 +17,7 @@ class StartsWithExpressionTest {
   void nullExpression() {
     StartsWithExpression expression = new StartsWithExpression(null, null);
     assertFalse(expression.evaluate(resolver));
-    assertEquals("startsWith(null, null)", expression.prettyPrint());
+    assertEquals("startsWith(null, null)", print(expression));
   }
 
   @Test
@@ -24,7 +25,7 @@ class StartsWithExpressionTest {
     StartsWithExpression expression =
         new StartsWithExpression(DSL.value(Values.UNDEFINED_OBJECT), new StringValue(null));
     assertFalse(expression.evaluate(resolver));
-    assertEquals("startsWith(UNDEFINED, \"null\")", expression.prettyPrint());
+    assertEquals("startsWith(UNDEFINED, \"null\")", print(expression));
   }
 
   @Test
@@ -32,10 +33,10 @@ class StartsWithExpressionTest {
     StartsWithExpression expression =
         new StartsWithExpression(DSL.value("abc"), new StringValue("ab"));
     assertTrue(expression.evaluate(resolver));
-    assertEquals("startsWith(\"abc\", \"ab\")", expression.prettyPrint());
+    assertEquals("startsWith(\"abc\", \"ab\")", print(expression));
 
     expression = new StartsWithExpression(DSL.value("abc"), new StringValue("bc"));
     assertFalse(expression.evaluate(resolver));
-    assertEquals("startsWith(\"abc\", \"bc\")", expression.prettyPrint());
+    assertEquals("startsWith(\"abc\", \"bc\")", print(expression));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/SubStringExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/SubStringExpressionTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.expressions;
 
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -16,7 +17,7 @@ public class SubStringExpressionTest {
   void nullExpression() {
     SubStringExpression expression = new SubStringExpression(null, 0, 0);
     assertTrue(expression.evaluate(resolver).isUndefined());
-    assertEquals("substring(null, 0, 0)", expression.prettyPrint());
+    assertEquals("substring(null, 0, 0)", print(expression));
   }
 
   @Test
@@ -24,20 +25,20 @@ public class SubStringExpressionTest {
     SubStringExpression expression =
         new SubStringExpression(DSL.value(Values.UNDEFINED_OBJECT), 0, 0);
     assertTrue(expression.evaluate(resolver).isUndefined());
-    assertEquals("substring(UNDEFINED, 0, 0)", expression.prettyPrint());
+    assertEquals("substring(UNDEFINED, 0, 0)", print(expression));
   }
 
   @Test
   void stringExpression() {
     SubStringExpression expression = new SubStringExpression(DSL.value("abc"), 0, 1);
     assertEquals("a", expression.evaluate(resolver).getValue());
-    assertEquals("substring(\"abc\", 0, 1)", expression.prettyPrint());
+    assertEquals("substring(\"abc\", 0, 1)", print(expression));
   }
 
   @Test
   void stringOutOfBoundsExpression() {
     SubStringExpression expression = new SubStringExpression(DSL.value("abc"), 0, 10);
     assertTrue(expression.evaluate(resolver).isUndefined());
-    assertEquals("substring(\"abc\", 0, 10)", expression.prettyPrint());
+    assertEquals("substring(\"abc\", 0, 10)", print(expression));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ValueRefExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ValueRefExpressionTest.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
 import static com.datadog.debugger.el.DSL.*;
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.el.DSL;
@@ -24,7 +25,7 @@ class ValueRefExpressionTest {
     assertNotNull(val);
     assertFalse(val.isUndefined());
     assertEquals(instance.getB(), val.getValue());
-    assertEquals("b", valueRef.prettyPrint());
+    assertEquals("b", print(valueRef));
   }
 
   @Test
@@ -39,12 +40,12 @@ class ValueRefExpressionTest {
     ValueReferenceResolver ctx = RefResolverHelper.createResolver(instance);
 
     assertFalse(isEmpty.evaluate(ctx));
-    assertEquals("isEmpty(b)", isEmpty.prettyPrint());
+    assertEquals("isEmpty(b)", print(isEmpty));
 
     assertTrue(isEmptyInvalid.evaluate(ctx));
     assertFalse(and(isEmptyInvalid, isEmpty).evaluate(ctx));
     assertTrue(or(isEmptyInvalid, isEmpty).evaluate(ctx));
-    assertEquals("isEmpty(x)", isEmptyInvalid.prettyPrint());
+    assertEquals("isEmpty(x)", print(isEmptyInvalid));
   }
 
   @Test
@@ -73,22 +74,22 @@ class ValueRefExpressionTest {
 
     ValueRefExpression expression = DSL.ref(ValueReferences.DURATION_REF);
     assertEquals(duration, expression.evaluate(resolver).getValue());
-    assertEquals("@duration", expression.prettyPrint());
+    assertEquals("@duration", print(expression));
     expression = DSL.ref(ValueReferences.RETURN_REF);
     assertEquals(returnVal, expression.evaluate(resolver).getValue());
-    assertEquals("@return", expression.prettyPrint());
+    assertEquals("@return", print(expression));
     expression = DSL.ref(limitArg);
     assertEquals(limit, expression.evaluate(resolver).getValue());
-    assertEquals("limit", expression.prettyPrint());
+    assertEquals("limit", print(expression));
     expression = DSL.ref(msgArg);
     assertEquals(msg, expression.evaluate(resolver).getValue());
-    assertEquals("msg", expression.prettyPrint());
+    assertEquals("msg", print(expression));
     expression = DSL.ref(iVar);
     assertEquals(
         (long) i, expression.evaluate(resolver).getValue()); // int value is widened to long
-    assertEquals("i", expression.prettyPrint());
+    assertEquals("i", print(expression));
     expression = DSL.ref(ValueReferences.synthetic("invalid"));
     assertEquals(Values.UNDEFINED_OBJECT, expression.evaluate(resolver).getValue());
-    assertEquals("@invalid", expression.prettyPrint());
+    assertEquals("@invalid", print(expression));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/BooleanValueTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/BooleanValueTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.values;
 
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
@@ -13,7 +14,7 @@ class BooleanValueTest {
     assertTrue(instance.isNull());
     assertFalse(instance.isUndefined());
     assertNull(instance.getValue());
-    assertEquals("null", instance.prettyPrint());
+    assertEquals("null", print(instance));
   }
 
   @ParameterizedTest
@@ -23,6 +24,6 @@ class BooleanValueTest {
     assertFalse(instance.isNull());
     assertFalse(instance.isUndefined());
     assertEquals(expected, instance.getValue());
-    assertEquals(String.valueOf(expected), instance.prettyPrint());
+    assertEquals(String.valueOf(expected), print(instance));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/ListLiteralTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/ListLiteralTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.values;
 
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.el.Value;
@@ -25,7 +26,7 @@ class ListLiteralTest {
     assertTrue(literal.isNull());
     assertTrue(literal.isEmpty());
     assertFalse(literal.isUndefined());
-    assertEquals(String.valueOf((Object) null), literal.prettyPrint());
+    assertEquals(String.valueOf((Object) null), print(literal));
   }
 
   private void checkUndefinedLiteral(Object undefinedValue) {
@@ -33,6 +34,6 @@ class ListLiteralTest {
     assertFalse(literal.isNull());
     assertTrue(literal.isEmpty());
     assertTrue(literal.isUndefined());
-    assertEquals(String.valueOf((Object) null), literal.prettyPrint());
+    assertEquals(String.valueOf((Object) null), print(literal));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/ListValueTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/ListValueTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.values;
 
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.el.Value;
@@ -28,7 +29,7 @@ class ListValueTest {
     }
     assertThrows(IllegalArgumentException.class, () -> listValue.get(-1));
     assertThrows(IllegalArgumentException.class, () -> listValue.get(stringList.size()));
-    assertEquals("List", listValue.prettyPrint());
+    assertEquals("List", print(listValue));
   }
 
   @Test
@@ -37,7 +38,7 @@ class ListValueTest {
     assertTrue(listValue.isEmpty());
 
     assertThrows(IllegalArgumentException.class, () -> listValue.get(-1));
-    assertEquals("null", listValue.prettyPrint());
+    assertEquals("null", print(listValue));
   }
 
   @Test
@@ -60,7 +61,7 @@ class ListValueTest {
     }
     assertThrows(IllegalArgumentException.class, () -> listValue.get(-1));
     assertThrows(IllegalArgumentException.class, () -> listValue.get(array.length));
-    assertEquals("java.lang.Object[]", listValue.prettyPrint());
+    assertEquals("java.lang.Object[]", print(listValue));
   }
 
   @Test
@@ -82,6 +83,6 @@ class ListValueTest {
     }
     assertThrows(IllegalArgumentException.class, () -> listValue.get(-1));
     assertThrows(IllegalArgumentException.class, () -> listValue.get(intArray.length));
-    assertEquals("int[][]", listValue.prettyPrint());
+    assertEquals("int[][]", print(listValue));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/MapValueEmptyTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/MapValueEmptyTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.values;
 
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.el.Value;
@@ -18,7 +19,7 @@ class MapValueEmptyTest {
 
   @Test
   void prettyPrint() {
-    assertEquals("Map", instance.prettyPrint());
+    assertEquals("Map", print(instance));
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/MapValueNullTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/MapValueNullTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.values;
 
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.el.Value;
@@ -16,7 +17,7 @@ class MapValueNullTest {
 
   @Test
   void prettyPrint() {
-    assertEquals("null", instance.prettyPrint());
+    assertEquals("null", print(instance));
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/MapValueTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/MapValueTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.values;
 
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.el.Value;
@@ -22,7 +23,7 @@ class MapValueTest {
 
   @Test
   void prettyPrint() {
-    assertEquals("Map", instance.prettyPrint());
+    assertEquals("Map", print(instance));
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/MapValueUndefinedTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/MapValueUndefinedTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.values;
 
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -17,7 +18,7 @@ class MapValueUndefinedTest {
 
   @Test
   void prettyPrint() {
-    assertEquals("null", instance.prettyPrint());
+    assertEquals("null", print(instance));
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/NumericValueTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/NumericValueTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.values;
 
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.math.BigDecimal;
@@ -13,7 +14,7 @@ class NumericValueTest {
     assertTrue(instance.isNull());
     assertFalse(instance.isUndefined());
     assertNull(instance.getValue());
-    assertEquals("null", instance.prettyPrint());
+    assertEquals("null", print(instance));
   }
 
   @Test
@@ -24,7 +25,7 @@ class NumericValueTest {
     assertFalse(instance.isUndefined());
     assertNotEquals(expected, instance.getValue());
     assertEquals((long) expected, instance.getValue());
-    assertEquals("1", instance.prettyPrint());
+    assertEquals("1", print(instance));
   }
 
   @Test
@@ -35,7 +36,7 @@ class NumericValueTest {
     assertFalse(instance.isUndefined());
     assertNotEquals(expected, instance.getValue());
     assertEquals((long) expected, instance.getValue());
-    assertEquals("1", instance.prettyPrint());
+    assertEquals("1", print(instance));
   }
 
   @Test
@@ -46,7 +47,7 @@ class NumericValueTest {
     assertFalse(instance.isUndefined());
     assertNotEquals(expected, instance.getValue());
     assertEquals((long) expected, instance.getValue());
-    assertEquals("1", instance.prettyPrint());
+    assertEquals("1", print(instance));
   }
 
   @Test
@@ -56,7 +57,7 @@ class NumericValueTest {
     assertFalse(instance.isNull());
     assertFalse(instance.isUndefined());
     assertEquals(expected, instance.getValue());
-    assertEquals("1", instance.prettyPrint());
+    assertEquals("1", print(instance));
   }
 
   @Test
@@ -66,7 +67,7 @@ class NumericValueTest {
     assertFalse(instance.isNull());
     assertFalse(instance.isUndefined());
     assertEquals((double) expected, instance.getValue());
-    assertEquals("1.0", instance.prettyPrint());
+    assertEquals("1.0", print(instance));
   }
 
   @Test
@@ -76,7 +77,7 @@ class NumericValueTest {
     assertFalse(instance.isNull());
     assertFalse(instance.isUndefined());
     assertEquals(expected, instance.getValue());
-    assertEquals("1.0", instance.prettyPrint());
+    assertEquals("1.0", print(instance));
   }
 
   @Test
@@ -86,7 +87,7 @@ class NumericValueTest {
     assertFalse(instance.isNull());
     assertFalse(instance.isUndefined());
     assertEquals(expected, instance.getValue());
-    assertEquals("1.0", instance.prettyPrint());
+    assertEquals("1.0", print(instance));
   }
 
   @Test
@@ -96,6 +97,6 @@ class NumericValueTest {
     assertFalse(instance.isNull());
     assertFalse(instance.isUndefined());
     assertEquals(expected, instance.getValue());
-    assertEquals("1234567890", instance.prettyPrint());
+    assertEquals("1234567890", print(instance));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/ObjectValueTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/ObjectValueTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.values;
 
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import datadog.trace.bootstrap.debugger.el.Values;
@@ -12,13 +13,13 @@ class ObjectValueTest {
     assertTrue(instance.isNull());
     assertFalse(instance.isUndefined());
     assertEquals(Values.NULL_OBJECT, instance.getValue());
-    assertEquals("null", instance.prettyPrint());
+    assertEquals("null", print(instance));
 
     instance = new ObjectValue(Values.NULL_OBJECT);
     assertTrue(instance.isNull());
     assertFalse(instance.isUndefined());
     assertEquals(Values.NULL_OBJECT, instance.getValue());
-    assertEquals("null", instance.prettyPrint());
+    assertEquals("null", print(instance));
   }
 
   @Test
@@ -28,7 +29,7 @@ class ObjectValueTest {
     assertFalse(instance.isNull());
     assertFalse(instance.isUndefined());
     assertEquals(expected, instance.getValue());
-    assertEquals("java.lang.Object", instance.prettyPrint());
+    assertEquals("java.lang.Object", print(instance));
   }
 
   @Test
@@ -38,6 +39,6 @@ class ObjectValueTest {
     assertFalse(instance.isNull());
     assertTrue(instance.isUndefined());
     assertEquals(expected, instance.getValue());
-    assertEquals("UNDEFINED", instance.prettyPrint());
+    assertEquals("UNDEFINED", print(instance));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/StringValueTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/StringValueTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.values;
 
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
@@ -15,7 +16,7 @@ class StringValueTest {
     assertFalse(instance.isEmpty());
     assertNull(instance.getValue());
     assertEquals(-1, instance.length());
-    assertEquals("\"null\"", instance.prettyPrint());
+    assertEquals("\"null\"", print(instance));
   }
 
   @ParameterizedTest
@@ -27,6 +28,6 @@ class StringValueTest {
     assertEquals(expected.isEmpty(), instance.isEmpty());
     assertEquals(expected, instance.getValue());
     assertEquals(expected.length(), instance.length());
-    assertEquals("\"" + expected + "\"", instance.prettyPrint());
+    assertEquals("\"" + expected + "\"", print(instance));
   }
 }


### PR DESCRIPTION
# What Does This Do
Visitor pattern is introduced in Expression nodes to allow traverse the AST for different purpose like emitting byte code or pretty printing.
Retrofit pretty printing into a visitor.

# Motivation

# Additional Notes
