### PR TITLE
Fix internal-api test compile with JDK >8 default

### DIFF
--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -18,6 +18,10 @@ compileJava {
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/tries.gradle"
 
+tasks.compileTestJava.configure {
+  setJavaVersion(it, 8)
+}
+
 minimumBranchCoverage = 0.7
 minimumInstructionCoverage = 0.8
 excludedClassesCoverage += [


### PR DESCRIPTION
# What Does This Do
Forces JDK 8 when compiling internal-api tests.

# Motivation
Unless JAVA_HOME was set to JDK 8, internal-api test compilation would fail.

# Additional Notes
