### PR TITLE
More appropriate fix for flakiness in HttpServerTest

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -819,7 +819,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     when:
     def response = client.newCall(request).execute()
     response.body().string() == PATH_PARAM.body
-    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.waitForTraces(2)
     if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
@@ -836,9 +836,6 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
         edgeTags.size() == DSM_EDGE_TAGS.size()
       }
     }
-
-    cleanup:
-    TEST_WRITER.waitForTraces(1)
   }
 
   def "test success with multiple header attached parent"() {


### PR DESCRIPTION
Fixes a problem introduced in commit 02dd2cea245c90da90443f5ae29ffa98149476eb. The theory being that when waiting for 1 trace, either 1 (the appsec-span) or 2 traces will be obtained. If 2 traces are obtained, then the cleanup wait for an extra trace will cause a longish delay.