### PR TITLE
Set 'env' to 'none' if not set or empty

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDIntakeTraceInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDIntakeTraceInterceptor.java
@@ -47,9 +47,7 @@ public class DDIntakeTraceInterceptor implements TraceInterceptor {
       span.setResourceName(span.getOperationName());
     }
 
-    if (span.getTag("env") != null) {
-      span.setTag("env", TraceUtils.normalizeEnv((String) span.getTag("env")));
-    }
+    span.setTag("env", TraceUtils.normalizeEnv((String) span.getTag("env")));
 
     final short httpStatusCode = span.getHttpStatusCode();
     if (httpStatusCode != 0 && !isValidStatusCode(httpStatusCode)) {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDIntakeTraceInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDIntakeTraceInterceptorTest.groovy
@@ -72,4 +72,18 @@ class DDIntakeTraceInterceptorTest extends DDCoreSpecification {
     def span = trace[0]
     span.type == originalSpanType
   }
+
+  def "test default env setting"() {
+    setup:
+    tracer.buildSpan("my-operation-name").start().finish()
+    writer.waitForTraces(1)
+
+    expect:
+    def trace = writer.firstTrace()
+    trace.size() == 1
+
+    def span = trace[0]
+
+    span.getTag("env") == "none"
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/util/TraceUtils.java
+++ b/internal-api/src/main/java/datadog/trace/util/TraceUtils.java
@@ -19,6 +19,7 @@ public class TraceUtils {
 
   static final String DEFAULT_SERVICE_NAME = "unnamed-service";
   static final String DEFAULT_OPERATION_NAME = "unnamed_operation";
+  static final String DEFAULT_ENV = "none";
 
   private static final Logger log = LoggerFactory.getLogger(TraceUtils.class);
 
@@ -73,7 +74,7 @@ public class TraceUtils {
 
   public static String normalizeEnv(final String env) {
     if (env == null || env.length() == 0) {
-      return "";
+      return DEFAULT_ENV;
     }
 
     String e = truncate(env, MAX_ENV_LEN);

--- a/internal-api/src/test/groovy/datadog/trace/util/TraceUtilsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/util/TraceUtilsTest.groovy
@@ -114,8 +114,8 @@ class TraceUtilsTest extends DDSpecification {
 
     where:
     env | expected
-    null | ""
-    "" | ""
+    null             | TraceUtils.DEFAULT_ENV
+    ""               | TraceUtils.DEFAULT_ENV
     "ok" | "ok"
     repeat("a",300)|repeat("a",200)
   }


### PR DESCRIPTION
# What Does This Do
This change updates span data normalisation logic used by DD Intake writer (i.e. in configurations where the tracer writes directly to backend, with no DD Agent involved).
The logic is updated so that `env` tag is set to `none` if no other value is provided for it (or if provided value is empty).

# Motivation
This was requested by the backend.

# Additional Notes
Normally this data normalisation is done by the agent, but in configurations where the tracer writes directly to the backend, it has to be replicated in the tracer.
