### PR TITLE
naming schema: servlet, tomcat and jetty

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -15,6 +15,7 @@ import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.IGSpanInfo;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.ActiveSubsystems;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -89,6 +90,13 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
   protected abstract int peerPort(CONNECTION connection);
 
   protected abstract int status(RESPONSE response);
+
+  public CharSequence operationName() {
+    return SpanNaming.instance()
+        .namingSchema()
+        .server()
+        .operationForComponent(component().toString());
+  }
 
   @Override
   protected CharSequence spanType() {

--- a/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/JettyDecorator.java
@@ -15,9 +15,11 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 
 public class JettyDecorator extends HttpServerDecorator<Request, Request, Response, Request> {
-  public static final CharSequence SERVLET_REQUEST = UTF8BytesString.create("servlet.request");
   public static final CharSequence JETTY_SERVER = UTF8BytesString.create("jetty-server");
   public static final JettyDecorator DECORATE = new JettyDecorator();
+  public static final CharSequence SERVLET_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
+
   public static final String DD_CONTEXT_PATH_ATTRIBUTE = "datadog.context.path";
   public static final String DD_SERVLET_PATH_ATTRIBUTE = "datadog.servlet.path";
 

--- a/dd-java-agent/instrumentation/jetty-11/src/test/groovy/Jetty11Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-11/src/test/groovy/Jetty11Test.groovy
@@ -1,6 +1,7 @@
 import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import jakarta.servlet.http.HttpServlet
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.AbstractHandler
@@ -13,7 +14,7 @@ import org.eclipse.jetty.servlet.ServletContextHandler
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.*
 
-class Jetty11Test extends HttpServerTest<Server> {
+abstract class Jetty11Test extends HttpServerTest<Server> {
 
   class JettyServer implements HttpServer {
     def port = 0
@@ -82,7 +83,7 @@ class Jetty11Test extends HttpServerTest<Server> {
 
   @Override
   String expectedOperationName() {
-    return "servlet.request"
+    return operation()
   }
 
   @Override
@@ -164,4 +165,12 @@ class Jetty11Test extends HttpServerTest<Server> {
       }
     }
   }
+}
+
+class Jetty11V0ForkedTest extends Jetty11Test implements TestingGenericHttpNamingConventions.ServerV0 {
+
+}
+
+class Jetty11V1ForkedTest extends Jetty11Test implements TestingGenericHttpNamingConventions.ServerV1 {
+
 }

--- a/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyDecorator.java
@@ -15,9 +15,10 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 
 public class JettyDecorator extends HttpServerDecorator<Request, Request, Response, Request> {
-  public static final CharSequence SERVLET_REQUEST = UTF8BytesString.create("servlet.request");
   public static final CharSequence JETTY_SERVER = UTF8BytesString.create("jetty-server");
   public static final JettyDecorator DECORATE = new JettyDecorator();
+  public static final CharSequence SERVLET_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
   public static final String DD_CONTEXT_PATH_ATTRIBUTE = "datadog.context.path";
   public static final String DD_SERVLET_PATH_ATTRIBUTE = "datadog.servlet.path";
 

--- a/dd-java-agent/instrumentation/jetty-7.0/src/test/groovy/Jetty70Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/test/groovy/Jetty70Test.groovy
@@ -1,6 +1,7 @@
 import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import org.eclipse.jetty.server.Request
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.AbstractHandler
@@ -22,7 +23,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRE
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 
-class Jetty70Test extends HttpServerTest<Server> {
+abstract class Jetty70Test extends HttpServerTest<Server> {
 
   class JettyServer implements HttpServer {
     def port = 0
@@ -83,7 +84,7 @@ class Jetty70Test extends HttpServerTest<Server> {
 
   @Override
   String expectedOperationName() {
-    return "servlet.request"
+    return component()
   }
 
   @Override
@@ -168,4 +169,12 @@ class Jetty70Test extends HttpServerTest<Server> {
       }
     }
   }
+}
+
+class Jetty70V0ForkedTest extends Jetty70Test implements TestingGenericHttpNamingConventions.ServerV0 {
+
+}
+
+class Jetty70V1ForkedTest extends Jetty70Test implements TestingGenericHttpNamingConventions.ServerV1 {
+
 }

--- a/dd-java-agent/instrumentation/jetty-7.0/src/test/groovy/JettyContinuationHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/test/groovy/JettyContinuationHandlerTest.groovy
@@ -1,3 +1,4 @@
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import org.eclipse.jetty.continuation.Continuation
 import org.eclipse.jetty.continuation.ContinuationSupport
 import org.eclipse.jetty.server.Request
@@ -9,7 +10,7 @@ import javax.servlet.http.HttpServletResponse
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
-class JettyContinuationHandlerTest extends Jetty70Test {
+abstract class JettyContinuationHandlerTest extends Jetty70Test {
 
   @Override
   AbstractHandler handler() {
@@ -34,4 +35,10 @@ class JettyContinuationHandlerTest extends Jetty70Test {
       baseRequest.handled = true
     }
   }
+}
+
+class JettyContinuationHandlerV0ForkedTest extends JettyContinuationHandlerTest implements TestingGenericHttpNamingConventions.ServerV0 {
+}
+
+class JettyContinuationHandlerV1ForkedTest extends JettyContinuationHandlerTest implements TestingGenericHttpNamingConventions.ServerV1 {
 }

--- a/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyDecorator.java
@@ -15,9 +15,10 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 
 public class JettyDecorator extends HttpServerDecorator<Request, Request, Response, Request> {
-  public static final CharSequence SERVLET_REQUEST = UTF8BytesString.create("servlet.request");
   public static final CharSequence JETTY_SERVER = UTF8BytesString.create("jetty-server");
   public static final JettyDecorator DECORATE = new JettyDecorator();
+  public static final CharSequence SERVLET_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
   public static final String DD_CONTEXT_PATH_ATTRIBUTE = "datadog.context.path";
   public static final String DD_SERVLET_PATH_ATTRIBUTE = "datadog.servlet.path";
 

--- a/dd-java-agent/instrumentation/jetty-7.6/src/test/groovy/Jetty76Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-7.6/src/test/groovy/Jetty76Test.groovy
@@ -1,6 +1,7 @@
 import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import org.eclipse.jetty.server.Request
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.AbstractHandler
@@ -21,7 +22,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRE
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 
-class Jetty76Test extends HttpServerTest<Server> {
+abstract class Jetty76Test extends HttpServerTest<Server> {
 
   class JettyServer implements HttpServer {
     def port = 0
@@ -82,7 +83,7 @@ class Jetty76Test extends HttpServerTest<Server> {
 
   @Override
   String expectedOperationName() {
-    return "servlet.request"
+    return operation()
   }
 
   @Override
@@ -153,4 +154,12 @@ class Jetty76Test extends HttpServerTest<Server> {
       }
     }
   }
+}
+
+class Jetty76V0ForkedTest extends Jetty76Test implements TestingGenericHttpNamingConventions.ServerV0 {
+
+}
+
+class Jetty76V1ForkedTest extends Jetty76Test implements TestingGenericHttpNamingConventions.ServerV1 {
+
 }

--- a/dd-java-agent/instrumentation/jetty-7.6/src/test/groovy/JettyContinuationHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-7.6/src/test/groovy/JettyContinuationHandlerTest.groovy
@@ -1,3 +1,4 @@
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import org.eclipse.jetty.continuation.Continuation
 import org.eclipse.jetty.continuation.ContinuationSupport
 import org.eclipse.jetty.server.Request
@@ -9,7 +10,7 @@ import javax.servlet.http.HttpServletResponse
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
-class JettyContinuationHandlerTest extends Jetty76Test {
+abstract class JettyContinuationHandlerTest extends Jetty76Test {
 
   @Override
   AbstractHandler handler() {
@@ -34,4 +35,10 @@ class JettyContinuationHandlerTest extends Jetty76Test {
       baseRequest.handled = true
     }
   }
+}
+
+class JettyContinuationHandlerV0ForkedTest extends JettyContinuationHandlerTest implements TestingGenericHttpNamingConventions.ServerV0 {
+}
+
+class JettyContinuationHandlerV1ForkedTest extends JettyContinuationHandlerTest implements TestingGenericHttpNamingConventions.ServerV1 {
 }

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyDecorator.java
@@ -15,9 +15,10 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 
 public class JettyDecorator extends HttpServerDecorator<Request, Request, Response, Request> {
-  public static final CharSequence SERVLET_REQUEST = UTF8BytesString.create("servlet.request");
   public static final CharSequence JETTY_SERVER = UTF8BytesString.create("jetty-server");
   public static final JettyDecorator DECORATE = new JettyDecorator();
+  public static final CharSequence SERVLET_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
   public static final String DD_CONTEXT_PATH_ATTRIBUTE = "datadog.context.path";
   public static final String DD_SERVLET_PATH_ATTRIBUTE = "datadog.servlet.path";
 

--- a/dd-java-agent/instrumentation/jetty-9/src/test/groovy/Jetty9Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-9/src/test/groovy/Jetty9Test.groovy
@@ -1,6 +1,7 @@
 import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import org.eclipse.jetty.server.Request
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.AbstractHandler
@@ -23,7 +24,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRE
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 
-class Jetty9Test extends HttpServerTest<Server> {
+abstract class Jetty9Test extends HttpServerTest<Server> {
 
   class JettyServer implements HttpServer {
     def port = 0
@@ -84,7 +85,7 @@ class Jetty9Test extends HttpServerTest<Server> {
 
   @Override
   String expectedOperationName() {
-    return "servlet.request"
+    return operation()
   }
 
   @Override
@@ -166,4 +167,12 @@ class Jetty9Test extends HttpServerTest<Server> {
       }
     }
   }
+}
+
+class Jetty9V0ForkedTest extends Jetty9Test implements TestingGenericHttpNamingConventions.ServerV0 {
+
+}
+
+class Jetty9V1ForkedTest extends Jetty9Test implements TestingGenericHttpNamingConventions.ServerV1 {
+
 }

--- a/dd-java-agent/instrumentation/jetty-9/src/test/groovy/JettyContinuationHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-9/src/test/groovy/JettyContinuationHandlerTest.groovy
@@ -1,3 +1,4 @@
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import org.eclipse.jetty.continuation.Continuation
 import org.eclipse.jetty.continuation.ContinuationSupport
 import org.eclipse.jetty.server.Request
@@ -9,7 +10,7 @@ import javax.servlet.http.HttpServletResponse
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
-class JettyContinuationHandlerTest extends Jetty9Test {
+abstract class JettyContinuationHandlerTest extends Jetty9Test {
 
   @Override
   AbstractHandler handler() {
@@ -40,4 +41,12 @@ class JettyContinuationHandlerTest extends Jetty9Test {
       baseRequest.handled = true
     }
   }
+}
+
+class JettyContinuationHandlerV0ForkedTest extends JettyContinuationHandlerTest implements TestingGenericHttpNamingConventions.ServerV0 {
+
+}
+
+class JettyContinuationHandlerV1ForkedTest extends JettyContinuationHandlerTest implements TestingGenericHttpNamingConventions.ServerV1 {
+
 }

--- a/dd-java-agent/instrumentation/mule-4/src/test/groovy/mule4/MuleForkedTest.groovy
+++ b/dd-java-agent/instrumentation/mule-4/src/test/groovy/mule4/MuleForkedTest.groovy
@@ -96,7 +96,7 @@ class MuleForkedTest extends WithHttpServer<MuleTestContainer> {
     assertTraces(1) {
       trace(2) {
         span(0) {
-          operationName "grizzly.request"
+          operationName operation()
           resourceName "GET /client-request"
           spanType DDSpanTypes.HTTP_SERVER
           tags {
@@ -153,7 +153,7 @@ class MuleForkedTest extends WithHttpServer<MuleTestContainer> {
     assertTraces(1) {
       trace(1 + names.size()) { traceAssert ->
         traceAssert.span(0) {
-          operationName "grizzly.request"
+          operationName operation()
           resourceName "PUT /pfe-request"
           spanType DDSpanTypes.HTTP_SERVER
           tags {
@@ -190,5 +190,21 @@ class MuleForkedTest extends WithHttpServer<MuleTestContainer> {
         }
       }
     }
+  }
+
+  //test for v1 will be added once grizzly will support v1 naming
+  @Override
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "grizzly.request"
   }
 }

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Decorator.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Decorator.java
@@ -12,9 +12,10 @@ import javax.servlet.http.HttpServletRequest;
 public class Servlet2Decorator
     extends HttpServerDecorator<
         HttpServletRequest, HttpServletRequest, Integer, HttpServletRequest> {
-  public static final CharSequence SERVLET_REQUEST = UTF8BytesString.create("servlet.request");
   public static final CharSequence JAVA_WEB_SERVLET = UTF8BytesString.create("java-web-servlet");
   public static final Servlet2Decorator DECORATE = new Servlet2Decorator();
+  public static final CharSequence SERVLET_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
 
   @Override
   protected String[] instrumentationNames() {

--- a/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
@@ -1,6 +1,7 @@
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.ErrorHandler
 import org.eclipse.jetty.servlet.ServletContextHandler
@@ -15,7 +16,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FO
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.UNKNOWN
 
-class JettyServlet2Test extends HttpServerTest<Server> {
+abstract class JettyServlet2Test extends HttpServerTest<Server> {
 
   private static final CONTEXT = "ctx"
 
@@ -87,7 +88,7 @@ class JettyServlet2Test extends HttpServerTest<Server> {
 
   @Override
   String expectedOperationName() {
-    return "servlet.request"
+    return operation()
   }
 
   @Override
@@ -181,4 +182,12 @@ class JettyServlet2Test extends HttpServerTest<Server> {
   //
   //    security
   //  }
+}
+
+class JettyServlet2V0ForkedTest extends JettyServlet2Test implements TestingGenericHttpNamingConventions.ServerV0 {
+
+}
+
+class JettyServlet2V1ForkedTest extends JettyServlet2Test implements TestingGenericHttpNamingConventions.ServerV1 {
+
 }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
@@ -12,9 +12,11 @@ import javax.servlet.http.HttpServletResponse;
 public class Servlet3Decorator
     extends HttpServerDecorator<
         HttpServletRequest, HttpServletRequest, HttpServletResponse, HttpServletRequest> {
-  public static final CharSequence SERVLET_REQUEST = UTF8BytesString.create("servlet.request");
   public static final CharSequence JAVA_WEB_SERVLET = UTF8BytesString.create("java-web-servlet");
+
   public static final Servlet3Decorator DECORATE = new Servlet3Decorator();
+  public static final CharSequence SERVLET_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
   public static final String DD_CONTEXT_PATH_ATTRIBUTE = "datadog.context.path";
   public static final String DD_SERVLET_PATH_ATTRIBUTE = "datadog.servlet.path";
 

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
@@ -1,5 +1,6 @@
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -19,7 +20,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.TIMEOU
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.UNKNOWN
 import static org.junit.Assume.assumeTrue
 
-abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERVER> {
+abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERVER> implements TestingGenericHttpNamingConventions.ServerV0 {
   @Override
   boolean testRequestBody() {
     true
@@ -51,7 +52,7 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
 
   @Override
   String expectedOperationName() {
-    return "servlet.request"
+    return operation()
   }
 
   boolean hasHandlerSpan() {

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
@@ -1,5 +1,6 @@
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServer
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.servlet3.AsyncDispatcherDecorator
@@ -216,6 +217,11 @@ class JettyServlet3TestSync extends JettyServlet3Test {
   }
 }
 
+
+class JettyServlet3SyncV1ForkedTest extends JettyServlet3TestSync implements TestingGenericHttpNamingConventions.ServerV1 {
+
+}
+
 class JettyServlet3TestAsync extends JettyServlet3Test {
 
   @Override
@@ -235,6 +241,9 @@ class JettyServlet3TestAsync extends JettyServlet3Test {
   }
 }
 
+class JettyServlet3ASyncV1ForkedTest extends JettyServlet3TestAsync implements TestingGenericHttpNamingConventions.ServerV1 {
+
+}
 class JettyServlet3TestFakeAsync extends JettyServlet3Test {
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
@@ -1,6 +1,7 @@
 import com.google.common.io.Files
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServer
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.api.CorrelationIdentifier
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.servlet3.AsyncDispatcherDecorator
@@ -341,6 +342,10 @@ class TomcatServlet3TestSync extends TomcatServlet3Test {
   }
 }
 
+class TomcatServlet3SyncV1ForkedTest extends TomcatServlet3TestSync implements TestingGenericHttpNamingConventions.ServerV1 {
+
+}
+
 class TomcatServlet3TestAsync extends TomcatServlet3Test {
 
   @Override
@@ -358,6 +363,10 @@ class TomcatServlet3TestAsync extends TomcatServlet3Test {
     // The exception will just cause an async timeout
     false
   }
+}
+
+class TomcatServlet3AsyncV1ForkedTest extends TomcatServlet3TestAsync implements TestingGenericHttpNamingConventions.ServerV1 {
+
 }
 
 class TomcatServlet3TestFakeAsync extends TomcatServlet3Test {

--- a/dd-java-agent/instrumentation/spring-cloud-zuul-2/src/test/groovy/ProxyRequestHelperTest.groovy
+++ b/dd-java-agent/instrumentation/spring-cloud-zuul-2/src/test/groovy/ProxyRequestHelperTest.groovy
@@ -81,14 +81,14 @@ class ProxyRequestHelperTest extends WithHttpServer<ConfigurableApplicationConte
       trace (3) {
         sortSpansByStart()
         //zuul
-        serverSpan(it, "servlet.request", DDSpanTypes.HTTP_SERVER)
+        serverSpan(it, operation(), DDSpanTypes.HTTP_SERVER)
         serverSpan(it, "spring.handler", DDSpanTypes.HTTP_SERVER)
         serverSpan(it, "http.request", DDSpanTypes.HTTP_CLIENT)
       }
       //spring application
       trace (2) {
         sortSpansByStart()
-        serverSpan(it, "servlet.request", DDSpanTypes.HTTP_SERVER, trace(0)[2])
+        serverSpan(it, operation(), DDSpanTypes.HTTP_SERVER, trace(0)[2])
         serverSpan(it, "spring.handler", DDSpanTypes.HTTP_SERVER)
       }
     }
@@ -111,25 +111,25 @@ class ProxyRequestHelperTest extends WithHttpServer<ConfigurableApplicationConte
     assertTraces(4) {
       trace (3) {
         sortSpansByStart()
-        serverSpan(it, "servlet.request", DDSpanTypes.HTTP_SERVER)
+        serverSpan(it, operation(), DDSpanTypes.HTTP_SERVER)
         serverSpan(it, "spring.handler", DDSpanTypes.HTTP_SERVER)
         serverSpan(it, "http.request", DDSpanTypes.HTTP_CLIENT)
       }
       trace (3) {
         sortSpansByStart()
-        serverSpan(it, "servlet.request", DDSpanTypes.HTTP_SERVER, trace(0)[2])
+        serverSpan(it, operation(), DDSpanTypes.HTTP_SERVER, trace(0)[2])
         serverSpan(it, "spring.handler", DDSpanTypes.HTTP_SERVER)
         serverSpan(it, "http.request", DDSpanTypes.HTTP_CLIENT)
       }
       trace (3) {
         sortSpansByStart()
-        serverSpan(it, "servlet.request", DDSpanTypes.HTTP_SERVER, trace(1)[2])
+        serverSpan(it, operation(), DDSpanTypes.HTTP_SERVER, trace(1)[2])
         serverSpan(it, "spring.handler", DDSpanTypes.HTTP_SERVER)
         serverSpan(it, "http.request", DDSpanTypes.HTTP_CLIENT)
       }
       trace (2) {
         sortSpansByStart()
-        serverSpan(it, "servlet.request", DDSpanTypes.HTTP_SERVER, trace(2)[2])
+        serverSpan(it, operation(), DDSpanTypes.HTTP_SERVER, trace(2)[2])
         serverSpan(it, "spring.handler", DDSpanTypes.HTTP_SERVER)
       }
     }
@@ -190,5 +190,20 @@ class ProxyRequestHelperTest extends WithHttpServer<ConfigurableApplicationConte
       operationName opName
       spanType type
     }
+  }
+  // tests for V1 will be added once servlet will support v1 naming
+  @Override
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "servlet.request"
   }
 }

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/TomcatDecorator.java
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/TomcatDecorator.java
@@ -14,13 +14,15 @@ import org.apache.catalina.connector.Response;
 
 public class TomcatDecorator
     extends HttpServerDecorator<Request, Request, Response, org.apache.coyote.Request> {
-  public static final CharSequence SERVLET_REQUEST = UTF8BytesString.create("servlet.request");
   public static final CharSequence TOMCAT_SERVER = UTF8BytesString.create("tomcat-server");
+
   public static final TomcatDecorator DECORATE = new TomcatDecorator();
   public static final String DD_EXTRACTED_CONTEXT_ATTRIBUTE = "datadog.extracted-context";
   public static final String DD_CONTEXT_PATH_ATTRIBUTE = "datadog.context.path";
   public static final String DD_SERVLET_PATH_ATTRIBUTE = "datadog.servlet.path";
   public static final String DD_REAL_STATUS_CODE = "datadog.servlet.real_status_code";
+  public static final CharSequence SERVLET_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
 
   @Override
   protected String[] instrumentationNames() {

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/test/groovy/AbstractServletTest.groovy
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/test/groovy/AbstractServletTest.groovy
@@ -18,7 +18,7 @@ abstract class AbstractServletTest<SERVER, CONTEXT> extends HttpServerTest<SERVE
 
   @Override
   String component() {
-    return TomcatDecorator.DECORATE.component()
+    return TomcatDecorator.TOMCAT_SERVER
   }
 
   @Override
@@ -28,7 +28,7 @@ abstract class AbstractServletTest<SERVER, CONTEXT> extends HttpServerTest<SERVE
 
   @Override
   String expectedOperationName() {
-    return "servlet.request"
+    return operation()
   }
 
   boolean hasHandlerSpan() {

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/test/groovy/TomcatServletTest.groovy
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/test/groovy/TomcatServletTest.groovy
@@ -1,6 +1,7 @@
 import com.google.common.io.Files
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServer
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.api.DDTags
 import org.apache.catalina.Context
 import org.apache.catalina.Engine
@@ -26,7 +27,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static org.junit.Assume.assumeTrue
 
 @Unroll
-class TomcatServletTest extends AbstractServletTest<Embedded, Context> {
+abstract class TomcatServletTest extends AbstractServletTest<Embedded, Context> {
 
   class TomcatServer implements HttpServer {
     def port = 0
@@ -290,4 +291,10 @@ class TomcatServletTest extends AbstractServletTest<Embedded, Context> {
   }
 }
 
+class TomcatServletV0ForkedTest extends TomcatServletTest implements TestingGenericHttpNamingConventions.ServerV0 {
 
+}
+
+class TomcatServletV1ForkedTest extends TomcatServletTest implements TestingGenericHttpNamingConventions.ServerV1 {
+
+}

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -2,6 +2,7 @@ package datadog.trace.agent.test.base
 
 import ch.qos.logback.classic.Level
 import datadog.appsec.api.blocking.Blocking
+import datadog.appsec.api.blocking.BlockingContentType
 import datadog.appsec.api.blocking.BlockingDetails
 import datadog.appsec.api.blocking.BlockingService
 import datadog.trace.agent.test.asserts.TraceAssert
@@ -12,7 +13,6 @@ import datadog.trace.api.config.GeneralConfig
 import datadog.trace.api.env.CapturedEnvironment
 import datadog.trace.api.function.TriConsumer
 import datadog.trace.api.function.TriFunction
-import datadog.appsec.api.blocking.BlockingContentType
 import datadog.trace.api.gateway.BlockResponseFunction
 import datadog.trace.api.gateway.Events
 import datadog.trace.api.gateway.Flow
@@ -36,7 +36,6 @@ import okhttp3.RequestBody
 import okhttp3.Response
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import spock.lang.Shared
 import spock.lang.Unroll
 
 import java.util.function.BiFunction
@@ -125,7 +124,6 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     // We don't inject a matching response header tag here since it would be always on and show up in all the tests
   }
 
-  @Shared
   String component = component()
 
   abstract String component()
@@ -311,6 +309,21 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
 
   boolean testMultipleHeader() {
     true
+  }
+
+  @Override
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return expectedOperationName()
   }
 
   enum ServerEndpoint {
@@ -1548,7 +1561,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     def expectedUrl = expectedUrl(endpoint, address)
     trace.span {
       serviceName expectedServiceName()
-      operationName expectedOperationName()
+      operationName operation()
       resourceName expectedResourceName(endpoint, method, address)
       spanType DDSpanTypes.HTTP_SERVER
       errored expectedErrored(endpoint)

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/WithHttpServer.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/WithHttpServer.groovy
@@ -1,6 +1,6 @@
 package datadog.trace.agent.test.base
 
-import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.agent.test.utils.OkHttpUtils
 import datadog.trace.agent.test.utils.PortUtils
 import net.bytebuddy.utility.JavaModule
@@ -11,7 +11,7 @@ import spock.lang.Subject
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
-abstract class WithHttpServer<SERVER> extends AgentTestRunner {
+abstract class WithHttpServer<SERVER> extends VersionedNamingTestBase {
 
   @Shared
   @Subject

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/naming/NamingConventions.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/naming/NamingConventions.groovy
@@ -33,6 +33,38 @@ class TestingGenericHttpNamingConventions {
       return "http.client.request"
     }
   }
+  trait ServerV0 implements VersionedNamingTest {
+    @Override
+    int version() {
+      return 0
+    }
+
+    @Override
+    String service() {
+      return null
+    }
+
+    @Override
+    String operation() {
+      return "servlet.request"
+    }
+  }
+  trait ServerV1 implements VersionedNamingTest {
+    @Override
+    int version() {
+      return 1
+    }
+
+    @Override
+    String service() {
+      return null
+    }
+
+    @Override
+    String operation() {
+      return "http.server.request"
+    }
+  }
 }
 
 class TestingNettyHttpNamingConventions {
@@ -56,3 +88,4 @@ class TestingNettyHttpNamingConventions {
   trait ClientV1 extends TestingGenericHttpNamingConventions.ClientV1 {
   }
 }
+

--- a/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
@@ -24,6 +24,13 @@ public interface NamingSchema {
    */
   ForDatabase database();
 
+  /**
+   * Get the naming policy for servers.
+   *
+   * @return a {@link NamingSchema.ForServer} instance.
+   */
+  ForServer server();
+
   interface ForCache {
     /**
      * Calculate the operation name for a cache span.
@@ -84,5 +91,25 @@ public interface NamingSchema {
      */
     @Nonnull
     String service(@Nonnull String ddService, @Nonnull String databaseType);
+  }
+
+  interface ForServer {
+    /**
+     * Calculate the operation name for a server span.
+     *
+     * @param protocol the protocol used (e.g. http, soap, rmi ..)
+     * @return the operation name
+     */
+    @Nonnull
+    String operationForProtocol(@Nonnull String protocol);
+
+    /**
+     * Calculate the operation name for a server span.
+     *
+     * @param component the name of the instrumentation component
+     * @return the operation name
+     */
+    @Nonnull
+    String operationForComponent(@Nonnull String component);
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/NamingSchemaV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/NamingSchemaV0.java
@@ -5,8 +5,8 @@ import datadog.trace.api.naming.NamingSchema;
 public class NamingSchemaV0 implements NamingSchema {
   private final NamingSchema.ForCache cacheNaming = new CacheNamingV0();
   private final NamingSchema.ForClient clientNaming = new ClientNamingV0();
-
   private final NamingSchema.ForDatabase databaseNaming = new DatabaseNamingV0();
+  private final NamingSchema.ForServer serverNaming = new ServerNamingV0();
 
   @Override
   public NamingSchema.ForCache cache() {
@@ -21,5 +21,10 @@ public class NamingSchemaV0 implements NamingSchema {
   @Override
   public ForDatabase database() {
     return databaseNaming;
+  }
+
+  @Override
+  public ForServer server() {
+    return serverNaming;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/ServerNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/ServerNamingV0.java
@@ -1,0 +1,21 @@
+package datadog.trace.api.naming.v0;
+
+import datadog.trace.api.naming.NamingSchema;
+import javax.annotation.Nonnull;
+
+public class ServerNamingV0 implements NamingSchema.ForServer {
+  @Nonnull
+  @Override
+  public String operationForProtocol(@Nonnull String protocol) {
+    // cases will be addressed in subsequent PRs (for grpc and rmi)
+    return protocol + ".request";
+  }
+
+  @Nonnull
+  @Override
+  public String operationForComponent(@Nonnull String component) {
+    // more cases will be added in subsequent PRs.
+    // Defaulting to servlet.request since it's for the majority of http server instrumentations
+    return "servlet.request";
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/NamingSchemaV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/NamingSchemaV1.java
@@ -5,8 +5,8 @@ import datadog.trace.api.naming.NamingSchema;
 public class NamingSchemaV1 implements NamingSchema {
   private final NamingSchema.ForCache cacheNaming = new CacheNamingV1();
   private final NamingSchema.ForClient clientNaming = new ClientNamingV1();
-
   private final NamingSchema.ForDatabase databaseNaming = new DatabaseNamingV1();
+  private final NamingSchema.ForServer serverNaming = new ServerNamingV1();
 
   @Override
   public NamingSchema.ForCache cache() {
@@ -21,5 +21,10 @@ public class NamingSchemaV1 implements NamingSchema {
   @Override
   public ForDatabase database() {
     return databaseNaming;
+  }
+
+  @Override
+  public ForServer server() {
+    return serverNaming;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/ServerNamingV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/ServerNamingV1.java
@@ -1,0 +1,19 @@
+package datadog.trace.api.naming.v1;
+
+import datadog.trace.api.naming.NamingSchema;
+import javax.annotation.Nonnull;
+
+public class ServerNamingV1 implements NamingSchema.ForServer {
+
+  @Nonnull
+  @Override
+  public String operationForProtocol(@Nonnull String protocol) {
+    return protocol + "server.request";
+  }
+
+  @Nonnull
+  @Override
+  public String operationForComponent(@Nonnull String component) {
+    return "http.server.request";
+  }
+}


### PR DESCRIPTION
# What Does This Do

v1 naming schema changes for servlet, tomcat and jetty:
* operation:  `http.server.request`

# Motivation

# Additional Notes
