### PR TITLE
naming schema: restlet

### DIFF
--- a/dd-java-agent/instrumentation/restlet-2.2/build.gradle
+++ b/dd-java-agent/instrumentation/restlet-2.2/build.gradle
@@ -21,13 +21,13 @@ apply plugin: 'org.unbroken-dome.test-sets'
 
 testSets {
   // Header classes have moved around versions, so we need to split out parts of the test code
-  baseTest
+  baseForkedTest {dirName "baseTest"}
 
   latestDepTest
 }
 
 tasks.named("test").configure {
-  dependsOn "baseTest"
+  dependsOn "baseForkedTest"
 }
 
 dependencies {
@@ -35,7 +35,7 @@ dependencies {
 
   testImplementation group: 'org.restlet.jse', name: 'org.restlet', version: '2.2.0'
 
-  baseTestImplementation sourceSets.test.output
+  baseForkedTestImplementation sourceSets.test.output
 
   latestDepTestImplementation group: 'org.restlet.jse', name: 'org.restlet', version: '2.4+'
   latestDepTestImplementation sourceSets.test.output

--- a/dd-java-agent/instrumentation/restlet-2.2/src/baseTest/groovy/RestletTest.groovy
+++ b/dd-java-agent/instrumentation/restlet-2.2/src/baseTest/groovy/RestletTest.groovy
@@ -1,10 +1,11 @@
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import org.restlet.Request
 import org.restlet.Response
 import org.restlet.engine.header.Header
 import org.restlet.routing.Filter
 import org.restlet.util.Series
 
-class RestletTest extends RestletTestBase {
+abstract class RestletTest extends RestletTestBase {
 
   @Override
   protected Filter createHeaderFilter() {
@@ -24,4 +25,11 @@ class RestletTest extends RestletTestBase {
       super.afterHandle(request, response)
     }
   }
+}
+
+class RestletV0ForkedTest extends RestletTest {
+  //V0 expected operation already defined on the base test class
+}
+
+class RestletV1ForkedTest extends RestletTest implements TestingGenericHttpNamingConventions.ServerV1 {
 }

--- a/dd-java-agent/instrumentation/restlet-2.2/src/main/java/datadog/trace/instrumentation/restlet/RestletDecorator.java
+++ b/dd-java-agent/instrumentation/restlet-2.2/src/main/java/datadog/trace/instrumentation/restlet/RestletDecorator.java
@@ -11,10 +11,12 @@ import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 
 public class RestletDecorator
     extends HttpServerDecorator<HttpExchange, HttpExchange, HttpExchange, HttpExchange> {
-  public static final CharSequence RESTLET_REQUEST = UTF8BytesString.create("restlet-http.request");
   public static final CharSequence RESTLET_HTTP_SERVER =
       UTF8BytesString.create("restlet-http-server");
   public static final RestletDecorator DECORATE = new RestletDecorator();
+
+  private static final CharSequence RESTLET_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
 
   @Override
   protected String[] instrumentationNames() {

--- a/dd-java-agent/instrumentation/restlet-2.2/src/test/groovy/RestletTestBase.groovy
+++ b/dd-java-agent/instrumentation/restlet-2.2/src/test/groovy/RestletTestBase.groovy
@@ -77,6 +77,11 @@ abstract class RestletTestBase extends HttpServerTest<Component> {
 
   @Override
   String expectedOperationName() {
+    return operation()
+  }
+
+  @Override
+  String operation() {
     return "restlet-http.request"
   }
 

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/ServerNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/ServerNamingV0.java
@@ -30,6 +30,9 @@ public class ServerNamingV0 implements NamingSchema.ForServer {
       case "spray-http-server":
         prefix = "spray-http";
         break;
+      case "restlet-http-server":
+        prefix = "restlet-http";
+        break;
       default:
         prefix = "servlet";
         break;


### PR DESCRIPTION
# What Does This Do

v1 naming schema changes for restlet:
* operation: `http.server.request`

# Motivation

# Additional Notes
