### PR TITLE
naming schema: grpc client

### DIFF
--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/ClientCallImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/ClientCallImplInstrumentation.java
@@ -5,7 +5,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.instrumentation.grpc.client.GrpcClientDecorator.CLIENT_PATHWAY_EDGE_TAGS;
 import static datadog.trace.instrumentation.grpc.client.GrpcClientDecorator.DECORATE;
-import static datadog.trace.instrumentation.grpc.client.GrpcClientDecorator.GRPC_CLIENT;
+import static datadog.trace.instrumentation.grpc.client.GrpcClientDecorator.OPERATION_NAME;
 import static datadog.trace.instrumentation.grpc.client.GrpcInjectAdapter.SETTER;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -66,7 +66,7 @@ public final class ClientCallImplInstrumentation extends Instrumenter.Tracing
     public static void capture(@Advice.This io.grpc.ClientCall<?, ?> call) {
       AgentSpan span = AgentTracer.activeSpan();
       // embed the span in the call only if a grpc.client span is active
-      if (null != span && GRPC_CLIENT.equals(span.getOperationName())) {
+      if (null != span && OPERATION_NAME.equals(span.getOperationName())) {
         InstrumentationContext.get(ClientCall.class, AgentSpan.class).put(call, span);
       }
     }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientDecorator.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientDecorator.java
@@ -7,6 +7,7 @@ import static datadog.trace.core.datastreams.TagsProcessor.TYPE_TAG;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.GenericClassValue;
+import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -19,11 +20,13 @@ import java.util.Set;
 import java.util.function.Function;
 
 public class GrpcClientDecorator extends ClientDecorator {
-  public static final CharSequence GRPC_CLIENT = UTF8BytesString.create("grpc.client");
+  public static final CharSequence OPERATION_NAME =
+      UTF8BytesString.create(
+          SpanNaming.instance().namingSchema().client().operationForProtocol("grpc"));
   public static final CharSequence COMPONENT_NAME = UTF8BytesString.create("grpc-client");
   public static final CharSequence GRPC_MESSAGE = UTF8BytesString.create("grpc.message");
 
-  private static final LinkedHashMap<String, String> createClientPathwaySortedTags() {
+  private static LinkedHashMap<String, String> createClientPathwaySortedTags() {
     LinkedHashMap<String, String> result = new LinkedHashMap<>();
     result.put(DIRECTION_TAG, DIRECTION_OUT);
     result.put(TYPE_TAG, "grpc");
@@ -88,7 +91,7 @@ public class GrpcClientDecorator extends ClientDecorator {
       return null;
     }
     AgentSpan span =
-        startSpan(GRPC_CLIENT)
+        startSpan(OPERATION_NAME)
             .setTag("request.type", requestMessageType(method))
             .setTag("response.type", responseMessageType(method));
     span.setResourceName(method.getFullMethodName());

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/MessagesAvailableInstrumentation.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/MessagesAvailableInstrumentation.java
@@ -5,8 +5,8 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.grpc.client.GrpcClientDecorator.DECORATE;
-import static datadog.trace.instrumentation.grpc.client.GrpcClientDecorator.GRPC_CLIENT;
 import static datadog.trace.instrumentation.grpc.client.GrpcClientDecorator.GRPC_MESSAGE;
+import static datadog.trace.instrumentation.grpc.client.GrpcClientDecorator.OPERATION_NAME;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
@@ -56,7 +56,7 @@ public final class MessagesAvailableInstrumentation extends Instrumenter.Tracing
     @Advice.OnMethodEnter
     public static AgentScope before() {
       AgentSpan clientSpan = activeSpan();
-      if (clientSpan != null && clientSpan.getOperationName() == GRPC_CLIENT) {
+      if (clientSpan != null && OPERATION_NAME.equals(clientSpan.getOperationName())) {
         AgentSpan messageSpan =
             startSpan(GRPC_MESSAGE).setTag("message.type", clientSpan.getTag("response.type"));
         DECORATE.afterStart(messageSpan);

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
@@ -1,5 +1,5 @@
 import com.google.common.util.concurrent.MoreExecutors
-import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import example.GreeterGrpc
@@ -16,7 +16,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
-class GrpcStreamingTest extends AgentTestRunner {
+abstract class GrpcStreamingTest extends VersionedNamingTestBase {
 
   @Override
   protected void configurePreAgent() {
@@ -130,7 +130,7 @@ class GrpcStreamingTest extends AgentTestRunner {
     assertTraces(2) {
       trace((clientMessageCount * serverMessageCount) + 1) {
         span {
-          operationName "grpc.client"
+          operationName operation()
           resourceName "example.Greeter/Conversation"
           spanType DDSpanTypes.RPC
           parent()
@@ -211,5 +211,41 @@ class GrpcStreamingTest extends AgentTestRunner {
 
     clientRange = 1..clientMessageCount
     serverRange = 1..serverMessageCount
+  }
+}
+
+class GrpcStreamingV0ForkedTest extends GrpcStreamingTest {
+
+  @Override
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "grpc.client"
+  }
+}
+
+class GrpcStreamingV1ForkedTest extends GrpcStreamingTest {
+
+  @Override
+  int version() {
+    return 1
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "grpc.client.request"
   }
 }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -1,5 +1,5 @@
 import com.google.common.util.concurrent.MoreExecutors
-import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
@@ -37,7 +37,7 @@ import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.api.gateway.Events.EVENTS
 
-abstract class GrpcTest extends AgentTestRunner {
+abstract class GrpcTest extends VersionedNamingTestBase {
 
   @Shared
   def ig
@@ -122,7 +122,7 @@ abstract class GrpcTest extends AgentTestRunner {
       trace(3) {
         basicSpan(it, "parent")
         span {
-          operationName "grpc.client"
+          operationName operation()
           resourceName "example.Greeter/SayHello"
           spanType DDSpanTypes.RPC
           childOf span(0)
@@ -260,7 +260,7 @@ abstract class GrpcTest extends AgentTestRunner {
     assertTraces(2) {
       trace(1) {
         span {
-          operationName "grpc.client"
+          operationName operation()
           resourceName "example.Greeter/SayHello"
           spanType DDSpanTypes.RPC
           parent()
@@ -360,7 +360,7 @@ abstract class GrpcTest extends AgentTestRunner {
     assertTraces(2) {
       trace(1) {
         span {
-          operationName "grpc.client"
+          operationName operation()
           resourceName "example.Greeter/SayHello"
           spanType DDSpanTypes.RPC
           parent()
@@ -547,7 +547,7 @@ abstract class GrpcTest extends AgentTestRunner {
     assertTraces(1) {
       trace(2) {
         span {
-          operationName "grpc.client"
+          operationName operation()
           resourceName "example.Greeter/IgnoreInbound"
           spanType DDSpanTypes.RPC
           parent()
@@ -596,7 +596,7 @@ abstract class GrpcTest extends AgentTestRunner {
   }
 }
 
-class GrpcDataStreamsEnabledForkedTest extends GrpcTest {
+abstract class GrpcDataStreamsEnabledForkedTest extends GrpcTest {
   @Override
   protected void configurePreAgent() {
     super.configurePreAgent()
@@ -607,7 +607,42 @@ class GrpcDataStreamsEnabledForkedTest extends GrpcTest {
   protected boolean isDataStreamsEnabled() {
     return true
   }
+}
 
+class GrpcDataStreamsEnabledV0ForkedTest extends GrpcDataStreamsEnabledForkedTest {
+
+  @Override
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "grpc.client"
+  }
+}
+
+class GrpcDataStreamsEnabledV1ForkedTest extends GrpcDataStreamsEnabledForkedTest {
+
+  @Override
+  int version() {
+    return 1
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "grpc.client.request"
+  }
 }
 
 class GrpcDataStreamsDisabledForkedTest extends GrpcTest {
@@ -620,5 +655,20 @@ class GrpcDataStreamsDisabledForkedTest extends GrpcTest {
   @Override
   protected boolean isDataStreamsEnabled() {
     return false
+  }
+
+  @Override
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "grpc.client"
   }
 }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/HierarchyMatcherGrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/HierarchyMatcherGrpcStreamingTest.groovy
@@ -4,4 +4,19 @@ class HierarchyMatcherGrpcStreamingTest extends GrpcStreamingTest {
     super.configurePreAgent()
     injectSysConfig("dd.integration.grpc.matching.shortcut.enabled", "false")
   }
+
+  @Override
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "grpc.client"
+  }
 }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/HierarchyMatcherGrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/HierarchyMatcherGrpcTest.groovy
@@ -5,4 +5,18 @@ class HierarchyMatcherGrpcTest extends GrpcTest {
     super.configurePreAgent()
     injectSysConfig("dd.integration.grpc.matching.shortcut.enabled", "false")
   }
+  @Override
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "grpc.client"
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/ClientNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/ClientNamingV0.java
@@ -7,7 +7,11 @@ public class ClientNamingV0 implements NamingSchema.ForClient {
   @Nonnull
   @Override
   public String operationForProtocol(@Nonnull String protocol) {
-    return protocol + ".request";
+    String postfix = ".request";
+    if ("grpc".equals(protocol)) {
+      postfix = ".client";
+    }
+    return protocol + postfix;
   }
 
   @Nonnull


### PR DESCRIPTION
# What Does This Do

v1 naming schema changes for grpc clients:
* operation: `grpc.client.request`

# Motivation

# Additional Notes
