### PR TITLE
Avoid relocating com.kenai.jffi in dd-trace-ot

### DIFF
--- a/dd-trace-ot/build.gradle
+++ b/dd-trace-ot/build.gradle
@@ -90,7 +90,11 @@ shadowJar {
     exclude(dependency('org.slf4j:'))
   }
 
-  relocate('com.', 'ddtrot.com.')
+  relocate('com.', 'ddtrot.com.') {
+    // don't relocate native methods
+    exclude('com.kenai.jffi.*')
+    exclude('com.kenai.jffi.internal.*')
+  }
   relocate('dogstatsd/', 'ddtrot/dogstatsd/')
   relocate('jni/', 'ddtrot/jni/')
   relocate('jnr/', 'ddtrot/jnr/')

--- a/test-published-dependencies/ot-is-shaded/build.gradle
+++ b/test-published-dependencies/ot-is-shaded/build.gradle
@@ -91,6 +91,9 @@ tasks.register('checkJarContents', CheckJarContentsTask) {
     '^[^/]*\\.version$',
     '^DDSketch.proto$',
     '^META-INF/.*$',
+    '^com/$',
+    '^com/kenai/$',
+    '^com/kenai/jffi/.*$',
     '^datadog/.*$',
     '^ddtrot/.*$'
   ]

--- a/test-published-dependencies/ot-pulls-in-api/src/test/java/CreateTracerTest.java
+++ b/test-published-dependencies/ot-pulls-in-api/src/test/java/CreateTracerTest.java
@@ -1,6 +1,8 @@
 import datadog.opentracing.DDTracer;
 import io.opentracing.util.GlobalTracer;
 import org.junit.jupiter.api.Test;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class CreateTracerTest {
 
@@ -12,5 +14,19 @@ public class CreateTracerTest {
     tracer.activateSpan(tracer.buildSpan("test-span").start()).close();
     // Sleep a bit so the trace sending machinery has a chance to start
     Thread.sleep(1000);
+  }
+
+  @Test
+  void buildTracerWithUDS() throws Exception {
+    // trigger use of JNR and JFFI to validate native method linking
+    Path fakeSocketPath = Files.createTempFile("dd-java", "test-uds");
+    System.setProperty("dd.trace.agent.url", "unix://" + fakeSocketPath.toUri().getPath());
+    try {
+      // we don't need to actually use the tracer, just build it
+      DDTracer.builder().serviceName("TestServiceWithUDS").build();
+    } finally {
+      System.clearProperty("dd.trace.agent.url");
+      Files.delete(fakeSocketPath);
+    }
   }
 }


### PR DESCRIPTION
because it contains native methods that have to match to the embedded native libraries