### PR TITLE
naming schema: netty server

### DIFF
--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/NettyHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/NettyHttpServerDecorator.java
@@ -32,8 +32,10 @@ public class NettyHttpServerDecorator
     extends HttpServerDecorator<HttpRequest, Channel, HttpResponse, HttpHeaders> {
   public static final CharSequence NETTY = UTF8BytesString.create("netty");
   public static final CharSequence NETTY_CONNECT = UTF8BytesString.create("netty.connect");
-  public static final CharSequence NETTY_REQUEST = UTF8BytesString.create("netty.request");
+
   public static final NettyHttpServerDecorator DECORATE = new NettyHttpServerDecorator();
+  private static final CharSequence NETTY_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
 
   @Override
   protected String[] instrumentationNames() {

--- a/dd-java-agent/instrumentation/netty-3.8/src/test/groovy/datadog/trace/instrumentation/netty38/Netty38ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-3.8/src/test/groovy/datadog/trace/instrumentation/netty38/Netty38ServerTest.groovy
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.netty38
 import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.agent.test.naming.TestingNettyHttpNamingConventions
 import datadog.trace.instrumentation.netty38.server.NettyHttpServerDecorator
 import org.jboss.netty.bootstrap.ServerBootstrap
 import org.jboss.netty.buffer.ChannelBuffer
@@ -45,7 +46,7 @@ import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.LOCATION
 import static org.jboss.netty.handler.codec.http.HttpVersion.HTTP_1_1
 
-class Netty38ServerTest extends HttpServerTest<ServerBootstrap> {
+abstract class Netty38ServerTest extends HttpServerTest<ServerBootstrap> {
 
   static final LoggingHandler LOGGING_HANDLER
   static {
@@ -180,11 +181,17 @@ class Netty38ServerTest extends HttpServerTest<ServerBootstrap> {
 
   @Override
   String expectedOperationName() {
-    "netty.request"
+    component()
   }
 
   @Override
   boolean testBlocking() {
     true
   }
+}
+
+class Netty38ServerV0ForkedTest extends Netty38ServerTest implements TestingNettyHttpNamingConventions.ServerV0 {
+}
+
+class Netty38ServerV1ForkedTest extends Netty38ServerTest implements TestingNettyHttpNamingConventions.ServerV1 {
 }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/NettyHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/NettyHttpServerDecorator.java
@@ -28,8 +28,10 @@ public class NettyHttpServerDecorator
     extends HttpServerDecorator<HttpRequest, Channel, HttpResponse, HttpHeaders> {
   public static final CharSequence NETTY = UTF8BytesString.create("netty");
   public static final CharSequence NETTY_CONNECT = UTF8BytesString.create("netty.connect");
-  public static final CharSequence NETTY_REQUEST = UTF8BytesString.create("netty.request");
+
   public static final NettyHttpServerDecorator DECORATE = new NettyHttpServerDecorator();
+  private static final CharSequence NETTY_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
 
   @Override
   protected String[] instrumentationNames() {

--- a/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
@@ -1,6 +1,7 @@
 import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.agent.test.naming.TestingNettyHttpNamingConventions
 import datadog.trace.instrumentation.netty40.server.NettyHttpServerDecorator
 import io.netty.bootstrap.ServerBootstrap
 import io.netty.buffer.ByteBuf
@@ -38,7 +39,7 @@ import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1
 
-class Netty40ServerTest extends HttpServerTest<EventLoopGroup> {
+abstract class Netty40ServerTest extends HttpServerTest<EventLoopGroup> {
 
   static final LoggingHandler LOGGING_HANDLER = new LoggingHandler(SERVER_LOGGER.name, LogLevel.DEBUG)
 
@@ -149,11 +150,17 @@ class Netty40ServerTest extends HttpServerTest<EventLoopGroup> {
 
   @Override
   String expectedOperationName() {
-    "netty.request"
+    operation()
   }
 
   @Override
   boolean testBlocking() {
     true
   }
+}
+
+class Netty40ServerV0ForkedTest extends Netty40ServerTest implements TestingNettyHttpNamingConventions.ServerV0 {
+}
+
+class Netty40ServerV1ForkedTest extends Netty40ServerTest implements TestingNettyHttpNamingConventions.ServerV1 {
 }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/NettyHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/NettyHttpServerDecorator.java
@@ -28,8 +28,10 @@ public class NettyHttpServerDecorator
     extends HttpServerDecorator<HttpRequest, Channel, HttpResponse, HttpHeaders> {
   public static final CharSequence NETTY = UTF8BytesString.create("netty");
   public static final CharSequence NETTY_CONNECT = UTF8BytesString.create("netty.connect");
-  public static final CharSequence NETTY_REQUEST = UTF8BytesString.create("netty.request");
+
   public static final NettyHttpServerDecorator DECORATE = new NettyHttpServerDecorator();
+  private static final CharSequence NETTY_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
 
   @Override
   protected String[] instrumentationNames() {

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ServerTest.groovy
@@ -1,6 +1,7 @@
 import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.agent.test.naming.TestingNettyHttpNamingConventions
 import datadog.trace.instrumentation.netty41.server.NettyHttpServerDecorator
 import io.netty.bootstrap.ServerBootstrap
 import io.netty.buffer.ByteBuf
@@ -42,7 +43,7 @@ import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1
 
-class Netty41ServerTest extends HttpServerTest<EventLoopGroup> {
+abstract class Netty41ServerTest extends HttpServerTest<EventLoopGroup> {
 
   static final LoggingHandler LOGGING_HANDLER = new LoggingHandler(SERVER_LOGGER.name, LogLevel.DEBUG)
 
@@ -179,7 +180,7 @@ class Netty41ServerTest extends HttpServerTest<EventLoopGroup> {
 
   @Override
   String expectedOperationName() {
-    "netty.request"
+    operation()
   }
 
   @Override
@@ -191,4 +192,12 @@ class Netty41ServerTest extends HttpServerTest<EventLoopGroup> {
   boolean testBlocking() {
     true
   }
+}
+
+class Netty41ServerV0ForkedTest extends Netty41ServerTest implements TestingNettyHttpNamingConventions.ServerV0 {
+
+}
+
+class Netty41ServerV1ForkedTest extends Netty41ServerTest implements TestingNettyHttpNamingConventions.ServerV1 {
+
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/naming/NamingConventions.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/naming/NamingConventions.groovy
@@ -87,5 +87,25 @@ class TestingNettyHttpNamingConventions {
 
   trait ClientV1 extends TestingGenericHttpNamingConventions.ClientV1 {
   }
+
+  trait ServerV0 implements VersionedNamingTest {
+    @Override
+    int version() {
+      return 0
+    }
+
+    @Override
+    String service() {
+      return null
+    }
+
+    @Override
+    String operation() {
+      return "netty.request"
+    }
+  }
+
+  trait ServerV1 extends TestingGenericHttpNamingConventions.ServerV1 {
+  }
 }
 

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/ServerNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/ServerNamingV0.java
@@ -24,8 +24,9 @@ public class ServerNamingV0 implements NamingSchema.ForServer {
       case "akka-http-server":
         prefix = "akka-http";
         break;
+      case "netty":
       case "finatra":
-        prefix = "finatra";
+        prefix = component;
         break;
       case "spray-http-server":
         prefix = "spray-http";


### PR DESCRIPTION
# What Does This Do

v1 naming changes for netty servers:
* operation: `http.server.request`

# Motivation

# Additional Notes
