### PR TITLE
[data streams] Add null checks in Kafka

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/ConsumerCoordinatorInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/ConsumerCoordinatorInstrumentation.java
@@ -63,11 +63,17 @@ public final class ConsumerCoordinatorInstrumentation extends Instrumenter.Traci
       if (requestFuture.failed()) {
         return;
       }
+      if (offsets == null) {
+        return;
+      }
       String consumerGroup =
           InstrumentationContext.get(ConsumerCoordinator.class, String.class).get(coordinator);
       for (Map.Entry<TopicPartition, OffsetAndMetadata> entry : offsets.entrySet()) {
         if (consumerGroup == null) {
           consumerGroup = "";
+        }
+        if (entry.getKey() == null || entry.getValue() == null) {
+          continue;
         }
         LinkedHashMap<String, String> sortedTags = new LinkedHashMap<>();
         sortedTags.put(CONSUMER_GROUP_TAG, consumerGroup);

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerCallback.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerCallback.java
@@ -29,11 +29,6 @@ public class KafkaProducerCallback implements Callback {
   public void onCompletion(final RecordMetadata metadata, final Exception exception) {
     PRODUCER_DECORATE.onError(span, exception);
     PRODUCER_DECORATE.beforeFinish(span);
-    LinkedHashMap<String, String> sortedTags = new LinkedHashMap<>();
-    sortedTags.put(PARTITION_TAG, String.valueOf(metadata.partition()));
-    sortedTags.put(TOPIC_TAG, metadata.topic());
-    sortedTags.put(TYPE_TAG, "kafka_produce");
-    AgentTracer.get().getDataStreamsMonitoring().trackBacklog(sortedTags, metadata.offset());
     span.finish();
     if (callback != null) {
       if (parent != null) {
@@ -45,5 +40,13 @@ public class KafkaProducerCallback implements Callback {
         callback.onCompletion(metadata, exception);
       }
     }
+    if (metadata == null) {
+      return;
+    }
+    LinkedHashMap<String, String> sortedTags = new LinkedHashMap<>();
+    sortedTags.put(PARTITION_TAG, String.valueOf(metadata.partition()));
+    sortedTags.put(TOPIC_TAG, metadata.topic());
+    sortedTags.put(TYPE_TAG, "kafka_produce");
+    AgentTracer.get().getDataStreamsMonitoring().trackBacklog(sortedTags, metadata.offset());
   }
 }


### PR DESCRIPTION
# What Does This Do

Add null check to fix a crash introduced by https://github.com/DataDog/dd-trace-java/pull/4616/files#diff-6228932522cfbf261e1cacb00103a4eaf3d68aafbc6f42494d57b9aa0eeb79c8R33

When metadata is null.
I also added null checks every else where not having them could crash the application.

# Motivation

# Additional Notes
