### PR TITLE
naming schema: spray

### DIFF
--- a/dd-java-agent/instrumentation/spray-1.3/src/main/scala/datadog/trace/instrumentation/spray/SprayHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spray-1.3/src/main/scala/datadog/trace/instrumentation/spray/SprayHttpServerDecorator.java
@@ -13,11 +13,12 @@ import spray.routing.RequestContext;
 
 public class SprayHttpServerDecorator
     extends HttpServerDecorator<HttpRequest, RequestContext, HttpResponse, HttpRequest> {
-  public static final CharSequence SPRAY_HTTP_REQUEST =
-      UTF8BytesString.create("spray-http.request");
   public static final CharSequence SPRAY_HTTP_SERVER = UTF8BytesString.create("spray-http-server");
 
   public static final SprayHttpServerDecorator DECORATE = new SprayHttpServerDecorator();
+
+  private static final CharSequence SPRAY_HTTP_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
 
   @Override
   protected AgentPropagation.ContextVisitor<HttpRequest> getter() {

--- a/dd-java-agent/instrumentation/spray-1.3/src/main/scala/datadog/trace/instrumentation/spray/SprayHttpServerRunSealedRouteAdvice.java
+++ b/dd-java-agent/instrumentation/spray-1.3/src/main/scala/datadog/trace/instrumentation/spray/SprayHttpServerRunSealedRouteAdvice.java
@@ -4,7 +4,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.spray.SprayHttpServerDecorator.DECORATE;
-import static datadog.trace.instrumentation.spray.SprayHttpServerDecorator.SPRAY_HTTP_REQUEST;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -25,7 +24,7 @@ public class SprayHttpServerRunSealedRouteAdvice {
       span = DECORATE.startSpan(request, extractedContext);
     } else {
       extractedContext = null;
-      span = startSpan(SPRAY_HTTP_REQUEST);
+      span = startSpan(DECORATE.spanName());
     }
 
     DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/spray-1.3/src/test/groovy/SprayServerTest.groovy
+++ b/dd-java-agent/instrumentation/spray-1.3/src/test/groovy/SprayServerTest.groovy
@@ -1,8 +1,9 @@
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.spray.SprayHttpServerDecorator
 
-class SprayServerTest extends HttpServerTest<SprayHttpTestWebServer> {
+abstract class SprayServerTest extends HttpServerTest<SprayHttpTestWebServer> {
 
   @Override
   HttpServer server() {
@@ -23,7 +24,7 @@ class SprayServerTest extends HttpServerTest<SprayHttpTestWebServer> {
 
   @Override
   String expectedOperationName() {
-    return SprayHttpServerDecorator.DECORATE.SPRAY_HTTP_REQUEST
+    return operation()
   }
 
   @Override
@@ -55,4 +56,24 @@ class SprayServerTest extends HttpServerTest<SprayHttpTestWebServer> {
   @Override
   def setup() {
   }
+}
+
+class SprayServerV0ForkedTest extends SprayServerTest {
+  @Override
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "spray-http.request"
+  }
+}
+
+class SprayServerV1ForkedTest extends SprayServerTest implements TestingGenericHttpNamingConventions.ServerV1 {
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/ServerNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/ServerNamingV0.java
@@ -27,6 +27,9 @@ public class ServerNamingV0 implements NamingSchema.ForServer {
       case "finatra":
         prefix = "finatra";
         break;
+      case "spray-http-server":
+        prefix = "spray-http";
+        break;
       default:
         prefix = "servlet";
         break;


### PR DESCRIPTION
# What Does This Do

v1 naming schema changes for spray:
* operation: `http.server.request`

# Motivation

# Additional Notes
