### PR TITLE
Break out some hex string utilities used for W3C headers

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/DDSpanId.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDSpanId.java
@@ -1,5 +1,7 @@
 package datadog.trace.api;
 
+import datadog.trace.api.internal.util.HexStringUtils;
+
 /** Class with methods for working with the unsigned 64 bit id used for Span ids. */
 public final class DDSpanId {
 
@@ -32,6 +34,21 @@ public final class DDSpanId {
    */
   public static long fromHex(String s) throws NumberFormatException {
     return DDId.parseUnsignedLongHex(s);
+  }
+
+  /**
+   * Parse the span id from the given {@code String} hex representation of the unsigned 64 bit id.
+   *
+   * @param s String in hex of unsigned 64 bit id
+   * @param start the start index of the hex value
+   * @param len the len of the hex value
+   * @param lowerCaseOnly if the allowed hex characters are lower case only
+   * @return long
+   * @throws NumberFormatException
+   */
+  public static long fromHex(String s, int start, int len, boolean lowerCaseOnly)
+      throws NumberFormatException {
+    return HexStringUtils.parseUnsignedLongHex(s, start, len, lowerCaseOnly);
   }
 
   /**

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTraceId.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTraceId.java
@@ -1,5 +1,7 @@
 package datadog.trace.api;
 
+import datadog.trace.api.internal.util.HexStringUtils;
+
 /**
  * Class encapsulating the unsigned 64 bit id used for Traceids.
  *
@@ -66,9 +68,47 @@ public class DDTraceId {
       throw new NumberFormatException("null");
     }
 
-    int len = s.length();
-    int trimmed = Math.min(s.length(), 16);
-    return new DDTraceId(DDId.parseUnsignedLongHex(s, len - trimmed, trimmed), null, s);
+    return fromHexTruncatedWithOriginal(s, 0, s.length(), false);
+  }
+
+  /**
+   * Create a new {@code DDTraceId} from the given {@code String} hex representation of the unsigned
+   * 64 bit (or more) id truncated to 64 bits, while retaining the original {@code String}
+   * representation for use in headers.
+   *
+   * @param s String in hex of unsigned 64 bit (or more) id
+   * @param start the start index of the hex value
+   * @param len the len of the hex value
+   * @param lowerCaseOnly if the allowed hex characters are lower case only
+   * @return DDTraceId
+   * @throws NumberFormatException
+   */
+  public static DDTraceId fromHexTruncatedWithOriginal(
+      String s, int start, int len, boolean lowerCaseOnly) throws NumberFormatException {
+    if (s == null) {
+      throw new NumberFormatException("null");
+    }
+    int size = s.length();
+    if (start < 0 || len <= 0 || len > 32 || start + len > size) {
+      throw new NumberFormatException("Illegal start or length");
+    }
+    int trimmed = Math.min(len, 16);
+    int end = start + len;
+    int trimmedStart = end - trimmed;
+    if (trimmedStart > 0) {
+      // we need to check that the characters we don't parse are valid
+      HexStringUtils.parseUnsignedLongHex(s, start, trimmedStart, lowerCaseOnly);
+    }
+    String original;
+    if (start == 0 && end == len) {
+      original = s;
+    } else {
+      original = s.substring(start, end);
+    }
+    return new DDTraceId(
+        HexStringUtils.parseUnsignedLongHex(s, trimmedStart, trimmed, lowerCaseOnly),
+        null,
+        original);
   }
 
   private static DDTraceId create(long id, String str) {

--- a/dd-trace-api/src/main/java/datadog/trace/api/internal/util/HexStringUtils.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/internal/util/HexStringUtils.java
@@ -1,0 +1,66 @@
+package datadog.trace.api.internal.util;
+
+public class HexStringUtils {
+
+  private HexStringUtils() {}
+
+  /**
+   * Parse the hex representation of the unsigned 64 bit long from the {@code String}.
+   *
+   * @param s String in hex of unsigned 64 bits
+   * @param start the start index of the hex value
+   * @param len the len of the hex value
+   * @param lowerCaseOnly if the allowed hex characters are lower case only
+   * @return long
+   * @throws NumberFormatException
+   */
+  public static long parseUnsignedLongHex(String s, int start, int len, boolean lowerCaseOnly)
+      throws NumberFormatException {
+    if (s == null) {
+      throw new NumberFormatException("null");
+    }
+
+    if (len > 0 && start >= 0 && start + len <= s.length()) {
+      if (len > 16 && (len - firstNonZeroCharacter(s, start)) > 16) {
+        // Unsigned 64 bits max is 16 digits, so this always overflows
+        throw numberFormatOutOfLongRange(s);
+      }
+      long result = 0;
+      int ok = 0;
+      for (int i = 0; i < len && ok >= 0; i++, start++) {
+        char c = s.charAt(start);
+        int d = Character.digit(c, 16);
+        if (lowerCaseOnly && Character.isUpperCase(c)) {
+          ok = -1;
+        }
+        ok |= d;
+        result = result << 4 | d;
+      }
+      if (ok < 0) {
+        throw new NumberFormatException("Illegal character in " + s.substring(start, len));
+      }
+      return result;
+    } else {
+      throw new NumberFormatException("Empty input string");
+    }
+  }
+
+  private static int firstNonZeroCharacter(String s, int start) {
+    int firstNonZero = start;
+    for (; firstNonZero < s.length(); firstNonZero++) {
+      if (s.charAt(firstNonZero) != '0') break;
+    }
+    return firstNonZero;
+  }
+
+  /**
+   * Creates a {@code NumberFormatException} with a consistent error message.
+   *
+   * @param s the {@code String} that exceeds the range of a {@code Long}
+   * @return NumberFormatException
+   */
+  public static NumberFormatException numberFormatOutOfLongRange(String s) {
+    return new NumberFormatException(
+        String.format("String value %s exceeds range of unsigned long.", s));
+  }
+}

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/DDSpanIdTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/DDSpanIdTest.groovy
@@ -68,6 +68,35 @@ class DDSpanIdTest extends DDSpecification {
     "123456789abcdef"        | 81985529216486895
   }
 
+  def "convert ids from part of hex String"() {
+    when:
+    Long ddid = null
+    try {
+      ddid = DDSpanId.fromHex(hexId, start, length, lcOnly)
+    } catch (NumberFormatException ignored) {
+    }
+
+    then:
+    if (expectedId) {
+      assert ddid == expectedId
+    } else {
+      assert !ddid
+    }
+
+    where:
+    hexId            | start| length | lcOnly | expectedId
+    null             |  1   |  1     | false  | null
+    ""               |  1   |  1     | false  | null
+    "00"             | -1   |  1     | false  | null
+    "00"             |  0   |  0     | false  | null
+    "00"             |  0   |  1     | false  | DDSpanId.ZERO
+    "00"             |  1   |  1     | false  | DDSpanId.ZERO
+    "00"             |  1   |  1     | false  | DDSpanId.ZERO
+    "f" * 16         |  0   | 16     | true   | DDSpanId.MAX
+    "f" * 12 + "Ffff"|  0   | 16     | true   | null
+    "f" * 12 + "Ffff"|  0   | 16     | false  | DDSpanId.MAX
+  }
+
   def "fail on illegal hex String"() {
     when:
     DDTraceId.fromHex(hexId)

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/DDTraceIdTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/DDTraceIdTest.groovy
@@ -146,14 +146,23 @@ class DDTraceIdTest extends DDSpecification {
 
   def "convert ids from/to hex String and truncate to 64 bits while keeping the original"() {
     when:
-    final ddid = DDTraceId.fromHexTruncatedWithOriginal(hexId)
+    DDTraceId ddid = null
+    try {
+      ddid = DDTraceId.fromHexTruncatedWithOriginal(hexId)
+    } catch (NumberFormatException ignored) {
+    }
 
     then:
-    ddid == expectedId
-    ddid.toHexStringOrOriginal() == hexId
+    if (expectedId) {
+      assert ddid == expectedId
+      assert ddid.toHexStringOrOriginal() == hexId
+    } else {
+      assert !ddid
+    }
 
     where:
     hexId                          | expectedId
+    null                           | null
     "000"                          | DDTraceId.ZERO
     "0001"                         | DDTraceId.ONE
     "f" * 16                       | DDTraceId.MAX
@@ -162,6 +171,36 @@ class DDTraceIdTest extends DDSpecification {
     "0" * 4 + "8" + "0" * 15       | DDTraceId.from(Long.MIN_VALUE)
     "1" * 8 + "0" * 8 + "cafebabe" | DDTraceId.from(3405691582)
     "1" * 12 + "0123456789abcdef"  | DDTraceId.from(81985529216486895)
+  }
+
+  def "convert ids from/to part of hex String and truncate to 64 bits while keeping the original part"() {
+    when:
+    DDTraceId ddid = null
+    try {
+      ddid = DDTraceId.fromHexTruncatedWithOriginal(hexId, start, length, lcOnly)
+    } catch (NumberFormatException ignored) {
+    }
+
+    then:
+    if (expectedId) {
+      assert ddid == expectedId
+      assert ddid.toHexStringOrOriginal() == expectedHex
+    } else {
+      assert !ddid
+    }
+
+    where:
+    hexId                          | start| length | lcOnly | expectedHex | expectedId
+    null                           |  1   |  1     | false  | null        | null
+    ""                             |  1   |  1     | false  | null        | null
+    "00"                           | -1   |  1     | false  | null        | null
+    "00"                           |  0   |  0     | false  | null        | null
+    "00"                           |  1   |  1     | false  | "0"         | DDTraceId.ZERO
+    "0001"                         |  2   |  2     | false  | "01"        | DDTraceId.ONE
+    "f" * 16                       |  0   |  16    | true   | "f" * 16    | DDTraceId.MAX
+    "f" * 12 + "Ffff"              |  0   |  16    | true   | null        | null
+    "fFff" + ("f" * 16)            |  0   |  20    | true   | null        | null
+    "Cafe" + ("f" * 16) + "F00d"   |  4   |  16    | false  | "f" * 16    | DDTraceId.MAX
   }
 
   def "exception created on SecureRandom strategy"() {


### PR DESCRIPTION
# What Does This Do

Breaks out some hex string utilities used for both DDId and W3C headers.

# Motivation

Reuse all the things!

# Additional Notes
