### PR TITLE
Naming schema: http url connection

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
@@ -17,7 +17,7 @@ import java.util.LinkedHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends ClientDecorator {
+public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends UriBasedClientDecorator {
   public static final LinkedHashMap<String, String> CLIENT_PATHWAY_EDGE_TAGS;
 
   static {
@@ -62,26 +62,16 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends ClientDecor
       try {
         final URI url = url(request);
         if (url != null) {
-          String host = url.getHost();
-          String path = url.getPath();
-          int port = url.getPort();
-          span.setTag(Tags.HTTP_URL, URIUtils.buildURL(url.getScheme(), host, port, path));
-          if (null != host && !host.isEmpty()) {
-            span.setTag(Tags.PEER_HOSTNAME, host);
-            if (Config.get().isHttpClientSplitByDomain() && host.charAt(0) >= 'A') {
-              span.setServiceName(host);
-            }
-            if (port > 0) {
-              setPeerPort(span, port);
-            }
-          }
-
+          onURI(span, url);
+          span.setTag(
+              Tags.HTTP_URL,
+              URIUtils.buildURL(url.getScheme(), url.getHost(), url.getPort(), url.getPath()));
           if (Config.get().isHttpClientTagQueryString()) {
             span.setTag(DDTags.HTTP_QUERY, url.getQuery());
             span.setTag(DDTags.HTTP_FRAGMENT, url.getFragment());
           }
           if (shouldSetResourceName()) {
-            HTTP_RESOURCE_DECORATOR.withClientPath(span, method, path);
+            HTTP_RESOURCE_DECORATOR.withClientPath(span, method, url.getPath());
           }
         } else if (shouldSetResourceName()) {
           span.setResourceName(DEFAULT_RESOURCE_NAME);

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/UriBasedClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/UriBasedClientDecorator.java
@@ -1,0 +1,38 @@
+package datadog.trace.bootstrap.instrumentation.decorator;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.cache.DDCache;
+import datadog.trace.api.cache.DDCaches;
+import datadog.trace.api.naming.SpanNaming;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import java.net.URI;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+
+public abstract class UriBasedClientDecorator extends ClientDecorator {
+  private static final DDCache<String, CharSequence> CACHE = DDCaches.newFixedSizeCache(16);
+
+  private static final Function<String, CharSequence> ADDER =
+      protocol ->
+          UTF8BytesString.create(SpanNaming.instance().namingSchema().client().operation(protocol));
+
+  public void onURI(@Nonnull final AgentSpan span, @Nonnull final URI uri) {
+    String host = uri.getHost();
+    int port = uri.getPort();
+    if (null != host && !host.isEmpty()) {
+      span.setTag(Tags.PEER_HOSTNAME, host);
+      if (Config.get().isHttpClientSplitByDomain() && host.charAt(0) >= 'A') {
+        span.setServiceName(host);
+      }
+      if (port > 0) {
+        setPeerPort(span, port);
+      }
+    }
+  }
+
+  public CharSequence operationName(@Nonnull final String protocol) {
+    return CACHE.computeIfAbsent(protocol, ADDER);
+  }
+}

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/UrlConnectionDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/UrlConnectionDecorator.java
@@ -1,0 +1,53 @@
+package datadog.trace.bootstrap.instrumentation.decorator;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UrlConnectionDecorator extends UriBasedClientDecorator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(UrlConnectionDecorator.class);
+
+  public static final CharSequence COMPONENT = UTF8BytesString.create("UrlConnection");
+  public static final UrlConnectionDecorator DECORATE = new UrlConnectionDecorator();
+
+  @Override
+  protected String[] instrumentationNames() {
+    return new String[] {"urlconnection", "httpurlconnection"};
+  }
+
+  @Override
+  protected CharSequence spanType() {
+    return InternalSpanTypes.HTTP_CLIENT;
+  }
+
+  @Override
+  protected CharSequence component() {
+    return COMPONENT;
+  }
+
+  @Override
+  protected String service() {
+    return null;
+  }
+
+  @Override
+  public void onURI(@Nonnull AgentSpan span, @Nonnull URI uri) {
+    super.onURI(span, uri);
+    span.setTag(Tags.HTTP_URL, uri.toString());
+  }
+
+  public void onURL(@Nonnull final AgentSpan span, @Nonnull final URL url) {
+    try {
+      onURI(span, url.toURI());
+    } catch (URISyntaxException e) {
+      LOGGER.debug("Error tagging url", e);
+    }
+  }
+}

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/httpurlconnection/HttpUrlState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/httpurlconnection/HttpUrlState.java
@@ -10,16 +10,13 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.net.HttpURLConnection;
 
 public class HttpUrlState {
-
-  public static final String OPERATION_NAME = "http.request";
-
   public static final ContextStore.Factory<HttpUrlState> FACTORY = HttpUrlState::new;
 
   private volatile AgentSpan span = null;
   private volatile boolean finished = false;
 
   public AgentSpan start(final HttpURLConnection connection) {
-    span = startSpan(OPERATION_NAME);
+    span = startSpan(DECORATE.operationName("http"));
     try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, connection);

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/UrlConnectionDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/UrlConnectionDecoratorTest.groovy
@@ -1,0 +1,80 @@
+package datadog.trace.bootstrap.instrumentation.decorator
+
+import datadog.trace.api.DDSpanTypes
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString
+
+class UrlConnectionDecoratorTest extends ClientDecoratorTest {
+  def "test url handling for #url"() {
+    setup:
+    def decorator = newDecorator()
+
+    when:
+    decorator.onURI(span, new URI(url))
+
+    then:
+    if (expectedUrl) {
+      1 * span.setTag(Tags.HTTP_URL, expectedUrl)
+    }
+    if (hostname) {
+      1 * span.setTag(Tags.PEER_HOSTNAME, hostname)
+    }
+    if (port) {
+      1 * span.setTag(Tags.PEER_PORT, port)
+    }
+    0 * _
+
+    where:
+    url                                  | expectedUrl                          | hostname | port
+    "https://host:0"                     | "https://host:0"                     | "host"   | null
+    "https://host/path"                  | "https://host/path"                  | "host"   | null
+    "http://host:99/path?query#fragment" | "http://host:99/path?query#fragment" | "host"   | 99
+  }
+
+  def "test operation name for protocol #protocol"() {
+    setup:
+    def decorator = newDecorator()
+
+    when:
+    def operationName = decorator.operationName(protocol)
+
+    then:
+    operationName instanceof UTF8BytesString
+    operationName.toString() == expectedOperationName
+
+    where:
+    protocol  | expectedOperationName
+    "http"    | "http.request"
+    "ftp"     | "ftp.request"
+    "file"    | "file.request"
+  }
+
+  @Override
+  def newDecorator() {
+    return new UrlConnectionDecorator() {
+        @Override
+        protected String[] instrumentationNames() {
+          return ["test1", "test2"]
+        }
+
+        @Override
+        protected CharSequence spanType() {
+          return DDSpanTypes.TEST
+        }
+
+        @Override
+        protected String service() {
+          return null
+        }
+
+        @Override
+        protected CharSequence component() {
+          return "test-component"
+        }
+
+        protected boolean traceAnalyticsDefault() {
+          return true
+        }
+      }
+  }
+}

--- a/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/UrlInstrumentation.java
+++ b/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/UrlInstrumentation.java
@@ -1,21 +1,17 @@
 package datadog.trace.instrumentation.http_url_connection;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static datadog.trace.api.cache.RadixTreeCache.PORTS;
-import static datadog.trace.api.cache.RadixTreeCache.UNSET_PORT;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.bootstrap.instrumentation.decorator.UrlConnectionDecorator.DECORATE;
 import static datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourceDecorator.HTTP_RESOURCE_DECORATOR;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
-import datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.net.URL;
 import java.net.URLStreamHandler;
 import net.bytebuddy.asm.Advice;
@@ -23,8 +19,6 @@ import net.bytebuddy.asm.Advice;
 @AutoService(Instrumenter.class)
 public class UrlInstrumentation extends Instrumenter.Tracing
     implements Instrumenter.ForBootstrap, Instrumenter.ForSingleType {
-
-  public static final String COMPONENT = "UrlConnection";
 
   public UrlInstrumentation() {
     super("urlconnection", "httpurlconnection");
@@ -53,23 +47,11 @@ public class UrlInstrumentation extends Instrumenter.Tracing
         String protocol = url.getProtocol();
         protocol = protocol != null ? protocol : "url";
 
-        final AgentSpan span =
-            startSpan(protocol + ".request")
-                .setTag(Tags.SPAN_KIND, Tags.SPAN_KIND_CLIENT)
-                .setSpanType(InternalSpanTypes.HTTP_CLIENT)
-                .setTag(Tags.COMPONENT, COMPONENT);
+        final AgentSpan span = startSpan(DECORATE.operationName(protocol));
 
         try (final AgentScope scope = activateSpan(span)) {
-          span.setTag(Tags.HTTP_URL, url.toString());
-          String host = url.getHost();
-          int port = url.getPort();
-          if (null != host && !host.isEmpty()) {
-            span.setTag(Tags.PEER_HOSTNAME, host);
-            span.setTag(Tags.PEER_PORT, port > UNSET_PORT ? PORTS.get(port) : PORTS.get(80));
-            if (Config.get().isHttpClientSplitByDomain() && host.charAt(0) >= 'A') {
-              span.setServiceName(host);
-            }
-          }
+          DECORATE.afterStart(span);
+          DECORATE.onURL(span, url);
           HTTP_RESOURCE_DECORATOR.withClientPath(span, null, url.getPath());
 
           span.setError(true);

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -10,10 +10,9 @@ import sun.net.www.protocol.https.HttpsURLConnectionImpl
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
-import static datadog.trace.bootstrap.instrumentation.httpurlconnection.HttpUrlState.OPERATION_NAME
 
 @Timeout(5)
-class HttpUrlConnectionTest extends HttpClientTest {
+abstract class HttpUrlConnectionTest extends HttpClientTest {
 
   static final RESPONSE = "Hello."
   static final STATUS = 200
@@ -102,7 +101,7 @@ class HttpUrlConnectionTest extends HttpClientTest {
           if (renameService) {
             serviceName "localhost"
           }
-          operationName OPERATION_NAME
+          operationName operation()
           resourceName "GET $url.path"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
@@ -122,7 +121,7 @@ class HttpUrlConnectionTest extends HttpClientTest {
           if (renameService) {
             serviceName "localhost"
           }
-          operationName OPERATION_NAME
+          operationName operation()
           resourceName "GET $url.path"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
@@ -192,7 +191,7 @@ class HttpUrlConnectionTest extends HttpClientTest {
           if (renameService) {
             serviceName "localhost"
           }
-          operationName OPERATION_NAME
+          operationName operation()
           resourceName "GET $url.path"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
@@ -212,7 +211,7 @@ class HttpUrlConnectionTest extends HttpClientTest {
           if (renameService) {
             serviceName "localhost"
           }
-          operationName OPERATION_NAME
+          operationName operation()
           resourceName "GET $url.path"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
@@ -267,7 +266,7 @@ class HttpUrlConnectionTest extends HttpClientTest {
           if (renameService) {
             serviceName "localhost"
           }
-          operationName OPERATION_NAME
+          operationName operation()
           resourceName "GET $url.path"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
@@ -338,7 +337,7 @@ class HttpUrlConnectionTest extends HttpClientTest {
           if (renameService) {
             serviceName "localhost"
           }
-          operationName OPERATION_NAME
+          operationName operation()
           resourceName "POST $url.path"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
@@ -372,5 +371,24 @@ class HttpUrlConnectionTest extends HttpClientTest {
 
     then:
     instance != null
+  }
+}
+
+class HttpUrlConnectionV0ForkedTest extends HttpUrlConnectionTest {}
+
+class HttpUrlConnectionV1ForkedTest extends HttpUrlConnectionTest {
+  @Override
+  protected int version() {
+    return 1
+  }
+
+  @Override
+  protected String service() {
+    return null
+  }
+
+  @Override
+  protected String operation() {
+    return "http.client.request"
   }
 }

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
@@ -1,16 +1,15 @@
-import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.DatadogClassLoader
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import datadog.trace.instrumentation.http_url_connection.UrlInstrumentation
+import datadog.trace.bootstrap.instrumentation.decorator.UrlConnectionDecorator
 
 import static datadog.trace.agent.test.utils.PortUtils.UNUSABLE_PORT
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
-import static datadog.trace.bootstrap.instrumentation.httpurlconnection.HttpUrlState.OPERATION_NAME
 
-class UrlConnectionTest extends AgentTestRunner {
+abstract class UrlConnectionTest extends VersionedNamingTestBase {
 
   def "trace request with connection failure #scheme"() {
     when:
@@ -42,7 +41,7 @@ class UrlConnectionTest extends AgentTestRunner {
           if (renameService) {
             serviceName "localhost"
           }
-          operationName OPERATION_NAME
+          operationName operation("http")
           resourceName "GET /"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
@@ -95,13 +94,13 @@ class UrlConnectionTest extends AgentTestRunner {
           }
         }
         span {
-          operationName "file.request"
+          operationName operation(url.protocol)
           resourceName "$url.path"
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           errored true
           tags {
-            "$Tags.COMPONENT" UrlInstrumentation.COMPONENT
+            "$Tags.COMPONENT" UrlConnectionDecorator.COMPONENT
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             // FIXME: These tags really make no sense for non-http connections, why do we set them?
             "$Tags.HTTP_URL" "$url"
@@ -143,5 +142,43 @@ class UrlConnectionTest extends AgentTestRunner {
         }
       }
     }
+  }
+
+  @Override
+  protected final String service() {
+    return null
+  }
+
+  @Override
+  protected final String operation() {
+    return null
+  }
+
+  abstract String operation(String protocol)
+}
+
+class UrlConnectionV0ForkedTest extends UrlConnectionTest {
+
+  @Override
+  protected int version() {
+    return 0
+  }
+
+  @Override
+  String operation(String protocol) {
+    return "${protocol}.request"
+  }
+}
+
+class UrlConnectionV1ForkedTest extends UrlConnectionTest {
+
+  @Override
+  protected int version() {
+    return 1
+  }
+
+  @Override
+  String operation(String protocol) {
+    return "${protocol}.client.request"
   }
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -1,7 +1,8 @@
 package datadog.trace.agent.test.base
 
-import datadog.trace.agent.test.AgentTestRunner
+
 import datadog.trace.agent.test.asserts.TraceAssert
+import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.agent.test.server.http.HttpProxy
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
@@ -27,7 +28,7 @@ import static datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecora
 import static org.junit.Assume.assumeTrue
 
 @Unroll
-abstract class HttpClientTest extends AgentTestRunner {
+abstract class HttpClientTest extends VersionedNamingTestBase {
   protected static final BODY_METHODS = ["POST", "PUT"]
   protected static final int CONNECT_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(3) as int
   protected static final int READ_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(5) as int
@@ -780,7 +781,7 @@ abstract class HttpClientTest extends AgentTestRunner {
   }
 
   String expectedOperationName() {
-    return "http.request"
+    return operation()
   }
 
   int size(int size) {
@@ -821,5 +822,20 @@ abstract class HttpClientTest extends AgentTestRunner {
     // FIXME: this hack is here because callback with parent is broken in play-ws when the stream()
     // function is used.  There is no way to stop a test from a derived class hence the flag
     true
+  }
+
+  @Override
+  protected int version() {
+    return 0
+  }
+
+  @Override
+  protected String service() {
+    return null
+  }
+
+  @Override
+  protected String operation() {
+    return "http.request"
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
@@ -11,6 +11,13 @@ public interface NamingSchema {
   ForCache cache();
 
   /**
+   * Get the naming policy for clients (http, soap, ...).
+   *
+   * @return a {@link NamingSchema.ForCache} instance.
+   */
+  ForClient client();
+
+  /**
    * Get the naming policy for databases.
    *
    * @return a {@link NamingSchema.ForDatabase} instance.
@@ -36,6 +43,17 @@ public interface NamingSchema {
      */
     @Nonnull
     String service(@Nonnull String ddService, @Nonnull String cacheSystem);
+  }
+
+  interface ForClient {
+    /**
+     * Calculate the operation name for a client span.
+     *
+     * @param protocol the protocol used (e.g. http, ftp, ..)
+     * @return the operation name
+     */
+    @Nonnull
+    String operation(@Nonnull String protocol);
   }
 
   interface ForDatabase {

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/ClientNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/ClientNamingV0.java
@@ -1,0 +1,12 @@
+package datadog.trace.api.naming.v0;
+
+import datadog.trace.api.naming.NamingSchema;
+import javax.annotation.Nonnull;
+
+public class ClientNamingV0 implements NamingSchema.ForClient {
+  @Nonnull
+  @Override
+  public String operation(@Nonnull String protocol) {
+    return protocol + ".request";
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/NamingSchemaV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/NamingSchemaV0.java
@@ -4,12 +4,18 @@ import datadog.trace.api.naming.NamingSchema;
 
 public class NamingSchemaV0 implements NamingSchema {
   private final NamingSchema.ForCache cacheNaming = new CacheNamingV0();
+  private final NamingSchema.ForClient clientNaming = new ClientNamingV0();
 
   private final NamingSchema.ForDatabase databaseNaming = new DatabaseNamingV0();
 
   @Override
   public NamingSchema.ForCache cache() {
     return cacheNaming;
+  }
+
+  @Override
+  public ForClient client() {
+    return clientNaming;
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/ClientNamingV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/ClientNamingV1.java
@@ -1,0 +1,27 @@
+package datadog.trace.api.naming.v1;
+
+import datadog.trace.api.naming.NamingSchema;
+import javax.annotation.Nonnull;
+
+public class ClientNamingV1 implements NamingSchema.ForClient {
+
+  @Nonnull
+  private String normalizeProtocol(@Nonnull final String protocol) {
+    switch (protocol) {
+      case "http":
+      case "https":
+        return "http";
+      case "ftp":
+      case "ftps":
+        return "ftp";
+      default:
+        return protocol;
+    }
+  }
+
+  @Nonnull
+  @Override
+  public String operation(@Nonnull String protocol) {
+    return normalizeProtocol(protocol) + ".client.request";
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/NamingSchemaV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/NamingSchemaV1.java
@@ -4,12 +4,18 @@ import datadog.trace.api.naming.NamingSchema;
 
 public class NamingSchemaV1 implements NamingSchema {
   private final NamingSchema.ForCache cacheNaming = new CacheNamingV1();
+  private final NamingSchema.ForClient clientNaming = new ClientNamingV1();
 
   private final NamingSchema.ForDatabase databaseNaming = new DatabaseNamingV1();
 
   @Override
   public NamingSchema.ForCache cache() {
     return cacheNaming;
+  }
+
+  @Override
+  public ForClient client() {
+    return clientNaming;
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

v1 naming schema for url connection client spans:
* operation `{{protocol}}.client.request`

special cases for {{protocol}} :
* http/https -> will use http
* ftp/ftps -> will use ftp

# Motivation

# Additional Notes
