### PR TITLE
Naming schema: mongodb changes

### DIFF
--- a/dd-java-agent/instrumentation/mongo/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/build.gradle
@@ -1,5 +1,6 @@
 apply from: "$rootDir/gradle/java.gradle"
 
 dependencies {
-  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '1.50.5'
+  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '4.5.1'
+  testImplementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
 }

--- a/dd-java-agent/instrumentation/mongo/common/src/main/java/datadog/trace/instrumentation/mongo/MongoCommandListener.java
+++ b/dd-java-agent/instrumentation/mongo/common/src/main/java/datadog/trace/instrumentation/mongo/MongoCommandListener.java
@@ -122,7 +122,7 @@ public final class MongoCommandListener implements CommandListener {
     if (listenerAccessor != null) {
       listenerAccessor.putIfAbsent(event.getConnectionDescription(), this);
     }
-    final AgentSpan span = startSpan(MongoDecorator.MONGO_QUERY);
+    final AgentSpan span = startSpan(MongoDecorator.OPERATION_NAME);
     try (final AgentScope scope = activateSpan(span)) {
       decorator.afterStart(span);
       decorator.onConnection(span, event);

--- a/dd-java-agent/instrumentation/mongo/driver-3.1-core-test/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1-core-test/build.gradle
@@ -9,7 +9,8 @@ testSets {
 }
 dependencies {
   testImplementation project(':dd-java-agent:instrumentation:mongo').sourceSets.test.output
-  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '1.50.5'
+  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '4.5.1'
+  testImplementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
 
   // We need to pull in this dependency to get the 'suspend span' instrumentation for spock tests
   // as well as to test the instrumentaiton 'layering' (3.4 instrumentation should take precedence

--- a/dd-java-agent/instrumentation/mongo/driver-3.1-core-test/src/test/groovy/MongoCore31ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1-core-test/src/test/groovy/MongoCore31ClientTest.groovy
@@ -8,9 +8,6 @@ import com.mongodb.event.CommandFailedEvent
 import com.mongodb.event.CommandListener
 import com.mongodb.event.CommandStartedEvent
 import com.mongodb.event.CommandSucceededEvent
-import datadog.trace.agent.test.asserts.TraceAssert
-import datadog.trace.api.DDSpanTypes
-import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
 import org.bson.BsonDocument
 import org.bson.BsonString
@@ -22,7 +19,7 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
-class MongoCore31ClientTest extends MongoBaseTest {
+abstract class MongoCore31ClientTest extends MongoBaseTest {
 
   @Shared
   MongoClient client
@@ -246,29 +243,40 @@ class MongoCore31ClientTest extends MongoBaseTest {
     where:
     collectionName = randomCollectionName()
   }
+}
 
-  def mongoSpan(TraceAssert trace, int index, String operation, String statement, boolean renameService = false, String instance = "some-description", Object parentSpan = null, Throwable exception = null) {
-    trace.span {
-      serviceName renameService ? instance : "mongo"
-      operationName "mongo.query"
-      resourceName matchesStatement(statement)
-      spanType DDSpanTypes.MONGO
-      if (parentSpan == null) {
-        parent()
-      } else {
-        childOf((DDSpan) parentSpan)
-      }
-      topLevel true
-      tags {
-        "$Tags.COMPONENT" "java-mongo"
-        "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-        "$Tags.PEER_HOSTNAME" "localhost"
-        "$Tags.PEER_PORT" port
-        "$Tags.DB_TYPE" "mongo"
-        "$Tags.DB_INSTANCE" instance
-        "$Tags.DB_OPERATION" operation
-        defaultTags()
-      }
-    }
+class MongoCore31ClientV0ForkedTest extends MongoCore31ClientTest {
+
+  @Override
+  protected int version() {
+    return 0
+  }
+
+  @Override
+  protected String service() {
+    return V0_SERVICE
+  }
+
+  @Override
+  protected String operation() {
+    return V0_OPERATION
+  }
+}
+
+class MongoCore31ClientV1ForkedTest extends MongoCore31ClientTest {
+
+  @Override
+  protected int version() {
+    return 1
+  }
+
+  @Override
+  protected String service() {
+    return V1_SERVICE
+  }
+
+  @Override
+  protected String operation() {
+    return V1_OPERATION
   }
 }

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/build.gradle
@@ -36,7 +36,9 @@ dependencies {
   }
 
   testImplementation project(':dd-java-agent:instrumentation:mongo').sourceSets.test.output
-  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '1.50.5'
+  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '4.5.1'
+  testImplementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
+
 
   testImplementation project(':dd-java-agent:instrumentation:mongo:bson-document')
 

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoJava31ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoJava31ClientTest.groovy
@@ -8,9 +8,6 @@ import com.mongodb.event.CommandFailedEvent
 import com.mongodb.event.CommandListener
 import com.mongodb.event.CommandStartedEvent
 import com.mongodb.event.CommandSucceededEvent
-import datadog.trace.agent.test.asserts.TraceAssert
-import datadog.trace.api.DDSpanTypes
-import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
 import org.bson.BsonDocument
 import org.bson.BsonString
@@ -22,7 +19,7 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
-class MongoJava31ClientTest extends MongoBaseTest {
+abstract class MongoJava31ClientTest extends MongoBaseTest {
 
   @Shared
   MongoClient client
@@ -35,9 +32,11 @@ class MongoJava31ClientTest extends MongoBaseTest {
         @Override
         void commandStarted(CommandStartedEvent event) {
         }
+
         @Override
         void commandSucceeded(CommandSucceededEvent event) {
         }
+
         @Override
         void commandFailed(CommandFailedEvent event) {
         }
@@ -80,7 +79,7 @@ class MongoJava31ClientTest extends MongoBaseTest {
     then:
     assertTraces(1) {
       trace(1) {
-        mongoSpan(it, 0, "create","{\"create\":\"$collectionName\",\"capped\":\"?\"}", false, databaseName)
+        mongoSpan(it, 0, "create", "{\"create\":\"$collectionName\",\"capped\":\"?\"}", false, databaseName)
       }
     }
 
@@ -246,29 +245,40 @@ class MongoJava31ClientTest extends MongoBaseTest {
     where:
     collectionName = randomCollectionName()
   }
+}
 
-  def mongoSpan(TraceAssert trace, int index, String operation, String statement, boolean renameService = false, String instance = "some-description", Object parentSpan = null, Throwable exception = null) {
-    trace.span {
-      serviceName renameService ? instance : "mongo"
-      operationName "mongo.query"
-      resourceName matchesStatement(statement)
-      spanType DDSpanTypes.MONGO
-      if (parentSpan == null) {
-        parent()
-      } else {
-        childOf((DDSpan) parentSpan)
-      }
-      topLevel true
-      tags {
-        "$Tags.COMPONENT" "java-mongo"
-        "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-        "$Tags.PEER_HOSTNAME" "localhost"
-        "$Tags.PEER_PORT" port
-        "$Tags.DB_TYPE" "mongo"
-        "$Tags.DB_INSTANCE" instance
-        "$Tags.DB_OPERATION" operation
-        defaultTags()
-      }
-    }
+class MongoJava31ClientV0ForkedTest extends MongoJava31ClientTest {
+
+  @Override
+  protected int version() {
+    return 0
+  }
+
+  @Override
+  protected String service() {
+    return V0_SERVICE
+  }
+
+  @Override
+  protected String operation() {
+    return V0_OPERATION
+  }
+}
+
+class MongoJava31ClientV1ForkedTest extends MongoJava31ClientTest {
+
+  @Override
+  protected int version() {
+    return 1
+  }
+
+  @Override
+  protected String service() {
+    return V1_SERVICE
+  }
+
+  @Override
+  protected String operation() {
+    return V1_OPERATION
   }
 }

--- a/dd-java-agent/instrumentation/mongo/driver-3.10-sync-test/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-3.10-sync-test/build.gradle
@@ -21,7 +21,8 @@ dependencies {
   }
 
   testImplementation project(':dd-java-agent:instrumentation:mongo').sourceSets.test.output
-  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '1.50.5'
+  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '4.5.1'
+  testImplementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
 
   testImplementation group: 'org.mongodb', name: 'mongodb-driver-sync', version: '3.10.0'
   latestDepTestImplementation group: 'org.mongodb', name: 'mongodb-driver-sync', version: '3.+'

--- a/dd-java-agent/instrumentation/mongo/driver-3.10-sync-test/src/test/groovy/MongoSyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.10-sync-test/src/test/groovy/MongoSyncClientTest.groovy
@@ -3,9 +3,6 @@ import com.mongodb.client.MongoClient
 import com.mongodb.client.MongoClients
 import com.mongodb.client.MongoCollection
 import com.mongodb.client.MongoDatabase
-import datadog.trace.agent.test.asserts.TraceAssert
-import datadog.trace.api.DDSpanTypes
-import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
 import org.bson.BsonDocument
 import org.bson.BsonString
@@ -17,13 +14,13 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
-class MongoSyncClientTest extends MongoBaseTest {
+abstract class MongoSyncClientTest extends MongoBaseTest {
 
   @Shared
   MongoClient client
 
   def setup() throws Exception {
-    client = MongoClients.create("mongodb://localhost:$port/?appname=some-instance")
+    client = MongoClients.create("mongodb://localhost:$port/?appname=some-description")
   }
 
   def cleanup() throws Exception {
@@ -233,29 +230,40 @@ class MongoSyncClientTest extends MongoBaseTest {
     where:
     collectionName = randomCollectionName()
   }
+}
 
-  def mongoSpan(TraceAssert trace, int index, String operation, String statement, boolean renameService = false, String instance = "some-instance", Object parentSpan = null, Throwable exception = null) {
-    trace.span {
-      serviceName renameService ? instance : "mongo"
-      operationName "mongo.query"
-      resourceName matchesStatement(statement)
-      spanType DDSpanTypes.MONGO
-      if (parentSpan == null) {
-        parent()
-      } else {
-        childOf((DDSpan) parentSpan)
-      }
-      topLevel true
-      tags {
-        "$Tags.COMPONENT" "java-mongo"
-        "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-        "$Tags.PEER_HOSTNAME" "localhost"
-        "$Tags.PEER_PORT" port
-        "$Tags.DB_TYPE" "mongo"
-        "$Tags.DB_INSTANCE" instance
-        "$Tags.DB_OPERATION" operation
-        defaultTags()
-      }
-    }
+class MongoSyncClientV0ForkedTest extends MongoSyncClientTest {
+
+  @Override
+  protected int version() {
+    return 0
+  }
+
+  @Override
+  protected String service() {
+    return V0_SERVICE
+  }
+
+  @Override
+  protected String operation() {
+    return V0_OPERATION
+  }
+}
+
+class MongoSyncClientV1ForkedTest extends MongoSyncClientTest {
+
+  @Override
+  protected int version() {
+    return 1
+  }
+
+  @Override
+  protected String service() {
+    return V1_SERVICE
+  }
+
+  @Override
+  protected String operation() {
+    return V1_OPERATION
   }
 }

--- a/dd-java-agent/instrumentation/mongo/driver-3.3-async-test/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-3.3-async-test/build.gradle
@@ -18,7 +18,8 @@ dependencies {
   }
 
   testImplementation project(':dd-java-agent:instrumentation:mongo').sourceSets.test.output
-  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '1.50.5'
+  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '4.5.1'
+  testImplementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
 
   testImplementation group: 'org.mongodb', name: 'mongodb-driver-async', version: '3.3.0'
   latestDepTestImplementation group: 'org.mongodb', name: 'mongodb-driver-async', version: '+'

--- a/dd-java-agent/instrumentation/mongo/driver-3.3-async-test/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.3-async-test/src/test/groovy/MongoAsyncClientTest.groovy
@@ -4,9 +4,6 @@ import com.mongodb.async.client.*
 import com.mongodb.client.result.DeleteResult
 import com.mongodb.client.result.UpdateResult
 import com.mongodb.connection.ClusterSettings
-import datadog.trace.agent.test.asserts.TraceAssert
-import datadog.trace.api.DDSpanTypes
-import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
 import org.bson.BsonDocument
 import org.bson.BsonString
@@ -19,7 +16,7 @@ import java.util.concurrent.CountDownLatch
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
-class MongoAsyncClientTest extends MongoBaseTest {
+abstract class MongoAsyncClientTest extends MongoBaseTest {
 
   @Shared
   MongoClient client
@@ -68,7 +65,7 @@ class MongoAsyncClientTest extends MongoBaseTest {
     then:
     assertTraces(1) {
       trace(1) {
-        mongoSpan(it, 0, "create", "{\"create\":\"$collectionName\",\"capped\":\"?\"}", databaseName)
+        mongoSpan(it, 0, "create", "{\"create\":\"$collectionName\",\"capped\":\"?\"}", false, databaseName)
       }
     }
 
@@ -230,29 +227,40 @@ class MongoAsyncClientTest extends MongoBaseTest {
         }
       }
   }
+}
 
-  def mongoSpan(TraceAssert trace, int index, String operation, String statement, String instance = "some-description", Object parentSpan = null, Throwable exception = null) {
-    trace.span {
-      serviceName "mongo"
-      operationName "mongo.query"
-      resourceName matchesStatement(statement)
-      spanType DDSpanTypes.MONGO
-      if (parentSpan == null) {
-        parent()
-      } else {
-        childOf((DDSpan) parentSpan)
-      }
-      topLevel true
-      tags {
-        "$Tags.COMPONENT" "java-mongo"
-        "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-        "$Tags.PEER_HOSTNAME" "localhost"
-        "$Tags.PEER_PORT" port
-        "$Tags.DB_TYPE" "mongo"
-        "$Tags.DB_INSTANCE" instance
-        "$Tags.DB_OPERATION" operation
-        defaultTags()
-      }
-    }
+class MongoAsyncClientV0ForkedTest extends MongoAsyncClientTest {
+
+  @Override
+  protected int version() {
+    return 0
+  }
+
+  @Override
+  protected String service() {
+    return V0_SERVICE
+  }
+
+  @Override
+  protected String operation() {
+    return V0_OPERATION
+  }
+}
+
+class MongoAsyncClientV1ForkedTest extends MongoAsyncClientTest {
+
+  @Override
+  protected int version() {
+    return 1
+  }
+
+  @Override
+  protected String service() {
+    return V1_SERVICE
+  }
+
+  @Override
+  protected String operation() {
+    return V1_OPERATION
   }
 }

--- a/dd-java-agent/instrumentation/mongo/driver-3.4/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-3.4/build.gradle
@@ -44,7 +44,9 @@ dependencies {
   }
 
   testImplementation project(':dd-java-agent:instrumentation:mongo').sourceSets.test.output
-  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '1.50.5'
+  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '4.5.1'
+  testImplementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
+
 
   // We need to pull in this dependency to get the 'suspend span' instrumentation for spock tests
   // as well as to test the instrumentaiton 'layering' (3.4 instrumentation should take precedence

--- a/dd-java-agent/instrumentation/mongo/driver-3.4/src/test/groovy/MongoJava34ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.4/src/test/groovy/MongoJava34ClientTest.groovy
@@ -8,9 +8,6 @@ import com.mongodb.event.CommandFailedEvent
 import com.mongodb.event.CommandListener
 import com.mongodb.event.CommandStartedEvent
 import com.mongodb.event.CommandSucceededEvent
-import datadog.trace.agent.test.asserts.TraceAssert
-import datadog.trace.api.DDSpanTypes
-import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
 import org.bson.BsonDocument
 import org.bson.BsonString
@@ -22,7 +19,7 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
-class MongoJava34ClientTest extends MongoBaseTest {
+abstract class MongoJava34ClientTest extends MongoBaseTest {
 
   @Shared
   MongoClient client
@@ -246,29 +243,40 @@ class MongoJava34ClientTest extends MongoBaseTest {
     where:
     collectionName = randomCollectionName()
   }
+}
 
-  def mongoSpan(TraceAssert trace, int index, String operation, String statement, boolean renameService = false, String instance = "some-description", Object parentSpan = null, Throwable exception = null) {
-    trace.span {
-      serviceName renameService ? instance : "mongo"
-      operationName "mongo.query"
-      resourceName matchesStatement(statement)
-      spanType DDSpanTypes.MONGO
-      if (parentSpan == null) {
-        parent()
-      } else {
-        childOf((DDSpan) parentSpan)
-      }
-      topLevel true
-      tags {
-        "$Tags.COMPONENT" "java-mongo"
-        "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-        "$Tags.PEER_HOSTNAME" "localhost"
-        "$Tags.PEER_PORT" port
-        "$Tags.DB_TYPE" "mongo"
-        "$Tags.DB_INSTANCE" instance
-        "$Tags.DB_OPERATION" operation
-        defaultTags()
-      }
-    }
+class MongoJava34ClientV0ForkedTest extends MongoJava34ClientTest {
+
+  @Override
+  protected int version() {
+    return 0
+  }
+
+  @Override
+  protected String service() {
+    return V0_SERVICE
+  }
+
+  @Override
+  protected String operation() {
+    return V0_OPERATION
+  }
+}
+
+class MongoJava34ClientV1ForkedTest extends MongoJava34ClientTest {
+
+  @Override
+  protected int version() {
+    return 1
+  }
+
+  @Override
+  protected String service() {
+    return V1_SERVICE
+  }
+
+  @Override
+  protected String operation() {
+    return V1_OPERATION
   }
 }

--- a/dd-java-agent/instrumentation/mongo/driver-3.7-core-test/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-3.7-core-test/build.gradle
@@ -10,7 +10,8 @@ testSets {
 
 dependencies {
   testImplementation project(':dd-java-agent:instrumentation:mongo').sourceSets.test.output
-  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '1.50.5'
+  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '4.5.1'
+  testImplementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
 
   // We need to pull in this dependency to get the 'suspend span' instrumentation for spock tests
   // as well as to test the instrumentaiton 'layering' (3.4 instrumentation should take precedence

--- a/dd-java-agent/instrumentation/mongo/driver-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-4.0/build.gradle
@@ -39,7 +39,8 @@ dependencies {
   }
 
   testImplementation project(':dd-java-agent:instrumentation:mongo').sourceSets.test.output
-  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '1.50.5'
+  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '4.5.1'
+  testImplementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
 
   testImplementation group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.0.1'
   testImplementation group: 'org.mongodb', name: 'mongodb-driver-reactivestreams', version: '4.0.1'  // race condition bug in 4.0.0

--- a/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/MongoReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/MongoReactiveClientTest.groovy
@@ -4,9 +4,6 @@ import com.mongodb.reactivestreams.client.MongoClient
 import com.mongodb.reactivestreams.client.MongoClients
 import com.mongodb.reactivestreams.client.MongoCollection
 import com.mongodb.reactivestreams.client.MongoDatabase
-import datadog.trace.agent.test.asserts.TraceAssert
-import datadog.trace.api.DDSpanTypes
-import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
 import org.bson.BsonDocument
 import org.bson.BsonString
@@ -22,13 +19,13 @@ import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
-class MongoReactiveClientTest extends MongoBaseTest {
+abstract class MongoReactiveClientTest extends MongoBaseTest {
 
   @Shared
   MongoClient client
 
   def setup() throws Exception {
-    client = MongoClients.create("mongodb://localhost:$port/?appname=some-instance")
+    client = MongoClients.create("mongodb://localhost:$port/?appname=some-description")
   }
 
   def cleanup() throws Exception {
@@ -101,7 +98,7 @@ class MongoReactiveClientTest extends MongoBaseTest {
       trace(2) {
         sortSpansByStart()
         basicSpan(it, 0,"parent")
-        mongoSpan(it, 1, "create", "{\"create\":\"$collectionName\",\"capped\":\"?\"}", "some-instance", span(0))
+        mongoSpan(it, 1, "create", "{\"create\":\"$collectionName\",\"capped\":\"?\"}", false, "some-description", span(0))
       }
     }
 
@@ -119,7 +116,7 @@ class MongoReactiveClientTest extends MongoBaseTest {
     then:
     assertTraces(1) {
       trace(1) {
-        mongoSpan(it, 0, "create", "{\"create\":\"$collectionName\",\"capped\":\"?\"}", databaseName)
+        mongoSpan(it, 0, "create", "{\"create\":\"$collectionName\",\"capped\":\"?\"}", false, databaseName)
       }
     }
 
@@ -141,7 +138,7 @@ class MongoReactiveClientTest extends MongoBaseTest {
       trace(2) {
         sortSpansByStart()
         basicSpan(it, 0,"parent")
-        mongoSpan(it, 1, "create", "{\"create\":\"$collectionName\",\"capped\":\"?\"}", databaseName, span(0))
+        mongoSpan(it, 1, "create", "{\"create\":\"$collectionName\",\"capped\":\"?\"}", false, databaseName, span(0))
       }
     }
 
@@ -185,7 +182,7 @@ class MongoReactiveClientTest extends MongoBaseTest {
       trace(2) {
         sortSpansByStart()
         basicSpan(it, 0,"parent")
-        mongoSpan(it, 1, "count", "{\"count\":\"$collectionName\",\"query\":{}}", "some-instance", span(0))
+        mongoSpan(it, 1, "count", "{\"count\":\"$collectionName\",\"query\":{}}", false, "some-description", span(0))
       }
     }
 
@@ -236,8 +233,8 @@ class MongoReactiveClientTest extends MongoBaseTest {
       trace(3) {
         sortSpansByStart()
         basicSpan(it, 0,"parent")
-        mongoSpan(it, 1, "insert", "{\"insert\":\"$collectionName\",\"ordered\":true,\"documents\":[]}", "some-instance", span(0))
-        mongoSpan(it, 2, "count", "{\"count\":\"$collectionName\",\"query\":{}}", "some-instance", span(0))
+        mongoSpan(it, 1, "insert", "{\"insert\":\"$collectionName\",\"ordered\":true,\"documents\":[]}", false, "some-description", span(0))
+        mongoSpan(it, 2, "count", "{\"count\":\"$collectionName\",\"query\":{}}", false, "some-description", span(0))
       }
     }
 
@@ -300,8 +297,8 @@ class MongoReactiveClientTest extends MongoBaseTest {
       trace(3) {
         sortSpansByStart()
         basicSpan(it, 0,"parent")
-        mongoSpan(it, 1, "update", "{\"update\":\"$collectionName\",\"ordered\":true,\"updates\":[]}", "some-instance", span(0))
-        mongoSpan(it, 2, "count", "{\"count\":\"$collectionName\",\"query\":{}}", "some-instance", span(0))
+        mongoSpan(it, 1, "update", "{\"update\":\"$collectionName\",\"ordered\":true,\"updates\":[]}", false, "some-description", span(0))
+        mongoSpan(it, 2, "count", "{\"count\":\"$collectionName\",\"query\":{}}", false, "some-description", span(0))
       }
     }
 
@@ -360,8 +357,8 @@ class MongoReactiveClientTest extends MongoBaseTest {
       trace(3) {
         sortSpansByStart()
         basicSpan(it, 0,"parent")
-        mongoSpan(it, 1, "delete", "{\"delete\":\"$collectionName\",\"ordered\":true,\"deletes\":[]}", "some-instance", span(0))
-        mongoSpan(it, 2, "count", "{\"count\":\"$collectionName\",\"query\":{}}", "some-instance", span(0))
+        mongoSpan(it, 1, "delete", "{\"delete\":\"$collectionName\",\"ordered\":true,\"deletes\":[]}", false, "some-description", span(0))
+        mongoSpan(it, 2, "count", "{\"count\":\"$collectionName\",\"query\":{}}", false, "some-description", span(0))
       }
     }
 
@@ -397,29 +394,40 @@ class MongoReactiveClientTest extends MongoBaseTest {
         }
       }
   }
+}
 
-  def mongoSpan(TraceAssert trace, int index, String operation, String statement, String instance = "some-instance", Object parentSpan = null, Throwable exception = null) {
-    trace.span(index) {
-      serviceName "mongo"
-      operationName "mongo.query"
-      resourceName matchesStatement(statement)
-      spanType DDSpanTypes.MONGO
-      if (parentSpan == null) {
-        parent()
-      } else {
-        childOf((DDSpan) parentSpan)
-      }
-      topLevel true
-      tags {
-        "$Tags.COMPONENT" "java-mongo"
-        "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-        "$Tags.PEER_HOSTNAME" "localhost"
-        "$Tags.PEER_PORT" port
-        "$Tags.DB_TYPE" "mongo"
-        "$Tags.DB_INSTANCE" instance
-        "$Tags.DB_OPERATION" operation
-        defaultTags()
-      }
-    }
+class MongoReactiveClientV0ForkedTest extends MongoReactiveClientTest {
+
+  @Override
+  protected int version() {
+    return 0
+  }
+
+  @Override
+  protected String service() {
+    return V0_SERVICE
+  }
+
+  @Override
+  protected String operation() {
+    return V0_OPERATION
+  }
+}
+
+class MongoReactiveClientV1ForkedTest extends MongoReactiveClientTest {
+
+  @Override
+  protected int version() {
+    return 1
+  }
+
+  @Override
+  protected String service() {
+    return V1_SERVICE
+  }
+
+  @Override
+  protected String operation() {
+    return V1_OPERATION
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
@@ -10,6 +10,13 @@ public interface NamingSchema {
    */
   ForCache cache();
 
+  /**
+   * Get the naming policy for databases.
+   *
+   * @return a {@link NamingSchema.ForDatabase} instance.
+   */
+  ForDatabase database();
+
   interface ForCache {
     /**
      * Calculate the operation name for a cache span.
@@ -29,5 +36,26 @@ public interface NamingSchema {
      */
     @Nonnull
     String service(@Nonnull String ddService, @Nonnull String cacheSystem);
+  }
+
+  interface ForDatabase {
+    /**
+     * Calculate the operation name for a database span.
+     *
+     * @param databaseType the database type (e.g. postgres, elasticsearch,..)
+     * @return the operation name
+     */
+    @Nonnull
+    String operation(@Nonnull String databaseType);
+
+    /**
+     * Calculate the service name for a database span.
+     *
+     * @param ddService the configured service name as set by the user.
+     * @param databaseType the database type (e.g. postgres, elasticsearch,..)
+     * @return the service name
+     */
+    @Nonnull
+    String service(@Nonnull String ddService, @Nonnull String databaseType);
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/DatabaseNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/DatabaseNamingV0.java
@@ -1,0 +1,18 @@
+package datadog.trace.api.naming.v0;
+
+import datadog.trace.api.naming.NamingSchema;
+import javax.annotation.Nonnull;
+
+public class DatabaseNamingV0 implements NamingSchema.ForDatabase {
+  @Nonnull
+  @Override
+  public String operation(@Nonnull String databaseType) {
+    return databaseType + ".query";
+  }
+
+  @Nonnull
+  @Override
+  public String service(@Nonnull String ddService, @Nonnull String databaseType) {
+    return databaseType;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/NamingSchemaV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/NamingSchemaV0.java
@@ -5,8 +5,15 @@ import datadog.trace.api.naming.NamingSchema;
 public class NamingSchemaV0 implements NamingSchema {
   private final NamingSchema.ForCache cacheNaming = new CacheNamingV0();
 
+  private final NamingSchema.ForDatabase databaseNaming = new DatabaseNamingV0();
+
   @Override
   public NamingSchema.ForCache cache() {
     return cacheNaming;
+  }
+
+  @Override
+  public ForDatabase database() {
+    return databaseNaming;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/DatabaseNamingV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/DatabaseNamingV1.java
@@ -1,0 +1,28 @@
+package datadog.trace.api.naming.v1;
+
+import datadog.trace.api.naming.NamingSchema;
+import javax.annotation.Nonnull;
+
+public class DatabaseNamingV1 implements NamingSchema.ForDatabase {
+  @Nonnull
+  private String normalizeDatabaseType(@Nonnull String databaseType) {
+    // there will more entries (e.g. postgres,..) since the name we use is not always
+    // the one chosen for v1 naming conventions
+    if ("mongo".equals(databaseType)) {
+      return "mongodb";
+    }
+    return databaseType;
+  }
+
+  @Nonnull
+  @Override
+  public String operation(@Nonnull String databaseType) {
+    return normalizeDatabaseType(databaseType) + ".query";
+  }
+
+  @Nonnull
+  @Override
+  public String service(@Nonnull String ddService, @Nonnull String databaseType) {
+    return ddService + "-" + normalizeDatabaseType(databaseType);
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/NamingSchemaV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/NamingSchemaV1.java
@@ -5,8 +5,15 @@ import datadog.trace.api.naming.NamingSchema;
 public class NamingSchemaV1 implements NamingSchema {
   private final NamingSchema.ForCache cacheNaming = new CacheNamingV1();
 
+  private final NamingSchema.ForDatabase databaseNaming = new DatabaseNamingV1();
+
   @Override
   public NamingSchema.ForCache cache() {
     return cacheNaming;
+  }
+
+  @Override
+  public ForDatabase database() {
+    return databaseNaming;
   }
 }


### PR DESCRIPTION
# What Does This Do

Implements naming schema changes for mongodb instrumentations (all drivers):
* service name: `{{DD_SERVICE}}-mongodb`
* operation: `mongodb.query`

# Motivation

# Additional Notes
