### PR TITLE
Naming schema: http clients

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
@@ -5,6 +5,7 @@ import static datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourc
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
+import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -94,5 +95,12 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends UriBasedCli
       }
     }
     return span;
+  }
+
+  public String operationName() {
+    return SpanNaming.instance()
+        .namingSchema()
+        .client()
+        .operationForComponent(component().toString());
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/UriBasedClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/UriBasedClientDecorator.java
@@ -1,22 +1,12 @@
 package datadog.trace.bootstrap.instrumentation.decorator;
 
 import datadog.trace.api.Config;
-import datadog.trace.api.cache.DDCache;
-import datadog.trace.api.cache.DDCaches;
-import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
-import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import java.net.URI;
-import java.util.function.Function;
 import javax.annotation.Nonnull;
 
 public abstract class UriBasedClientDecorator extends ClientDecorator {
-  private static final DDCache<String, CharSequence> CACHE = DDCaches.newFixedSizeCache(16);
-
-  private static final Function<String, CharSequence> ADDER =
-      protocol ->
-          UTF8BytesString.create(SpanNaming.instance().namingSchema().client().operation(protocol));
 
   public void onURI(@Nonnull final AgentSpan span, @Nonnull final URI uri) {
     String host = uri.getHost();
@@ -30,9 +20,5 @@ public abstract class UriBasedClientDecorator extends ClientDecorator {
         setPeerPort(span, port);
       }
     }
-  }
-
-  public CharSequence operationName(@Nonnull final String protocol) {
-    return CACHE.computeIfAbsent(protocol, ADDER);
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/httpurlconnection/HttpUrlConnectionDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/httpurlconnection/HttpUrlConnectionDecorator.java
@@ -8,10 +8,13 @@ import java.net.URISyntaxException;
 
 public class HttpUrlConnectionDecorator extends HttpClientDecorator<HttpURLConnection, Integer> {
 
-  private static final CharSequence HTTP_URL_CONNECTION =
+  public static final CharSequence HTTP_URL_CONNECTION =
       UTF8BytesString.create("http-url-connection");
 
   public static final HttpUrlConnectionDecorator DECORATE = new HttpUrlConnectionDecorator();
+
+  public static final CharSequence OPERATION_NAME =
+      UTF8BytesString.create(DECORATE.operationName());
 
   @Override
   protected String[] instrumentationNames() {

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/httpurlconnection/HttpUrlState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/httpurlconnection/HttpUrlState.java
@@ -16,7 +16,7 @@ public class HttpUrlState {
   private volatile boolean finished = false;
 
   public AgentSpan start(final HttpURLConnection connection) {
-    span = startSpan(DECORATE.operationName("http"));
+    span = startSpan(DECORATE.operationName());
     try (final AgentScope scope = activateSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, connection);

--- a/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeAsyncClientTest.groovy
@@ -64,34 +64,34 @@ abstract class AerospikeAsyncClientTest extends AerospikeBaseTest {
 
 class AerospikeAsyncClientV0ForkedTest extends AerospikeAsyncClientTest {
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "aerospike"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "aerospike.query"
   }
 }
 
 class AerospikeAsyncClientV1ForkedTest extends AerospikeAsyncClientTest {
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return Config.get().getServiceName() + "-aerospike"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "aerospike.query"
   }
 }

--- a/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeClientTest.groovy
+++ b/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeClientTest.groovy
@@ -42,34 +42,34 @@ abstract class AerospikeClientTest extends AerospikeBaseTest {
 
 class AerospikeClientV0ForkedTest extends AerospikeClientTest {
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "aerospike"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "aerospike.query"
   }
 }
 
 class AerospikeClientV1ForkedTest extends AerospikeClientTest {
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return Config.get().getServiceName() + "-aerospike"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "aerospike.query"
   }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/baseTest/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/baseTest/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -8,6 +8,7 @@ import akka.http.javadsl.model.headers.RawHeader
 import akka.http.scaladsl.settings.ConnectionPoolSettings
 import akka.stream.ActorMaterializer
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.akkahttp.AkkaHttpClientDecorator
@@ -61,11 +62,6 @@ abstract class AkkaHttpClientInstrumentationTest extends HttpClientTest {
   }
 
   @Override
-  String expectedOperationName() {
-    return "akka-http.client.request"
-  }
-
-  @Override
   boolean testRedirects() {
     false
   }
@@ -91,7 +87,7 @@ abstract class AkkaHttpClientInstrumentationTest extends HttpClientTest {
       trace(1) {
         span {
           parent()
-          operationName "akka-http.client.request"
+          operationName operation()
           resourceName "akka-http.client.request"
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
@@ -110,7 +106,8 @@ abstract class AkkaHttpClientInstrumentationTest extends HttpClientTest {
   }
 }
 
-class AkkaHttpJavaClientInstrumentationTest extends AkkaHttpClientInstrumentationTest {
+
+abstract class AkkaHttpJavaClientInstrumentationTest extends AkkaHttpClientInstrumentationTest {
   @Override
   CompletionStage<HttpResponse> doRequest(HttpRequest request) {
     if (callsNeedMaterializer) {
@@ -120,7 +117,8 @@ class AkkaHttpJavaClientInstrumentationTest extends AkkaHttpClientInstrumentatio
   }
 }
 
-class AkkaHttpScalaClientInstrumentationTest extends AkkaHttpClientInstrumentationTest {
+
+abstract class AkkaHttpScalaClientInstrumentationTest extends AkkaHttpClientInstrumentationTest {
   @Override
   CompletionStage<HttpResponse> doRequest(HttpRequest request) {
     def http = akka.http.scaladsl.Http.apply(system)
@@ -133,4 +131,47 @@ class AkkaHttpScalaClientInstrumentationTest extends AkkaHttpClientInstrumentati
     }
     return FutureConverters.toJava(f)
   }
+}
+
+class AkkaHttpJavaClientInstrumentationV0ForkedTest extends AkkaHttpJavaClientInstrumentationTest {
+
+  @Override
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "akka-http.client.request"
+  }
+}
+
+class AkkaHttpJavaClientInstrumentationV1ForkedTest extends AkkaHttpJavaClientInstrumentationTest implements TestingGenericHttpNamingConventions.ClientV1 {
+}
+
+class AkkaHttpScalaClientInstrumentationV0ForkedTest extends AkkaHttpScalaClientInstrumentationTest {
+
+  @Override
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "akka-http.client.request"
+  }
+}
+
+class AkkaHttpScalaClientInstrumentationV1ForkedTest extends AkkaHttpScalaClientInstrumentationTest implements TestingGenericHttpNamingConventions.ClientV1{
+
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpClientDecorator.java
@@ -8,10 +8,10 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 public class AkkaHttpClientDecorator extends HttpClientDecorator<HttpRequest, HttpResponse> {
-  public static final CharSequence AKKA_CLIENT_REQUEST =
-      UTF8BytesString.create("akka-http.client.request");
   public static final CharSequence AKKA_HTTP_CLIENT = UTF8BytesString.create("akka-http-client");
   public static final AkkaHttpClientDecorator DECORATE = new AkkaHttpClientDecorator();
+  public static final CharSequence AKKA_CLIENT_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
 
   @Override
   protected String[] instrumentationNames() {

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientDecorator.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientDecorator.java
@@ -14,12 +14,12 @@ import org.apache.http.protocol.HttpCoreContext;
 
 public class ApacheHttpAsyncClientDecorator extends HttpClientDecorator<HttpRequest, HttpContext> {
 
-  public static final CharSequence HTTP_REQUEST = UTF8BytesString.create("http.request");
   public static final CharSequence APACHE_HTTPASYNCCLIENT =
       UTF8BytesString.create("apache-httpasyncclient");
 
   public static final ApacheHttpAsyncClientDecorator DECORATE =
       new ApacheHttpAsyncClientDecorator();
+  public static final CharSequence HTTP_REQUEST = UTF8BytesString.create(DECORATE.operationName());
 
   @Override
   protected String[] instrumentationNames() {

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientCallbackTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientCallbackTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator
 import org.apache.http.HttpResponse
 import org.apache.http.client.config.RequestConfig
@@ -13,7 +14,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
 @Timeout(5)
-class ApacheHttpAsyncClientCallbackTest extends HttpClientTest {
+class ApacheHttpAsyncClientCallbackTest extends HttpClientTest implements TestingGenericHttpNamingConventions.ClientV0 {
 
   @Shared
   RequestConfig requestConfig = RequestConfig.custom()

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientNullCallbackTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientNullCallbackTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator
 import org.apache.http.client.config.RequestConfig
 import org.apache.http.impl.nio.client.HttpAsyncClients
@@ -10,7 +11,7 @@ import spock.lang.Timeout
 import java.util.concurrent.Future
 
 @Timeout(5)
-class ApacheHttpAsyncClientNullCallbackTest extends HttpClientTest {
+class ApacheHttpAsyncClientNullCallbackTest extends HttpClientTest implements TestingGenericHttpNamingConventions.ClientV0{
 
   @Shared
   RequestConfig requestConfig = RequestConfig.custom()

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator
 import org.apache.http.HttpResponse
 import org.apache.http.client.config.RequestConfig
@@ -12,7 +13,7 @@ import spock.lang.Timeout
 import java.util.concurrent.CountDownLatch
 
 @Timeout(5)
-class ApacheHttpAsyncClientTest extends HttpClientTest {
+abstract class ApacheHttpAsyncClientTest extends HttpClientTest {
 
   @Shared
   RequestConfig requestConfig = RequestConfig.custom()
@@ -80,4 +81,10 @@ class ApacheHttpAsyncClientTest extends HttpClientTest {
   boolean testRemoteConnection() {
     false // otherwise SocketTimeoutException for https requests
   }
+}
+
+class ApacheHttpAsyncClientV0ForkedTest extends ApacheHttpAsyncClientTest implements TestingGenericHttpNamingConventions.ClientV0 {
+}
+
+class ApacheHttpAsyncClientV1ForkedTest extends ApacheHttpAsyncClientTest implements TestingGenericHttpNamingConventions.ClientV1 {
 }

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientDecorator.java
@@ -8,9 +8,10 @@ import org.apache.http.client.methods.HttpUriRequest;
 
 public class ApacheHttpClientDecorator extends HttpClientDecorator<HttpUriRequest, HttpResponse> {
 
-  public static final CharSequence HTTP_REQUEST = UTF8BytesString.create("http.request");
   public static final CharSequence APACHE_HTTP_CLIENT = UTF8BytesString.create("apache-httpclient");
   public static final ApacheHttpClientDecorator DECORATE = new ApacheHttpClientDecorator();
+
+  public static final CharSequence HTTP_REQUEST = UTF8BytesString.create(DECORATE.operationName());
 
   @Override
   protected String[] instrumentationNames() {

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/ApacheHttpClientResponseHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/ApacheHttpClientResponseHandlerTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.apachehttpclient.ApacheHttpClientDecorator
 import org.apache.http.HttpResponse
 import org.apache.http.client.ResponseHandler
@@ -10,7 +11,7 @@ import spock.lang.Shared
 import spock.lang.Timeout
 
 @Timeout(5)
-class ApacheHttpClientResponseHandlerTest extends HttpClientTest {
+class ApacheHttpClientResponseHandlerTest extends HttpClientTest implements TestingGenericHttpNamingConventions.ClientV0 {
 
   @Shared
   def client = new DefaultHttpClient()

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/ApacheHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/ApacheHttpClientTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.apachehttpclient.ApacheHttpClientDecorator
 import org.apache.http.HttpHost
 import org.apache.http.HttpRequest
@@ -12,7 +13,7 @@ import org.apache.http.protocol.BasicHttpContext
 import spock.lang.Shared
 import spock.lang.Timeout
 
-abstract class ApacheHttpClientTest<T extends HttpRequest> extends HttpClientTest {
+abstract class ApacheHttpClientTest<T extends HttpRequest> extends HttpClientTest implements TestingGenericHttpNamingConventions.ClientV0 {
   @Shared
   def client = new DefaultHttpClient()
 
@@ -175,8 +176,7 @@ class ApacheClientUriRequestResponseHandler extends ApacheHttpClientTest<HttpUri
   }
 }
 
-@Timeout(5)
-class ApacheClientUriRequestResponseHandlerContext extends ApacheHttpClientTest<HttpUriRequest> {
+abstract class ApacheClientUriRequestResponseHandlerContext extends ApacheHttpClientTest<HttpUriRequest> {
   @Override
   HttpUriRequest createRequest(String method, URI uri) {
     return new HttpUriRequest(method, uri)
@@ -186,4 +186,12 @@ class ApacheClientUriRequestResponseHandlerContext extends ApacheHttpClientTest<
   HttpResponse executeRequest(HttpUriRequest request, URI uri) {
     return client.execute(request, { response -> response })
   }
+}
+
+@Timeout(5)
+class ApacheClientUriRequestResponseHandlerContextV0ForkedTest extends ApacheClientUriRequestResponseHandlerContext {
+}
+
+@Timeout(5)
+class ApacheClientUriRequestResponseHandlerContextV1ForkedTest extends ApacheClientUriRequestResponseHandlerContext implements TestingGenericHttpNamingConventions.ClientV1 {
 }

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpClientDecorator.java
@@ -9,10 +9,10 @@ import org.apache.hc.core5.http.HttpResponse;
 
 public class ApacheHttpClientDecorator extends HttpClientDecorator<HttpRequest, HttpResponse> {
 
-  public static final CharSequence HTTP_REQUEST = UTF8BytesString.create("http.request");
   public static final CharSequence APACHE_HTTP_CLIENT =
       UTF8BytesString.create("apache-httpclient5");
   public static final ApacheHttpClientDecorator DECORATE = new ApacheHttpClientDecorator();
+  public static final CharSequence HTTP_REQUEST = UTF8BytesString.create(DECORATE.operationName());
 
   @Override
   protected String[] instrumentationNames() {

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpAsyncClient5Test.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpAsyncClient5Test.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequests
 import org.apache.hc.client5.http.config.RequestConfig
@@ -11,7 +12,7 @@ import java.util.concurrent.TimeUnit
 
 import static org.apache.hc.core5.reactor.IOReactorConfig.custom
 
-class ApacheHttpAsyncClient5Test<T extends HttpRequest> extends HttpClientTest {
+abstract class ApacheHttpAsyncClient5Test<T extends HttpRequest> extends HttpClientTest {
 
   @Shared
   def ioReactorConfig = custom()
@@ -54,4 +55,10 @@ class ApacheHttpAsyncClient5Test<T extends HttpRequest> extends HttpClientTest {
     callback?.call()
     return response.code
   }
+}
+
+class ApacheHttpAsyncClient5NamingV0ForkedTest extends ApacheHttpAsyncClient5Test implements TestingGenericHttpNamingConventions.ClientV0 {
+}
+
+class ApacheHttpAsyncClient5NamingV1ForkedTest extends ApacheHttpAsyncClient5Test implements TestingGenericHttpNamingConventions.ClientV1 {
 }

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpClientResponseHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpClientResponseHandlerTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator
 import org.apache.hc.client5.http.config.RequestConfig
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse
@@ -14,7 +15,7 @@ import spock.lang.Timeout
 import java.util.concurrent.TimeUnit
 
 @Timeout(5)
-class ApacheHttpClientResponseHandlerTest extends HttpClientTest {
+class ApacheHttpClientResponseHandlerTest extends HttpClientTest implements TestingGenericHttpNamingConventions.ClientV0 {
 
   @Shared
   def client = HttpClients.custom()

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpClientTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator
 import org.apache.hc.client5.http.config.RequestConfig
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse
@@ -15,7 +16,7 @@ import spock.lang.Timeout
 
 import java.util.concurrent.TimeUnit
 
-abstract class ApacheHttpClientTest<T extends HttpRequest> extends HttpClientTest {
+abstract class ApacheHttpClientTest<T extends HttpRequest> extends HttpClientTest implements TestingGenericHttpNamingConventions.ClientV0 {
 
   @Shared
   def client = HttpClients.custom()
@@ -181,8 +182,7 @@ class ApacheClientRequestContextResponseHandler extends ApacheHttpClientTest<Cla
   }
 }
 
-@Timeout(5)
-class ApacheClientResponseHandlerAll extends ApacheHttpClientTest<ClassicHttpRequest> {
+abstract class ApacheClientResponseHandlerAll extends ApacheHttpClientTest<ClassicHttpRequest> {
   @Override
   ClassicHttpRequest createRequest(String method, URI uri) {
     return new BasicClassicHttpRequest(method, fullPathFromURI(uri))
@@ -193,3 +193,12 @@ class ApacheClientResponseHandlerAll extends ApacheHttpClientTest<ClassicHttpReq
     return client.execute(new HttpHost(uri.scheme, uri.host, uri.port), request, new BasicHttpContext(), { CloseableHttpResponse response -> response })
   }
 }
+
+@Timeout(5)
+class ApacheClientResponseHandlerAllV0ForkedTest extends ApacheClientResponseHandlerAll {
+}
+
+@Timeout(5)
+class ApacheClientResponseHandlerAllV1ForkedTest extends ApacheClientResponseHandlerAll implements TestingGenericHttpNamingConventions.ClientV1 {
+}
+

--- a/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/CommonsHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/CommonsHttpClientDecorator.java
@@ -9,10 +9,11 @@ import org.apache.commons.httpclient.StatusLine;
 import org.apache.commons.httpclient.URIException;
 
 public class CommonsHttpClientDecorator extends HttpClientDecorator<HttpMethod, HttpMethod> {
-  public static final CharSequence HTTP_REQUEST = UTF8BytesString.create("http.request");
   public static final CharSequence COMMONS_HTTP_CLIENT =
       UTF8BytesString.create("commons-http-client");
   public static final CommonsHttpClientDecorator DECORATE = new CommonsHttpClientDecorator();
+
+  public static final CharSequence HTTP_REQUEST = UTF8BytesString.create(DECORATE.operationName());
 
   @Override
   protected String[] instrumentationNames() {

--- a/dd-java-agent/instrumentation/commons-httpclient-2/src/test/groovy/CommonsHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/src/test/groovy/CommonsHttpClientTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.commonshttpclient.CommonsHttpClientDecorator
 import org.apache.commons.httpclient.HttpClient
 import org.apache.commons.httpclient.HttpMethod
@@ -13,7 +14,7 @@ import spock.lang.Shared
 import spock.lang.Timeout
 
 @Timeout(5)
-class CommonsHttpClientTest extends HttpClientTest {
+abstract class CommonsHttpClientTest extends HttpClientTest {
   @Shared
   HttpClient client = new HttpClient()
 
@@ -73,4 +74,10 @@ class CommonsHttpClientTest extends HttpClientTest {
     // Generates 4 spans
     false
   }
+}
+
+class CommonsHttpClientV0ForkedTest extends CommonsHttpClientTest implements TestingGenericHttpNamingConventions.ClientV0 {
+}
+
+class CommonsHttpClientV1ForkedTest extends CommonsHttpClientTest implements TestingGenericHttpNamingConventions.ClientV1 {
 }

--- a/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
@@ -189,17 +189,17 @@ class CouchbaseAsyncClientV0ForkedTest extends CouchbaseAsyncClientTest {
 
 class CouchbaseAsyncClientV1ForkedTest extends CouchbaseAsyncClientTest {
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return Config.get().getServiceName() + "-couchbase"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "couchbase.query"
   }
 }

--- a/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
@@ -131,17 +131,17 @@ class CouchbaseClientV0ForkedTest extends CouchbaseClientTest {
 
 class CouchbaseClientV1ForkedTest extends CouchbaseClientTest {
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return Config.get().getServiceName() + "-couchbase"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "couchbase.query"
   }
 }

--- a/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
@@ -160,17 +160,17 @@ abstract class AbstractCouchbaseTest extends VersionedNamingTestBase {
   }
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "couchbase"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "couchbase.call"
   }
 }

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/test/groovy/CouchbaseClient31Test.groovy
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/test/groovy/CouchbaseClient31Test.groovy
@@ -418,34 +418,34 @@ abstract class CouchbaseClient31Test extends VersionedNamingTestBase {
 
 class CouchbaseClient31V0ForkedTest extends CouchbaseClient31Test {
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "couchbase"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "couchbase.call"
   }
 }
 
 class CouchbaseClient31V1ForkedTest extends CouchbaseClient31Test {
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return Config.get().getServiceName() + "-couchbase"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "couchbase.query"
   }
 }

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/test/groovy/CouchbaseClient32Test.groovy
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/test/groovy/CouchbaseClient32Test.groovy
@@ -429,34 +429,34 @@ abstract class CouchbaseClient32Test extends VersionedNamingTestBase {
 
 class CouchbaseClient32V0ForkedTest extends CouchbaseClient32Test {
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "couchbase"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "couchbase.call"
   }
 }
 
 class CouchbaseClient32V1ForkedTest extends CouchbaseClient32Test {
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return Config.get().getServiceName() + "-couchbase"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "couchbase.query"
   }
 }

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/src/test/groovy/CassandraClientTest.groovy
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/src/test/groovy/CassandraClientTest.groovy
@@ -161,17 +161,17 @@ abstract class CassandraClientTest extends VersionedNamingTestBase {
 class CassandraClientV0ForkedTest extends CassandraClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "cassandra"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "cassandra.query"
   }
 }
@@ -179,17 +179,17 @@ class CassandraClientV0ForkedTest extends CassandraClientTest {
 class CassandraClientV1ForkedTest extends CassandraClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return Config.get().getServiceName() + "-cassandra"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "cassandra.query"
   }
 }

--- a/dd-java-agent/instrumentation/datastax-cassandra-4/src/test/groovy/CassandraClientTest.groovy
+++ b/dd-java-agent/instrumentation/datastax-cassandra-4/src/test/groovy/CassandraClientTest.groovy
@@ -242,17 +242,17 @@ abstract class CassandraClientTest extends VersionedNamingTestBase {
 class CassandraClientV0ForkedTest extends CassandraClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "cassandra"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "cassandra.query"
   }
 }
@@ -260,17 +260,17 @@ class CassandraClientV0ForkedTest extends CassandraClientTest {
 class CassandraClientV1ForkedTest extends CassandraClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return Config.get().getServiceName() + "-cassandra"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "cassandra.query"
   }
 }

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
@@ -1,6 +1,7 @@
 import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.naming.SpanNaming
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.test.util.Flaky
 import groovy.json.JsonSlurper
@@ -103,7 +104,7 @@ abstract class Elasticsearch5RestClientTest extends VersionedNamingTestBase {
         span {
           serviceName service()
           resourceName "GET _cluster/health"
-          operationName "http.request"
+          operationName SpanNaming.instance().namingSchema().client().operationForComponent("apache-httpasyncclient")
           spanType DDSpanTypes.HTTP_CLIENT
           childOf span(0)
           tags {
@@ -120,38 +121,38 @@ abstract class Elasticsearch5RestClientTest extends VersionedNamingTestBase {
   }
 }
 
-class Elasticsearch6RestClientV0ForkedTest extends Elasticsearch5RestClientTest {
+class Elasticsearch5RestClientV0ForkedTest extends Elasticsearch5RestClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "elasticsearch"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "elasticsearch.rest.query"
   }
 }
 
-class Elasticsearch6RestClientV1ForkedTest extends Elasticsearch5RestClientTest {
+class Elasticsearch5RestClientV1ForkedTest extends Elasticsearch5RestClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return Config.get().getServiceName() + "-elasticsearch"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "elasticsearch.query"
   }
 }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -290,17 +290,17 @@ abstract class Elasticsearch2NodeClientTest extends VersionedNamingTestBase {
 class Elasticsearch2NodeClientV0ForkedTest extends Elasticsearch2NodeClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "elasticsearch"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "elasticsearch.query"
   }
 }
@@ -308,17 +308,17 @@ class Elasticsearch2NodeClientV0ForkedTest extends Elasticsearch2NodeClientTest 
 class Elasticsearch2NodeClientV1ForkedTest extends Elasticsearch2NodeClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return Config.get().getServiceName() + "-elasticsearch"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "elasticsearch.query"
   }
 }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -352,17 +352,17 @@ abstract class Elasticsearch2TransportClientTest extends VersionedNamingTestBase
 class Elasticsearch2TransportClientV0ForkedTest extends Elasticsearch2TransportClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "elasticsearch"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "elasticsearch.query"
   }
 }
@@ -370,17 +370,17 @@ class Elasticsearch2TransportClientV0ForkedTest extends Elasticsearch2TransportC
 class Elasticsearch2TransportClientV1ForkedTest extends Elasticsearch2TransportClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return Config.get().getServiceName() + "-elasticsearch"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "elasticsearch.query"
   }
 }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -303,17 +303,17 @@ abstract class Elasticsearch2SpringRepositoryTest extends VersionedNamingTestBas
 class Elasticsearch2SpringRepositoryV0ForkedTest extends Elasticsearch2SpringRepositoryTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "elasticsearch"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "elasticsearch.query"
   }
 }
@@ -321,17 +321,17 @@ class Elasticsearch2SpringRepositoryV0ForkedTest extends Elasticsearch2SpringRep
 class Elasticsearch2SpringRepositoryV1ForkedTest extends Elasticsearch2SpringRepositoryTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return datadog.trace.api.Config.get().getServiceName() + "-elasticsearch"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "elasticsearch.query"
   }
 }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -353,17 +353,17 @@ abstract class Elasticsearch2SpringTemplateTest extends VersionedNamingTestBase 
 class Elasticsearch2SpringTemplateV0ForkedTest extends Elasticsearch2SpringTemplateTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "elasticsearch"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "elasticsearch.query"
   }
 }
@@ -371,17 +371,17 @@ class Elasticsearch2SpringTemplateV0ForkedTest extends Elasticsearch2SpringTempl
 class Elasticsearch2SpringTemplateV1ForkedTest extends Elasticsearch2SpringTemplateTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return datadog.trace.api.Config.get().getServiceName() + "-elasticsearch"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "elasticsearch.query"
   }
 }

--- a/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
@@ -16,8 +16,8 @@ public class GoogleHttpClientDecorator extends HttpClientDecorator<HttpRequest, 
   private static final Pattern URL_REPLACEMENT = Pattern.compile("%20");
   public static final CharSequence GOOGLE_HTTP_CLIENT =
       UTF8BytesString.create("google-http-client");
-  public static final CharSequence HTTP_REQUEST = UTF8BytesString.create("http.request");
   public static final GoogleHttpClientDecorator DECORATE = new GoogleHttpClientDecorator();
+  public static final CharSequence HTTP_REQUEST = UTF8BytesString.create(DECORATE.operationName());
 
   @Override
   protected String method(final HttpRequest httpRequest) {

--- a/dd-java-agent/instrumentation/google-http-client/src/test/groovy/GoogleHttpClientAsyncTest.groovy
+++ b/dd-java-agent/instrumentation/google-http-client/src/test/groovy/GoogleHttpClientAsyncTest.groovy
@@ -1,11 +1,12 @@
 import com.google.api.client.http.HttpRequest
 import com.google.api.client.http.HttpResponse
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.test.util.Flaky
 import spock.lang.Timeout
 
 @Flaky
 @Timeout(5)
-class GoogleHttpClientAsyncTest extends AbstractGoogleHttpClientTest {
+class GoogleHttpClientAsyncTest extends AbstractGoogleHttpClientTest implements TestingGenericHttpNamingConventions.ClientV0 {
   @Override
   HttpResponse executeRequest(HttpRequest request) {
     return request.executeAsync().get()

--- a/dd-java-agent/instrumentation/google-http-client/src/test/groovy/GoogleHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/google-http-client/src/test/groovy/GoogleHttpClientTest.groovy
@@ -1,12 +1,20 @@
 import com.google.api.client.http.HttpRequest
 import com.google.api.client.http.HttpResponse
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import spock.lang.Timeout
 
-@Timeout(5)
-class GoogleHttpClientTest extends AbstractGoogleHttpClientTest {
+abstract class GoogleHttpClientTest extends AbstractGoogleHttpClientTest {
 
   @Override
   HttpResponse executeRequest(HttpRequest request) {
     return request.execute()
   }
+}
+
+@Timeout(5)
+class GoogleHttpClientV0ForkedTest extends GoogleHttpClientTest implements TestingGenericHttpNamingConventions.ClientV0 {
+}
+
+@Timeout(5)
+class GoogleHttpClientV1ForkedTest extends GoogleHttpClientTest implements TestingGenericHttpNamingConventions.ClientV1 {
 }

--- a/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/ClientDecorator.java
+++ b/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/ClientDecorator.java
@@ -9,10 +9,11 @@ import java.net.URISyntaxException;
 
 public class ClientDecorator extends HttpClientDecorator<Request, Response> {
 
-  public static final CharSequence HTTP_REQUEST = UTF8BytesString.create("http.request");
   private static final CharSequence GRIZZLY_HTTP_ASYNC_CLIENT =
       UTF8BytesString.create("grizzly-http-async-client");
   public static final ClientDecorator DECORATE = new ClientDecorator();
+
+  public static final CharSequence HTTP_REQUEST = UTF8BytesString.create(DECORATE.operationName());
 
   @Override
   protected String[] instrumentationNames() {

--- a/dd-java-agent/instrumentation/grizzly-client-1.9/src/test/groovy/GrizzlyAsyncHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-client-1.9/src/test/groovy/GrizzlyAsyncHttpClientTest.groovy
@@ -5,11 +5,12 @@ import com.ning.http.client.RequestBuilder
 import com.ning.http.client.Response
 import com.ning.http.client.uri.Uri
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.grizzly.client.ClientDecorator
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 
-class GrizzlyAsyncHttpClientTest extends HttpClientTest {
+abstract class GrizzlyAsyncHttpClientTest extends HttpClientTest {
 
   @AutoCleanup
   @Shared
@@ -76,4 +77,9 @@ class GrizzlyAsyncHttpClientTest extends HttpClientTest {
   }
 }
 
+class GrizzlyAsyncHttpClientV0ForkedTest extends GrizzlyAsyncHttpClientTest implements TestingGenericHttpNamingConventions.ClientV0 {
+}
+
+class GrizzlyAsyncHttpClientV1ForkedTest extends GrizzlyAsyncHttpClientTest implements TestingGenericHttpNamingConventions.ClientV1 {
+}
 

--- a/dd-java-agent/instrumentation/hazelcast-3.6/src/test/groovy/test/hazelcast/v3/HazelcastTest.groovy
+++ b/dd-java-agent/instrumentation/hazelcast-3.6/src/test/groovy/test/hazelcast/v3/HazelcastTest.groovy
@@ -354,17 +354,17 @@ abstract class HazelcastTest extends VersionedNamingTestBase {
 class HazelcastV0ForkedTest extends HazelcastTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "hazelcast-sdk"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "hazelcast.invoke"
   }
 }
@@ -372,17 +372,17 @@ class HazelcastV0ForkedTest extends HazelcastTest {
 class HazelcastV1ForkedTest extends HazelcastTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return datadog.trace.api.Config.get().getServiceName() + "-hazelcast"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "hazelcast.command"
   }
 }

--- a/dd-java-agent/instrumentation/hazelcast-3.9/src/test/groovy/test/hazelcast/v39/HazelcastTest.groovy
+++ b/dd-java-agent/instrumentation/hazelcast-3.9/src/test/groovy/test/hazelcast/v39/HazelcastTest.groovy
@@ -412,17 +412,17 @@ abstract class HazelcastTest extends VersionedNamingTestBase {
 class HazelcastV0ForkedTest extends HazelcastTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "hazelcast-sdk"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "hazelcast.invoke"
   }
 }
@@ -430,17 +430,17 @@ class HazelcastV0ForkedTest extends HazelcastTest {
 class HazelcastV1ForkedTest extends HazelcastTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return datadog.trace.api.Config.get().getServiceName() + "-hazelcast"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "hazelcast.command"
   }
 }

--- a/dd-java-agent/instrumentation/hazelcast-4.0/src/test/groovy/test/hazelcast/v4/HazelcastTest.groovy
+++ b/dd-java-agent/instrumentation/hazelcast-4.0/src/test/groovy/test/hazelcast/v4/HazelcastTest.groovy
@@ -444,17 +444,17 @@ abstract class HazelcastTest extends VersionedNamingTestBase {
 class HazelcastV0ForkedTest extends HazelcastTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "hazelcast-sdk"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "hazelcast.invoke"
   }
 }
@@ -462,17 +462,17 @@ class HazelcastV0ForkedTest extends HazelcastTest {
 class HazelcastV1ForkedTest extends HazelcastTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return datadog.trace.api.Config.get().getServiceName() + "-hazelcast"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "hazelcast.command"
   }
 }

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionConnectFirstTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionConnectFirstTest.groovy
@@ -1,9 +1,10 @@
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import spock.lang.Timeout
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
 
 @Timeout(5)
-class HttpUrlConnectionConnectFirstTest extends HttpUrlConnectionTest {
+class HttpUrlConnectionConnectFirstTest extends HttpUrlConnectionTest implements TestingGenericHttpNamingConventions.ClientV0{
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionResponseCodeOnlyTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionResponseCodeOnlyTest.groovy
@@ -1,7 +1,8 @@
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import spock.lang.Timeout
 
 @Timeout(5)
-class HttpUrlConnectionResponseCodeOnlyTest extends HttpUrlConnectionTest {
+class HttpUrlConnectionResponseCodeOnlyTest extends HttpUrlConnectionTest implements TestingGenericHttpNamingConventions.ClientV0 {
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.bootstrap.instrumentation.httpurlconnection.HttpUrlConnectionDecorator
@@ -47,7 +48,7 @@ abstract class HttpUrlConnectionTest extends HttpClientTest {
 
   @Override
   CharSequence component() {
-    return HttpUrlConnectionDecorator.DECORATE.component()
+    return HttpUrlConnectionDecorator.HTTP_URL_CONNECTION
   }
 
   @Override
@@ -374,21 +375,7 @@ abstract class HttpUrlConnectionTest extends HttpClientTest {
   }
 }
 
-class HttpUrlConnectionV0ForkedTest extends HttpUrlConnectionTest {}
+class HttpUrlConnectionV0ForkedTest extends HttpUrlConnectionTest implements TestingGenericHttpNamingConventions.ClientV0 {}
 
-class HttpUrlConnectionV1ForkedTest extends HttpUrlConnectionTest {
-  @Override
-  protected int version() {
-    return 1
-  }
-
-  @Override
-  protected String service() {
-    return null
-  }
-
-  @Override
-  protected String operation() {
-    return "http.client.request"
-  }
+class HttpUrlConnectionV1ForkedTest extends HttpUrlConnectionTest implements TestingGenericHttpNamingConventions.ClientV1 {
 }

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionUseCachesFalseTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionUseCachesFalseTest.groovy
@@ -1,9 +1,10 @@
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import spock.lang.Timeout
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
 
 @Timeout(5)
-class HttpUrlConnectionUseCachesFalseTest extends HttpUrlConnectionTest {
+class HttpUrlConnectionUseCachesFalseTest extends HttpUrlConnectionTest implements TestingGenericHttpNamingConventions.ClientV0 {
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/SpringRestTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/SpringRestTemplateTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.bootstrap.instrumentation.httpurlconnection.HttpUrlConnectionDecorator
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
@@ -12,7 +13,7 @@ import spock.lang.Shared
 import spock.lang.Timeout
 
 @Timeout(5)
-class SpringRestTemplateTest extends HttpClientTest {
+abstract class SpringRestTemplateTest extends HttpClientTest {
 
   @Shared
   ClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory()
@@ -60,4 +61,10 @@ class SpringRestTemplateTest extends HttpClientTest {
     // FIXME: exception wrapped in ResourceAccessException
     return false
   }
+}
+
+class SpringRestTemplateV0ForkedTest extends SpringRestTemplateTest implements TestingGenericHttpNamingConventions.ClientV0 {
+}
+
+class SpringRestTemplateV1ForkedTest extends SpringRestTemplateTest implements TestingGenericHttpNamingConventions.ClientV1 {
 }

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
@@ -145,12 +145,12 @@ abstract class UrlConnectionTest extends VersionedNamingTestBase {
   }
 
   @Override
-  protected final String service() {
+  final String service() {
     return null
   }
 
   @Override
-  protected final String operation() {
+  final String operation() {
     return null
   }
 
@@ -160,7 +160,7 @@ abstract class UrlConnectionTest extends VersionedNamingTestBase {
 class UrlConnectionV0ForkedTest extends UrlConnectionTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
@@ -173,7 +173,7 @@ class UrlConnectionV0ForkedTest extends UrlConnectionTest {
 class UrlConnectionV1ForkedTest extends UrlConnectionTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 

--- a/dd-java-agent/instrumentation/ignite-2.0/src/test/groovy/test/IgniteCacheAsyncTest.groovy
+++ b/dd-java-agent/instrumentation/ignite-2.0/src/test/groovy/test/IgniteCacheAsyncTest.groovy
@@ -78,17 +78,17 @@ abstract class IgniteCacheAsyncTest extends AbstractIgniteTest {
 class IgniteCacheAsyncV0ForkedTest extends IgniteCacheAsyncTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return AbstractIgniteTest.V0_SERVICE
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return AbstractIgniteTest.V0_OPERATION
   }
 }
@@ -96,17 +96,17 @@ class IgniteCacheAsyncV0ForkedTest extends IgniteCacheAsyncTest {
 class IgniteCacheAsyncV1ForkedTest extends IgniteCacheAsyncTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return AbstractIgniteTest.V1_SERVICE
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return AbstractIgniteTest.V1_OPERATION
   }
 }

--- a/dd-java-agent/instrumentation/ignite-2.0/src/test/groovy/test/IgniteCacheFailureTest.groovy
+++ b/dd-java-agent/instrumentation/ignite-2.0/src/test/groovy/test/IgniteCacheFailureTest.groovy
@@ -153,17 +153,17 @@ abstract class IgniteCacheFailureTest extends VersionedNamingTestBase {
 class IgniteCacheFailureV0ForkedTest extends IgniteCacheFailureTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return AbstractIgniteTest.V0_SERVICE
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return AbstractIgniteTest.V0_OPERATION
   }
 }
@@ -171,17 +171,17 @@ class IgniteCacheFailureV0ForkedTest extends IgniteCacheFailureTest {
 class IgniteCacheFailureV1ForkedTest extends IgniteCacheFailureTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return AbstractIgniteTest.V1_SERVICE
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return AbstractIgniteTest.V1_OPERATION
   }
 }

--- a/dd-java-agent/instrumentation/ignite-2.0/src/test/groovy/test/IgniteCacheSyncTest.groovy
+++ b/dd-java-agent/instrumentation/ignite-2.0/src/test/groovy/test/IgniteCacheSyncTest.groovy
@@ -311,17 +311,17 @@ abstract class IgniteCacheSyncTest extends AbstractIgniteTest {
 class IgniteCacheSyncV0ForkedTest extends IgniteCacheSyncTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return AbstractIgniteTest.V0_SERVICE
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return AbstractIgniteTest.V0_OPERATION
   }
 }
@@ -329,17 +329,17 @@ class IgniteCacheSyncV0ForkedTest extends IgniteCacheSyncTest {
 class IgniteCacheSyncV1ForkedTest extends IgniteCacheSyncTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return AbstractIgniteTest.V1_SERVICE
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return AbstractIgniteTest.V1_OPERATION
   }
 }

--- a/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Decorator.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Decorator.java
@@ -9,10 +9,10 @@ import java.net.URI;
 public class JaxRsClientV1Decorator extends HttpClientDecorator<ClientRequest, ClientResponse> {
 
   public static final CharSequence JAX_RS_CLIENT = UTF8BytesString.create("jax-rs.client");
-  public static final CharSequence JAX_RS_CLIENT_CALL =
-      UTF8BytesString.create("jax-rs.client.call");
 
   public static final JaxRsClientV1Decorator DECORATE = new JaxRsClientV1Decorator();
+  public static final CharSequence JAX_RS_CLIENT_CALL =
+      UTF8BytesString.create(DECORATE.operationName());
 
   @Override
   protected String[] instrumentationNames() {

--- a/dd-java-agent/instrumentation/jax-rs-client-1.1/src/test/groovy/JaxRsClientV1Test.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client-1.1/src/test/groovy/JaxRsClientV1Test.groovy
@@ -3,12 +3,12 @@ import com.sun.jersey.api.client.ClientResponse
 import com.sun.jersey.api.client.filter.GZIPContentEncodingFilter
 import com.sun.jersey.api.client.filter.LoggingFilter
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.jaxrs.v1.JaxRsClientV1Decorator
 import spock.lang.Shared
 import spock.lang.Timeout
 
-@Timeout(5)
-class JaxRsClientV1Test extends HttpClientTest {
+abstract class JaxRsClientV1Test extends HttpClientTest {
 
   @Shared
   Client client = Client.create()
@@ -37,12 +37,30 @@ class JaxRsClientV1Test extends HttpClientTest {
     return JaxRsClientV1Decorator.DECORATE.component()
   }
 
-  @Override
-  String expectedOperationName() {
-    return "jax-rs.client.call"
-  }
-
   boolean testCircularRedirects() {
     false
   }
+}
+
+@Timeout(5)
+class JaxRsClientV1NamingV0ForkedTest extends JaxRsClientV1Test {
+
+  @Override
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "jax-rs.client.call"
+  }
+}
+
+@Timeout(5)
+class JaxRsClientV1NamingV1ForkedTest extends JaxRsClientV1Test implements TestingGenericHttpNamingConventions.ClientV1 {
 }

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/JaxRsClientDecorator.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/JaxRsClientDecorator.java
@@ -9,10 +9,10 @@ import javax.ws.rs.client.ClientResponseContext;
 public class JaxRsClientDecorator
     extends HttpClientDecorator<ClientRequestContext, ClientResponseContext> {
   public static final CharSequence JAX_RS_CLIENT = UTF8BytesString.create("jax-rs.client");
-  public static final CharSequence JAX_RS_CLIENT_CALL =
-      UTF8BytesString.create("jax-rs.client.call");
-
   public static final JaxRsClientDecorator DECORATE = new JaxRsClientDecorator();
+
+  public static final CharSequence JAX_RS_CLIENT_CALL =
+      UTF8BytesString.create(DECORATE.operationName());
 
   @Override
   protected String[] instrumentationNames() {

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientAsyncTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientAsyncTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.jaxrs.JaxRsClientDecorator
 import org.apache.cxf.jaxrs.client.spec.ClientBuilderImpl
 import org.glassfish.jersey.client.ClientConfig
@@ -8,18 +9,13 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder
 import spock.lang.IgnoreIf
 import spock.lang.Timeout
 
-import javax.ws.rs.client.AsyncInvoker
-import javax.ws.rs.client.Client
-import javax.ws.rs.client.ClientBuilder
-import javax.ws.rs.client.Entity
-import javax.ws.rs.client.InvocationCallback
-import javax.ws.rs.client.WebTarget
+import javax.ws.rs.client.*
 import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
-abstract class JaxRsClientAsyncTest extends HttpClientTest {
+abstract class JaxRsClientAsyncTest extends HttpClientTest  {
   @Override
   def setup() {
   }
@@ -61,8 +57,20 @@ abstract class JaxRsClientAsyncTest extends HttpClientTest {
     return JaxRsClientDecorator.DECORATE.component()
   }
 
+
+
   @Override
-  String expectedOperationName() {
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
     return "jax-rs.client.call"
   }
 
@@ -85,8 +93,7 @@ class JerseyClientAsyncTest extends JaxRsClientAsyncTest {
   }
 }
 
-@Timeout(5)
-class ResteasyClientAsyncTest extends JaxRsClientAsyncTest {
+abstract class ResteasyClientAsyncTest extends JaxRsClientAsyncTest {
 
   @Override
   ClientBuilder builder() {
@@ -98,6 +105,13 @@ class ResteasyClientAsyncTest extends JaxRsClientAsyncTest {
   boolean testRedirects() {
     false
   }
+}
+@Timeout(5)
+class ResteasyClientAsyncV0ForkedTest extends ResteasyClientAsyncTest {
+}
+
+@Timeout(5)
+class ResteasyClientAsyncV1ForkedTest extends ResteasyClientAsyncTest implements TestingGenericHttpNamingConventions.ClientV1{
 }
 
 @Timeout(5)

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.jaxrs.JaxRsClientDecorator
 import datadog.trace.test.util.Flaky
 import org.apache.cxf.jaxrs.client.spec.ClientBuilderImpl
@@ -42,7 +43,17 @@ abstract class JaxRsClientTest extends HttpClientTest {
   }
 
   @Override
-  String expectedOperationName() {
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
     return "jax-rs.client.call"
   }
 
@@ -67,8 +78,7 @@ class JerseyClientTest extends JaxRsClientTest {
   }
 }
 
-@Timeout(5)
-class ResteasyClientTest extends JaxRsClientTest {
+abstract class ResteasyClientTest extends JaxRsClientTest {
 
   @Override
   ClientBuilder builder() {
@@ -80,6 +90,14 @@ class ResteasyClientTest extends JaxRsClientTest {
   boolean testRedirects() {
     false
   }
+}
+
+@Timeout(5)
+class ResteasyClientV0ForkedTest extends ResteasyClientTest {
+}
+
+@Timeout(5)
+class ResteasyClientV1ForkedTest extends ResteasyClientTest implements TestingGenericHttpNamingConventions.ClientV1 {
 }
 
 @Timeout(5)

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
@@ -790,12 +790,12 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
       .connect(url, properties)
   }
   @Override
-  protected final String service() {
+  final String service() {
     return null
   }
 
   @Override
-  protected final String operation() {
+  final String operation() {
     return null
   }
 
@@ -807,7 +807,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
 class JDBCInstrumentationV0ForkedTest extends JDBCInstrumentationTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
@@ -825,7 +825,7 @@ class JDBCInstrumentationV0ForkedTest extends JDBCInstrumentationTest {
 class JDBCInstrumentationV1ForkedTest extends JDBCInstrumentationTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
@@ -491,12 +491,12 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
   }
 
   @Override
-  protected final String service() {
+  final String service() {
     return null
   }
 
   @Override
-  protected final String operation() {
+  final String operation() {
     return null
   }
 
@@ -508,7 +508,7 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
 class RemoteJDBCInstrumentationV0ForkedTest extends RemoteJDBCInstrumentationTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
@@ -533,7 +533,7 @@ class RemoteJDBCInstrumentationV1ForkedTest extends RemoteJDBCInstrumentationTes
   }
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 

--- a/dd-java-agent/instrumentation/jedis-1.4/src/test/groovy/JedisClientTest.groovy
+++ b/dd-java-agent/instrumentation/jedis-1.4/src/test/groovy/JedisClientTest.groovy
@@ -162,34 +162,34 @@ abstract class JedisClientTest extends VersionedNamingTestBase {
 class JedisClientV0ForkedTest extends JedisClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.query"
   }
 }
 class JedisClientV1ForkedTest extends JedisClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return Config.get().getServiceName() + "-redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.command"
   }
 }

--- a/dd-java-agent/instrumentation/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
+++ b/dd-java-agent/instrumentation/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
@@ -301,17 +301,17 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
 class Jedis30ClientV0ForkedTest extends Jedis30ClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.query"
   }
 }
@@ -319,17 +319,17 @@ class Jedis30ClientV0ForkedTest extends Jedis30ClientTest {
 class Jedis30ClientV1ForkedTest extends Jedis30ClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return Config.get().getServiceName() + "-redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.command"
   }
 }

--- a/dd-java-agent/instrumentation/jedis-4.0/src/test/groovy/Jedis40ClientTest.groovy
+++ b/dd-java-agent/instrumentation/jedis-4.0/src/test/groovy/Jedis40ClientTest.groovy
@@ -301,17 +301,17 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
 class Jedis40ClientV0ForkedTest extends Jedis40ClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.query"
   }
 }
@@ -319,17 +319,17 @@ class Jedis40ClientV0ForkedTest extends Jedis40ClientTest {
 class Jedis40ClientV1ForkedTest extends Jedis40ClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return Config.get().getServiceName() + "-redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.command"
   }
 }

--- a/dd-java-agent/instrumentation/jetty-client-9.1/src/main/java/datadog/trace/instrumentation/jetty_client/JettyClientDecorator.java
+++ b/dd-java-agent/instrumentation/jetty-client-9.1/src/main/java/datadog/trace/instrumentation/jetty_client/JettyClientDecorator.java
@@ -8,8 +8,8 @@ import org.eclipse.jetty.client.api.Response;
 
 public class JettyClientDecorator extends HttpClientDecorator<Request, Response> {
   public static final CharSequence JETTY_CLIENT = UTF8BytesString.create("jetty-client");
-  public static final CharSequence HTTP_REQUEST = UTF8BytesString.create("http.request");
   public static final JettyClientDecorator DECORATE = new JettyClientDecorator();
+  public static final CharSequence HTTP_REQUEST = UTF8BytesString.create(DECORATE.operationName());
 
   @Override
   protected String[] instrumentationNames() {

--- a/dd-java-agent/instrumentation/jetty-client-9.1/src/test/groovy/JettyClientTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-client-9.1/src/test/groovy/JettyClientTest.groovy
@@ -1,5 +1,5 @@
 import datadog.trace.agent.test.base.HttpClientTest
-
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import org.eclipse.jetty.client.HttpClient
 import org.eclipse.jetty.client.HttpProxy
 import org.eclipse.jetty.client.HttpResponseException
@@ -13,7 +13,7 @@ import spock.lang.Subject
 
 import java.util.concurrent.ExecutionException
 
-class JettyClientTest extends HttpClientTest {
+abstract class JettyClientTest extends HttpClientTest {
 
   @Shared
   @Subject
@@ -91,4 +91,10 @@ class JettyClientTest extends HttpClientTest {
   boolean testProxy() {
     false // doesn't produce CONNECT span.
   }
+}
+
+class JettyClientV0ForkedTest extends JettyClientTest implements TestingGenericHttpNamingConventions.ClientV0 {
+}
+
+class JettyClientV1ForkedTest extends JettyClientTest implements TestingGenericHttpNamingConventions.ClientV1 {
 }

--- a/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4AsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4AsyncClientTest.groovy
@@ -541,17 +541,17 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
 class Lettuce4AsyncClientV0ForkedTest extends Lettuce4AsyncClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.query"
   }
 }
@@ -559,17 +559,17 @@ class Lettuce4AsyncClientV0ForkedTest extends Lettuce4AsyncClientTest {
 class Lettuce4AsyncClientV1ForkedTest extends Lettuce4AsyncClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return Config.get().getServiceName() + "-redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.command"
   }
 }

--- a/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4SyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4SyncClientTest.groovy
@@ -386,17 +386,17 @@ abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
 class Lettuce4SyncClientV0ForkedTest extends Lettuce4SyncClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.query"
   }
 }
@@ -404,17 +404,17 @@ class Lettuce4SyncClientV0ForkedTest extends Lettuce4SyncClientTest {
 class Lettuce4SyncClientV1ForkedTest extends Lettuce4SyncClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return Config.get().getServiceName() + "-redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.command"
   }
 }

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5AsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5AsyncClientTest.groovy
@@ -546,17 +546,17 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
 class Lettuce5SyncClientV0ForkedTest extends Lettuce5AsyncClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.query"
   }
 }
@@ -564,17 +564,17 @@ class Lettuce5SyncClientV0ForkedTest extends Lettuce5AsyncClientTest {
 class Lettuce5SyncClientV1ForkedTest extends Lettuce5AsyncClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return Config.get().getServiceName() + "-redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.command"
   }
 }

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
@@ -563,17 +563,17 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
 class Lettuce5ReactiveClientV0ForkedTest extends Lettuce5ReactiveClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.query"
   }
 }
@@ -581,17 +581,17 @@ class Lettuce5ReactiveClientV0ForkedTest extends Lettuce5ReactiveClientTest {
 class Lettuce5ReactiveClientV1ForkedTest extends Lettuce5ReactiveClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return Config.get().getServiceName() + "-redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.command"
   }
 }

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5SyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5SyncClientTest.groovy
@@ -388,17 +388,17 @@ abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
 class Lettuce5AsyncClientV0ForkedTest extends Lettuce5AsyncClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.query"
   }
 }
@@ -406,17 +406,17 @@ class Lettuce5AsyncClientV0ForkedTest extends Lettuce5AsyncClientTest {
 class Lettuce5AsyncClientV1ForkedTest extends Lettuce5AsyncClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return Config.get().getServiceName() + "-redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.command"
   }
 }

--- a/dd-java-agent/instrumentation/mongo/driver-3.1-core-test/src/test/groovy/MongoCore31ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1-core-test/src/test/groovy/MongoCore31ClientTest.groovy
@@ -248,17 +248,17 @@ abstract class MongoCore31ClientTest extends MongoBaseTest {
 class MongoCore31ClientV0ForkedTest extends MongoCore31ClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return V0_SERVICE
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return V0_OPERATION
   }
 }
@@ -266,17 +266,17 @@ class MongoCore31ClientV0ForkedTest extends MongoCore31ClientTest {
 class MongoCore31ClientV1ForkedTest extends MongoCore31ClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return V1_SERVICE
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return V1_OPERATION
   }
 }

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoJava31ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoJava31ClientTest.groovy
@@ -250,17 +250,17 @@ abstract class MongoJava31ClientTest extends MongoBaseTest {
 class MongoJava31ClientV0ForkedTest extends MongoJava31ClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return V0_SERVICE
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return V0_OPERATION
   }
 }
@@ -268,17 +268,17 @@ class MongoJava31ClientV0ForkedTest extends MongoJava31ClientTest {
 class MongoJava31ClientV1ForkedTest extends MongoJava31ClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return V1_SERVICE
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return V1_OPERATION
   }
 }

--- a/dd-java-agent/instrumentation/mongo/driver-3.10-sync-test/src/test/groovy/MongoSyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.10-sync-test/src/test/groovy/MongoSyncClientTest.groovy
@@ -235,17 +235,17 @@ abstract class MongoSyncClientTest extends MongoBaseTest {
 class MongoSyncClientV0ForkedTest extends MongoSyncClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return V0_SERVICE
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return V0_OPERATION
   }
 }
@@ -253,17 +253,17 @@ class MongoSyncClientV0ForkedTest extends MongoSyncClientTest {
 class MongoSyncClientV1ForkedTest extends MongoSyncClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return V1_SERVICE
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return V1_OPERATION
   }
 }

--- a/dd-java-agent/instrumentation/mongo/driver-3.3-async-test/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.3-async-test/src/test/groovy/MongoAsyncClientTest.groovy
@@ -232,17 +232,17 @@ abstract class MongoAsyncClientTest extends MongoBaseTest {
 class MongoAsyncClientV0ForkedTest extends MongoAsyncClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return V0_SERVICE
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return V0_OPERATION
   }
 }
@@ -250,17 +250,17 @@ class MongoAsyncClientV0ForkedTest extends MongoAsyncClientTest {
 class MongoAsyncClientV1ForkedTest extends MongoAsyncClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return V1_SERVICE
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return V1_OPERATION
   }
 }

--- a/dd-java-agent/instrumentation/mongo/driver-3.4/src/test/groovy/MongoJava34ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.4/src/test/groovy/MongoJava34ClientTest.groovy
@@ -248,17 +248,17 @@ abstract class MongoJava34ClientTest extends MongoBaseTest {
 class MongoJava34ClientV0ForkedTest extends MongoJava34ClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return V0_SERVICE
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return V0_OPERATION
   }
 }
@@ -266,17 +266,17 @@ class MongoJava34ClientV0ForkedTest extends MongoJava34ClientTest {
 class MongoJava34ClientV1ForkedTest extends MongoJava34ClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return V1_SERVICE
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return V1_OPERATION
   }
 }

--- a/dd-java-agent/instrumentation/mongo/driver-3.7-core-test/src/test/groovy/MongoCore37ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.7-core-test/src/test/groovy/MongoCore37ClientTest.groovy
@@ -235,17 +235,17 @@ abstract class MongoCore37ClientTest extends MongoBaseTest {
 class MongoCore37ClientV0ForkedTest extends MongoCore37ClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return V0_SERVICE
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return V0_OPERATION
   }
 }
@@ -253,17 +253,17 @@ class MongoCore37ClientV0ForkedTest extends MongoCore37ClientTest {
 class MongoCore37ClientV1ForkedTest extends MongoCore37ClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return V1_SERVICE
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return V1_OPERATION
   }
 }

--- a/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/Mongo4ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/Mongo4ClientTest.groovy
@@ -235,17 +235,17 @@ abstract class Mongo4ClientTest extends MongoBaseTest {
 class Mongo4ClientV0ForkedTest extends Mongo4ClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return V0_SERVICE
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return V0_OPERATION
   }
 }
@@ -253,17 +253,17 @@ class Mongo4ClientV0ForkedTest extends Mongo4ClientTest {
 class Mongo4ClientV1ForkedTest extends Mongo4ClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return V1_SERVICE
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return V1_OPERATION
   }
 }

--- a/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/MongoReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/MongoReactiveClientTest.groovy
@@ -399,17 +399,17 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
 class MongoReactiveClientV0ForkedTest extends MongoReactiveClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return V0_SERVICE
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return V0_OPERATION
   }
 }
@@ -417,17 +417,17 @@ class MongoReactiveClientV0ForkedTest extends MongoReactiveClientTest {
 class MongoReactiveClientV1ForkedTest extends MongoReactiveClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return V1_SERVICE
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return V1_OPERATION
   }
 }

--- a/dd-java-agent/instrumentation/netty-3.8/src/latestDepTest/groovy/datadog/trace/instrumentation/netty38/latestdep/Netty38ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-3.8/src/latestDepTest/groovy/datadog/trace/instrumentation/netty38/latestdep/Netty38ClientTest.groovy
@@ -18,7 +18,7 @@ import static datadog.trace.agent.test.utils.PortUtils.UNUSABLE_PORT
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
-class Netty38ClientTest extends HttpClientTest {
+abstract class Netty38ClientTest extends HttpClientTest {
 
   @Shared
   def clientConfig = new AsyncHttpClientConfig.Builder()
@@ -51,10 +51,6 @@ class Netty38ClientTest extends HttpClientTest {
     return NettyHttpClientDecorator.DECORATE.component()
   }
 
-  @Override
-  String expectedOperationName() {
-    return "netty.client.request"
-  }
 
   @Override
   boolean testRedirects() {
@@ -118,3 +114,40 @@ class Netty38ClientTest extends HttpClientTest {
     method = "GET"
   }
 }
+
+class Netty38ClientV0ForkedTest extends Netty38ClientTest {
+
+  @Override
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "netty.client.request"
+  }
+}
+
+class Netty38ClientV1ForkedTest extends Netty38ClientTest {
+
+  @Override
+  int version() {
+    return 1
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "http.client.request"
+  }
+}
+

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/NettyHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/NettyHttpClientDecorator.java
@@ -11,12 +11,13 @@ import org.jboss.netty.handler.codec.http.HttpResponse;
 
 public class NettyHttpClientDecorator extends HttpClientDecorator<HttpRequest, HttpResponse> {
   public static final CharSequence NETTY_CLIENT = UTF8BytesString.create("netty-client");
-  public static final CharSequence NETTY_CLIENT_REQUEST =
-      UTF8BytesString.create("netty.client.request");
 
   public static final NettyHttpClientDecorator DECORATE = new NettyHttpClientDecorator("http://");
   public static final NettyHttpClientDecorator DECORATE_SECURE =
       new NettyHttpClientDecorator("https://");
+
+  public static final CharSequence NETTY_CLIENT_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
 
   private final String uriPrefix;
 

--- a/dd-java-agent/instrumentation/netty-3.8/src/test/groovy/datadog/trace/instrumentation/netty38/Netty38ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-3.8/src/test/groovy/datadog/trace/instrumentation/netty38/Netty38ClientTest.groovy
@@ -5,6 +5,7 @@ import com.ning.http.client.AsyncHttpClient
 import com.ning.http.client.AsyncHttpClientConfig
 import com.ning.http.client.Response
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingNettyHttpNamingConventions
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.netty38.client.NettyHttpClientDecorator
 import org.jboss.netty.handler.codec.embedder.EncoderEmbedder
@@ -22,7 +23,7 @@ import static datadog.trace.agent.test.utils.PortUtils.UNUSABLE_PORT
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
-class Netty38ClientTest extends HttpClientTest {
+abstract class Netty38ClientTest extends HttpClientTest {
 
   @Shared
   def clientConfig = new AsyncHttpClientConfig.Builder()
@@ -55,10 +56,6 @@ class Netty38ClientTest extends HttpClientTest {
     return NettyHttpClientDecorator.DECORATE.component()
   }
 
-  @Override
-  String expectedOperationName() {
-    return "netty.client.request"
-  }
 
   @Override
   boolean testRedirects() {
@@ -132,4 +129,10 @@ class Netty38ClientTest extends HttpClientTest {
     then:
     noExceptionThrown()
   }
+}
+
+class Netty38ClientV0ForkedTest extends Netty38ClientTest implements TestingNettyHttpNamingConventions.ClientV0  {
+}
+
+class Netty38ClientV1ForkedTest extends Netty38ClientTest implements TestingNettyHttpNamingConventions.ClientV1 {
 }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/NettyHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/NettyHttpClientDecorator.java
@@ -13,12 +13,12 @@ import java.net.URISyntaxException;
 public class NettyHttpClientDecorator extends HttpClientDecorator<HttpRequest, HttpResponse> {
 
   public static final CharSequence NETTY_CLIENT = UTF8BytesString.create("netty-client");
-  public static final CharSequence NETTY_CLIENT_REQUEST =
-      UTF8BytesString.create("netty.client.request");
 
   public static final NettyHttpClientDecorator DECORATE = new NettyHttpClientDecorator("http://");
   public static final NettyHttpClientDecorator DECORATE_SECURE =
       new NettyHttpClientDecorator("https://");
+  public static final CharSequence NETTY_CLIENT_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
 
   private final String uriPrefix;
 

--- a/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingNettyHttpNamingConventions
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.netty40.client.NettyHttpClientDecorator
 import io.netty.channel.embedded.EmbeddedChannel
@@ -24,8 +25,7 @@ import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static org.asynchttpclient.Dsl.asyncHttpClient
 
-@Timeout(5)
-class Netty40ClientTest extends HttpClientTest {
+abstract class Netty40ClientTest extends HttpClientTest {
 
   @Override
   boolean useStrictTraceWrites() {
@@ -71,11 +71,6 @@ class Netty40ClientTest extends HttpClientTest {
   @Override
   CharSequence component() {
     return NettyHttpClientDecorator.DECORATE.component()
-  }
-
-  @Override
-  String expectedOperationName() {
-    return "netty.client.request"
   }
 
   @Override
@@ -157,4 +152,14 @@ class Netty40ClientTest extends HttpClientTest {
     then:
     noExceptionThrown()
   }
+}
+
+@Timeout(5)
+class Netty40ClientV0ForkedTest extends Netty40ClientTest implements TestingNettyHttpNamingConventions.ClientV0 {
+
+}
+
+@Timeout(5)
+class Netty40ClientV1ForkedTest extends Netty40ClientTest implements TestingNettyHttpNamingConventions.ClientV1 {
+
 }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/NettyHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/NettyHttpClientDecorator.java
@@ -13,12 +13,12 @@ import java.net.URISyntaxException;
 public class NettyHttpClientDecorator extends HttpClientDecorator<HttpRequest, HttpResponse> {
 
   public static final CharSequence NETTY_CLIENT = UTF8BytesString.create("netty-client");
-  public static final CharSequence NETTY_CLIENT_REQUEST =
-      UTF8BytesString.create("netty.client.request");
 
   public static final NettyHttpClientDecorator DECORATE = new NettyHttpClientDecorator("http://");
   public static final NettyHttpClientDecorator DECORATE_SECURE =
       new NettyHttpClientDecorator("https://");
+  public static final CharSequence NETTY_CLIENT_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
 
   private final String uriPrefix;
 

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingNettyHttpNamingConventions
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
 import io.netty.channel.AbstractChannel
@@ -9,11 +10,7 @@ import io.netty.handler.codec.http.HttpRequestEncoder
 import io.netty.handler.codec.http.HttpVersion
 import io.netty.handler.ssl.SslContextBuilder
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory
-import org.asynchttpclient.AsyncCompletionHandler
-import org.asynchttpclient.AsyncHttpClient
-import org.asynchttpclient.BoundRequestBuilder
-import org.asynchttpclient.DefaultAsyncHttpClientConfig
-import org.asynchttpclient.Response
+import org.asynchttpclient.*
 import org.asynchttpclient.proxy.ProxyServer
 import spock.lang.AutoCleanup
 import spock.lang.Timeout
@@ -26,7 +23,7 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static org.asynchttpclient.Dsl.asyncHttpClient
 
 @Timeout(5)
-class Netty41ClientTest extends HttpClientTest {
+abstract class Netty41ClientTest extends HttpClientTest {
 
   def clientConfig = DefaultAsyncHttpClientConfig.Builder.newInstance()
   .setConnectTimeout(CONNECT_TIMEOUT_MS)
@@ -66,11 +63,6 @@ class Netty41ClientTest extends HttpClientTest {
   @Override
   CharSequence component() {
     return NettyHttpClientDecorator.DECORATE.component()
-  }
-
-  @Override
-  String expectedOperationName() {
-    return "netty.client.request"
   }
 
   @Override
@@ -147,5 +139,11 @@ class Netty41ClientTest extends HttpClientTest {
     then:
     noExceptionThrown()
   }
+}
 
+class Netty41ClientV0ForkedTest extends Netty41ClientTest implements TestingNettyHttpNamingConventions.ClientV0 {
+
+}
+
+class Netty41ClientV1ForkedTest extends Netty41ClientTest implements TestingNettyHttpNamingConventions.ClientV1 {
 }

--- a/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/OkHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/OkHttpClientDecorator.java
@@ -8,9 +8,10 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 public class OkHttpClientDecorator extends HttpClientDecorator<Request, Response> {
-  public static final CharSequence OKHTTP_REQUEST = UTF8BytesString.create("okhttp.request");
   public static final CharSequence OKHTTP = UTF8BytesString.create("okhttp");
   public static final OkHttpClientDecorator DECORATE = new OkHttpClientDecorator();
+  public static final CharSequence OKHTTP_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
 
   @Override
   protected String method(Request request) {

--- a/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/OkHttp2AsyncTest.groovy
+++ b/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/OkHttp2AsyncTest.groovy
@@ -1,10 +1,6 @@
-import com.squareup.okhttp.Callback
-import com.squareup.okhttp.Headers
-import com.squareup.okhttp.MediaType
-import com.squareup.okhttp.Request
-import com.squareup.okhttp.RequestBody
-import com.squareup.okhttp.Response
+import com.squareup.okhttp.*
 import com.squareup.okhttp.internal.http.HttpMethod
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.agent.test.utils.TraceUtils
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 
@@ -13,7 +9,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 import static java.util.concurrent.TimeUnit.SECONDS
 
-class OkHttp2AsyncTest extends OkHttp2Test {
+abstract class OkHttp2AsyncTest extends OkHttp2Test {
   @Override
   boolean useStrictTraceWrites() {
     // TODO fix this by making sure that spans get closed properly
@@ -75,4 +71,25 @@ class OkHttp2AsyncTest extends OkHttp2Test {
 
     method = "GET"
   }
+}
+
+class OkHttp2AsyncV0ForkedTest extends OkHttp2AsyncTest {
+
+  @Override
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "okhttp.request"
+  }
+}
+
+class OkHttp2AsyncV1ForkedTest extends OkHttp2AsyncTest implements TestingGenericHttpNamingConventions.ClientV1 {
 }

--- a/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/OkHttp2Test.groovy
+++ b/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/OkHttp2Test.groovy
@@ -1,18 +1,14 @@
-import com.squareup.okhttp.Headers
-import com.squareup.okhttp.MediaType
-import com.squareup.okhttp.OkHttpClient
-import com.squareup.okhttp.Request
-import com.squareup.okhttp.RequestBody
+import com.squareup.okhttp.*
 import com.squareup.okhttp.internal.http.HttpMethod
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.okhttp2.OkHttpClientDecorator
 import spock.lang.Shared
 import spock.lang.Timeout
 
 import java.util.concurrent.TimeUnit
 
-@Timeout(5)
-class OkHttp2Test extends HttpClientTest {
+abstract class OkHttp2Test extends HttpClientTest {
   @Override
   boolean useStrictTraceWrites() {
     // TODO fix this by making sure that spans get closed properly
@@ -48,13 +44,30 @@ class OkHttp2Test extends HttpClientTest {
     return OkHttpClientDecorator.DECORATE.component()
   }
 
-  @Override
-  String expectedOperationName() {
-    return "okhttp.request"
-  }
-
-
   boolean testRedirects() {
     false
   }
+}
+
+@Timeout(5)
+class OkHttp2V0ForkedTest extends OkHttp2Test {
+
+  @Override
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "okhttp.request"
+  }
+}
+
+@Timeout(5)
+class OkHttp2V1ForkedTest extends OkHttp2Test implements TestingGenericHttpNamingConventions.ClientV1 {
 }

--- a/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/OkHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/OkHttpClientDecorator.java
@@ -7,9 +7,11 @@ import okhttp3.Request;
 import okhttp3.Response;
 
 public class OkHttpClientDecorator extends HttpClientDecorator<Request, Response> {
-  public static final CharSequence OKHTTP_REQUEST = UTF8BytesString.create("okhttp.request");
   public static final CharSequence OKHTTP = UTF8BytesString.create("okhttp");
   public static final OkHttpClientDecorator DECORATE = new OkHttpClientDecorator();
+
+  public static final CharSequence OKHTTP_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
 
   @Override
   protected String[] instrumentationNames() {

--- a/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3AsyncTest.groovy
+++ b/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3AsyncTest.groovy
@@ -1,3 +1,4 @@
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.agent.test.utils.TraceUtils
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import okhttp3.Call
@@ -14,7 +15,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 import static java.util.concurrent.TimeUnit.SECONDS
 
-class OkHttp3AsyncTest extends OkHttp3Test {
+abstract class OkHttp3AsyncTest extends OkHttp3Test {
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
     def reqBody = HttpMethod.requiresRequestBody(method) ? RequestBody.create(MediaType.parse("text/plain"), body) : null
@@ -70,4 +71,26 @@ class OkHttp3AsyncTest extends OkHttp3Test {
 
     method = "GET"
   }
+}
+
+
+class OkHttp3AsyncV0ForkedTest extends OkHttp3AsyncTest {
+
+  @Override
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "okhttp.request"
+  }
+}
+
+class OkHttp3AsyncV1ForkedTest extends OkHttp3AsyncTest implements TestingGenericHttpNamingConventions.ClientV1 {
 }

--- a/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
+++ b/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
@@ -1,17 +1,13 @@
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.okhttp3.OkHttpClientDecorator
-import okhttp3.Headers
-import okhttp3.MediaType
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.RequestBody
+import okhttp3.*
 import okhttp3.internal.http.HttpMethod
 import spock.lang.Timeout
 
 import java.util.concurrent.TimeUnit
 
-@Timeout(5)
-class OkHttp3Test extends HttpClientTest {
+abstract class OkHttp3Test extends HttpClientTest {
 
   @Override
   protected void configurePreAgent() {
@@ -51,12 +47,6 @@ class OkHttp3Test extends HttpClientTest {
     return OkHttpClientDecorator.DECORATE.component()
   }
 
-  @Override
-  String expectedOperationName() {
-    return "okhttp.request"
-  }
-
-
   boolean testRedirects() {
     false
   }
@@ -83,4 +73,27 @@ class OkHttp3Test extends HttpClientTest {
     method = "GET"
     url = server.address.resolve(path)
   }
+}
+
+@Timeout(5)
+class OkHttp3V0ForkedTest extends OkHttp3Test {
+
+  @Override
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "okhttp.request"
+  }
+}
+
+@Timeout(5)
+class OkHttp3V1ForkedTest extends OkHttp3Test implements TestingGenericHttpNamingConventions.ClientV1 {
 }

--- a/dd-java-agent/instrumentation/play-2.3/src/test/groovy/client/PlayWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.3/src/test/groovy/client/PlayWSClientTest.groovy
@@ -1,6 +1,7 @@
 package client
 
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingNettyHttpNamingConventions
 import datadog.trace.instrumentation.netty38.client.NettyHttpClientDecorator
 import play.GlobalSettings
 import play.libs.ws.WS
@@ -10,7 +11,7 @@ import spock.lang.Shared
 
 import java.util.concurrent.TimeUnit
 
-class PlayWSClientTest extends HttpClientTest {
+class PlayWSClientTest extends HttpClientTest implements TestingNettyHttpNamingConventions.ClientV0 {
   @Shared
   def application = new FakeApplication(
   new File("."),
@@ -56,10 +57,6 @@ class PlayWSClientTest extends HttpClientTest {
     return NettyHttpClientDecorator.DECORATE.component()
   }
 
-  @Override
-  String expectedOperationName() {
-    return "netty.client.request"
-  }
 
   @Override
   boolean testRedirects() {

--- a/dd-java-agent/instrumentation/play-2.4/src/test/groovy/client/PlayWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/groovy/client/PlayWSClientTest.groovy
@@ -1,6 +1,7 @@
 package client
 
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingNettyHttpNamingConventions
 import datadog.trace.instrumentation.netty40.client.NettyHttpClientDecorator
 import play.libs.ws.WS
 import spock.lang.AutoCleanup
@@ -11,7 +12,7 @@ import spock.lang.Timeout
 // Play 2.6+ uses a separately versioned client that shades the underlying dependency
 // This means our built in instrumentation won't work.
 @Timeout(5)
-class PlayWSClientTest extends HttpClientTest {
+abstract class PlayWSClientTest extends HttpClientTest {
   @Subject
   @Shared
   @AutoCleanup
@@ -38,10 +39,6 @@ class PlayWSClientTest extends HttpClientTest {
     return NettyHttpClientDecorator.DECORATE.component()
   }
 
-  @Override
-  String expectedOperationName() {
-    return "netty.client.request"
-  }
 
   @Override
   boolean testRedirects() {
@@ -57,4 +54,10 @@ class PlayWSClientTest extends HttpClientTest {
   boolean testRemoteConnection() {
     return false
   }
+}
+
+class PlayWSClientV0ForkedTest extends PlayWSClientTest implements TestingNettyHttpNamingConventions.ClientV0  {
+}
+
+class PlayWSClientV1ForkedTest extends PlayWSClientTest implements TestingNettyHttpNamingConventions.ClientV1{
 }

--- a/dd-java-agent/instrumentation/play-ws-1/src/test/groovy/PlayWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/play-ws-1/src/test/groovy/PlayWSClientTest.groovy
@@ -1,3 +1,4 @@
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import play.libs.ws.StandaloneWSClient
 import play.libs.ws.StandaloneWSRequest
 import play.libs.ws.StandaloneWSResponse
@@ -12,8 +13,7 @@ import spock.lang.Timeout
 
 import java.util.concurrent.TimeUnit
 
-@Timeout(5)
-class PlayJavaWSClientTest extends PlayWSClientTestBase {
+abstract class PlayJavaWSClientTest extends PlayWSClientTestBase {
   @Shared
   StandaloneWSClient wsClient
 
@@ -133,4 +133,14 @@ class PlayScalaStreamedWSClientTest extends PlayWSClientTestBase {
   def cleanupSpec() {
     wsClient?.close()
   }
+}
+
+@Timeout(5)
+class PlayJavaWSClientV0ForkedTest extends  PlayJavaWSClientTest {
+
+}
+
+@Timeout(5)
+class PlayJavaWSClientV1ForkedTest extends PlayJavaWSClientTest implements TestingGenericHttpNamingConventions.ClientV1 {
+
 }

--- a/dd-java-agent/instrumentation/play-ws-2/src/test/groovy/PlayWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/play-ws-2/src/test/groovy/PlayWSClientTest.groovy
@@ -1,3 +1,4 @@
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import play.libs.ws.StandaloneWSClient
 import play.libs.ws.StandaloneWSRequest
 import play.libs.ws.StandaloneWSResponse
@@ -11,7 +12,7 @@ import spock.lang.Shared
 
 import java.util.concurrent.TimeUnit
 
-class PlayJavaWSClientTest extends PlayWSClientTestBase {
+abstract class PlayJavaWSClientTest extends PlayWSClientTestBase {
   @Shared
   StandaloneWSClient wsClient
 
@@ -128,4 +129,12 @@ class PlayScalaStreamedWSClientTest extends PlayWSClientTestBase {
   def cleanupSpec() {
     wsClient?.close()
   }
+}
+
+class PlayJavaWSClientV0ForkedTest extends  PlayJavaWSClientTest {
+
+}
+
+class PlayJavaWSClientV1ForkedTest extends PlayJavaWSClientTest implements TestingGenericHttpNamingConventions.ClientV1 {
+
 }

--- a/dd-java-agent/instrumentation/play-ws/src/main/java/datadog/trace/instrumentation/playws/PlayWSClientDecorator.java
+++ b/dd-java-agent/instrumentation/play-ws/src/main/java/datadog/trace/instrumentation/playws/PlayWSClientDecorator.java
@@ -8,9 +8,10 @@ import play.shaded.ahc.org.asynchttpclient.Request;
 import play.shaded.ahc.org.asynchttpclient.Response;
 
 public class PlayWSClientDecorator extends HttpClientDecorator<Request, Response> {
-  public static final CharSequence PLAY_WS_REQUEST = UTF8BytesString.create("play-ws.request");
   public static final CharSequence PLAY_WS = UTF8BytesString.create("play-ws");
   public static final PlayWSClientDecorator DECORATE = new PlayWSClientDecorator();
+  public static final CharSequence PLAY_WS_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
 
   @Override
   protected String method(final Request request) {

--- a/dd-java-agent/instrumentation/play-ws/src/test/groovy/PlayWSClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/play-ws/src/test/groovy/PlayWSClientTestBase.groovy
@@ -44,10 +44,6 @@ abstract class PlayWSClientTestBase extends HttpClientTest {
     return PlayWSClientDecorator.DECORATE.component()
   }
 
-  String expectedOperationName() {
-    return "play-ws.request"
-  }
-
   @Override
   boolean testCircularRedirects() {
     return false
@@ -56,5 +52,20 @@ abstract class PlayWSClientTestBase extends HttpClientTest {
   @Override
   boolean testCallbackWithParent() {
     return false
+  }
+
+  @Override
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "play-ws.request"
   }
 }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/client/RatpackHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/client/RatpackHttpClientTest.groovy
@@ -1,6 +1,7 @@
 package client
 
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingNettyHttpNamingConventions
 import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
 import ratpack.exec.ExecResult
 import ratpack.http.client.HttpClient
@@ -12,7 +13,7 @@ import spock.lang.Timeout
 import java.time.Duration
 
 @Timeout(5)
-class RatpackHttpClientTest extends HttpClientTest {
+class RatpackHttpClientTest extends HttpClientTest implements TestingNettyHttpNamingConventions.ClientV0 {
 
   @AutoCleanup
   @Shared
@@ -53,10 +54,6 @@ class RatpackHttpClientTest extends HttpClientTest {
     return NettyHttpClientDecorator.DECORATE.component()
   }
 
-  @Override
-  String expectedOperationName() {
-    return "netty.client.request"
-  }
 
   @Override
   boolean testRedirects() {

--- a/dd-java-agent/instrumentation/reactor-netty-1/src/test/groovy/ReactorNettyHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-netty-1/src/test/groovy/ReactorNettyHttpClientTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingNettyHttpNamingConventions
 import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
 import io.netty.handler.codec.http.HttpMethod
 import reactor.core.publisher.Flux
@@ -14,7 +15,7 @@ import java.util.function.BiFunction
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
-class ReactorNettyHttpClientTest extends HttpClientTest {
+class ReactorNettyHttpClientTest extends HttpClientTest implements TestingNettyHttpNamingConventions.ClientV0{
   // Can't be @Shared otherwise field-injected classes get loaded too early.
   HttpClient httpClient = HttpClient.create()
   .followRedirect(true)
@@ -43,10 +44,6 @@ class ReactorNettyHttpClientTest extends HttpClientTest {
     return NettyHttpClientDecorator.DECORATE.component()
   }
 
-  @Override
-  String expectedOperationName() {
-    return "netty.client.request"
-  }
 
   @Override
   boolean testRedirects() {

--- a/dd-java-agent/instrumentation/rediscala-1.8.0/src/test/groovy/RediscalaClientTest.groovy
+++ b/dd-java-agent/instrumentation/rediscala-1.8.0/src/test/groovy/RediscalaClientTest.groovy
@@ -149,17 +149,17 @@ abstract class RediscalaClientTest extends VersionedNamingTestBase {
 class RediscalaClientV0ForkedTest extends RediscalaClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.query"
   }
 }
@@ -167,17 +167,17 @@ class RediscalaClientV0ForkedTest extends RediscalaClientTest {
 class RediscalaClientV1ForkedTest extends RediscalaClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return Config.get().getServiceName() + "-redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.command"
   }
 }

--- a/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redisson20/groovy/RedissonClientTest.groovy
+++ b/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redisson20/groovy/RedissonClientTest.groovy
@@ -551,17 +551,17 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 class RedissonClientV0ForkedTest extends RedissonClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.query"
   }
 }
@@ -569,17 +569,17 @@ class RedissonClientV0ForkedTest extends RedissonClientTest {
 class RedissonClientV1ForkedTest extends RedissonClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return datadog.trace.api.Config.get().getServiceName() + "-redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.command"
   }
 }

--- a/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redisson23/groovy/RedissonClientTest.groovy
+++ b/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redisson23/groovy/RedissonClientTest.groovy
@@ -554,17 +554,17 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 class RedissonClientV0ForkedTest extends RedissonClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.query"
   }
 }
@@ -572,17 +572,17 @@ class RedissonClientV0ForkedTest extends RedissonClientTest {
 class RedissonClientV1ForkedTest extends RedissonClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return datadog.trace.api.Config.get().getServiceName() + "-redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.command"
   }
 }

--- a/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redissonLatest/groovy/RedissonClientTest.groovy
+++ b/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redissonLatest/groovy/RedissonClientTest.groovy
@@ -544,17 +544,17 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 class RedissonClientV0ForkedTest extends RedissonClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.query"
   }
 }
@@ -562,17 +562,17 @@ class RedissonClientV0ForkedTest extends RedissonClientTest {
 class RedissonClientV1ForkedTest extends RedissonClientTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return datadog.trace.api.Config.get().getServiceName() + "-redis"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "redis.command"
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientDecorator.java
@@ -12,8 +12,6 @@ import org.springframework.web.reactive.function.client.ClientResponse;
 
 public class SpringWebfluxHttpClientDecorator
     extends HttpClientDecorator<ClientRequest, ClientResponse> {
-
-  public static final CharSequence HTTP_REQUEST = UTF8BytesString.create("http.request");
   public static final CharSequence SPRING_WEBFLUX_CLIENT =
       UTF8BytesString.create("spring-webflux-client");
   public static final CharSequence CANCELLED = UTF8BytesString.create("cancelled");
@@ -24,6 +22,8 @@ public class SpringWebfluxHttpClientDecorator
 
   public static final SpringWebfluxHttpClientDecorator DECORATE =
       new SpringWebfluxHttpClientDecorator();
+
+  public static final CharSequence HTTP_REQUEST = UTF8BytesString.create(DECORATE.operationName());
 
   public void onCancel(final AgentSpan span) {
     span.setTag("event", CANCELLED);

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBase.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBase.groovy
@@ -2,6 +2,7 @@ package dd.trace.instrumentation.springwebflux.client
 
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -17,7 +18,7 @@ import reactor.core.publisher.Mono
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
-abstract class SpringWebfluxHttpClientBase extends HttpClientTest {
+abstract class SpringWebfluxHttpClientBase extends HttpClientTest implements TestingGenericHttpNamingConventions.ClientV0 {
 
   @Override
   boolean useStrictTraceWrites() {
@@ -68,7 +69,7 @@ abstract class SpringWebfluxHttpClientBase extends HttpClientTest {
         if (renameService) {
           serviceName("localhost")
         }
-        operationName "netty.client.request"
+        operationName NettyHttpClientDecorator.DECORATE.operationName()
         resourceName "$method $uri.path"
         spanType DDSpanTypes.HTTP_CLIENT
         errored error

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientDoOnSuccessOrErrorTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientDoOnSuccessOrErrorTest.groovy
@@ -1,5 +1,6 @@
 package dd.trace.instrumentation.springwebflux.client
 
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import org.springframework.http.HttpMethod
 import org.springframework.web.reactive.function.client.ClientResponse
 import org.springframework.web.reactive.function.client.WebClient
@@ -7,8 +8,7 @@ import spock.lang.Timeout
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
-@Timeout(5)
-class SpringWebfluxHttpClientDoOnSuccessOrErrorTest extends SpringWebfluxHttpClientBase {
+abstract class SpringWebfluxHttpClientDoOnSuccessOrErrorTest extends SpringWebfluxHttpClientBase {
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
@@ -40,4 +40,12 @@ class SpringWebfluxHttpClientDoOnSuccessOrErrorTest extends SpringWebfluxHttpCli
   @Override
   void check() {
   }
+}
+
+@Timeout(5)
+class SpringWebfluxHttpClientDoOnSuccessOrErrorV0ForkedTest extends SpringWebfluxHttpClientDoOnSuccessOrErrorTest {
+}
+
+@Timeout(5)
+class SpringWebfluxHttpClientDoOnSuccessOrErrorV1ForkedTest extends SpringWebfluxHttpClientDoOnSuccessOrErrorTest implements TestingGenericHttpNamingConventions.ClientV1 {
 }

--- a/dd-java-agent/instrumentation/spring-webflux-6/src/main/java17/datadog/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/spring-webflux-6/src/main/java17/datadog/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientDecorator.java
@@ -13,7 +13,6 @@ import org.springframework.web.reactive.function.client.ClientResponse;
 public class SpringWebfluxHttpClientDecorator
     extends HttpClientDecorator<ClientRequest, ClientResponse> {
 
-  public static final CharSequence HTTP_REQUEST = UTF8BytesString.create("http.request");
   public static final CharSequence SPRING_WEBFLUX_CLIENT =
       UTF8BytesString.create("spring-webflux-client");
   public static final CharSequence CANCELLED = UTF8BytesString.create("cancelled");
@@ -24,6 +23,8 @@ public class SpringWebfluxHttpClientDecorator
 
   public static final SpringWebfluxHttpClientDecorator DECORATE =
       new SpringWebfluxHttpClientDecorator();
+
+  public static final CharSequence HTTP_REQUEST = UTF8BytesString.create(DECORATE.operationName());
 
   public void onCancel(final AgentSpan span) {
     span.setTag("event", CANCELLED);

--- a/dd-java-agent/instrumentation/spring-webflux-6/src/test/groovy/dd/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientBase.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-6/src/test/groovy/dd/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientBase.groovy
@@ -2,8 +2,10 @@ package dd.trace.instrumentation.springwebflux6.client
 
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
+import datadog.trace.api.naming.SpanNaming
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
 import datadog.trace.instrumentation.springwebflux6.client.SpringWebfluxHttpClientDecorator
@@ -17,7 +19,7 @@ import reactor.core.publisher.Mono
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
-abstract class SpringWebfluxHttpClientBase extends HttpClientTest {
+abstract class SpringWebfluxHttpClientBase extends HttpClientTest implements TestingGenericHttpNamingConventions.ClientV0 {
 
   @Override
   boolean useStrictTraceWrites() {
@@ -66,7 +68,7 @@ abstract class SpringWebfluxHttpClientBase extends HttpClientTest {
         if (renameService) {
           serviceName("localhost")
         }
-        operationName "netty.client.request"
+        operationName SpanNaming.instance().namingSchema().client().operationForComponent(NettyHttpClientDecorator.DECORATE.component().toString())
         resourceName "$method $uri.path"
         spanType DDSpanTypes.HTTP_CLIENT
         errored error

--- a/dd-java-agent/instrumentation/spring-webflux-6/src/test/groovy/dd/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientDoOnSuccessOrErrorTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-6/src/test/groovy/dd/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientDoOnSuccessOrErrorTest.groovy
@@ -1,5 +1,6 @@
 package dd.trace.instrumentation.springwebflux6.client
 
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import org.springframework.http.HttpMethod
 import org.springframework.web.reactive.function.client.ClientResponse
 import org.springframework.web.reactive.function.client.WebClient
@@ -7,8 +8,7 @@ import spock.lang.Timeout
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
-@Timeout(5)
-class SpringWebfluxHttpClientDoOnSuccessOrErrorTest extends SpringWebfluxHttpClientBase {
+abstract class SpringWebfluxHttpClientDoOnSuccessOrErrorTest extends SpringWebfluxHttpClientBase {
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
@@ -40,4 +40,12 @@ class SpringWebfluxHttpClientDoOnSuccessOrErrorTest extends SpringWebfluxHttpCli
   @Override
   void check() {
   }
+}
+
+@Timeout(5)
+class SpringWebfluxHttpClientDoOnSuccessOrErrorV0ForkedTest extends SpringWebfluxHttpClientDoOnSuccessOrErrorTest {
+}
+
+@Timeout(5)
+class SpringWebfluxHttpClientDoOnSuccessOrErrorV1ForkedTest extends SpringWebfluxHttpClientDoOnSuccessOrErrorTest implements TestingGenericHttpNamingConventions.ClientV1 {
 }

--- a/dd-java-agent/instrumentation/spymemcached-2.12/src/test/groovy/datadog/trace/instrumentation/spymemcached/SpymemcachedTest.groovy
+++ b/dd-java-agent/instrumentation/spymemcached-2.12/src/test/groovy/datadog/trace/instrumentation/spymemcached/SpymemcachedTest.groovy
@@ -715,17 +715,17 @@ abstract class SpymemcachedTest extends VersionedNamingTestBase {
 class SpymemcachedV0ForkedTest extends SpymemcachedTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 0
   }
 
   @Override
-  protected String service() {
+  String service() {
     return "memcached"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "memcached.query"
   }
 }
@@ -733,17 +733,17 @@ class SpymemcachedV0ForkedTest extends SpymemcachedTest {
 class SpymemcachedV1ForkedTest extends SpymemcachedTest {
 
   @Override
-  protected int version() {
+  int version() {
     return 1
   }
 
   @Override
-  protected String service() {
+  String service() {
     return Config.get().getServiceName() + "-memcached"
   }
 
   @Override
-  protected String operation() {
+  String operation() {
     return "memcached.command"
   }
 }

--- a/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseClientDecorator.java
+++ b/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseClientDecorator.java
@@ -10,10 +10,9 @@ import org.apache.http.HttpResponse;
 
 public final class SynapseClientDecorator extends HttpClientDecorator<HttpRequest, HttpResponse> {
   public static final SynapseClientDecorator DECORATE = new SynapseClientDecorator();
-
-  public static final CharSequence SYNAPSE_REQUEST = UTF8BytesString.create("http.request");
   public static final CharSequence SYNAPSE_CLIENT = UTF8BytesString.create("synapse-client");
-
+  public static final CharSequence SYNAPSE_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
   public static final String SYNAPSE_SPAN_KEY = "dd.trace.synapse.span";
   public static final String SYNAPSE_CONTINUATION_KEY = "dd.trace.synapse.continuation";
 

--- a/dd-java-agent/instrumentation/synapse-3/src/test/groovy/datadog/trace/instrumentation/synapse3/SynapseTest.groovy
+++ b/dd-java-agent/instrumentation/synapse-3/src/test/groovy/datadog/trace/instrumentation/synapse3/SynapseTest.groovy
@@ -1,7 +1,9 @@
 package datadog.trace.instrumentation.synapse3
 
-import datadog.trace.agent.test.AgentTestRunner
+
 import datadog.trace.agent.test.asserts.TraceAssert
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
+import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.agent.test.utils.OkHttpUtils
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
@@ -30,7 +32,7 @@ import java.lang.reflect.Field
 import java.util.concurrent.TimeUnit
 
 @Flaky("Occasionally times out when receiving traces")
-class SynapseTest extends AgentTestRunner {
+abstract class SynapseTest extends VersionedNamingTestBase {
 
   String expectedServiceName() {
     CapturedEnvironment.get().getProperties().get(GeneralConfig.SERVICE_NAME)
@@ -285,7 +287,7 @@ class SynapseTest extends AgentTestRunner {
   def clientSpan(TraceAssert trace, int index, String method, int statusCode, Object parentSpan = null) {
     trace.span {
       serviceName expectedServiceName()
-      operationName "http.request"
+      operationName operation()
       resourceName "${method} /services/SimpleStockQuoteService"
       spanType DDSpanTypes.HTTP_CLIENT
       errored statusCode >= 500
@@ -305,5 +307,12 @@ class SynapseTest extends AgentTestRunner {
       }
     }
   }
+}
+
+class SynapseV0ForkedTest extends SynapseTest implements TestingGenericHttpNamingConventions.ClientV0 {
+
+}
+
+class SynapseV1ForkedTest extends SynapseTest implements TestingGenericHttpNamingConventions.ClientV1 {
 
 }

--- a/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxCircuitBreakerWebClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxCircuitBreakerWebClientForkedTest.groovy
@@ -1,6 +1,7 @@
 package client
 
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingNettyHttpNamingConventions
 import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
 import io.vertx.circuitbreaker.CircuitBreakerOptions
 import io.vertx.core.VertxOptions
@@ -16,7 +17,7 @@ import spock.lang.Timeout
 import java.util.concurrent.CompletableFuture
 
 @Timeout(10)
-class VertxRxCircuitBreakerWebClientForkedTest extends HttpClientTest {
+class VertxRxCircuitBreakerWebClientForkedTest extends HttpClientTest implements TestingNettyHttpNamingConventions.ClientV0 {
 
   @Override
   boolean useStrictTraceWrites() {
@@ -68,11 +69,6 @@ class VertxRxCircuitBreakerWebClientForkedTest extends HttpClientTest {
   @Override
   CharSequence component() {
     return NettyHttpClientDecorator.DECORATE.component()
-  }
-
-  @Override
-  String expectedOperationName() {
-    return "netty.client.request"
   }
 
   @Override

--- a/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxWebClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxWebClientForkedTest.groovy
@@ -1,6 +1,7 @@
 package client
 
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingNettyHttpNamingConventions
 import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
 import io.vertx.core.VertxOptions
 import io.vertx.core.http.HttpMethod
@@ -12,7 +13,7 @@ import spock.lang.Shared
 import spock.lang.Timeout
 
 @Timeout(10)
-class VertxRxWebClientForkedTest extends HttpClientTest {
+class VertxRxWebClientForkedTest extends HttpClientTest implements TestingNettyHttpNamingConventions.ClientV0 {
 
   @Override
   boolean useStrictTraceWrites() {
@@ -45,11 +46,6 @@ class VertxRxWebClientForkedTest extends HttpClientTest {
   @Override
   CharSequence component() {
     return NettyHttpClientDecorator.DECORATE.component()
-  }
-
-  @Override
-  String expectedOperationName() {
-    return "netty.client.request"
   }
 
   @Override

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/client/VertxHttpClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/client/VertxHttpClientForkedTest.groovy
@@ -1,6 +1,7 @@
 package client
 
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingNettyHttpNamingConventions
 import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
 import io.vertx.core.Vertx
 import io.vertx.core.VertxOptions
@@ -13,7 +14,7 @@ import spock.lang.Shared
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
-class VertxHttpClientForkedTest extends HttpClientTest {
+class VertxHttpClientForkedTest extends HttpClientTest implements TestingNettyHttpNamingConventions.ClientV0 {
 
   @Override
   boolean useStrictTraceWrites() {
@@ -52,11 +53,6 @@ class VertxHttpClientForkedTest extends HttpClientTest {
   @Override
   CharSequence component() {
     return NettyHttpClientDecorator.DECORATE.component()
-  }
-
-  @Override
-  String expectedOperationName() {
-    return "netty.client.request"
   }
 
   @Override

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/client/VertxHttpClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/client/VertxHttpClientForkedTest.groovy
@@ -1,6 +1,7 @@
 package client
 
 import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.naming.TestingNettyHttpNamingConventions
 import datadog.trace.instrumentation.netty41.client.NettyHttpClientDecorator
 import io.vertx.core.Vertx
 import io.vertx.core.VertxOptions
@@ -13,7 +14,7 @@ import spock.lang.Shared
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
-class VertxHttpClientForkedTest extends HttpClientTest {
+class VertxHttpClientForkedTest extends HttpClientTest implements TestingNettyHttpNamingConventions.ClientV0 {
 
   @Override
   boolean useStrictTraceWrites() {
@@ -57,11 +58,6 @@ class VertxHttpClientForkedTest extends HttpClientTest {
   @Override
   CharSequence component() {
     return NettyHttpClientDecorator.DECORATE.component()
-  }
-
-  @Override
-  String expectedOperationName() {
-    return "netty.client.request"
   }
 
   @Override

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -86,7 +86,6 @@ abstract class HttpClientTest extends VersionedNamingTestBase {
   @Shared
   ProxySelector proxySelector
 
-  @Shared
   String component = component()
 
   @Override
@@ -749,7 +748,7 @@ abstract class HttpClientTest extends VersionedNamingTestBase {
       if (renameService) {
         serviceName uri.host
       }
-      operationName expectedOperationName()
+      operationName operation()
       resourceName "$method $uri.path"
       spanType DDSpanTypes.HTTP_CLIENT
       errored error
@@ -778,10 +777,6 @@ abstract class HttpClientTest extends VersionedNamingTestBase {
         defaultTags()
       }
     }
-  }
-
-  String expectedOperationName() {
-    return operation()
   }
 
   int size(int size) {
@@ -822,20 +817,5 @@ abstract class HttpClientTest extends VersionedNamingTestBase {
     // FIXME: this hack is here because callback with parent is broken in play-ws when the stream()
     // function is used.  There is no way to stop a test from a derived class hence the flag
     true
-  }
-
-  @Override
-  protected int version() {
-    return 0
-  }
-
-  @Override
-  protected String service() {
-    return null
-  }
-
-  @Override
-  protected String operation() {
-    return "http.request"
   }
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/naming/NamingConventions.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/naming/NamingConventions.groovy
@@ -1,0 +1,58 @@
+package datadog.trace.agent.test.naming
+
+class TestingGenericHttpNamingConventions {
+  trait ClientV0 implements VersionedNamingTest {
+    @Override
+    int version() {
+      return 0
+    }
+
+    @Override
+    String service() {
+      return null
+    }
+
+    @Override
+    String operation() {
+      return "http.request"
+    }
+  }
+  trait ClientV1 implements VersionedNamingTest {
+    @Override
+    int version() {
+      return 1
+    }
+
+    @Override
+    String service() {
+      return null
+    }
+
+    @Override
+    String operation() {
+      return "http.client.request"
+    }
+  }
+}
+
+class TestingNettyHttpNamingConventions {
+  trait ClientV0 implements VersionedNamingTest {
+    @Override
+    int version() {
+      return 0
+    }
+
+    @Override
+    String service() {
+      return null
+    }
+
+    @Override
+    String operation() {
+      return "netty.client.request"
+    }
+  }
+
+  trait ClientV1 extends TestingGenericHttpNamingConventions.ClientV1 {
+  }
+}

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/naming/VersionedNamingTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/naming/VersionedNamingTest.groovy
@@ -1,0 +1,9 @@
+package datadog.trace.agent.test.naming
+
+interface VersionedNamingTest {
+  int version()
+
+  String service()
+
+  String operation()
+}

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/naming/VersionedNamingTestBase.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/naming/VersionedNamingTestBase.groovy
@@ -3,10 +3,8 @@ package datadog.trace.agent.test.naming
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.config.TracerConfig
 
-abstract class VersionedNamingTestBase extends AgentTestRunner {
-  protected abstract int version()
-  protected abstract String service()
-  protected abstract String operation()
+abstract class VersionedNamingTestBase extends AgentTestRunner implements VersionedNamingTest {
+
 
   @Override
   protected void configurePreAgent() {

--- a/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
@@ -53,7 +53,16 @@ public interface NamingSchema {
      * @return the operation name
      */
     @Nonnull
-    String operation(@Nonnull String protocol);
+    String operationForProtocol(@Nonnull String protocol);
+
+    /**
+     * Calculate the operation name for a client span.
+     *
+     * @param component the name of the instrumentation componen
+     * @return the operation name
+     */
+    @Nonnull
+    String operationForComponent(@Nonnull String component);
   }
 
   interface ForDatabase {

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/ClientNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/ClientNamingV0.java
@@ -6,7 +6,25 @@ import javax.annotation.Nonnull;
 public class ClientNamingV0 implements NamingSchema.ForClient {
   @Nonnull
   @Override
-  public String operation(@Nonnull String protocol) {
+  public String operationForProtocol(@Nonnull String protocol) {
     return protocol + ".request";
+  }
+
+  @Nonnull
+  @Override
+  public String operationForComponent(@Nonnull String component) {
+    switch (component) {
+      case "play-ws":
+      case "okhttp":
+        return component + ".request";
+      case "netty-client":
+        return "netty.client.request";
+      case "akka-http-client":
+        return "akka-http.client.request";
+      case "jax-rs.client":
+        return "jax-rs.client.call";
+      default:
+        return "http.request";
+    }
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/ClientNamingV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/ClientNamingV1.java
@@ -21,7 +21,13 @@ public class ClientNamingV1 implements NamingSchema.ForClient {
 
   @Nonnull
   @Override
-  public String operation(@Nonnull String protocol) {
+  public String operationForProtocol(@Nonnull String protocol) {
     return normalizeProtocol(protocol) + ".client.request";
+  }
+
+  @Nonnull
+  @Override
+  public String operationForComponent(@Nonnull String component) {
+    return "http.client.request";
   }
 }


### PR DESCRIPTION
# What Does This Do

v1 changes for http client naming schema:
* operation: `http.client.request`

Service name is unchanged.

# Motivation

# Additional Notes
