### PR TITLE
Add 'env' tag assertion to test frameworks integration tests

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/TestFrameworkTest.groovy
@@ -104,6 +104,7 @@ abstract class TestFrameworkTest extends AgentTestRunner {
           tag(key, val)
         }
 
+        "$Tags.ENV" String
         "$Tags.OS_VERSION" String
         "$Tags.OS_PLATFORM" String
         "$Tags.OS_ARCHITECTURE" String
@@ -177,6 +178,7 @@ abstract class TestFrameworkTest extends AgentTestRunner {
           tag(key, val)
         }
 
+        "$Tags.ENV" String
         "$Tags.OS_VERSION" String
         "$Tags.OS_PLATFORM" String
         "$Tags.OS_ARCHITECTURE" String
@@ -261,6 +263,7 @@ abstract class TestFrameworkTest extends AgentTestRunner {
           tag(key, val)
         }
 
+        "$Tags.ENV" String
         "$Tags.OS_VERSION" String
         "$Tags.OS_PLATFORM" String
         "$Tags.OS_ARCHITECTURE" String

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDIntakeTraceInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDIntakeTraceInterceptor.java
@@ -7,6 +7,7 @@ import static datadog.trace.util.TraceUtils.normalizeSpanType;
 
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.api.interceptor.TraceInterceptor;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.core.DDSpan;
 import datadog.trace.util.TraceUtils;
 import java.util.Collection;
@@ -47,7 +48,7 @@ public class DDIntakeTraceInterceptor implements TraceInterceptor {
       span.setResourceName(span.getOperationName());
     }
 
-    span.setTag("env", TraceUtils.normalizeEnv((String) span.getTag("env")));
+    span.setTag(Tags.ENV, TraceUtils.normalizeEnv((String) span.getTag(Tags.ENV)));
 
     final short httpStatusCode = span.getHttpStatusCode();
     if (httpStatusCode != 0 && !isValidStatusCode(httpStatusCode)) {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
@@ -92,4 +92,6 @@ public class Tags {
   public static final String DD_SERVICE = "dd.service";
   public static final String DD_VERSION = "dd.version";
   public static final String DD_ENV = "dd.env";
+
+  public static final String ENV = "env";
 }


### PR DESCRIPTION
# What Does This Do
This change updates integration tests that verify test frameworks instrumentation (junit4, junit5, test NG).
The update is to add `env` tag assertion for every emitted span.

# Motivation
A [recent change](https://github.com/DataDog/dd-trace-java/pull/4765) introduced logic that populates `env` tag with a default value if it is missing (only when running the tracer in agentless mode).
The integration tests require every span tag to be asserted, which is why assert for `env` tag needs to be added.

# Additional Notes
It is only verified that the tag is always present, its contents are checked by the tests that were added for the earlier change.
