### PR TITLE
Add source file path detection for Kotlin

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/RepoIndexSourcePathResolver.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/RepoIndexSourcePathResolver.java
@@ -18,7 +18,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Set;
 import javax.annotation.Nullable;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
@@ -199,7 +198,6 @@ public class RepoIndexSourcePathResolver implements SourcePathResolver {
     private final List<String> sourceRoots;
     private final RepoIndexingStats indexingStats;
     private final Path repoRoot;
-    private final Set<SourceType> sourceTypes;
 
     private Path currentSourceRoot;
 
@@ -209,7 +207,6 @@ public class RepoIndexSourcePathResolver implements SourcePathResolver {
       trieBuilder = new ClassNameTrie.Builder();
       sourceRoots = new ArrayList<>();
       indexingStats = new RepoIndexingStats();
-      sourceTypes = EnumSet.noneOf(SourceType.class);
     }
 
     @Override
@@ -225,7 +222,6 @@ public class RepoIndexSourcePathResolver implements SourcePathResolver {
         String fileName = file.getFileName().toString();
         SourceType sourceType = SourceType.getByFileName(fileName);
         if (sourceType != null) {
-          sourceTypes.add(sourceType);
           indexingStats.sourceFilesVisited++;
 
           if (currentSourceRoot == null) {
@@ -265,7 +261,7 @@ public class RepoIndexSourcePathResolver implements SourcePathResolver {
     }
 
     public RepoIndex getIndex() {
-      return new RepoIndex(trieBuilder.buildTrie(), sourceRoots, sourceTypes);
+      return new RepoIndex(trieBuilder.buildTrie(), sourceRoots);
     }
   }
 
@@ -277,23 +273,10 @@ public class RepoIndexSourcePathResolver implements SourcePathResolver {
   private static final class RepoIndex {
     private final ClassNameTrie trie;
     private final List<String> sourceRoots;
-    private final Set<SourceType> sourceTypes;
-    private final boolean hasNonJavaSources;
 
-    private RepoIndex(ClassNameTrie trie, List<String> sourceRoots, Set<SourceType> sourceTypes) {
+    private RepoIndex(ClassNameTrie trie, List<String> sourceRoots) {
       this.trie = trie;
       this.sourceRoots = sourceRoots;
-      this.sourceTypes = sourceTypes;
-      hasNonJavaSources = hasNonJavaSources(sourceTypes);
-    }
-
-    private boolean hasNonJavaSources(Set<SourceType> sourceTypes) {
-      for (SourceType sourceType : sourceTypes) {
-        if (sourceType != SourceType.JAVA) {
-          return true;
-        }
-      }
-      return false;
     }
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/RepoIndexSourcePathResolver.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/RepoIndexSourcePathResolver.java
@@ -5,6 +5,7 @@ import datadog.trace.util.ClassNameTrie;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Modifier;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -62,27 +63,47 @@ public class RepoIndexSourcePathResolver implements SourcePathResolver {
     }
 
     String topLevelClassName = stripNestedClassNames(c.getName());
-    for (SourceType sourceType : index.sourceTypes) {
-      String extension = sourceType.getExtension();
-      String classNameWithExtension = topLevelClassName + extension;
-      int sourceRootIdx = index.trie.apply(classNameWithExtension);
-      if (sourceRootIdx >= 0) {
-        String sourceRoot = index.sourceRoots.get(sourceRootIdx);
-        return sourceRoot
-            + File.separatorChar
-            + topLevelClassName.replace('.', File.separatorChar)
-            + extension;
-      }
+    SourceType sourceType = detectSourceType(c);
+    String extension = sourceType.getExtension();
+    String classNameWithExtension = topLevelClassName + extension;
+    int sourceRootIdx = index.trie.apply(classNameWithExtension);
+    if (sourceRootIdx >= 0) {
+      String sourceRoot = index.sourceRoots.get(sourceRootIdx);
+      return sourceRoot
+          + File.separatorChar
+          + topLevelClassName.replace('.', File.separatorChar)
+          + extension;
     }
 
     boolean packagePrivateClass = (c.getModifiers() & ACCESS_MODIFIERS) == 0;
-    if (packagePrivateClass || index.hasNonJavaSources) {
+    if (packagePrivateClass || sourceType != SourceType.JAVA) {
       return getSourcePathForPackagePrivateOrNonJavaClass(c);
 
     } else {
       log.debug("Could not find source root for class {}", c.getName());
       return null;
     }
+  }
+
+  private SourceType detectSourceType(Class<?> c) {
+    Class<?>[] interfaces = c.getInterfaces();
+    for (Class<?> anInterface : interfaces) {
+      String interfaceName = anInterface.getName();
+      if ("groovy.lang.GroovyObject".equals(interfaceName)) {
+        return SourceType.GROOVY;
+      }
+    }
+
+    Annotation[] annotations = c.getAnnotations();
+    for (Annotation annotation : annotations) {
+      Class<? extends Annotation> annotationType = annotation.annotationType();
+      if ("kotlin.Metadata".equals(annotationType.getName())) {
+        return SourceType.KOTLIN;
+      }
+    }
+
+    // assuming Java
+    return SourceType.JAVA;
   }
 
   private String stripNestedClassNames(String className) {

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/source/RepoIndexSourcePathResolverTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/source/RepoIndexSourcePathResolverTest.groovy
@@ -72,6 +72,17 @@ class RepoIndexSourcePathResolverTest extends Specification {
     sourcePathResolver.getSourcePath(PackagePrivateClass) == expectedSourcePath
   }
 
+  def "test source path resolution for non-java class whose file name is different from class name"() {
+    setup:
+    def expectedSourcePath = givenSourceFile(RepoIndexSourcePathResolverTest, repoRoot + "/src")
+
+    when:
+    def sourcePathResolver = new RepoIndexSourcePathResolver(repoRoot, sourceRootResolver, fileSystem)
+
+    then:
+    sourcePathResolver.getSourcePath(PublicClassWhoseNameDoesNotCorrespondToFileName) == expectedSourcePath
+  }
+
   def "test source path for non-indexed class"() {
     setup:
 
@@ -149,4 +160,7 @@ class RepoIndexSourcePathResolverTest extends Specification {
 
 @PackageScope
 class PackagePrivateClass {
+}
+
+class PublicClassWhoseNameDoesNotCorrespondToFileName {
 }

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/source/RepoIndexSourcePathResolverTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/source/RepoIndexSourcePathResolverTest.groovy
@@ -121,7 +121,7 @@ class RepoIndexSourcePathResolverTest extends Specification {
   def "test source path resolution for repo with multiple files"() {
     setup:
     def expectedSourcePathOne = givenSourceFile(RepoIndexSourcePathResolverTest, repoRoot + "/src")
-    def expectedSourcePathTwo = givenSourceFile(RepoIndexSourcePathResolver, repoRoot + "/src")
+    def expectedSourcePathTwo = givenSourceFile(RepoIndexSourcePathResolver, repoRoot + "/src", RepoIndexSourcePathResolver.SourceType.JAVA)
 
     givenRepoFile(fileSystem.getPath(repoRoot, "README.md"))
 
@@ -134,8 +134,8 @@ class RepoIndexSourcePathResolverTest extends Specification {
     sourcePathResolver.getSourcePath(RepoIndexSourcePathResolver) == expectedSourcePathTwo
   }
 
-  private String givenSourceFile(Class c, String sourceRoot) {
-    def classPath = fileSystem.getPath(generateSourceFileName(c, sourceRoot))
+  private String givenSourceFile(Class c, String sourceRoot, RepoIndexSourcePathResolver.SourceType sourceType = RepoIndexSourcePathResolver.SourceType.GROOVY) {
+    def classPath = fileSystem.getPath(generateSourceFileName(c, sourceRoot, sourceType))
     sourceRootResolver.getSourceRoot(classPath) >> fileSystem.getPath(sourceRoot)
 
     givenRepoFile(classPath)
@@ -148,8 +148,8 @@ class RepoIndexSourcePathResolverTest extends Specification {
     Files.write(file, "STUB FILE BODY".getBytes())
   }
 
-  private static String generateSourceFileName(Class c, String sourceRoot) {
-    return sourceRoot + File.separator + c.getName().replace(".", File.separator) + RepoIndexSourcePathResolver.SourceType.GROOVY.extension
+  private static String generateSourceFileName(Class c, String sourceRoot, RepoIndexSourcePathResolver.SourceType sourceType = RepoIndexSourcePathResolver.SourceType.GROOVY) {
+    return sourceRoot + File.separator + c.getName().replace(".", File.separator) + sourceType.extension
   }
 
   private static final class InnerClass {


### PR DESCRIPTION
# What Does This Do
This change updates logic that detects class source file paths, so that Kotlin classes are supported.

# Motivation
The logic is used by CI Visibility part of the tracer to set source code related tags.
Some of CI Visibility customers are using it with Kotlin-based projects.

# Additional Notes
The change consisted of three main parts:
* update the list of file extensions that are added to repository index, adding `.kt`
* add logic to infer class source language
* update condition for parsing class information to obtain the source file name attribute (previously that was done only for package-private classes, not it is also done for non-Java classes)
