### PR TITLE
Add 128-bit trace id generation support

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -141,6 +141,8 @@ public final class ConfigDefaults {
   static final int DEFAULT_TELEMETRY_HEARTBEAT_INTERVAL = 60; // in seconds
   static final boolean DEFAULT_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED = true;
 
+  static final boolean DEFAULT_TRACE_128_BIT_TRACEID_GENERATION_ENABLED = false;
+  static final boolean DEFAULT_TRACE_128_BIT_TRACEID_LOGGING_ENABLED = false;
   static final boolean DEFAULT_SECURE_RANDOM = false;
 
   public static final int DEFAULT_TRACE_X_DATADOG_TAGS_MAX_LENGTH = 512;

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTraceId.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTraceId.java
@@ -3,43 +3,69 @@ package datadog.trace.api;
 import datadog.trace.api.internal.util.HexStringUtils;
 
 /**
- * Class encapsulating the unsigned 64 bit id used for Traceids.
+ * Class encapsulating the unsigned 128-bit id used for Traceids.
  *
  * <p>It contains generation of new ids, parsing, and to string for both decimal and hex
  * representations. The decimal string representation is either kept from parsing, or generated on
  * demand and cached.
+ *
+ * <p>{@link DDTraceId} can represent either a 128-bits TraceId or a 64-bit TraceId. For 128-bit
+ * TraceId, {@link #highOrderBits} contains a 32-bit timestamp store on the 32 higher bits and
+ * {@link #lowOrderBits} contains a unique and random 64-bit id. For 64-bit TraceId, {@link
+ * #highOrderBits} is set to <code>0</code> and {@link #lowOrderBits} contains a unique and random
+ * 63-bit id.
  */
 public class DDTraceId {
-
-  public static final DDTraceId ZERO = new DDTraceId(0, "0", null);
+  public static final DDTraceId ZERO = new DDTraceId(0, 0, "0", null);
   public static final DDTraceId MAX =
-      new DDTraceId(-1, "18446744073709551615", null); // All bits set
+      new DDTraceId(0, -1, "18446744073709551615", null); // All bits set
 
   // Convenience constant used from tests
   public static final DDTraceId ONE = DDTraceId.from(1);
 
   /**
    * Create a new {@code DDTraceId} from the given {@code long} interpreted as the bits of the
-   * unsigned 64 bit id. This means that values larger than Long.MAX_VALUE will be represented as
+   * unsigned 64-bit id. This means that values larger than Long.MAX_VALUE will be represented as
    * negative numbers.
    *
-   * @param id long representing the bits of the unsigned 64 bit id
+   * @param id long representing the bits of the unsigned 64-bit id
    * @return DDTraceId
    */
   public static DDTraceId from(long id) {
-    return DDTraceId.create(id, null);
+    return DDTraceId.create(0, id, null);
   }
 
   /**
-   * Create a new {@code DDTraceId} from the given {@code String} representation of the unsigned 64
-   * bit id.
+   * Create a new 128-bit {@link DDTraceId} from the given {@code long}s interpreted as high order
+   * and low order bits of the 128-bit id.
    *
-   * @param s String of unsigned 64 bit id
+   * @param highOrderBits long representing the high-order bits of the {@link DDTraceId}.
+   * @param lowOrderBits long representing the random id low-order bits.
    * @return DDTraceId
-   * @throws NumberFormatException
    */
-  public static DDTraceId from(String s) throws NumberFormatException {
-    return DDTraceId.create(DDId.parseUnsignedLong(s), s);
+  public static DDTraceId from(long highOrderBits, long lowOrderBits) {
+    return DDTraceId.create(highOrderBits, lowOrderBits, null);
+  }
+
+  /**
+   * Create a {@link DDTraceId} from a TraceId {@link String} representation. Both 64-bit unsigned
+   * id and 32 hexadecimal lowercase characters are allowed.
+   *
+   * @param s The TraceId {@link String} representation to parse.
+   * @return The parsed TraceId.
+   * @throws IllegalArgumentException if the string to parse is not valid.
+   */
+  public static DDTraceId from(String s) throws IllegalArgumentException {
+    if (s == null) {
+      throw new IllegalArgumentException("s can't be null");
+    }
+    if (s.length() == 32) {
+      return DDTraceId.create(
+          HexStringUtils.parseUnsignedLongHex(s, 0, 16, false),
+          HexStringUtils.parseUnsignedLongHex(s, 16, 16, false),
+          s);
+    }
+    return DDTraceId.create(0, DDId.parseUnsignedLong(s), s);
   }
 
   /**
@@ -50,8 +76,9 @@ public class DDTraceId {
    * @return DDTraceId
    * @throws NumberFormatException
    */
-  public static DDTraceId fromHex(String s) throws NumberFormatException {
-    return DDTraceId.create(DDId.parseUnsignedLongHex(s), null);
+  public static DDTraceId fromHex(String s)
+      throws NumberFormatException { // TODO Add 128-bits support
+    return DDTraceId.create(0, DDId.parseUnsignedLongHex(s), null);
   }
 
   /**
@@ -63,11 +90,11 @@ public class DDTraceId {
    * @return DDTraceId
    * @throws NumberFormatException
    */
-  public static DDTraceId fromHexTruncatedWithOriginal(String s) throws NumberFormatException {
+  public static DDTraceId fromHexTruncatedWithOriginal(String s)
+      throws NumberFormatException { // TODO Add 128-bits support
     if (s == null) {
       throw new NumberFormatException("null");
     }
-
     return fromHexTruncatedWithOriginal(s, 0, s.length(), false);
   }
 
@@ -106,23 +133,29 @@ public class DDTraceId {
       original = s.substring(start, end);
     }
     return new DDTraceId(
+        0,
         HexStringUtils.parseUnsignedLongHex(s, trimmedStart, trimmed, lowerCaseOnly),
         null,
         original);
   }
 
-  private static DDTraceId create(long id, String str) {
+  private static DDTraceId create(long highOrderBits, long id, String str) {
     if (id == 0) return ZERO;
     if (id == -1) return MAX;
-    return new DDTraceId(id, str, null);
+    return new DDTraceId(highOrderBits, id, str, null);
   }
 
-  private final long id;
+  /** Represents the high-order 64 bits of the 128-bit {@link DDTraceId}. */
+  private final long highOrderBits;
+  /** Represents the low-order 64 bits of the 128-bit {@link DDTraceId}. */
+  private final long lowOrderBits;
+
   private String str; // cache for string representation
   private String hex; //
 
-  private DDTraceId(long id, String str, String original) {
-    this.id = id;
+  private DDTraceId(long highOrderBits, long lowOrderBits, String str, String original) {
+    this.highOrderBits = highOrderBits;
+    this.lowOrderBits = lowOrderBits;
     this.str = str;
     this.hex = original;
   }
@@ -132,20 +165,21 @@ public class DDTraceId {
     if (this == o) return true;
     if (!(o instanceof DDTraceId)) return false;
     DDTraceId ddId = (DDTraceId) o;
-    return this.id == ddId.id;
+    return this.highOrderBits == ddId.highOrderBits && this.lowOrderBits == ddId.lowOrderBits;
   }
 
   @Override
   public int hashCode() {
-    long id = this.id;
+    long id = this.lowOrderBits;
     return (int) (id ^ (id >>> 32));
   }
 
   /**
-   * Returns the decimal string representation of the unsigned 64 bit id. The {@code String} will be
-   * cached.
+   * Returns the {@link String} representation of the TraceId. The string representation depends on
+   * the TraceId type. For 64-bit TraceId, it is an unsigned 64-bit id. For 128-bit TraceId, it is a
+   * 32 lowercase hexadecimal characters. The {@link String} representation will be cached.
    *
-   * @return decimal string
+   * @return The {@link String} representation of the TraceId.
    */
   @Override
   public String toString() {
@@ -153,7 +187,14 @@ public class DDTraceId {
     // This race condition is intentional and benign.
     // The worst that can happen is that an identical value is produced and written into the field.
     if (s == null) {
-      this.str = s = Long.toUnsignedString(this.id);
+      if (this.highOrderBits == 0L) {
+        this.str = s = Long.toUnsignedString(this.lowOrderBits);
+      } else {
+        this.str =
+            s =
+                DDId.toHexStringPadded(this.highOrderBits, 16)
+                    + DDId.toHexStringPadded(this.lowOrderBits, 16);
+      }
     }
     return s;
   }
@@ -166,7 +207,7 @@ public class DDTraceId {
    */
   public String toHexString() {
     // TODO use the cached String and trim it if necessary
-    return Long.toHexString(this.id);
+    return Long.toHexString(this.lowOrderBits);
   }
 
   /**
@@ -178,7 +219,7 @@ public class DDTraceId {
    */
   public String toHexStringPadded(int size) {
     // TODO use the cached String and pad it if necessary
-    return DDId.toHexStringPadded(this.id, size);
+    return DDId.toHexStringPadded(this.lowOrderBits, size);
   }
 
   /**
@@ -203,6 +244,6 @@ public class DDTraceId {
    * @return long value representing the bits of the unsigned 64 bit id.
    */
   public long toLong() {
-    return this.id;
+    return this.lowOrderBits;
   }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/IdGenerationStrategy.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/IdGenerationStrategy.java
@@ -1,5 +1,7 @@
 package datadog.trace.api;
 
+import static datadog.trace.api.IdGenerationStrategy.Trace128bitStrategy.UNSUPPORTED;
+
 import java.security.SecureRandom;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
@@ -11,16 +13,25 @@ import java.util.concurrent.atomic.AtomicLong;
  * configuration based, for example 128 bit trace ids et.c., without changing the public API.
  */
 public abstract class IdGenerationStrategy {
-  private IdGenerationStrategy() {}
+  protected final Trace128bitStrategy trace128bitStrategy;
+
+  private IdGenerationStrategy(Trace128bitStrategy trace128bitStrategy) {
+    this.trace128bitStrategy = trace128bitStrategy;
+  }
 
   public static IdGenerationStrategy fromName(String name) {
+    return fromName(name, UNSUPPORTED);
+  }
+
+  public static IdGenerationStrategy fromName(
+      String name, Trace128bitStrategy trace128bitStrategy) {
     switch (name.toUpperCase()) {
       case "RANDOM":
-        return new Random();
+        return new Random(trace128bitStrategy);
       case "SEQUENTIAL":
-        return new Sequential();
+        return new Sequential(trace128bitStrategy);
       case "SECURE_RANDOM":
-        return new SRandom();
+        return new SRandom(trace128bitStrategy);
       default:
         return null;
     }
@@ -30,10 +41,34 @@ public abstract class IdGenerationStrategy {
 
   public abstract long generateSpanId();
 
+  protected long generateHighOrderBits() {
+    long timestamp = System.currentTimeMillis() / 1000;
+    return timestamp << 32;
+  }
+
+  public enum Trace128bitStrategy {
+    GENERATION,
+    GENERATION_AND_LOG_INJECTION,
+    UNSUPPORTED;
+
+    public static Trace128bitStrategy get(boolean withGeneration, boolean withLogInjection) {
+      if (!withGeneration) {
+        return UNSUPPORTED;
+      }
+      return withLogInjection ? GENERATION_AND_LOG_INJECTION : GENERATION;
+    }
+  }
+
   static final class Random extends IdGenerationStrategy {
+    private Random(Trace128bitStrategy trace128bitStrategy) {
+      super(trace128bitStrategy);
+    }
+
     @Override
     public DDTraceId generateTraceId() {
-      return DDTraceId.from(ThreadLocalRandom.current().nextLong(1, Long.MAX_VALUE));
+      return this.trace128bitStrategy != UNSUPPORTED
+          ? DDTraceId.from(generateHighOrderBits(), ThreadLocalRandom.current().nextLong())
+          : DDTraceId.from(ThreadLocalRandom.current().nextLong(1, Long.MAX_VALUE));
     }
 
     @Override
@@ -43,7 +78,12 @@ public abstract class IdGenerationStrategy {
   }
 
   static final class Sequential extends IdGenerationStrategy {
-    private final AtomicLong id = new AtomicLong(0);
+    private final AtomicLong id;
+
+    private Sequential(Trace128bitStrategy trace128bitStrategy) {
+      super(trace128bitStrategy);
+      this.id = new AtomicLong(0);
+    }
 
     @Override
     public DDTraceId generateTraceId() {
@@ -64,11 +104,12 @@ public abstract class IdGenerationStrategy {
   static final class SRandom extends IdGenerationStrategy {
     private final SecureRandom secureRandom;
 
-    SRandom() {
-      this(SecureRandom::getInstanceStrong);
+    SRandom(Trace128bitStrategy trace128bitStrategy) {
+      this(trace128bitStrategy, SecureRandom::getInstanceStrong);
     }
 
-    SRandom(ThrowingSupplier<SecureRandom> supplier) {
+    SRandom(Trace128bitStrategy trace128bitStrategy, ThrowingSupplier<SecureRandom> supplier) {
+      super(trace128bitStrategy);
       try {
         secureRandom = supplier.get();
       } catch (Throwable e) {
@@ -86,7 +127,9 @@ public abstract class IdGenerationStrategy {
 
     @Override
     public DDTraceId generateTraceId() {
-      return DDTraceId.from(getNonZeroPositiveLong());
+      return this.trace128bitStrategy != UNSUPPORTED
+          ? DDTraceId.from(generateHighOrderBits(), secureRandom.nextLong())
+          : DDTraceId.from(getNonZeroPositiveLong());
     }
 
     @Override

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -79,6 +79,10 @@ public final class TracerConfig {
 
   public static final String CLIENT_IP_ENABLED = "trace.client-ip.enabled";
 
+  public static final String TRACE_128_BIT_TRACEID_GENERATION_ENABLED =
+      "trace.128.bit.traceid.generation.enabled";
+  public static final String TRACE_128_BIT_TRACEID_LOGGING_ENABLED =
+      "trace.128.bit.traceid.logging.enabled";
   public static final String SECURE_RANDOM = "trace.secure-random";
 
   /**

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/DDSpanIdTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/DDSpanIdTest.groovy
@@ -2,6 +2,8 @@ package datadog.trace.api
 
 import datadog.trace.test.util.DDSpecification
 
+import static datadog.trace.api.IdGenerationStrategy.Trace128bitStrategy.UNSUPPORTED
+
 class DDSpanIdTest extends DDSpecification {
 
   def "convert ids from/to String #stringId"() {
@@ -117,7 +119,7 @@ class DDSpanIdTest extends DDSpecification {
 
   def "generate id with #strategyName"() {
     when:
-    def strategy = IdGenerationStrategy.fromName(strategyName)
+    def strategy = IdGenerationStrategy.fromName(strategyName, UNSUPPORTED)
     def spanIds = (0..32768).collect { strategy.generateSpanId() }
     Set<Long> checked = new HashSet<>()
 


### PR DESCRIPTION
# What Does This Do

Introduce changes to support 128-bit trace ids.

# Motivation

Provide better interoperability with external tracing systems.

# Additional Notes

I wonder if it won't be cleaner to abstract `DDTraceId` and have dedicated types, one for 64-bit id and another for 128-bit id.  
If such types existed, I should be easier to make accessible only 64-bit formatting methods only to the 64-bit type and disambiguate existing ones, like `fromString()` / `fromHex()` and `toString()` / `toHex()`, which should not be different for the 128-bit type as its String representation is a 32 hex chars String.
But such change would be more invasive.

About `Trace128Strategy` enum, I might remove it for a 128-bit generation flag boolean only.
It seems like the code in charge of injecting trace id into logs already heavily rely on `Config` to get other values to inject (like serviceName, env, version) so it should be able to query `Config` 128-bit logging by itself.