### PR TITLE
naming schema: rmi clients

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/rmi/RmiClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/rmi/RmiClientDecorator.java
@@ -1,11 +1,14 @@
 package datadog.trace.bootstrap.instrumentation.rmi;
 
+import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.ClientDecorator;
 
 public class RmiClientDecorator extends ClientDecorator {
-  public static final CharSequence RMI_INVOKE = UTF8BytesString.create("rmi.invoke");
+  public static final CharSequence RMI_INVOKE =
+      UTF8BytesString.create(
+          SpanNaming.instance().namingSchema().client().operationForProtocol("rmi"));
   public static final CharSequence RMI_CLIENT = UTF8BytesString.create("rmi-client");
   public static final RmiClientDecorator DECORATE = new RmiClientDecorator();
 

--- a/dd-java-agent/instrumentation/rmi/src/test/groovy/RmiTest.groovy
+++ b/dd-java-agent/instrumentation/rmi/src/test/groovy/RmiTest.groovy
@@ -1,4 +1,4 @@
-import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -14,7 +14,7 @@ import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
-class RmiTest extends AgentTestRunner {
+abstract class RmiTest extends VersionedNamingTestBase {
   def registryPort = PortUtils.randomOpenPort()
   def serverRegistry = LocateRegistry.createRegistry(registryPort)
   def clientRegistry = LocateRegistry.getRegistry("localhost", registryPort)
@@ -41,7 +41,7 @@ class RmiTest extends AgentTestRunner {
         basicSpan(it, "parent")
         span {
           resourceName "Greeter.hello"
-          operationName "rmi.invoke"
+          operationName operation()
           childOf span(0)
           spanType DDSpanTypes.RPC
           measured true
@@ -121,7 +121,7 @@ class RmiTest extends AgentTestRunner {
         basicSpan(it, "parent", null, thrownException)
         span {
           resourceName "Greeter.exceptional"
-          operationName "rmi.invoke"
+          operationName operation()
           childOf span(0)
           errored true
           spanType DDSpanTypes.RPC
@@ -176,7 +176,7 @@ class RmiTest extends AgentTestRunner {
         basicSpan(it, "parent")
         span {
           resourceName "Greeter.hello"
-          operationName "rmi.invoke"
+          operationName operation()
           spanType DDSpanTypes.RPC
           childOf span(0)
           measured true
@@ -205,5 +205,41 @@ class RmiTest extends AgentTestRunner {
 
     cleanup:
     serverRegistry.unbind(ServerLegacy.RMI_ID)
+  }
+}
+
+class RmiV0ForkedTest extends RmiTest {
+
+  @Override
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "rmi.invoke"
+  }
+}
+
+class RmiV1ForkedTest extends RmiTest {
+
+  @Override
+  int version() {
+    return 1
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "rmi.client.request"
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/ClientNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/ClientNamingV0.java
@@ -7,10 +7,18 @@ public class ClientNamingV0 implements NamingSchema.ForClient {
   @Nonnull
   @Override
   public String operationForProtocol(@Nonnull String protocol) {
-    String postfix = ".request";
-    if ("grpc".equals(protocol)) {
-      postfix = ".client";
+    final String postfix;
+    switch (protocol) {
+      case "grpc":
+        postfix = ".client";
+        break;
+      case "rmi":
+        postfix = ".invoke";
+        break;
+      default:
+        postfix = ".request";
     }
+
     return protocol + postfix;
   }
 


### PR DESCRIPTION
# What Does This Do

v1 naming schema changes for rmi clients:
* operation: `rmi.client.request`


# Motivation

# Additional Notes
