### PR TITLE
Align DD_TRACE_PROPAGATION_STYLE* names with other tracers

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/PropagationStyle.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/PropagationStyle.java
@@ -11,7 +11,7 @@ import java.util.List;
 @Deprecated
 public enum PropagationStyle {
   DATADOG(TracePropagationStyle.DATADOG),
-  B3(TracePropagationStyle.B3, TracePropagationStyle.B3MULTI),
+  B3(TracePropagationStyle.B3SINGLE, TracePropagationStyle.B3MULTI),
   HAYSTACK(TracePropagationStyle.HAYSTACK),
   XRAY(TracePropagationStyle.XRAY);
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/TracePropagationStyle.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/TracePropagationStyle.java
@@ -6,7 +6,7 @@ public enum TracePropagationStyle {
   DATADOG,
   // B3 single header context propagation style
   // https://github.com/openzipkin/b3-propagation/tree/master#single-header
-  B3,
+  B3SINGLE,
   // B3 multi header context propagation style
   // https://github.com/openzipkin/b3-propagation/tree/master#multiple-headers
   B3MULTI,
@@ -15,15 +15,21 @@ public enum TracePropagationStyle {
   HAYSTACK,
   // Amazon X-Ray context propagation style
   // https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader
-  XRAY;
+  XRAY,
+  // None does not extract or inject
+  NONE;
 
   public static TracePropagationStyle valueOfDisplayName(String displayName) {
     String convertedName = displayName.toUpperCase().replace(' ', '_');
     // Another name for B3 for cross tracer compatibility
-    if (convertedName.equals("B3_SINGLE_HEADER")) {
-      return B3;
+    switch (convertedName) {
+      case "B3_SINGLE_HEADER":
+        return B3SINGLE;
+      case "B3":
+        return B3MULTI;
+      default:
+        return TracePropagationStyle.valueOf(convertedName);
     }
-    return TracePropagationStyle.valueOf(convertedName);
   }
 
   private String displayName;

--- a/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
@@ -87,6 +87,14 @@ public final class StatusLogger extends JsonAdapter<Config>
     writer.value(!agentServiceCheck(config));
     writer.name("debug");
     writer.value(config.isDebugEnabled());
+    writer.name("trace_propagation_style_extract");
+    writer.beginArray();
+    writeSet(writer, config.getTracePropagationStylesToExtract());
+    writer.endArray();
+    writer.name("trace_propagation_style_inject");
+    writer.beginArray();
+    writeSet(writer, config.getTracePropagationStylesToInject());
+    writer.endArray();
     writer.name("analytics_enabled");
     writer.value(config.isTraceAnalyticsEnabled());
     writer.name("sample_rate");
@@ -166,6 +174,12 @@ public final class StatusLogger extends JsonAdapter<Config>
       }
     }
     writer.endObject();
+  }
+
+  private static void writeSet(JsonWriter writer, Set<?> set) throws IOException {
+    for (Object o : set) {
+      writer.value(o.toString());
+    }
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -66,7 +66,7 @@ public class HttpCodec {
         case DATADOG:
           result.put(style, DatadogHttpCodec.newInjector(reverseBaggageMapping));
           break;
-        case B3:
+        case B3SINGLE:
           result.put(style, B3HttpCodec.SINGLE_INJECTOR);
           break;
         case B3MULTI:
@@ -77,6 +77,9 @@ public class HttpCodec {
           break;
         case XRAY:
           result.put(style, XRayHttpCodec.newInjector(reverseBaggageMapping));
+          break;
+        case NONE:
+          result.put(style, NoneCodec.INJECTOR);
           break;
         default:
           log.debug("No implementation found to inject propagation style: {}", style);
@@ -96,7 +99,7 @@ public class HttpCodec {
         case DATADOG:
           extractors.add(DatadogHttpCodec.newExtractor(taggedHeaders, baggageMapping, config));
           break;
-        case B3:
+        case B3SINGLE:
           extractors.add(B3HttpCodec.newSingleExtractor(taggedHeaders, baggageMapping, config));
           break;
         case B3MULTI:
@@ -107,6 +110,9 @@ public class HttpCodec {
           break;
         case XRAY:
           extractors.add(XRayHttpCodec.newExtractor(taggedHeaders, baggageMapping));
+          break;
+        case NONE:
+          extractors.add(NoneCodec.EXTRACTOR);
           break;
         default:
           log.debug("No implementation found to extract propagation style: {}", style);

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/NoneCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/NoneCodec.java
@@ -1,0 +1,23 @@
+package datadog.trace.core.propagation;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.bootstrap.instrumentation.api.TagContext;
+import datadog.trace.core.DDSpanContext;
+
+public class NoneCodec {
+
+  public static final HttpCodec.Injector INJECTOR =
+      new HttpCodec.Injector() {
+        @Override
+        public <C> void inject(
+            DDSpanContext context, C carrier, AgentPropagation.Setter<C> setter) {}
+      };
+
+  public static final HttpCodec.Extractor EXTRACTOR =
+      new HttpCodec.Extractor() {
+        @Override
+        public <C> TagContext extract(C carrier, AgentPropagation.ContextVisitor<C> getter) {
+          return null;
+        }
+      };
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
@@ -11,7 +11,7 @@ import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.DDSpanContext
 import datadog.trace.core.test.DDCoreSpecification
 
-import static datadog.trace.api.TracePropagationStyle.B3
+import static datadog.trace.api.TracePropagationStyle.B3SINGLE
 import static datadog.trace.api.TracePropagationStyle.B3MULTI
 import static datadog.trace.api.TracePropagationStyle.DATADOG
 import static datadog.trace.core.propagation.B3HttpCodec.B3_KEY
@@ -78,7 +78,7 @@ class HttpInjectorTest extends DDCoreSpecification {
         1 * carrier.put(B3HttpCodec.SAMPLING_PRIORITY_KEY, "1")
       }
     }
-    if (styles.contains(B3)) {
+    if (styles.contains(B3SINGLE)) {
       if (samplingPriority != UNSET) {
         1 * carrier.put(B3_KEY, traceId.toString() + "-" + spanId.toString() + "-1")
       } else {
@@ -92,21 +92,21 @@ class HttpInjectorTest extends DDCoreSpecification {
 
     where:
     // spotless:off
-    styles                 | samplingPriority | samplingMechanism | origin
-    [DATADOG, B3]          | UNSET            | UNKNOWN           | null
-    [DATADOG, B3]          | SAMPLER_KEEP     | DEFAULT           | "saipan"
-    [DATADOG]              | UNSET            | UNKNOWN           | null
-    [DATADOG]              | SAMPLER_KEEP     | DEFAULT           | "saipan"
-    [B3]                   | UNSET            | UNKNOWN           | null
-    [B3]                   | SAMPLER_KEEP     | DEFAULT           | "saipan"
-    [B3, DATADOG]          | SAMPLER_KEEP     | DEFAULT           | "saipan"
-    [DATADOG, B3MULTI, B3] | UNSET            | UNKNOWN           | null
-    [DATADOG, B3MULTI, B3] | SAMPLER_KEEP     | DEFAULT           | "saipan"
-    [DATADOG, B3MULTI]     | UNSET            | UNKNOWN           | null
-    [DATADOG, B3MULTI]     | SAMPLER_KEEP     | DEFAULT           | "saipan"
-    [B3MULTI]              | UNSET            | UNKNOWN           | null
-    [B3MULTI]              | SAMPLER_KEEP     | DEFAULT           | "saipan"
-    [B3MULTI, DATADOG]     | SAMPLER_KEEP     | DEFAULT           | "saipan"
+    styles                       | samplingPriority | samplingMechanism | origin
+    [DATADOG, B3SINGLE]          | UNSET            | UNKNOWN           | null
+    [DATADOG, B3SINGLE]          | SAMPLER_KEEP     | DEFAULT           | "saipan"
+    [DATADOG]                    | UNSET            | UNKNOWN           | null
+    [DATADOG]                    | SAMPLER_KEEP     | DEFAULT           | "saipan"
+    [B3SINGLE]                   | UNSET            | UNKNOWN           | null
+    [B3SINGLE]                   | SAMPLER_KEEP     | DEFAULT           | "saipan"
+    [B3SINGLE, DATADOG]          | SAMPLER_KEEP     | DEFAULT           | "saipan"
+    [DATADOG, B3MULTI, B3SINGLE] | UNSET            | UNKNOWN           | null
+    [DATADOG, B3MULTI, B3SINGLE] | SAMPLER_KEEP     | DEFAULT           | "saipan"
+    [DATADOG, B3MULTI]           | UNSET            | UNKNOWN           | null
+    [DATADOG, B3MULTI]           | SAMPLER_KEEP     | DEFAULT           | "saipan"
+    [B3MULTI]                    | UNSET            | UNKNOWN           | null
+    [B3MULTI]                    | SAMPLER_KEEP     | DEFAULT           | "saipan"
+    [B3MULTI, DATADOG]           | SAMPLER_KEEP     | DEFAULT           | "saipan"
     // spotless:on
   }
 
@@ -165,7 +165,7 @@ class HttpInjectorTest extends DDCoreSpecification {
       if (samplingPriority != UNSET) {
         1 * carrier.put(B3HttpCodec.SAMPLING_PRIORITY_KEY, "1")
       }
-    } else if (style == B3) {
+    } else if (style == B3SINGLE) {
       if (samplingPriority != UNSET) {
         1 * carrier.put(B3_KEY, traceId.toString() + "-" + spanId.toString() + "-1")
       } else {
@@ -179,16 +179,16 @@ class HttpInjectorTest extends DDCoreSpecification {
 
     where:
     // spotless:off
-    style   | samplingPriority | samplingMechanism | origin
-    DATADOG | UNSET            | UNKNOWN           | null
-    DATADOG | SAMPLER_KEEP     | DEFAULT           | null
-    DATADOG | SAMPLER_KEEP     | DEFAULT           | "saipan"
-    B3      | UNSET            | UNKNOWN           | null
-    B3      | SAMPLER_KEEP     | DEFAULT           | null
-    B3      | SAMPLER_KEEP     | DEFAULT           | "saipan"
-    B3MULTI | UNSET            | UNKNOWN           | null
-    B3MULTI | SAMPLER_KEEP     | DEFAULT           | null
-    B3MULTI | SAMPLER_KEEP     | DEFAULT           | "saipan"
+    style    | samplingPriority | samplingMechanism | origin
+    DATADOG  | UNSET            | UNKNOWN           | null
+    DATADOG  | SAMPLER_KEEP     | DEFAULT           | null
+    DATADOG  | SAMPLER_KEEP     | DEFAULT           | "saipan"
+    B3SINGLE | UNSET            | UNKNOWN           | null
+    B3SINGLE | SAMPLER_KEEP     | DEFAULT           | null
+    B3SINGLE | SAMPLER_KEEP     | DEFAULT           | "saipan"
+    B3MULTI  | UNSET            | UNKNOWN           | null
+    B3MULTI  | SAMPLER_KEEP     | DEFAULT           | null
+    B3MULTI  | SAMPLER_KEEP     | DEFAULT           | "saipan"
     // spotless:on
   }
 }

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -261,8 +261,8 @@ class ConfigTest extends DDSpecification {
     config.reportHostName == true
     config.propagationStylesToExtract.toList() == [PropagationStyle.DATADOG, PropagationStyle.B3]
     config.propagationStylesToInject.toList() == [PropagationStyle.B3, PropagationStyle.DATADOG]
-    config.tracePropagationStylesToExtract.toList() == [DATADOG, B3, B3MULTI]
-    config.tracePropagationStylesToInject.toList() == [B3, B3MULTI, DATADOG]
+    config.tracePropagationStylesToExtract.toList() == [DATADOG, B3SINGLE, B3MULTI]
+    config.tracePropagationStylesToInject.toList() == [B3SINGLE, B3MULTI, DATADOG]
     config.jmxFetchEnabled == false
     config.jmxFetchMetricsConfigs == ["/foo.yaml", "/bar.yaml"]
     config.jmxFetchCheckPeriod == 100
@@ -432,8 +432,8 @@ class ConfigTest extends DDSpecification {
     config.reportHostName == true
     config.propagationStylesToExtract.toList() == [PropagationStyle.DATADOG, PropagationStyle.B3]
     config.propagationStylesToInject.toList() == [PropagationStyle.B3, PropagationStyle.DATADOG]
-    config.tracePropagationStylesToExtract.toList() == [DATADOG, B3, B3MULTI]
-    config.tracePropagationStylesToInject.toList() == [B3, B3MULTI, DATADOG]
+    config.tracePropagationStylesToExtract.toList() == [DATADOG, B3SINGLE, B3MULTI]
+    config.tracePropagationStylesToInject.toList() == [B3SINGLE, B3MULTI, DATADOG]
     config.jmxFetchEnabled == false
     config.jmxFetchMetricsConfigs == ["/foo.yaml", "/bar.yaml"]
     config.jmxFetchCheckPeriod == 100
@@ -511,8 +511,8 @@ class ConfigTest extends DDSpecification {
     config.writerType == "LoggingWriter"
     config.propagationStylesToExtract.toList() == [PropagationStyle.B3, PropagationStyle.DATADOG]
     config.propagationStylesToInject.toList() == [PropagationStyle.DATADOG, PropagationStyle.B3]
-    config.tracePropagationStylesToExtract.toList() == [B3, B3MULTI, DATADOG]
-    config.tracePropagationStylesToInject.toList() == [DATADOG, B3, B3MULTI]
+    config.tracePropagationStylesToExtract.toList() == [B3SINGLE, B3MULTI, DATADOG]
+    config.tracePropagationStylesToInject.toList() == [DATADOG, B3SINGLE, B3MULTI]
     config.jmxFetchMetricsConfigs == ["some/file"]
     config.reportHostName == true
     config.xDatadogTagsMaxLength == 42
@@ -696,8 +696,8 @@ class ConfigTest extends DDSpecification {
     config.partialFlushMinSpans == 15
     config.propagationStylesToExtract.toList() == [PropagationStyle.B3, PropagationStyle.DATADOG]
     config.propagationStylesToInject.toList() == [PropagationStyle.DATADOG, PropagationStyle.B3]
-    config.tracePropagationStylesToExtract.toList() == [B3, B3MULTI, DATADOG]
-    config.tracePropagationStylesToInject.toList() == [DATADOG, B3, B3MULTI]
+    config.tracePropagationStylesToExtract.toList() == [B3SINGLE, B3MULTI, DATADOG]
+    config.tracePropagationStylesToInject.toList() == [DATADOG, B3SINGLE, B3MULTI]
     config.jmxFetchMetricsConfigs == ["/foo.yaml", "/bar.yaml"]
     config.jmxFetchCheckPeriod == 100
     config.jmxFetchRefreshBeansPeriod == 200
@@ -2178,20 +2178,21 @@ class ConfigTest extends DDSpecification {
 
     where:
     // spotless:off
-    pse                      | psi                      | tps      | tpse               | tpsi    | ePSE                       | ePSI                       | eTPSE         | eTPSI
-    PropagationStyle.DATADOG | PropagationStyle.B3      | null     | null               | null    | [PropagationStyle.DATADOG] | [PropagationStyle.B3]      | [DATADOG]     | [B3, B3MULTI]
-    PropagationStyle.B3      | PropagationStyle.DATADOG | null     | null               | null    | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [B3, B3MULTI] | [DATADOG]
-    PropagationStyle.B3      | PropagationStyle.DATADOG | HAYSTACK | null               | null    | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [HAYSTACK]    | [HAYSTACK]
-    PropagationStyle.B3      | PropagationStyle.DATADOG | HAYSTACK | B3                 | null    | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [B3]          | [HAYSTACK]
-    PropagationStyle.B3      | PropagationStyle.DATADOG | HAYSTACK | null               | B3MULTI | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [HAYSTACK]    | [B3MULTI]
-    PropagationStyle.B3      | PropagationStyle.DATADOG | HAYSTACK | B3                 | B3MULTI | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [B3]          | [B3MULTI]
-    PropagationStyle.B3      | PropagationStyle.DATADOG | null     | B3                 | B3MULTI | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [B3]          | [B3MULTI]
-    null                     | null                     | HAYSTACK | null               | null    | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [HAYSTACK]    | [HAYSTACK]
-    null                     | null                     | HAYSTACK | B3                 | B3MULTI | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [B3]          | [B3MULTI]
-    null                     | null                     | null     | B3                 | B3MULTI | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [B3]          | [B3MULTI]
-    null                     | null                     | null     | null               | null    | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [DATADOG]     | [DATADOG]
-    null                     | null                     | null     | null               | null    | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [DATADOG]     | [DATADOG]
-    null                     | null                     | null     | "b3 single header" | null    | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [B3]          | [DATADOG]
+    pse                      | psi                      | tps      | tpse               | tpsi    | ePSE                       | ePSI                       | eTPSE               | eTPSI
+    PropagationStyle.DATADOG | PropagationStyle.B3      | null     | null               | null    | [PropagationStyle.DATADOG] | [PropagationStyle.B3]      | [DATADOG]           | [B3SINGLE, B3MULTI]
+    PropagationStyle.B3      | PropagationStyle.DATADOG | null     | null               | null    | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [B3SINGLE, B3MULTI] | [DATADOG]
+    PropagationStyle.B3      | PropagationStyle.DATADOG | HAYSTACK | null               | null    | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [HAYSTACK]          | [HAYSTACK]
+    PropagationStyle.B3      | PropagationStyle.DATADOG | HAYSTACK | B3SINGLE           | null    | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [B3SINGLE]          | [HAYSTACK]
+    PropagationStyle.B3      | PropagationStyle.DATADOG | HAYSTACK | null               | B3MULTI | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [HAYSTACK]          | [B3MULTI]
+    PropagationStyle.B3      | PropagationStyle.DATADOG | HAYSTACK | B3SINGLE           | B3MULTI | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [B3SINGLE]          | [B3MULTI]
+    PropagationStyle.B3      | PropagationStyle.DATADOG | null     | B3SINGLE           | B3MULTI | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [B3SINGLE]          | [B3MULTI]
+    null                     | null                     | HAYSTACK | null               | null    | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [HAYSTACK]          | [HAYSTACK]
+    null                     | null                     | HAYSTACK | B3SINGLE           | B3MULTI | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [B3SINGLE]          | [B3MULTI]
+    null                     | null                     | null     | B3SINGLE           | B3MULTI | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [B3SINGLE]          | [B3MULTI]
+    null                     | null                     | null     | null               | null    | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [DATADOG]           | [DATADOG]
+    null                     | null                     | null     | null               | null    | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [DATADOG]           | [DATADOG]
+    null                     | null                     | null     | "b3 single header" | null    | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [B3SINGLE]          | [DATADOG]
+    null                     | null                     | null     | "b3"               | null    | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [B3MULTI]           | [DATADOG]
     // spotless:on
   }
 }


### PR DESCRIPTION
# What Does This Do

Changes some names of `DD_TRACE_PROPAGATION_STYLE_*` settings to align with other Datadog tracers.

# Motivation

Minimize discrepancies in configuration between Datadog tracers.

# Additional Notes

This is a breaking change if someone started using `DD_TRACE_PROPAGATION_STYLE*` settings and the `B3` propagator since `B3` now mean [B3 multi header](https://github.com/openzipkin/b3-propagation/tree/master#multiple-headers) while before it meant [B3 single header](https://github.com/openzipkin/b3-propagation/tree/master#single-header). The risk of this is considered low, since the setting has not been documented yet.