### PR TITLE
naming schema: grpc server

### DIFF
--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerDecorator.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerDecorator.java
@@ -7,6 +7,7 @@ import static datadog.trace.core.datastreams.TagsProcessor.TYPE_TAG;
 import datadog.trace.api.Config;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
+import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -23,7 +24,9 @@ public class GrpcServerDecorator extends ServerDecorator {
       Config.get().isGrpcServerTrimPackageResource();
   private static final BitSet SERVER_ERROR_STATUSES = Config.get().getGrpcServerErrorStatuses();
 
-  public static final CharSequence GRPC_SERVER = UTF8BytesString.create("grpc.server");
+  public static final CharSequence GRPC_SERVER =
+      UTF8BytesString.create(
+          SpanNaming.instance().namingSchema().server().operationForProtocol("grpc"));
   public static final CharSequence COMPONENT_NAME = UTF8BytesString.create("grpc-server");
   public static final CharSequence GRPC_MESSAGE = UTF8BytesString.create("grpc.message");
 

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
@@ -19,6 +19,20 @@ import java.util.concurrent.atomic.AtomicReference
 abstract class GrpcStreamingTest extends VersionedNamingTestBase {
 
   @Override
+  final String service() {
+    return null
+  }
+
+  @Override
+  final String operation() {
+    return null
+  }
+
+  protected abstract String clientOperation()
+
+  protected abstract String serverOperation()
+
+  @Override
   protected void configurePreAgent() {
     super.configurePreAgent()
     injectSysConfig("dd.trace.grpc.ignored.inbound.methods", "example.Greeter/IgnoreInbound")
@@ -130,7 +144,7 @@ abstract class GrpcStreamingTest extends VersionedNamingTestBase {
     assertTraces(2) {
       trace((clientMessageCount * serverMessageCount) + 1) {
         span {
-          operationName operation()
+          operationName clientOperation()
           resourceName "example.Greeter/Conversation"
           spanType DDSpanTypes.RPC
           parent()
@@ -162,7 +176,7 @@ abstract class GrpcStreamingTest extends VersionedNamingTestBase {
       }
       trace(clientMessageCount + 1) {
         span {
-          operationName "grpc.server"
+          operationName serverOperation()
           resourceName "example.Greeter/Conversation"
           spanType DDSpanTypes.RPC
           childOf trace(0).get(0)
@@ -222,13 +236,13 @@ class GrpcStreamingV0ForkedTest extends GrpcStreamingTest {
   }
 
   @Override
-  String service() {
-    return null
+  protected String clientOperation() {
+    return "grpc.client"
   }
 
   @Override
-  String operation() {
-    return "grpc.client"
+  protected String serverOperation() {
+    return "grpc.server"
   }
 }
 
@@ -240,12 +254,12 @@ class GrpcStreamingV1ForkedTest extends GrpcStreamingTest {
   }
 
   @Override
-  String service() {
-    return null
+  protected String clientOperation() {
+    return "grpc.client.request"
   }
 
   @Override
-  String operation() {
-    return "grpc.client.request"
+  protected String serverOperation() {
+    return "grpc.server.request"
   }
 }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/HierarchyMatcherGrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/HierarchyMatcherGrpcStreamingTest.groovy
@@ -11,12 +11,12 @@ class HierarchyMatcherGrpcStreamingTest extends GrpcStreamingTest {
   }
 
   @Override
-  String service() {
-    return null
+  String clientOperation() {
+    return "grpc.client"
   }
 
   @Override
-  String operation() {
-    return "grpc.client"
+  String serverOperation() {
+    return "grpc.server"
   }
 }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/HierarchyMatcherGrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/HierarchyMatcherGrpcTest.groovy
@@ -11,12 +11,12 @@ class HierarchyMatcherGrpcTest extends GrpcTest {
   }
 
   @Override
-  String service() {
-    return null
+  String clientOperation() {
+    return "grpc.client"
   }
 
   @Override
-  String operation() {
-    return "grpc.client"
+  String serverOperation() {
+    return "grpc.server"
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/ServerNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/ServerNamingV0.java
@@ -7,7 +7,9 @@ public class ServerNamingV0 implements NamingSchema.ForServer {
   @Nonnull
   @Override
   public String operationForProtocol(@Nonnull String protocol) {
-    // cases will be addressed in subsequent PRs (for grpc and rmi)
+    if ("grpc".equals(protocol)) {
+      return "grpc.server";
+    }
     return protocol + ".request";
   }
 

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/ServerNamingV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/ServerNamingV1.java
@@ -8,7 +8,7 @@ public class ServerNamingV1 implements NamingSchema.ForServer {
   @Nonnull
   @Override
   public String operationForProtocol(@Nonnull String protocol) {
-    return protocol + "server.request";
+    return protocol + ".server.request";
   }
 
   @Nonnull


### PR DESCRIPTION
# What Does This Do

v1 naming schema changes for grpc server:
* operation: `grpc.server.request`

# Motivation

# Additional Notes
