### PR TITLE
Fix DD Intake trace interceptor

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDIntakeTraceInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDIntakeTraceInterceptor.java
@@ -37,7 +37,7 @@ public class DDIntakeTraceInterceptor implements TraceInterceptor {
   private void process(DDSpan span) {
     span.setServiceName(normalizeServiceName(span.getServiceName()));
     span.setOperationName(normalizeOperationName(span.getOperationName()));
-    span.setSpanType(normalizeSpanType(span.getSpanType()));
+    span.setSpanType(normalizeSpanType(span.getType()));
 
     if (span.getResourceName() == null || span.getResourceName().length() == 0) {
       log.debug(
@@ -52,7 +52,7 @@ public class DDIntakeTraceInterceptor implements TraceInterceptor {
     }
 
     final short httpStatusCode = span.getHttpStatusCode();
-    if (!isValidStatusCode(httpStatusCode)) {
+    if (httpStatusCode != 0 && !isValidStatusCode(httpStatusCode)) {
       log.debug(
           "Fixing malformed trace. HTTP status code is invalid (reason:invalid_http_status_code), dropping invalid http.status_code={}: {}",
           httpStatusCode,
@@ -63,6 +63,6 @@ public class DDIntakeTraceInterceptor implements TraceInterceptor {
 
   @Override
   public int priority() {
-    return 0;
+    return 1;
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDIntakeTraceInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDIntakeTraceInterceptorTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.common.writer.ddintake
 
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.test.DDCoreSpecification
 import spock.lang.Timeout
@@ -11,7 +12,7 @@ class DDIntakeTraceInterceptorTest extends DDCoreSpecification {
   def writer = new ListWriter()
   def tracer = tracerBuilder().writer(writer).build()
 
-  def setup(){
+  def setup() {
     tracer.addTraceInterceptor(DDIntakeTraceInterceptor.INSTANCE)
   }
 
@@ -26,7 +27,7 @@ class DDIntakeTraceInterceptorTest extends DDCoreSpecification {
       .withSpanType("my-span-type")
       .withServiceName("my-service-name")
       .withTag("some-tag-key", "some-tag-value")
-      .withTag("env","     My_____Env     ")
+      .withTag("env", "     My_____Env     ")
       .withTag(Tags.HTTP_STATUS, httpStatus)
       .start().finish()
     writer.waitForTraces(1)
@@ -47,10 +48,28 @@ class DDIntakeTraceInterceptorTest extends DDCoreSpecification {
 
     where:
     httpStatus | expectedHttpStatus
-    null | null
-    "" | null
-    "500" | 500
-    500 | 500
-    600 | null
+    null       | null
+    ""         | null
+    "500"      | 500
+    500        | 500
+    600        | null
+  }
+
+  def "test normalization does not implicitly convert span type"() {
+    setup:
+    def originalSpanType = UTF8BytesString.create("a UTF8 span type")
+    tracer.buildSpan("my-operation-name")
+      .withSpanType(originalSpanType)
+      .start().finish()
+
+    when:
+    writer.waitForTraces(1)
+
+    then:
+    def trace = writer.firstTrace()
+    trace.size() == 1
+
+    def span = trace[0]
+    span.type == originalSpanType
   }
 }

--- a/internal-api/src/main/java/datadog/trace/util/TraceUtils.java
+++ b/internal-api/src/main/java/datadog/trace/util/TraceUtils.java
@@ -61,7 +61,7 @@ public class TraceUtils {
     return name;
   }
 
-  public static String normalizeSpanType(final String spanType) {
+  public static CharSequence normalizeSpanType(final CharSequence spanType) {
     if (spanType != null && spanType.length() > MAX_TYPE_LEN) {
       log.debug(
           "Fixing malformed trace. Type is too long (reason:type_truncate), truncating span.type to length={}",
@@ -85,6 +85,7 @@ public class TraceUtils {
   }
 
   // spotless:off
+
   /**
    * Normalizes a tag value:
    * - Only letters, digits, ":", ".", "-", "_" and "/" are allowed.
@@ -146,6 +147,7 @@ public class TraceUtils {
   }
 
   // spotless:off
+
   /**
    * Normalizes the span name:
    * - Only alphanumeric chars, "_" and "." are allowed.


### PR DESCRIPTION
# What Does This Do
This change fixes DD Intake trace interceptor.
The span writer ignored the interceptor because of deduplication logic (the writer stores a set of interceptors that are differentiated by priority; if multiple interceptors with the same priority are added to the writer, all but one will be ignored).
The fix is to change the priority of the interceptor, making it unique.

# Motivation
The goal of the interceptor is to normalise spans/tags submitted directly to DD Intake in agentless mode.
Normalisation includes filling in empty span fields with default values, or truncating fields that are too long.
The normalised fields are service name, operation name, resource name, span type, etc.
This normalisation logic is similar to what is done by the agent, which is why it needs to be replicated in agentless mode.

# Additional Notes
Span type normalisation operation was changed to preserve original span type object in case no normalisation is applied.
Prior to that, the original object (a `UTF8BytesString`) was changed to a regular string even if the data didn't need to be normalised.
Using the original object is more optimal, because it contains pre-computed serialisation result. 