### PR TITLE
Fix issue when converting bytes and floats to string in invoke dynamic

### DIFF
--- a/dd-java-agent/instrumentation/java-lang/java-lang-9/src/main/java/datadog/trace/instrumentation/java/lang/invoke/StringConcatFactoryCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/java-lang-9/src/main/java/datadog/trace/instrumentation/java/lang/invoke/StringConcatFactoryCallSite.java
@@ -155,24 +155,18 @@ public class StringConcatFactoryCallSite {
 
   private static MethodHandle toStringConverterFor(final Class<?> cl) {
     try {
-      final MethodHandles.Lookup lookup = MethodHandles.publicLookup();
-      if (cl == byte.class || cl == short.class || cl == int.class) {
-        return lookup.findStatic(String.class, "valueOf", methodType(String.class, int.class));
-      } else if (cl == boolean.class) {
-        return lookup.findStatic(String.class, "valueOf", methodType(String.class, boolean.class));
-      } else if (cl == char.class) {
-        return lookup.findStatic(String.class, "valueOf", methodType(String.class, char.class));
-      } else if (cl == long.class) {
-        return lookup.findStatic(String.class, "valueOf", methodType(String.class, long.class));
-      } else if (cl == float.class) {
-        return lookup.findStatic(String.class, "valueOf", methodType(String.class, float.class));
-      } else if (cl == double.class) {
-        return lookup.findStatic(String.class, "valueOf", methodType(String.class, double.class));
+      final MethodType methodType;
+      if (cl.isPrimitive()) {
+        final Class<?> target = cl == byte.class || cl == short.class ? int.class : cl;
+        methodType = methodType(String.class, target);
       } else {
-        final MethodHandle handle =
-            lookup.findStatic(String.class, "valueOf", methodType(String.class, Object.class));
-        return handle.asType(methodType(String.class, cl));
+        methodType = methodType(String.class, Object.class);
       }
+      final MethodHandles.Lookup lookup = MethodHandles.publicLookup();
+      final MethodHandle handle = lookup.findStatic(String.class, "valueOf", methodType);
+      return methodType.parameterType(0) == cl
+          ? handle
+          : handle.asType(methodType(String.class, cl));
     } catch (Exception e) {
       throw new RuntimeException("Failed to fetch string converter for " + cl, e);
     }

--- a/dd-java-agent/instrumentation/java-lang/java-lang-9/src/test/groovy/datadog/trace/instrumentation/java/lang/invoke/StringConcatFactoryCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-lang/java-lang-9/src/test/groovy/datadog/trace/instrumentation/java/lang/invoke/StringConcatFactoryCallSiteTest.groovy
@@ -4,11 +4,15 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.propagation.StringModule
 import foo.bar.TestStringConcatFactorySuite
+import groovy.transform.CompileDynamic
 import spock.lang.Requires
+
+import static foo.bar.TestStringConcatFactorySuite.stringPlusWithPrimitive
 
 @Requires({
   jvm.java9Compatible
 })
+@CompileDynamic
 class StringConcatFactoryCallSiteTest extends AgentTestRunner {
 
   @Override
@@ -16,7 +20,7 @@ class StringConcatFactoryCallSiteTest extends AgentTestRunner {
     injectSysConfig("dd.iast.enabled", "true")
   }
 
-  def 'test string concat factory'() {
+  void 'test string concat factory'() {
     setup:
     StringModule iastModule = Mock(StringModule)
     InstrumentationBridge.registerIastModule(iastModule)
@@ -36,7 +40,7 @@ class StringConcatFactoryCallSiteTest extends AgentTestRunner {
     0 * _
   }
 
-  def 'test string concat factory with constants '() {
+  void 'test string concat factory with constants '() {
     setup:
     StringModule iastModule = Mock(StringModule)
     InstrumentationBridge.registerIastModule(iastModule)
@@ -56,7 +60,7 @@ class StringConcatFactoryCallSiteTest extends AgentTestRunner {
     0 * _
   }
 
-  def 'test string concat factory with flag constants'() {
+  void 'test string concat factory with flag constants'() {
     setup:
     StringModule iastModule = Mock(StringModule)
     InstrumentationBridge.registerIastModule(iastModule)
@@ -76,7 +80,7 @@ class StringConcatFactoryCallSiteTest extends AgentTestRunner {
     0 * _
   }
 
-  def 'test string concat factory with object args'() {
+  void 'test string concat factory with object args'() {
     setup:
     StringModule iastModule = Mock(StringModule)
     InstrumentationBridge.registerIastModule(iastModule)
@@ -98,7 +102,7 @@ class StringConcatFactoryCallSiteTest extends AgentTestRunner {
     0 * _
   }
 
-  def 'test string concat factory with null args'() {
+  void 'test string concat factory with null args'() {
     setup:
     StringModule iastModule = Mock(StringModule)
     InstrumentationBridge.registerIastModule(iastModule)
@@ -118,7 +122,7 @@ class StringConcatFactoryCallSiteTest extends AgentTestRunner {
     0 * _
   }
 
-  def 'test string concat factory with multiple args'() {
+  void 'test string concat factory with multiple args'() {
     setup:
     StringModule iastModule = Mock(StringModule)
     InstrumentationBridge.registerIastModule(iastModule)
@@ -141,7 +145,7 @@ class StringConcatFactoryCallSiteTest extends AgentTestRunner {
     0 * _
   }
 
-  def 'test string concat factory with utf constants'() {
+  void 'test string concat factory with utf constants'() {
     setup:
     StringModule iastModule = Mock(StringModule)
     InstrumentationBridge.registerIastModule(iastModule)
@@ -159,5 +163,35 @@ class StringConcatFactoryCallSiteTest extends AgentTestRunner {
       ['𠆢\u0001𠆢'] as Object[],
       [-2, 0, -5, 1, -1] as int[])
     0 * _
+  }
+
+  void 'test string concat factory with primitives'() {
+    setup:
+    final iastModule = Mock(StringModule)
+    InstrumentationBridge.registerIastModule(iastModule)
+
+    when:
+    final result = method.call()
+
+    then:
+    result == expectedResult
+    1 * iastModule.onStringConcatFactory(
+      expectedResult,
+      expectedArgs,
+      '\u0001\u0001',
+      [] as Object[],
+      [0, 1] as int[])
+    0 * _
+
+    where:
+    method                                                                 | expectedResult           | expectedArgs
+    { it -> stringPlusWithPrimitive('Hello World! in ', (int) 2023) }      | 'Hello World! in 2023'   | ['Hello World! in ', '2023']
+    { it -> stringPlusWithPrimitive('Give me a number : ', (byte) 5) }     | 'Give me a number : 5'   | ['Give me a number : ', '5']
+    { it -> stringPlusWithPrimitive('Give me a number : ', (short) 5) }    | 'Give me a number : 5'   | ['Give me a number : ', '5']
+    { it -> stringPlusWithPrimitive('Are you mad? ', (boolean) false) }    | 'Are you mad? false'     | ['Are you mad? ', 'false']
+    { it -> stringPlusWithPrimitive('Give me a letter : ', (char) 'c') }   | 'Give me a letter : c'   | ['Give me a letter : ', 'c']
+    { it -> stringPlusWithPrimitive('Hello World! in ', (long) 2023) }     | 'Hello World! in 2023'   | ['Hello World! in ', '2023']
+    { it -> stringPlusWithPrimitive('Hello World! in ', (float) 2023.0) }  | 'Hello World! in 2023.0' | ['Hello World! in ', '2023.0']
+    { it -> stringPlusWithPrimitive('Hello World! in ', (double) 2023.0) } | 'Hello World! in 2023.0' | ['Hello World! in ', '2023.0']
   }
 }

--- a/dd-java-agent/instrumentation/java-lang/java-lang-9/src/test/java/foo/bar/TestStringConcatFactorySuite.java
+++ b/dd-java-agent/instrumentation/java-lang/java-lang-9/src/test/java/foo/bar/TestStringConcatFactorySuite.java
@@ -55,4 +55,60 @@ public abstract class TestStringConcatFactorySuite {
     LOGGER.debug("After string plus {}", result);
     return result;
   }
+
+  public static String stringPlusWithPrimitive(final String left, final int right) {
+    LOGGER.debug("Before string plus with primitive {} {}", left, right);
+    final String result = left + right;
+    LOGGER.debug("After string plus with primitive {}", result);
+    return result;
+  }
+
+  public static String stringPlusWithPrimitive(final String left, final byte right) {
+    LOGGER.debug("Before string plus with primitive {} {}", left, right);
+    final String result = left + right;
+    LOGGER.debug("After string plus with primitive {}", result);
+    return result;
+  }
+
+  public static String stringPlusWithPrimitive(final String left, final short right) {
+    LOGGER.debug("Before string plus with primitive {} {}", left, right);
+    final String result = left + right;
+    LOGGER.debug("After string plus with primitive {}", result);
+    return result;
+  }
+
+  public static String stringPlusWithPrimitive(final String left, final boolean right) {
+    LOGGER.debug("Before string plus with primitive {} {}", left, right);
+    final String result = left + right;
+    LOGGER.debug("After string plus with primitive {}", result);
+    return result;
+  }
+
+  public static String stringPlusWithPrimitive(final String left, final char right) {
+    LOGGER.debug("Before string plus with primitive {} {}", left, right);
+    final String result = left + right;
+    LOGGER.debug("After string plus with primitive {}", result);
+    return result;
+  }
+
+  public static String stringPlusWithPrimitive(final String left, final long right) {
+    LOGGER.debug("Before string plus with primitive {} {}", left, right);
+    final String result = left + right;
+    LOGGER.debug("After string plus with primitive {}", result);
+    return result;
+  }
+
+  public static String stringPlusWithPrimitive(final String left, final float right) {
+    LOGGER.debug("Before string plus with primitive {} {}", left, right);
+    final String result = left + right;
+    LOGGER.debug("After string plus with primitive {}", result);
+    return result;
+  }
+
+  public static String stringPlusWithPrimitive(final String left, final double right) {
+    LOGGER.debug("Before string plus with primitive {} {}", left, right);
+    final String result = left + right;
+    LOGGER.debug("After string plus with primitive {}", result);
+    return result;
+  }
 }


### PR DESCRIPTION
# What Does This Do
Adapts the method signature for the conversion of bytes and shorts to strings, since `String#valueOf` does not have specific methods we were using the integer version but forgot to revert the signature before passing it to the `StringConcatFactory`

# Motivation
The call site for invoke dynamic started failing with:

```
java.lang.BootstrapMethodError: CallSite bootstrap method initialization exception
	at java.base/java.lang.invoke.CallSite.makeSite(CallSite.java:336)
	at java.base/java.lang.invoke.MethodHandleNatives.linkCallSiteImpl(MethodHandleNatives.java:258)
	at java.base/java.lang.invoke.MethodHandleNatives.linkCallSite(MethodHandleNatives.java:248)
	at foo.bar.TestStringConcatFactorySuite.stringPlusWithPrimitive(TestStringConcatFactorySuite.java:61)
	at datadog.trace.instrumentation.java.lang.invoke.StringConcatFactoryCallSiteTest.test string concat factory with primitives(StringConcatFactoryCallSiteTest.groovy:174)
Caused by: java.lang.invoke.WrongMethodTypeException: MethodHandle(String,int)String should be of type (String,short)String
	at java.base/java.lang.invoke.CallSite.wrongTargetType(CallSite.java:201)
	at java.base/java.lang.invoke.CallSite.makeSite(CallSite.java:325)
	... 4 more
```


# Additional Notes
