### PR TITLE
Ignore additional proxy classes generated by Weld

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ProxyClassIgnores.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ProxyClassIgnores.java
@@ -11,6 +11,8 @@ public class ProxyClassIgnores {
           || name.contains("$__sisu")
           || name.contains("$$EnhancerByGuice$$")
           || name.contains("$$EnhancerByProxool$$")
+          || name.contains("$$$view")
+          || name.contains("$$_Weld$EnterpriseProxy")
           || name.contains("$$_WeldClientProxy")) {
         return true;
       }


### PR DESCRIPTION
# What Does This Do
Ignore additional proxy classes generated by Weld

# Motivation
https://github.com/DataDog/dd-trace-java/pull/3534 added certain classes generated by Weld to the ignore list, this PR adds additional classes based on real world usage.

# Additional Notes
