### PR TITLE
Trace distributed work related to consuming SQS messages

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSHttpClientInstrumentation.java
@@ -14,6 +14,7 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import net.bytebuddy.asm.Advice;
 
 /**
@@ -54,7 +55,9 @@ public class AWSHttpClientInstrumentation extends Instrumenter.Tracing
 
       final AgentScope scope = activeScope();
       // check name in case TracingRequestHandler failed to activate the span
-      if (scope != null && AWS_HTTP.equals(scope.span().getSpanName())) {
+      if (scope != null
+          && (AWS_HTTP.equals(scope.span().getSpanName())
+              || scope.span() instanceof AgentTracer.NoopAgentSpan)) {
         scope.close();
       }
 
@@ -102,7 +105,9 @@ public class AWSHttpClientInstrumentation extends Instrumenter.Tracing
 
         final AgentScope scope = activeScope();
         // check name in case TracingRequestHandler failed to activate the span
-        if (scope != null && AWS_HTTP.equals(scope.span().getSpanName())) {
+        if (scope != null
+            && (AWS_HTTP.equals(scope.span().getSpanName())
+                || scope.span() instanceof AgentTracer.NoopAgentSpan)) {
           scope.close();
         }
 

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
@@ -4,6 +4,7 @@ import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.AmazonWebServiceResponse;
 import com.amazonaws.Request;
 import com.amazonaws.Response;
+import datadog.trace.api.Config;
 import datadog.trace.api.Functions;
 import datadog.trace.api.cache.QualifiedClassNameCache;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
@@ -23,6 +24,9 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
   private static final Pattern AMAZON_PATTERN = Pattern.compile("Amazon", Pattern.LITERAL);
 
   static final CharSequence COMPONENT_NAME = UTF8BytesString.create("java-aws-sdk");
+
+  public static final boolean AWS_LEGACY_TRACING =
+      Config.get().isLegacyTracingEnabled(false, "aws-sdk");
 
   private final QualifiedClassNameCache cache =
       new QualifiedClassNameCache(

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
@@ -28,6 +28,11 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
   public static final boolean AWS_LEGACY_TRACING =
       Config.get().isLegacyTracingEnabled(false, "aws-sdk");
 
+  public static final boolean SQS_LEGACY_TRACING = Config.get().isLegacyTracingEnabled(true, "sqs");
+
+  private static final String SQS_SERVICE_NAME =
+      AWS_LEGACY_TRACING || SQS_LEGACY_TRACING ? "sqs" : Config.get().getServiceName();
+
   private final QualifiedClassNameCache cache =
       new QualifiedClassNameCache(
           new Function<Class<?>, CharSequence>() {
@@ -68,7 +73,8 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
       case "SQS.SendMessageBatch":
       case "SQS.ReceiveMessage":
       case "SQS.DeleteMessage":
-        span.setServiceName("sqs");
+      case "SQS.DeleteMessageBatch":
+        span.setServiceName(SQS_SERVICE_NAME);
         break;
       case "SNS.Publish":
         span.setServiceName("sns");

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsClientInstrumentation.java
@@ -1,12 +1,16 @@
 package datadog.trace.instrumentation.aws.v2;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.InstrumentationContext;
 import java.util.List;
+import java.util.Map;
 import net.bytebuddy.asm.Advice;
+import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 
 /** AWS SDK v2 instrumentation */
@@ -17,6 +21,11 @@ public final class AwsClientInstrumentation extends AbstractAwsClientInstrumenta
   @Override
   public String instrumentedType() {
     return "software.amazon.awssdk.core.client.builder.SdkDefaultClientBuilder";
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return singletonMap("software.amazon.awssdk.core.SdkResponse", "java.lang.String");
   }
 
   @Override
@@ -34,7 +43,9 @@ public final class AwsClientInstrumentation extends AbstractAwsClientInstrumenta
           return; // list already has our interceptor, return to builder
         }
       }
-      interceptors.add(new TracingExecutionInterceptor());
+      interceptors.add(
+          new TracingExecutionInterceptor(
+              InstrumentationContext.get(SdkResponse.class, String.class)));
     }
   }
 }

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsHttpClientInstrumentation.java
@@ -14,6 +14,7 @@ import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -65,7 +66,9 @@ public final class AwsHttpClientInstrumentation extends AbstractAwsClientInstrum
     public static AgentScope methodEnter(@Advice.This final Object thiz) {
       final AgentScope scope = activeScope();
       // check name in case TracingExecutionInterceptor failed to activate the span
-      if (scope != null && AWS_HTTP.equals(scope.span().getSpanName())) {
+      if (scope != null
+          && (AWS_HTTP.equals(scope.span().getSpanName())
+              || scope.span() instanceof AgentTracer.NoopAgentSpan)) {
         if (thiz instanceof MakeAsyncHttpRequestStage) {
           scope.close(); // close async legacy HTTP span to avoid Netty leak
         } else {

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
@@ -29,6 +29,11 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
   public static final boolean AWS_LEGACY_TRACING =
       Config.get().isLegacyTracingEnabled(false, "aws-sdk");
 
+  public static final boolean SQS_LEGACY_TRACING = Config.get().isLegacyTracingEnabled(true, "sqs");
+
+  private static final String SQS_SERVICE_NAME =
+      AWS_LEGACY_TRACING || SQS_LEGACY_TRACING ? "sqs" : Config.get().getServiceName();
+
   public AgentSpan onSdkRequest(final AgentSpan span, final SdkRequest request) {
     // S3
     request
@@ -73,7 +78,8 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
       case "Sqs.SendMessageBatch":
       case "Sqs.ReceiveMessage":
       case "Sqs.DeleteMessage":
-        span.setServiceName("sqs");
+      case "Sqs.DeleteMessageBatch":
+        span.setServiceName(SQS_SERVICE_NAME);
         break;
       case "Sns.Publish":
         span.setServiceName("sns");

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.aws.v2;
 
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
@@ -24,6 +25,9 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
 
   // We only want tag interceptor to take priority
   private static final byte RESOURCE_NAME_PRIORITY = ResourceNamePriorities.TAG_INTERCEPTOR - 1;
+
+  public static final boolean AWS_LEGACY_TRACING =
+      Config.get().isLegacyTracingEnabled(false, "aws-sdk");
 
   public AgentSpan onSdkRequest(final AgentSpan span, final SdkRequest request) {
     // S3

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/TracingExecutionInterceptor.java
@@ -1,9 +1,11 @@
 package datadog.trace.instrumentation.aws.v2;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.aws.v2.AwsSdkClientDecorator.AWS_HTTP;
+import static datadog.trace.instrumentation.aws.v2.AwsSdkClientDecorator.AWS_LEGACY_TRACING;
 import static datadog.trace.instrumentation.aws.v2.AwsSdkClientDecorator.DECORATE;
 
 import datadog.trace.api.Config;
@@ -11,6 +13,7 @@ import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
@@ -28,6 +31,10 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
   @Override
   public void beforeExecution(
       final Context.BeforeExecution context, final ExecutionAttributes executionAttributes) {
+    if (!AWS_LEGACY_TRACING && isPollingRequest(context.request())) {
+      return; // SQS messages spans are created by aws-java-sqs-2.0
+    }
+
     final AgentSpan span = startSpan(AWS_HTTP);
     DECORATE.afterStart(span);
     executionAttributes.putAttribute(SPAN_ATTRIBUTE, span);
@@ -37,10 +44,11 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
   public void afterMarshalling(
       final Context.AfterMarshalling context, final ExecutionAttributes executionAttributes) {
     final AgentSpan span = executionAttributes.getAttribute(SPAN_ATTRIBUTE);
-
-    DECORATE.onRequest(span, context.httpRequest());
-    DECORATE.onSdkRequest(span, context.request());
-    DECORATE.onAttributes(span, executionAttributes);
+    if (span != null) {
+      DECORATE.onRequest(span, context.httpRequest());
+      DECORATE.onSdkRequest(span, context.request());
+      DECORATE.onAttributes(span, executionAttributes);
+    }
   }
 
   @Override
@@ -49,9 +57,11 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
     if (Config.get().isAwsPropagationEnabled()) {
       try {
         final AgentSpan span = executionAttributes.getAttribute(SPAN_ATTRIBUTE);
-        SdkHttpRequest.Builder requestBuilder = context.httpRequest().toBuilder();
-        propagate().inject(span, requestBuilder, DECORATE, TracePropagationStyle.XRAY);
-        return requestBuilder.build();
+        if (span != null) {
+          SdkHttpRequest.Builder requestBuilder = context.httpRequest().toBuilder();
+          propagate().inject(span, requestBuilder, DECORATE, TracePropagationStyle.XRAY);
+          return requestBuilder.build();
+        }
       } catch (Throwable e) {
         log.warn("Unable to inject trace header", e);
       }
@@ -62,10 +72,19 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
   @Override
   public void beforeTransmission(
       final Context.BeforeTransmission context, final ExecutionAttributes executionAttributes) {
-    final AgentSpan span = executionAttributes.getAttribute(SPAN_ATTRIBUTE);
-    // This scope will be closed by AwsHttpClientInstrumentation since ExecutionInterceptor API
-    // doesn't provide a way to run code in same thread after transmission has been scheduled.
-    activateSpan(span);
+    final AgentSpan span;
+    if (!AWS_LEGACY_TRACING && isPollingRequest(context.request())) {
+      // SQS messages spans are created by aws-java-sqs-2.0 - replace client scope with no-op,
+      // so we can tell when receive call is complete without affecting the rest of the trace
+      span = noopSpan();
+    } else {
+      span = executionAttributes.getAttribute(SPAN_ATTRIBUTE);
+    }
+    if (span != null) {
+      // This scope will be closed by AwsHttpClientInstrumentation since ExecutionInterceptor API
+      // doesn't provide a way to run code in same thread after transmission has been scheduled.
+      activateSpan(span);
+    }
   }
 
   @Override
@@ -92,6 +111,12 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
       DECORATE.beforeFinish(span);
       span.finish();
     }
+  }
+
+  private static boolean isPollingRequest(SdkRequest request) {
+    return null != request
+        && "software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest"
+            .equals(request.getClass().getName());
   }
 
   public static void muzzleCheck() {

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/AbstractSqsInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/AbstractSqsInstrumentation.java
@@ -1,0 +1,9 @@
+package datadog.trace.instrumentation.aws.v1.sqs;
+
+import datadog.trace.agent.tooling.Instrumenter;
+
+public abstract class AbstractSqsInstrumentation extends Instrumenter.Tracing {
+  public AbstractSqsInstrumentation() {
+    super("sqs", "aws-sdk");
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/MessageExtractAdapter.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/MessageExtractAdapter.java
@@ -1,0 +1,38 @@
+package datadog.trace.instrumentation.aws.v1.sqs;
+
+import com.amazonaws.services.sqs.model.Message;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class MessageExtractAdapter implements AgentPropagation.ContextVisitor<Message> {
+  private static final Logger log = LoggerFactory.getLogger(MessageExtractAdapter.class);
+
+  public static final MessageExtractAdapter GETTER = new MessageExtractAdapter();
+
+  @Override
+  public void forEachKey(Message carrier, AgentPropagation.KeyClassifier classifier) {
+    for (Map.Entry<String, String> entry : carrier.getAttributes().entrySet()) {
+      String key = entry.getKey();
+      if ("AWSTraceHeader".equalsIgnoreCase(key)) {
+        key = "X-Amzn-Trace-Id";
+      }
+      if (!classifier.accept(key, entry.getValue())) {
+        return;
+      }
+    }
+  }
+
+  public long extractTimeInQueueStart(final Message carrier) {
+    try {
+      Map<String, String> attributes = carrier.getAttributes();
+      if (attributes.containsKey("SentTimestamp")) {
+        return Long.parseLong(attributes.get("SentTimestamp"));
+      }
+    } catch (Exception e) {
+      log.debug("Unable to get SQS sent time", e);
+    }
+    return 0;
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/QueueBufferConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/QueueBufferConfigInstrumentation.java
@@ -16,11 +16,8 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(Instrumenter.class)
-public class QueueBufferConfigInstrumentation extends Instrumenter.Tracing
+public class QueueBufferConfigInstrumentation extends AbstractSqsInstrumentation
     implements Instrumenter.ForSingleType, Instrumenter.WithTypeStructure {
-  public QueueBufferConfigInstrumentation() {
-    super("aws-sdk");
-  }
 
   @Override
   public String instrumentedType() {

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsDecorator.java
@@ -1,0 +1,77 @@
+package datadog.trace.instrumentation.aws.v1.sqs;
+
+import static datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes.MESSAGE_BROKER;
+import static datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes.MESSAGE_CONSUMER;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_BROKER;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_CONSUMER;
+
+import datadog.trace.api.Config;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import datadog.trace.bootstrap.instrumentation.decorator.MessagingClientDecorator;
+
+public class SqsDecorator extends MessagingClientDecorator {
+
+  public static final CharSequence AWS_HTTP = UTF8BytesString.create("aws.http");
+  static final CharSequence COMPONENT_NAME = UTF8BytesString.create("java-aws-sdk");
+
+  public static final CharSequence SQS_RECEIVE = UTF8BytesString.create("SQS.ReceiveMessage");
+  public static final CharSequence SQS_DELIVER = UTF8BytesString.create("SQS.DeliverMessage");
+
+  public static final boolean SQS_LEGACY_TRACING =
+      Config.get().isLegacyTracingEnabled(false, "sqs");
+
+  private final String spanKind;
+  private final CharSequence spanType;
+  private final String serviceName;
+
+  private static final String LOCAL_SERVICE_NAME =
+      SQS_LEGACY_TRACING ? "sqs" : Config.get().getServiceName();
+
+  public static final SqsDecorator CONSUMER_DECORATE =
+      new SqsDecorator(SPAN_KIND_CONSUMER, MESSAGE_CONSUMER, LOCAL_SERVICE_NAME);
+
+  public static final SqsDecorator BROKER_DECORATE =
+      new SqsDecorator(
+          SPAN_KIND_BROKER, MESSAGE_BROKER, null /* service name will be set later on */);
+
+  protected SqsDecorator(String spanKind, CharSequence spanType, String serviceName) {
+    this.spanKind = spanKind;
+    this.spanType = spanType;
+    this.serviceName = serviceName;
+  }
+
+  @Override
+  protected CharSequence spanType() {
+    return spanType;
+  }
+
+  @Override
+  protected String[] instrumentationNames() {
+    return new String[] {"aws-sdk"};
+  }
+
+  @Override
+  protected String service() {
+    return serviceName;
+  }
+
+  @Override
+  protected CharSequence component() {
+    return COMPONENT_NAME;
+  }
+
+  @Override
+  protected String spanKind() {
+    return spanKind;
+  }
+
+  public void onConsume(final AgentSpan span) {
+    span.setResourceName(SQS_RECEIVE);
+  }
+
+  public void onTimeInQueue(final AgentSpan span) {
+    span.setResourceName(SQS_DELIVER);
+    span.setServiceName("sqs");
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsDecorator.java
@@ -18,8 +18,7 @@ public class SqsDecorator extends MessagingClientDecorator {
   public static final CharSequence SQS_RECEIVE = UTF8BytesString.create("SQS.ReceiveMessage");
   public static final CharSequence SQS_DELIVER = UTF8BytesString.create("SQS.DeliverMessage");
 
-  public static final boolean SQS_LEGACY_TRACING =
-      Config.get().isLegacyTracingEnabled(false, "sqs");
+  public static final boolean SQS_LEGACY_TRACING = Config.get().isLegacyTracingEnabled(true, "sqs");
 
   private final String spanKind;
   private final CharSequence spanType;
@@ -66,12 +65,17 @@ public class SqsDecorator extends MessagingClientDecorator {
     return spanKind;
   }
 
-  public void onConsume(final AgentSpan span) {
+  public void onConsume(final AgentSpan span, final String queueUrl) {
     span.setResourceName(SQS_RECEIVE);
+    span.setTag("aws.service", "AmazonSQS");
+    span.setTag("aws.operation", "ReceiveMessageRequest");
+    span.setTag("aws.agent", COMPONENT_NAME);
+    span.setTag("aws.queue.url", queueUrl);
   }
 
-  public void onTimeInQueue(final AgentSpan span) {
-    span.setResourceName(SQS_DELIVER);
+  public void onTimeInQueue(final AgentSpan span, final String queueUrl) {
     span.setServiceName("sqs");
+    span.setResourceName(SQS_DELIVER);
+    span.setTag("aws.queue.url", queueUrl);
   }
 }

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsJmsMessageInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsJmsMessageInstrumentation.java
@@ -15,11 +15,8 @@ import javax.jms.JMSException;
 import net.bytebuddy.asm.Advice;
 
 @AutoService(Instrumenter.class)
-public class SqsJmsMessageInstrumentation extends Instrumenter.Tracing
+public class SqsJmsMessageInstrumentation extends AbstractSqsInstrumentation
     implements Instrumenter.ForSingleType {
-  public SqsJmsMessageInstrumentation() {
-    super("aws-sdk");
-  }
 
   @Override
   public String instrumentedType() {

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsReceiveRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsReceiveRequestInstrumentation.java
@@ -1,14 +1,20 @@
 package datadog.trace.instrumentation.aws.v1.sqs;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
-import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.amazonaws.services.sqs.model.ReceiveMessageResult;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.Config;
+import datadog.trace.bootstrap.InstrumentationContext;
 import java.util.List;
+import java.util.Map;
 import net.bytebuddy.asm.Advice;
 
 @AutoService(Instrumenter.class)
@@ -17,19 +23,28 @@ public class SqsReceiveRequestInstrumentation extends AbstractSqsInstrumentation
 
   @Override
   public String instrumentedType() {
-    return "com.amazonaws.services.sqs.model.ReceiveMessageRequest";
+    return "com.amazonaws.services.sqs.AmazonSQSClient";
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return singletonMap(
+        "com.amazonaws.services.sqs.model.ReceiveMessageResult", "java.lang.String");
   }
 
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(
-        isConstructor().or(isMethod().and(namedOneOf("setAttributeNames", "withAttributeNames"))),
+        isMethod()
+            .and(namedOneOf("receiveMessage", "executeReceiveMessage"))
+            .and(takesArgument(0, named("com.amazonaws.services.sqs.model.ReceiveMessageRequest")))
+            .and(returns(named("com.amazonaws.services.sqs.model.ReceiveMessageResult"))),
         getClass().getName() + "$ReceiveMessageRequestAdvice");
   }
 
   public static class ReceiveMessageRequestAdvice {
-    @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void onExit(@Advice.This ReceiveMessageRequest request) {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter(@Advice.Argument(0) ReceiveMessageRequest request) {
       if (Config.get().isSqsPropagationEnabled()) {
         // ReceiveMessageRequest always returns a mutable list which we can append to
         List<String> attributeNames = request.getAttributeNames();
@@ -40,6 +55,15 @@ public class SqsReceiveRequestInstrumentation extends AbstractSqsInstrumentation
         }
         attributeNames.add("AWSTraceHeader");
       }
+    }
+
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onExit(
+        @Advice.Argument(0) ReceiveMessageRequest request,
+        @Advice.Return ReceiveMessageResult result) {
+      // store queueUrl inside response for SqsReceiveResultInstrumentation
+      InstrumentationContext.get(ReceiveMessageResult.class, String.class)
+          .put(result, request.getQueueUrl());
     }
   }
 }

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsReceiveRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsReceiveRequestInstrumentation.java
@@ -12,11 +12,8 @@ import java.util.List;
 import net.bytebuddy.asm.Advice;
 
 @AutoService(Instrumenter.class)
-public class SqsReceiveRequestInstrumentation extends Instrumenter.Tracing
+public class SqsReceiveRequestInstrumentation extends AbstractSqsInstrumentation
     implements Instrumenter.ForSingleType {
-  public SqsReceiveRequestInstrumentation() {
-    super("aws-sdk");
-  }
 
   @Override
   public String instrumentedType() {

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsReceiveResultInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsReceiveResultInstrumentation.java
@@ -13,11 +13,8 @@ import java.util.List;
 import net.bytebuddy.asm.Advice;
 
 @AutoService(Instrumenter.class)
-public class SqsReceiveResultInstrumentation extends Instrumenter.Tracing
+public class SqsReceiveResultInstrumentation extends AbstractSqsInstrumentation
     implements Instrumenter.ForSingleType {
-  public SqsReceiveResultInstrumentation() {
-    super("aws-sdk");
-  }
 
   @Override
   public String instrumentedType() {

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsReceiveResultInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsReceiveResultInstrumentation.java
@@ -1,0 +1,62 @@
+package datadog.trace.instrumentation.aws.v1.sqs;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+
+import com.amazonaws.services.sqs.model.Message;
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.InstrumenterConfig;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.util.List;
+import net.bytebuddy.asm.Advice;
+
+@AutoService(Instrumenter.class)
+public class SqsReceiveResultInstrumentation extends Instrumenter.Tracing
+    implements Instrumenter.ForSingleType {
+  public SqsReceiveResultInstrumentation() {
+    super("aws-sdk");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "com.amazonaws.services.sqs.model.ReceiveMessageResult";
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return super.isEnabled()
+        // we don't need to instrument messages when we're doing legacy AWS-SDK tracing
+        && !InstrumenterConfig.get().isLegacyInstrumentationEnabled(false, "aws-sdk");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".MessageExtractAdapter",
+      packageName + ".SqsDecorator",
+      packageName + ".TracingIterator",
+      packageName + ".TracingList",
+      packageName + ".TracingListIterator"
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod().and(named("getMessages")), getClass().getName() + "$GetMessagesAdvice");
+  }
+
+  public static class GetMessagesAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onExit(@Advice.Return(readOnly = false) List<Message> messages) {
+      if (messages != null
+          && !messages.isEmpty()
+          && !(messages instanceof TracingList)
+          && !(activeSpan() instanceof AgentTracer.NoopAgentSpan)) {
+        messages = new TracingList(messages);
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingIterator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingIterator.java
@@ -23,6 +23,7 @@ public class TracingIterator<L extends Iterator<Message>> implements Iterator<Me
 
   protected final L delegate;
   private final String queueUrl;
+  private AgentSpan.Context batchContext;
 
   public TracingIterator(L delegate, String queueUrl) {
     this.delegate = delegate;
@@ -50,33 +51,37 @@ public class TracingIterator<L extends Iterator<Message>> implements Iterator<Me
     try {
       closePrevious(true);
       if (message != null) {
-        AgentSpan span, queueSpan = null;
-        if (Config.get().isSqsPropagationEnabled()) {
-          AgentSpan.Context spanContext = propagate().extract(message, GETTER);
-          long timeInQueueStart = GETTER.extractTimeInQueueStart(message);
-          if (timeInQueueStart == 0 || SQS_LEGACY_TRACING) {
-            span = startSpan(AWS_HTTP, spanContext);
-          } else {
-            queueSpan = startSpan(AWS_HTTP, spanContext, MILLISECONDS.toMicros(timeInQueueStart));
-            BROKER_DECORATE.afterStart(queueSpan);
-            BROKER_DECORATE.onTimeInQueue(queueSpan, queueUrl);
-            span = startSpan(AWS_HTTP, queueSpan.context());
-            BROKER_DECORATE.beforeFinish(queueSpan);
-            // The queueSpan will be finished after inner span has been activated to ensure that
-            // spans are written out together by TraceStructureWriter when running in strict mode
+        AgentSpan queueSpan = null;
+        if (batchContext == null) {
+          // first grab any incoming distributed context
+          AgentSpan.Context spanContext =
+              Config.get().isSqsPropagationEnabled() ? propagate().extract(message, GETTER) : null;
+          // next add a time-in-queue span for non-legacy SQS traces
+          if (!SQS_LEGACY_TRACING) {
+            long timeInQueueStart = GETTER.extractTimeInQueueStart(message);
+            if (timeInQueueStart > 0) {
+              queueSpan = startSpan(AWS_HTTP, spanContext, MILLISECONDS.toMicros(timeInQueueStart));
+              BROKER_DECORATE.afterStart(queueSpan);
+              BROKER_DECORATE.onTimeInQueue(queueSpan, queueUrl);
+              spanContext = queueSpan.context();
+              // The queueSpan will be finished after inner span has been activated to ensure that
+              // spans are written out together by TraceStructureWriter when running in strict mode
+            }
           }
-        } else {
-          span = startSpan(AWS_HTTP, null);
+          // re-use this context for any other messages received in this batch
+          batchContext = spanContext;
         }
+        AgentSpan span = startSpan(AWS_HTTP, batchContext);
         CONSUMER_DECORATE.afterStart(span);
         CONSUMER_DECORATE.onConsume(span, queueUrl);
         activateNext(span);
-        if (null != queueSpan) {
+        if (queueSpan != null) {
+          BROKER_DECORATE.beforeFinish(queueSpan);
           queueSpan.finish();
         }
       }
     } catch (Exception e) {
-      log.debug("Error starting new message span", e);
+      log.debug("Problem tracing new SQS message span", e);
     }
   }
 

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingIterator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingIterator.java
@@ -22,9 +22,11 @@ public class TracingIterator<L extends Iterator<Message>> implements Iterator<Me
   private static final Logger log = LoggerFactory.getLogger(TracingIterator.class);
 
   protected final L delegate;
+  private final String queueUrl;
 
-  public TracingIterator(L delegate) {
+  public TracingIterator(L delegate, String queueUrl) {
     this.delegate = delegate;
+    this.queueUrl = queueUrl;
   }
 
   @Override
@@ -57,7 +59,7 @@ public class TracingIterator<L extends Iterator<Message>> implements Iterator<Me
           } else {
             queueSpan = startSpan(AWS_HTTP, spanContext, MILLISECONDS.toMicros(timeInQueueStart));
             BROKER_DECORATE.afterStart(queueSpan);
-            BROKER_DECORATE.onTimeInQueue(queueSpan);
+            BROKER_DECORATE.onTimeInQueue(queueSpan, queueUrl);
             span = startSpan(AWS_HTTP, queueSpan.context());
             BROKER_DECORATE.beforeFinish(queueSpan);
             // The queueSpan will be finished after inner span has been activated to ensure that
@@ -67,7 +69,7 @@ public class TracingIterator<L extends Iterator<Message>> implements Iterator<Me
           span = startSpan(AWS_HTTP, null);
         }
         CONSUMER_DECORATE.afterStart(span);
-        CONSUMER_DECORATE.onConsume(span);
+        CONSUMER_DECORATE.onConsume(span, queueUrl);
         activateNext(span);
         if (null != queueSpan) {
           queueSpan.finish();

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingIterator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingIterator.java
@@ -1,0 +1,85 @@
+package datadog.trace.instrumentation.aws.v1.sqs;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateNext;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.closePrevious;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.aws.v1.sqs.MessageExtractAdapter.GETTER;
+import static datadog.trace.instrumentation.aws.v1.sqs.SqsDecorator.AWS_HTTP;
+import static datadog.trace.instrumentation.aws.v1.sqs.SqsDecorator.BROKER_DECORATE;
+import static datadog.trace.instrumentation.aws.v1.sqs.SqsDecorator.CONSUMER_DECORATE;
+import static datadog.trace.instrumentation.aws.v1.sqs.SqsDecorator.SQS_LEGACY_TRACING;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import com.amazonaws.services.sqs.model.Message;
+import datadog.trace.api.Config;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.util.Iterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TracingIterator<L extends Iterator<Message>> implements Iterator<Message> {
+  private static final Logger log = LoggerFactory.getLogger(TracingIterator.class);
+
+  protected final L delegate;
+
+  public TracingIterator(L delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public boolean hasNext() {
+    boolean moreMessages = delegate.hasNext();
+    if (!moreMessages) {
+      // no more messages, use this as a signal to close the last iteration scope
+      closePrevious(true);
+    }
+    return moreMessages;
+  }
+
+  @Override
+  public Message next() {
+    Message next = delegate.next();
+    startNewMessageSpan(next);
+    return next;
+  }
+
+  protected void startNewMessageSpan(Message message) {
+    try {
+      closePrevious(true);
+      if (message != null) {
+        AgentSpan span, queueSpan = null;
+        if (Config.get().isSqsPropagationEnabled()) {
+          AgentSpan.Context spanContext = propagate().extract(message, GETTER);
+          long timeInQueueStart = GETTER.extractTimeInQueueStart(message);
+          if (timeInQueueStart == 0 || SQS_LEGACY_TRACING) {
+            span = startSpan(AWS_HTTP, spanContext);
+          } else {
+            queueSpan = startSpan(AWS_HTTP, spanContext, MILLISECONDS.toMicros(timeInQueueStart));
+            BROKER_DECORATE.afterStart(queueSpan);
+            BROKER_DECORATE.onTimeInQueue(queueSpan);
+            span = startSpan(AWS_HTTP, queueSpan.context());
+            BROKER_DECORATE.beforeFinish(queueSpan);
+            // The queueSpan will be finished after inner span has been activated to ensure that
+            // spans are written out together by TraceStructureWriter when running in strict mode
+          }
+        } else {
+          span = startSpan(AWS_HTTP, null);
+        }
+        CONSUMER_DECORATE.afterStart(span);
+        CONSUMER_DECORATE.onConsume(span);
+        activateNext(span);
+        if (null != queueSpan) {
+          queueSpan.finish();
+        }
+      }
+    } catch (Exception e) {
+      log.debug("Error starting new message span", e);
+    }
+  }
+
+  @Override
+  public void remove() {
+    delegate.remove();
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingList.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingList.java
@@ -1,0 +1,137 @@
+package datadog.trace.instrumentation.aws.v1.sqs;
+
+import com.amazonaws.services.sqs.model.Message;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+
+public class TracingList implements List<Message> {
+  private final List<Message> delegate;
+
+  public TracingList(List<Message> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public int size() {
+    return delegate.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return delegate.isEmpty();
+  }
+
+  @Override
+  public boolean contains(Object o) {
+    return delegate.contains(o);
+  }
+
+  @Override
+  public Iterator<Message> iterator() {
+    return listIterator(0);
+  }
+
+  @Override
+  public Object[] toArray() {
+    return delegate.toArray();
+  }
+
+  @Override
+  public <T> T[] toArray(T[] a) {
+    return delegate.toArray(a);
+  }
+
+  @Override
+  public boolean add(Message message) {
+    return delegate.add(message);
+  }
+
+  @Override
+  public boolean remove(Object o) {
+    return delegate.remove(o);
+  }
+
+  @Override
+  public boolean containsAll(Collection<?> c) {
+    return delegate.containsAll(c);
+  }
+
+  @Override
+  public boolean addAll(Collection<? extends Message> c) {
+    return delegate.addAll(c);
+  }
+
+  @Override
+  public boolean addAll(int index, Collection<? extends Message> c) {
+    return delegate.addAll(index, c);
+  }
+
+  @Override
+  public boolean removeAll(Collection<?> c) {
+    return delegate.removeAll(c);
+  }
+
+  @Override
+  public boolean retainAll(Collection<?> c) {
+    return delegate.retainAll(c);
+  }
+
+  @Override
+  public void clear() {
+    delegate.clear();
+  }
+
+  @Override
+  public Message get(int index) {
+    // TODO: should this be instrumented as well?
+    return delegate.get(index);
+  }
+
+  @Override
+  public Message set(int index, Message element) {
+    return delegate.set(index, element);
+  }
+
+  @Override
+  public void add(int index, Message element) {
+    delegate.add(index, element);
+  }
+
+  @Override
+  public Message remove(int index) {
+    return delegate.remove(index);
+  }
+
+  @Override
+  public int indexOf(Object o) {
+    return delegate.indexOf(o);
+  }
+
+  @Override
+  public int lastIndexOf(Object o) {
+    return delegate.lastIndexOf(o);
+  }
+
+  @Override
+  public ListIterator<Message> listIterator() {
+    return listIterator(0);
+  }
+
+  @Override
+  public ListIterator<Message> listIterator(int index) {
+    // every iteration will add spans. Not only the very first one
+    return new TracingListIterator(delegate.listIterator(index));
+  }
+
+  @Override
+  public List<Message> subList(int fromIndex, int toIndex) {
+    return new TracingList(delegate.subList(fromIndex, toIndex));
+  }
+
+  @Override
+  public String toString() {
+    return delegate.toString();
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingList.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingList.java
@@ -8,9 +8,11 @@ import java.util.ListIterator;
 
 public class TracingList implements List<Message> {
   private final List<Message> delegate;
+  private final String queueUrl;
 
-  public TracingList(List<Message> delegate) {
+  public TracingList(List<Message> delegate, String queueUrl) {
     this.delegate = delegate;
+    this.queueUrl = queueUrl;
   }
 
   @Override
@@ -85,8 +87,7 @@ public class TracingList implements List<Message> {
 
   @Override
   public Message get(int index) {
-    // TODO: should this be instrumented as well?
-    return delegate.get(index);
+    return delegate.get(index); // not currently covered by iteration span
   }
 
   @Override
@@ -122,12 +123,12 @@ public class TracingList implements List<Message> {
   @Override
   public ListIterator<Message> listIterator(int index) {
     // every iteration will add spans. Not only the very first one
-    return new TracingListIterator(delegate.listIterator(index));
+    return new TracingListIterator(delegate.listIterator(index), queueUrl);
   }
 
   @Override
   public List<Message> subList(int fromIndex, int toIndex) {
-    return new TracingList(delegate.subList(fromIndex, toIndex));
+    return new TracingList(delegate.subList(fromIndex, toIndex), queueUrl);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingListIterator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingListIterator.java
@@ -8,8 +8,8 @@ import java.util.ListIterator;
 public class TracingListIterator extends TracingIterator<ListIterator<Message>>
     implements ListIterator<Message> {
 
-  public TracingListIterator(ListIterator<Message> delegate) {
-    super(delegate);
+  public TracingListIterator(ListIterator<Message> delegate, String queueUrl) {
+    super(delegate, queueUrl);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingListIterator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingListIterator.java
@@ -1,0 +1,51 @@
+package datadog.trace.instrumentation.aws.v1.sqs;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.closePrevious;
+
+import com.amazonaws.services.sqs.model.Message;
+import java.util.ListIterator;
+
+public class TracingListIterator extends TracingIterator<ListIterator<Message>>
+    implements ListIterator<Message> {
+
+  public TracingListIterator(ListIterator<Message> delegate) {
+    super(delegate);
+  }
+
+  @Override
+  public boolean hasPrevious() {
+    boolean moreMessages = delegate.hasPrevious();
+    if (!moreMessages) {
+      // no more messages, use this as a signal to close the last iteration scope
+      closePrevious(true);
+    }
+    return moreMessages;
+  }
+
+  @Override
+  public Message previous() {
+    Message prev = delegate.previous();
+    startNewMessageSpan(prev);
+    return prev;
+  }
+
+  @Override
+  public int nextIndex() {
+    return delegate.nextIndex();
+  }
+
+  @Override
+  public int previousIndex() {
+    return delegate.previousIndex();
+  }
+
+  @Override
+  public void set(Message message) {
+    delegate.set(message);
+  }
+
+  @Override
+  public void add(Message message) {
+    delegate.add(message);
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/SqsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/SqsClientTest.groovy
@@ -30,7 +30,7 @@ class SqsClientTest extends AgentTestRunner {
   protected void configurePreAgent() {
     super.configurePreAgent()
     // Set a service name that gets sorted early with SORT_BY_NAMES
-    injectSysConfig(GeneralConfig.SERVICE_NAME, "A")
+    injectSysConfig(GeneralConfig.SERVICE_NAME, "A-service")
   }
 
   @Shared
@@ -62,6 +62,8 @@ class SqsClientTest extends AgentTestRunner {
       client.sendMessage(queueUrl, 'sometext')
     })
     def messages = client.receiveMessage(queueUrl).messages
+
+    messages.forEach {/* consume to create message spans */ }
 
     then:
     def sendSpan
@@ -99,24 +101,18 @@ class SqsClientTest extends AgentTestRunner {
           serviceName "sqs"
           operationName "aws.http"
           resourceName "SQS.ReceiveMessage"
-          spanType DDSpanTypes.HTTP_CLIENT
+          spanType DDSpanTypes.MESSAGE_CONSUMER
           errored false
           measured true
-          parent()
+          childOf(sendSpan)
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
-            "$Tags.HTTP_METHOD" "POST"
-            "$Tags.HTTP_STATUS" 200
-            "$Tags.PEER_PORT" address.port
-            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "aws.service" "AmazonSQS"
-            "aws.endpoint" "http://localhost:${address.port}"
             "aws.operation" "ReceiveMessageRequest"
             "aws.agent" "java-aws-sdk"
             "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
-            defaultTags()
+            defaultTags(true)
           }
         }
       }
@@ -236,24 +232,18 @@ class SqsClientTest extends AgentTestRunner {
           serviceName "sqs"
           operationName "aws.http"
           resourceName "SQS.ReceiveMessage"
-          spanType DDSpanTypes.HTTP_CLIENT
+          spanType DDSpanTypes.MESSAGE_CONSUMER
           errored false
           measured true
-          parent()
+          childOf(sendSpan)
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
-            "$Tags.HTTP_METHOD" "POST"
-            "$Tags.HTTP_STATUS" 200
-            "$Tags.PEER_PORT" address.port
-            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "aws.service" "AmazonSQS"
-            "aws.endpoint" "http://localhost:${address.port}"
             "aws.operation" "ReceiveMessageRequest"
             "aws.agent" "java-aws-sdk"
             "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
-            defaultTags()
+            defaultTags(true)
           }
         }
       }

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/TimeInQueueForkedTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/TimeInQueueForkedTest.groovy
@@ -56,7 +56,7 @@ class TimeInQueueForkedTest extends AgentTestRunner {
     "just one more message"
   ]
 
-  def "sync messages without SentTimestamps have no time-in-queue spans"() {
+  def "sync messages without SentTimestamps have no time-in-queue span"() {
     setup:
     def client = AmazonSQSClientBuilder.standard()
       .withEndpointConfiguration(endpoint)
@@ -92,7 +92,7 @@ class TimeInQueueForkedTest extends AgentTestRunner {
     client.shutdown()
   }
 
-  def "async messages without SentTimestamps have no time-in-queue spans"() {
+  def "async messages without SentTimestamps have no time-in-queue span"() {
     setup:
     def client = AmazonSQSAsyncClientBuilder.standard()
       .withEndpointConfiguration(endpoint)
@@ -128,7 +128,7 @@ class TimeInQueueForkedTest extends AgentTestRunner {
     client.shutdown()
   }
 
-  def "sync messages with SentTimestamps have time-in-queue spans"() {
+  def "sync messages with SentTimestamps have time-in-queue span"() {
     setup:
     def client = AmazonSQSClientBuilder.standard()
       .withEndpointConfiguration(endpoint)
@@ -165,7 +165,7 @@ class TimeInQueueForkedTest extends AgentTestRunner {
     client.shutdown()
   }
 
-  def "async messages with SentTimestamps have time-in-queue spans"() {
+  def "async messages with SentTimestamps have time-in-queue span"() {
     setup:
     def client = AmazonSQSAsyncClientBuilder.standard()
       .withEndpointConfiguration(endpoint)
@@ -229,7 +229,7 @@ class TimeInQueueForkedTest extends AgentTestRunner {
   }
 
   private void assertSqsTraceWithTimeInQueue() {
-    def sendSpan
+    def sendSpan, queueSpan
     assertTraces(6) {
       trace(2) {
         basicSpan(it, "parent")
@@ -239,22 +239,19 @@ class TimeInQueueForkedTest extends AgentTestRunner {
       trace(2) {
         consumerSpan(it, span(1))
         timeInQueueSpan(it, sendSpan)
+        queueSpan = span(1)
       }
-      trace(2) {
-        consumerSpan(it, span(1))
-        timeInQueueSpan(it, sendSpan)
+      trace(1) {
+        consumerSpan(it, queueSpan)
       }
-      trace(2) {
-        consumerSpan(it, span(1))
-        timeInQueueSpan(it, sendSpan)
+      trace(1) {
+        consumerSpan(it, queueSpan)
       }
-      trace(2) {
-        consumerSpan(it, span(1))
-        timeInQueueSpan(it, sendSpan)
+      trace(1) {
+        consumerSpan(it, queueSpan)
       }
-      trace(2) {
-        consumerSpan(it, span(1))
-        timeInQueueSpan(it, sendSpan)
+      trace(1) {
+        consumerSpan(it, queueSpan)
       }
     }
   }

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/TimeInQueueForkedTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/TimeInQueueForkedTest.groovy
@@ -1,0 +1,327 @@
+import com.amazonaws.SDKGlobalConfiguration
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.AnonymousAWSCredentials
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest
+import com.amazonaws.services.sqs.model.SendMessageBatchRequest
+import com.amazonaws.services.sqs.model.SendMessageBatchRequestEntry
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.asserts.TraceAssert
+import datadog.trace.agent.test.utils.TraceUtils
+import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.config.GeneralConfig
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import org.elasticmq.rest.sqs.SQSRestServerBuilder
+import spock.lang.Shared
+
+import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
+
+class TimeInQueueForkedTest extends AgentTestRunner {
+
+  def setup() {
+    System.setProperty(SDKGlobalConfiguration.ACCESS_KEY_SYSTEM_PROPERTY, "my-access-key")
+    System.setProperty(SDKGlobalConfiguration.SECRET_KEY_SYSTEM_PROPERTY, "my-secret-key")
+  }
+
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("sqs.legacy.tracing.enabled", 'false')
+    // Set a service name that gets sorted early with SORT_BY_NAMES
+    injectSysConfig(GeneralConfig.SERVICE_NAME, "A-service")
+  }
+
+  @Shared
+  def credentialsProvider = new AWSStaticCredentialsProvider(new AnonymousAWSCredentials())
+  @Shared
+  def server = SQSRestServerBuilder.withInterface("localhost").withDynamicPort().start()
+  @Shared
+  def address = server.waitUntilStarted().localAddress()
+  @Shared
+  def endpoint = new AwsClientBuilder.EndpointConfiguration("http://localhost:${address.port}", "elasticmq")
+
+  def cleanupSpec() {
+    if (server != null) {
+      server.stopAndWait()
+    }
+  }
+
+  def sentMessages = [
+    "a message",
+    "another message",
+    "yet another message",
+    "another message again",
+    "just one more message"
+  ]
+
+  def "sync messages without SentTimestamps have no time-in-queue spans"() {
+    setup:
+    def client = AmazonSQSClientBuilder.standard()
+      .withEndpointConfiguration(endpoint)
+      .withCredentials(credentialsProvider)
+      .build()
+    def queueUrl = client.createQueue('somequeue').queueUrl
+    TEST_WRITER.clear()
+
+    when:
+    TraceUtils.runUnderTrace('parent', {
+      client.sendMessageBatch(new SendMessageBatchRequest()
+        .withQueueUrl(queueUrl)
+        .withEntries(
+        sentMessages.withIndex().collect {
+          new SendMessageBatchRequestEntry(
+            it.second as String, it.first)
+        }
+        ))
+    })
+    def messages = client.receiveMessage(
+      new ReceiveMessageRequest()
+      .withQueueUrl(queueUrl)
+      .withMaxNumberOfMessages(10)
+      ).messages.collect {
+        it.body
+      }
+
+    then:
+    messages.sort() == sentMessages.sort()
+    assertSqsTrace()
+
+    cleanup:
+    client.shutdown()
+  }
+
+  def "async messages without SentTimestamps have no time-in-queue spans"() {
+    setup:
+    def client = AmazonSQSAsyncClientBuilder.standard()
+      .withEndpointConfiguration(endpoint)
+      .withCredentials(credentialsProvider)
+      .build()
+    def queueUrl = client.createQueue('somequeue').queueUrl
+    TEST_WRITER.clear()
+
+    when:
+    TraceUtils.runUnderTrace('parent', {
+      client.sendMessageBatch(new SendMessageBatchRequest()
+        .withQueueUrl(queueUrl)
+        .withEntries(
+        sentMessages.withIndex().collect {
+          new SendMessageBatchRequestEntry(
+            it.second as String, it.first)
+        }
+        ))
+    })
+    def messages = client.receiveMessage(
+      new ReceiveMessageRequest()
+      .withQueueUrl(queueUrl)
+      .withMaxNumberOfMessages(10)
+      ).messages.collect {
+        it.body
+      }
+
+    then:
+    messages.sort() == sentMessages.sort()
+    assertSqsTrace()
+
+    cleanup:
+    client.shutdown()
+  }
+
+  def "sync messages with SentTimestamps have time-in-queue spans"() {
+    setup:
+    def client = AmazonSQSClientBuilder.standard()
+      .withEndpointConfiguration(endpoint)
+      .withCredentials(credentialsProvider)
+      .build()
+    def queueUrl = client.createQueue('somequeue').queueUrl
+    TEST_WRITER.clear()
+
+    when:
+    TraceUtils.runUnderTrace('parent', {
+      client.sendMessageBatch(new SendMessageBatchRequest()
+        .withQueueUrl(queueUrl)
+        .withEntries(
+        sentMessages.withIndex().collect {
+          new SendMessageBatchRequestEntry(
+            it.second as String, it.first)
+        }
+        ))
+    })
+    def messages = client.receiveMessage(
+      new ReceiveMessageRequest()
+      .withQueueUrl(queueUrl)
+      .withMaxNumberOfMessages(10)
+      .withAttributeNames("SentTimestamp")
+      ).messages.collect {
+        it.body
+      }
+
+    then:
+    messages.sort() == sentMessages.sort()
+    assertSqsTraceWithTimeInQueue()
+
+    cleanup:
+    client.shutdown()
+  }
+
+  def "async messages with SentTimestamps have time-in-queue spans"() {
+    setup:
+    def client = AmazonSQSAsyncClientBuilder.standard()
+      .withEndpointConfiguration(endpoint)
+      .withCredentials(credentialsProvider)
+      .build()
+    def queueUrl = client.createQueue('somequeue').queueUrl
+    TEST_WRITER.clear()
+
+    when:
+    TraceUtils.runUnderTrace('parent', {
+      client.sendMessageBatch(new SendMessageBatchRequest()
+        .withQueueUrl(queueUrl)
+        .withEntries(
+        sentMessages.withIndex().collect {
+          new SendMessageBatchRequestEntry(
+            it.second as String, it.first)
+        }
+        ))
+    })
+    def messages = client.receiveMessage(
+      new ReceiveMessageRequest()
+      .withQueueUrl(queueUrl)
+      .withMaxNumberOfMessages(10)
+      .withAttributeNames("SentTimestamp")
+      ).messages.collect {
+        it.body
+      }
+
+    then:
+    messages.sort() == sentMessages.sort()
+    assertSqsTraceWithTimeInQueue()
+
+    cleanup:
+    client.shutdown()
+  }
+
+  private void assertSqsTrace() {
+    def sendSpan
+    assertTraces(6) {
+      trace(2) {
+        basicSpan(it, "parent")
+        producerSpan(it, span(0))
+        sendSpan = span(1)
+      }
+      trace(1) {
+        consumerSpan(it, sendSpan)
+      }
+      trace(1) {
+        consumerSpan(it, sendSpan)
+      }
+      trace(1) {
+        consumerSpan(it, sendSpan)
+      }
+      trace(1) {
+        consumerSpan(it, sendSpan)
+      }
+      trace(1) {
+        consumerSpan(it, sendSpan)
+      }
+    }
+  }
+
+  private void assertSqsTraceWithTimeInQueue() {
+    def sendSpan
+    assertTraces(6) {
+      trace(2) {
+        basicSpan(it, "parent")
+        producerSpan(it, span(0))
+        sendSpan = span(1)
+      }
+      trace(2) {
+        consumerSpan(it, span(1))
+        timeInQueueSpan(it, sendSpan)
+      }
+      trace(2) {
+        consumerSpan(it, span(1))
+        timeInQueueSpan(it, sendSpan)
+      }
+      trace(2) {
+        consumerSpan(it, span(1))
+        timeInQueueSpan(it, sendSpan)
+      }
+      trace(2) {
+        consumerSpan(it, span(1))
+        timeInQueueSpan(it, sendSpan)
+      }
+      trace(2) {
+        consumerSpan(it, span(1))
+        timeInQueueSpan(it, sendSpan)
+      }
+    }
+  }
+
+  def producerSpan(TraceAssert traceAssert, parent) {
+    traceAssert.span {
+      serviceName "sqs"
+      operationName "aws.http"
+      resourceName "SQS.SendMessageBatch"
+      spanType DDSpanTypes.HTTP_CLIENT
+      errored false
+      measured true
+      childOf(parent)
+      tags {
+        "$Tags.COMPONENT" "java-aws-sdk"
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+        "$Tags.HTTP_URL" "http://localhost:${address.port}/"
+        "$Tags.HTTP_METHOD" "POST"
+        "$Tags.HTTP_STATUS" 200
+        "$Tags.PEER_PORT" address.port
+        "$Tags.PEER_HOSTNAME" "localhost"
+        "aws.service" "AmazonSQS"
+        "aws.endpoint" "http://localhost:${address.port}"
+        "aws.operation" "SendMessageBatchRequest"
+        "aws.agent" "java-aws-sdk"
+        "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+        defaultTags()
+      }
+    }
+  }
+
+  def consumerSpan(TraceAssert traceAssert, parent) {
+    traceAssert.span {
+      serviceName "A-service"
+      operationName "aws.http"
+      resourceName "SQS.ReceiveMessage"
+      spanType DDSpanTypes.MESSAGE_CONSUMER
+      errored false
+      measured true
+      childOf(parent)
+      tags {
+        "$Tags.COMPONENT" "java-aws-sdk"
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+        "aws.service" "AmazonSQS"
+        "aws.operation" "ReceiveMessageRequest"
+        "aws.agent" "java-aws-sdk"
+        "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+        defaultTags(parent.resourceName as String == "SQS.SendMessageBatch")
+      }
+    }
+  }
+
+  def timeInQueueSpan(TraceAssert traceAssert, parent) {
+    traceAssert.span {
+      serviceName "sqs"
+      operationName "aws.http"
+      resourceName "SQS.DeliverMessage"
+      spanType DDSpanTypes.MESSAGE_BROKER
+      errored false
+      measured true
+      childOf(parent)
+      tags {
+        "$Tags.COMPONENT" "java-aws-sdk"
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_BROKER
+        "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+        defaultTags(true)
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/TimeInQueueForkedTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/TimeInQueueForkedTest.groovy
@@ -261,7 +261,7 @@ class TimeInQueueForkedTest extends AgentTestRunner {
 
   def producerSpan(TraceAssert traceAssert, parent) {
     traceAssert.span {
-      serviceName "sqs"
+      serviceName "A-service"
       operationName "aws.http"
       resourceName "SQS.SendMessageBatch"
       spanType DDSpanTypes.HTTP_CLIENT

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/AbstractSqsInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/AbstractSqsInstrumentation.java
@@ -1,0 +1,9 @@
+package datadog.trace.instrumentation.aws.v2.sqs;
+
+import datadog.trace.agent.tooling.Instrumenter;
+
+public abstract class AbstractSqsInstrumentation extends Instrumenter.Tracing {
+  public AbstractSqsInstrumentation() {
+    super("sqs", "aws-sdk");
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/MessageExtractAdapter.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/MessageExtractAdapter.java
@@ -1,0 +1,38 @@
+package datadog.trace.instrumentation.aws.v2.sqs;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+public final class MessageExtractAdapter implements AgentPropagation.ContextVisitor<Message> {
+  private static final Logger log = LoggerFactory.getLogger(MessageExtractAdapter.class);
+
+  public static final MessageExtractAdapter GETTER = new MessageExtractAdapter();
+
+  @Override
+  public void forEachKey(Message carrier, AgentPropagation.KeyClassifier classifier) {
+    for (Map.Entry<String, String> entry : carrier.attributesAsStrings().entrySet()) {
+      String key = entry.getKey();
+      if ("AWSTraceHeader".equalsIgnoreCase(key)) {
+        key = "X-Amzn-Trace-Id";
+      }
+      if (!classifier.accept(key, entry.getValue())) {
+        return;
+      }
+    }
+  }
+
+  public long extractTimeInQueueStart(final Message carrier) {
+    try {
+      Map<String, String> attributes = carrier.attributesAsStrings();
+      if (attributes.containsKey("SentTimestamp")) {
+        return Long.parseLong(attributes.get("SentTimestamp"));
+      }
+    } catch (Exception e) {
+      log.debug("Unable to get SQS sent time", e);
+    }
+    return 0;
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsDecorator.java
@@ -18,8 +18,7 @@ public class SqsDecorator extends MessagingClientDecorator {
   public static final CharSequence SQS_RECEIVE = UTF8BytesString.create("Sqs.ReceiveMessage");
   public static final CharSequence SQS_DELIVER = UTF8BytesString.create("Sqs.DeliverMessage");
 
-  public static final boolean SQS_LEGACY_TRACING =
-      Config.get().isLegacyTracingEnabled(false, "sqs");
+  public static final boolean SQS_LEGACY_TRACING = Config.get().isLegacyTracingEnabled(true, "sqs");
 
   private final String spanKind;
   private final CharSequence spanType;
@@ -66,12 +65,19 @@ public class SqsDecorator extends MessagingClientDecorator {
     return spanKind;
   }
 
-  public void onConsume(final AgentSpan span) {
+  public void onConsume(final AgentSpan span, final String queueUrl, String requestId) {
     span.setResourceName(SQS_RECEIVE);
+    span.setTag("aws.service", "Sqs");
+    span.setTag("aws.operation", "ReceiveMessage");
+    span.setTag("aws.agent", COMPONENT_NAME);
+    span.setTag("aws.queue.url", queueUrl);
+    span.setTag("aws.requestId", requestId);
   }
 
-  public void onTimeInQueue(final AgentSpan span) {
-    span.setResourceName(SQS_DELIVER);
+  public void onTimeInQueue(final AgentSpan span, final String queueUrl, String requestId) {
     span.setServiceName("sqs");
+    span.setResourceName(SQS_DELIVER);
+    span.setTag("aws.queue.url", queueUrl);
+    span.setTag("aws.requestId", requestId);
   }
 }

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsDecorator.java
@@ -1,0 +1,77 @@
+package datadog.trace.instrumentation.aws.v2.sqs;
+
+import static datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes.MESSAGE_BROKER;
+import static datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes.MESSAGE_CONSUMER;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_BROKER;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_CONSUMER;
+
+import datadog.trace.api.Config;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import datadog.trace.bootstrap.instrumentation.decorator.MessagingClientDecorator;
+
+public class SqsDecorator extends MessagingClientDecorator {
+
+  public static final CharSequence AWS_HTTP = UTF8BytesString.create("aws.http");
+  static final CharSequence COMPONENT_NAME = UTF8BytesString.create("java-aws-sdk");
+
+  public static final CharSequence SQS_RECEIVE = UTF8BytesString.create("Sqs.ReceiveMessage");
+  public static final CharSequence SQS_DELIVER = UTF8BytesString.create("Sqs.DeliverMessage");
+
+  public static final boolean SQS_LEGACY_TRACING =
+      Config.get().isLegacyTracingEnabled(false, "sqs");
+
+  private final String spanKind;
+  private final CharSequence spanType;
+  private final String serviceName;
+
+  private static final String LOCAL_SERVICE_NAME =
+      SQS_LEGACY_TRACING ? "sqs" : Config.get().getServiceName();
+
+  public static final SqsDecorator CONSUMER_DECORATE =
+      new SqsDecorator(SPAN_KIND_CONSUMER, MESSAGE_CONSUMER, LOCAL_SERVICE_NAME);
+
+  public static final SqsDecorator BROKER_DECORATE =
+      new SqsDecorator(
+          SPAN_KIND_BROKER, MESSAGE_BROKER, null /* service name will be set later on */);
+
+  protected SqsDecorator(String spanKind, CharSequence spanType, String serviceName) {
+    this.spanKind = spanKind;
+    this.spanType = spanType;
+    this.serviceName = serviceName;
+  }
+
+  @Override
+  protected CharSequence spanType() {
+    return spanType;
+  }
+
+  @Override
+  protected String[] instrumentationNames() {
+    return new String[] {"aws-sdk"};
+  }
+
+  @Override
+  protected String service() {
+    return serviceName;
+  }
+
+  @Override
+  protected CharSequence component() {
+    return COMPONENT_NAME;
+  }
+
+  @Override
+  protected String spanKind() {
+    return spanKind;
+  }
+
+  public void onConsume(final AgentSpan span) {
+    span.setResourceName(SQS_RECEIVE);
+  }
+
+  public void onTimeInQueue(final AgentSpan span) {
+    span.setResourceName(SQS_DELIVER);
+    span.setServiceName("sqs");
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsJmsMessageInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsJmsMessageInstrumentation.java
@@ -15,11 +15,8 @@ import net.bytebuddy.asm.Advice;
 import software.amazon.awssdk.services.sqs.model.Message;
 
 @AutoService(Instrumenter.class)
-public class SqsJmsMessageInstrumentation extends Instrumenter.Tracing
+public class SqsJmsMessageInstrumentation extends AbstractSqsInstrumentation
     implements Instrumenter.ForSingleType {
-  public SqsJmsMessageInstrumentation() {
-    super("aws-sdk");
-  }
 
   @Override
   public String instrumentedType() {

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsReceiveRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsReceiveRequestInstrumentation.java
@@ -14,11 +14,8 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(Instrumenter.class)
-public class SqsReceiveRequestInstrumentation extends Instrumenter.Tracing
+public class SqsReceiveRequestInstrumentation extends AbstractSqsInstrumentation
     implements Instrumenter.ForSingleType, Instrumenter.WithTypeStructure {
-  public SqsReceiveRequestInstrumentation() {
-    super("aws-sdk");
-  }
 
   @Override
   public String instrumentedType() {

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsReceiveResultInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsReceiveResultInstrumentation.java
@@ -13,11 +13,8 @@ import net.bytebuddy.asm.Advice;
 import software.amazon.awssdk.services.sqs.model.Message;
 
 @AutoService(Instrumenter.class)
-public class SqsReceiveResultInstrumentation extends Instrumenter.Tracing
+public class SqsReceiveResultInstrumentation extends AbstractSqsInstrumentation
     implements Instrumenter.ForSingleType {
-  public SqsReceiveResultInstrumentation() {
-    super("aws-sdk");
-  }
 
   @Override
   public String instrumentedType() {

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsReceiveResultInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsReceiveResultInstrumentation.java
@@ -1,16 +1,19 @@
 package datadog.trace.instrumentation.aws.v2.sqs;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.InstrumenterConfig;
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.InstrumentationContext;
 import java.util.List;
+import java.util.Map;
 import net.bytebuddy.asm.Advice;
+import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
 
 @AutoService(Instrumenter.class)
 public class SqsReceiveResultInstrumentation extends AbstractSqsInstrumentation
@@ -40,6 +43,11 @@ public class SqsReceiveResultInstrumentation extends AbstractSqsInstrumentation
   }
 
   @Override
+  public Map<String, String> contextStore() {
+    return singletonMap("software.amazon.awssdk.core.SdkResponse", "java.lang.String");
+  }
+
+  @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(
         isMethod().and(named("messages")), getClass().getName() + "$GetMessagesAdvice");
@@ -47,12 +55,14 @@ public class SqsReceiveResultInstrumentation extends AbstractSqsInstrumentation
 
   public static class GetMessagesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void onExit(@Advice.Return(readOnly = false) List<Message> messages) {
-      if (messages != null
-          && !messages.isEmpty()
-          && !(messages instanceof TracingList)
-          && !(activeSpan() instanceof AgentTracer.NoopAgentSpan)) {
-        messages = new TracingList(messages);
+    public static void onExit(
+        @Advice.This ReceiveMessageResponse result,
+        @Advice.Return(readOnly = false) List<Message> messages) {
+      if (messages != null && !messages.isEmpty() && !(messages instanceof TracingList)) {
+        String queueUrl = InstrumentationContext.get(SdkResponse.class, String.class).get(result);
+        if (queueUrl != null) {
+          messages = new TracingList(messages, queueUrl, result.responseMetadata().requestId());
+        }
       }
     }
   }

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsReceiveResultInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsReceiveResultInstrumentation.java
@@ -1,0 +1,62 @@
+package datadog.trace.instrumentation.aws.v2.sqs;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.InstrumenterConfig;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.util.List;
+import net.bytebuddy.asm.Advice;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+@AutoService(Instrumenter.class)
+public class SqsReceiveResultInstrumentation extends Instrumenter.Tracing
+    implements Instrumenter.ForSingleType {
+  public SqsReceiveResultInstrumentation() {
+    super("aws-sdk");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse";
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return super.isEnabled()
+        // we don't need to instrument messages when we're doing legacy AWS-SDK tracing
+        && !InstrumenterConfig.get().isLegacyInstrumentationEnabled(false, "aws-sdk");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".MessageExtractAdapter",
+      packageName + ".SqsDecorator",
+      packageName + ".TracingIterator",
+      packageName + ".TracingList",
+      packageName + ".TracingListIterator"
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod().and(named("messages")), getClass().getName() + "$GetMessagesAdvice");
+  }
+
+  public static class GetMessagesAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onExit(@Advice.Return(readOnly = false) List<Message> messages) {
+      if (messages != null
+          && !messages.isEmpty()
+          && !(messages instanceof TracingList)
+          && !(activeSpan() instanceof AgentTracer.NoopAgentSpan)) {
+        messages = new TracingList(messages);
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingIterator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingIterator.java
@@ -1,0 +1,85 @@
+package datadog.trace.instrumentation.aws.v2.sqs;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateNext;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.closePrevious;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.aws.v2.sqs.MessageExtractAdapter.GETTER;
+import static datadog.trace.instrumentation.aws.v2.sqs.SqsDecorator.AWS_HTTP;
+import static datadog.trace.instrumentation.aws.v2.sqs.SqsDecorator.BROKER_DECORATE;
+import static datadog.trace.instrumentation.aws.v2.sqs.SqsDecorator.CONSUMER_DECORATE;
+import static datadog.trace.instrumentation.aws.v2.sqs.SqsDecorator.SQS_LEGACY_TRACING;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import datadog.trace.api.Config;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.util.Iterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+public class TracingIterator<L extends Iterator<Message>> implements Iterator<Message> {
+  private static final Logger log = LoggerFactory.getLogger(TracingIterator.class);
+
+  protected final L delegate;
+
+  public TracingIterator(L delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public boolean hasNext() {
+    boolean moreMessages = delegate.hasNext();
+    if (!moreMessages) {
+      // no more messages, use this as a signal to close the last iteration scope
+      closePrevious(true);
+    }
+    return moreMessages;
+  }
+
+  @Override
+  public Message next() {
+    Message next = delegate.next();
+    startNewMessageSpan(next);
+    return next;
+  }
+
+  protected void startNewMessageSpan(Message message) {
+    try {
+      closePrevious(true);
+      if (message != null) {
+        AgentSpan span, queueSpan = null;
+        if (Config.get().isSqsPropagationEnabled()) {
+          AgentSpan.Context spanContext = propagate().extract(message, GETTER);
+          long timeInQueueStart = GETTER.extractTimeInQueueStart(message);
+          if (timeInQueueStart == 0 || SQS_LEGACY_TRACING) {
+            span = startSpan(AWS_HTTP, spanContext);
+          } else {
+            queueSpan = startSpan(AWS_HTTP, spanContext, MILLISECONDS.toMicros(timeInQueueStart));
+            BROKER_DECORATE.afterStart(queueSpan);
+            BROKER_DECORATE.onTimeInQueue(queueSpan);
+            span = startSpan(AWS_HTTP, queueSpan.context());
+            BROKER_DECORATE.beforeFinish(queueSpan);
+            // The queueSpan will be finished after inner span has been activated to ensure that
+            // spans are written out together by TraceStructureWriter when running in strict mode
+          }
+        } else {
+          span = startSpan(AWS_HTTP, null);
+        }
+        CONSUMER_DECORATE.afterStart(span);
+        CONSUMER_DECORATE.onConsume(span);
+        activateNext(span);
+        if (null != queueSpan) {
+          queueSpan.finish();
+        }
+      }
+    } catch (Exception e) {
+      log.debug("Error starting new message span", e);
+    }
+  }
+
+  @Override
+  public void remove() {
+    delegate.remove();
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingList.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingList.java
@@ -1,0 +1,137 @@
+package datadog.trace.instrumentation.aws.v2.sqs;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+public class TracingList implements List<Message> {
+  private final List<Message> delegate;
+
+  public TracingList(List<Message> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public int size() {
+    return delegate.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return delegate.isEmpty();
+  }
+
+  @Override
+  public boolean contains(Object o) {
+    return delegate.contains(o);
+  }
+
+  @Override
+  public Iterator<Message> iterator() {
+    return listIterator(0);
+  }
+
+  @Override
+  public Object[] toArray() {
+    return delegate.toArray();
+  }
+
+  @Override
+  public <T> T[] toArray(T[] a) {
+    return delegate.toArray(a);
+  }
+
+  @Override
+  public boolean add(Message message) {
+    return delegate.add(message);
+  }
+
+  @Override
+  public boolean remove(Object o) {
+    return delegate.remove(o);
+  }
+
+  @Override
+  public boolean containsAll(Collection<?> c) {
+    return delegate.containsAll(c);
+  }
+
+  @Override
+  public boolean addAll(Collection<? extends Message> c) {
+    return delegate.addAll(c);
+  }
+
+  @Override
+  public boolean addAll(int index, Collection<? extends Message> c) {
+    return delegate.addAll(index, c);
+  }
+
+  @Override
+  public boolean removeAll(Collection<?> c) {
+    return delegate.removeAll(c);
+  }
+
+  @Override
+  public boolean retainAll(Collection<?> c) {
+    return delegate.retainAll(c);
+  }
+
+  @Override
+  public void clear() {
+    delegate.clear();
+  }
+
+  @Override
+  public Message get(int index) {
+    // TODO: should this be instrumented as well?
+    return delegate.get(index);
+  }
+
+  @Override
+  public Message set(int index, Message element) {
+    return delegate.set(index, element);
+  }
+
+  @Override
+  public void add(int index, Message element) {
+    delegate.add(index, element);
+  }
+
+  @Override
+  public Message remove(int index) {
+    return delegate.remove(index);
+  }
+
+  @Override
+  public int indexOf(Object o) {
+    return delegate.indexOf(o);
+  }
+
+  @Override
+  public int lastIndexOf(Object o) {
+    return delegate.lastIndexOf(o);
+  }
+
+  @Override
+  public ListIterator<Message> listIterator() {
+    return listIterator(0);
+  }
+
+  @Override
+  public ListIterator<Message> listIterator(int index) {
+    // every iteration will add spans. Not only the very first one
+    return new TracingListIterator(delegate.listIterator(index));
+  }
+
+  @Override
+  public List<Message> subList(int fromIndex, int toIndex) {
+    return new TracingList(delegate.subList(fromIndex, toIndex));
+  }
+
+  @Override
+  public String toString() {
+    return delegate.toString();
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingList.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingList.java
@@ -8,9 +8,13 @@ import software.amazon.awssdk.services.sqs.model.Message;
 
 public class TracingList implements List<Message> {
   private final List<Message> delegate;
+  private final String queueUrl;
+  private final String requestId;
 
-  public TracingList(List<Message> delegate) {
+  public TracingList(List<Message> delegate, String queueUrl, String requestId) {
     this.delegate = delegate;
+    this.queueUrl = queueUrl;
+    this.requestId = requestId;
   }
 
   @Override
@@ -85,8 +89,7 @@ public class TracingList implements List<Message> {
 
   @Override
   public Message get(int index) {
-    // TODO: should this be instrumented as well?
-    return delegate.get(index);
+    return delegate.get(index); // not currently covered by iteration span
   }
 
   @Override
@@ -122,12 +125,12 @@ public class TracingList implements List<Message> {
   @Override
   public ListIterator<Message> listIterator(int index) {
     // every iteration will add spans. Not only the very first one
-    return new TracingListIterator(delegate.listIterator(index));
+    return new TracingListIterator(delegate.listIterator(index), queueUrl, requestId);
   }
 
   @Override
   public List<Message> subList(int fromIndex, int toIndex) {
-    return new TracingList(delegate.subList(fromIndex, toIndex));
+    return new TracingList(delegate.subList(fromIndex, toIndex), queueUrl, requestId);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingListIterator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingListIterator.java
@@ -1,0 +1,51 @@
+package datadog.trace.instrumentation.aws.v2.sqs;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.closePrevious;
+
+import java.util.ListIterator;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+public class TracingListIterator extends TracingIterator<ListIterator<Message>>
+    implements ListIterator<Message> {
+
+  public TracingListIterator(ListIterator<Message> delegate) {
+    super(delegate);
+  }
+
+  @Override
+  public boolean hasPrevious() {
+    boolean moreMessages = delegate.hasPrevious();
+    if (!moreMessages) {
+      // no more messages, use this as a signal to close the last iteration scope
+      closePrevious(true);
+    }
+    return moreMessages;
+  }
+
+  @Override
+  public Message previous() {
+    Message prev = delegate.previous();
+    startNewMessageSpan(prev);
+    return prev;
+  }
+
+  @Override
+  public int nextIndex() {
+    return delegate.nextIndex();
+  }
+
+  @Override
+  public int previousIndex() {
+    return delegate.previousIndex();
+  }
+
+  @Override
+  public void set(Message message) {
+    delegate.set(message);
+  }
+
+  @Override
+  public void add(Message message) {
+    delegate.add(message);
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingListIterator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingListIterator.java
@@ -8,8 +8,8 @@ import software.amazon.awssdk.services.sqs.model.Message;
 public class TracingListIterator extends TracingIterator<ListIterator<Message>>
     implements ListIterator<Message> {
 
-  public TracingListIterator(ListIterator<Message> delegate) {
-    super(delegate);
+  public TracingListIterator(ListIterator<Message> delegate, String queueUrl, String requestId) {
+    super(delegate, queueUrl, requestId);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/SqsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/SqsClientTest.groovy
@@ -32,7 +32,7 @@ class SqsClientTest extends AgentTestRunner {
   protected void configurePreAgent() {
     super.configurePreAgent()
     // Set a service name that gets sorted early with SORT_BY_NAMES
-    injectSysConfig(GeneralConfig.SERVICE_NAME, "A")
+    injectSysConfig(GeneralConfig.SERVICE_NAME, "A-service")
   }
 
   @Shared
@@ -65,6 +65,8 @@ class SqsClientTest extends AgentTestRunner {
       client.sendMessage(SendMessageRequest.builder().queueUrl(queueUrl).messageBody('sometext').build())
     })
     def messages = client.receiveMessage(ReceiveMessageRequest.builder().queueUrl(queueUrl).build()).messages()
+
+    messages.forEach {/* consume to create message spans */ }
 
     then:
     def sendSpan
@@ -102,24 +104,19 @@ class SqsClientTest extends AgentTestRunner {
           serviceName "sqs"
           operationName "aws.http"
           resourceName "Sqs.ReceiveMessage"
-          spanType DDSpanTypes.HTTP_CLIENT
+          spanType DDSpanTypes.MESSAGE_CONSUMER
           errored false
           measured true
-          parent()
+          childOf(sendSpan)
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
-            "$Tags.HTTP_METHOD" "POST"
-            "$Tags.HTTP_STATUS" 200
-            "$Tags.PEER_PORT" address.port
-            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "aws.service" "Sqs"
             "aws.operation" "ReceiveMessage"
             "aws.agent" "java-aws-sdk"
             "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
             "aws.requestId" "00000000-0000-0000-0000-000000000000"
-            defaultTags()
+            defaultTags(true)
           }
         }
       }
@@ -235,24 +232,19 @@ class SqsClientTest extends AgentTestRunner {
           serviceName "sqs"
           operationName "aws.http"
           resourceName "Sqs.ReceiveMessage"
-          spanType DDSpanTypes.HTTP_CLIENT
+          spanType DDSpanTypes.MESSAGE_CONSUMER
           errored false
           measured true
-          parent()
+          childOf(sendSpan)
           tags {
             "$Tags.COMPONENT" "java-aws-sdk"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.HTTP_URL" "http://localhost:${address.port}/"
-            "$Tags.HTTP_METHOD" "POST"
-            "$Tags.HTTP_STATUS" 200
-            "$Tags.PEER_PORT" address.port
-            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "aws.service" "Sqs"
             "aws.operation" "ReceiveMessage"
             "aws.agent" "java-aws-sdk"
             "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
             "aws.requestId" "00000000-0000-0000-0000-000000000000"
-            defaultTags()
+            defaultTags(true)
           }
         }
       }

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/TimeInQueueForkedTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/TimeInQueueForkedTest.groovy
@@ -285,7 +285,7 @@ class TimeInQueueForkedTest extends AgentTestRunner {
 
   def producerSpan(TraceAssert traceAssert, parent) {
     traceAssert.span {
-      serviceName "sqs"
+      serviceName "A-service"
       operationName "aws.http"
       resourceName "Sqs.SendMessageBatch"
       spanType DDSpanTypes.HTTP_CLIENT

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/TimeInQueueForkedTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/TimeInQueueForkedTest.groovy
@@ -1,0 +1,353 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.asserts.TraceAssert
+import datadog.trace.agent.test.utils.TraceUtils
+import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.config.GeneralConfig
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import org.elasticmq.rest.sqs.SQSRestServerBuilder
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
+import software.amazon.awssdk.core.SdkSystemSetting
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import software.amazon.awssdk.services.sqs.SqsClient
+import software.amazon.awssdk.services.sqs.model.CreateQueueRequest
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry
+import spock.lang.Shared
+
+import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
+
+class TimeInQueueForkedTest extends AgentTestRunner {
+
+  def setup() {
+    System.setProperty(SdkSystemSetting.AWS_ACCESS_KEY_ID.property(), "my-access-key")
+    System.setProperty(SdkSystemSetting.AWS_SECRET_ACCESS_KEY.property(), "my-secret-key")
+  }
+
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("sqs.legacy.tracing.enabled", 'false')
+    // Set a service name that gets sorted early with SORT_BY_NAMES
+    injectSysConfig(GeneralConfig.SERVICE_NAME, "A-service")
+  }
+
+  @Shared
+  def credentialsProvider = AnonymousCredentialsProvider.create()
+  @Shared
+  def server = SQSRestServerBuilder.withInterface("localhost").withDynamicPort().start()
+  @Shared
+  def address = server.waitUntilStarted().localAddress()
+  @Shared
+  def endpoint = URI.create("http://localhost:${address.port}")
+
+  def cleanupSpec() {
+    if (server != null) {
+      server.stopAndWait()
+    }
+  }
+
+  def sentMessages = [
+    "a message",
+    "another message",
+    "yet another message",
+    "another message again",
+    "just one more message"
+  ]
+
+  def "sync messages without SentTimestamps have no time-in-queue spans"() {
+    setup:
+    def client = SqsClient.builder()
+      .region(Region.EU_CENTRAL_1)
+      .endpointOverride(endpoint)
+      .credentialsProvider(credentialsProvider)
+      .build()
+    def queueUrl = client.createQueue(
+      CreateQueueRequest.builder().queueName('somequeue').build()
+      ).queueUrl()
+    TEST_WRITER.clear()
+
+    when:
+    TraceUtils.runUnderTrace('parent', {
+      client.sendMessageBatch(SendMessageBatchRequest.builder()
+        .queueUrl(queueUrl)
+        .entries(
+        sentMessages.withIndex().collect {
+          SendMessageBatchRequestEntry.builder()
+            .messageBody(it.first)
+            .id(it.second as String)
+            .build()
+        }
+        ).build())
+    })
+    def messages = client.receiveMessage(
+      ReceiveMessageRequest.builder()
+      .queueUrl(queueUrl)
+      .maxNumberOfMessages(10)
+      .build()
+      ).messages().collect {
+        it.body()
+      }
+
+    then:
+    messages.sort() == sentMessages.sort()
+    assertSqsTrace()
+
+    cleanup:
+    client.close()
+  }
+
+  def "async messages without SentTimestamps have no time-in-queue spans"() {
+    setup:
+    def client = SqsAsyncClient.builder()
+      .region(Region.EU_CENTRAL_1)
+      .endpointOverride(endpoint)
+      .credentialsProvider(credentialsProvider)
+      .build()
+    def queueUrl = client.createQueue(
+      CreateQueueRequest.builder().queueName('somequeue').build()
+      ).join().queueUrl()
+    TEST_WRITER.clear()
+
+    when:
+    TraceUtils.runUnderTrace('parent', {
+      client.sendMessageBatch(SendMessageBatchRequest.builder()
+        .queueUrl(queueUrl)
+        .entries(
+        sentMessages.withIndex().collect {
+          SendMessageBatchRequestEntry.builder()
+            .messageBody(it.first)
+            .id(it.second as String)
+            .build()
+        }
+        ).build()).join()
+    })
+    def messages = client.receiveMessage(
+      ReceiveMessageRequest.builder()
+      .queueUrl(queueUrl)
+      .maxNumberOfMessages(10)
+      .build()
+      ).join().messages().collect {
+        it.body()
+      }
+
+    then:
+    messages.sort() == sentMessages.sort()
+    assertSqsTrace()
+
+    cleanup:
+    client.close()
+  }
+
+  def "sync messages with SentTimestamps have time-in-queue spans"() {
+    setup:
+    def client = SqsClient.builder()
+      .region(Region.EU_CENTRAL_1)
+      .endpointOverride(endpoint)
+      .credentialsProvider(credentialsProvider)
+      .build()
+    def queueUrl = client.createQueue(
+      CreateQueueRequest.builder().queueName('somequeue').build()
+      ).queueUrl()
+    TEST_WRITER.clear()
+
+    when:
+    TraceUtils.runUnderTrace('parent', {
+      client.sendMessageBatch(SendMessageBatchRequest.builder()
+        .queueUrl(queueUrl)
+        .entries(
+        sentMessages.withIndex().collect {
+          SendMessageBatchRequestEntry.builder()
+            .messageBody(it.first)
+            .id(it.second as String)
+            .build()
+        }
+        ).build())
+    })
+    def messages = client.receiveMessage(
+      ReceiveMessageRequest.builder()
+      .queueUrl(queueUrl)
+      .attributeNamesWithStrings("SentTimestamp")
+      .maxNumberOfMessages(10)
+      .build()
+      ).messages().collect {
+        it.body()
+      }
+
+    then:
+    messages.sort() == sentMessages.sort()
+    assertSqsTraceWithTimeInQueue()
+
+    cleanup:
+    client.close()
+  }
+
+  def "async messages with SentTimestamps have time-in-queue spans"() {
+    setup:
+    def client = SqsAsyncClient.builder()
+      .region(Region.EU_CENTRAL_1)
+      .endpointOverride(endpoint)
+      .credentialsProvider(credentialsProvider)
+      .build()
+    def queueUrl = client.createQueue(
+      CreateQueueRequest.builder().queueName('somequeue').build()
+      ).join().queueUrl()
+    TEST_WRITER.clear()
+
+    when:
+    TraceUtils.runUnderTrace('parent', {
+      client.sendMessageBatch(SendMessageBatchRequest.builder()
+        .queueUrl(queueUrl)
+        .entries(
+        sentMessages.withIndex().collect {
+          SendMessageBatchRequestEntry.builder()
+            .messageBody(it.first)
+            .id(it.second as String)
+            .build()
+        }
+        ).build()).join()
+    })
+    def messages = client.receiveMessage(
+      ReceiveMessageRequest.builder()
+      .queueUrl(queueUrl)
+      .attributeNamesWithStrings("SentTimestamp")
+      .maxNumberOfMessages(10)
+      .build()
+      ).join().messages().collect {
+        it.body()
+      }
+
+    then:
+    messages.sort() == sentMessages.sort()
+    assertSqsTraceWithTimeInQueue()
+
+    cleanup:
+    client.close()
+  }
+
+  private void assertSqsTrace() {
+    def sendSpan
+    assertTraces(6) {
+      trace(2) {
+        basicSpan(it, "parent")
+        producerSpan(it, span(0))
+        sendSpan = span(1)
+      }
+      trace(1) {
+        consumerSpan(it, sendSpan)
+      }
+      trace(1) {
+        consumerSpan(it, sendSpan)
+      }
+      trace(1) {
+        consumerSpan(it, sendSpan)
+      }
+      trace(1) {
+        consumerSpan(it, sendSpan)
+      }
+      trace(1) {
+        consumerSpan(it, sendSpan)
+      }
+    }
+  }
+
+  private void assertSqsTraceWithTimeInQueue() {
+    def sendSpan
+    assertTraces(6) {
+      trace(2) {
+        basicSpan(it, "parent")
+        producerSpan(it, span(0))
+        sendSpan = span(1)
+      }
+      trace(2) {
+        consumerSpan(it, span(1))
+        timeInQueueSpan(it, sendSpan)
+      }
+      trace(2) {
+        consumerSpan(it, span(1))
+        timeInQueueSpan(it, sendSpan)
+      }
+      trace(2) {
+        consumerSpan(it, span(1))
+        timeInQueueSpan(it, sendSpan)
+      }
+      trace(2) {
+        consumerSpan(it, span(1))
+        timeInQueueSpan(it, sendSpan)
+      }
+      trace(2) {
+        consumerSpan(it, span(1))
+        timeInQueueSpan(it, sendSpan)
+      }
+    }
+  }
+
+  def producerSpan(TraceAssert traceAssert, parent) {
+    traceAssert.span {
+      serviceName "sqs"
+      operationName "aws.http"
+      resourceName "Sqs.SendMessageBatch"
+      spanType DDSpanTypes.HTTP_CLIENT
+      errored false
+      measured true
+      childOf(parent)
+      tags {
+        "$Tags.COMPONENT" "java-aws-sdk"
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+        "$Tags.HTTP_URL" "http://localhost:${address.port}/"
+        "$Tags.HTTP_METHOD" "POST"
+        "$Tags.HTTP_STATUS" 200
+        "$Tags.PEER_PORT" address.port
+        "$Tags.PEER_HOSTNAME" "localhost"
+        "aws.service" "Sqs"
+        "aws.operation" "SendMessageBatch"
+        "aws.agent" "java-aws-sdk"
+        "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+        "aws.requestId" "00000000-0000-0000-0000-000000000000"
+        defaultTags()
+      }
+    }
+  }
+
+  def consumerSpan(TraceAssert traceAssert, parent) {
+    traceAssert.span {
+      serviceName "A-service"
+      operationName "aws.http"
+      resourceName "Sqs.ReceiveMessage"
+      spanType DDSpanTypes.MESSAGE_CONSUMER
+      errored false
+      measured true
+      childOf(parent)
+      tags {
+        "$Tags.COMPONENT" "java-aws-sdk"
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+        "aws.service" "Sqs"
+        "aws.operation" "ReceiveMessage"
+        "aws.agent" "java-aws-sdk"
+        "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+        "aws.requestId" "00000000-0000-0000-0000-000000000000"
+        defaultTags(parent.resourceName as String == "Sqs.SendMessageBatch")
+      }
+    }
+  }
+
+  def timeInQueueSpan(TraceAssert traceAssert, parent) {
+    traceAssert.span {
+      serviceName "sqs"
+      operationName "aws.http"
+      resourceName "Sqs.DeliverMessage"
+      spanType DDSpanTypes.MESSAGE_BROKER
+      errored false
+      measured true
+      childOf(parent)
+      tags {
+        "$Tags.COMPONENT" "java-aws-sdk"
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_BROKER
+        "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+        "aws.requestId" "00000000-0000-0000-0000-000000000000"
+        defaultTags(true)
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/TimeInQueueForkedTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/TimeInQueueForkedTest.groovy
@@ -56,7 +56,7 @@ class TimeInQueueForkedTest extends AgentTestRunner {
     "just one more message"
   ]
 
-  def "sync messages without SentTimestamps have no time-in-queue spans"() {
+  def "sync messages without SentTimestamps have no time-in-queue span"() {
     setup:
     def client = SqsClient.builder()
       .region(Region.EU_CENTRAL_1)
@@ -98,7 +98,7 @@ class TimeInQueueForkedTest extends AgentTestRunner {
     client.close()
   }
 
-  def "async messages without SentTimestamps have no time-in-queue spans"() {
+  def "async messages without SentTimestamps have no time-in-queue span"() {
     setup:
     def client = SqsAsyncClient.builder()
       .region(Region.EU_CENTRAL_1)
@@ -140,7 +140,7 @@ class TimeInQueueForkedTest extends AgentTestRunner {
     client.close()
   }
 
-  def "sync messages with SentTimestamps have time-in-queue spans"() {
+  def "sync messages with SentTimestamps have time-in-queue span"() {
     setup:
     def client = SqsClient.builder()
       .region(Region.EU_CENTRAL_1)
@@ -183,7 +183,7 @@ class TimeInQueueForkedTest extends AgentTestRunner {
     client.close()
   }
 
-  def "async messages with SentTimestamps have time-in-queue spans"() {
+  def "async messages with SentTimestamps have time-in-queue span"() {
     setup:
     def client = SqsAsyncClient.builder()
       .region(Region.EU_CENTRAL_1)
@@ -253,7 +253,7 @@ class TimeInQueueForkedTest extends AgentTestRunner {
   }
 
   private void assertSqsTraceWithTimeInQueue() {
-    def sendSpan
+    def sendSpan, queueSpan
     assertTraces(6) {
       trace(2) {
         basicSpan(it, "parent")
@@ -263,22 +263,19 @@ class TimeInQueueForkedTest extends AgentTestRunner {
       trace(2) {
         consumerSpan(it, span(1))
         timeInQueueSpan(it, sendSpan)
+        queueSpan = span(1)
       }
-      trace(2) {
-        consumerSpan(it, span(1))
-        timeInQueueSpan(it, sendSpan)
+      trace(1) {
+        consumerSpan(it, queueSpan)
       }
-      trace(2) {
-        consumerSpan(it, span(1))
-        timeInQueueSpan(it, sendSpan)
+      trace(1) {
+        consumerSpan(it, queueSpan)
       }
-      trace(2) {
-        consumerSpan(it, span(1))
-        timeInQueueSpan(it, sendSpan)
+      trace(1) {
+        consumerSpan(it, queueSpan)
       }
-      trace(2) {
-        consumerSpan(it, span(1))
-        timeInQueueSpan(it, sendSpan)
+      trace(1) {
+        consumerSpan(it, queueSpan)
       }
     }
   }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1284,7 +1284,7 @@ public class Config {
     debuggerExcludeFile = configProvider.getString(DEBUGGER_EXCLUDE_FILE);
 
     awsPropagationEnabled = isPropagationEnabled(true, "aws", "aws-sdk");
-    sqsPropagationEnabled = awsPropagationEnabled && isPropagationEnabled(true, "sqs");
+    sqsPropagationEnabled = isPropagationEnabled(true, "sqs");
 
     kafkaClientPropagationEnabled = isPropagationEnabled(true, "kafka", "kafka.client");
     kafkaClientPropagationDisabledTopics =

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1283,7 +1283,7 @@ public class Config {
             DEBUGGER_INSTRUMENT_THE_WORLD, DEFAULT_DEBUGGER_INSTRUMENT_THE_WORLD);
     debuggerExcludeFile = configProvider.getString(DEBUGGER_EXCLUDE_FILE);
 
-    awsPropagationEnabled = isPropagationEnabled(true, "aws");
+    awsPropagationEnabled = isPropagationEnabled(true, "aws", "aws-sdk");
     sqsPropagationEnabled = awsPropagationEnabled && isPropagationEnabled(true, "sqs");
 
     kafkaClientPropagationEnabled = isPropagationEnabled(true, "kafka", "kafka.client");


### PR DESCRIPTION
### Builds on top of #4739

# What Does This Do

This PR enables more accurate distributed tracing of work related to consuming SQS messages.

The resulting traces (and switches) are modelled on existing messaging instrumentations such as Kafka and JMS.

It also avoids generating consuming spans when `SQS.receiveMessage` returns no messages.

# Additional Notes

## Example SQS distributed trace (default configuration)

The Java tracer will track work done while consuming SQS messages and attempt to connect that work back to the trace that produced those messages. The producing and consuming spans, as well as any work done consuming messages, will have a service name of `sqs`.

![dd_sqs_legacy_tracing_enabled_true](https://user-images.githubusercontent.com/145851/219685278-a1819aef-5c67-4711-ad96-7024794e6c9a.png)

## Example SQS distributed trace with time-in-queue span

When legacy SQS tracing is disabled the Java Tracer will add a "time-in-queue" span representing the time the message spent on the queue between being produced and consumed. The "time-in-queue" span will have a service name of "sqs".

The producing and consuming spans, plus any work done related to that message, will now use the application's service name. Only the "time-in-queue" span will have a service name of "sqs".

`-Ddd.sqs.legacy.tracing.enabled=false` 

`DD_SQS_LEGACY_TRACING_ENABLED=false`

![dd_sqs_legacy_tracing_enabled_false](https://user-images.githubusercontent.com/145851/219685117-6b15e853-f15b-48f6-959c-94d7ced91c77.png)

## Example trace without any special SQS handling

If you want to restore the behaviour in 0.88.0 and earlier releases where AWS-SDK calls were modelled as simple HTTP client calls, and included the underlying HTTP span, then you can re-enable legacy AWS-SDK tracing with the following option.

`-Ddd.aws-sdk.legacy.tracing.enabled=true`

`DD_AWS_SDK_LEGACY_TRACING_ENABLED=true`

![dd_aws_sdk_legacy_tracing_enabled=true](https://user-images.githubusercontent.com/145851/219685403-ccc18419-346f-42e4-b441-f515bbabe9cf.png)

## Example disconnected SQS trace

Tracking and including work related to SQS messages in the the original trace may lead to some very big traces.

Use the following setting on selected processes to break very long distributed traces into more manageable chunks.

`-Ddd.sqs.propagation.enabled=false`

`DD_SQS_PROPAGATION_ENABLED=false`

![dd_sqs_propagation_enabled_false](https://user-images.githubusercontent.com/145851/219685490-fdb42cf0-8e86-42d8-aec1-1d2c6fbeb2ff.png)

## Example disconnected SQS trace with time-in-queue span 

You can also turn off propagation at the AWS-SDK level, which removes generation of `X-Amzn-Trace-Id` headers for all AWS-SDK calls, not just SQS.

Note you can still enable "time-in-queue" spans even when the `X-Amzn-Trace-Id` header is not available.

`-Ddd.sqs.legacy.tracing.enabled=false -Ddd.aws-sdk.propagation.enabled=false`

`DD_SQS_LEGACY_TRACING_ENABLED=false; DD_AWS_SDK_PROPAGATION_ENABLED=false`

![dd_aws_sdk_propagation_enabled_false](https://user-images.githubusercontent.com/145851/219685581-fd817914-1dfb-4411-a572-b29c38762fb9.png)
