### PR TITLE
naming schema: undertow

### DIFF
--- a/dd-java-agent/instrumentation/undertow/src/main/java/datadog/trace/instrumentation/undertow/UndertowDecorator.java
+++ b/dd-java-agent/instrumentation/undertow/src/main/java/datadog/trace/instrumentation/undertow/UndertowDecorator.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.undertow;
 
 import datadog.trace.api.gateway.BlockResponseFunction;
+import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstanceStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
@@ -14,9 +15,9 @@ import io.undertow.util.AttachmentKey;
 public class UndertowDecorator
     extends HttpServerDecorator<
         HttpServerExchange, HttpServerExchange, HttpServerExchange, HttpServerExchange> {
-  public static final CharSequence UNDERTOW_REQUEST =
-      UTF8BytesString.create("undertow-http.request");
-  public static final CharSequence SERVLET_REQUEST = UTF8BytesString.create("servlet.request");
+  public static final CharSequence SERVLET_REQUEST =
+      UTF8BytesString.create(
+          SpanNaming.instance().namingSchema().server().operationForComponent("java-web-servlet"));
   public static final CharSequence UNDERTOW_HTTP_SERVER =
       UTF8BytesString.create("undertow-http-server");
 
@@ -30,6 +31,8 @@ public class UndertowDecorator
           "DD_UNDERTOW_CONTINUATION", AttachmentKey.create(AgentScope.Continuation.class));
 
   public static final UndertowDecorator DECORATE = new UndertowDecorator();
+  public static final CharSequence UNDERTOW_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
 
   @Override
   protected String[] instrumentationNames() {

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowDispatcherTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowDispatcherTest.groovy
@@ -2,6 +2,7 @@ import datadog.appsec.api.blocking.Blocking
 import datadog.appsec.api.blocking.BlockingException
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import io.undertow.Handlers
 import io.undertow.Undertow
 import io.undertow.UndertowOptions
@@ -12,7 +13,7 @@ import io.undertow.util.StatusCodes
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.*
 
-class UndertowDispatcherTest extends HttpServerTest<Undertow> {
+abstract class UndertowDispatcherTest extends HttpServerTest<Undertow> {
   class UndertowServer implements HttpServer {
     def port = 0
     Undertow undertowServer
@@ -153,7 +154,7 @@ class UndertowDispatcherTest extends HttpServerTest<Undertow> {
 
   @Override
   String expectedOperationName() {
-    return 'undertow-http.request'
+    return operation()
   }
 
   @Override
@@ -181,4 +182,24 @@ class UndertowDispatcherTest extends HttpServerTest<Undertow> {
       Collections.emptyMap()
     }
   }
+}
+
+class UndertowDispatcherV0ForkedTest extends UndertowDispatcherTest {
+  @Override
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "undertow-http.request"
+  }
+}
+
+class UndertowDispatcherV1ForkedTest extends UndertowDispatcherTest implements TestingGenericHttpNamingConventions.ServerV1 {
 }

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowServletTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowServletTest.groovy
@@ -1,6 +1,7 @@
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import io.undertow.Undertow
 import io.undertow.UndertowOptions
 import io.undertow.server.handlers.PathHandler
@@ -20,7 +21,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRE
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 
-class UndertowServletTest extends HttpServerTest<Undertow> {
+abstract class UndertowServletTest extends HttpServerTest<Undertow> {
   private static final CONTEXT = "ctx"
 
   class UndertowServer implements HttpServer {
@@ -87,7 +88,7 @@ class UndertowServletTest extends HttpServerTest<Undertow> {
 
   @Override
   String expectedOperationName() {
-    return 'servlet.request'
+    return operation()
   }
 
   @Override
@@ -140,4 +141,10 @@ class UndertowServletTest extends HttpServerTest<Undertow> {
       throw new UnsupportedOperationException("responseSpan not implemented for " + endpoint)
     }
   }
+}
+
+class UndertowServletV0ForkedTest extends UndertowServletTest implements TestingGenericHttpNamingConventions.ServerV0 {
+}
+
+class UndertowServletV1ForkedTest extends UndertowServletTest implements TestingGenericHttpNamingConventions.ServerV1 {
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/ServerNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/ServerNamingV0.java
@@ -16,6 +16,9 @@ public class ServerNamingV0 implements NamingSchema.ForServer {
   public String operationForComponent(@Nonnull String component) {
     // more cases will be added in subsequent PRs.
     // Defaulting to servlet.request since it's for the majority of http server instrumentations
+    if ("undertow-http-server".equals(component)) {
+      return "undertow-http.request";
+    }
     return "servlet.request";
   }
 }


### PR DESCRIPTION
# What Does This Do

v1 naming schema changes for undertow:
* operation: `http.server.request`

# Motivation

# Additional Notes
