### PR TITLE
Fix duplicate listeners registration for JUnit5

### DIFF
--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5Instrumentation.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5Instrumentation.java
@@ -6,6 +6,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.ServiceLoader;
@@ -53,6 +54,9 @@ public class JUnit5Instrumentation extends Instrumenter.CiVisibility
 
   public static class JUnit5Advice {
 
+    @SuppressFBWarnings(
+        value = "UC_USELESS_OBJECT",
+        justification = "listeners is the return value of the instrumented method")
     @Advice.OnMethodExit
     public static void addTracingListener(
         @Advice.Return(readOnly = false) Collection<TestExecutionListener> listeners) {


### PR DESCRIPTION
# What Does This Do
This PR changes JUnit5 instrumentation: instead of adding CI Visibility listener in `org.junit.platform.launcher.Launcher#<init>` it now does so in `org.junit.platform.launcher.core.LauncherConfig#getAdditionalTestExecutionListeners`

# Motivation
Previous version hooked into every implementation of `org.junit.platform.launcher.Launcher`.
Sometimes, e.g. when JUnit5 is run with Maven, there are multiple nested launchers.
Adding the listener when each of these launchers is created leads to duplicates in the listeners collection.
As the result, every event is processed by CI Visibility multiple times (which is not a problem currently, due to various safety checks that exist in the code, but makes the code fragile and leads to redundant computation). 

# Additional Notes
Tested with Gradle/Jupiter engine, Maven/Jupiter engine and Maven/Cucumber engine.
