### PR TITLE
Remove span name

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
@@ -43,7 +43,7 @@ public class DebuggerContext {
   }
 
   public interface Tracer {
-    DebuggerSpan createSpan(String operationName, String[] tags);
+    DebuggerSpan createSpan(String resourceName, String[] tags);
   }
 
   public interface SnapshotSerializer {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerProductChangesListener.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerProductChangesListener.java
@@ -2,6 +2,7 @@ package com.datadog.debugger.agent;
 
 import com.datadog.debugger.probe.LogProbe;
 import com.datadog.debugger.probe.MetricProbe;
+import com.datadog.debugger.probe.SpanProbe;
 import com.datadog.debugger.util.MoshiHelper;
 import com.squareup.moshi.JsonAdapter;
 import datadog.remoteconfig.state.ParsedConfigKey;
@@ -35,6 +36,9 @@ public class DebuggerProductChangesListener implements ProductListener {
     static final JsonAdapter<LogProbe> LOG_PROBE_JSON_ADAPTER =
         MoshiHelper.createMoshiConfig().adapter(LogProbe.class);
 
+    static final JsonAdapter<SpanProbe> SPAN_PROBE_JSON_ADAPTER =
+        MoshiHelper.createMoshiConfig().adapter(SpanProbe.class);
+
     static Configuration deserializeConfiguration(byte[] content) throws IOException {
       return CONFIGURATION_JSON_ADAPTER.fromJson(
           Okio.buffer(Okio.source(new ByteArrayInputStream(content))));
@@ -47,6 +51,11 @@ public class DebuggerProductChangesListener implements ProductListener {
 
     static LogProbe deserializeLogProbe(byte[] content) throws IOException {
       return LOG_PROBE_JSON_ADAPTER.fromJson(
+          Okio.buffer(Okio.source(new ByteArrayInputStream(content))));
+    }
+
+    static SpanProbe deserializeSpanProbe(byte[] content) throws IOException {
+      return SPAN_PROBE_JSON_ADAPTER.fromJson(
           Okio.buffer(Okio.source(new ByteArrayInputStream(content))));
     }
   }
@@ -80,6 +89,9 @@ public class DebuggerProductChangesListener implements ProductListener {
     } else if (configId.startsWith("logProbe_")) {
       LogProbe logProbe = Adapter.deserializeLogProbe(content);
       configChunks.put(configId, (builder) -> builder.add(logProbe.copy()));
+    } else if (configId.startsWith("spanProbe_")) {
+      SpanProbe spanProbe = Adapter.deserializeSpanProbe(content);
+      configChunks.put(configId, (builder) -> builder.add(spanProbe));
     } else if (IS_UUID.test(configId)) {
       Configuration newConfig = Adapter.deserializeConfiguration(content);
       if (newConfig.getService().equals(serviceName)) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTracer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTracer.java
@@ -8,13 +8,16 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 
 public class DebuggerTracer implements DebuggerContext.Tracer {
+  private static final String OPERATION_NAME = "dd.dynamic.span";
+
   @Override
-  public DebuggerSpan createSpan(String operationName, String[] tags) {
+  public DebuggerSpan createSpan(String resourceName, String[] tags) {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
     if (tracerAPI == null) {
       return DebuggerSpan.NOOP_SPAN;
     }
-    AgentSpan dynamicSpan = tracerAPI.startSpan(operationName);
+    AgentSpan dynamicSpan =
+        tracerAPI.buildSpan(OPERATION_NAME).withResourceName(resourceName).start();
     if (tags != null) {
       for (String tag : tags) {
         int idx = tag.indexOf(':');

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanProbe.java
@@ -10,21 +10,14 @@ import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.MethodNode;
 
 public class SpanProbe extends ProbeDefinition {
-  private String name;
   // no-arg constructor is required by Moshi to avoid creating instance with unsafe and by-passing
   // constructors, including field initializers.
   public SpanProbe() {
-    this(LANGUAGE, null, true, null, null, null);
+    this(LANGUAGE, null, true, null, null);
   }
 
-  public SpanProbe(
-      String language, String id, boolean active, String[] tagStrs, Where where, String name) {
+  public SpanProbe(String language, String id, boolean active, String[] tagStrs, Where where) {
     super(language, id, active, tagStrs, where, MethodLocation.DEFAULT);
-    this.name = name;
-  }
-
-  public String getName() {
-    return name;
   }
 
   @Override
@@ -39,7 +32,7 @@ public class SpanProbe extends ProbeDefinition {
   @Generated
   @Override
   public int hashCode() {
-    int result = Objects.hash(language, id, active, tagMap, where, evaluateAt, name);
+    int result = Objects.hash(language, id, active, tagMap, where, evaluateAt);
     result = 31 * result + Arrays.hashCode(tags);
     return result;
   }
@@ -56,8 +49,7 @@ public class SpanProbe extends ProbeDefinition {
         && Arrays.equals(tags, that.tags)
         && Objects.equals(tagMap, that.tagMap)
         && Objects.equals(where, that.where)
-        && Objects.equals(evaluateAt, that.evaluateAt)
-        && Objects.equals(name, that.name);
+        && Objects.equals(evaluateAt, that.evaluateAt);
   }
 
   @Generated
@@ -80,8 +72,6 @@ public class SpanProbe extends ProbeDefinition {
         + where
         + ", evaluateAt="
         + evaluateAt
-        + ", name="
-        + name
         + "} ";
   }
 
@@ -90,15 +80,8 @@ public class SpanProbe extends ProbeDefinition {
   }
 
   public static class Builder extends ProbeDefinition.Builder<Builder> {
-    private String name;
-
-    public SpanProbe.Builder name(String name) {
-      this.name = name;
-      return this;
-    }
-
     public SpanProbe build() {
-      return new SpanProbe(LANGUAGE, probeId, active, tagStrs, where, name);
+      return new SpanProbe(LANGUAGE, probeId, active, tagStrs, where);
     }
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
@@ -188,7 +188,6 @@ public class ConfigurationTest {
     // span probe
     assertEquals(1, config0.getSpanProbes().size());
     SpanProbe spanProbe1 = config0.getSpanProbes().iterator().next();
-    assertEquals("span", spanProbe1.getName());
     SpanProbe spanProbe2 = config1.getSpanProbes().iterator().next();
     assertEquals("12-23", spanProbe2.getWhere().getLines()[0]);
   }
@@ -200,7 +199,7 @@ public class ConfigurationTest {
     LogProbe log1 =
         createLog(
             "log1", "this is a log line with arg={arg}", "java.lang.String", "indexOf", "(String)");
-    SpanProbe span1 = createSpan("span1", "java.lang.String", "indexOf", "(String)", "span");
+    SpanProbe span1 = createSpan("span1", "java.lang.String", "indexOf", "(String)");
     Configuration.FilterList allowList =
         new Configuration.FilterList(
             Arrays.asList("java.lang.util"), Arrays.asList("java.lang.String"));
@@ -229,7 +228,7 @@ public class ConfigurationTest {
             "java.lang.String",
             "indexOf",
             "(String)");
-    SpanProbe span2 = createSpan("span2", "String.java", 12, 23, "span");
+    SpanProbe span2 = createSpan("span2", "String.java", 12, 23);
     Configuration.FilterList allowList =
         new Configuration.FilterList(
             Arrays.asList("java.lang.util"), Arrays.asList("java.lang.String"));
@@ -300,7 +299,7 @@ public class ConfigurationTest {
   }
 
   private static SpanProbe createSpan(
-      String id, String typeName, String methodName, String signature, String spanName) {
+      String id, String typeName, String methodName, String signature) {
     return SpanProbe.builder()
         .language("java")
         .probeId(id)
@@ -308,19 +307,16 @@ public class ConfigurationTest {
         .where(typeName, methodName, signature)
         .evaluateAt(ProbeDefinition.MethodLocation.ENTRY)
         .tags("tag1:value1", "tag2:value2")
-        .name(spanName)
         .build();
   }
 
-  private static SpanProbe createSpan(
-      String id, String sourceFile, int lineFrom, int lineTill, String spanName) {
+  private static SpanProbe createSpan(String id, String sourceFile, int lineFrom, int lineTill) {
     return SpanProbe.builder()
         .language("java")
         .probeId(id)
         .active(true)
         .where(sourceFile, lineFrom, lineTill)
         .tags("tag1:value1", "tag2:value2")
-        .name(spanName)
         .build();
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTracerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTracerTest.java
@@ -16,10 +16,14 @@ class DebuggerTracerTest {
     DebuggerTracer debuggerTracer = new DebuggerTracer();
     DebuggerSpan span = debuggerTracer.createSpan("a-span", new String[] {"foo:bar"});
     AgentSpan underlyingSpan = ((DebuggerTracer.DebuggerSpanImpl) span).underlyingSpan;
-    assertEquals("a-span", underlyingSpan.getSpanName());
+    assertEquals("dd.dynamic.span", underlyingSpan.getSpanName());
+    assertEquals("a-span", underlyingSpan.getResourceName());
     assertEquals(0, underlyingSpan.getDurationNano());
     assertEquals(
-        "a-span", ((DebuggerTracer.DebuggerSpanImpl) span).currentScope.span().getSpanName());
+        "dd.dynamic.span",
+        ((DebuggerTracer.DebuggerSpanImpl) span).currentScope.span().getSpanName());
+    assertEquals(
+        "a-span", ((DebuggerTracer.DebuggerSpanImpl) span).currentScope.span().getResourceName());
     span.finish();
     assertNotEquals(0, underlyingSpan.getDurationNano());
   }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanProbeInstrumentationTest.java
@@ -25,13 +25,12 @@ public class SpanProbeInstrumentationTest extends ProbeInstrumentationTest {
   @Test
   public void methodSimpleSpan() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
-    MockTracer tracer =
-        installSingleSpan(CLASS_NAME, "main", "int (java.lang.String)", "main-span", null);
+    MockTracer tracer = installSingleSpan(CLASS_NAME, "main", "int (java.lang.String)", null);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(3, result);
     assertEquals(1, tracer.spans.size());
-    assertEquals("main-span", tracer.spans.get(0).name);
+    assertEquals(CLASS_NAME + ".main", tracer.spans.get(0).resourceName);
     assertTrue(tracer.spans.get(0).isFinished());
   }
 
@@ -39,14 +38,13 @@ public class SpanProbeInstrumentationTest extends ProbeInstrumentationTest {
   public void methodSimpleSpanWithTags() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
     MockTracer tracer =
-        installSingleSpan(
-            CLASS_NAME, "main", "int (java.lang.String)", "main-span", "tag1:foo1", "tag2:foo2");
+        installSingleSpan(CLASS_NAME, "main", "int (java.lang.String)", "tag1:foo1", "tag2:foo2");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(3, result);
     assertEquals(1, tracer.spans.size());
     MockSpan span = tracer.spans.get(0);
-    assertEquals("main-span", span.name);
+    assertEquals(CLASS_NAME + ".main", span.resourceName);
     assertTrue(span.isFinished());
     Assert.assertArrayEquals(new String[] {"tag1:foo1", "tag2:foo2"}, span.tags);
   }
@@ -54,19 +52,19 @@ public class SpanProbeInstrumentationTest extends ProbeInstrumentationTest {
   @Test
   public void lineRangeSimpleSpan() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
-    MockTracer tracer = installSingleSpan(CLASS_NAME + ".java", 4, 8, "main-span", null);
+    MockTracer tracer = installSingleSpan(CLASS_NAME + ".java", 4, 8, null);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(3, result);
     assertEquals(1, tracer.spans.size());
-    assertEquals("main-span", tracer.spans.get(0).name);
+    assertEquals(CLASS_NAME + ".main:L4-8", tracer.spans.get(0).resourceName);
     assertTrue(tracer.spans.get(0).isFinished());
   }
 
   @Test
   public void invalidLineSimpleSpan() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
-    MockTracer tracer = installSingleSpan(CLASS_NAME + ".java", 4, 10, "main-span", null);
+    MockTracer tracer = installSingleSpan(CLASS_NAME + ".java", 4, 10, null);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(3, result);
@@ -77,14 +75,14 @@ public class SpanProbeInstrumentationTest extends ProbeInstrumentationTest {
   }
 
   private MockTracer installSingleSpan(
-      String typeName, String methodName, String signature, String spanName, String... tags) {
-    SpanProbe spanProbe = createSpan(SPAN_ID, spanName, typeName, methodName, signature, tags);
+      String typeName, String methodName, String signature, String... tags) {
+    SpanProbe spanProbe = createSpan(SPAN_ID, typeName, methodName, signature, tags);
     return installSpanProbes(spanProbe);
   }
 
   private MockTracer installSingleSpan(
-      String sourceFile, int lineFrom, int lineTill, String spanName, String... tags) {
-    SpanProbe spanProbe = createSpan(SPAN_ID, spanName, sourceFile, lineFrom, lineTill, tags);
+      String sourceFile, int lineFrom, int lineTill, String... tags) {
+    SpanProbe spanProbe = createSpan(SPAN_ID, sourceFile, lineFrom, lineTill, tags);
     return installSpanProbes(spanProbe);
   }
 
@@ -114,8 +112,8 @@ public class SpanProbeInstrumentationTest extends ProbeInstrumentationTest {
     List<MockSpan> spans = new ArrayList<>();
 
     @Override
-    public DebuggerSpan createSpan(String operationName, String[] tags) {
-      MockSpan mockSpan = new MockSpan(operationName, tags);
+    public DebuggerSpan createSpan(String resourceName, String[] tags) {
+      MockSpan mockSpan = new MockSpan(resourceName, tags);
       spans.add(mockSpan);
       return mockSpan;
     }
@@ -124,11 +122,11 @@ public class SpanProbeInstrumentationTest extends ProbeInstrumentationTest {
   static class MockSpan implements DebuggerSpan {
     boolean finished;
     Throwable throwable;
-    String name;
+    String resourceName;
     String[] tags;
 
-    public MockSpan(String name, String[] tags) {
-      this.name = name;
+    public MockSpan(String resourceName, String[] tags) {
+      this.resourceName = resourceName;
       this.tags = tags;
     }
 
@@ -148,27 +146,16 @@ public class SpanProbeInstrumentationTest extends ProbeInstrumentationTest {
   }
 
   private static SpanProbe createSpan(
-      String id,
-      String spanName,
-      String typeName,
-      String methodName,
-      String signature,
-      String[] tags) {
+      String id, String typeName, String methodName, String signature, String[] tags) {
     return SpanProbe.builder()
         .probeId(id)
         .where(typeName, methodName, signature)
         .tags(tags)
-        .name(spanName)
         .build();
   }
 
   private static SpanProbe createSpan(
-      String id, String spanName, String sourceFile, int lineFrom, int lineTill, String[] tags) {
-    return SpanProbe.builder()
-        .probeId(id)
-        .where(sourceFile, lineFrom, lineTill)
-        .tags(tags)
-        .name(spanName)
-        .build();
+      String id, String sourceFile, int lineFrom, int lineTill, String[] tags) {
+    return SpanProbe.builder().probeId(id).where(sourceFile, lineFrom, lineTill).tags(tags).build();
   }
 }


### PR DESCRIPTION
# What Does This Do
Use constant for OperationName (spanName)
Use method name eventually + line numbers for resource name 
make it deserializable from remote config

# Motivation

# Additional Notes
