### PR TITLE
Fix docker base image gitlab jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -202,14 +202,13 @@ tracer-base-image-release:
       when: never
     - if: '$CI_COMMIT_BRANCH == "master" && $CI_COMMIT_TAG =~ /^v1\..*/'
       when: on_success
-    - when: manual
   dependencies:
   - build
   script:
     - echo $GH_TOKEN|docker login ghcr.io/datadog -u uploader --password-stdin
     - mkdir -p ./tooling/ci/binaries/ && cp workspace/dd-java-agent/build/libs/*.jar ./tooling/ci/binaries/dd-java-agent.jar
-    - docker build -t ghcr.io/datadog/system-tests/dd-trace-java:latest -f ./tooling/ci/Dockerfile .
-    - docker push ghcr.io/datadog/system-tests/dd-trace-java:latest  
+    - docker build -t ghcr.io/datadog/dd-trace-java/dd-trace-java:latest -f ./tooling/ci/Dockerfile .
+    - docker push ghcr.io/datadog/dd-trace-java/dd-trace-java:latest  
 
 tracer-base-image-snapshot:
   extends: .ci_authenticated_job
@@ -219,11 +218,10 @@ tracer-base-image-snapshot:
       when: never
     - if: '$CI_COMMIT_BRANCH == "master"'
       when: on_success
-    - when: manual
   dependencies:
   - build
   script:
     - echo $GH_TOKEN|docker login ghcr.io/datadog -u uploader --password-stdin
     - mkdir -p ./tooling/ci/binaries/ && cp workspace/dd-java-agent/build/libs/*.jar ./tooling/ci/binaries/dd-java-agent.jar
-    - docker build -t ghcr.io/datadog/system-tests/dd-trace-java:latest_snapshot -f ./tooling/ci/Dockerfile .
-    - docker push ghcr.io/datadog/system-tests/dd-trace-java:latest_snapshot  
+    - docker build -t ghcr.io/datadog/dd-trace-java/dd-trace-java:latest_snapshot -f ./tooling/ci/Dockerfile .
+    - docker push ghcr.io/datadog/dd-trace-java/dd-trace-java:latest_snapshot  


### PR DESCRIPTION
Two fixes:

* Change image path: from system-tests to dd-trace-java
* Remove manual trigger in order to avoid not ending checks in pull request. The build proccess will only trigger on a commit on master

# What Does This Do

# Motivation

# Additional Notes
