### PR TITLE
update to Java profiler library 0.15.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -34,7 +34,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    jplib         : "0.14.0",
+    jplib         : "0.15.0",
     asm           : "9.4"
   ]
 


### PR DESCRIPTION
# What Does This Do
* Introduces rate limiting for non-JFR allocation profiling
* Combines allocation sampling for memory leak and allocation profiles (halves the overhead of having both profile types enabled)
* More efficient chunk rotation (reduces overhead)

# Motivation

# Additional Notes
