### PR TITLE
Fix evaluateAt resolution for line probe

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
@@ -271,7 +271,11 @@ public class Snapshot {
   }
 
   private boolean resolveEvaluateAt(ProbeDetails probe, MethodLocation methodLocation) {
-    if (methodLocation == MethodLocation.DEFAULT || methodLocation == MethodLocation.ENTRY) {
+    if (methodLocation == MethodLocation.DEFAULT) {
+      // line probe, no evaluation of probe's evaluateAt
+      return true;
+    }
+    if (methodLocation == MethodLocation.ENTRY) {
       return probe.getEvaluateAt() == MethodLocation.DEFAULT
           || probe.getEvaluateAt() == MethodLocation.ENTRY;
     }
@@ -474,6 +478,10 @@ public class Snapshot {
           + '\''
           + ", probeLocation="
           + location
+          + ", evaluateAt="
+          + evaluateAt
+          + ", captureSnapshot="
+          + captureSnapshot
           + ", script="
           + script
           + ", tags="
@@ -1277,6 +1285,22 @@ public class Snapshot {
 
     public void setHasLogTemplateErrors() {
       this.hasLogTemplateErrors = true;
+    }
+
+    @Override
+    public String toString() {
+      return "SnapshotStatus{"
+          + "capturing="
+          + capturing
+          + ", sending="
+          + sending
+          + ", hasConditionErrors="
+          + hasConditionErrors
+          + ", hasLogTemplateErrors="
+          + hasLogTemplateErrors
+          + ", probeDetails="
+          + probeDetails
+          + '}';
     }
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -783,7 +783,7 @@ public class CapturedSnapshotTest {
   @Test
   public void simpleConditionTest() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot08";
-    LogProbe logProbes =
+    LogProbe logProbe =
         createProbeBuilder(PROBE_ID, CLASS_NAME, "doit", "int (java.lang.String)")
             .when(
                 new ProbeCondition(
@@ -806,7 +806,7 @@ public class CapturedSnapshotTest {
                     "(fld == 11 && typed.fld.fld.msg == \"hello\") && (arg == '5' && @duration > 0)"))
             .evaluateAt(ProbeDefinition.MethodLocation.EXIT)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
+    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     for (int i = 0; i < 100; i++) {
       int result = Reflect.on(testClass).call("main", String.valueOf(i)).get();
@@ -815,6 +815,22 @@ public class CapturedSnapshotTest {
     Assert.assertEquals(1, listener.snapshots.size());
     assertCaptureArgs(
         listener.snapshots.get(0).getCaptures().getReturn(), "arg", "java.lang.String", "5");
+  }
+
+  @Test
+  public void simpleFalseConditionTest() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot08";
+    LogProbe logProbe =
+        createProbeBuilder(PROBE_ID, CLASS_NAME, "doit", "int (java.lang.String)", "35")
+            .when(
+                new ProbeCondition(DSL.when(DSL.eq(DSL.ref("arg"), DSL.value("5"))), "arg == '5'"))
+            .evaluateAt(ProbeDefinition.MethodLocation.EXIT)
+            .build();
+    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbe);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "0").get();
+    Assert.assertEquals(3, result);
+    Assert.assertEquals(0, listener.snapshots.size());
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do
No need to resolve `evaluateAt` attribute for line probe.
config for the probe can now embed `evaluateAt` with any value, even for line probe

# Motivation
Conditions was not evaluated for line probes

# Additional Notes
