### PR TITLE
Naming schema: elasticsearch

### DIFF
--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5RestClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5RestClientInstrumentation.java
@@ -5,7 +5,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOn
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchRestClientDecorator.DECORATE;
-import static datadog.trace.instrumentation.elasticsearch.ElasticsearchRestClientDecorator.ELASTICSEARCH_REST_QUERY;
+import static datadog.trace.instrumentation.elasticsearch.ElasticsearchRestClientDecorator.OPERATION_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
@@ -58,7 +58,7 @@ public class Elasticsearch5RestClientInstrumentation extends Instrumenter.Tracin
         @Advice.Argument(1) final String endpoint,
         @Advice.Argument(value = 5, readOnly = false) ResponseListener responseListener) {
 
-      final AgentSpan span = startSpan(ELASTICSEARCH_REST_QUERY);
+      final AgentSpan span = startSpan(OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, method, endpoint);
 

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
@@ -1,4 +1,5 @@
-import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.naming.VersionedNamingTestBase
+import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.test.util.Flaky
@@ -22,7 +23,7 @@ import spock.lang.Shared
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 @Flaky
-class Elasticsearch5RestClientTest extends AgentTestRunner {
+abstract class Elasticsearch5RestClientTest extends VersionedNamingTestBase {
   @Shared
   TransportAddress httpTransportAddress
   @Shared
@@ -83,9 +84,9 @@ class Elasticsearch5RestClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(2) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "GET _cluster/health"
-          operationName "elasticsearch.rest.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           parent()
           tags {
@@ -100,7 +101,7 @@ class Elasticsearch5RestClientTest extends AgentTestRunner {
           }
         }
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "GET _cluster/health"
           operationName "http.request"
           spanType DDSpanTypes.HTTP_CLIENT
@@ -116,5 +117,41 @@ class Elasticsearch5RestClientTest extends AgentTestRunner {
         }
       }
     }
+  }
+}
+
+class Elasticsearch6RestClientV0ForkedTest extends Elasticsearch5RestClientTest {
+
+  @Override
+  protected int version() {
+    return 0
+  }
+
+  @Override
+  protected String service() {
+    return "elasticsearch"
+  }
+
+  @Override
+  protected String operation() {
+    return "elasticsearch.rest.query"
+  }
+}
+
+class Elasticsearch6RestClientV1ForkedTest extends Elasticsearch5RestClientTest {
+
+  @Override
+  protected int version() {
+    return 1
+  }
+
+  @Override
+  protected String service() {
+    return Config.get().getServiceName() + "-elasticsearch"
+  }
+
+  @Override
+  protected String operation() {
+    return "elasticsearch.query"
   }
 }

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/main/java/datadog/trace/instrumentation/elasticsearch6_4/Elasticsearch6RestClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/src/main/java/datadog/trace/instrumentation/elasticsearch6_4/Elasticsearch6RestClientInstrumentation.java
@@ -4,7 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchRestClientDecorator.DECORATE;
-import static datadog.trace.instrumentation.elasticsearch.ElasticsearchRestClientDecorator.ELASTICSEARCH_REST_QUERY;
+import static datadog.trace.instrumentation.elasticsearch.ElasticsearchRestClientDecorator.OPERATION_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
@@ -56,7 +56,7 @@ public class Elasticsearch6RestClientInstrumentation extends Instrumenter.Tracin
         @Advice.Argument(0) final Request request,
         @Advice.Argument(value = 1, readOnly = false) ResponseListener responseListener) {
 
-      final AgentSpan span = startSpan(ELASTICSEARCH_REST_QUERY);
+      final AgentSpan span = startSpan(OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request.getMethod(), request.getEndpoint());
 

--- a/dd-java-agent/instrumentation/elasticsearch/rest-7/src/main/java/datadog/trace/instrumentation/elasticsearch7/Elasticsearch7RestClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-7/src/main/java/datadog/trace/instrumentation/elasticsearch7/Elasticsearch7RestClientInstrumentation.java
@@ -5,7 +5,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchRestClientDecorator.DECORATE;
-import static datadog.trace.instrumentation.elasticsearch.ElasticsearchRestClientDecorator.ELASTICSEARCH_REST_QUERY;
+import static datadog.trace.instrumentation.elasticsearch.ElasticsearchRestClientDecorator.OPERATION_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
@@ -73,7 +73,7 @@ public class Elasticsearch7RestClientInstrumentation extends Instrumenter.Tracin
         @Advice.Argument(value = 1, readOnly = false, optional = true)
             ResponseListener responseListener) {
 
-      final AgentSpan span = startSpan(ELASTICSEARCH_REST_QUERY);
+      final AgentSpan span = startSpan(OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request.getMethod(), request.getEndpoint());
 

--- a/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchTransportClientDecorator.java
+++ b/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchTransportClientDecorator.java
@@ -1,28 +1,28 @@
 package datadog.trace.instrumentation.elasticsearch;
 
-import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_TYPE;
-
+import datadog.trace.api.Config;
+import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
-import datadog.trace.bootstrap.instrumentation.decorator.DatabaseClientDecorator;
+import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
 
-public class ElasticsearchTransportClientDecorator extends DatabaseClientDecorator {
+public class ElasticsearchTransportClientDecorator extends DBTypeProcessingDatabaseClientDecorator {
 
-  public static final CharSequence ELASTICSEARCH_QUERY =
-      UTF8BytesString.create("elasticsearch.query");
+  private static final String DB_TYPE = "elasticsearch";
+  private static final String SERVICE_NAME =
+      SpanNaming.instance()
+          .namingSchema()
+          .database()
+          .service(Config.get().getServiceName(), DB_TYPE);
+
+  public static final CharSequence OPERATION_NAME =
+      UTF8BytesString.create(SpanNaming.instance().namingSchema().database().operation(DB_TYPE));
   public static final CharSequence ELASTICSEARCH_JAVA =
       UTF8BytesString.create("elasticsearch-java");
 
   public static final ElasticsearchTransportClientDecorator DECORATE =
       new ElasticsearchTransportClientDecorator();
-
-  @Override
-  public AgentSpan afterStart(AgentSpan span) {
-    span.setServiceName(dbType());
-    span.setTag(DB_TYPE, dbType());
-    return super.afterStart(span);
-  }
 
   @Override
   protected String[] instrumentationNames() {
@@ -31,7 +31,7 @@ public class ElasticsearchTransportClientDecorator extends DatabaseClientDecorat
 
   @Override
   protected String service() {
-    return "elasticsearch";
+    return SERVICE_NAME;
   }
 
   @Override
@@ -46,7 +46,7 @@ public class ElasticsearchTransportClientDecorator extends DatabaseClientDecorat
 
   @Override
   protected String dbType() {
-    return "elasticsearch";
+    return DB_TYPE;
   }
 
   @Override
@@ -80,4 +80,7 @@ public class ElasticsearchTransportClientDecorator extends DatabaseClientDecorat
     }
     return span;
   }
+
+  @Override
+  protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {}
 }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/main/java/datadog/trace/instrumentation/elasticsearch2/Elasticsearch2TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/main/java/datadog/trace/instrumentation/elasticsearch2/Elasticsearch2TransportClientInstrumentation.java
@@ -4,7 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
-import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.ELASTICSEARCH_QUERY;
+import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.OPERATION_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
@@ -62,7 +62,7 @@ public class Elasticsearch2TransportClientInstrumentation extends Instrumenter.T
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final AgentSpan span = startSpan(ELASTICSEARCH_QUERY);
+      final AgentSpan span = startSpan(OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -1,4 +1,5 @@
-import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.naming.VersionedNamingTestBase
+import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.test.util.Flaky
@@ -13,7 +14,7 @@ import spock.lang.Shared
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 @Flaky
-class Elasticsearch2NodeClientTest extends AgentTestRunner {
+abstract class Elasticsearch2NodeClientTest extends VersionedNamingTestBase {
   public static final long TIMEOUT = 10000 // 10 seconds
 
   @Shared
@@ -67,9 +68,9 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -95,9 +96,9 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           errored true
           tags {
@@ -162,9 +163,9 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
     assertTraces(6) {
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "CreateIndexAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -179,9 +180,9 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
       }
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -195,9 +196,9 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
       }
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -217,9 +218,9 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
       }
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "IndexAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -237,9 +238,9 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
       }
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -254,9 +255,9 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
       }
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -283,5 +284,41 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
     indexName = "test-index"
     indexType = "test-type"
     id = "1"
+  }
+}
+
+class Elasticsearch2NodeClientV0ForkedTest extends Elasticsearch2NodeClientTest {
+
+  @Override
+  protected int version() {
+    return 0
+  }
+
+  @Override
+  protected String service() {
+    return "elasticsearch"
+  }
+
+  @Override
+  protected String operation() {
+    return "elasticsearch.query"
+  }
+}
+
+class Elasticsearch2NodeClientV1ForkedTest extends Elasticsearch2NodeClientTest {
+
+  @Override
+  protected int version() {
+    return 1
+  }
+
+  @Override
+  protected String service() {
+    return Config.get().getServiceName() + "-elasticsearch"
+  }
+
+  @Override
+  protected String operation() {
+    return "elasticsearch.query"
   }
 }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -1,4 +1,5 @@
-import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.naming.VersionedNamingTestBase
+import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.test.util.Flaky
@@ -18,7 +19,7 @@ import spock.lang.Shared
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 @Flaky
-class Elasticsearch2TransportClientTest extends AgentTestRunner {
+abstract class Elasticsearch2TransportClientTest extends VersionedNamingTestBase {
   public static final long TIMEOUT = 10000 // 10 seconds
 
   @Shared
@@ -83,9 +84,9 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -117,9 +118,9 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "ClusterStatsAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -149,9 +150,9 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           errored true
           tags {
@@ -215,9 +216,9 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     assertTraces(6) {
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "CreateIndexAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -235,9 +236,9 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
       }
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -254,9 +255,9 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
       }
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -277,9 +278,9 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
       }
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "IndexAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -298,9 +299,9 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
       }
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -315,9 +316,9 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
       }
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "GetAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -345,5 +346,41 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     indexName = "test-index"
     indexType = "test-type"
     id = "1"
+  }
+}
+
+class Elasticsearch2TransportClientV0ForkedTest extends Elasticsearch2TransportClientTest {
+
+  @Override
+  protected int version() {
+    return 0
+  }
+
+  @Override
+  protected String service() {
+    return "elasticsearch"
+  }
+
+  @Override
+  protected String operation() {
+    return "elasticsearch.query"
+  }
+}
+
+class Elasticsearch2TransportClientV1ForkedTest extends Elasticsearch2TransportClientTest {
+
+  @Override
+  protected int version() {
+    return 1
+  }
+
+  @Override
+  protected String service() {
+    return Config.get().getServiceName() + "-elasticsearch"
+  }
+
+  @Override
+  protected String operation() {
+    return "elasticsearch.query"
   }
 }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -1,6 +1,6 @@
 package springdata
 
-import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.test.util.Flaky
@@ -22,7 +22,7 @@ import spock.lang.Shared
 import java.util.concurrent.atomic.AtomicLong
 
 @Flaky
-class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
+abstract class Elasticsearch2SpringTemplateTest extends VersionedNamingTestBase {
   public static final long TIMEOUT = 10000 // 10 seconds
 
   @Shared
@@ -73,9 +73,9 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
     assertTraces(1) {
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "RefreshAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           errored true
           tags {
@@ -132,9 +132,9 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
     assertTraces(7) {
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "CreateIndexAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -149,9 +149,9 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
       }
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "ClusterHealthAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -165,9 +165,9 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
       }
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "SearchAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -183,9 +183,9 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
       }
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "IndexAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -203,9 +203,9 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
       }
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "PutMappingAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -220,9 +220,9 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
       }
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "RefreshAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -240,9 +240,9 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
       }
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "SearchAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -271,7 +271,10 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
     setup:
 
     template.createIndex(indexName)
+    TEST_WRITER.waitForTraces(1)
     testNode.client().admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
+    TEST_WRITER.waitForTraces(2)
+
     template.index(IndexQueryBuilder.newInstance()
       .withObject(new Doc(id: 1, data: "doc a"))
       .withIndexName(indexName)
@@ -322,9 +325,9 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
     assertTraces(1) {
       trace(1) {
         span {
-          serviceName "elasticsearch"
+          serviceName service()
           resourceName "SearchAction"
-          operationName "elasticsearch.query"
+          operationName operation()
           spanType DDSpanTypes.ELASTICSEARCH
           tags {
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -344,5 +347,41 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
 
     where:
     indexName = "test-index-extract"
+  }
+}
+
+class Elasticsearch2SpringTemplateV0ForkedTest extends Elasticsearch2SpringTemplateTest {
+
+  @Override
+  protected int version() {
+    return 0
+  }
+
+  @Override
+  protected String service() {
+    return "elasticsearch"
+  }
+
+  @Override
+  protected String operation() {
+    return "elasticsearch.query"
+  }
+}
+
+class Elasticsearch2SpringTemplateV1ForkedTest extends Elasticsearch2SpringTemplateTest {
+
+  @Override
+  protected int version() {
+    return 1
+  }
+
+  @Override
+  protected String service() {
+    return datadog.trace.api.Config.get().getServiceName() + "-elasticsearch"
+  }
+
+  @Override
+  protected String operation() {
+    return "elasticsearch.query"
   }
 }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/Elasticsearch53TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/Elasticsearch53TransportClientInstrumentation.java
@@ -4,7 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
-import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.ELASTICSEARCH_QUERY;
+import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.OPERATION_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
@@ -63,7 +63,7 @@ public class Elasticsearch53TransportClientInstrumentation extends Instrumenter.
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final AgentSpan span = startSpan(ELASTICSEARCH_QUERY);
+      final AgentSpan span = startSpan(OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/Elasticsearch5TransportClientInstrumentation.java
@@ -4,7 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
-import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.ELASTICSEARCH_QUERY;
+import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.OPERATION_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
@@ -62,7 +62,7 @@ public class Elasticsearch5TransportClientInstrumentation extends Instrumenter.T
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final AgentSpan span = startSpan(ELASTICSEARCH_QUERY);
+      final AgentSpan span = startSpan(OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/Elasticsearch6TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/Elasticsearch6TransportClientInstrumentation.java
@@ -4,7 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
-import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.ELASTICSEARCH_QUERY;
+import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.OPERATION_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
@@ -66,7 +66,7 @@ public class Elasticsearch6TransportClientInstrumentation extends Instrumenter.T
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final AgentSpan span = startSpan(ELASTICSEARCH_QUERY);
+      final AgentSpan span = startSpan(OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/dd-java-agent/instrumentation/elasticsearch/transport-7.3/src/main/java/datadog/trace/instrumentation/elasticsearch7_3/Elasticsearch73TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-7.3/src/main/java/datadog/trace/instrumentation/elasticsearch7_3/Elasticsearch73TransportClientInstrumentation.java
@@ -5,7 +5,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
-import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.ELASTICSEARCH_QUERY;
+import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.OPERATION_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
@@ -73,7 +73,7 @@ public class Elasticsearch73TransportClientInstrumentation extends Instrumenter.
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final AgentSpan span = startSpan(ELASTICSEARCH_QUERY);
+      final AgentSpan span = startSpan(OPERATION_NAME);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/DatabaseNamingV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/DatabaseNamingV1.java
@@ -8,8 +8,11 @@ public class DatabaseNamingV1 implements NamingSchema.ForDatabase {
   private String normalizeDatabaseType(@Nonnull String databaseType) {
     // there will more entries (e.g. postgres,..) since the name we use is not always
     // the one chosen for v1 naming conventions
-    if ("mongo".equals(databaseType)) {
-      return "mongodb";
+    switch (databaseType) {
+      case "mongo":
+        return "mongodb";
+      case "elasticsearch.rest":
+        return "elasticsearch";
     }
     return databaseType;
   }


### PR DESCRIPTION
# What Does This Do

v1 Naming schema changes for elasticsearch (both rest and node transport):
* service: `{{DD-SERVICE}}-elasticsearch`
* operation: `elasticsearch.query`

# Motivation

# Additional Notes
