### PR TITLE
Tag profile events with span operation name 

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
@@ -2,6 +2,7 @@ package com.datadog.profiling.ddprof;
 
 import static datadog.trace.api.Platform.isJ9;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_CONTEXT_ATTRIBUTES;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_CONTEXT_ATTRIBUTES_SPAN_NAME_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_ALLOC_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_ALLOC_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_ALLOC_INTERVAL;
@@ -245,6 +246,14 @@ public class DatadogProfilerConfig {
   public static boolean isQueueingTimeEnabled(ConfigProvider configProvider) {
     return configProvider.getBoolean(
         PROFILING_QUEUEING_TIME_ENABLED, PROFILING_QUEUEING_TIME_ENABLED_DEFAULT);
+  }
+
+  public static boolean isSpanNameContextAttributeEnabled() {
+    return isSpanNameContextAttributeEnabled(ConfigProvider.getInstance());
+  }
+
+  public static boolean isSpanNameContextAttributeEnabled(ConfigProvider configProvider) {
+    return configProvider.getBoolean(PROFILING_CONTEXT_ATTRIBUTES_SPAN_NAME_ENABLED, true);
   }
 
   public static String getString(ConfigProvider configProvider, String key, String defaultValue) {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/TestProfilingContextIntegration.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/TestProfilingContextIntegration.groovy
@@ -1,5 +1,6 @@
 package datadog.trace.agent.test
 
+import datadog.trace.bootstrap.instrumentation.api.ProfilerContext
 import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration
 
 import java.util.concurrent.atomic.AtomicInteger
@@ -15,6 +16,14 @@ class TestProfilingContextIntegration implements ProfilingContextIntegration {
   @Override
   void onDetach() {
     detachments.incrementAndGet()
+  }
+
+  @Override
+  void setContext(ProfilerContext profilerContext) {
+  }
+
+  @Override
+  void clearContext() {
   }
 
   @Override

--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/JFRBasedProfilingIntegrationTest.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/JFRBasedProfilingIntegrationTest.java
@@ -98,6 +98,8 @@ class JFRBasedProfilingIntegrationTest {
   public static final IAttribute<String> FOO = attr("foo", "", "", PLAIN_TEXT);
   public static final IAttribute<String> BAR = attr("bar", "", "", PLAIN_TEXT);
 
+  public static final IAttribute<String> OPERATION = attr("operation", "", "", PLAIN_TEXT);
+
   private MockWebServer profilingServer;
   private MockWebServer tracingServer;
 
@@ -528,6 +530,7 @@ class JFRBasedProfilingIntegrationTest {
         IItemCollection executionSamples =
             events.apply(ItemFilters.type("datadog.ExecutionSample"));
         Set<Long> rootSpanIds = new HashSet<>();
+        Set<String> operations = new HashSet<>();
         Set<String> values = new HashSet<>();
         for (IItemIterable executionSampleEvents : executionSamples) {
           IMemberAccessor<IQuantity, IItem> rootSpanIdAccessor =
@@ -536,8 +539,14 @@ class JFRBasedProfilingIntegrationTest {
               FOO.getAccessor(executionSampleEvents.getType());
           IMemberAccessor<String, IItem> barAccessor =
               BAR.getAccessor(executionSampleEvents.getType());
+          IMemberAccessor<String, IItem> operationAccessor =
+              OPERATION.getAccessor(executionSampleEvents.getType());
           for (IItem executionSample : executionSampleEvents) {
-            rootSpanIds.add(rootSpanIdAccessor.getMember(executionSample).longValue());
+            long rootSpanId = rootSpanIdAccessor.getMember(executionSample).longValue();
+            rootSpanIds.add(rootSpanId);
+            if (rootSpanId != 0) {
+              operations.add(operationAccessor.getMember(executionSample));
+            }
             String foo = fooAccessor.getMember(executionSample);
             if (foo != null) {
               values.add(foo);
@@ -545,6 +554,8 @@ class JFRBasedProfilingIntegrationTest {
             assertNull(barAccessor.getMember(executionSample));
           }
         }
+        assertEquals(1, operations.size(), "wrong number of operation names");
+        assertEquals("trace.annotation", operations.iterator().next(), "wrong operation names");
         int matches = 0;
         for (IItemIterable event : endpointEvents) {
           IMemberAccessor<IQuantity, IItem> rootSpanIdAccessor =

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -147,6 +147,9 @@ public final class ProfilingConfig {
   public static final String PROFILING_CONTEXT_ATTRIBUTES =
       "profiling.experimental.context.attributes";
 
+  public static final String PROFILING_CONTEXT_ATTRIBUTES_SPAN_NAME_ENABLED =
+      "profiling.experimental.context.attributes.span.name.enabled";
+
   public static final String PROFILING_QUEUEING_TIME_ENABLED =
       "profiling.ddprof.experimental.queueing.time.enabled";
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1387,7 +1387,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
               requestContextDataIast,
               pathwayContext,
               disableSamplingMechanismValidation,
-              propagationTags);
+              propagationTags,
+              profilingContextIntegration);
 
       // By setting the tags on the context we apply decorators to any tags that have been set via
       // the builder. This is the order that the tags were added previously, but maybe the `tags`

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeStack.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeStack.java
@@ -1,6 +1,7 @@
 package datadog.trace.core.scopemanager;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.ProfilerContext;
 import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration;
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import java.util.ArrayDeque;
@@ -110,20 +111,20 @@ final class ScopeStack {
   }
 
   private void onTopChanged(ContinuableScope top) {
-    long spanId = top.span.getSpanId();
-    AgentSpan rootSpan = top.span.getLocalRootSpan();
-    long rootSpanId = rootSpan == null ? spanId : rootSpan.getSpanId();
-    profilingContextIntegration.setContext(rootSpanId, spanId);
+    AgentSpan.Context context = top.span.context();
+    if (context instanceof ProfilerContext) {
+      profilingContextIntegration.setContext((ProfilerContext) context);
+    }
   }
 
-  /** Notifies context thread listeners that this thread has a context now */
+  /** Notifies profiler that this thread has a context now */
   private void onBecomeNonEmpty() {
     profilingContextIntegration.onAttach();
   }
 
-  /** Notifies context thread listeners that this thread no longer has a context */
+  /** Notifies profiler that this thread no longer has a context */
   private void onBecomeEmpty() {
-    profilingContextIntegration.setContext(0, 0);
+    profilingContextIntegration.clearContext();
     profilingContextIntegration.onDetach();
   }
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -34,7 +34,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    jplib         : "0.15.0",
+    jplib         : "0.19.0",
     asm           : "9.4"
   ]
 

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -90,6 +90,7 @@ excludedClassesCoverage += [
   // Interface with default method
   "datadog.trace.api.StatsDClientManager",
   // a stub
+  "datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration",
   "datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration.NoOp",
 ]
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ProfilerContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ProfilerContext.java
@@ -1,0 +1,11 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+public interface ProfilerContext {
+
+  long getSpanId();
+
+  /** @return the span id of the local root span, or the span itself */
+  long getRootSpanId();
+
+  int getEncodedOperationName();
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ProfilingContextIntegration.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ProfilingContextIntegration.java
@@ -9,11 +9,19 @@ public interface ProfilingContextIntegration extends ProfilingContext {
   /** Invoked when a thread exits */
   void onDetach();
 
+  void setContext(ProfilerContext profilerContext);
+
+  void clearContext();
+
   void setContext(long rootSpanId, long spanId);
 
   boolean isQueuingTimeEnabled();
 
   void recordQueueingTime(long duration);
+
+  default int encode(CharSequence constant) {
+    return 0;
+  }
 
   final class NoOp implements ProfilingContextIntegration {
 
@@ -31,6 +39,12 @@ public interface ProfilingContextIntegration extends ProfilingContext {
 
     @Override
     public void onDetach() {}
+
+    @Override
+    public void setContext(ProfilerContext profilerContext) {}
+
+    @Override
+    public void clearContext() {}
 
     @Override
     public void setContext(long rootSpanId, long spanId) {}


### PR DESCRIPTION
# What Does This Do

This allows the span operation name to be recorded on profiling events (i.e. CPU, allocation, wall-time, memory leak samples). It does this by adding an operation attribute to the custom tags provided by the user, and every time a scope is activated, the operation name is set along with the span id and root span id we already set per scope activation. Profiling context can't store strings directly because we don't have enough space in each thread-local slot to do that, so they need to be dictionarized (replace them with an integer encoding) so we can store the dictionary code in the thread-local slot. The dictionary is then stored in a constant pool in the JFR recording.

Since scope activation can be an incredibly high frequency operation in some kinds of applications, the dictionarization requirement means we would need to do a potentially expensive lookup at an unpredictable rate, so instead module boundaries are broken slightly and the dictionarized operation name is stored in `DDSpanContext`. `DDSpanContext` is made to implement a new `ProfilerContext` interface which provides the context fields originating in the tracer, and this allows us to move a little more profiler logic out of the scope stack.

To do the dictionarization, we rely on the profiler library, so this value cached in `DDSpanContext` should not be relied upon by other products.

# Motivation

# Additional Notes
