### PR TITLE
Fix flakiness in HttpServerTest

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -836,6 +836,9 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
         edgeTags.size() == DSM_EDGE_TAGS.size()
       }
     }
+
+    cleanup:
+    TEST_WRITER.waitForTraces(1)
   }
 
   def "test success with multiple header attached parent"() {


### PR DESCRIPTION
A trace may leak to the subsequent test.