### PR TITLE
Fix IllegalStateException caused by Flows instrumentation in Kotlin coroutines

### DIFF
--- a/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.3/src/main/java/datadog/trace/instrumentation/kotlin/coroutines/KotlinCoroutines13Instrumentation.java
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.3/src/main/java/datadog/trace/instrumentation/kotlin/coroutines/KotlinCoroutines13Instrumentation.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.kotlin.coroutines;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.instrumentation.kotlin.coroutines.CoroutineContextHelper.getScopeStateContext;
+import static datadog.trace.instrumentation.kotlin.coroutines.CoroutineContextHelper.initializeScopeStateContextIfActive;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -8,8 +10,11 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.instrumentation.kotlin.coroutines.ScopeStateCoroutineContext.ScopeStateCoroutineContextItem;
 import kotlin.coroutines.CoroutineContext;
 import kotlinx.coroutines.AbstractCoroutine;
+import kotlinx.coroutines.Job;
 import net.bytebuddy.asm.Advice;
 
 @AutoService(Instrumenter.class)
@@ -28,8 +33,7 @@ public class KotlinCoroutines13Instrumentation extends AbstractCoroutinesInstrum
   }
 
   /**
-   * Guarantees every coroutine created has a new instance of ScopeStateCoroutineContext, so that it
-   * is never inherited from the parent context.
+   * Guarantees every coroutine created has an instance of ScopeStateCoroutineContext
    *
    * @see ScopeStateCoroutineContext
    * @see AbstractCoroutine#AbstractCoroutine(CoroutineContext, boolean)
@@ -37,15 +41,23 @@ public class KotlinCoroutines13Instrumentation extends AbstractCoroutinesInstrum
   public static class AbstractCoroutineConstructorAdvice {
     @Advice.OnMethodEnter
     public static void constructorInvocation(
-        @Advice.Argument(value = 0, readOnly = false) CoroutineContext parentContext,
-        @Advice.Argument(value = 1) final boolean active) {
-      final ScopeStateCoroutineContext scopeStackContext = new ScopeStateCoroutineContext();
-      parentContext = parentContext.plus(scopeStackContext);
-      if (active) {
-        // if this is not a lazy coroutine, inherit parent span from the coroutine constructor call
-        // site
-        scopeStackContext.maybeInitialize();
+        @Advice.Argument(value = 0, readOnly = false) CoroutineContext parentContext) {
+      final ScopeStateCoroutineContext scopeStackContext = getScopeStateContext(parentContext);
+      if (scopeStackContext == null) {
+        parentContext =
+            parentContext.plus(
+                new ScopeStateCoroutineContext(
+                    InstrumentationContext.get(Job.class, ScopeStateCoroutineContextItem.class)));
       }
+    }
+
+    @Advice.OnMethodExit
+    public static void constructorInvocationOnMethodExit(
+        @Advice.This final AbstractCoroutine<?> coroutine,
+        @Advice.Argument(value = 1) final boolean active) {
+      // if this is not a lazy coroutine, inherit parent span from
+      // the coroutine constructor call site
+      initializeScopeStateContextIfActive(coroutine, active);
     }
   }
 }

--- a/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.5/src/main/java/datadog/trace/instrumentation/kotlin/coroutines/KotlinCoroutines15Instrumentation.java
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.5/src/main/java/datadog/trace/instrumentation/kotlin/coroutines/KotlinCoroutines15Instrumentation.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.kotlin.coroutines;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.instrumentation.kotlin.coroutines.CoroutineContextHelper.getScopeStateContext;
+import static datadog.trace.instrumentation.kotlin.coroutines.CoroutineContextHelper.initializeScopeStateContextIfActive;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -8,8 +10,11 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.instrumentation.kotlin.coroutines.ScopeStateCoroutineContext.ScopeStateCoroutineContextItem;
 import kotlin.coroutines.CoroutineContext;
 import kotlinx.coroutines.AbstractCoroutine;
+import kotlinx.coroutines.Job;
 import net.bytebuddy.asm.Advice;
 
 @AutoService(Instrumenter.class)
@@ -28,8 +33,7 @@ public class KotlinCoroutines15Instrumentation extends AbstractCoroutinesInstrum
   }
 
   /**
-   * Guarantees every coroutine created has a new instance of ScopeStateCoroutineContext, so that it
-   * is never inherited from the parent context.
+   * Guarantees every coroutine created has an instance of ScopeStateCoroutineContext
    *
    * @see ScopeStateCoroutineContext
    * @see AbstractCoroutine#AbstractCoroutine(CoroutineContext, boolean, boolean)
@@ -37,15 +41,23 @@ public class KotlinCoroutines15Instrumentation extends AbstractCoroutinesInstrum
   public static class AbstractCoroutineConstructorAdvice {
     @Advice.OnMethodEnter
     public static void constructorInvocation(
-        @Advice.Argument(value = 0, readOnly = false) CoroutineContext parentContext,
-        @Advice.Argument(value = 2) final boolean active) {
-      final ScopeStateCoroutineContext scopeStackContext = new ScopeStateCoroutineContext();
-      parentContext = parentContext.plus(scopeStackContext);
-      if (active) {
-        // if this is not a lazy coroutine, inherit parent span from the coroutine constructor call
-        // site
-        scopeStackContext.maybeInitialize();
+        @Advice.Argument(value = 0, readOnly = false) CoroutineContext parentContext) {
+      final ScopeStateCoroutineContext scopeStackContext = getScopeStateContext(parentContext);
+      if (scopeStackContext == null) {
+        parentContext =
+            parentContext.plus(
+                new ScopeStateCoroutineContext(
+                    InstrumentationContext.get(Job.class, ScopeStateCoroutineContextItem.class)));
       }
+    }
+
+    @Advice.OnMethodExit
+    public static void constructorInvocationOnMethodExit(
+        @Advice.This final AbstractCoroutine<?> coroutine,
+        @Advice.Argument(value = 2) final boolean active) {
+      // if this is not a lazy coroutine, inherit parent span from
+      // the coroutine constructor call site
+      initializeScopeStateContextIfActive(coroutine, active);
     }
   }
 }

--- a/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.5/src/test/groovy/KotlinCoroutineInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.5/src/test/groovy/KotlinCoroutineInstrumentationTest.groovy
@@ -12,7 +12,24 @@ class KotlinCoroutineInstrumentationTest extends AbstractKotlinCoroutineInstrume
   def "kotlin traced across flows"() {
     setup:
     KotlinCoroutineTests kotlinTest = new KotlinCoroutineTests(dispatcher)
-    int expectedNumberOfSpans = kotlinTest.tracedAcrossFlows()
+    int expectedNumberOfSpans = kotlinTest.tracedAcrossFlows(false)
+    TEST_WRITER.waitForTraces(1)
+    List<DDSpan> trace = TEST_WRITER.get(0)
+
+    expect:
+    trace.size() == expectedNumberOfSpans
+    trace[0].resourceName.toString() == "KotlinCoroutineTests.tracedAcrossFlows"
+    findSpan(trace, "produce_2").context().getParentId() == trace[0].context().getSpanId()
+    findSpan(trace, "consume_2").context().getParentId() == trace[0].context().getSpanId()
+
+    where:
+    dispatcher << AbstractKotlinCoroutineInstrumentationTest.dispatchersToTest
+  }
+
+  def "kotlin traced across flows with modified context"() {
+    setup:
+    KotlinCoroutineTests kotlinTest = new KotlinCoroutineTests(dispatcher)
+    int expectedNumberOfSpans = kotlinTest.tracedAcrossFlows(true)
     TEST_WRITER.waitForTraces(1)
     List<DDSpan> trace = TEST_WRITER.get(0)
 

--- a/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.5/src/test/kotlin/KotlinCoroutineTests.kt
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.5/src/test/kotlin/KotlinCoroutineTests.kt
@@ -6,16 +6,23 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 
 @SuppressFBWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
 class KotlinCoroutineTests(dispatcher: CoroutineDispatcher) : CoreKotlinCoroutineTests(dispatcher) {
 
   @Trace
-  fun tracedAcrossFlows(): Int = runTest {
+  fun tracedAcrossFlows(withModifiedContext: Boolean): Int = runTest {
     val producer = flow {
       repeat(3) {
         tracedChild("produce_$it")
-        emit(it)
+        if (withModifiedContext) {
+          withTimeout(100) {
+            emit(it)
+          }
+        } else {
+          emit(it)
+        }
       }
     }.flowOn(jobName("producer"))
 

--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/main/java/datadog/trace/instrumentation/kotlin/coroutines/CoroutineContextHelper.java
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/main/java/datadog/trace/instrumentation/kotlin/coroutines/CoroutineContextHelper.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.kotlin.coroutines;
 
 import kotlin.coroutines.CoroutineContext;
+import kotlinx.coroutines.AbstractCoroutine;
 import kotlinx.coroutines.Job;
 import org.jetbrains.annotations.Nullable;
 
@@ -18,5 +19,28 @@ public class CoroutineContextHelper {
   @Nullable
   public static ScopeStateCoroutineContext getScopeStateContext(final CoroutineContext context) {
     return context.get(ScopeStateCoroutineContext.KEY);
+  }
+
+  public static void initializeScopeStateContextIfActive(
+      final AbstractCoroutine<?> coroutine, final boolean active) {
+    if (active) {
+      initializeScopeStateContext(coroutine);
+    }
+  }
+
+  public static void initializeScopeStateContext(final AbstractCoroutine<?> coroutine) {
+    final ScopeStateCoroutineContext scopeStackContext =
+        getScopeStateContext(coroutine.getContext());
+    if (scopeStackContext != null) {
+      scopeStackContext.maybeInitialize(coroutine);
+    }
+  }
+
+  public static void closeScopeStateContext(final AbstractCoroutine<?> coroutine) {
+    final ScopeStateCoroutineContext scopeStackContext =
+        getScopeStateContext(coroutine.getContext());
+    if (scopeStackContext != null) {
+      scopeStackContext.maybeCloseScopeAndCancelContinuation(coroutine);
+    }
   }
 }

--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/main/java/datadog/trace/instrumentation/kotlin/coroutines/ScopeStateCoroutineContext.java
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/main/java/datadog/trace/instrumentation/kotlin/coroutines/ScopeStateCoroutineContext.java
@@ -1,10 +1,12 @@
 package datadog.trace.instrumentation.kotlin.coroutines;
 
+import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.ScopeState;
 import kotlin.coroutines.CoroutineContext;
 import kotlin.jvm.functions.Function2;
+import kotlinx.coroutines.Job;
 import kotlinx.coroutines.ThreadContextElement;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -12,27 +14,19 @@ import org.jetbrains.annotations.Nullable;
 public class ScopeStateCoroutineContext implements ThreadContextElement<ScopeState> {
 
   public static final Key<ScopeStateCoroutineContext> KEY = new ContextElementKey();
-  private final ScopeState coroutineScopeState;
-  @Nullable private AgentScope.Continuation continuation;
-  @Nullable private AgentScope continuationScope;
-  private boolean isInitialized = false;
 
-  public ScopeStateCoroutineContext() {
-    coroutineScopeState = AgentTracer.get().newScopeState();
+  private final ContextStore<Job, ScopeStateCoroutineContextItem> contextItemPerCoroutine;
+
+  public ScopeStateCoroutineContext(
+      final ContextStore<Job, ScopeStateCoroutineContextItem> contextItemPerCoroutine) {
+    this.contextItemPerCoroutine = contextItemPerCoroutine;
   }
 
-  /**
-   * If there is an active scope at the time of invocation, and it is async propagated, then
-   * captures the scope's continuation
-   */
-  public void maybeInitialize() {
-    if (!isInitialized) {
-      final AgentScope activeScope = AgentTracer.get().activeScope();
-      if (activeScope != null && activeScope.isAsyncPropagating()) {
-        continuation = activeScope.captureConcurrent();
-      }
-      isInitialized = true;
-    }
+  /** Get a context item instance for the coroutine and try to initialize it */
+  public void maybeInitialize(final Job coroutine) {
+    contextItemPerCoroutine
+        .putIfAbsent(coroutine, ScopeStateCoroutineContextItem::new)
+        .maybeInitialize();
   }
 
   @Override
@@ -46,33 +40,27 @@ public class ScopeStateCoroutineContext implements ThreadContextElement<ScopeSta
     final ScopeState oldScopeState = AgentTracer.get().newScopeState();
     oldScopeState.fetchFromActive();
 
-    coroutineScopeState.activate();
-
-    if (continuation != null && continuationScope == null) {
-      continuationScope = continuation.activate();
+    final Job coroutine = CoroutineContextHelper.getJob(coroutineContext);
+    final ScopeStateCoroutineContextItem contextItem = contextItemPerCoroutine.get(coroutine);
+    if (contextItem != null) {
+      contextItem.activate();
     }
 
     return oldScopeState;
   }
 
-  /**
-   * If the context element has a captured scope continuation and an active scope, then closes the
-   * scope and cancels the continuation.
-   */
-  public void maybeCloseScopeAndCancelContinuation() {
-    final ScopeState currentThreadScopeState = AgentTracer.get().newScopeState();
-    currentThreadScopeState.fetchFromActive();
+  /** If there's a context item for the coroutine then try to close it */
+  public void maybeCloseScopeAndCancelContinuation(final Job coroutine) {
+    final ScopeStateCoroutineContextItem contextItem = contextItemPerCoroutine.get(coroutine);
+    if (contextItem != null) {
+      final ScopeState currentThreadScopeState = AgentTracer.get().newScopeState();
+      currentThreadScopeState.fetchFromActive();
 
-    coroutineScopeState.activate();
+      contextItem.maybeCloseScopeAndCancelContinuation();
+      contextItemPerCoroutine.remove(coroutine);
 
-    if (continuationScope != null) {
-      continuationScope.close();
+      currentThreadScopeState.activate();
     }
-    if (continuation != null) {
-      continuation.cancel();
-    }
-
-    currentThreadScopeState.activate();
   }
 
   @Nullable
@@ -106,4 +94,52 @@ public class ScopeStateCoroutineContext implements ThreadContextElement<ScopeSta
   }
 
   static class ContextElementKey implements Key<ScopeStateCoroutineContext> {}
+
+  public static class ScopeStateCoroutineContextItem {
+    private final ScopeState coroutineScopeState;
+    @Nullable private AgentScope.Continuation continuation;
+    @Nullable private AgentScope continuationScope;
+    private boolean isInitialized = false;
+
+    public ScopeStateCoroutineContextItem() {
+      coroutineScopeState = AgentTracer.get().newScopeState();
+    }
+
+    public void activate() {
+      coroutineScopeState.activate();
+
+      if (continuation != null && continuationScope == null) {
+        continuationScope = continuation.activate();
+      }
+    }
+
+    /**
+     * If there is an active scope at the time of invocation, and it is async propagated, then
+     * captures the scope's continuation
+     */
+    public void maybeInitialize() {
+      if (!isInitialized) {
+        final AgentScope activeScope = AgentTracer.get().activeScope();
+        if (activeScope != null && activeScope.isAsyncPropagating()) {
+          continuation = activeScope.captureConcurrent();
+        }
+        isInitialized = true;
+      }
+    }
+
+    /**
+     * If the context item has a captured scope continuation and an active scope, then closes the
+     * scope and cancels the continuation.
+     */
+    public void maybeCloseScopeAndCancelContinuation() {
+      coroutineScopeState.activate();
+
+      if (continuationScope != null) {
+        continuationScope.close();
+      }
+      if (continuation != null) {
+        continuation.cancel();
+      }
+    }
+  }
 }


### PR DESCRIPTION
# What Does This Do
Makes `ScopeStateCoroutineContext` inheritable by introducing an internal map of a child coroutine (aka Job) (inheriting the context) to the context item holding the continuation. This way each child coroutine will hold the same context element while having individual state internally.
Solves #4718 .

# Motivation
To fix an `IllegalStateException` thrown by [this](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/common/src/flow/internal/SafeCollector.common.kt) Flows collector in case of a modified context.

# Additional Notes
This is a followup to #4405 and  #4624 