### PR TITLE
Exclude datadog.trace.api.internal.util from shading in dd-trace-ot

### DIFF
--- a/dd-trace-ot/build.gradle
+++ b/dd-trace-ot/build.gradle
@@ -111,6 +111,7 @@ shadowJar {
     exclude('datadog.trace.api.experimental.*')
     exclude('datadog.trace.api.interceptor.*')
     exclude('datadog.trace.api.internal.*')
+    exclude('datadog.trace.api.internal.util.*')
     exclude('datadog.trace.api.sampling.*')
     exclude('datadog.trace.context.*')
   }


### PR DESCRIPTION
# What Does This Do

Excludes `datadog.trace.api.internal.util` from shading in `dd-trace-ot`

# Motivation

It should not be shaded.

# Additional Notes

Does not affect anything right now by pure luck, since none of the `core` classes access anything in that package directly. The W3C propagator will, and then things break since the class won't exist.
