### PR TITLE
naming schema: finatra

### DIFF
--- a/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraDecorator.java
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraDecorator.java
@@ -14,8 +14,10 @@ public class FinatraDecorator extends HttpServerDecorator<Request, Request, Resp
   public static final CharSequence FINATRA = UTF8BytesString.create("finatra");
   public static final CharSequence FINATRA_CONTROLLER =
       UTF8BytesString.create("finatra.controller");
-  private static final CharSequence FINATRA_REQUEST = UTF8BytesString.create("finatra.request");
   public static final FinatraDecorator DECORATE = new FinatraDecorator();
+
+  private static final CharSequence FINATRA_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
 
   @Override
   protected CharSequence component() {

--- a/dd-java-agent/instrumentation/finatra-2.9/src/test/groovy/FinatraServerTest.groovy
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/test/groovy/FinatraServerTest.groovy
@@ -4,6 +4,7 @@ import com.twitter.util.Closable
 import com.twitter.util.Duration
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.finatra.FinatraDecorator
@@ -14,7 +15,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
-class FinatraServerTest extends HttpServerTest<HttpServer> {
+abstract class FinatraServerTest extends HttpServerTest<HttpServer> {
   private static final Duration TIMEOUT = Duration.fromSeconds(5)
   private static final long STARTUP_TIMEOUT = 20 // SECONDS
 
@@ -62,7 +63,7 @@ class FinatraServerTest extends HttpServerTest<HttpServer> {
 
   @Override
   String expectedOperationName() {
-    return "finatra.request"
+    return operation()
   }
 
   @Override
@@ -94,4 +95,24 @@ class FinatraServerTest extends HttpServerTest<HttpServer> {
       }
     }
   }
+}
+
+class FinatraServerV0ForkedTest extends FinatraServerTest {
+  @Override
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "finatra.request"
+  }
+}
+
+class FinatraServerV1ForkedTest extends FinatraServerTest implements TestingGenericHttpNamingConventions.ServerV1 {
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/ServerNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/ServerNamingV0.java
@@ -24,6 +24,9 @@ public class ServerNamingV0 implements NamingSchema.ForServer {
       case "akka-http-server":
         prefix = "akka-http";
         break;
+      case "finatra":
+        prefix = "finatra";
+        break;
       default:
         prefix = "servlet";
         break;


### PR DESCRIPTION
# What Does This Do

v1 naming changes for finatra: 
* operation: `http.server.request`

# Motivation

# Additional Notes
