### PR TITLE
Xix Netty instrumentations to avoid errors when casting EmbeddedSocketAddress to InetSocketAddress

### DIFF
--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientRequestTracingHandler.java
@@ -15,6 +15,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
 import datadog.trace.instrumentation.netty38.ChannelTraceContext;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.MessageEvent;
@@ -58,7 +59,11 @@ public class HttpClientRequestTracingHandler extends SimpleChannelDownstreamHand
     try (final AgentScope scope = activateSpan(span)) {
       decorate.afterStart(span);
       decorate.onRequest(span, request);
-      decorate.onPeerConnection(span, (InetSocketAddress) ctx.getChannel().getRemoteAddress());
+
+      SocketAddress socketAddress = ctx.getChannel().getRemoteAddress();
+      if (socketAddress instanceof InetSocketAddress) {
+        decorate.onPeerConnection(span, (InetSocketAddress) socketAddress);
+      }
 
       propagate().inject(span, request.headers(), SETTER);
       propagate()


### PR DESCRIPTION
# What Does This Do
This change updates Netty instrumentations, adding a check to see if channel address can be cast to an `InetSocketAddress`, before this cast is executed.

# Motivation
Not every channel in Netty returns an `InetSocketAddress`, when asked for remote address.
There exists and `EmbeddedChannel` (used primarily for testing), which returns `EmbeddedSocketAddress`.
`EmbeddedSocketAddress` cannot be cast to `InetSocketAddress` (although they share the same parent - `SocketAddress` - which is the declared return type of the method that returns remote address), so instrumentation throws an exceptions when trying to perform the cast.

