### PR TITLE
Add test suite level visibility support for JUnit5

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java
@@ -3,6 +3,7 @@ package datadog.trace.bootstrap.instrumentation.decorator;
 import static datadog.trace.util.Strings.toJson;
 
 import datadog.trace.api.Config;
+import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.civisibility.InstrumentationBridge;
 import datadog.trace.api.civisibility.codeowners.Codeowners;
@@ -17,10 +18,19 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class TestDecorator extends BaseDecorator {
+
+  private static final Logger log = LoggerFactory.getLogger(TestDecorator.class);
 
   public static final String TEST_TYPE = "test";
   public static final String TEST_PASS = "pass";
@@ -28,7 +38,8 @@ public abstract class TestDecorator extends BaseDecorator {
   public static final String TEST_SKIP = "skip";
   public static final UTF8BytesString CIAPP_TEST_ORIGIN = UTF8BytesString.create("ciapp-test");
 
-  public TestDecorator() {}
+  private final ConcurrentMap<TestSuiteDescriptor, AgentSpan> activeTestSuites =
+      new ConcurrentHashMap<>();
 
   public boolean isCI() {
     return InstrumentationBridge.isCi();
@@ -44,8 +55,12 @@ public abstract class TestDecorator extends BaseDecorator {
     return TEST_TYPE;
   }
 
-  protected String spanKind() {
+  protected String testSpanKind() {
     return Tags.SPAN_KIND_TEST;
+  }
+
+  protected String testSuiteSpanKind() {
+    return Tags.SPAN_KIND_TEST_SUITE;
   }
 
   protected String runtimeName() {
@@ -78,12 +93,11 @@ public abstract class TestDecorator extends BaseDecorator {
 
   @Override
   protected CharSequence spanType() {
-    return InternalSpanTypes.TEST;
+    return null;
   }
 
   @Override
   public AgentSpan afterStart(final AgentSpan span) {
-    span.setTag(Tags.SPAN_KIND, spanKind());
     span.setTag(Tags.TEST_FRAMEWORK, testFramework());
     span.setTag(Tags.TEST_TYPE, testType());
     span.setSamplingPriority(PrioritySampling.SAMPLER_KEEP);
@@ -103,14 +117,73 @@ public abstract class TestDecorator extends BaseDecorator {
     return super.afterStart(span);
   }
 
-  protected AgentSpan afterTestStart(
+  protected void afterTestSuiteStart(
+      final AgentSpan span,
+      final String testSuiteName,
+      final @Nullable String version,
+      final @Nullable Class<?> testClass,
+      final @Nullable List<String> categories) {
+    span.setSpanType(InternalSpanTypes.TEST_SUITE_END);
+    span.setTag(Tags.SPAN_KIND, testSuiteSpanKind());
+
+    span.setResourceName(testSuiteName);
+    span.setTag(Tags.TEST_SUITE, testSuiteName);
+
+    // default value that may be overwritten later based on statuses of individual test cases
+    span.setTag(Tags.TEST_STATUS, TEST_SKIP);
+
+    // Version can be null. The testing framework version extraction is best-effort basis.
+    if (version != null) {
+      span.setTag(Tags.TEST_FRAMEWORK_VERSION, version);
+    }
+
+    // FIXME
+    //  test.module
+    //  test.bundle -- exactly the same as test.module
+
+    if (categories != null) {
+      span.setTag(
+          Tags.TEST_TRAITS, toJson(Collections.singletonMap("category", toJson(categories))));
+    }
+
+    if (testClass != null) {
+      if (Config.get().isCiVisibilitySourceDataEnabled()) {
+        SourcePathResolver sourcePathResolver = InstrumentationBridge.getSourcePathResolver();
+        String sourcePath = sourcePathResolver.getSourcePath(testClass);
+        if (sourcePath != null && !sourcePath.isEmpty()) {
+          span.setTag(Tags.TEST_SOURCE_FILE, sourcePath);
+        }
+      }
+    }
+
+    TestSuiteDescriptor testSuiteDescriptor = new TestSuiteDescriptor(testSuiteName, testClass);
+    activeTestSuites.put(testSuiteDescriptor, span);
+
+    afterStart(span);
+  }
+
+  protected void beforeTestSuiteFinish(
+      AgentSpan span, final String testSuiteName, final @Nullable Class<?> testClass) {
+    TestSuiteDescriptor testSuiteDescriptor = new TestSuiteDescriptor(testSuiteName, testClass);
+    activeTestSuites.remove(testSuiteDescriptor);
+
+    span.setTag(Tags.TEST_SUITE_ID, span.getSpanId());
+
+    beforeFinish(span);
+  }
+
+  protected void afterTestStart(
       final AgentSpan span,
       final String testSuiteName,
       final String testName,
-      final String testParameters,
-      final String version,
-      final Class<?> testClass,
-      final Method testMethod) {
+      final @Nullable String testParameters,
+      final @Nullable String version,
+      final @Nullable Class<?> testClass,
+      final @Nullable Method testMethod,
+      final @Nullable List<String> categories) {
+
+    span.setSpanType(InternalSpanTypes.TEST);
+    span.setTag(Tags.SPAN_KIND, testSpanKind());
 
     span.setResourceName(testSuiteName + "." + testName);
     span.setTag(Tags.TEST_SUITE, testSuiteName);
@@ -125,11 +198,16 @@ public abstract class TestDecorator extends BaseDecorator {
       span.setTag(Tags.TEST_FRAMEWORK_VERSION, version);
     }
 
+    if (categories != null) {
+      span.setTag(
+          Tags.TEST_TRAITS, toJson(Collections.singletonMap("category", toJson(categories))));
+    }
+
     if (Config.get().isCiVisibilitySourceDataEnabled()) {
       populateSourceDataTags(span, testClass, testMethod);
     }
 
-    return afterStart(span);
+    afterStart(span);
   }
 
   private void populateSourceDataTags(AgentSpan span, Class<?> testClass, Method testMethod) {
@@ -161,6 +239,46 @@ public abstract class TestDecorator extends BaseDecorator {
     }
   }
 
+  protected void beforeTestFinish(
+      AgentSpan span, String testSuiteName, @Nullable Class<?> testClass) {
+    TestSuiteDescriptor testSuiteDescriptor = new TestSuiteDescriptor(testSuiteName, testClass);
+    AgentSpan testSuiteSpan = activeTestSuites.get(testSuiteDescriptor);
+    if (testSuiteSpan != null) {
+      long testSuiteSpanId = testSuiteSpan.getSpanId();
+      span.setTag(Tags.TEST_SUITE_ID, testSuiteSpanId);
+
+      String testSuiteStatus = (String) testSuiteSpan.getTag(Tags.TEST_STATUS);
+      String testCaseStatus = (String) span.getTag(Tags.TEST_STATUS);
+      switch (testCaseStatus) {
+        case TEST_SKIP:
+          // a test suite will have SKIP status by default
+          break;
+        case TEST_PASS:
+          if (!TEST_FAIL.equals(testSuiteStatus)) {
+            // if at least one test case passes (i.e. is not skipped) and no test cases fail,
+            // test suite status should be PASS
+            testSuiteSpan.setTag(Tags.TEST_STATUS, TEST_PASS);
+          }
+          break;
+        case TEST_FAIL:
+          // if at least one test case fails, test suite status should be FAIL
+          testSuiteSpan.setTag(Tags.TEST_STATUS, TEST_FAIL);
+          break;
+        default:
+          log.debug(
+              "Unexpected test case status {} for test case with ID {}",
+              testCaseStatus,
+              span.getSpanId());
+          break;
+      }
+
+    } else {
+      // TODO log a warning (when test suite level visibility support is there for all frameworks
+    }
+
+    beforeFinish(span);
+  }
+
   public List<Method> testMethods(
       final Class<?> testClass, final Class<? extends Annotation> testAnnotation) {
     final List<Method> testMethods = new ArrayList<>();
@@ -174,12 +292,49 @@ public abstract class TestDecorator extends BaseDecorator {
     return testMethods;
   }
 
-  public boolean isTestSpan(final AgentSpan activeSpan) {
+  public boolean isTestSpan(@Nullable final AgentSpan activeSpan) {
     if (activeSpan == null) {
       return false;
     }
 
-    return spanKind().equals(activeSpan.getSpanType())
+    return DDSpanTypes.TEST.equals(activeSpan.getSpanType())
         && testType().equals(activeSpan.getTag(Tags.TEST_TYPE));
+  }
+
+  public boolean isTestSuiteSpan(@Nullable final AgentSpan activeSpan) {
+    if (activeSpan == null) {
+      return false;
+    }
+
+    return DDSpanTypes.TEST_SUITE_END.equals(activeSpan.getSpanType())
+        && testType().equals(activeSpan.getTag(Tags.TEST_TYPE));
+  }
+
+  private static final class TestSuiteDescriptor {
+    private final String testSuiteName;
+    private final Class<?> testClass;
+
+    private TestSuiteDescriptor(String testSuiteName, Class<?> testClass) {
+      this.testSuiteName = testSuiteName;
+      this.testClass = testClass;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      TestSuiteDescriptor that = (TestSuiteDescriptor) o;
+      return Objects.equals(testSuiteName, that.testSuiteName)
+          && Objects.equals(testClass, that.testClass);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(testSuiteName, testClass);
+    }
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java
@@ -153,6 +153,11 @@ public abstract class TestDecorator extends BaseDecorator {
   }
 
   protected boolean tryTestSuiteStart(String testSuiteName, Class<?> testClass) {
+    if (testModuleState == null) {
+      // do not create test suite spans for legacy setups that do not create modules
+      return false;
+    }
+
     TestSuiteDescriptor testSuiteDescriptor = new TestSuiteDescriptor(testSuiteName, testClass);
     Integer counter = testSuiteNestedCallCounters.merge(testSuiteDescriptor, 1, Integer::sum);
     return counter == 1;

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java
@@ -176,7 +176,7 @@ public abstract class TestDecorator extends BaseDecorator {
       final String testSuiteName,
       final @Nullable String version,
       final @Nullable Class<?> testClass,
-      final @Nullable List<String> categories) {
+      final @Nullable Collection<String> categories) {
     span.setSpanType(InternalSpanTypes.TEST_SUITE_END);
     span.setTag(Tags.SPAN_KIND, testSuiteSpanKind());
 
@@ -192,7 +192,7 @@ public abstract class TestDecorator extends BaseDecorator {
 
     if (categories != null && !categories.isEmpty()) {
       span.setTag(
-          Tags.TEST_TRAITS, toJson(Collections.singletonMap("category", toJson(categories))));
+          Tags.TEST_TRAITS, toJson(Collections.singletonMap("category", toJson(categories)), true));
     }
 
     if (testClass != null) {
@@ -238,7 +238,7 @@ public abstract class TestDecorator extends BaseDecorator {
       final @Nullable String version,
       final @Nullable Class<?> testClass,
       final @Nullable Method testMethod,
-      final @Nullable List<String> categories) {
+      final @Nullable Collection<String> categories) {
 
     span.setSpanType(InternalSpanTypes.TEST);
     span.setTag(Tags.SPAN_KIND, testSpanKind());
@@ -260,7 +260,7 @@ public abstract class TestDecorator extends BaseDecorator {
 
     if (categories != null && !categories.isEmpty()) {
       span.setTag(
-          Tags.TEST_TRAITS, toJson(Collections.singletonMap("category", toJson(categories))));
+          Tags.TEST_TRAITS, toJson(Collections.singletonMap("category", toJson(categories)), true));
     }
 
     if (Config.get().isCiVisibilitySourceDataEnabled()) {

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/TestDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/TestDecoratorTest.groovy
@@ -30,7 +30,7 @@ class TestDecoratorTest extends BaseDecoratorTest {
 
     then:
     1 * span.setTag(Tags.COMPONENT, "test-component")
-    1 * span.setTag(Tags.SPAN_KIND, decorator.spanKind())
+    1 * span.setTag(Tags.SPAN_KIND, decorator.testSpanKind())
     1 * span.setSpanType(decorator.spanType())
     1 * span.setTag(Tags.TEST_FRAMEWORK, decorator.testFramework())
     1 * span.setTag(Tags.TEST_TYPE, decorator.testType())
@@ -81,7 +81,7 @@ class TestDecoratorTest extends BaseDecoratorTest {
         }
 
         @Override
-        protected String spanKind() {
+        protected String testSpanKind() {
           return "test-type"
         }
 

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/TestDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/TestDecoratorTest.groovy
@@ -30,7 +30,6 @@ class TestDecoratorTest extends BaseDecoratorTest {
 
     then:
     1 * span.setTag(Tags.COMPONENT, "test-component")
-    1 * span.setTag(Tags.SPAN_KIND, decorator.testSpanKind())
     1 * span.setSpanType(decorator.spanType())
     1 * span.setTag(Tags.TEST_FRAMEWORK, decorator.testFramework())
     1 * span.setTag(Tags.TEST_TYPE, decorator.testType())

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
@@ -10,6 +10,7 @@ import datadog.trace.civisibility.source.BestEfforSourcePathResolver;
 import datadog.trace.civisibility.source.CompilerAidedSourcePathResolver;
 import datadog.trace.civisibility.source.MethodLinesResolverImpl;
 import datadog.trace.civisibility.source.RepoIndexSourcePathResolver;
+import java.io.File;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,5 +59,34 @@ public class CiVisibilitySystem {
       InstrumentationBridge.setCodeowners(path -> null);
       InstrumentationBridge.setSourcePathResolver(clazz -> null);
     }
+
+    InstrumentationBridge.setModule(getModulePath(repoRoot));
+  }
+
+  private static String getModulePath(String repoRoot) {
+    if (repoRoot == null) {
+      return null;
+    }
+
+    if (!repoRoot.endsWith(File.separator)) {
+      repoRoot += File.separator;
+    }
+
+    String currentPath =
+        firstNonNull(System.getProperty("basedir"), System.getProperty("user.dir"));
+    if (currentPath == null || !currentPath.startsWith(repoRoot)) {
+      return null;
+    }
+
+    return currentPath.substring(repoRoot.length());
+  }
+
+  private static String firstNonNull(String... strings) {
+    for (String s : strings) {
+      if (s != null) {
+        return s;
+      }
+    }
+    return null;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/CodeownersImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/CodeownersImpl.java
@@ -9,6 +9,7 @@ import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class CodeownersImpl implements Codeowners {
@@ -26,7 +27,7 @@ public class CodeownersImpl implements Codeowners {
    * @return the list of teams/people who own the provided path
    */
   @Override
-  public @Nullable Collection<String> getOwners(String path) {
+  public @Nullable Collection<String> getOwners(@Nonnull String path) {
     char[] pathCharacters = path.toCharArray();
     for (Entry entry : entries) {
       if (entry.getMatcher().consume(pathCharacters, 0) >= 0) {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/BestEfforSourcePathResolver.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/BestEfforSourcePathResolver.java
@@ -1,6 +1,7 @@
 package datadog.trace.civisibility.source;
 
 import datadog.trace.api.civisibility.source.SourcePathResolver;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class BestEfforSourcePathResolver implements SourcePathResolver {
@@ -13,7 +14,7 @@ public class BestEfforSourcePathResolver implements SourcePathResolver {
 
   @Nullable
   @Override
-  public String getSourcePath(Class<?> c) {
+  public String getSourcePath(@Nonnull Class<?> c) {
     for (SourcePathResolver delegate : delegates) {
       String sourcePath = delegate.getSourcePath(c);
       if (sourcePath != null) {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/CompilerAidedSourcePathResolver.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/CompilerAidedSourcePathResolver.java
@@ -3,6 +3,7 @@ package datadog.trace.civisibility.source;
 import datadog.compiler.utils.CompilerUtils;
 import datadog.trace.api.civisibility.source.SourcePathResolver;
 import java.io.File;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class CompilerAidedSourcePathResolver implements SourcePathResolver {
@@ -15,7 +16,7 @@ public class CompilerAidedSourcePathResolver implements SourcePathResolver {
 
   @Nullable
   @Override
-  public String getSourcePath(Class<?> c) {
+  public String getSourcePath(@Nonnull Class<?> c) {
     String absoluteSourcePath = CompilerUtils.getSourcePath(c);
     if (absoluteSourcePath != null && absoluteSourcePath.startsWith(repoRoot)) {
       return absoluteSourcePath.substring(repoRoot.length());

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/MethodLinesResolverImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/MethodLinesResolverImpl.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Label;
@@ -23,8 +24,9 @@ public class MethodLinesResolverImpl implements MethodLinesResolver {
   private final DDCache<Class<?>, ClassMethodLines> methodLinesCache =
       DDCaches.newFixedSizeIdentityCache(16);
 
+  @Nonnull
   @Override
-  public MethodLines getLines(Method method) {
+  public MethodLines getLines(@Nonnull Method method) {
     try {
       ClassMethodLines classMethodLines =
           methodLinesCache.computeIfAbsent(method.getDeclaringClass(), ClassMethodLines::parse);

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/RepoIndexSourcePathResolver.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/RepoIndexSourcePathResolver.java
@@ -17,6 +17,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
@@ -51,7 +52,7 @@ public class RepoIndexSourcePathResolver implements SourcePathResolver {
 
   @Nullable
   @Override
-  public String getSourcePath(Class<?> c) {
+  public String getSourcePath(@Nonnull Class<?> c) {
     if (index == null) {
       synchronized (indexInitializationLock) {
         if (index == null) {

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Decorator.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Decorator.java
@@ -1,12 +1,17 @@
 package datadog.trace.instrumentation.junit4;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+
 import datadog.trace.api.DisableTestTrace;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.decorator.TestDecorator;
 import java.lang.reflect.Method;
+import java.util.List;
+import org.junit.Test;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
+import org.junit.runners.model.TestClass;
 
 public class JUnit4Decorator extends TestDecorator {
   public static final JUnit4Decorator DECORATE = new JUnit4Decorator();
@@ -27,21 +32,73 @@ public class JUnit4Decorator extends TestDecorator {
   }
 
   public boolean skipTrace(final Description description) {
-    return description.getAnnotation(DisableTestTrace.class) != null
-        || (description.getTestClass() != null
-            && description.getTestClass().getAnnotation(DisableTestTrace.class) != null);
+    if (description.getAnnotation(DisableTestTrace.class) != null) {
+      return true;
+    }
+    Class<?> testClass = description.getTestClass();
+    return testClass != null && testClass.getAnnotation(DisableTestTrace.class) != null;
+  }
+
+  public boolean skipTrace(final TestClass junitTestClass) {
+    if (junitTestClass == null) {
+      return false;
+    }
+    Class<?> testClass = junitTestClass.getJavaClass();
+    return testClass != null && testClass.getAnnotation(DisableTestTrace.class) != null;
+  }
+
+  public void onTestSuiteStart(
+      final AgentSpan span, final String version, final TestClass junitTestClass) {
+    String testSuiteName = junitTestClass.getName();
+    Class<?> testClass = junitTestClass.getJavaClass();
+    List<String> categories = JUnit4Utils.getCategories(testClass, null);
+
+    afterTestSuiteStart(span, testSuiteName, version, testClass, categories);
+  }
+
+  public void onTestSuiteIgnored(
+      final AgentSpan span,
+      final String version,
+      final Description description,
+      final String reason) {
+    Class<?> testClass = description.getTestClass();
+    String testSuiteName = testClass.getName();
+    List<String> categories = JUnit4Utils.getCategories(testClass, null);
+
+    afterTestSuiteStart(span, testSuiteName, version, testClass, categories);
+
+    List<Method> testMethods = testMethods(testClass, Test.class);
+    for (Method testMethod : testMethods) {
+      final AgentSpan testCaseSpan = startSpan("junit.test");
+      onTestIgnored(testCaseSpan, version, description, testMethod, reason);
+      // We set a duration of 1 ns, because a span with duration==0 has a special treatment in the
+      // tracer.
+      testCaseSpan.finishWithDuration(1L);
+    }
+
+    span.setTag(Tags.TEST_SKIP_REASON, reason);
+
+    beforeTestSuiteFinish(span, testSuiteName, testClass);
+  }
+
+  public void onTestSuiteFinish(final AgentSpan span, final TestClass junitTestClass) {
+    String testSuiteName = junitTestClass.getName();
+    Class<?> testClass = junitTestClass.getJavaClass();
+    beforeTestSuiteFinish(span, testSuiteName, testClass);
   }
 
   public void onTestStart(
       final AgentSpan span, final String version, final Description description) {
     Class<?> testClass = description.getTestClass();
     Method testMethod = JUnit4Utils.getTestMethod(description);
+    List<String> categories = JUnit4Utils.getCategories(testClass, testMethod);
 
     String testSuiteName = description.getClassName();
     String testName = JUnit4Utils.getTestName(description, testMethod);
     String testParameters = JUnit4Utils.getParameters(description);
 
-    afterTestStart(span, testSuiteName, testName, testParameters, version, testClass, testMethod);
+    afterTestStart(
+        span, testSuiteName, testName, testParameters, version, testClass, testMethod, categories);
 
     // We cannot set TEST_PASS status in onTestFinish(...) method because that method
     // is executed always after onTestFailure. For that reason, TEST_PASS status is preset
@@ -55,17 +112,18 @@ public class JUnit4Decorator extends TestDecorator {
       final Description description,
       final Method testMethod,
       final String reason) {
-    final Class<?> testClass = description.getTestClass();
+    Class<?> testClass = description.getTestClass();
+    List<String> categories = JUnit4Utils.getCategories(testClass, testMethod);
 
-    final String testSuiteName = description.getClassName();
-    final String testName = JUnit4Utils.getTestName(description, testMethod);
+    String testSuiteName = description.getClassName();
+    String testName = JUnit4Utils.getTestName(description, testMethod);
 
-    afterTestStart(span, testSuiteName, testName, null, version, testClass, testMethod);
+    afterTestStart(span, testSuiteName, testName, null, version, testClass, testMethod, categories);
 
     span.setTag(Tags.TEST_STATUS, TEST_SKIP);
     span.setTag(Tags.TEST_SKIP_REASON, reason);
 
-    beforeFinish(span);
+    beforeTestFinish(span, testSuiteName, testClass);
   }
 
   public void onTestFailure(final AgentSpan span, final Failure failure) {
@@ -77,16 +135,38 @@ public class JUnit4Decorator extends TestDecorator {
     }
   }
 
-  public void onTestAssumptionFailure(final AgentSpan span, final Failure failure) {
+  public void onTestFinish(final AgentSpan span, final Description description) {
+    String testSuiteName = description.getClassName();
+    Class<?> testClass = description.getTestClass();
+    beforeTestFinish(span, testSuiteName, testClass);
+  }
+
+  public void onTestAssumptionFailure(final AgentSpan span, final String reason) {
     // The consensus is to treat "assumptions failure" as skipped tests.
     span.setTag(Tags.TEST_STATUS, TEST_SKIP);
-    final Throwable throwable = failure.getException();
-    if (throwable != null) {
-      span.setTag(Tags.TEST_SKIP_REASON, throwable.getMessage());
+    if (reason != null) {
+      span.setTag(Tags.TEST_SKIP_REASON, reason);
     }
   }
 
-  public void onTestFinish(final AgentSpan span) {
-    beforeFinish(span);
+  public void onTestSuiteAssumptionFailure(
+      final AgentSpan span,
+      final String version,
+      final Description description,
+      final String reason) {
+    // The consensus is to treat "assumptions failure" as skipped tests.
+    span.setTag(Tags.TEST_STATUS, TEST_SKIP);
+    if (reason != null) {
+      span.setTag(Tags.TEST_SKIP_REASON, reason);
+    }
+
+    List<Method> testMethods = testMethods(description.getTestClass(), Test.class);
+    for (Method testMethod : testMethods) {
+      final AgentSpan testCaseSpan = startSpan("junit.test");
+      onTestIgnored(testCaseSpan, version, description, testMethod, reason);
+      // We set a duration of 1 ns, because a span with duration==0 has a special treatment in the
+      // tracer.
+      testCaseSpan.finishWithDuration(1L);
+    }
   }
 }

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Decorator.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Decorator.java
@@ -55,6 +55,26 @@ public class JUnit4Decorator extends TestDecorator {
     beforeTestModuleFinish(span);
   }
 
+  // sometimes JUnit invokes multiple nested runners with the same suite class
+  // (this happens, for instance, for parameterized tests)
+  // in this case we maintain a counter to determine which runner invocation is the first,
+  // and to only trigger processing once
+  public boolean tryTestSuiteStart(final TestClass junitTestClass) {
+    String testSuiteName = junitTestClass.getName();
+    Class<?> testClass = junitTestClass.getJavaClass();
+    return tryTestSuiteStart(testSuiteName, testClass);
+  }
+
+  // sometimes JUnit invokes multiple nested runners with the same suite class
+  // (this happens, for instance, for parameterized tests)
+  // in this case we maintain a counter to determine which runner invocation is the last,
+  // and to only trigger processing once
+  public boolean tryTestSuiteFinish(final TestClass junitTestClass) {
+    String testSuiteName = junitTestClass.getName();
+    Class<?> testClass = junitTestClass.getJavaClass();
+    return tryTestSuiteFinish(testSuiteName, testClass);
+  }
+
   public void onTestSuiteStart(
       final AgentSpan span, final String version, final TestClass junitTestClass) {
     String testSuiteName = junitTestClass.getName();

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Decorator.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Decorator.java
@@ -47,6 +47,14 @@ public class JUnit4Decorator extends TestDecorator {
     return testClass != null && testClass.getAnnotation(DisableTestTrace.class) != null;
   }
 
+  public void onTestModuleStart(final AgentSpan span, final String version) {
+    afterTestModuleStart(span, version);
+  }
+
+  public void onTestModuleFinish(final AgentSpan span) {
+    beforeTestModuleFinish(span);
+  }
+
   public void onTestSuiteStart(
       final AgentSpan span, final String version, final TestClass junitTestClass) {
     String testSuiteName = junitTestClass.getName();

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Instrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Instrumentation.java
@@ -2,16 +2,15 @@ package datadog.trace.instrumentation.junit4;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import java.util.List;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.junit.rules.RuleChain;
-import org.junit.runner.notification.RunListener;
 import org.junit.runner.notification.RunNotifier;
 
 @AutoService(Instrumenter.class)
@@ -24,7 +23,7 @@ public class JUnit4Instrumentation extends Instrumenter.CiVisibility
 
   @Override
   public String hierarchyMarkerType() {
-    return "org.junit.runner.Runner";
+    return "org.junit.runner.notification.RunNotifier";
   }
 
   @Override
@@ -44,27 +43,15 @@ public class JUnit4Instrumentation extends Instrumenter.CiVisibility
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(
-        named("run").and(takesArgument(0, named("org.junit.runner.notification.RunNotifier"))),
-        JUnit4Instrumentation.class.getName() + "$JUnit4Advice");
+        isConstructor(), JUnit4Instrumentation.class.getName() + "$JUnit4Advice");
   }
 
   public static class JUnit4Advice {
-    @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void addTracingListener(@Advice.Argument(0) final RunNotifier runNotifier) {
-      final List<RunListener> runListeners = JUnit4Utils.runListenersFromRunNotifier(runNotifier);
-      if (runListeners == null) {
-        return;
-      }
-
-      // This prevents installing the TracingListener multiple times.
-      for (final RunListener listener : runListeners) {
-        if (JUnit4Utils.isTracingListener(listener)) {
-          return;
-        }
-      }
-
-      final TracingListener tracingListener = new TracingListener();
-      runNotifier.addListener(tracingListener);
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void addTracingListener(
+        @Advice.This(typing = Assigner.Typing.DYNAMIC) final RunNotifier runNotifier) {
+      runNotifier.removeListener(TracingListener.INSTANCE);
+      runNotifier.addListener(TracingListener.INSTANCE);
     }
 
     // JUnit 4.10 and above

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
@@ -4,9 +4,11 @@ import datadog.trace.util.Strings;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.Description;
 import org.junit.runner.notification.RunListener;
 import org.junit.runner.notification.RunNotifier;
@@ -198,5 +200,37 @@ public abstract class JUnit4Utils {
     // No public access to the test parameters map in JUnit4.
     // In this case, we store the fullTestName in the "metadata.test_name" object.
     return "{\"metadata\":{\"test_name\":\"" + Strings.escapeToJson(methodName) + "\"}}";
+  }
+
+  public static List<String> getCategories(Class<?> testClass, @Nullable Method testMethod) {
+    List<String> categories = new ArrayList<>();
+
+    if (testClass != null) {
+      Category categoryAnnotation = testClass.getAnnotation(Category.class);
+      if (categoryAnnotation != null) {
+        for (Class<?> category : categoryAnnotation.value()) {
+          categories.add(category.getName());
+        }
+      }
+    }
+
+    if (testMethod != null) {
+      Category categoryAnnotation = testMethod.getAnnotation(Category.class);
+      if (categoryAnnotation != null) {
+        for (Class<?> category : categoryAnnotation.value()) {
+          categories.add(category.getName());
+        }
+      }
+    }
+
+    return categories;
+  }
+
+  public static boolean isTestCaseDescription(final Description description) {
+    return description.getMethodName() != null && !"".equals(description.getMethodName());
+  }
+
+  public static boolean isTestSuiteDescription(final Description description) {
+    return description.getTestClass() != null;
   }
 }

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
@@ -131,6 +131,8 @@ public abstract class JUnit4Utils {
           }
         }
       }
+    } else if (methodName.contains("[")) {
+      methodName = testNameNormalizerRegex.matcher(methodName).replaceAll("");
     }
 
     try {

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
@@ -18,11 +18,16 @@ import org.junit.runners.model.TestClass;
 
 public class TracingListener extends RunListener {
 
+  public static final TracingListener INSTANCE = new TracingListener();
+
   private final String version;
 
-  public TracingListener() {
+  private TracingListener() {
     version = Version.id();
+  }
 
+  @Override
+  public void testRunStarted(Description description) {
     final AgentSpan span = startSpan("junit.test_module");
     final AgentScope scope = activateSpan(span);
     scope.setAsyncPropagation(true);

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
@@ -34,7 +34,7 @@ class JUnit4Test extends TestFrameworkTest {
     assertTraces(1) {
       trace(3, true) {
         long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, "org.example.TestSucceed", TestDecorator.TEST_PASS)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSucceed", TestDecorator.TEST_PASS)
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceed", "test_succeed", TestDecorator.TEST_PASS)
       }
     }
@@ -48,7 +48,7 @@ class JUnit4Test extends TestFrameworkTest {
     assertTraces(1) {
       trace(3, true) {
         long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, "org.example.TestInheritance", TestDecorator.TEST_PASS)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestInheritance", TestDecorator.TEST_PASS)
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestInheritance", "test_succeed", TestDecorator.TEST_PASS)
       }
     }
@@ -66,7 +66,7 @@ class JUnit4Test extends TestFrameworkTest {
     assertTraces(1) {
       trace(3, true) {
         long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_FAIL)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, "org.example.TestFailed", TestDecorator.TEST_FAIL)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestFailed", TestDecorator.TEST_FAIL)
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailed", "test_failed", TestDecorator.TEST_FAIL, null, exception)
       }
     }
@@ -87,7 +87,7 @@ class JUnit4Test extends TestFrameworkTest {
     assertTraces(1) {
       trace(3, true) {
         long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_FAIL)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, "org.example.TestError", TestDecorator.TEST_FAIL)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestError", TestDecorator.TEST_FAIL)
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestError", "test_error", TestDecorator.TEST_FAIL, null, exception)
       }
     }
@@ -104,7 +104,7 @@ class JUnit4Test extends TestFrameworkTest {
     assertTraces(1) {
       trace(3, true) {
         long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_SKIP)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, "org.example.TestSkipped", TestDecorator.TEST_SKIP)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSkipped", TestDecorator.TEST_SKIP)
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
       }
     }
@@ -121,7 +121,7 @@ class JUnit4Test extends TestFrameworkTest {
     assertTraces(1) {
       trace(4, true) {
         long testModuleId = testModuleSpan(it, 2, TestDecorator.TEST_SKIP)
-        long testSuiteId = testSuiteSpan(it, 3, testModuleId, "org.example.TestSkippedClass", TestDecorator.TEST_SKIP, testTags, null, true)
+        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestSkippedClass", TestDecorator.TEST_SKIP, testTags, null, true)
         testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestSkippedClass", "test_class_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSkippedClass", "test_class_another_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
       }
@@ -139,7 +139,7 @@ class JUnit4Test extends TestFrameworkTest {
     assertTraces(1) {
       trace(4, true) {
         long testModuleId = testModuleSpan(it, 2, TestDecorator.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 3, testModuleId, "org.example.TestSucceedAndSkipped", TestDecorator.TEST_PASS)
+        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestSucceedAndSkipped", TestDecorator.TEST_PASS)
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceedAndSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
         testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestSucceedAndSkipped", "test_succeed", TestDecorator.TEST_PASS)
       }
@@ -157,7 +157,7 @@ class JUnit4Test extends TestFrameworkTest {
     assertTraces(1) {
       trace(5, true) {
         long testModuleId = testModuleSpan(it, 3, TestDecorator.TEST_FAIL)
-        long testSuiteId = testSuiteSpan(it, 4, testModuleId, "org.example.TestFailedAndSucceed", TestDecorator.TEST_FAIL)
+        long testSuiteId = testSuiteSpan(it, 4, testModuleId, testModuleId, "org.example.TestFailedAndSucceed", TestDecorator.TEST_FAIL)
         testSpan(it, 2, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_succeed", TestDecorator.TEST_PASS)
         testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_failed", TestDecorator.TEST_FAIL, null, exception)
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_another_succeed", TestDecorator.TEST_PASS)
@@ -176,7 +176,7 @@ class JUnit4Test extends TestFrameworkTest {
     assertTraces(1) {
       trace(4, true) {
         long testModuleId = testModuleSpan(it, 2, TestDecorator.TEST_FAIL)
-        long testSuiteId = testSuiteSpan(it, 3, testModuleId, "org.example.TestFailedSuiteTearDown", TestDecorator.TEST_FAIL, null, exception)
+        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestFailedSuiteTearDown", TestDecorator.TEST_FAIL, null, exception)
         testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestFailedSuiteTearDown", "test_succeed", TestDecorator.TEST_PASS)
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedSuiteTearDown", "test_another_succeed", TestDecorator.TEST_PASS)
       }
@@ -194,7 +194,7 @@ class JUnit4Test extends TestFrameworkTest {
     assertTraces(1) {
       trace(2, true) {
         long testModuleId = testModuleSpan(it, 0, TestDecorator.TEST_FAIL)
-        testSuiteSpan(it, 1, testModuleId, "org.example.TestFailedSuiteSetup", TestDecorator.TEST_FAIL, null, exception)
+        testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestFailedSuiteSetup", TestDecorator.TEST_FAIL, null, exception)
       }
     }
 
@@ -210,7 +210,7 @@ class JUnit4Test extends TestFrameworkTest {
     assertTraces(1) {
       trace(3, true) {
         long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_SKIP)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, "org.example.TestAssumption", TestDecorator.TEST_SKIP)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestAssumption", TestDecorator.TEST_SKIP)
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestAssumption", "test_fail_assumption", TestDecorator.TEST_SKIP, testTags)
       }
     }
@@ -227,7 +227,7 @@ class JUnit4Test extends TestFrameworkTest {
     assertTraces(1) {
       trace(3, true) {
         long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, "org.example.TestSucceedWithCategories",
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSucceedWithCategories",
           TestDecorator.TEST_PASS, null, null, false,
           ["org.example.Slow", "org.example.Flaky"])
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceedWithCategories", "test_succeed",
@@ -245,7 +245,7 @@ class JUnit4Test extends TestFrameworkTest {
     assertTraces(1) {
       trace(3, true) {
         long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_SKIP)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, "org.example.TestSuiteSetUpAssumption", TestDecorator.TEST_SKIP)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSuiteSetUpAssumption", TestDecorator.TEST_SKIP)
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSuiteSetUpAssumption", "test_succeed", TestDecorator.TEST_SKIP, null, null, true)
       }
     }
@@ -259,7 +259,7 @@ class JUnit4Test extends TestFrameworkTest {
     assertTraces(1) {
       trace(4, true) {
         long testModuleId = testModuleSpan(it, 2, TestDecorator.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 3, testModuleId, "org.example.TestAssumptionAndSucceed", TestDecorator.TEST_PASS)
+        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestAssumptionAndSucceed", TestDecorator.TEST_PASS)
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestAssumptionAndSucceed", "test_fail_assumption", TestDecorator.TEST_SKIP, testTags)
         testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestAssumptionAndSucceed", "test_succeed", TestDecorator.TEST_PASS)
       }
@@ -278,10 +278,10 @@ class JUnit4Test extends TestFrameworkTest {
       trace(6, true) {
         long testModuleId = testModuleSpan(it, 3, TestDecorator.TEST_PASS)
 
-        long firstSuiteId = testSuiteSpan(it, 4, testModuleId, "org.example.TestSucceed", TestDecorator.TEST_PASS)
+        long firstSuiteId = testSuiteSpan(it, 4, testModuleId, testModuleId, "org.example.TestSucceed", TestDecorator.TEST_PASS)
         testSpan(it, 0, testModuleId, firstSuiteId, "org.example.TestSucceed", "test_succeed", TestDecorator.TEST_PASS)
 
-        long secondSuiteId = testSuiteSpan(it, 5, testModuleId, "org.example.TestSucceedAndSkipped", TestDecorator.TEST_PASS)
+        long secondSuiteId = testSuiteSpan(it, 5, testModuleId, testModuleId, "org.example.TestSucceedAndSkipped", TestDecorator.TEST_PASS)
         testSpan(it, 1, testModuleId, secondSuiteId, "org.example.TestSucceedAndSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
         testSpan(it, 2, testModuleId, secondSuiteId, "org.example.TestSucceedAndSkipped", "test_succeed", TestDecorator.TEST_PASS)
       }
@@ -300,10 +300,10 @@ class JUnit4Test extends TestFrameworkTest {
       trace(7, true) {
         long testModuleId = testModuleSpan(it, 4, TestDecorator.TEST_FAIL)
 
-        long firstSuiteId = testSuiteSpan(it, 6, testModuleId, "org.example.TestSucceed", TestDecorator.TEST_PASS)
+        long firstSuiteId = testSuiteSpan(it, 6, testModuleId, testModuleId, "org.example.TestSucceed", TestDecorator.TEST_PASS)
         testSpan(it, 3, testModuleId, firstSuiteId, "org.example.TestSucceed", "test_succeed", TestDecorator.TEST_PASS)
 
-        long secondSuiteId = testSuiteSpan(it, 5, testModuleId, "org.example.TestFailedAndSucceed", TestDecorator.TEST_FAIL)
+        long secondSuiteId = testSuiteSpan(it, 5, testModuleId, testModuleId, "org.example.TestFailedAndSucceed", TestDecorator.TEST_FAIL)
         testSpan(it, 2, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_succeed", TestDecorator.TEST_PASS)
         testSpan(it, 1, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_failed", TestDecorator.TEST_FAIL, null, exception)
         testSpan(it, 0, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_another_succeed", TestDecorator.TEST_PASS)
@@ -321,7 +321,7 @@ class JUnit4Test extends TestFrameworkTest {
     assertTraces(1) {
       trace(4, true) {
         long testModuleId = testModuleSpan(it, 2, TestDecorator.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 3, testModuleId, "org.example.TestParameterized", TestDecorator.TEST_PASS)
+        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestParameterized", TestDecorator.TEST_PASS)
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestParameterized", "parameterized_test_succeed", TestDecorator.TEST_PASS, testTags_1)
         testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestParameterized", "parameterized_test_succeed", TestDecorator.TEST_PASS, testTags_0)
       }

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
@@ -5,20 +5,25 @@ import datadog.trace.bootstrap.instrumentation.decorator.TestDecorator
 import datadog.trace.instrumentation.junit4.JUnit4Decorator
 import junit.runner.Version
 import org.example.TestAssumption
+import org.example.TestAssumptionAndSucceed
 import org.example.TestError
 import org.example.TestFailed
+import org.example.TestFailedAndSucceed
 import org.example.TestInheritance
 import org.example.TestParameterized
 import org.example.TestSkipped
 import org.example.TestSkippedClass
 import org.example.TestSucceed
+import org.example.TestSucceedAndSkipped
+import org.example.TestSucceedWithCategories
+import org.example.TestSuiteSetUpAssumption
+import org.example.TestSuiteSetupFail
+import org.example.TestSuiteTearDownFail
 import org.junit.runner.JUnitCore
-import spock.lang.Shared
 
 @DisableTestTrace(reason = "avoid self-tracing")
 class JUnit4Test extends TestFrameworkTest {
 
-  @Shared
   def runner = new JUnitCore()
 
   def "test success generates spans"() {
@@ -27,8 +32,10 @@ class JUnit4Test extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(1) {
-        testSpan(it, 0, "org.example.TestSucceed", "test_succeed", TestDecorator.TEST_PASS)
+      trace(3, true) {
+        long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_PASS)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, "org.example.TestSucceed", TestDecorator.TEST_PASS)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceed", "test_succeed", TestDecorator.TEST_PASS)
       }
     }
   }
@@ -39,8 +46,10 @@ class JUnit4Test extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(1) {
-        testSpan(it, 0, "org.example.TestInheritance", "test_succeed", TestDecorator.TEST_PASS)
+      trace(3, true) {
+        long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_PASS)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, "org.example.TestInheritance", TestDecorator.TEST_PASS)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestInheritance", "test_succeed", TestDecorator.TEST_PASS)
       }
     }
   }
@@ -55,8 +64,10 @@ class JUnit4Test extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(1) {
-        testSpan(it, 0, "org.example.TestFailed", "test_failed", TestDecorator.TEST_FAIL, null, exception)
+      trace(3, true) {
+        long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_FAIL)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, "org.example.TestFailed", TestDecorator.TEST_FAIL)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailed", "test_failed", TestDecorator.TEST_FAIL, null, exception)
       }
     }
 
@@ -74,8 +85,10 @@ class JUnit4Test extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(1) {
-        testSpan(it, 0, "org.example.TestError", "test_error", TestDecorator.TEST_FAIL, null, exception)
+      trace(3, true) {
+        long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_FAIL)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, "org.example.TestError", TestDecorator.TEST_FAIL)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestError", "test_error", TestDecorator.TEST_FAIL, null, exception)
       }
     }
 
@@ -89,13 +102,15 @@ class JUnit4Test extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(1) {
-        testSpan(it, 0, "org.example.TestSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
+      trace(3, true) {
+        long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_SKIP)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, "org.example.TestSkipped", TestDecorator.TEST_SKIP)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
       }
     }
 
     where:
-    testTags = ["$Tags.TEST_SKIP_REASON": "Ignore reason in test"]
+    testTags = [(Tags.TEST_SKIP_REASON): "Ignore reason in test"]
   }
 
   def "test class skipped generated spans"() {
@@ -104,13 +119,87 @@ class JUnit4Test extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(1) {
-        testSpan(it, 0, "org.example.TestSkippedClass", "test_class_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
+      trace(4, true) {
+        long testModuleId = testModuleSpan(it, 2, TestDecorator.TEST_SKIP)
+        long testSuiteId = testSuiteSpan(it, 3, testModuleId, "org.example.TestSkippedClass", TestDecorator.TEST_SKIP, testTags, null, true)
+        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestSkippedClass", "test_class_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSkippedClass", "test_class_another_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
       }
     }
 
     where:
-    testTags = ["$Tags.TEST_SKIP_REASON": "Ignore reason in class"]
+    testTags = [(Tags.TEST_SKIP_REASON): "Ignore reason in class"]
+  }
+
+  def "test success and skipped generates spans"() {
+    setup:
+    runner.run(TestSucceedAndSkipped)
+
+    expect:
+    assertTraces(1) {
+      trace(4, true) {
+        long testModuleId = testModuleSpan(it, 2, TestDecorator.TEST_PASS)
+        long testSuiteId = testSuiteSpan(it, 3, testModuleId, "org.example.TestSucceedAndSkipped", TestDecorator.TEST_PASS)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceedAndSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
+        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestSucceedAndSkipped", "test_succeed", TestDecorator.TEST_PASS)
+      }
+    }
+
+    where:
+    testTags = [(Tags.TEST_SKIP_REASON): "Ignore reason in test"]
+  }
+
+  def "test success and failure generates spans"() {
+    setup:
+    runner.run(TestFailedAndSucceed)
+
+    expect:
+    assertTraces(1) {
+      trace(5, true) {
+        long testModuleId = testModuleSpan(it, 3, TestDecorator.TEST_FAIL)
+        long testSuiteId = testSuiteSpan(it, 4, testModuleId, "org.example.TestFailedAndSucceed", TestDecorator.TEST_FAIL)
+        testSpan(it, 2, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_succeed", TestDecorator.TEST_PASS)
+        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_failed", TestDecorator.TEST_FAIL, null, exception)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_another_succeed", TestDecorator.TEST_PASS)
+      }
+    }
+
+    where:
+    exception = new AssertionError()
+  }
+
+  def "test suite teardown failure generates spans"() {
+    setup:
+    runner.run(TestSuiteTearDownFail)
+
+    expect:
+    assertTraces(1) {
+      trace(4, true) {
+        long testModuleId = testModuleSpan(it, 2, TestDecorator.TEST_FAIL)
+        long testSuiteId = testSuiteSpan(it, 3, testModuleId, "org.example.TestSuiteTearDownFail", TestDecorator.TEST_FAIL, null, exception)
+        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestSuiteTearDownFail", "test_succeed", TestDecorator.TEST_PASS)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSuiteTearDownFail", "test_another_succeed", TestDecorator.TEST_PASS)
+      }
+    }
+
+    where:
+    exception = new RuntimeException("suite tear down failed")
+  }
+
+  def "test suite setup failure generates spans"() {
+    setup:
+    runner.run(TestSuiteSetupFail)
+
+    expect:
+    assertTraces(1) {
+      trace(2, true) {
+        long testModuleId = testModuleSpan(it, 0, TestDecorator.TEST_FAIL)
+        testSuiteSpan(it, 1, testModuleId, "org.example.TestSuiteSetupFail", TestDecorator.TEST_FAIL, null, exception)
+      }
+    }
+
+    where:
+    exception = new RuntimeException("suite set up failed")
   }
 
   def "test with failing assumptions generated spans"() {
@@ -119,37 +208,133 @@ class JUnit4Test extends TestFrameworkTest {
 
     expect:
     assertTraces(1) {
-      trace(1) {
-        testSpan(it, 0, "org.example.TestAssumption", "test_fail_assumption", TestDecorator.TEST_SKIP, testTags)
+      trace(3, true) {
+        long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_SKIP)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, "org.example.TestAssumption", TestDecorator.TEST_SKIP)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestAssumption", "test_fail_assumption", TestDecorator.TEST_SKIP, testTags)
       }
     }
 
     where:
-    testTags = ["$Tags.TEST_SKIP_REASON": "got: <false>, expected: is <true>"]
+    testTags = [(Tags.TEST_SKIP_REASON): "got: <false>, expected: is <true>"]
+  }
+
+  def "test categories are included in spans"() {
+    setup:
+    runner.run(TestSucceedWithCategories)
+
+    expect:
+    assertTraces(1) {
+      trace(3, true) {
+        long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_PASS)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, "org.example.TestSucceedWithCategories",
+          TestDecorator.TEST_PASS, null, null, false,
+          ["org.example.Slow", "org.example.Flaky"])
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceedWithCategories", "test_succeed",
+          TestDecorator.TEST_PASS, null, null, false,
+          ["org.example.Slow", "org.example.Flaky", "org.example.End2End", "org.example.Browser"])
+      }
+    }
+  }
+
+  def "test assumption failure during suite setup"() {
+    setup:
+    runner.run(TestSuiteSetUpAssumption)
+
+    expect:
+    assertTraces(1) {
+      trace(3, true) {
+        long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_SKIP)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, "org.example.TestSuiteSetUpAssumption", TestDecorator.TEST_SKIP)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSuiteSetUpAssumption", "test_succeed", TestDecorator.TEST_SKIP, null, null, true)
+      }
+    }
+  }
+
+  def "test assumption failure in a multi-test-case suite"() {
+    setup:
+    runner.run(TestAssumptionAndSucceed)
+
+    expect:
+    assertTraces(1) {
+      trace(4, true) {
+        long testModuleId = testModuleSpan(it, 2, TestDecorator.TEST_PASS)
+        long testSuiteId = testSuiteSpan(it, 3, testModuleId, "org.example.TestAssumptionAndSucceed", TestDecorator.TEST_PASS)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestAssumptionAndSucceed", "test_fail_assumption", TestDecorator.TEST_SKIP, testTags)
+        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestAssumptionAndSucceed", "test_succeed", TestDecorator.TEST_PASS)
+      }
+    }
+
+    where:
+    testTags = [(Tags.TEST_SKIP_REASON): "got: <false>, expected: is <true>"]
+  }
+
+  def "test multiple successful suites"() {
+    setup:
+    runner.run(TestSucceed, TestSucceedAndSkipped)
+
+    expect:
+    assertTraces(1) {
+      trace(6, true) {
+        long testModuleId = testModuleSpan(it, 3, TestDecorator.TEST_PASS)
+
+        long firstSuiteId = testSuiteSpan(it, 4, testModuleId, "org.example.TestSucceed", TestDecorator.TEST_PASS)
+        testSpan(it, 0, testModuleId, firstSuiteId, "org.example.TestSucceed", "test_succeed", TestDecorator.TEST_PASS)
+
+        long secondSuiteId = testSuiteSpan(it, 5, testModuleId, "org.example.TestSucceedAndSkipped", TestDecorator.TEST_PASS)
+        testSpan(it, 1, testModuleId, secondSuiteId, "org.example.TestSucceedAndSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
+        testSpan(it, 2, testModuleId, secondSuiteId, "org.example.TestSucceedAndSkipped", "test_succeed", TestDecorator.TEST_PASS)
+      }
+    }
+
+    where:
+    testTags = [(Tags.TEST_SKIP_REASON): "Ignore reason in test"]
+  }
+
+  def "test successful suite and failing suite"() {
+    setup:
+    runner.run(TestSucceed, TestFailedAndSucceed)
+
+    expect:
+    assertTraces(1) {
+      trace(7, true) {
+        long testModuleId = testModuleSpan(it, 4, TestDecorator.TEST_FAIL)
+
+        long firstSuiteId = testSuiteSpan(it, 6, testModuleId, "org.example.TestSucceed", TestDecorator.TEST_PASS)
+        testSpan(it, 3, testModuleId, firstSuiteId, "org.example.TestSucceed", "test_succeed", TestDecorator.TEST_PASS)
+
+        long secondSuiteId = testSuiteSpan(it, 5, testModuleId, "org.example.TestFailedAndSucceed", TestDecorator.TEST_FAIL)
+        testSpan(it, 2, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_succeed", TestDecorator.TEST_PASS)
+        testSpan(it, 1, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_failed", TestDecorator.TEST_FAIL, null, exception)
+        testSpan(it, 0, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_another_succeed", TestDecorator.TEST_PASS)
+      }
+    }
+
+    where:
+    exception = new AssertionError()
   }
 
   def "test parameterized"() {
     setup:
     runner.run(TestParameterized)
 
-
-    assertTraces(2) {
-      trace(1) {
-        testSpan(it, 0, "org.example.TestParameterized", "parameterized_test_succeed", TestDecorator.TEST_PASS, testTags_0)
-      }
-      trace(1) {
-        testSpan(it, 0, "org.example.TestParameterized", "parameterized_test_succeed", TestDecorator.TEST_PASS, testTags_1)
+    assertTraces(1) {
+      trace(4, true) {
+        long testModuleId = testModuleSpan(it, 2, TestDecorator.TEST_PASS)
+        long testSuiteId = testSuiteSpan(it, 3, testModuleId, "org.example.TestParameterized", TestDecorator.TEST_PASS)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestParameterized", "parameterized_test_succeed", TestDecorator.TEST_PASS, testTags_1)
+        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestParameterized", "parameterized_test_succeed", TestDecorator.TEST_PASS, testTags_0)
       }
     }
 
     where:
-    testTags_0 = ["$Tags.TEST_PARAMETERS": '{"metadata":{"test_name":"parameterized_test_succeed[0]"}}']
-    testTags_1 = ["$Tags.TEST_PARAMETERS": '{"metadata":{"test_name":"parameterized_test_succeed[1]"}}']
+    testTags_0 = [(Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"parameterized_test_succeed[0]"}}']
+    testTags_1 = [(Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"parameterized_test_succeed[1]"}}']
   }
 
   @Override
-  String expectedOperationName() {
-    return "junit.test"
+  String expectedOperationPrefix() {
+    return "junit"
   }
 
   @Override

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
@@ -9,6 +9,8 @@ import org.example.TestAssumptionAndSucceed
 import org.example.TestError
 import org.example.TestFailed
 import org.example.TestFailedAndSucceed
+import org.example.TestFailedSuiteSetup
+import org.example.TestFailedSuiteTearDown
 import org.example.TestInheritance
 import org.example.TestParameterized
 import org.example.TestSkipped
@@ -17,8 +19,6 @@ import org.example.TestSucceed
 import org.example.TestSucceedAndSkipped
 import org.example.TestSucceedWithCategories
 import org.example.TestSuiteSetUpAssumption
-import org.example.TestSuiteSetupFail
-import org.example.TestSuiteTearDownFail
 import org.junit.runner.JUnitCore
 
 @DisableTestTrace(reason = "avoid self-tracing")
@@ -170,15 +170,15 @@ class JUnit4Test extends TestFrameworkTest {
 
   def "test suite teardown failure generates spans"() {
     setup:
-    runner.run(TestSuiteTearDownFail)
+    runner.run(TestFailedSuiteTearDown)
 
     expect:
     assertTraces(1) {
       trace(4, true) {
         long testModuleId = testModuleSpan(it, 2, TestDecorator.TEST_FAIL)
-        long testSuiteId = testSuiteSpan(it, 3, testModuleId, "org.example.TestSuiteTearDownFail", TestDecorator.TEST_FAIL, null, exception)
-        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestSuiteTearDownFail", "test_succeed", TestDecorator.TEST_PASS)
-        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSuiteTearDownFail", "test_another_succeed", TestDecorator.TEST_PASS)
+        long testSuiteId = testSuiteSpan(it, 3, testModuleId, "org.example.TestFailedSuiteTearDown", TestDecorator.TEST_FAIL, null, exception)
+        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestFailedSuiteTearDown", "test_succeed", TestDecorator.TEST_PASS)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedSuiteTearDown", "test_another_succeed", TestDecorator.TEST_PASS)
       }
     }
 
@@ -188,13 +188,13 @@ class JUnit4Test extends TestFrameworkTest {
 
   def "test suite setup failure generates spans"() {
     setup:
-    runner.run(TestSuiteSetupFail)
+    runner.run(TestFailedSuiteSetup)
 
     expect:
     assertTraces(1) {
       trace(2, true) {
         long testModuleId = testModuleSpan(it, 0, TestDecorator.TEST_FAIL)
-        testSuiteSpan(it, 1, testModuleId, "org.example.TestSuiteSetupFail", TestDecorator.TEST_FAIL, null, exception)
+        testSuiteSpan(it, 1, testModuleId, "org.example.TestFailedSuiteSetup", TestDecorator.TEST_FAIL, null, exception)
       }
     }
 

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestAssumptionAndSucceed.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestAssumptionAndSucceed.java
@@ -1,0 +1,19 @@
+package org.example;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import org.junit.Test;
+
+public class TestAssumptionAndSucceed {
+
+  @Test
+  public void test_succeed() {
+    assertTrue(true);
+  }
+
+  @Test
+  public void test_fail_assumption() {
+    assumeTrue(1 > 2);
+  }
+}

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestFailedAndSucceed.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestFailedAndSucceed.java
@@ -1,0 +1,23 @@
+package org.example;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class TestFailedAndSucceed {
+
+  @Test
+  public void test_succeed() {
+    assertTrue(true);
+  }
+
+  @Test
+  public void test_failed() {
+    assertTrue(false);
+  }
+
+  @Test
+  public void test_another_succeed() {
+    assertTrue(true);
+  }
+}

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestFailedSuiteSetup.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestFailedSuiteSetup.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestSuiteSetupFail {
+public class TestFailedSuiteSetup {
 
   @BeforeClass
   public static void suiteSetup() {

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestFailedSuiteTearDown.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestFailedSuiteTearDown.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.AfterClass;
 import org.junit.Test;
 
-public class TestSuiteTearDownFail {
+public class TestFailedSuiteTearDown {
 
   @AfterClass
   public static void suiteTearDown() {

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestSkippedClass.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestSkippedClass.java
@@ -8,4 +8,7 @@ public class TestSkippedClass {
 
   @Test
   public void test_class_skipped() {}
+
+  @Test
+  public void test_class_another_skipped() {}
 }

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestSucceedAndSkipped.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestSucceedAndSkipped.java
@@ -1,0 +1,18 @@
+package org.example;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class TestSucceedAndSkipped {
+
+  @Test
+  public void test_succeed() {
+    assertTrue(true);
+  }
+
+  @Ignore("Ignore reason in test")
+  @Test
+  public void test_skipped() {}
+}

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestSucceedWithCategories.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestSucceedWithCategories.java
@@ -1,0 +1,24 @@
+package org.example;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category({Slow.class, Flaky.class})
+public class TestSucceedWithCategories {
+
+  @Category({End2End.class, Browser.class})
+  @Test
+  public void test_succeed() {
+    assertTrue(true);
+  }
+}
+
+class End2End {}
+
+class Browser {}
+
+class Slow {}
+
+class Flaky {}

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestSuiteSetUpAssumption.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestSuiteSetUpAssumption.java
@@ -1,0 +1,20 @@
+package org.example;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestSuiteSetUpAssumption {
+
+  @BeforeClass
+  public static void suiteSetup() {
+    assumeTrue(1 > 2);
+  }
+
+  @Test
+  public void test_succeed() {
+    assertTrue(true);
+  }
+}

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestSuiteSetupFail.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestSuiteSetupFail.java
@@ -1,0 +1,19 @@
+package org.example;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestSuiteSetupFail {
+
+  @BeforeClass
+  public static void suiteSetup() {
+    throw new RuntimeException("suite set up failed");
+  }
+
+  @Test
+  public void test_succeed() {
+    assertTrue(true);
+  }
+}

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestSuiteTearDownFail.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestSuiteTearDownFail.java
@@ -1,0 +1,24 @@
+package org.example;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.AfterClass;
+import org.junit.Test;
+
+public class TestSuiteTearDownFail {
+
+  @AfterClass
+  public static void suiteTearDown() {
+    throw new RuntimeException("suite tear down failed");
+  }
+
+  @Test
+  public void test_succeed() {
+    assertTrue(true);
+  }
+
+  @Test
+  public void test_another_succeed() {
+    assertTrue(true);
+  }
+}

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5Decorator.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5Decorator.java
@@ -4,7 +4,10 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.decorator.TestDecorator;
 import java.lang.reflect.Method;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.TestIdentifier;
 
@@ -27,6 +30,54 @@ public class JUnit5Decorator extends TestDecorator {
     return "junit";
   }
 
+  public void onTestModuleStart(final AgentSpan span, final String version) {
+    afterTestModuleStart(span, version);
+  }
+
+  public void onTestModuleFinish(final AgentSpan span) {
+    beforeTestModuleFinish(span);
+  }
+
+  // sometimes JUnit invokes multiple nested runners with the same suite class
+  // (this happens, for instance, for parameterized tests)
+  // in this case we maintain a counter to determine which runner invocation is the first,
+  // and to only trigger processing once
+  public boolean tryTestSuiteStart(final TestIdentifier testIdentifier) {
+    Class<?> testClass = JUnit5Utils.getJavaClass(testIdentifier);
+    String testSuiteName =
+        testClass != null ? testClass.getName() : testIdentifier.getLegacyReportingName();
+    return tryTestSuiteStart(testSuiteName, testClass);
+  }
+
+  // sometimes JUnit invokes multiple nested runners with the same suite class
+  // (this happens, for instance, for parameterized tests)
+  // in this case we maintain a counter to determine which runner invocation is the first,
+  // and to only trigger processing once
+  public boolean tryTestSuiteFinish(final TestIdentifier testIdentifier) {
+    Class<?> testClass = JUnit5Utils.getJavaClass(testIdentifier);
+    String testSuiteName =
+        testClass != null ? testClass.getName() : testIdentifier.getLegacyReportingName();
+    return tryTestSuiteFinish(testSuiteName, testClass);
+  }
+
+  public void onTestSuiteStart(
+      final AgentSpan span, final String version, final TestIdentifier testIdentifier) {
+    Class<?> testClass = JUnit5Utils.getJavaClass(testIdentifier);
+    String testSuiteName =
+        testClass != null ? testClass.getName() : testIdentifier.getLegacyReportingName();
+    List<String> tags =
+        testIdentifier.getTags().stream().map(TestTag::getName).collect(Collectors.toList());
+
+    afterTestSuiteStart(span, testSuiteName, version, testClass, tags);
+  }
+
+  public void onTestSuiteFinish(final AgentSpan span, final TestIdentifier testIdentifier) {
+    Class<?> testClass = JUnit5Utils.getJavaClass(testIdentifier);
+    String testSuiteName =
+        testClass != null ? testClass.getName() : testIdentifier.getLegacyReportingName();
+    beforeTestSuiteFinish(span, testSuiteName, testClass);
+  }
+
   public void onTestStart(
       final AgentSpan span,
       final String version,
@@ -39,56 +90,33 @@ public class JUnit5Decorator extends TestDecorator {
     Class<?> testClass = JUnit5Utils.getTestClass(methodSource);
     Method testMethod = JUnit5Utils.getTestMethod(methodSource);
 
+    List<String> tags =
+        testIdentifier.getTags().stream().map(TestTag::getName).collect(Collectors.toList());
     afterTestStart(
-        span, testSuitName, testName, testParameters, version, testClass, testMethod, null);
+        span, testSuitName, testName, testParameters, version, testClass, testMethod, tags);
 
     span.setTag(Tags.TEST_STATUS, TEST_PASS);
   }
 
-  public void onTestIgnore(
-      final AgentSpan span,
-      final String version,
-      final MethodSource methodSource,
-      final String reason) {
+  public void onTestFinish(final AgentSpan span, final MethodSource methodSource) {
     String testSuiteName = methodSource.getClassName();
-    String testName = methodSource.getMethodName();
-
     Class<?> testClass = JUnit5Utils.getTestClass(methodSource);
-    Method testMethod = JUnit5Utils.getTestMethod(methodSource);
-
-    afterTestStart(span, testSuiteName, testName, null, version, testClass, testMethod, null);
-
-    span.setTag(Tags.TEST_STATUS, TEST_SKIP);
-    span.setTag(Tags.TEST_SKIP_REASON, reason);
-
     beforeTestFinish(span, testSuiteName, testClass);
   }
 
-  public void onTestFinish(
-      final AgentSpan span, final MethodSource methodSource, final TestExecutionResult result) {
+  public void onPossibleFailure(AgentSpan span, TestExecutionResult result) {
     result
         .getThrowable()
         .ifPresent(
             throwable -> {
-              switch (throwable.getClass().getName()) {
-                case "org.junit.AssumptionViolatedException":
-                case "org.junit.internal.AssumptionViolatedException":
-                case "org.opentest4j.TestAbortedException":
-                case "org.opentest4j.TestSkippedException":
-                  // If the test assumption fails, one of the following exceptions will be thrown.
-                  // The consensus is to treat "assumptions failure" as skipped tests.
-                  span.setTag(Tags.TEST_STATUS, TEST_SKIP);
-                  span.setTag(Tags.TEST_SKIP_REASON, throwable.getMessage());
-                  break;
-                default:
-                  span.setError(true);
-                  span.addThrowable(throwable);
-                  span.setTag(Tags.TEST_STATUS, TEST_FAIL);
+              if (JUnit5Utils.isAssumptionFailure(throwable)) {
+                span.setTag(Tags.TEST_STATUS, TEST_SKIP);
+                span.setTag(Tags.TEST_SKIP_REASON, throwable.getMessage());
+              } else {
+                span.setError(true);
+                span.addThrowable(throwable);
+                span.setTag(Tags.TEST_STATUS, TEST_FAIL);
               }
             });
-
-    String testSuiteName = methodSource.getClassName();
-    Class<?> testClass = JUnit5Utils.getTestClass(methodSource);
-    beforeTestFinish(span, testSuiteName, testClass);
   }
 }

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5Decorator.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5Decorator.java
@@ -39,7 +39,8 @@ public class JUnit5Decorator extends TestDecorator {
     Class<?> testClass = JUnit5Utils.getTestClass(methodSource);
     Method testMethod = JUnit5Utils.getTestMethod(methodSource);
 
-    afterTestStart(span, testSuitName, testName, testParameters, version, testClass, testMethod);
+    afterTestStart(
+        span, testSuitName, testName, testParameters, version, testClass, testMethod, null);
 
     span.setTag(Tags.TEST_STATUS, TEST_PASS);
   }
@@ -55,15 +56,16 @@ public class JUnit5Decorator extends TestDecorator {
     Class<?> testClass = JUnit5Utils.getTestClass(methodSource);
     Method testMethod = JUnit5Utils.getTestMethod(methodSource);
 
-    afterTestStart(span, testSuiteName, testName, null, version, testClass, testMethod);
+    afterTestStart(span, testSuiteName, testName, null, version, testClass, testMethod, null);
 
     span.setTag(Tags.TEST_STATUS, TEST_SKIP);
     span.setTag(Tags.TEST_SKIP_REASON, reason);
 
-    beforeFinish(span);
+    beforeTestFinish(span, testSuiteName, testClass);
   }
 
-  public void onTestFinish(final AgentSpan span, final TestExecutionResult result) {
+  public void onTestFinish(
+      final AgentSpan span, final MethodSource methodSource, final TestExecutionResult result) {
     result
         .getThrowable()
         .ifPresent(
@@ -85,6 +87,8 @@ public class JUnit5Decorator extends TestDecorator {
               }
             });
 
-    beforeFinish(span);
+    String testSuiteName = methodSource.getClassName();
+    Class<?> testClass = JUnit5Utils.getTestClass(methodSource);
+    beforeTestFinish(span, testSuiteName, testClass);
   }
 }

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5Instrumentation.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5Instrumentation.java
@@ -6,6 +6,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.ServiceLoader;
@@ -53,6 +54,9 @@ public class JUnit5Instrumentation extends Instrumenter.CiVisibility
 
   public static class JUnit5Advice {
 
+    @SuppressFBWarnings(
+        value = "UC_USELESS_OBJECT",
+        justification = "listeners is the return value of the instrumented method")
     @Advice.OnMethodExit
     public static void addTracingListener(
         @Advice.Return(readOnly = false) Collection<TestExecutionListener> listeners) {

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5Utils.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5Utils.java
@@ -4,6 +4,9 @@ import datadog.trace.util.Strings;
 import java.lang.reflect.Method;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.TestIdentifier;
 
@@ -37,6 +40,21 @@ public abstract class JUnit5Utils {
       method.setAccessible(true);
       return method;
     } catch (Exception e) {
+      return null;
+    }
+  }
+
+  public static Class<?> getJavaClass(TestIdentifier testIdentifier) {
+    TestSource testSource = testIdentifier.getSource().orElse(null);
+    if (testSource instanceof ClassSource) {
+      ClassSource classSource = (ClassSource) testSource;
+      return classSource.getJavaClass();
+
+    } else if (testSource instanceof MethodSource) {
+      MethodSource methodSource = (MethodSource) testSource;
+      return getTestClass(methodSource);
+
+    } else {
       return null;
     }
   }
@@ -88,5 +106,40 @@ public abstract class JUnit5Utils {
     return "{\"metadata\":{\"test_name\":\""
         + Strings.escapeToJson(testIdentifier.getDisplayName())
         + "\"}}";
+  }
+
+  /*
+   * JUnit5 considers parameterized or factory test cases as containers.
+   * We need to differentiate this type of containers from "regular" ones, that are test classes
+   */
+  public static boolean isTestCase(TestIdentifier testIdentifier) {
+    return testIdentifier.isContainer() && getMethodSourceOrNull(testIdentifier) != null;
+  }
+
+  public static boolean isRootContainer(TestIdentifier testIdentifier) {
+    return !testIdentifier.getParentId().isPresent();
+  }
+
+  private static MethodSource getMethodSourceOrNull(TestIdentifier testIdentifier) {
+    return (MethodSource)
+        testIdentifier.getSource().filter(s -> s instanceof MethodSource).orElse(null);
+  }
+
+  public static boolean isAssumptionFailure(TestExecutionResult result) {
+    return result.getThrowable().map(JUnit5Utils::isAssumptionFailure).orElse(false);
+  }
+
+  public static boolean isAssumptionFailure(Throwable throwable) {
+    switch (throwable.getClass().getName()) {
+      case "org.junit.AssumptionViolatedException":
+      case "org.junit.internal.AssumptionViolatedException":
+      case "org.opentest4j.TestAbortedException":
+      case "org.opentest4j.TestSkippedException":
+        // If the test assumption fails, one of the following exceptions will be thrown.
+        // The consensus is to treat "assumptions failure" as skipped tests.
+        return true;
+      default:
+        return false;
+    }
   }
 }

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/TracingListener.java
@@ -95,7 +95,7 @@ public class TracingListener implements TestExecutionListener {
                 scope.close();
               }
 
-              DECORATE.onTestFinish(span, testExecutionResult);
+              DECORATE.onTestFinish(span, (MethodSource) testSource, testExecutionResult);
               span.finish();
             });
   }

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
@@ -3,17 +3,27 @@ import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.bootstrap.instrumentation.decorator.TestDecorator
 import datadog.trace.instrumentation.junit5.JUnit5Decorator
 import org.example.TestAssumption
+import org.example.TestAssumptionAndSucceed
 import org.example.TestAssumptionLegacy
 import org.example.TestError
 import org.example.TestFactory
 import org.example.TestFailed
+import org.example.TestFailedAndSucceed
+import org.example.TestFailedSuiteSetup
+import org.example.TestFailedSuiteTearDown
 import org.example.TestInheritance
 import org.example.TestParameterized
 import org.example.TestRepeated
 import org.example.TestSkipped
 import org.example.TestSkippedClass
+import org.example.TestSkippedNested
 import org.example.TestSucceed
+import org.example.TestSucceedAndSkipped
+import org.example.TestSucceedNested
+import org.example.TestSucceedWithCategories
+import org.example.TestSuiteSetUpAssumption
 import org.example.TestTemplate
+import org.junit.platform.engine.DiscoverySelector
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder
 import org.junit.platform.launcher.core.LauncherFactory
 import org.opentest4j.AssertionFailedError
@@ -24,130 +34,110 @@ class JUnit5Test extends TestFrameworkTest {
 
   def "test success generate spans"() {
     setup:
-    def launcherReq = LauncherDiscoveryRequestBuilder.request()
-      .selectors(selectClass(TestSucceed)).build()
-    def launcher = LauncherFactory.create()
-    launcher.execute(launcherReq)
+    runTestClasses(TestSucceed)
 
     expect:
     assertTraces(1) {
-      trace(1) {
-        testSpan(it, 0, null, null, "org.example.TestSucceed", "test_succeed", TestDecorator.TEST_PASS)
+      trace(3, true) {
+        long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_PASS)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSucceed", TestDecorator.TEST_PASS)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceed", "test_succeed", TestDecorator.TEST_PASS)
       }
     }
   }
 
   def "test inheritance generates spans"() {
     setup:
-    def launcherReq = LauncherDiscoveryRequestBuilder.request()
-      .selectors(selectClass(TestInheritance)).build()
-    def launcher = LauncherFactory.create()
-    launcher.execute(launcherReq)
+    runTestClasses(TestInheritance)
 
     expect:
     assertTraces(1) {
-      trace(1) {
-        testSpan(it, 0, null, null, "org.example.TestInheritance", "test_succeed", TestDecorator.TEST_PASS)
+      trace(3, true) {
+        long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_PASS)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestInheritance", TestDecorator.TEST_PASS)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestInheritance", "test_succeed", TestDecorator.TEST_PASS)
       }
     }
   }
 
   def "test parameterized generates spans"() {
     setup:
-    def launcherReq = LauncherDiscoveryRequestBuilder.request()
-      .selectors(selectClass(TestParameterized)).build()
-    def launcher = LauncherFactory.create()
-    launcher.execute(launcherReq)
+    runTestClasses(TestParameterized)
 
     expect:
-    assertTraces(2) {
-      trace(1) {
-        testSpan(it, 0, null, null, "org.example.TestParameterized", "test_parameterized", TestDecorator.TEST_PASS, testTags_0)
-      }
-      trace(1) {
-        testSpan(it, 0, null, null, "org.example.TestParameterized", "test_parameterized", TestDecorator.TEST_PASS, testTags_1)
+    assertTraces(1) {
+      trace(4, true) {
+        long testModuleId = testModuleSpan(it, 2, TestDecorator.TEST_PASS)
+        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestParameterized", TestDecorator.TEST_PASS)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestParameterized", "test_parameterized", TestDecorator.TEST_PASS, testTags_1)
+        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestParameterized", "test_parameterized", TestDecorator.TEST_PASS, testTags_0)
       }
     }
 
     where:
-    testTags_0 = ["$Tags.TEST_PARAMETERS": '{"metadata":{"test_name":"[1] 0, 0, 0, some:\\\"parameter\\\""}}']
-    testTags_1 = ["$Tags.TEST_PARAMETERS": '{"metadata":{"test_name":"[2] 1, 1, 2, some:\\\"parameter\\\""}}']
+    testTags_0 = [(Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"[1] 0, 0, 0, some:\\\"parameter\\\""}}']
+    testTags_1 = [(Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"[2] 1, 1, 2, some:\\\"parameter\\\""}}']
   }
 
   def "test repeated generates spans"() {
     setup:
-    def launcherReq = LauncherDiscoveryRequestBuilder.request()
-      .selectors(selectClass(TestRepeated)).build()
-    def launcher = LauncherFactory.create()
-    launcher.execute(launcherReq)
+    runTestClasses(TestRepeated)
 
     expect:
-    assertTraces(2) {
-      trace(1) {
-        testSpan(it, 0, null, null, "org.example.TestRepeated", "test_repeated", TestDecorator.TEST_PASS)
-      }
-      trace(1) {
-        testSpan(it, 0, null, null, "org.example.TestRepeated", "test_repeated", TestDecorator.TEST_PASS)
+    assertTraces(1) {
+      trace(4, true) {
+        long testModuleId = testModuleSpan(it, 2, TestDecorator.TEST_PASS)
+        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestRepeated", TestDecorator.TEST_PASS)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestRepeated", "test_repeated", TestDecorator.TEST_PASS)
+        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestRepeated", "test_repeated", TestDecorator.TEST_PASS)
       }
     }
   }
 
   def "test template generates spans"() {
     setup:
-    def launcherReq = LauncherDiscoveryRequestBuilder.request()
-      .selectors(selectClass(TestTemplate)).build()
-    def launcher = LauncherFactory.create()
-    launcher.execute(launcherReq)
+    runTestClasses(TestTemplate)
 
     expect:
-    assertTraces(2) {
-      trace(1) {
-        testSpan(it, 0, null, null, "org.example.TestTemplate", "test_template", TestDecorator.TEST_PASS, testTags_0)
-      }
-      trace(1) {
-        testSpan(it, 0, null, null, "org.example.TestTemplate", "test_template", TestDecorator.TEST_PASS, testTags_1)
+    assertTraces(1) {
+      trace(4, true) {
+        long testModuleId = testModuleSpan(it, 2, TestDecorator.TEST_PASS)
+        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestTemplate", TestDecorator.TEST_PASS)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestTemplate", "test_template", TestDecorator.TEST_PASS, testTags_1)
+        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestTemplate", "test_template", TestDecorator.TEST_PASS, testTags_0)
       }
     }
 
     where:
-    testTags_0 = ["$Tags.TEST_PARAMETERS": "{\"metadata\":{\"test_name\":\"test_template_1\"}}"]
-    testTags_1 = ["$Tags.TEST_PARAMETERS": "{\"metadata\":{\"test_name\":\"test_template_2\"}}"]
+    testTags_0 = [(Tags.TEST_PARAMETERS): "{\"metadata\":{\"test_name\":\"test_template_1\"}}"]
+    testTags_1 = [(Tags.TEST_PARAMETERS): "{\"metadata\":{\"test_name\":\"test_template_2\"}}"]
   }
 
   def "test factory generates spans"() {
     setup:
-    def launcherReq = LauncherDiscoveryRequestBuilder.request()
-      .selectors(selectClass(TestFactory)).build()
-    def launcher = LauncherFactory.create()
-    launcher.execute(launcherReq)
+    runTestClasses(TestFactory)
 
     expect:
-    assertTraces(2) {
-      trace(1) {
-        testSpan(it, 0, null, null, "org.example.TestFactory", "test_factory", TestDecorator.TEST_PASS)
-      }
-      trace(1) {
-        testSpan(it, 0, null, null, "org.example.TestFactory", "test_factory", TestDecorator.TEST_PASS)
+    assertTraces(1) {
+      trace(4, true) {
+        long testModuleId = testModuleSpan(it, 2, TestDecorator.TEST_PASS)
+        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestFactory", TestDecorator.TEST_PASS)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFactory", "test_factory", TestDecorator.TEST_PASS)
+        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestFactory", "test_factory", TestDecorator.TEST_PASS)
       }
     }
   }
 
   def "test failed generates spans"() {
     setup:
-    def launcherReq = LauncherDiscoveryRequestBuilder.request()
-      .selectors(selectClass(TestFailed)).build()
-    def launcher = LauncherFactory.create()
-
-    try {
-      launcher.execute(launcherReq)
-    } catch (Throwable ignored) {
-      // Ignored
-    }
+    runTestClassesSuppressingExceptions(TestFailed)
 
     expect:
     assertTraces(1) {
-      trace(1) {
-        testSpan(it, 0, null, null, "org.example.TestFailed", "test_failed", TestDecorator.TEST_FAIL, null, exception)
+      trace(3, true) {
+        long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_FAIL)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestFailed", TestDecorator.TEST_FAIL)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailed", "test_failed", TestDecorator.TEST_FAIL, null, exception)
       }
     }
 
@@ -157,20 +147,14 @@ class JUnit5Test extends TestFrameworkTest {
 
   def "test error generates spans"() {
     setup:
-    def launcherReq = LauncherDiscoveryRequestBuilder.request()
-      .selectors(selectClass(TestError)).build()
-    def launcher = LauncherFactory.create()
-
-    try {
-      launcher.execute(launcherReq)
-    } catch (Throwable ignored) {
-      // Ignored
-    }
+    runTestClassesSuppressingExceptions(TestError)
 
     expect:
     assertTraces(1) {
-      trace(1) {
-        testSpan(it, 0, null, null, "org.example.TestError", "test_error", TestDecorator.TEST_FAIL, null, exception)
+      trace(3, true) {
+        long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_FAIL)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestError", TestDecorator.TEST_FAIL)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestError", "test_error", TestDecorator.TEST_FAIL, null, exception)
       }
     }
 
@@ -180,74 +164,303 @@ class JUnit5Test extends TestFrameworkTest {
 
   def "test skipped generates spans"() {
     setup:
-    def launcherReq = LauncherDiscoveryRequestBuilder.request()
-      .selectors(selectClass(TestSkipped)).build()
-    def launcher = LauncherFactory.create()
-    launcher.execute(launcherReq)
+    runTestClasses(TestSkipped)
 
     expect:
     assertTraces(1) {
-      trace(1) {
-        testSpan(it, 0, null, null, "org.example.TestSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
+      trace(3, true) {
+        long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_SKIP)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSkipped", TestDecorator.TEST_SKIP)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
       }
     }
 
     where:
-    testTags = ["$Tags.TEST_SKIP_REASON": "Ignore reason in test"]
+    testTags = [(Tags.TEST_SKIP_REASON): "Ignore reason in test"]
   }
 
   def "test class skipped generated spans"() {
     setup:
-    def launcherReq = LauncherDiscoveryRequestBuilder.request()
-      .selectors(selectClass(TestSkippedClass)).build()
-    def launcher = LauncherFactory.create()
-    launcher.execute(launcherReq)
+    runTestClasses(TestSkippedClass)
 
     expect:
     assertTraces(1) {
-      trace(1) {
-        testSpan(it, 0, null, null, "org.example.TestSkippedClass", "test_class_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
+      trace(6, true) {
+        long testModuleId = testModuleSpan(it, 4, TestDecorator.TEST_SKIP)
+        long testSuiteId = testSuiteSpan(it, 5, testModuleId, testModuleId, "org.example.TestSkippedClass", TestDecorator.TEST_SKIP, testTags)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSkippedClass", "test_case_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
+        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestSkippedClass", "test_factory_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
+        testSpan(it, 2, testModuleId, testSuiteId, "org.example.TestSkippedClass", "test_parameterized_skipped", TestDecorator.TEST_SKIP, parameterizedTestTags, null, true)
+        testSpan(it, 3, testModuleId, testSuiteId, "org.example.TestSkippedClass", "test_repeated_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
       }
     }
 
     where:
-    testTags = ["$Tags.TEST_SKIP_REASON": "Ignore reason in class"]
+    testTags = [(Tags.TEST_SKIP_REASON): "Ignore reason in class"]
+    parameterizedTestTags = [(Tags.TEST_SKIP_REASON): "Ignore reason in class", (Tags.TEST_PARAMETERS): "{\"metadata\":{\"test_name\":\"test_parameterized_skipped(int, int, int, String)\"}}"]
   }
 
   def "test with failing assumptions generated spans"() {
     setup:
-    def launcherReq = LauncherDiscoveryRequestBuilder.request()
-      .selectors(selectClass(TestAssumption)).build()
-    def launcher = LauncherFactory.create()
-    launcher.execute(launcherReq)
+    runTestClasses(TestAssumption)
 
     expect:
     assertTraces(1) {
-      trace(1) {
-        testSpan(it, 0, null, null, "org.example.TestAssumption", "test_fail_assumption", TestDecorator.TEST_SKIP, testTags)
+      trace(3, true) {
+        long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_SKIP)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestAssumption", TestDecorator.TEST_SKIP)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestAssumption", "test_fail_assumption", TestDecorator.TEST_SKIP, testTags)
       }
     }
 
     where:
-    testTags = ["$Tags.TEST_SKIP_REASON": "Assumption failed: assumption is not true"]
+    testTags = [(Tags.TEST_SKIP_REASON): "Assumption failed: assumption is not true"]
   }
 
   def "test with failing legacy assumptions generated spans"() {
     setup:
-    def launcherReq = LauncherDiscoveryRequestBuilder.request()
-      .selectors(selectClass(TestAssumptionLegacy)).build()
-    def launcher = LauncherFactory.create()
-    launcher.execute(launcherReq)
+    runTestClasses(TestAssumptionLegacy)
 
     expect:
     assertTraces(1) {
-      trace(1) {
-        testSpan(it, 0, null, null, "org.example.TestAssumptionLegacy", "test_fail_assumption_legacy", TestDecorator.TEST_SKIP, testTags)
+      trace(3, true) {
+        long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_SKIP)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestAssumptionLegacy", TestDecorator.TEST_SKIP)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestAssumptionLegacy", "test_fail_assumption_legacy", TestDecorator.TEST_SKIP, testTags)
       }
     }
 
     where:
-    testTags = ["$Tags.TEST_SKIP_REASON": "assumption is not fulfilled"]
+    testTags = [(Tags.TEST_SKIP_REASON): "assumption is not fulfilled"]
+  }
+
+  def "test success and skipped generates spans"() {
+    setup:
+    runTestClasses(TestSucceedAndSkipped)
+
+    expect:
+    assertTraces(1) {
+      trace(4, true) {
+        long testModuleId = testModuleSpan(it, 2, TestDecorator.TEST_PASS)
+        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestSucceedAndSkipped", TestDecorator.TEST_PASS)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceedAndSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
+        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestSucceedAndSkipped", "test_succeed", TestDecorator.TEST_PASS)
+      }
+    }
+
+    where:
+    testTags = [(Tags.TEST_SKIP_REASON): "Ignore reason in test"]
+  }
+
+  def "test success and failure generates spans"() {
+    setup:
+    runTestClasses(TestFailedAndSucceed)
+
+    expect:
+    assertTraces(1) {
+      trace(5, true) {
+        long testModuleId = testModuleSpan(it, 3, TestDecorator.TEST_FAIL)
+        long testSuiteId = testSuiteSpan(it, 4, testModuleId, testModuleId, "org.example.TestFailedAndSucceed", TestDecorator.TEST_FAIL)
+        testSpan(it, 2, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_succeed", TestDecorator.TEST_PASS)
+        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_failed", TestDecorator.TEST_FAIL, null, exception)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_another_succeed", TestDecorator.TEST_PASS)
+      }
+    }
+
+    where:
+    exception = new AssertionFailedError("expected: <true> but was: <false>")
+  }
+
+  def "test suite teardown failure generates spans"() {
+    setup:
+    runTestClasses(TestFailedSuiteTearDown)
+
+    expect:
+    assertTraces(1) {
+      trace(4, true) {
+        long testModuleId = testModuleSpan(it, 2, TestDecorator.TEST_FAIL)
+        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestFailedSuiteTearDown", TestDecorator.TEST_FAIL, null, exception)
+        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestFailedSuiteTearDown", "test_succeed", TestDecorator.TEST_PASS)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedSuiteTearDown", "test_another_succeed", TestDecorator.TEST_PASS)
+      }
+    }
+
+    where:
+    exception = new RuntimeException("suite tear down failed")
+  }
+
+  def "test suite setup failure generates spans"() {
+    setup:
+    runTestClasses(TestFailedSuiteSetup)
+
+    expect:
+    assertTraces(1) {
+      trace(2, true) {
+        long testModuleId = testModuleSpan(it, 0, TestDecorator.TEST_FAIL)
+        testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestFailedSuiteSetup", TestDecorator.TEST_FAIL, null, exception)
+      }
+    }
+
+    where:
+    exception = new RuntimeException("suite set up failed")
+  }
+
+  def "test categories are included in spans"() {
+    setup:
+    runTestClasses(TestSucceedWithCategories)
+
+    expect:
+    assertTraces(1) {
+      trace(3, true) {
+        long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_PASS)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSucceedWithCategories",
+          TestDecorator.TEST_PASS, null, null, false,
+          ["Slow", "Flaky"])
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceedWithCategories", "test_succeed",
+          TestDecorator.TEST_PASS, null, null, false,
+          ["End2end", "Browser", "Slow", "Flaky"])
+      }
+    }
+  }
+
+  def "test assumption failure during suite setup"() {
+    setup:
+    runTestClasses(TestSuiteSetUpAssumption)
+
+    expect:
+    assertTraces(1) {
+      trace(3, true) {
+        long testModuleId = testModuleSpan(it, 1, TestDecorator.TEST_SKIP)
+        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSuiteSetUpAssumption", TestDecorator.TEST_SKIP, testTags)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSuiteSetUpAssumption", "test_succeed", TestDecorator.TEST_SKIP, testTags, null, true)
+      }
+    }
+
+    where:
+    testTags = [(Tags.TEST_SKIP_REASON): "Assumption failed: assumption is not true"]
+  }
+
+  def "test assumption failure in a multi-test-case suite"() {
+    setup:
+    runTestClasses(TestAssumptionAndSucceed)
+
+    expect:
+    assertTraces(1) {
+      trace(4, true) {
+        long testModuleId = testModuleSpan(it, 2, TestDecorator.TEST_PASS)
+        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestAssumptionAndSucceed", TestDecorator.TEST_PASS)
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestAssumptionAndSucceed", "test_fail_assumption", TestDecorator.TEST_SKIP, testTags)
+        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestAssumptionAndSucceed", "test_succeed", TestDecorator.TEST_PASS)
+      }
+    }
+
+    where:
+    testTags = [(Tags.TEST_SKIP_REASON): "Assumption failed: assumption is not true"]
+  }
+
+  def "test multiple successful suites"() {
+    setup:
+    runTestClasses(TestSucceed, TestSucceedAndSkipped)
+
+    expect:
+    assertTraces(1) {
+      trace(6, true) {
+        long testModuleId = testModuleSpan(it, 3, TestDecorator.TEST_PASS)
+
+        long firstSuiteId = testSuiteSpan(it, 4, testModuleId, testModuleId, "org.example.TestSucceed", TestDecorator.TEST_PASS)
+        testSpan(it, 0, testModuleId, firstSuiteId, "org.example.TestSucceed", "test_succeed", TestDecorator.TEST_PASS)
+
+        long secondSuiteId = testSuiteSpan(it, 5, testModuleId, testModuleId, "org.example.TestSucceedAndSkipped", TestDecorator.TEST_PASS)
+        testSpan(it, 1, testModuleId, secondSuiteId, "org.example.TestSucceedAndSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
+        testSpan(it, 2, testModuleId, secondSuiteId, "org.example.TestSucceedAndSkipped", "test_succeed", TestDecorator.TEST_PASS)
+      }
+    }
+
+    where:
+    testTags = [(Tags.TEST_SKIP_REASON): "Ignore reason in test"]
+  }
+
+  def "test successful suite and failing suite"() {
+    setup:
+    runTestClasses(TestSucceed, TestFailedAndSucceed)
+
+    expect:
+    assertTraces(1) {
+      trace(7, true) {
+        long testModuleId = testModuleSpan(it, 4, TestDecorator.TEST_FAIL)
+
+        long firstSuiteId = testSuiteSpan(it, 6, testModuleId, testModuleId, "org.example.TestSucceed", TestDecorator.TEST_PASS)
+        testSpan(it, 3, testModuleId, firstSuiteId, "org.example.TestSucceed", "test_succeed", TestDecorator.TEST_PASS)
+
+        long secondSuiteId = testSuiteSpan(it, 5, testModuleId, testModuleId, "org.example.TestFailedAndSucceed", TestDecorator.TEST_FAIL)
+        testSpan(it, 2, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_succeed", TestDecorator.TEST_PASS)
+        testSpan(it, 1, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_failed", TestDecorator.TEST_FAIL, null, exception)
+        testSpan(it, 0, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_another_succeed", TestDecorator.TEST_PASS)
+      }
+    }
+
+    where:
+    exception = new AssertionFailedError("expected: <true> but was: <false>")
+  }
+
+  def "test nested successful suites"() {
+    setup:
+    runTestClasses(TestSucceedNested)
+
+    expect:
+    assertTraces(1) {
+      trace(5, true) {
+        long testModuleId = testModuleSpan(it, 2, TestDecorator.TEST_PASS)
+
+        long topLevelSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestSucceedNested", TestDecorator.TEST_PASS)
+        testSpan(it, 1, testModuleId, topLevelSuiteId, "org.example.TestSucceedNested", "test_succeed", TestDecorator.TEST_PASS)
+
+        long nestedSuiteId = testSuiteSpan(it, 4, topLevelSuiteId, testModuleId, 'org.example.TestSucceedNested$NestedSuite', TestDecorator.TEST_PASS)
+        testSpan(it, 0, testModuleId, nestedSuiteId, 'org.example.TestSucceedNested$NestedSuite', "test_succeed_nested", TestDecorator.TEST_PASS)
+      }
+    }
+  }
+
+  def "test nested skipped suites"() {
+    setup:
+    runTestClasses(TestSkippedNested)
+
+    expect:
+    assertTraces(1) {
+      trace(5, true) {
+        long testModuleId = testModuleSpan(it, 2, TestDecorator.TEST_SKIP)
+
+        long topLevelSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestSkippedNested", TestDecorator.TEST_SKIP, testTags)
+        testSpan(it, 1, testModuleId, topLevelSuiteId, "org.example.TestSkippedNested", "test_succeed", TestDecorator.TEST_SKIP, testTags, null, true)
+
+        long nestedSuiteId = testSuiteSpan(it, 4, topLevelSuiteId, testModuleId, 'org.example.TestSkippedNested$NestedSuite', TestDecorator.TEST_SKIP, testTags)
+        testSpan(it, 0, testModuleId, nestedSuiteId, 'org.example.TestSkippedNested$NestedSuite', "test_succeed_nested", TestDecorator.TEST_SKIP, testTags, null, true)
+      }
+    }
+
+    where:
+    testTags = [(Tags.TEST_SKIP_REASON): "Ignore reason in class"]
+  }
+
+  private static void runTestClasses(Class<?>... classes) {
+    DiscoverySelector[] selectors = new DiscoverySelector[classes.length]
+    for (i in 0..<classes.length) {
+      selectors[i] = selectClass(classes[i])
+    }
+
+    def launcherReq = LauncherDiscoveryRequestBuilder.request()
+      .selectors(selectors)
+      .build()
+
+    def launcher = LauncherFactory.create()
+    launcher.execute(launcherReq)
+  }
+
+  private static void runTestClassesSuppressingExceptions(Class<?>... classes) {
+    try {
+      runTestClasses(classes)
+    } catch (Throwable ignored) {
+    }
   }
 
   @Override

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
@@ -32,7 +32,7 @@ class JUnit5Test extends TestFrameworkTest {
     expect:
     assertTraces(1) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestSucceed", "test_succeed", TestDecorator.TEST_PASS)
+        testSpan(it, 0, null, null, "org.example.TestSucceed", "test_succeed", TestDecorator.TEST_PASS)
       }
     }
   }
@@ -47,7 +47,7 @@ class JUnit5Test extends TestFrameworkTest {
     expect:
     assertTraces(1) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestInheritance", "test_succeed", TestDecorator.TEST_PASS)
+        testSpan(it, 0, null, null, "org.example.TestInheritance", "test_succeed", TestDecorator.TEST_PASS)
       }
     }
   }
@@ -62,10 +62,10 @@ class JUnit5Test extends TestFrameworkTest {
     expect:
     assertTraces(2) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestParameterized", "test_parameterized", TestDecorator.TEST_PASS, testTags_0)
+        testSpan(it, 0, null, null, "org.example.TestParameterized", "test_parameterized", TestDecorator.TEST_PASS, testTags_0)
       }
       trace(1) {
-        testSpan(it, 0, "org.example.TestParameterized", "test_parameterized", TestDecorator.TEST_PASS, testTags_1)
+        testSpan(it, 0, null, null, "org.example.TestParameterized", "test_parameterized", TestDecorator.TEST_PASS, testTags_1)
       }
     }
 
@@ -84,10 +84,10 @@ class JUnit5Test extends TestFrameworkTest {
     expect:
     assertTraces(2) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestRepeated", "test_repeated", TestDecorator.TEST_PASS)
+        testSpan(it, 0, null, null, "org.example.TestRepeated", "test_repeated", TestDecorator.TEST_PASS)
       }
       trace(1) {
-        testSpan(it, 0, "org.example.TestRepeated", "test_repeated", TestDecorator.TEST_PASS)
+        testSpan(it, 0, null, null, "org.example.TestRepeated", "test_repeated", TestDecorator.TEST_PASS)
       }
     }
   }
@@ -102,10 +102,10 @@ class JUnit5Test extends TestFrameworkTest {
     expect:
     assertTraces(2) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestTemplate", "test_template", TestDecorator.TEST_PASS, testTags_0)
+        testSpan(it, 0, null, null, "org.example.TestTemplate", "test_template", TestDecorator.TEST_PASS, testTags_0)
       }
       trace(1) {
-        testSpan(it, 0, "org.example.TestTemplate", "test_template", TestDecorator.TEST_PASS, testTags_1)
+        testSpan(it, 0, null, null, "org.example.TestTemplate", "test_template", TestDecorator.TEST_PASS, testTags_1)
       }
     }
 
@@ -124,10 +124,10 @@ class JUnit5Test extends TestFrameworkTest {
     expect:
     assertTraces(2) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestFactory", "test_factory", TestDecorator.TEST_PASS)
+        testSpan(it, 0, null, null, "org.example.TestFactory", "test_factory", TestDecorator.TEST_PASS)
       }
       trace(1) {
-        testSpan(it, 0, "org.example.TestFactory", "test_factory", TestDecorator.TEST_PASS)
+        testSpan(it, 0, null, null, "org.example.TestFactory", "test_factory", TestDecorator.TEST_PASS)
       }
     }
   }
@@ -147,7 +147,7 @@ class JUnit5Test extends TestFrameworkTest {
     expect:
     assertTraces(1) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestFailed", "test_failed", TestDecorator.TEST_FAIL, null, exception)
+        testSpan(it, 0, null, null, "org.example.TestFailed", "test_failed", TestDecorator.TEST_FAIL, null, exception)
       }
     }
 
@@ -170,7 +170,7 @@ class JUnit5Test extends TestFrameworkTest {
     expect:
     assertTraces(1) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestError", "test_error", TestDecorator.TEST_FAIL, null, exception)
+        testSpan(it, 0, null, null, "org.example.TestError", "test_error", TestDecorator.TEST_FAIL, null, exception)
       }
     }
 
@@ -188,7 +188,7 @@ class JUnit5Test extends TestFrameworkTest {
     expect:
     assertTraces(1) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
+        testSpan(it, 0, null, null, "org.example.TestSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
       }
     }
 
@@ -206,7 +206,7 @@ class JUnit5Test extends TestFrameworkTest {
     expect:
     assertTraces(1) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestSkippedClass", "test_class_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
+        testSpan(it, 0, null, null, "org.example.TestSkippedClass", "test_class_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
       }
     }
 
@@ -224,7 +224,7 @@ class JUnit5Test extends TestFrameworkTest {
     expect:
     assertTraces(1) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestAssumption", "test_fail_assumption", TestDecorator.TEST_SKIP, testTags)
+        testSpan(it, 0, null, null, "org.example.TestAssumption", "test_fail_assumption", TestDecorator.TEST_SKIP, testTags)
       }
     }
 
@@ -242,7 +242,7 @@ class JUnit5Test extends TestFrameworkTest {
     expect:
     assertTraces(1) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestAssumptionLegacy", "test_fail_assumption_legacy", TestDecorator.TEST_SKIP, testTags)
+        testSpan(it, 0, null, null, "org.example.TestAssumptionLegacy", "test_fail_assumption_legacy", TestDecorator.TEST_SKIP, testTags)
       }
     }
 
@@ -251,8 +251,8 @@ class JUnit5Test extends TestFrameworkTest {
   }
 
   @Override
-  String expectedOperationName() {
-    return "junit.test"
+  String expectedOperationPrefix() {
+    return "junit"
   }
 
   @Override

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestAssumptionAndSucceed.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestAssumptionAndSucceed.java
@@ -1,0 +1,19 @@
+package org.example;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class TestAssumptionAndSucceed {
+
+  @Test
+  public void test_succeed() {
+    assertTrue(true);
+  }
+
+  @Test
+  public void test_fail_assumption() {
+    assumeTrue(1 > 2);
+  }
+}

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestFailedAndSucceed.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestFailedAndSucceed.java
@@ -1,0 +1,23 @@
+package org.example;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class TestFailedAndSucceed {
+
+  @Test
+  public void test_succeed() {
+    assertTrue(true);
+  }
+
+  @Test
+  public void test_failed() {
+    assertTrue(false);
+  }
+
+  @Test
+  public void test_another_succeed() {
+    assertTrue(true);
+  }
+}

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestFailedSuiteSetup.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestFailedSuiteSetup.java
@@ -1,0 +1,24 @@
+package org.example;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class TestFailedSuiteSetup {
+
+  @BeforeAll
+  public static void suiteSetup() {
+    throw new RuntimeException("suite set up failed");
+  }
+
+  @Test
+  public void test_succeed() {
+    assertTrue(true);
+  }
+
+  @Test
+  public void test_another_succeed() {
+    assertTrue(true);
+  }
+}

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestFailedSuiteTearDown.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestFailedSuiteTearDown.java
@@ -1,0 +1,24 @@
+package org.example;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+public class TestFailedSuiteTearDown {
+
+  @AfterAll
+  public static void suiteTearDown() {
+    throw new RuntimeException("suite tear down failed");
+  }
+
+  @Test
+  public void test_succeed() {
+    assertTrue(true);
+  }
+
+  @Test
+  public void test_another_succeed() {
+    assertTrue(true);
+  }
+}

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestSkippedClass.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestSkippedClass.java
@@ -1,11 +1,49 @@
 package org.example;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @Disabled("Ignore reason in class")
 public class TestSkippedClass {
 
   @Test
-  public void test_class_skipped() {}
+  public void test_case_skipped() {}
+
+  @org.junit.jupiter.api.TestFactory
+  public Iterable<DynamicTest> test_factory_skipped() {
+    return Arrays.asList(
+        DynamicTest.dynamicTest("dynamic_test_succeed", () -> assertEquals(0, 0)),
+        DynamicTest.dynamicTest("dynamic_test_succeed", () -> assertEquals(2, 1 + 1)));
+  }
+
+  @ParameterizedTest
+  @MethodSource("parameters")
+  public void test_parameterized_skipped(
+      final int first, final int second, final int expectedSum, final String message) {
+    final int actualSum = first + second;
+    assertEquals(expectedSum, actualSum);
+    assertNotNull(message);
+  }
+
+  static List<Arguments> parameters() {
+    return Arrays.asList(
+        () -> new Object[] {0, 0, "0", "some:\"parameter\""},
+        () -> new Object[] {1, 1, 2, "some:\"parameter\""});
+  }
+
+  @RepeatedTest(2)
+  public void test_repeated_skipped() {
+    assertTrue(true);
+  }
 }

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestSkippedNested.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestSkippedNested.java
@@ -1,0 +1,24 @@
+package org.example;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@Disabled("Ignore reason in class")
+public class TestSkippedNested {
+
+  @Test
+  public void test_succeed() {
+    assertTrue(true);
+  }
+
+  @Nested
+  class NestedSuite {
+    @Test
+    public void test_succeed_nested() {
+      assertTrue(true);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestSucceedAndSkipped.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestSucceedAndSkipped.java
@@ -1,0 +1,18 @@
+package org.example;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+public class TestSucceedAndSkipped {
+
+  @Test
+  public void test_succeed() {
+    assertTrue(true);
+  }
+
+  @Disabled("Ignore reason in test")
+  @Test
+  public void test_skipped() {}
+}

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestSucceedNested.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestSucceedNested.java
@@ -1,0 +1,22 @@
+package org.example;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class TestSucceedNested {
+
+  @Test
+  public void test_succeed() {
+    assertTrue(true);
+  }
+
+  @Nested
+  class NestedSuite {
+    @Test
+    public void test_succeed_nested() {
+      assertTrue(true);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestSucceedWithCategories.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestSucceedWithCategories.java
@@ -1,0 +1,17 @@
+package org.example;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
+import org.junit.jupiter.api.Test;
+
+@Tags({@Tag("Slow"), @Tag("Flaky")})
+public class TestSucceedWithCategories {
+
+  @Test
+  @Tags({@Tag("End2end"), @Tag("Browser")})
+  public void test_succeed() {
+    assertTrue(true);
+  }
+}

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestSuiteSetUpAssumption.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestSuiteSetUpAssumption.java
@@ -1,0 +1,20 @@
+package org.example;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class TestSuiteSetUpAssumption {
+
+  @BeforeAll
+  public static void suiteSetup() {
+    assumeTrue(1 > 2);
+  }
+
+  @Test
+  public void test_succeed() {
+    assertTrue(true);
+  }
+}

--- a/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TestNGDecorator.java
+++ b/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TestNGDecorator.java
@@ -33,13 +33,16 @@ public class TestNGDecorator extends TestDecorator {
     final Class<?> testClass = TestNGUtils.getTestClass(result);
     final Method testMethod = TestNGUtils.getTestMethod(result);
 
-    afterTestStart(span, testSuiteName, testName, testParameters, version, testClass, testMethod);
+    afterTestStart(
+        span, testSuiteName, testName, testParameters, version, testClass, testMethod, null);
   }
 
-  public void onTestSuccess(final AgentSpan span) {
+  public void onTestSuccess(final AgentSpan span, final ITestResult result) {
     span.setTag(Tags.TEST_STATUS, TEST_PASS);
 
-    beforeFinish(span);
+    final String testSuiteName = result.getInstanceName();
+    final Class<?> testClass = TestNGUtils.getTestClass(result);
+    beforeTestFinish(span, testSuiteName, testClass);
   }
 
   public void onTestFailure(final AgentSpan span, final ITestResult result) {
@@ -51,7 +54,9 @@ public class TestNGDecorator extends TestDecorator {
     span.setError(true);
     span.setTag(Tags.TEST_STATUS, TEST_FAIL);
 
-    beforeFinish(span);
+    final String testSuiteName = result.getInstanceName();
+    final Class<?> testClass = TestNGUtils.getTestClass(result);
+    beforeTestFinish(span, testSuiteName, testClass);
   }
 
   public void onTestIgnored(final AgentSpan span, final ITestResult result) {
@@ -63,6 +68,8 @@ public class TestNGDecorator extends TestDecorator {
 
     span.setTag(Tags.TEST_STATUS, TEST_SKIP);
 
-    beforeFinish(span);
+    final String testSuiteName = result.getInstanceName();
+    final Class<?> testClass = TestNGUtils.getTestClass(result);
+    beforeTestFinish(span, testSuiteName, testClass);
   }
 }

--- a/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TracingListener.java
+++ b/dd-java-agent/instrumentation/testng-6.4/src/main/java/datadog/trace/instrumentation/testng/TracingListener.java
@@ -46,7 +46,7 @@ public class TracingListener implements ITestListener {
   @Override
   public void onTestSuccess(final ITestResult result) {
     final AgentSpan span = AgentTracer.activeSpan();
-    if (span == null || !DECORATE.isTestSpan(AgentTracer.activeSpan())) {
+    if (!DECORATE.isTestSpan(span)) {
       return;
     }
 
@@ -55,14 +55,14 @@ public class TracingListener implements ITestListener {
       scope.close();
     }
 
-    DECORATE.onTestSuccess(span);
+    DECORATE.onTestSuccess(span, result);
     span.finish();
   }
 
   @Override
   public void onTestFailure(final ITestResult result) {
     final AgentSpan span = AgentTracer.activeSpan();
-    if (span == null || !DECORATE.isTestSpan(AgentTracer.activeSpan())) {
+    if (!DECORATE.isTestSpan(span)) {
       return;
     }
 
@@ -83,7 +83,7 @@ public class TracingListener implements ITestListener {
   @Override
   public void onTestSkipped(final ITestResult result) {
     final AgentSpan span = AgentTracer.activeSpan();
-    if (span == null || !DECORATE.isTestSpan(AgentTracer.activeSpan())) {
+    if (!DECORATE.isTestSpan(span)) {
       return;
     }
 

--- a/dd-java-agent/instrumentation/testng-6.4/src/test/groovy/TestNGTest.groovy
+++ b/dd-java-agent/instrumentation/testng-6.4/src/test/groovy/TestNGTest.groovy
@@ -25,7 +25,7 @@ class TestNGTest extends TestFrameworkTest {
     expect:
     assertTraces(1) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestSucceed", "test_succeed", TestDecorator.TEST_PASS)
+        testSpan(it, 0, null, null, "org.example.TestSucceed", "test_succeed", TestDecorator.TEST_PASS)
       }
     }
   }
@@ -40,7 +40,7 @@ class TestNGTest extends TestFrameworkTest {
     expect:
     assertTraces(1) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestInheritance", "test_succeed", TestDecorator.TEST_PASS)
+        testSpan(it, 0, null, null, "org.example.TestInheritance", "test_succeed", TestDecorator.TEST_PASS)
       }
     }
   }
@@ -59,7 +59,7 @@ class TestNGTest extends TestFrameworkTest {
     expect:
     assertTraces(1) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestFailed", "test_failed", TestDecorator.TEST_FAIL, null, exception)
+        testSpan(it, 0, null, null, "org.example.TestFailed", "test_failed", TestDecorator.TEST_FAIL, null, exception)
       }
     }
 
@@ -81,19 +81,19 @@ class TestNGTest extends TestFrameworkTest {
     expect:
     assertTraces(5) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestDecorator.TEST_FAIL, null, exception)
+        testSpan(it, 0, null, null, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestDecorator.TEST_FAIL, null, exception)
       }
       trace(1) {
-        testSpan(it, 0, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestDecorator.TEST_FAIL, null, exception)
+        testSpan(it, 0, null, null, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestDecorator.TEST_FAIL, null, exception)
       }
       trace(1) {
-        testSpan(it, 0, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestDecorator.TEST_PASS)
+        testSpan(it, 0, null, null, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestDecorator.TEST_PASS)
       }
       trace(1) {
-        testSpan(it, 0, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestDecorator.TEST_PASS)
+        testSpan(it, 0, null, null, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestDecorator.TEST_PASS)
       }
       trace(1) {
-        testSpan(it, 0, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestDecorator.TEST_PASS)
+        testSpan(it, 0, null, null, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestDecorator.TEST_PASS)
       }
     }
 
@@ -111,7 +111,7 @@ class TestNGTest extends TestFrameworkTest {
     expect:
     assertTraces(1) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestError", "test_error", TestDecorator.TEST_FAIL, null, exception)
+        testSpan(it, 0, null, null, "org.example.TestError", "test_error", TestDecorator.TEST_FAIL, null, exception)
       }
     }
 
@@ -129,7 +129,7 @@ class TestNGTest extends TestFrameworkTest {
     expect:
     assertTraces(1) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
+        testSpan(it, 0, null, null, "org.example.TestSkipped", "test_skipped", TestDecorator.TEST_SKIP, testTags, null, true)
       }
     }
 
@@ -147,10 +147,10 @@ class TestNGTest extends TestFrameworkTest {
     expect:
     assertTraces(2) {
       trace(1) {
-        testSpan(it, 0, "org.example.TestParameterized", "parameterized_test_succeed", TestDecorator.TEST_PASS, testTags_0)
+        testSpan(it, 0, null, null, "org.example.TestParameterized", "parameterized_test_succeed", TestDecorator.TEST_PASS, testTags_0)
       }
       trace(1) {
-        testSpan(it, 0, "org.example.TestParameterized", "parameterized_test_succeed", TestDecorator.TEST_PASS, testTags_1)
+        testSpan(it, 0, null, null, "org.example.TestParameterized", "parameterized_test_succeed", TestDecorator.TEST_PASS, testTags_1)
       }
     }
 
@@ -160,8 +160,8 @@ class TestNGTest extends TestFrameworkTest {
   }
 
   @Override
-  String expectedOperationName() {
-    return "testng.test"
+  String expectedOperationPrefix() {
+    return "testng"
   }
 
   @Override

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/SpanAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/SpanAssert.groovy
@@ -174,4 +174,8 @@ class SpanAssert {
     @DelegatesTo(value = TagsAssert, strategy = Closure.DELEGATE_FIRST) Closure spec) {
     assertTags(span, spec)
   }
+
+  DDSpan getSpan() {
+    return span
+  }
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
@@ -105,6 +105,7 @@ abstract class TestFrameworkTest extends AgentTestRunner {
 
   Long testSuiteSpan(final TraceAssert trace,
     final int index,
+    final Long parentId,
     final Long testModuleId,
     final String testSuite,
     final String testStatus,
@@ -119,7 +120,7 @@ abstract class TestFrameworkTest extends AgentTestRunner {
     trace.span(index) {
       testSuiteId = span.getTag(Tags.TEST_SUITE_ID)
 
-      parentSpanId(BigInteger.valueOf(testModuleId))
+      parentSpanId(BigInteger.valueOf(parentId))
       operationName expectedOperationPrefix() + ".test_suite"
       resourceName testSuite
       spanType DDSpanTypes.TEST_SUITE_END
@@ -152,7 +153,7 @@ abstract class TestFrameworkTest extends AgentTestRunner {
         }
 
         if (categories) {
-          "$Tags.TEST_TRAITS" Strings.toJson(["category": Strings.toJson(categories)])
+          "$Tags.TEST_TRAITS" Strings.toJson(["category": Strings.toJson(categories)], true)
         }
 
         ciTags.each { key, val ->
@@ -236,7 +237,7 @@ abstract class TestFrameworkTest extends AgentTestRunner {
         }
 
         if (categories) {
-          "$Tags.TEST_TRAITS" Strings.toJson(["category": Strings.toJson(categories)])
+          "$Tags.TEST_TRAITS" Strings.toJson(["category": Strings.toJson(categories)], true)
         }
 
         ciTags.each { key, val ->

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
@@ -10,17 +10,34 @@ import datadog.trace.api.civisibility.source.MethodLinesResolver
 import datadog.trace.api.civisibility.source.SourcePathResolver
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.bootstrap.instrumentation.decorator.TestDecorator
+import datadog.trace.util.Strings
 import spock.lang.Unroll
 
 @Unroll
 abstract class TestFrameworkTest extends AgentTestRunner {
 
+  static final String DUMMY_MODULE = "dummy_module"
+  static final String DUMMY_CI_TAG = "dummy_ci_tag"
+  static final String DUMMY_CI_TAG_VALUE = "dummy_ci_tag_value"
+  static final String DUMMY_SOURCE_PATH = "dummy_source_path"
+  static final int DUMMY_TEST_METHOD_START = 12
+  static final int DUMMY_TEST_METHOD_END = 18
+  static final Collection<String> DUMMY_CODE_OWNERS = ["owner1", "owner2"]
+
   def setupSpec() {
-    InstrumentationBridge.ci = false
-    InstrumentationBridge.ciTags = Collections.emptyMap()
-    InstrumentationBridge.codeowners = Stub(Codeowners)
+    InstrumentationBridge.ci = true
+    InstrumentationBridge.ciTags = [(DUMMY_CI_TAG): DUMMY_CI_TAG_VALUE]
+
     InstrumentationBridge.sourcePathResolver = Stub(SourcePathResolver)
+    InstrumentationBridge.sourcePathResolver.getSourcePath(_) >> DUMMY_SOURCE_PATH
+
     InstrumentationBridge.methodLinesResolver = Stub(MethodLinesResolver)
+    InstrumentationBridge.methodLinesResolver.getLines(_) >> new MethodLinesResolver.MethodLines(DUMMY_TEST_METHOD_START, DUMMY_TEST_METHOD_END)
+
+    InstrumentationBridge.codeowners = Stub(Codeowners)
+    InstrumentationBridge.codeowners.getOwners(DUMMY_SOURCE_PATH) >> DUMMY_CODE_OWNERS
+
+    InstrumentationBridge.module = DUMMY_MODULE
   }
 
   @Override
@@ -29,27 +46,30 @@ abstract class TestFrameworkTest extends AgentTestRunner {
     injectSysConfig("dd.civisibility.enabled", "true")
   }
 
-  void testSpan(TraceAssert trace, int index, final String testSuite, final String testName, final String testStatus, final Map<String, String> testTags = null, final Throwable exception = null, final boolean emptyDuration = false) {
+  Long testModuleSpan(final TraceAssert trace,
+    final int index,
+    final String testStatus,
+    final Map<String, String> testTags = null,
+    final Throwable exception = null) {
     def testFramework = expectedTestFramework()
     def testFrameworkVersion = expectedTestFrameworkVersion()
 
-    trace.span {
+    def testModuleId
+    trace.span(index) {
+      testModuleId = span.getTag(Tags.TEST_MODULE_ID)
+
       parent()
-      operationName expectedOperationName()
-      resourceName "$testSuite.$testName"
-      spanType DDSpanTypes.TEST
+      operationName expectedOperationPrefix() + ".test_module"
+      resourceName DUMMY_MODULE
+      spanType DDSpanTypes.TEST_MODULE_END
       errored exception != null
-      if (emptyDuration) {
-        duration({ it == 1L })
-      } else {
-        duration({ it > 1L })
-      }
+      duration({ it > 1L })
       tags {
         "$Tags.COMPONENT" component
-        "$Tags.SPAN_KIND" Tags.SPAN_KIND_TEST
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_TEST_MODULE
         "$Tags.TEST_TYPE" TestDecorator.TEST_TYPE
-        "$Tags.TEST_SUITE" testSuite
-        "$Tags.TEST_NAME" testName
+        "$Tags.TEST_MODULE" DUMMY_MODULE
+        "$Tags.TEST_BUNDLE" DUMMY_MODULE
         "$Tags.TEST_FRAMEWORK" testFramework
         if (testFrameworkVersion) {
           "$Tags.TEST_FRAMEWORK_VERSION" testFrameworkVersion
@@ -75,6 +95,162 @@ abstract class TestFrameworkTest extends AgentTestRunner {
         "$Tags.RUNTIME_VERSION" String
         "$DDTags.LIBRARY_VERSION_TAG_KEY" String
 
+        "$Tags.TEST_MODULE_ID" Long
+
+        defaultTags()
+      }
+    }
+    return testModuleId
+  }
+
+  Long testSuiteSpan(final TraceAssert trace,
+    final int index,
+    final Long testModuleId,
+    final String testSuite,
+    final String testStatus,
+    final Map<String, String> testTags = null,
+    final Throwable exception = null,
+    final boolean emptyDuration = false,
+    final Collection<String> categories = null) {
+    def testFramework = expectedTestFramework()
+    def testFrameworkVersion = expectedTestFrameworkVersion()
+
+    def testSuiteId
+    trace.span(index) {
+      testSuiteId = span.getTag(Tags.TEST_SUITE_ID)
+
+      parentSpanId(BigInteger.valueOf(testModuleId))
+      operationName expectedOperationPrefix() + ".test_suite"
+      resourceName testSuite
+      spanType DDSpanTypes.TEST_SUITE_END
+      errored exception != null
+      if (emptyDuration) {
+        duration({ it == 1L })
+      } else {
+        duration({ it > 1L })
+      }
+      tags {
+        "$Tags.COMPONENT" component
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_TEST_SUITE
+        "$Tags.TEST_TYPE" TestDecorator.TEST_TYPE
+        "$Tags.TEST_MODULE_ID" testModuleId
+        "$Tags.TEST_MODULE" DUMMY_MODULE
+        "$Tags.TEST_BUNDLE" DUMMY_MODULE
+        "$Tags.TEST_SUITE" testSuite
+        "$Tags.TEST_FRAMEWORK" testFramework
+        if (testFrameworkVersion) {
+          "$Tags.TEST_FRAMEWORK_VERSION" testFrameworkVersion
+        }
+        "$Tags.TEST_STATUS" testStatus
+        if (testTags) {
+          testTags.each { key, val -> tag(key, val) }
+        }
+        "$Tags.TEST_SOURCE_FILE" DUMMY_SOURCE_PATH
+
+        if (exception) {
+          errorTags(exception.class, exception.message)
+        }
+
+        if (categories) {
+          "$Tags.TEST_TRAITS" Strings.toJson(["category": Strings.toJson(categories)])
+        }
+
+        ciTags.each { key, val ->
+          tag(key, val)
+        }
+
+        "$Tags.OS_VERSION" String
+        "$Tags.OS_PLATFORM" String
+        "$Tags.OS_ARCHITECTURE" String
+        "$Tags.RUNTIME_VENDOR" String
+        "$Tags.RUNTIME_NAME" String
+        "$Tags.RUNTIME_VERSION" String
+        "$DDTags.LIBRARY_VERSION_TAG_KEY" String
+
+        "$Tags.TEST_SUITE_ID" Long
+
+        defaultTags()
+      }
+    }
+    return testSuiteId
+  }
+
+  void testSpan(final TraceAssert trace,
+    final int index,
+    final Long testModuleId,
+    final Long testSuiteId,
+    final String testSuite,
+    final String testName,
+    final String testStatus,
+    final Map<String, String> testTags = null,
+    final Throwable exception = null,
+    final boolean emptyDuration = false,
+    final Collection<String> categories = null) {
+    def testFramework = expectedTestFramework()
+    def testFrameworkVersion = expectedTestFrameworkVersion()
+
+    trace.span(index) {
+      if (testSuiteId != null) {
+        parentSpanId(BigInteger.valueOf(testSuiteId))
+      } else {
+        parent()
+      }
+      operationName expectedOperationPrefix() + ".test"
+      resourceName "$testSuite.$testName"
+      spanType DDSpanTypes.TEST
+      errored exception != null
+      if (emptyDuration) {
+        duration({ it == 1L })
+      } else {
+        duration({ it > 1L })
+      }
+      tags {
+        "$Tags.COMPONENT" component
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_TEST
+        "$Tags.TEST_TYPE" TestDecorator.TEST_TYPE
+        if (testModuleId != null) {
+          "$Tags.TEST_MODULE_ID" testModuleId
+        }
+        if (testSuiteId != null) {
+          "$Tags.TEST_SUITE_ID" testSuiteId
+        }
+        "$Tags.TEST_MODULE" DUMMY_MODULE
+        "$Tags.TEST_BUNDLE" DUMMY_MODULE
+        "$Tags.TEST_SUITE" testSuite
+        "$Tags.TEST_NAME" testName
+        "$Tags.TEST_FRAMEWORK" testFramework
+        if (testFrameworkVersion) {
+          "$Tags.TEST_FRAMEWORK_VERSION" testFrameworkVersion
+        }
+        "$Tags.TEST_STATUS" testStatus
+        if (testTags) {
+          testTags.each { key, val -> tag(key, val) }
+        }
+        "$Tags.TEST_SOURCE_FILE" DUMMY_SOURCE_PATH
+        "$Tags.TEST_SOURCE_START" DUMMY_TEST_METHOD_START
+        "$Tags.TEST_SOURCE_END" DUMMY_TEST_METHOD_END
+        "$Tags.TEST_CODEOWNERS" Strings.toJson(DUMMY_CODE_OWNERS)
+
+        if (exception) {
+          errorTags(exception.class, exception.message)
+        }
+
+        if (categories) {
+          "$Tags.TEST_TRAITS" Strings.toJson(["category": Strings.toJson(categories)])
+        }
+
+        ciTags.each { key, val ->
+          tag(key, val)
+        }
+
+        "$Tags.OS_VERSION" String
+        "$Tags.OS_PLATFORM" String
+        "$Tags.OS_ARCHITECTURE" String
+        "$Tags.RUNTIME_VENDOR" String
+        "$Tags.RUNTIME_NAME" String
+        "$Tags.RUNTIME_VERSION" String
+        "$DDTags.LIBRARY_VERSION_TAG_KEY" String
+
         defaultTags()
       }
     }
@@ -86,7 +262,7 @@ abstract class TestFrameworkTest extends AgentTestRunner {
 
   Map<String, String> ciTags = ciTags()
 
-  abstract String expectedOperationName()
+  abstract String expectedOperationPrefix()
 
   abstract String expectedTestFramework()
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDSpanTypes.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDSpanTypes.java
@@ -28,6 +28,7 @@ public class DDSpanTypes {
 
   public static final String TEST = "test";
   public static final String TEST_SUITE_END = "test_suite_end";
+  public static final String TEST_MODULE_END = "test_module_end";
 
   public static final String VULNERABILITY = "vulnerability";
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDSpanTypes.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDSpanTypes.java
@@ -27,6 +27,7 @@ public class DDSpanTypes {
   public static final String GRAPHQL = "graphql";
 
   public static final String TEST = "test";
+  public static final String TEST_SUITE_END = "test_suite_end";
 
   public static final String VULNERABILITY = "vulnerability";
 }

--- a/dd-trace-core/src/main/java/datadog/trace/civisibility/interceptor/CiVisibilityTraceInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/civisibility/interceptor/CiVisibilityTraceInterceptor.java
@@ -28,10 +28,11 @@ public class CiVisibilityTraceInterceptor implements TraceInterceptor {
 
     final DDSpan spanToCheck = null == localRootSpan ? firstSpan : localRootSpan;
 
-    // If root span does not have type == "test" or type == "test_suite_end", we drop the full
-    // trace.
+    // If root span is not a CI visbility span, we drop the full trace.
     CharSequence type = spanToCheck.getType(); // Don't null pointer if there is no type
-    if (!DDSpanTypes.TEST.contentEquals(type) && !DDSpanTypes.TEST_SUITE_END.contentEquals(type)) {
+    if (!DDSpanTypes.TEST.contentEquals(type)
+        && !DDSpanTypes.TEST_SUITE_END.contentEquals(type)
+        && !DDSpanTypes.TEST_MODULE_END.contentEquals(type)) {
       return Collections.emptyList();
     }
 

--- a/dd-trace-core/src/main/java/datadog/trace/civisibility/interceptor/CiVisibilityTraceInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/civisibility/interceptor/CiVisibilityTraceInterceptor.java
@@ -30,9 +30,10 @@ public class CiVisibilityTraceInterceptor implements TraceInterceptor {
 
     // If root span is not a CI visbility span, we drop the full trace.
     CharSequence type = spanToCheck.getType(); // Don't null pointer if there is no type
-    if (!DDSpanTypes.TEST.contentEquals(type)
-        && !DDSpanTypes.TEST_SUITE_END.contentEquals(type)
-        && !DDSpanTypes.TEST_MODULE_END.contentEquals(type)) {
+    if (type == null
+        || (!DDSpanTypes.TEST.contentEquals(type)
+            && !DDSpanTypes.TEST_SUITE_END.contentEquals(type)
+            && !DDSpanTypes.TEST_MODULE_END.contentEquals(type))) {
       return Collections.emptyList();
     }
 

--- a/dd-trace-core/src/main/java/datadog/trace/civisibility/interceptor/CiVisibilityTraceInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/civisibility/interceptor/CiVisibilityTraceInterceptor.java
@@ -1,5 +1,6 @@
 package datadog.trace.civisibility.interceptor;
 
+import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.api.interceptor.TraceInterceptor;
@@ -13,7 +14,6 @@ public class CiVisibilityTraceInterceptor implements TraceInterceptor {
 
   public static final CiVisibilityTraceInterceptor INSTANCE = new CiVisibilityTraceInterceptor();
 
-  static final String TEST_TYPE = "test";
   static final UTF8BytesString CIAPP_TEST_ORIGIN = UTF8BytesString.create("ciapp-test");
 
   @Override
@@ -28,9 +28,10 @@ public class CiVisibilityTraceInterceptor implements TraceInterceptor {
 
     final DDSpan spanToCheck = null == localRootSpan ? firstSpan : localRootSpan;
 
-    // If root span does not have type == "test", we drop the full trace.
+    // If root span does not have type == "test" or type == "test_suite_end", we drop the full
+    // trace.
     CharSequence type = spanToCheck.getType(); // Don't null pointer if there is no type
-    if (type == null || !TEST_TYPE.contentEquals(type)) {
+    if (!DDSpanTypes.TEST.contentEquals(type) && !DDSpanTypes.TEST_SUITE_END.contentEquals(type)) {
       return Collections.emptyList();
     }
 

--- a/dd-trace-core/src/main/java/datadog/trace/civisibility/writer/ddintake/CiTestCycleMapperV1.java
+++ b/dd-trace-core/src/main/java/datadog/trace/civisibility/writer/ddintake/CiTestCycleMapperV1.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Map;
 import okhttp3.RequestBody;
 
-public class CiTestCycleMapperV2 implements RemoteMapper {
+public class CiTestCycleMapperV1 implements RemoteMapper {
 
   private static final byte[] VERSION = "version".getBytes(StandardCharsets.UTF_8);
   private static final byte[] METADATA = "metadata".getBytes(StandardCharsets.UTF_8);
@@ -47,11 +47,11 @@ public class CiTestCycleMapperV2 implements RemoteMapper {
   private final MsgPackWriter headerWriter;
   private int eventCount = 0;
 
-  public CiTestCycleMapperV2(WellKnownTags wellKnownTags) {
+  public CiTestCycleMapperV1(WellKnownTags wellKnownTags) {
     this(wellKnownTags, DEFAULT_TOP_LEVEL_TAGS, 5 << 20);
   }
 
-  private CiTestCycleMapperV2(
+  private CiTestCycleMapperV1(
       WellKnownTags wellKnownTags, Collection<String> topLevelTags, int size) {
     this.wellKnownTags = wellKnownTags;
     this.topLevelTags = topLevelTags;
@@ -74,29 +74,34 @@ public class CiTestCycleMapperV2 implements RemoteMapper {
       Long traceId;
       Long spanId;
       Long parentId;
+      int version;
       if (InternalSpanTypes.TEST.equals(span.getType())) {
         type = InternalSpanTypes.TEST;
         traceId = span.getTraceId().toLong();
         spanId = span.getSpanId();
         parentId = span.getParentId();
+        version = 2;
 
       } else if (InternalSpanTypes.TEST_SUITE_END.equals(span.getType())) {
         type = InternalSpanTypes.TEST_SUITE_END;
         traceId = null;
         spanId = null;
         parentId = null;
+        version = 1;
 
       } else if (InternalSpanTypes.TEST_MODULE_END.equals(span.getType())) {
         type = InternalSpanTypes.TEST_MODULE_END;
         traceId = null;
         spanId = null;
         parentId = null;
+        version = 1;
 
       } else {
         type = SPAN_TYPE;
         traceId = span.getTraceId().toLong();
         spanId = span.getSpanId();
         parentId = span.getParentId();
+        version = 1;
       }
 
       int contentChildrenCount =
@@ -112,7 +117,7 @@ public class CiTestCycleMapperV2 implements RemoteMapper {
       writable.writeUTF8(type);
       /* 2 */
       writable.writeUTF8(VERSION);
-      writable.writeInt(2);
+      writable.writeInt(version);
       /* 3 */
       writable.writeUTF8(CONTENT);
       writable.startMap(contentChildrenCount);
@@ -175,7 +180,7 @@ public class CiTestCycleMapperV2 implements RemoteMapper {
     headerWriter.startMap(3);
     /* 1  */
     headerWriter.writeUTF8(VERSION);
-    headerWriter.writeInt(2);
+    headerWriter.writeInt(1);
     /* 2  */
     headerWriter.writeUTF8(METADATA);
     headerWriter.startMap(1);

--- a/dd-trace-core/src/main/java/datadog/trace/civisibility/writer/ddintake/CiTestCycleMapperV1.java
+++ b/dd-trace-core/src/main/java/datadog/trace/civisibility/writer/ddintake/CiTestCycleMapperV1.java
@@ -80,7 +80,10 @@ public class CiTestCycleMapperV1 implements RemoteMapper {
         traceId = span.getTraceId().toLong();
         spanId = span.getSpanId();
         parentId = span.getParentId();
-        version = 2;
+        // If there are no top-level tags,
+        // this is a test span that is not a part of a test suite,
+        // i.e. emitted by framework that does not support testing suites yet
+        version = topLevelTagsCount > 0 ? 2 : 1;
 
       } else if (InternalSpanTypes.TEST_SUITE_END.equals(span.getType())) {
         type = InternalSpanTypes.TEST_SUITE_END;

--- a/dd-trace-core/src/main/java/datadog/trace/civisibility/writer/ddintake/CiTestCycleMapperV2.java
+++ b/dd-trace-core/src/main/java/datadog/trace/civisibility/writer/ddintake/CiTestCycleMapperV2.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Map;
 import okhttp3.RequestBody;
 
-public class CiTestCycleMapperV1 implements RemoteMapper {
+public class CiTestCycleMapperV2 implements RemoteMapper {
 
   private static final byte[] VERSION = "version".getBytes(StandardCharsets.UTF_8);
   private static final byte[] METADATA = "metadata".getBytes(StandardCharsets.UTF_8);
@@ -35,7 +35,6 @@ public class CiTestCycleMapperV1 implements RemoteMapper {
   private static final byte[] TYPE = "type".getBytes(StandardCharsets.UTF_8);
   private static final byte[] CONTENT = "content".getBytes(StandardCharsets.UTF_8);
 
-  private static final UTF8BytesString TEST_TYPE = UTF8BytesString.create("test");
   private static final UTF8BytesString SPAN_TYPE = UTF8BytesString.create("span");
 
   private static final Collection<String> DEFAULT_TOP_LEVEL_TAGS =
@@ -48,11 +47,11 @@ public class CiTestCycleMapperV1 implements RemoteMapper {
   private final MsgPackWriter headerWriter;
   private int eventCount = 0;
 
-  public CiTestCycleMapperV1(WellKnownTags wellKnownTags) {
+  public CiTestCycleMapperV2(WellKnownTags wellKnownTags) {
     this(wellKnownTags, DEFAULT_TOP_LEVEL_TAGS, 5 << 20);
   }
 
-  private CiTestCycleMapperV1(
+  private CiTestCycleMapperV2(
       WellKnownTags wellKnownTags, Collection<String> topLevelTags, int size) {
     this.wellKnownTags = wellKnownTags;
     this.topLevelTags = topLevelTags;
@@ -71,37 +70,30 @@ public class CiTestCycleMapperV1 implements RemoteMapper {
         }
       }
 
-      // FIXME this part should be split into CITestCycleMapperV2 (and version should be determined
-      // based on test framework)
       UTF8BytesString type;
-      int version;
       Long traceId;
       Long spanId;
       Long parentId;
       if (InternalSpanTypes.TEST.equals(span.getType())) {
         type = InternalSpanTypes.TEST;
-        version = 2;
         traceId = span.getTraceId().toLong();
         spanId = span.getSpanId();
         parentId = span.getParentId();
 
       } else if (InternalSpanTypes.TEST_SUITE_END.equals(span.getType())) {
         type = InternalSpanTypes.TEST_SUITE_END;
-        version = 1;
         traceId = null;
         spanId = null;
         parentId = null;
 
       } else if (InternalSpanTypes.TEST_MODULE_END.equals(span.getType())) {
         type = InternalSpanTypes.TEST_MODULE_END;
-        version = 1;
         traceId = null;
         spanId = null;
         parentId = null;
 
       } else {
         type = SPAN_TYPE;
-        version = 1;
         traceId = span.getTraceId().toLong();
         spanId = span.getSpanId();
         parentId = span.getParentId();
@@ -120,7 +112,7 @@ public class CiTestCycleMapperV1 implements RemoteMapper {
       writable.writeUTF8(type);
       /* 2 */
       writable.writeUTF8(VERSION);
-      writable.writeInt(version);
+      writable.writeInt(2);
       /* 3 */
       writable.writeUTF8(CONTENT);
       writable.startMap(contentChildrenCount);
@@ -183,7 +175,7 @@ public class CiTestCycleMapperV1 implements RemoteMapper {
     headerWriter.startMap(3);
     /* 1  */
     headerWriter.writeUTF8(VERSION);
-    headerWriter.writeInt(1);
+    headerWriter.writeInt(2);
     /* 2  */
     headerWriter.writeUTF8(METADATA);
     headerWriter.startMap(1);

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDIntakeMapperDiscovery.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDIntakeMapperDiscovery.java
@@ -2,7 +2,7 @@ package datadog.trace.common.writer.ddintake;
 
 import datadog.trace.api.WellKnownTags;
 import datadog.trace.api.intake.TrackType;
-import datadog.trace.civisibility.writer.ddintake.CiTestCycleMapperV1;
+import datadog.trace.civisibility.writer.ddintake.CiTestCycleMapperV2;
 import datadog.trace.common.writer.RemoteMapper;
 import datadog.trace.common.writer.RemoteMapperDiscovery;
 
@@ -31,7 +31,7 @@ public class DDIntakeMapperDiscovery implements RemoteMapperDiscovery {
   public void discover() {
     reset();
     if (TrackType.CITESTCYCLE.equals(trackType)) {
-      mapper = new CiTestCycleMapperV1(wellKnownTags);
+      mapper = new CiTestCycleMapperV2(wellKnownTags);
     } else {
       mapper = RemoteMapper.NO_OP;
     }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDIntakeMapperDiscovery.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDIntakeMapperDiscovery.java
@@ -1,6 +1,5 @@
 package datadog.trace.common.writer.ddintake;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.WellKnownTags;
 import datadog.trace.api.intake.TrackType;
 import datadog.trace.civisibility.writer.ddintake.CiTestCycleMapperV1;
@@ -19,32 +18,27 @@ public class DDIntakeMapperDiscovery implements RemoteMapperDiscovery {
 
   private RemoteMapper mapper;
 
-  public DDIntakeMapperDiscovery(final TrackType trackType) {
-    this.trackType = trackType;
-    this.wellKnownTags = Config.get().getWellKnownTags();
-  }
-
   public DDIntakeMapperDiscovery(final TrackType trackType, final WellKnownTags wellKnownTags) {
     this.trackType = trackType;
     this.wellKnownTags = wellKnownTags;
   }
 
   private void reset() {
-    this.mapper = null;
+    mapper = null;
   }
 
   @Override
   public void discover() {
     reset();
     if (TrackType.CITESTCYCLE.equals(trackType)) {
-      this.mapper = new CiTestCycleMapperV1(wellKnownTags);
+      mapper = new CiTestCycleMapperV1(wellKnownTags);
     } else {
-      this.mapper = RemoteMapper.NO_OP;
+      mapper = RemoteMapper.NO_OP;
     }
   }
 
   @Override
   public RemoteMapper getMapper() {
-    return this.mapper;
+    return mapper;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDIntakeMapperDiscovery.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDIntakeMapperDiscovery.java
@@ -2,7 +2,7 @@ package datadog.trace.common.writer.ddintake;
 
 import datadog.trace.api.WellKnownTags;
 import datadog.trace.api.intake.TrackType;
-import datadog.trace.civisibility.writer.ddintake.CiTestCycleMapperV2;
+import datadog.trace.civisibility.writer.ddintake.CiTestCycleMapperV1;
 import datadog.trace.common.writer.RemoteMapper;
 import datadog.trace.common.writer.RemoteMapperDiscovery;
 
@@ -31,7 +31,7 @@ public class DDIntakeMapperDiscovery implements RemoteMapperDiscovery {
   public void discover() {
     reset();
     if (TrackType.CITESTCYCLE.equals(trackType)) {
-      mapper = new CiTestCycleMapperV2(wellKnownTags);
+      mapper = new CiTestCycleMapperV1(wellKnownTags);
     } else {
       mapper = RemoteMapper.NO_OP;
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/civisibility/interceptor/CiVisibilityTraceInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/civisibility/interceptor/CiVisibilityTraceInterceptorTest.groovy
@@ -1,5 +1,6 @@
 package datadog.trace.civisibility.interceptor
 
+import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.test.DDCoreSpecification
@@ -23,11 +24,11 @@ class CiVisibilityTraceInterceptorTest extends DDCoreSpecification {
     writer.size() == 0
   }
 
-  def "add ciapp origin and tracer version to all spans"() {
+  def "add ciapp origin and tracer version to spans of type #spanType"() {
     setup:
     tracer.addTraceInterceptor(CiVisibilityTraceInterceptor.INSTANCE)
 
-    tracer.buildSpan("sample-span").withSpanType(CiVisibilityTraceInterceptor.TEST_TYPE).start().finish()
+    tracer.buildSpan("sample-span").withSpanType(spanType).start().finish()
     writer.waitForTraces(1)
 
     expect:
@@ -38,5 +39,8 @@ class CiVisibilityTraceInterceptorTest extends DDCoreSpecification {
 
     span.context().origin == CiVisibilityTraceInterceptor.CIAPP_TEST_ORIGIN
     span.getTag(DDTags.LIBRARY_VERSION_TAG_KEY) != null
+
+    where:
+    spanType << [DDSpanTypes.TEST, DDSpanTypes.TEST_SUITE_END, DDSpanTypes.TEST_MODULE_END]
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/civisibility/writer/ddintake/CiTestCycleMapperV1PayloadTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/civisibility/writer/ddintake/CiTestCycleMapperV1PayloadTest.groovy
@@ -39,13 +39,13 @@ import static org.msgpack.core.MessageFormat.UINT32
 import static org.msgpack.core.MessageFormat.UINT64
 import static org.msgpack.core.MessageFormat.UINT8
 
-class CiTestCycleMapperV2PayloadTest extends DDSpecification {
+class CiTestCycleMapperV1PayloadTest extends DDSpecification {
 
   def "test traces written correctly with bufferSize=#bufferSize, traceCount=#traceCount, lowCardinality=#lowCardinality"() {
     setup:
     List<List<TraceGenerator.PojoSpan>> traces = generateRandomTraces(traceCount, lowCardinality)
     WellKnownTags wellKnownTags = new WellKnownTags("runtimeid", "hostname", "my-env", "service", "version", "language")
-    CiTestCycleMapperV2 mapper = new CiTestCycleMapperV2(wellKnownTags)
+    CiTestCycleMapperV1 mapper = new CiTestCycleMapperV1(wellKnownTags)
     PayloadVerifier verifier = new PayloadVerifier(wellKnownTags, traces, mapper)
     MsgPackWriter packer = new MsgPackWriter(new FlushingBuffer(bufferSize, verifier))
     when:
@@ -178,7 +178,7 @@ class CiTestCycleMapperV2PayloadTest extends DDSpecification {
     List<TraceGenerator.PojoSpan> trace = Collections.singletonList(span)
 
     WellKnownTags wellKnownTags = new WellKnownTags("runtimeid", "hostname", "my-env", "service", "version", "language")
-    CiTestCycleMapperV2 mapper = new CiTestCycleMapperV2(wellKnownTags)
+    CiTestCycleMapperV1 mapper = new CiTestCycleMapperV1(wellKnownTags)
 
     ByteBufferConsumer consumer = new CaptureConsumer()
     MsgPackWriter packer = new MsgPackWriter(new FlushingBuffer(100 << 10, consumer))
@@ -203,13 +203,13 @@ class CiTestCycleMapperV2PayloadTest extends DDSpecification {
   private static final class PayloadVerifier implements ByteBufferConsumer, WritableByteChannel {
 
     private final List<List<TraceGenerator.PojoSpan>> expectedTraces
-    private final CiTestCycleMapperV2 mapper
+    private final CiTestCycleMapperV1 mapper
     private final WellKnownTags wellKnownTags
     private ByteBuffer captured = ByteBuffer.allocate(200 << 10)
 
     private int position = 0
 
-    private PayloadVerifier(WellKnownTags wellKnownTags, List<List<TraceGenerator.PojoSpan>> traces, CiTestCycleMapperV2 mapper) {
+    private PayloadVerifier(WellKnownTags wellKnownTags, List<List<TraceGenerator.PojoSpan>> traces, CiTestCycleMapperV1 mapper) {
       this.expectedTraces = traces
       this.mapper = mapper
       this.wellKnownTags = wellKnownTags
@@ -237,7 +237,7 @@ class CiTestCycleMapperV2PayloadTest extends DDSpecification {
         MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(captured)
         assertEquals(3, unpacker.unpackMapHeader())
         assertEquals("version", unpacker.unpackString())
-        assertEquals(2, unpacker.unpackInt())
+        assertEquals(1, unpacker.unpackInt())
         assertEquals("metadata", unpacker.unpackString())
         assertEquals(1, unpacker.unpackMapHeader())
         assertEquals("*", unpacker.unpackString())
@@ -266,7 +266,7 @@ class CiTestCycleMapperV2PayloadTest extends DDSpecification {
             assertEquals("span", unpacker.unpackString())
           }
           assertEquals("version", unpacker.unpackString())
-          assertEquals(2, unpacker.unpackInt())
+          assertEquals(1, unpacker.unpackInt())
           assertEquals("content", unpacker.unpackString())
           assertEquals(11, unpacker.unpackMapHeader())
           assertEquals("trace_id", unpacker.unpackString())

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDEvpProxyApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDEvpProxyApiTest.groovy
@@ -11,6 +11,7 @@ import datadog.trace.api.WellKnownTags
 import datadog.trace.api.intake.TrackType
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.common.writer.Payload
 import datadog.trace.core.DDSpan
@@ -29,7 +30,7 @@ import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
 @Timeout(20)
 class DDEvpProxyApiTest extends DDCoreSpecification {
 
-  static WellKnownTags wellKnownTags = new WellKnownTags("my-runtime-id", "my-hostname", "my-env","my-service","my-version","my-language")
+  static WellKnownTags wellKnownTags = new WellKnownTags("my-runtime-id", "my-hostname", "my-env", "my-service", "my-version", "my-language")
   static String intakeSubdomain = "citestcycle-intake"
   static msgPackMapper = new ObjectMapper(new MessagePackFactory())
 
@@ -76,9 +77,9 @@ class DDEvpProxyApiTest extends DDCoreSpecification {
     def agentEvpProxy = httpServer {
       handlers {
         post(path) {
-          if(retry < 5) {
+          if (retry < 5) {
             response.status(503).send()
-            retry+=1
+            retry += 1
           } else {
             response.status(200).send()
           }
@@ -128,34 +129,113 @@ class DDEvpProxyApiTest extends DDCoreSpecification {
 
     where:
     // spotless:off
-    trackType             | apiVersion | evpProxyEndpoint      | traces | expectedRequestBody
-    TrackType.CITESTCYCLE | "v2"       | V2_EVP_PROXY_ENDPOINT | []     | [:]
-    TrackType.CITESTCYCLE | "v2"       | V2_EVP_PROXY_ENDPOINT | [[buildSpan(1L, "service.name", "my-service")]] | new TreeMap<>([
-      "version":1,
+    trackType             | apiVersion | evpProxyEndpoint      | traces                                                                                               | expectedRequestBody
+    TrackType.CITESTCYCLE | "v2"       | V2_EVP_PROXY_ENDPOINT | []                                                                                                   | [:]
+
+    TrackType.CITESTCYCLE | "v2"       | V2_EVP_PROXY_ENDPOINT | [[buildSpan(1L, "fakeType", ["service.name": "my-service"])]]                                        | new TreeMap<>([
+      "version" : 2,
       "metadata": new TreeMap<>([
-        "*":new TreeMap<>([
-          "env":"my-env",
-          "runtime-id":"my-runtime-id",
-          "language":"my-language"
+        "*": new TreeMap<>([
+          "env"       : "my-env",
+          "runtime-id": "my-runtime-id",
+          "language"  : "my-language"
         ])]),
-       "events":[new TreeMap<>([
-         "type":"span",
-         "version":1,
-         "content":new TreeMap<>([
-           "service":"my-service",
-           "name":"fakeOperation",
-           "resource":"fakeResource",
-           "error":0,
-           "trace_id":1L,
-           "span_id":1L,
-           "parent_id":0L,
-           "start":1000L,
-           "duration":10L,
-           "meta": [:],
-           "metrics":[:]
-         ])
-       ])]
-      ])
+      "events"  : [new TreeMap<>([
+        "type"   : "span",
+        "version": 2,
+        "content": new TreeMap<>([
+          "service"  : "my-service",
+          "name"     : "fakeOperation",
+          "resource" : "fakeResource",
+          "error"    : 0,
+          "trace_id" : 1L,
+          "span_id"  : 1L,
+          "parent_id": 0L,
+          "start"    : 1000L,
+          "duration" : 10L,
+          "meta"     : [:],
+          "metrics"  : [:]
+        ])
+      ])]
+    ])
+    TrackType.CITESTCYCLE | "v2"       | V2_EVP_PROXY_ENDPOINT | [[buildSpan(1L, InternalSpanTypes.TEST, ["test_suite_id": 123L, "test_module_id": 456L])]]           | new TreeMap<>([
+      "version" : 2,
+      "metadata": new TreeMap<>([
+        "*": new TreeMap<>([
+          "env"       : "my-env",
+          "runtime-id": "my-runtime-id",
+          "language"  : "my-language"
+        ])]),
+      "events"  : [new TreeMap<>([
+        "type"   : "test",
+        "version": 2,
+        "content": new TreeMap<>([
+          "test_suite_id" : 123L,
+          "test_module_id": 456L,
+          "service"       : "fakeService",
+          "name"          : "fakeOperation",
+          "resource"      : "fakeResource",
+          "error"         : 0,
+          "trace_id"      : 1L,
+          "span_id"       : 1L,
+          "parent_id"     : 0L,
+          "start"         : 1000L,
+          "duration"      : 10L,
+          "meta"          : [:],
+          "metrics"       : [:]
+        ])
+      ])]
+    ])
+    TrackType.CITESTCYCLE | "v2"       | V2_EVP_PROXY_ENDPOINT | [[buildSpan(1L, InternalSpanTypes.TEST_SUITE_END, ["test_suite_id": 123L, "test_module_id": 456L])]] | new TreeMap<>([
+      "version" : 2,
+      "metadata": new TreeMap<>([
+        "*": new TreeMap<>([
+          "env"       : "my-env",
+          "runtime-id": "my-runtime-id",
+          "language"  : "my-language"
+        ])]),
+      "events"  : [new TreeMap<>([
+        "type"   : "test_suite_end",
+        "version": 2,
+        "content": new TreeMap<>([
+          "test_suite_id" : 123L,
+          "test_module_id": 456L,
+          "service"       : "fakeService",
+          "name"          : "fakeOperation",
+          "resource"      : "fakeResource",
+          "error"         : 0,
+          "start"         : 1000L,
+          "duration"      : 10L,
+          "meta"          : [:],
+          "metrics"       : [:]
+        ])
+      ])]
+    ])
+    TrackType.CITESTCYCLE | "v2"       | V2_EVP_PROXY_ENDPOINT | [[buildSpan(1L, InternalSpanTypes.TEST_MODULE_END, ["test_module_id": 456L])]]                       | new TreeMap<>([
+      "version" : 2,
+      "metadata": new TreeMap<>([
+        "*": new TreeMap<>([
+          "env"       : "my-env",
+          "runtime-id": "my-runtime-id",
+          "language"  : "my-language"
+        ])]),
+      "events"  : [new TreeMap<>([
+        "type"   : "test_module_end",
+        "version": 2,
+        "content": new TreeMap<>([
+          "test_module_id": 456L,
+          "service"       : "fakeService",
+          "name"          : "fakeOperation",
+          "resource"      : "fakeResource",
+          "error"         : 0,
+          "start"         : 1000L,
+          "duration"      : 10L,
+          "meta"          : [:],
+          "metrics"       : [:]
+        ])
+      ])]
+    ])
+
     // spotless:on
     ignore = traces.each {
       it.each {
@@ -198,7 +278,7 @@ class DDEvpProxyApiTest extends DDCoreSpecification {
     Traces traceCapture = new Traces()
     def packer = new MsgPackWriter(new FlushingBuffer(1 << 20, traceCapture))
     def mapper = discoverMapper(trackType)
-    for(trace in traces) {
+    for (trace in traces) {
       packer.format(trace, mapper)
     }
     packer.flush()
@@ -207,7 +287,7 @@ class DDEvpProxyApiTest extends DDCoreSpecification {
       traces.isEmpty() ? ByteBuffer.allocate(0) : traceCapture.buffer)
   }
 
-  DDSpan buildSpan(long timestamp, String tag, String value) {
+  DDSpan buildSpan(long timestamp, CharSequence spanType, Map<String, Object> tags) {
     def tracer = tracerBuilder().writer(new ListWriter()).build()
 
     def context = new DDSpanContext(
@@ -222,7 +302,7 @@ class DDEvpProxyApiTest extends DDCoreSpecification {
       null,
       [:],
       false,
-      "fakeType",
+      spanType,
       0,
       tracer.pendingTraceFactory.create(DDTraceId.ONE),
       null,
@@ -232,7 +312,9 @@ class DDEvpProxyApiTest extends DDCoreSpecification {
       PropagationTags.factory().empty())
 
     def span = DDSpan.create(timestamp, context)
-    span.setTag(tag, value)
+    for (Map.Entry<String, Object> e : tags.entrySet()) {
+      span.setTag(e.key, e.value)
+    }
 
     tracer.close()
     return span

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDEvpProxyApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDEvpProxyApiTest.groovy
@@ -133,7 +133,7 @@ class DDEvpProxyApiTest extends DDCoreSpecification {
     TrackType.CITESTCYCLE | "v2"       | V2_EVP_PROXY_ENDPOINT | []                                                                                                   | [:]
 
     TrackType.CITESTCYCLE | "v2"       | V2_EVP_PROXY_ENDPOINT | [[buildSpan(1L, "fakeType", ["service.name": "my-service"])]]                                        | new TreeMap<>([
-      "version" : 2,
+      "version" : 1,
       "metadata": new TreeMap<>([
         "*": new TreeMap<>([
           "env"       : "my-env",
@@ -142,7 +142,7 @@ class DDEvpProxyApiTest extends DDCoreSpecification {
         ])]),
       "events"  : [new TreeMap<>([
         "type"   : "span",
-        "version": 2,
+        "version": 1,
         "content": new TreeMap<>([
           "service"  : "my-service",
           "name"     : "fakeOperation",
@@ -159,7 +159,7 @@ class DDEvpProxyApiTest extends DDCoreSpecification {
       ])]
     ])
     TrackType.CITESTCYCLE | "v2"       | V2_EVP_PROXY_ENDPOINT | [[buildSpan(1L, InternalSpanTypes.TEST, ["test_suite_id": 123L, "test_module_id": 456L])]]           | new TreeMap<>([
-      "version" : 2,
+      "version" : 1,
       "metadata": new TreeMap<>([
         "*": new TreeMap<>([
           "env"       : "my-env",
@@ -187,7 +187,7 @@ class DDEvpProxyApiTest extends DDCoreSpecification {
       ])]
     ])
     TrackType.CITESTCYCLE | "v2"       | V2_EVP_PROXY_ENDPOINT | [[buildSpan(1L, InternalSpanTypes.TEST_SUITE_END, ["test_suite_id": 123L, "test_module_id": 456L])]] | new TreeMap<>([
-      "version" : 2,
+      "version" : 1,
       "metadata": new TreeMap<>([
         "*": new TreeMap<>([
           "env"       : "my-env",
@@ -196,7 +196,7 @@ class DDEvpProxyApiTest extends DDCoreSpecification {
         ])]),
       "events"  : [new TreeMap<>([
         "type"   : "test_suite_end",
-        "version": 2,
+        "version": 1,
         "content": new TreeMap<>([
           "test_suite_id" : 123L,
           "test_module_id": 456L,
@@ -212,7 +212,7 @@ class DDEvpProxyApiTest extends DDCoreSpecification {
       ])]
     ])
     TrackType.CITESTCYCLE | "v2"       | V2_EVP_PROXY_ENDPOINT | [[buildSpan(1L, InternalSpanTypes.TEST_MODULE_END, ["test_module_id": 456L])]]                       | new TreeMap<>([
-      "version" : 2,
+      "version" : 1,
       "metadata": new TreeMap<>([
         "*": new TreeMap<>([
           "env"       : "my-env",
@@ -221,7 +221,7 @@ class DDEvpProxyApiTest extends DDCoreSpecification {
         ])]),
       "events"  : [new TreeMap<>([
         "type"   : "test_module_end",
-        "version": 2,
+        "version": 1,
         "content": new TreeMap<>([
           "test_module_id": 456L,
           "service"       : "fakeService",

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDIntakeApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDIntakeApiTest.groovy
@@ -163,7 +163,7 @@ class DDIntakeApiTest extends DDCoreSpecification {
     trackType             | apiVersion | traces                                                                                               | expectedRequestBody
     TrackType.CITESTCYCLE | "v2"       | []                                                                                                   | [:]
     TrackType.CITESTCYCLE | "v2"       | [[buildSpan(1L, "fakeType", ["service.name": "my-service"])]]                                        | new TreeMap<>([
-      "version" : 2,
+      "version" : 1,
       "metadata": new TreeMap<>([
         "*": new TreeMap<>([
           "env"       : "my-env",
@@ -172,7 +172,7 @@ class DDIntakeApiTest extends DDCoreSpecification {
         ])]),
       "events"  : [new TreeMap<>([
         "type"   : "span",
-        "version": 2,
+        "version": 1,
         "content": new TreeMap<>([
           "service"  : "my-service",
           "name"     : "fakeOperation",
@@ -189,7 +189,7 @@ class DDIntakeApiTest extends DDCoreSpecification {
       ])]
     ])
     TrackType.CITESTCYCLE | "v2"       | [[buildSpan(1L, InternalSpanTypes.TEST, ["test_suite_id": 123L, "test_module_id": 456L])]]           | new TreeMap<>([
-      "version" : 2,
+      "version" : 1,
       "metadata": new TreeMap<>([
         "*": new TreeMap<>([
           "env"       : "my-env",
@@ -217,7 +217,7 @@ class DDIntakeApiTest extends DDCoreSpecification {
       ])]
     ])
     TrackType.CITESTCYCLE | "v2"       | [[buildSpan(1L, InternalSpanTypes.TEST_SUITE_END, ["test_suite_id": 123L, "test_module_id": 456L])]] | new TreeMap<>([
-      "version" : 2,
+      "version" : 1,
       "metadata": new TreeMap<>([
         "*": new TreeMap<>([
           "env"       : "my-env",
@@ -226,7 +226,7 @@ class DDIntakeApiTest extends DDCoreSpecification {
         ])]),
       "events"  : [new TreeMap<>([
         "type"   : "test_suite_end",
-        "version": 2,
+        "version": 1,
         "content": new TreeMap<>([
           "test_suite_id" : 123L,
           "test_module_id": 456L,
@@ -242,7 +242,7 @@ class DDIntakeApiTest extends DDCoreSpecification {
       ])]
     ])
     TrackType.CITESTCYCLE | "v2"       | [[buildSpan(1L, InternalSpanTypes.TEST_MODULE_END, ["test_module_id": 456L])]]                       | new TreeMap<>([
-      "version" : 2,
+      "version" : 1,
       "metadata": new TreeMap<>([
         "*": new TreeMap<>([
           "env"       : "my-env",
@@ -251,7 +251,7 @@ class DDIntakeApiTest extends DDCoreSpecification {
         ])]),
       "events"  : [new TreeMap<>([
         "type"   : "test_module_end",
-        "version": 2,
+        "version": 1,
         "content": new TreeMap<>([
           "test_module_id": 456L,
           "service"       : "fakeService",

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/InstrumentationBridge.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/InstrumentationBridge.java
@@ -12,6 +12,7 @@ public abstract class InstrumentationBridge {
   private static volatile Codeowners CODEOWNERS;
   private static volatile MethodLinesResolver METHOD_LINES_RESOLVER;
   private static volatile SourcePathResolver SOURCE_PATH_RESOLVER;
+  private static volatile String MODULE;
 
   public static boolean isCi() {
     return CI;
@@ -51,5 +52,13 @@ public abstract class InstrumentationBridge {
 
   public static void setSourcePathResolver(SourcePathResolver sourcePathResolver) {
     SOURCE_PATH_RESOLVER = sourcePathResolver;
+  }
+
+  public static String getModule() {
+    return MODULE;
+  }
+
+  public static void setModule(String MODULE) {
+    InstrumentationBridge.MODULE = MODULE;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/codeowners/Codeowners.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/codeowners/Codeowners.java
@@ -1,6 +1,7 @@
 package datadog.trace.api.civisibility.codeowners;
 
 import java.util.Collection;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -10,5 +11,5 @@ import javax.annotation.Nullable;
  */
 public interface Codeowners {
   @Nullable
-  Collection<String> getOwners(String path);
+  Collection<String> getOwners(@Nonnull String path);
 }

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/source/MethodLinesResolver.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/source/MethodLinesResolver.java
@@ -1,10 +1,12 @@
 package datadog.trace.api.civisibility.source;
 
 import java.lang.reflect.Method;
+import javax.annotation.Nonnull;
 
 public interface MethodLinesResolver {
 
-  MethodLines getLines(Method method);
+  @Nonnull
+  MethodLines getLines(@Nonnull Method method);
 
   final class MethodLines {
     public static final MethodLines EMPTY = new MethodLines(Integer.MAX_VALUE, Integer.MIN_VALUE);

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/source/SourcePathResolver.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/source/SourcePathResolver.java
@@ -1,5 +1,6 @@
 package datadog.trace.api.civisibility.source;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public interface SourcePathResolver {
@@ -9,5 +10,5 @@ public interface SourcePathResolver {
    *     root. {@code null} is returned if the path could not be resolved
    */
   @Nullable
-  String getSourcePath(Class<?> c);
+  String getSourcePath(@Nonnull Class<?> c);
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InternalSpanTypes.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InternalSpanTypes.java
@@ -35,6 +35,8 @@ public class InternalSpanTypes {
   public static final CharSequence GRAPHQL = UTF8BytesString.create(DDSpanTypes.GRAPHQL);
 
   public static final CharSequence TEST = UTF8BytesString.create(DDSpanTypes.TEST);
+  public static final CharSequence TEST_SUITE_END =
+      UTF8BytesString.create(DDSpanTypes.TEST_SUITE_END);
 
   public static final CharSequence VULNERABILITY =
       UTF8BytesString.create(DDSpanTypes.VULNERABILITY);

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InternalSpanTypes.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InternalSpanTypes.java
@@ -34,10 +34,11 @@ public class InternalSpanTypes {
 
   public static final CharSequence GRAPHQL = UTF8BytesString.create(DDSpanTypes.GRAPHQL);
 
-  public static final CharSequence TEST = UTF8BytesString.create(DDSpanTypes.TEST);
-  public static final CharSequence TEST_SUITE_END =
+  public static final UTF8BytesString TEST = UTF8BytesString.create(DDSpanTypes.TEST);
+  public static final UTF8BytesString TEST_SUITE_END =
       UTF8BytesString.create(DDSpanTypes.TEST_SUITE_END);
-
-  public static final CharSequence VULNERABILITY =
+  public static final UTF8BytesString TEST_MODULE_END =
+      UTF8BytesString.create(DDSpanTypes.TEST_MODULE_END);
+  public static final UTF8BytesString VULNERABILITY =
       UTF8BytesString.create(DDSpanTypes.VULNERABILITY);
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
@@ -10,6 +10,7 @@ public class Tags {
   public static final String SPAN_KIND_BROKER = "broker";
   public static final String SPAN_KIND_TEST = "test";
   public static final String SPAN_KIND_TEST_SUITE = "test_suite_end";
+  public static final String SPAN_KIND_TEST_MODULE = "test_module_end";
 
   public static final String HTTP_URL = "http.url";
   public static final String HTTP_HOSTNAME = "http.hostname";
@@ -39,6 +40,8 @@ public class Tags {
   public static final String DB_STATEMENT = "db.statement";
   public static final String MESSAGE_BUS_DESTINATION = "message_bus.destination";
 
+  public static final String TEST_MODULE = "test.module";
+  public static final String TEST_BUNDLE = "test.bundle";
   public static final String TEST_SUITE = "test.suite";
   public static final String TEST_NAME = "test.name";
   public static final String TEST_STATUS = "test.status";

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
@@ -9,6 +9,7 @@ public class Tags {
   public static final String SPAN_KIND_CONSUMER = "consumer";
   public static final String SPAN_KIND_BROKER = "broker";
   public static final String SPAN_KIND_TEST = "test";
+  public static final String SPAN_KIND_TEST_SUITE = "test_suite_end";
 
   public static final String HTTP_URL = "http.url";
   public static final String HTTP_HOSTNAME = "http.hostname";
@@ -50,6 +51,11 @@ public class Tags {
   public static final String TEST_SOURCE_FILE = "test.source.file";
   public static final String TEST_SOURCE_START = "test.source.start";
   public static final String TEST_SOURCE_END = "test.source.end";
+  public static final String TEST_TRAITS = "test.traits";
+
+  public static final String TEST_SESSION_ID = "test_session_id";
+  public static final String TEST_MODULE_ID = "test_module_id";
+  public static final String TEST_SUITE_ID = "test_suite_id";
 
   public static final String CI_PROVIDER_NAME = "ci.provider.name";
   public static final String CI_PIPELINE_ID = "ci.pipeline.id";

--- a/internal-api/src/main/java/datadog/trace/util/Strings.java
+++ b/internal-api/src/main/java/datadog/trace/util/Strings.java
@@ -226,6 +226,10 @@ public final class Strings {
   }
 
   public static String toJson(final Map<String, String> map) {
+    return toJson(map, false);
+  }
+
+  public static String toJson(final Map<String, String> map, boolean valuesAreJson) {
     if (map == null || map.isEmpty()) {
       return "{}";
     }
@@ -233,11 +237,15 @@ public final class Strings {
     final Iterator<Entry<String, String>> entriesIter = map.entrySet().iterator();
     while (entriesIter.hasNext()) {
       final Entry<String, String> entry = entriesIter.next();
-      sb.append("\"")
-          .append(escapeToJson(entry.getKey()))
-          .append("\":\"")
-          .append(escapeToJson(entry.getValue()))
-          .append("\"");
+
+      sb.append("\"").append(escapeToJson(entry.getKey())).append("\":");
+
+      if (valuesAreJson) {
+        sb.append(entry.getValue());
+      } else {
+        sb.append("\"").append(escapeToJson(entry.getValue())).append("\"");
+      }
+
       if (entriesIter.hasNext()) {
         sb.append(",");
       }


### PR DESCRIPTION
# What Does This Do
This change adds hook into test lifecycle events reported by JUnit5 (test run started/finished, test suite started/finished).
The hooks report additional events (that correspond to starting/finishing a test module or a test suite) to backend.
Existing test case events are linked to suite events, suite events are linked to module events.

# Motivation
This is needed to support [test suite level visibility](https://docs.google.com/document/d/1Xr7SSi_68rjQ4lbTtEoj2uQEOhD6RJhXltzBa_W6nxA/edit#heading=h.22zs5d9o0pw1) for JUnit5 projects.
