### PR TITLE
Skip buildSrc tests by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,7 @@ jobs:
           command: >-
             MAVEN_OPTS="-Xms64M -Xmx256M"
             GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms2G -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
-            ./gradlew clean compile shadowJar test -PskipTests -PskipBuildSrcTest
+            ./gradlew clean compile shadowJar test -PskipTests
             << pipeline.parameters.gradle_flags >>
             --max-workers=8
             --rerun-tasks
@@ -264,7 +264,7 @@ jobs:
           name: Run spotless
           command: >-
             JAVA_HOME=$JAVA_11_HOME
-            ./gradlew spotlessCheck -PskipBuildSrcTest
+            ./gradlew spotlessCheck
             << pipeline.parameters.gradle_flags >>
             --max-workers=8
 
@@ -286,7 +286,7 @@ jobs:
           command: >-
             MAVEN_OPTS="-Xms64M -Xmx256M"
             GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms2G -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
-            ./gradlew check -PskipTests
+            ./gradlew check -PskipTests -PrunBuildSrcTests
             << pipeline.parameters.gradle_flags >>
             --max-workers=8
 
@@ -413,7 +413,6 @@ jobs:
             ./gradlew
             << parameters.gradleTarget >>
             << parameters.gradleParameters >>
-            -PskipBuildSrcTest
             <<# parameters.testJvm >>-PtestJvm=<< parameters.testJvm >><</ parameters.testJvm >>
             << pipeline.parameters.gradle_flags >>
             --max-workers=<< parameters.maxWorkers >>

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -48,5 +48,5 @@ dependencies {
 tasks.test {
   useJUnitPlatform()
   dependsOn(":call-site-instrumentation-plugin:build")
-  enabled = !project.hasProperty("skipBuildSrcTest")
+  enabled = project.hasProperty("runBuildSrcTests")
 }


### PR DESCRIPTION
# What Does This Do

* Skip buildSrc tests by default
* Run them with `-PrunBuildSrcTests`.
* The `check` job in CI will run them.

# Motivation

These tests are triggered on the gradle configuration stage, which can get on your nerves pretty quickly. Running them is rarely needed, since we touch them only once in a while. So we can get them out of every step (and local development) except for the `check` job.

# Additional Notes
