### PR TITLE
naming schema: aerospike

### DIFF
--- a/dd-java-agent/instrumentation/aerospike-4/src/main/java/datadog/trace/instrumentation/aerospike4/AerospikeClientDecorator.java
+++ b/dd-java-agent/instrumentation/aerospike-4/src/main/java/datadog/trace/instrumentation/aerospike4/AerospikeClientDecorator.java
@@ -7,6 +7,7 @@ import com.aerospike.client.cluster.Cluster;
 import com.aerospike.client.cluster.Node;
 import com.aerospike.client.cluster.Partition;
 import datadog.trace.api.Config;
+import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -14,9 +15,15 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
 
 public class AerospikeClientDecorator extends DBTypeProcessingDatabaseClientDecorator<Node> {
+  private static final String DB_TYPE = "aerospike";
+  private static final String SERVICE_NAME =
+      SpanNaming.instance()
+          .namingSchema()
+          .database()
+          .service(Config.get().getServiceName(), DB_TYPE);
   public static final UTF8BytesString JAVA_AEROSPIKE = UTF8BytesString.create("java-aerospike");
-  public static final UTF8BytesString AEROSPIKE_COMMAND =
-      UTF8BytesString.create("aerospike.command");
+  public static final UTF8BytesString OPERATION_NAME =
+      UTF8BytesString.create(SpanNaming.instance().namingSchema().database().operation(DB_TYPE));
 
   public static final AerospikeClientDecorator DECORATE = new AerospikeClientDecorator();
 
@@ -27,7 +34,7 @@ public class AerospikeClientDecorator extends DBTypeProcessingDatabaseClientDeco
 
   @Override
   protected String service() {
-    return "aerospike";
+    return SERVICE_NAME;
   }
 
   @Override
@@ -42,7 +49,7 @@ public class AerospikeClientDecorator extends DBTypeProcessingDatabaseClientDeco
 
   @Override
   protected String dbType() {
-    return "aerospike";
+    return DB_TYPE;
   }
 
   @Override
@@ -89,7 +96,7 @@ public class AerospikeClientDecorator extends DBTypeProcessingDatabaseClientDeco
   }
 
   public AgentSpan startAerospikeSpan(final String methodName) {
-    final AgentSpan span = startSpan(AEROSPIKE_COMMAND);
+    final AgentSpan span = startSpan(OPERATION_NAME);
     afterStart(span);
     withMethod(span, methodName);
     return span;
@@ -102,4 +109,7 @@ public class AerospikeClientDecorator extends DBTypeProcessingDatabaseClientDeco
     beforeFinish(span);
     span.finish();
   }
+
+  @Override
+  protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {}
 }

--- a/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeAsyncClientTest.groovy
@@ -8,11 +8,12 @@ import com.aerospike.client.async.EventLoops
 import com.aerospike.client.async.NioEventLoops
 import com.aerospike.client.listener.WriteListener
 import com.aerospike.client.policy.ClientPolicy
+import datadog.trace.api.Config
 import spock.lang.Shared
 
 import static org.junit.Assert.fail
 
-class AerospikeAsyncClientTest extends AerospikeBaseTest {
+abstract class AerospikeAsyncClientTest extends AerospikeBaseTest {
 
   @Shared
   AerospikeClient client
@@ -60,3 +61,38 @@ class AerospikeAsyncClientTest extends AerospikeBaseTest {
     }
   }
 }
+
+class AerospikeAsyncClientV0ForkedTest extends AerospikeAsyncClientTest {
+  @Override
+  protected int version() {
+    return 0
+  }
+
+  @Override
+  protected String service() {
+    return "aerospike"
+  }
+
+  @Override
+  protected String operation() {
+    return "aerospike.query"
+  }
+}
+
+class AerospikeAsyncClientV1ForkedTest extends AerospikeAsyncClientTest {
+  @Override
+  protected int version() {
+    return 1
+  }
+
+  @Override
+  protected String service() {
+    return Config.get().getServiceName() + "-aerospike"
+  }
+
+  @Override
+  protected String operation() {
+    return "aerospike.query"
+  }
+}
+

--- a/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeBaseTest.groovy
+++ b/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeBaseTest.groovy
@@ -1,7 +1,8 @@
 package datadog.trace.instrumentation.aerospike4
 
-import datadog.trace.agent.test.AgentTestRunner
+
 import datadog.trace.agent.test.asserts.TraceAssert
+import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
@@ -12,7 +13,7 @@ import static datadog.trace.agent.test.utils.PortUtils.waitForPortToOpen
 import static java.util.concurrent.TimeUnit.SECONDS
 import static org.testcontainers.containers.wait.strategy.Wait.forLogMessage
 
-abstract class AerospikeBaseTest extends AgentTestRunner {
+abstract class AerospikeBaseTest extends VersionedNamingTestBase {
 
   @Shared
   def aerospike
@@ -43,8 +44,8 @@ abstract class AerospikeBaseTest extends AgentTestRunner {
 
   def aerospikeSpan(TraceAssert trace, int index, String methodName, Object parentSpan = null) {
     trace.span {
-      serviceName "aerospike"
-      operationName "aerospike.query"
+      serviceName service()
+      operationName operation()
       resourceName methodName
       spanType DDSpanTypes.AEROSPIKE
       if (parentSpan == null) {

--- a/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeClientTest.groovy
+++ b/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeClientTest.groovy
@@ -3,9 +3,10 @@ package datadog.trace.instrumentation.aerospike4
 import com.aerospike.client.AerospikeClient
 import com.aerospike.client.Bin
 import com.aerospike.client.Key
+import datadog.trace.api.Config
 import spock.lang.Shared
 
-class AerospikeClientTest extends AerospikeBaseTest {
+abstract class AerospikeClientTest extends AerospikeBaseTest {
 
   @Shared
   AerospikeClient client
@@ -36,5 +37,39 @@ class AerospikeClientTest extends AerospikeBaseTest {
         aerospikeSpan(it, 0, "AerospikeClient.get")
       }
     }
+  }
+}
+
+class AerospikeClientV0ForkedTest extends AerospikeClientTest {
+  @Override
+  protected int version() {
+    return 0
+  }
+
+  @Override
+  protected String service() {
+    return "aerospike"
+  }
+
+  @Override
+  protected String operation() {
+    return "aerospike.query"
+  }
+}
+
+class AerospikeClientV1ForkedTest extends AerospikeClientTest {
+  @Override
+  protected int version() {
+    return 1
+  }
+
+  @Override
+  protected String service() {
+    return Config.get().getServiceName() + "-aerospike"
+  }
+
+  @Override
+  protected String operation() {
+    return "aerospike.query"
   }
 }


### PR DESCRIPTION
# What Does This Do

v1 naming schema changes for aerospike:
* service: `{{DD_SERVICE}}-aerospike`
* operation: `aerospike.query`

# Motivation

# Additional Notes
