### PR TITLE
Adjust profiling integration for changes in jplib 0.19.0

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -5,8 +5,6 @@ import static com.datadog.profiling.ddprof.DatadogProfilerConfig.getCStack;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.getContextAttributes;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.getCpuInterval;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.getLogLevel;
-import static com.datadog.profiling.ddprof.DatadogProfilerConfig.getMemleakCapacity;
-import static com.datadog.profiling.ddprof.DatadogProfilerConfig.getMemleakInterval;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.getSafeMode;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.getSchedulingEvent;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.getSchedulingEventInterval;
@@ -311,18 +309,16 @@ public final class DatadogProfiler {
       }
     }
     cmd.append(",loglevel=").append(getLogLevel(configProvider));
-    if (profilingModes.contains(ALLOCATION)) {
-      // allocation profiling is enabled
-      cmd.append(",alloc=").append(getAllocationInterval(configProvider)).append('b');
-    }
-    if (profilingModes.contains(MEMLEAK)) {
-      // memleak profiling is enabled
-      cmd.append(",memleak=")
-          .append(getMemleakInterval(configProvider))
-          .append('b')
-          .append(",memleakcap=")
-          .append(getMemleakCapacity(configProvider))
-          .append('b');
+    if (profilingModes.contains(ALLOCATION) || profilingModes.contains(MEMLEAK)) {
+      // allocation profiling or live heap profiling is enabled
+      cmd.append(",memory=").append(getAllocationInterval(configProvider)).append('b');
+      cmd.append(':');
+      if (profilingModes.contains(ALLOCATION)) {
+        cmd.append('a');
+      }
+      if (profilingModes.contains(MEMLEAK)) {
+        cmd.append('l');
+      }
     }
     String cmdString = cmd.toString();
     log.debug("Datadog profiler command line: {}", cmdString);

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -271,6 +271,10 @@ public final class DatadogProfiler {
     throw new IllegalStateException("Datadog profiler session has already been started");
   }
 
+  void dump(Path path) {
+    profiler.dump(path);
+  }
+
   String cmdStartProfiling(Path file) throws IllegalStateException {
     // 'start' = start, 'jfr=7' = store in JFR format ready for concatenation
     StringBuilder cmd = new StringBuilder("start,jfr=7");

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/test/java/com/datadog/profiling/ddprof/DatadogProfilerTest.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/test/java/com/datadog/profiling/ddprof/DatadogProfilerTest.java
@@ -79,16 +79,16 @@ class DatadogProfilerTest {
     String cmd = profiler.cmdStartProfiling(targetFile);
 
     if (profiler.enabledModes().contains(ProfilingMode.CPU)) {
-      assertTrue(cmd.contains("cpu="));
+      assertTrue(cmd.contains("cpu="), cmd);
     }
     if (profiler.enabledModes().contains(ProfilingMode.WALL)) {
-      assertTrue(cmd.contains("wall="));
+      assertTrue(cmd.contains("wall="), cmd);
     }
     if (profiler.enabledModes().contains(ProfilingMode.ALLOCATION)) {
-      assertTrue(cmd.contains("alloc="));
+      assertTrue(cmd.matches(".*?memory=[0-9]+b?:.*?a.*"), cmd);
     }
     if (profiler.enabledModes().contains(ProfilingMode.MEMLEAK)) {
-      assertTrue(cmd.contains("memleak="));
+      assertTrue(cmd.matches(".*?memory=[0-9]+b?:.*?l.*"), cmd);
     }
   }
 


### PR DESCRIPTION
# What Does This Do
- updates the jplib dependency to 0.19.0
- modifies the integration to use 'continuous dump' rather than stop/start profiler for periodic recording uploads
- modifies how the memory profiling is configured

# Motivation
The 'continuous dump' mode is a bit less expensive than full stop/start seuqence.
The allocation profiling and live object tracking was merged in jplib 0.15.0 but the integration code was not updated - this PR fixes that.

# Additional Notes
