### PR TITLE
Simplify scope activation in AWS-SDK instrumentations [2 of 3]

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSHttpClientInstrumentation.java
@@ -1,8 +1,10 @@
 package datadog.trace.instrumentation.aws.v0;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.instrumentation.aws.v0.OnErrorDecorator.AWS_HTTP;
 import static datadog.trace.instrumentation.aws.v0.OnErrorDecorator.DECORATE;
-import static datadog.trace.instrumentation.aws.v0.OnErrorDecorator.SCOPE_CONTEXT_KEY;
+import static datadog.trace.instrumentation.aws.v0.OnErrorDecorator.SPAN_CONTEXT_KEY;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
 import com.amazonaws.AmazonClientException;
@@ -49,14 +51,19 @@ public class AWSHttpClientInstrumentation extends Instrumenter.Tracing
     public static void methodExit(
         @Advice.Argument(value = 0, optional = true) final Request<?> request,
         @Advice.Thrown final Throwable throwable) {
-      if (throwable != null) {
-        final AgentScope scope = request.getHandlerContext(SCOPE_CONTEXT_KEY);
-        if (scope != null) {
-          request.addHandlerContext(SCOPE_CONTEXT_KEY, null);
-          final AgentSpan span = scope.span();
+
+      final AgentScope scope = activeScope();
+      // check name in case TracingRequestHandler failed to activate the span
+      if (scope != null && AWS_HTTP.equals(scope.span().getSpanName())) {
+        scope.close();
+      }
+
+      if (throwable != null && request != null) {
+        final AgentSpan span = request.getHandlerContext(SPAN_CONTEXT_KEY);
+        if (span != null) {
+          request.addHandlerContext(SPAN_CONTEXT_KEY, null);
           DECORATE.onError(span, throwable);
           DECORATE.beforeFinish(span);
-          scope.close();
           span.finish();
         }
       }
@@ -92,14 +99,19 @@ public class AWSHttpClientInstrumentation extends Instrumenter.Tracing
       public static void methodExit(
           @Advice.FieldValue("request") final Request<?> request,
           @Advice.Thrown final Throwable throwable) {
+
+        final AgentScope scope = activeScope();
+        // check name in case TracingRequestHandler failed to activate the span
+        if (scope != null && AWS_HTTP.equals(scope.span().getSpanName())) {
+          scope.close();
+        }
+
         if (throwable != null) {
-          final AgentScope scope = request.getHandlerContext(SCOPE_CONTEXT_KEY);
-          if (scope != null) {
-            request.addHandlerContext(SCOPE_CONTEXT_KEY, null);
-            final AgentSpan span = scope.span();
+          final AgentSpan span = request.getHandlerContext(SPAN_CONTEXT_KEY);
+          if (span != null) {
+            request.addHandlerContext(SPAN_CONTEXT_KEY, null);
             DECORATE.onError(span, throwable);
             DECORATE.beforeFinish(span);
-            scope.close();
             span.finish();
           }
         }

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
@@ -17,6 +17,7 @@ import java.util.regex.Pattern;
 public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response>
     implements AgentPropagation.Setter<Request<?>> {
   public static final AwsSdkClientDecorator DECORATE = new AwsSdkClientDecorator();
+  public static final CharSequence AWS_HTTP = UTF8BytesString.create("aws.http");
 
   private static final Pattern REQUEST_PATTERN = Pattern.compile("Request", Pattern.LITERAL);
   private static final Pattern AMAZON_PATTERN = Pattern.compile("Amazon", Pattern.LITERAL);

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/OnErrorDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/OnErrorDecorator.java
@@ -1,17 +1,19 @@
 package datadog.trace.instrumentation.aws.v0;
 
 import com.amazonaws.handlers.HandlerContextKey;
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
 
 public class OnErrorDecorator extends BaseDecorator {
-  // aws1.x sdk doesn't have any truly async clients so we can store scope in request context safely
-  public static final HandlerContextKey<AgentScope> SCOPE_CONTEXT_KEY =
-      new HandlerContextKey<>("DatadogScope"); // same as TracingRequestHandler.SCOPE_CONTEXT_KEY
+
+  public static final HandlerContextKey<AgentSpan> SPAN_CONTEXT_KEY =
+      new HandlerContextKey<>("DatadogSpan"); // same as TracingRequestHandler.SPAN_CONTEXT_KEY
 
   public static final OnErrorDecorator DECORATE = new OnErrorDecorator();
-  private static final CharSequence JAVA_AWS_SDK = UTF8BytesString.create("java-aws-sdk");
+  public static final CharSequence AWS_HTTP = UTF8BytesString.create("aws.http");
+
+  private static final CharSequence COMPONENT_NAME = UTF8BytesString.create("java-aws-sdk");
 
   @Override
   protected String[] instrumentationNames() {
@@ -25,6 +27,6 @@ public class OnErrorDecorator extends BaseDecorator {
 
   @Override
   protected CharSequence component() {
-    return JAVA_AWS_SDK;
+    return COMPONENT_NAME;
   }
 }

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/TracingRequestHandler.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/TracingRequestHandler.java
@@ -1,10 +1,9 @@
 package datadog.trace.instrumentation.aws.v0;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateNext;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.closePrevious;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.aws.v0.AwsSdkClientDecorator.AWS_HTTP;
 import static datadog.trace.instrumentation.aws.v0.AwsSdkClientDecorator.DECORATE;
 
 import com.amazonaws.AmazonWebServiceRequest;
@@ -14,20 +13,15 @@ import com.amazonaws.handlers.HandlerContextKey;
 import com.amazonaws.handlers.RequestHandler2;
 import datadog.trace.api.Config;
 import datadog.trace.api.TracePropagationStyle;
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Tracing Request Handler */
 public class TracingRequestHandler extends RequestHandler2 {
 
-  // aws1.x sdk doesn't have any truly async clients so we can store scope in request context safely
-  public static final HandlerContextKey<AgentScope> SCOPE_CONTEXT_KEY =
-      new HandlerContextKey<>("DatadogScope"); // same as OnErrorDecorator.SCOPE_CONTEXT_KEY
-
-  private static final CharSequence AWS_HTTP = UTF8BytesString.create("aws.http");
+  public static final HandlerContextKey<AgentSpan> SPAN_CONTEXT_KEY =
+      new HandlerContextKey<>("DatadogSpan"); // same as OnErrorDecorator.SPAN_CONTEXT_KEY
 
   private static final Logger log = LoggerFactory.getLogger(TracingRequestHandler.class);
 
@@ -38,17 +32,10 @@ public class TracingRequestHandler extends RequestHandler2 {
 
   @Override
   public void beforeRequest(final Request<?> request) {
-    boolean isPolling = isPollingRequest(request.getOriginalRequest());
-    if (isPolling) {
-      closePrevious(true);
-    }
     final AgentSpan span = startSpan(AWS_HTTP);
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, request);
-    if (isPolling) {
-      activateNext(span); // this scope will last until next poll
-    }
-    request.addHandlerContext(SCOPE_CONTEXT_KEY, activateSpan(span));
+    request.addHandlerContext(SPAN_CONTEXT_KEY, span);
     if (Config.get().isAwsPropagationEnabled()) {
       try {
         propagate().inject(span, request, DECORATE, TracePropagationStyle.XRAY);
@@ -56,43 +43,29 @@ public class TracingRequestHandler extends RequestHandler2 {
         log.warn("Unable to inject trace header", e);
       }
     }
+    // This scope will be closed by AwsHttpClientInstrumentation
+    activateSpan(span);
   }
 
   @Override
   public void afterResponse(final Request<?> request, final Response<?> response) {
-    final AgentScope scope = request.getHandlerContext(SCOPE_CONTEXT_KEY);
-    if (scope != null) {
-      request.addHandlerContext(SCOPE_CONTEXT_KEY, null);
-      DECORATE.onResponse(scope.span(), response);
-      DECORATE.beforeFinish(scope.span());
-      scope.close();
-      if (isPollingRequest(request.getOriginalRequest())) {
-        // will be finished on next poll
-      } else {
-        scope.span().finish();
-      }
+    final AgentSpan span = request.getHandlerContext(SPAN_CONTEXT_KEY);
+    if (span != null) {
+      request.addHandlerContext(SPAN_CONTEXT_KEY, null);
+      DECORATE.onResponse(span, response);
+      DECORATE.beforeFinish(span);
+      span.finish();
     }
   }
 
   @Override
   public void afterError(final Request<?> request, final Response<?> response, final Exception e) {
-    final AgentScope scope = request.getHandlerContext(SCOPE_CONTEXT_KEY);
-    if (scope != null) {
-      request.addHandlerContext(SCOPE_CONTEXT_KEY, null);
-      DECORATE.onError(scope.span(), e);
-      DECORATE.beforeFinish(scope.span());
-      scope.close();
-      if (isPollingRequest(request.getOriginalRequest())) {
-        // will be finished on next poll
-      } else {
-        scope.span().finish();
-      }
+    final AgentSpan span = request.getHandlerContext(SPAN_CONTEXT_KEY);
+    if (span != null) {
+      request.addHandlerContext(SPAN_CONTEXT_KEY, null);
+      DECORATE.onError(span, e);
+      DECORATE.beforeFinish(span);
+      span.finish();
     }
-  }
-
-  private static boolean isPollingRequest(AmazonWebServiceRequest request) {
-    return null != request
-        && "com.amazonaws.services.sqs.model.ReceiveMessageRequest"
-            .equals(request.getClass().getName());
   }
 }


### PR DESCRIPTION
### Builds on top of #4684

# What Does This Do

Avoid storing the scope in the v1 attributes; instead close any active AWS-SDK span when the client finishes its execution, like we do for v2. Also introduce a no-op scope when calling out from AWS to Netty in async mode to make sure that it can't accidentally capture continuations which incorrectly keep the AWS trace alive. (We close the AWS scope but there may be other scopes left on the stack that need protecting when the async AWS client calls Netty.)