### PR TITLE
service naming: jdbc

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
@@ -3,21 +3,46 @@ package datadog.trace.bootstrap.instrumentation.decorator;
 import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_TYPE;
 
 import datadog.trace.api.Config;
-import datadog.trace.api.Functions;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
+import datadog.trace.api.naming.NamingSchema;
+import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import java.util.function.Function;
 
 public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorator {
 
+  private static class NamingEntry {
+    private final String service;
+    private final CharSequence operation;
+
+    private NamingEntry(String service, CharSequence operation) {
+      this.service = service;
+      this.operation = operation;
+    }
+
+    public String getService() {
+      return service;
+    }
+
+    public CharSequence getOperation() {
+      return operation;
+    }
+  }
+
   // The total number of entries in the cache will normally be less than 4, since
   // most applications only have one or two DBs, and "jdbc" itself is also used as
   // one DB_TYPE, but set the cache size to 16 to help avoid collisions.
-  private static final DDCache<CharSequence, CharSequence> CACHE = DDCaches.newFixedSizeCache(16);
-  private static final Function<CharSequence, CharSequence> APPEND_OPERATION =
-      new Functions.Suffix(".query");
+  private static final DDCache<String, NamingEntry> CACHE = DDCaches.newFixedSizeCache(16);
+  private static final Function<String, NamingEntry> APPEND_OPERATION =
+      dbType -> {
+        final NamingSchema.ForDatabase schema = SpanNaming.instance().namingSchema().database();
+        return new NamingEntry(
+            schema.service(Config.get().getServiceName(), dbType),
+            UTF8BytesString.create(schema.operation(dbType)));
+      };
 
   protected abstract String dbType();
 
@@ -66,7 +91,8 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
   }
 
   protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {
-    span.setServiceName(dbType);
-    span.setOperationName(CACHE.computeIfAbsent(dbType, APPEND_OPERATION));
+    final NamingEntry namingEntry = CACHE.computeIfAbsent(dbType, APPEND_OPERATION);
+    span.setServiceName(namingEntry.getService());
+    span.setOperationName(namingEntry.getOperation());
   }
 }

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
@@ -1,7 +1,8 @@
 import com.mchange.v2.c3p0.ComboPooledDataSource
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
-import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.naming.VersionedNamingTestBase
+import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.apache.derby.jdbc.EmbeddedDataSource
@@ -23,7 +24,7 @@ import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
 
-class JDBCInstrumentationTest extends AgentTestRunner {
+abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
   @Shared
   def dbName = "jdbcUnitTest"
 
@@ -180,8 +181,8 @@ class JDBCInstrumentationTest extends AgentTestRunner {
       trace(2) {
         basicSpan(it, "parent")
         span {
-          serviceName renameService ? dbName.toLowerCase() : driver
-          operationName "${driver}.query"
+          serviceName renameService ? dbName.toLowerCase() : service(driver)
+          operationName this.operation(driver)
           resourceName obfuscatedQuery
           spanType DDSpanTypes.SQL
           childOf span(0)
@@ -248,8 +249,8 @@ class JDBCInstrumentationTest extends AgentTestRunner {
       trace(2) {
         basicSpan(it, "parent")
         span {
-          operationName "${driver}.query"
-          serviceName driver
+          operationName this.operation(driver)
+          serviceName service(driver)
           resourceName obfuscatedQuery
           spanType DDSpanTypes.SQL
           childOf span(0)
@@ -302,8 +303,8 @@ class JDBCInstrumentationTest extends AgentTestRunner {
       trace(2) {
         basicSpan(it, "parent")
         span {
-          operationName "${driver}.query"
-          serviceName driver
+          operationName this.operation(driver)
+          serviceName service(driver)
           resourceName obfuscatedQuery
           spanType DDSpanTypes.SQL
           childOf span(0)
@@ -356,8 +357,8 @@ class JDBCInstrumentationTest extends AgentTestRunner {
       trace(2) {
         basicSpan(it, "parent")
         span {
-          operationName "${driver}.query"
-          serviceName driver
+          operationName this.operation(driver)
+          serviceName service(driver)
           resourceName obfuscatedQuery
           spanType DDSpanTypes.SQL
           childOf span(0)
@@ -410,8 +411,8 @@ class JDBCInstrumentationTest extends AgentTestRunner {
       trace(2) {
         basicSpan(it, "parent")
         span {
-          operationName "${driver}.query"
-          serviceName driver
+          operationName this.operation(driver)
+          serviceName service(driver)
           resourceName query
           spanType DDSpanTypes.SQL
           childOf span(0)
@@ -466,8 +467,8 @@ class JDBCInstrumentationTest extends AgentTestRunner {
       trace(2) {
         basicSpan(it, "parent")
         span {
-          operationName "${driver}.query"
-          serviceName driver
+          operationName this.operation(driver)
+          serviceName service(driver)
           resourceName query
           spanType DDSpanTypes.SQL
           childOf span(0)
@@ -534,8 +535,8 @@ class JDBCInstrumentationTest extends AgentTestRunner {
       trace(2) {
         basicSpan(it, "parent")
         span {
-          operationName "${driver}.query"
-          serviceName driver
+          operationName this.operation(driver)
+          serviceName service(driver)
           resourceName obfuscatedQuery
           spanType DDSpanTypes.SQL
           childOf span(0)
@@ -652,8 +653,8 @@ class JDBCInstrumentationTest extends AgentTestRunner {
       trace(2) {
         basicSpan(it, "parent")
         span {
-          operationName "${database}.query"
-          serviceName database
+          operationName this.operation(database)
+          serviceName service(database)
           resourceName obfuscatedQuery
           spanType DDSpanTypes.SQL
           childOf span(0)
@@ -720,8 +721,8 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     assertTraces(5) {
       trace(1) {
         span {
-          operationName "${dbType}.query"
-          serviceName dbType
+          operationName this.operation(dbType)
+          serviceName service(dbType)
           resourceName obfuscatedQuery
           spanType DDSpanTypes.SQL
           errored false
@@ -740,8 +741,8 @@ class JDBCInstrumentationTest extends AgentTestRunner {
       for (int i = 1; i < numQueries; ++i) {
         trace(1) {
           span {
-            operationName "${dbType}.query"
-            serviceName dbType
+            operationName this.operation(dbType)
+            serviceName service(dbType)
             resourceName obfuscatedQuery
             spanType DDSpanTypes.SQL
             errored false
@@ -787,5 +788,54 @@ class JDBCInstrumentationTest extends AgentTestRunner {
   Connection connect(String driverClass, String url, Properties properties) {
     return newDriver(driverClass)
       .connect(url, properties)
+  }
+  @Override
+  protected final String service() {
+    return null
+  }
+
+  @Override
+  protected final String operation() {
+    return null
+  }
+
+  protected abstract String service(String dbType)
+
+  protected abstract String operation(String dbType)
+}
+
+class JDBCInstrumentationV0ForkedTest extends JDBCInstrumentationTest {
+
+  @Override
+  protected int version() {
+    return 0
+  }
+
+  @Override
+  protected String service(String dbType) {
+    return dbType
+  }
+
+  @Override
+  protected String operation(String dbType) {
+    return "${dbType}.query"
+  }
+}
+
+class JDBCInstrumentationV1ForkedTest extends JDBCInstrumentationTest {
+
+  @Override
+  protected int version() {
+    return 1
+  }
+
+  @Override
+  protected String service(String dbType) {
+    return Config.get().getServiceName() + "-${dbType}"
+  }
+
+  @Override
+  protected String operation(String dbType) {
+    return "${dbType}.query"
   }
 }

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
@@ -1,8 +1,9 @@
 import com.mchange.v2.c3p0.ComboPooledDataSource
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
-import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.agent.test.utils.PortUtils
+import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.testcontainers.containers.MySQLContainer
@@ -26,7 +27,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST
 
 // workaround for SSLHandShakeException on J9 only with Hikari/MySQL
 @Requires({ !System.getProperty("java.vendor").contains("IBM") })
-class RemoteJDBCInstrumentationTest extends AgentTestRunner {
+abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
   @Shared
   def dbName = "jdbcUnitTest"
 
@@ -196,8 +197,8 @@ class RemoteJDBCInstrumentationTest extends AgentTestRunner {
       trace(2) {
         basicSpan(it, "parent")
         span {
-          serviceName renameService ? dbName.toLowerCase() : driver
-          operationName "${driver}.query"
+          serviceName renameService ? dbName.toLowerCase() : service(driver)
+          operationName this.operation(driver)
           resourceName obfuscatedQuery
           spanType DDSpanTypes.SQL
           childOf span(0)
@@ -255,8 +256,8 @@ class RemoteJDBCInstrumentationTest extends AgentTestRunner {
       trace(2) {
         basicSpan(it, "parent")
         span {
-          operationName "${driver}.query"
-          serviceName driver
+          operationName this.operation(driver)
+          serviceName service(driver)
           resourceName obfuscatedQuery
           spanType DDSpanTypes.SQL
           childOf span(0)
@@ -313,8 +314,8 @@ class RemoteJDBCInstrumentationTest extends AgentTestRunner {
       trace(2) {
         basicSpan(it, "parent")
         span {
-          operationName "${driver}.query"
-          serviceName driver
+          operationName this.operation(driver)
+          serviceName service(driver)
           resourceName obfuscatedQuery
           spanType DDSpanTypes.SQL
           childOf span(0)
@@ -371,8 +372,8 @@ class RemoteJDBCInstrumentationTest extends AgentTestRunner {
       trace(2) {
         basicSpan(it, "parent")
         span {
-          operationName "${driver}.query"
-          serviceName driver
+          operationName this.operation(driver)
+          serviceName service(driver)
           resourceName obfuscatedQuery
           spanType DDSpanTypes.SQL
           childOf span(0)
@@ -430,8 +431,8 @@ class RemoteJDBCInstrumentationTest extends AgentTestRunner {
       trace(2) {
         basicSpan(it, "parent")
         span {
-          operationName "${driver}.query"
-          serviceName driver
+          operationName this.operation(driver)
+          serviceName service(driver)
           resourceName query
           spanType DDSpanTypes.SQL
           childOf span(0)
@@ -487,5 +488,62 @@ class RemoteJDBCInstrumentationTest extends AgentTestRunner {
   Connection connect(String driverClass, String url, Properties properties) {
     return newDriver(driverClass)
       .connect(url, properties)
+  }
+
+  @Override
+  protected final String service() {
+    return null
+  }
+
+  @Override
+  protected final String operation() {
+    return null
+  }
+
+  protected abstract String service(String dbType)
+
+  protected abstract String operation(String dbType)
+}
+
+class RemoteJDBCInstrumentationV0ForkedTest extends RemoteJDBCInstrumentationTest {
+
+  @Override
+  protected int version() {
+    return 0
+  }
+
+  @Override
+  protected String service(String dbType) {
+    return dbType
+  }
+
+  @Override
+  protected String operation(String dbType) {
+    return "${dbType}.query"
+  }
+}
+
+class RemoteJDBCInstrumentationV1ForkedTest extends RemoteJDBCInstrumentationTest {
+
+  def remapDbType(String dbType) {
+    if ("postgresql" == dbType) {
+      return "postgres"
+    }
+    return dbType
+  }
+
+  @Override
+  protected int version() {
+    return 1
+  }
+
+  @Override
+  protected String service(String dbType) {
+    return Config.get().getServiceName() + "-${remapDbType(dbType)}"
+  }
+
+  @Override
+  protected String operation(String dbType) {
+    return "${remapDbType(dbType)}.query"
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/DatabaseNamingV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/DatabaseNamingV1.java
@@ -13,6 +13,8 @@ public class DatabaseNamingV1 implements NamingSchema.ForDatabase {
         return "mongodb";
       case "elasticsearch.rest":
         return "elasticsearch";
+      case "postgresql":
+        return "postgres";
     }
     return databaseType;
   }


### PR DESCRIPTION
# What Does This Do

v1 naming schema changes for jdbc:
* service: `{{DD_SERVICE}}-{{DB_DRIVER}}`
* operation: `{{DB_DRIVER}}.query`

Special case for `postgresql` which will be renamed to `postgres`

# Motivation

# Additional Notes
