### PR TITLE
Test the right version in test-published-dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   dependencies {
-    classpath "pl.allegro.tech.build:axion-release-plugin:1.14.2"
+    classpath "pl.allegro.tech.build:axion-release-plugin:1.14.4"
   }
 
   configurations.all {
@@ -18,7 +18,7 @@ plugins {
   id "de.thetaphi.forbiddenapis" version "3.2"
 
   id 'org.unbroken-dome.test-sets' version '4.0.0'
-  id 'pl.allegro.tech.build.axion-release' version '1.14.2'
+  id 'pl.allegro.tech.build.axion-release' version '1.14.4'
   id 'io.github.gradle-nexus.publish-plugin' version '1.0.0'
 
   id "com.github.johnrengelman.shadow" version "7.1.2" apply false
@@ -112,16 +112,6 @@ wrapper {
   distributionType = Wrapper.DistributionType.ALL
 }
 
-allprojects {
-  tasks.withType(JavaForkOptions).configureEach {
-    maxHeapSize = System.properties["datadog.forkedMaxHeapSize"]
-    minHeapSize = System.properties["datadog.forkedMinHeapSize"]
-    jvmArgs "-XX:ErrorFile=/tmp/hs_err_pid%p.log"
-    jvmArgs "-XX:+HeapDumpOnOutOfMemoryError"
-    jvmArgs "-XX:HeapDumpPath=/tmp"
-  }
-}
-
 tasks.register('writeMuzzleTasksToFile') {
   doLast {
     def muzzleFile = file("${buildDir}/muzzleTasks")
@@ -130,5 +120,30 @@ tasks.register('writeMuzzleTasksToFile') {
     muzzleFile.text = subprojects.findAll { subproject -> subproject.plugins.hasPlugin('muzzle') }
     .collect { it.path + ":muzzle" }
     .join('\n')
+  }
+}
+
+def writeMainVersionFileTask = tasks.register('writeMainVersionFile') {
+  def versionFile = file("${rootProject.buildDir}/main.version")
+  inputs.property "version", scmVersion.version
+  outputs.file versionFile
+
+  doFirst {
+    assert versionFile.parentFile.mkdirs() || versionFile.parentFile.directory
+    versionFile.text = "${inputs.properties.version}"
+  }
+}
+
+allprojects {
+  tasks.withType(JavaForkOptions).configureEach {
+    maxHeapSize = System.properties["datadog.forkedMaxHeapSize"]
+    minHeapSize = System.properties["datadog.forkedMinHeapSize"]
+    jvmArgs "-XX:ErrorFile=/tmp/hs_err_pid%p.log"
+    jvmArgs "-XX:+HeapDumpOnOutOfMemoryError"
+    jvmArgs "-XX:HeapDumpPath=/tmp"
+  }
+
+  tasks.withType(PublishToMavenLocal).configureEach {
+    it.finalizedBy(writeMainVersionFileTask)
   }
 }

--- a/dd-smoke-tests/quarkus/application/build.gradle
+++ b/dd-smoke-tests/quarkus/application/build.gradle
@@ -2,7 +2,6 @@ plugins {
   id 'java'
   id 'io.quarkus'
   id "com.diffplug.spotless" version "6.11.0"
-  id 'pl.allegro.tech.build.axion-release' version '1.14.2'
 }
 
 def sharedRootDir = "$rootDir/../../../"

--- a/dd-smoke-tests/spring-boot-2.7-webflux/application/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.7-webflux/application/build.gradle
@@ -3,7 +3,6 @@ plugins {
   id 'org.springframework.boot' version '2.7.4'
   id 'io.spring.dependency-management' version '1.0.14.RELEASE'
   id "com.diffplug.spotless" version "6.11.0"
-  id 'pl.allegro.tech.build.axion-release' version '1.14.2'
 }
 
 def sharedRootDir = "$rootDir/../../../"

--- a/dd-smoke-tests/spring-boot-3.0-webflux/application/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.0-webflux/application/build.gradle
@@ -3,7 +3,6 @@ plugins {
   id 'org.springframework.boot' version '3.0.0'
   id 'io.spring.dependency-management' version '1.0.14.RELEASE'
   id "com.diffplug.spotless" version "6.11.0"
-  id 'pl.allegro.tech.build.axion-release' version '1.14.2'
 }
 
 def sharedRootDir = "$rootDir/../../../"

--- a/dd-smoke-tests/spring-boot-3.0-webmvc/application/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.0-webmvc/application/build.gradle
@@ -3,7 +3,6 @@ plugins {
   id 'org.springframework.boot' version '3.0.0'
   id 'io.spring.dependency-management' version '1.0.14.RELEASE'
   id "com.diffplug.spotless" version "6.11.0"
-  id 'pl.allegro.tech.build.axion-release' version '1.14.2'
 }
 
 def sharedRootDir = "$rootDir/../../../"

--- a/dd-smoke-tests/wildfly/spring-ear/build.gradle
+++ b/dd-smoke-tests/wildfly/spring-ear/build.gradle
@@ -2,7 +2,6 @@ plugins {
   id 'java'
   id 'ear'
   id "com.diffplug.spotless" version "6.11.0"
-  id 'pl.allegro.tech.build.axion-release' version '1.14.2'
 }
 
 def sharedRootDir = "$rootDir/../../../"

--- a/test-published-dependencies/build.gradle
+++ b/test-published-dependencies/build.gradle
@@ -1,21 +1,16 @@
 plugins {
   id "com.diffplug.spotless" version "6.11.0"
-  id 'pl.allegro.tech.build.axion-release' version '1.14.2'
 }
 
 def sharedConfigDirectory = "$rootDir/../gradle"
 rootProject.ext.sharedConfigDirectory = sharedConfigDirectory
 
-scmVersion {
-  repository {
-    directory = project.rootProject.file('../')
-  }
-}
-apply from: "$sharedConfigDirectory/scm.gradle"
+def isCI = System.getenv("CI") != null
+def versionFromFile = file("$rootDir/${isCI ? '../workspace' : '..'}/build/main.version").readLines().head()
 
 allprojects {
   group = 'com.datadoghq'
-  version = scmVersion.version
+  version = versionFromFile
 
   repositories {
     mavenLocal()


### PR DESCRIPTION
# What Does This Do

Removes the dependency on `axion-release` from _external_ gradle projects and makes `test-published-dependencies` use a file with the right version written by the `main` project.

# Motivation

The `scmVersion.repository.directory` setting of the `axion-release` plugin doesn't seem to work in the same way anymore and the `currentVersion` task returns the wrong version, i.e. `1.8.0` instead of `1.9.0-SNAPSHOT`, so we test the wrong version in `test-published-dependencies`.

# Additional Notes

The dependency on the `axion-release` plugin in a number of smoke tests had already been _removed_ in 0e306a78196 by setting `version = ""`.