### PR TITLE
HTTP client path mapping

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/http/AntPatternPathNormalizer.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/http/AntPatternPathNormalizer.java
@@ -13,6 +13,9 @@ import org.slf4j.LoggerFactory;
 final class AntPatternPathNormalizer extends PathNormalizer {
   private static final Logger log = LoggerFactory.getLogger(AntPatternPathNormalizer.class);
 
+  /** Used to preserve original value as is when it's mapped to this value. */
+  private static final String KEEP_AS_IS = "*";
+
   private final Map<String, String> resourceNameMatchers;
   private final AntPathMatcher matcher = new AntPathMatcher();
 
@@ -23,6 +26,9 @@ final class AntPatternPathNormalizer extends PathNormalizer {
         public String apply(String path) {
           for (Map.Entry<String, String> resourceNameMatcher : resourceNameMatchers.entrySet()) {
             if (matcher.match(resourceNameMatcher.getKey(), path)) {
+              if (KEEP_AS_IS.equals(resourceNameMatcher.getValue())) {
+                return path;
+              }
               return resourceNameMatcher.getValue();
             }
           }

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/http/AntPatternPathNormalizerTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/http/AntPatternPathNormalizerTest.groovy
@@ -90,4 +90,25 @@ class AntPatternPathNormalizerTest extends DDSpecification {
     then:
     result == null
   }
+
+  def "keep the original path "() {
+    given:
+    def matchers = [
+      "/test/**/*.html": "*",
+      "/dev/**/*.html" : "dev"
+    ]
+    AntPatternPathNormalizer normalizer = new AntPatternPathNormalizer(matchers)
+
+    when:
+    String result = normalizer.normalize(path)
+
+    then:
+    result == normalizedPath
+
+    where:
+    path                     | normalizedPath
+    "/test/foo/bar.html"     | "/test/foo/bar.html"
+    "/test/foo/bar/baz.html" | "/test/foo/bar/baz.html"
+    "/dev/foo/bar/baz.html"  | "dev"
+  }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -54,6 +54,8 @@ public final class TracerConfig {
   public static final String BAGGAGE_MAPPING = "trace.header.baggage";
   public static final String TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING =
       "trace.http.server.path-resource-name-mapping";
+  public static final String TRACE_HTTP_CLIENT_PATH_RESOURCE_NAME_MAPPING =
+      "trace.http.client.path-resource-name-mapping";
   public static final String HTTP_SERVER_ERROR_STATUSES = "http.server.error.statuses";
   public static final String HTTP_CLIENT_ERROR_STATUSES = "http.client.error.statuses";
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -281,6 +281,7 @@ import static datadog.trace.api.config.TracerConfig.TRACE_AGENT_URL;
 import static datadog.trace.api.config.TracerConfig.TRACE_ANALYTICS_ENABLED;
 import static datadog.trace.api.config.TracerConfig.TRACE_CLIENT_IP_HEADER;
 import static datadog.trace.api.config.TracerConfig.TRACE_CLIENT_IP_RESOLVER_ENABLED;
+import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_CLIENT_PATH_RESOURCE_NAME_MAPPING;
 import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING;
 import static datadog.trace.api.config.TracerConfig.TRACE_PROPAGATION_STYLE;
 import static datadog.trace.api.config.TracerConfig.TRACE_PROPAGATION_STYLE_EXTRACT;
@@ -419,6 +420,7 @@ public class Config {
   private final boolean httpServerRawResource;
   private final boolean httpServerRouteBasedNaming;
   private final Map<String, String> httpServerPathResourceNameMapping;
+  private final Map<String, String> httpClientPathResourceNameMapping;
   private final boolean httpClientTagQueryString;
   private final boolean httpClientSplitByDomain;
   private final boolean dbClientSplitByInstance;
@@ -819,6 +821,9 @@ public class Config {
 
     httpServerPathResourceNameMapping =
         configProvider.getOrderedMap(TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING);
+
+    httpClientPathResourceNameMapping =
+        configProvider.getOrderedMap(TRACE_HTTP_CLIENT_PATH_RESOURCE_NAME_MAPPING);
 
     httpServerErrorStatuses =
         configProvider.getIntegerRange(
@@ -1510,6 +1515,10 @@ public class Config {
 
   public Map<String, String> getHttpServerPathResourceNameMapping() {
     return httpServerPathResourceNameMapping;
+  }
+
+  public Map<String, String> getHttpClientPathResourceNameMapping() {
+    return httpClientPathResourceNameMapping;
   }
 
   public BitSet getHttpServerErrorStatuses() {
@@ -2902,6 +2911,8 @@ public class Config {
         + httpServerRouteBasedNaming
         + ", httpServerPathResourceNameMapping="
         + httpServerPathResourceNameMapping
+        + ", httpClientPathResourceNameMapping="
+        + httpClientPathResourceNameMapping
         + ", httpClientTagQueryString="
         + httpClientTagQueryString
         + ", httpClientSplitByDomain="


### PR DESCRIPTION
# What Does This Do

Introduces `TRACE_HTTP_CLIENT_PATH_RESOURCE_NAME_MAPPING` to define mapping for HTTP client paths.
It provides a way to define rules to map URL paths matching a pattern to a resource name and thus reduce unwanted cardinality, e.g. to collapse all JSP page calls into one resource name:
`/some/path/main/page.jsp`
`/some/path/settings/user/profile.jsp`
And with the `/some/**/*.jsp:some-jsp` mapping it will group those paths into one resource `some-jsp`.

Also, it supports excluding certain resources from being normalized, it's enabled with a resource name is `*`. E.g.
with mapping`/foo/*/bar:*` it preserves original `/foo/123/bar` whereas without this rule it would be normalized `/foo/?/bar`. This can be useful to tune Java Tracer to disable normalization for defined paths. E.g.
There are two distinct resources:
`/some-path/onlineId2accountId` and `/some-path/accountId2onlineId`
with `SimplePathNormalizer` it's mapped to `/some-path/?`
whereas with a defined mapping `/some-path/*:*` it preserves original path and these resources can be viewed separately.

Note, that this ability to exclude a path from normalization will work not only for client HTTP requests but for server too `TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING`, because it's part of shared class `AntPatternPathNormalizer`.

This mechanism only provides a way to configure simple mappings from a ant pattern to a resource name and doesn't allow any rewritings. It can only group paths to some defined names and exclude certain URL paths from being grouped by keeping the original value for the resource name, when matching pattern is mapped to `*`.

# Motivation

By default, Java Tracer normalizes URLs to be used as resource names. Currently, HTTP client calls use `SimplePathNormalizer` that replaces path chunks that look like a variable (has digits, except for v?? pattern) with `?`. It's done this way to reduce cardinality. But sometimes users want to adjust it for certain URL patterns by either keeping original URL path as a resource name or by grouping multiple URL path to the same resource name.

# Additional Notes

APMS-8428
APMS-8165
APMS-6080
APMS-8823

