### PR TITLE
Separate FixedSizePartialKeyCache from FixedSizeCache.

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/cache/DDCaches.java
+++ b/internal-api/src/main/java/datadog/trace/api/cache/DDCaches.java
@@ -55,6 +55,6 @@ public final class DDCaches {
   }
 
   public static <K, V> DDPartialKeyCache<K, V> newFixedSizePartialKeyCache(final int capacity) {
-    return new FixedSizeCache.FixedSizePartialKeyCache<>(capacity);
+    return new FixedSizePartialKeyCache<>(capacity);
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/cache/FixedSizeCache.java
+++ b/internal-api/src/main/java/datadog/trace/api/cache/FixedSizeCache.java
@@ -1,13 +1,8 @@
 package datadog.trace.api.cache;
 
 import datadog.trace.api.Pair;
-import datadog.trace.api.cache.DDPartialKeyCache.Comparator;
-import datadog.trace.api.cache.DDPartialKeyCache.Hasher;
-import datadog.trace.api.cache.DDPartialKeyCache.Producer;
 import java.util.Arrays;
 import java.util.function.Function;
-import java.util.function.IntFunction;
-import javax.annotation.Nullable;
 
 /**
  * This is a fixed size cache that only has one operation <code>computeIfAbsent</code>, that is used
@@ -20,24 +15,20 @@ import javax.annotation.Nullable;
  * computeIfAbsent</code> is idempotent, or otherwise you might not get back the value you expect
  * from a cache lookup.
  *
- * @param <E> element type
  * @param <K> key type
  * @param <V> value type
- * @param <H> hash function type
- * @param <C> comparison function type
- * @param <P> producer function type
  */
-abstract class FixedSizeCache<E, K, V, H, C, P> {
+abstract class FixedSizeCache<K, V> implements DDCache<K, V> {
 
   static final int MAXIMUM_CAPACITY = 1 << 30;
 
-  protected final int mask;
+  private final int mask;
   // This is a cache, so there is no need for volatile, atomics or synchronized.
   // All race conditions here are benign since you always read or write a full
   // Element that can not be modified, and eventually other threads will see it
   // or write the same information at that position, or other information in the
   // case of a collision.
-  protected final E[] elements;
+  private final Pair<K, V>[] elements;
 
   /**
    * Creates a <code>FixedSizeCache</code> that can hold up to <code>capacity</code> elements, if
@@ -45,7 +36,14 @@ abstract class FixedSizeCache<E, K, V, H, C, P> {
    *
    * @param capacity the maximum number of elements that the cache can hold
    */
-  FixedSizeCache(int capacity, IntFunction<E[]> initializer) {
+  @SuppressWarnings("unchecked")
+  FixedSizeCache(int capacity) {
+    int size = calculateSize(capacity);
+    this.elements = new Pair[size];
+    this.mask = size - 1;
+  }
+
+  static int calculateSize(int capacity) {
     if (capacity <= 0) {
       throw new IllegalArgumentException("Cache capacity must be > 0");
     }
@@ -54,9 +52,7 @@ abstract class FixedSizeCache<E, K, V, H, C, P> {
     }
     // compute a power of two size for the given capacity
     int n = -1 >>> Integer.numberOfLeadingZeros(capacity - 1);
-    n = (n < 0) ? 1 : (n >= MAXIMUM_CAPACITY) ? MAXIMUM_CAPACITY : n + 1;
-    this.elements = initializer.apply(n);
-    this.mask = n - 1;
+    return (n < 0) ? 1 : (n >= MAXIMUM_CAPACITY) ? MAXIMUM_CAPACITY : n + 1;
   }
 
   /**
@@ -66,38 +62,34 @@ abstract class FixedSizeCache<E, K, V, H, C, P> {
    * match or an unused slot. If there is no match or empty slot, the first slot is overwritten.
    *
    * @param key the key to look up
-   * @param m extra parameter that is passed along with the key
-   * @param n extra parameter that is passed along with the key
-   * @param hasher how to compute the hash using key, m, and n
-   * @param comparator how to compare the key, m, n, and value
-   * @param producer how to create a cached value base on the key, m, and n if the lookup fails
+   * @param producer how to create a cached value base on the key if the lookup fails
    * @return the cached or created and stored value
    */
-  protected final V internalComputeIfAbsent(
-      K key, int m, int n, H hasher, C comparator, P producer) {
+  @Override
+  public final V computeIfAbsent(K key, Function<K, ? extends V> producer) {
     if (key == null) {
       return null;
     }
 
-    int hash = hash(hasher, key, m, n);
-    int h = hash;
+    int h = hash(key);
     int firstPos = h & mask;
     V value;
+
     // try to find a slot or a match 3 times
     for (int i = 1; true; i++) {
       int pos = h & mask;
-      E current = elements[pos];
+      Pair<K, V> current = elements[pos];
       if (current == null) {
         // we found an empty slot, so store the value there
-        value = produceAndStoreValue(producer, hash, key, m, n, pos);
+        value = produceAndStoreValue(key, producer, pos);
         break;
-      } else if (equals(comparator, hash, key, m, n, current)) {
+      } else if (equals(key, current)) {
         // we found a cached key, so use that value
-        value = getValue(current);
+        value = current.getRight();
         break;
       } else if (i == 3) {
         // all 3 slots have been taken, so overwrite the first one
-        value = produceAndStoreValue(producer, hash, key, m, n, firstPos);
+        value = produceAndStoreValue(key, producer, firstPos);
         break;
       }
       // slot was occupied by someone else, so try another slot
@@ -106,125 +98,28 @@ abstract class FixedSizeCache<E, K, V, H, C, P> {
     return value;
   }
 
+  @Override
   public void clear() {
     Arrays.fill(elements, null);
   }
 
-  /**
-   * Compute the hash code using the hasher function, key, and extra parameters m, n.
-   *
-   * @param hasher hash function
-   * @param key the key to compute the hash for
-   * @param m extra parameter passed along with the key
-   * @param n extra parameter passed along with the key
-   * @return the hash code
-   */
-  protected abstract int hash(H hasher, K key, int m, int n);
+  abstract int hash(K key);
 
-  /**
-   * Compare the key and the current element using the comparator function, key, hash code, and
-   * extra parameters m, n.
-   *
-   * @param comparator compare function
-   * @param hash hash code
-   * @param key the key to compare
-   * @param m extra parameter passed along with the key
-   * @param n extra parameter passed along with the key
-   * @param current the element to compare against
-   * @return true if there is a match, false othervise
-   */
-  protected abstract boolean equals(C comparator, int hash, K key, int m, int n, E current);
+  abstract boolean equals(K key, Pair<K, V> current);
 
-  /**
-   * Produce a new value using the producer function, key, and extra parameters m, n.
-   *
-   * @param producer producer function
-   * @param key the key to create the value from
-   * @param m extra parameter passed along with the key
-   * @param n extra parameter passed along with the key
-   * @return a new value
-   */
-  protected abstract V produceValue(P producer, K key, int m, int n);
-
-  /**
-   * Create an element using the hash code key, and value.
-   *
-   * @param hash hash code
-   * @param key the key to create the element for
-   * @param value the value to create the element for
-   * @return a new element
-   */
-  protected abstract E toElement(int hash, K key, V value);
-
-  /**
-   * Get the value from an existing element.
-   *
-   * @param element
-   * @return the value contained in the element.
-   */
-  protected abstract V getValue(E element);
-
-  private V produceAndStoreValue(P producer, int hash, K key, int m, int n, int pos) {
-    V value = produceValue(producer, key, m, n);
-    elements[pos] = toElement(hash, key, value);
+  private V produceAndStoreValue(K key, Function<K, ? extends V> producer, int pos) {
+    V value = producer.apply(key);
+    elements[pos] = Pair.of(key, value);
     return value;
   }
 
-  private static int rehash(int v) {
+  static int rehash(int v) {
     int h = v * 0x9e3775cd;
     h = Integer.reverseBytes(h);
     return h * 0x9e3775cd;
   }
 
-  abstract static class FixedSizeKeyValueCache<K, V>
-      extends FixedSizeCache<Pair<K, V>, K, V, Void, Void, Function<K, ? extends V>>
-      implements DDCache<K, V> {
-    public FixedSizeKeyValueCache(int capacity) {
-      super(
-          capacity,
-          n -> {
-            @SuppressWarnings(value = {"rawtype", "unchecked"})
-            Pair<K, V>[] elements = (Pair<K, V>[]) new Pair[n];
-            return elements;
-          });
-    }
-
-    @Override
-    public final V computeIfAbsent(K key, Function<K, ? extends V> producer) {
-      return internalComputeIfAbsent(key, 0, 0, null, null, producer);
-    }
-
-    @Override
-    protected final int hash(Void unused, K key, int m, int n) {
-      return hash(key);
-    }
-
-    @Override
-    protected final boolean equals(Void unused, int hash, K key, int m, int n, Pair<K, V> current) {
-      return equals(key, current);
-    }
-
-    @Override
-    protected final V produceValue(Function<K, ? extends V> producer, K key, int m, int n) {
-      return producer.apply(key);
-    }
-
-    @Override
-    protected final Pair<K, V> toElement(int hash, K key, V value) {
-      return Pair.of(key, value);
-    }
-
-    @Override
-    protected final V getValue(Pair<K, V> element) {
-      return element.getRight();
-    }
-
-    abstract int hash(K key);
-
-    abstract boolean equals(K key, Pair<K, V> current);
-  }
-
-  static final class ObjectHash<K, V> extends FixedSizeKeyValueCache<K, V> {
+  static final class ObjectHash<K, V> extends FixedSizeCache<K, V> {
     ObjectHash(int capacity) {
       super(capacity);
     }
@@ -238,7 +133,7 @@ abstract class FixedSizeCache<E, K, V, H, C, P> {
     }
   }
 
-  static final class IdentityHash<K, V> extends FixedSizeKeyValueCache<K, V> {
+  static final class IdentityHash<K, V> extends FixedSizeCache<K, V> {
     IdentityHash(int capacity) {
       super(capacity);
     }
@@ -252,7 +147,7 @@ abstract class FixedSizeCache<E, K, V, H, C, P> {
     }
   }
 
-  static final class ArrayHash<K, V> extends FixedSizeKeyValueCache<K[], V> {
+  static final class ArrayHash<K, V> extends FixedSizeCache<K[], V> {
     ArrayHash(int capacity) {
       super(capacity);
     }
@@ -263,72 +158,6 @@ abstract class FixedSizeCache<E, K, V, H, C, P> {
 
     boolean equals(K[] key, Pair<K[], V> current) {
       return Arrays.equals(key, current.getLeft());
-    }
-  }
-
-  static final class FixedSizePartialKeyCache<K, V>
-      extends FixedSizeCache<
-          HVElement<V>, K, V, Hasher<K>, Comparator<K, V>, Producer<K, ? extends V>>
-      implements DDPartialKeyCache<K, V> {
-    public FixedSizePartialKeyCache(int capacity) {
-      super(
-          capacity,
-          n -> {
-            @SuppressWarnings(value = {"rawtype", "unchecked"})
-            HVElement<V>[] elements = (HVElement<V>[]) new HVElement[n];
-            return elements;
-          });
-    }
-
-    @Override
-    public V computeIfAbsent(
-        K key,
-        int m,
-        int n,
-        Hasher<K> hasher,
-        Comparator<K, V> comparator,
-        Producer<K, ? extends V> producer) {
-      return internalComputeIfAbsent(key, m, n, hasher, comparator, producer);
-    }
-
-    @Override
-    protected int hash(Hasher<K> hasher, K key, int m, int n) {
-      return hasher.apply(key, m, n);
-    }
-
-    @Override
-    protected boolean equals(
-        Comparator<K, V> comparator, int hash, K key, int m, int n, HVElement<V> current) {
-      return hash == current.hash && comparator.test(key, m, n, current.value);
-    }
-
-    @Override
-    protected V produceValue(Producer<K, ? extends V> producer, K key, int m, int n) {
-      return producer.apply(key, m, n);
-    }
-
-    @Override
-    protected HVElement<V> toElement(int hash, K key, V value) {
-      return HVElement.of(hash, value);
-    }
-
-    @Override
-    protected V getValue(HVElement<V> element) {
-      return element.value;
-    }
-  }
-
-  static final class HVElement<U> {
-    static <U> HVElement<U> of(int hash, U value) {
-      return new HVElement<>(hash, value);
-    }
-
-    final int hash;
-    final U value;
-
-    HVElement(int hash, @Nullable U value) {
-      this.hash = hash;
-      this.value = value;
     }
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/cache/FixedSizePartialKeyCache.java
+++ b/internal-api/src/main/java/datadog/trace/api/cache/FixedSizePartialKeyCache.java
@@ -1,0 +1,122 @@
+package datadog.trace.api.cache;
+
+import static datadog.trace.api.cache.FixedSizeCache.calculateSize;
+import static datadog.trace.api.cache.FixedSizeCache.rehash;
+
+import java.util.Arrays;
+import javax.annotation.Nullable;
+
+/**
+ * This is a fixed size cache that only has one operation <code>computeIfAbsent</code>, that is used
+ * to retrieve, or store and compute the cached value.
+ *
+ * <p>If there is a hash collision, the cache uses double hashing two more times to try to find a
+ * match or an unused slot.
+ *
+ * <p>The cache is thread safe, and assumes that the <code>Producer</code> passed into <code>
+ * computeIfAbsent</code> is idempotent, or otherwise you might not get back the value you expect
+ * from a cache lookup.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+final class FixedSizePartialKeyCache<K, V> implements DDPartialKeyCache<K, V> {
+
+  private final int mask;
+  // This is a cache, so there is no need for volatile, atomics or synchronized.
+  // All race conditions here are benign since you always read or write a full
+  // Element that can not be modified, and eventually other threads will see it
+  // or write the same information at that position, or other information in the
+  // case of a collision.
+  private final HVElement<V>[] elements;
+
+  /**
+   * Creates a <code>FixedSizePartialKeyCache</code> that can hold up to <code>capacity</code>
+   * elements, if the key hash function has perfect spread.
+   *
+   * @param capacity the maximum number of elements that the cache can hold
+   */
+  @SuppressWarnings("unchecked")
+  FixedSizePartialKeyCache(int capacity) {
+    int size = calculateSize(capacity);
+    this.elements = new HVElement[size];
+    this.mask = size - 1;
+  }
+
+  /**
+   * Look up or create and store a value in the cache.
+   *
+   * <p>If there is a hash collision, the method uses double hashing two more times to try to find a
+   * match or an unused slot. If there is no match or empty slot, the first slot is overwritten.
+   *
+   * @param key the key to look up
+   * @param m extra parameter that is passed along with the key
+   * @param n extra parameter that is passed along with the key
+   * @param hasher how to compute the hash using key, m, and n
+   * @param comparator how to compare the key, m, n, and value
+   * @param producer how to create a cached value base on the key, m, and n if the lookup fails
+   * @return the cached or created and stored value
+   */
+  @Override
+  public V computeIfAbsent(
+      K key,
+      int m,
+      int n,
+      Hasher<K> hasher,
+      Comparator<K, V> comparator,
+      Producer<K, ? extends V> producer) {
+    if (key == null) {
+      return null;
+    }
+
+    int hash = hasher.apply(key, m, n);
+
+    int h = hash;
+    int firstPos = h & mask;
+    V value;
+
+    // try to find a slot or a match 3 times
+    for (int i = 1; true; i++) {
+      int pos = h & mask;
+      HVElement<V> current = elements[pos];
+      if (current == null) {
+        // we found an empty slot, so store the value there
+        value = produceAndStoreValue(producer, hash, key, m, n, pos);
+        break;
+      } else if (hash == current.hash && comparator.test(key, m, n, current.value)) {
+        // we found a cached key, so use that value
+        value = current.value;
+        break;
+      } else if (i == 3) {
+        // all 3 slots have been taken, so overwrite the first one
+        value = produceAndStoreValue(producer, hash, key, m, n, firstPos);
+        break;
+      }
+      // slot was occupied by someone else, so try another slot
+      h = rehash(h);
+    }
+    return value;
+  }
+
+  @Override
+  public void clear() {
+    Arrays.fill(elements, null);
+  }
+
+  private V produceAndStoreValue(
+      Producer<K, ? extends V> producer, int hash, K key, int m, int n, int pos) {
+    V value = producer.apply(key, m, n);
+    elements[pos] = new HVElement<>(hash, value);
+    return value;
+  }
+
+  static final class HVElement<U> {
+    final int hash;
+    final U value;
+
+    HVElement(int hash, @Nullable U value) {
+      this.hash = hash;
+      this.value = value;
+    }
+  }
+}


### PR DESCRIPTION
By tolerating a small amount of duplication we can simplify the internals for each case while still sharing some helper methods. IMHO this is better than trying to share the loop code, which results in several (internal-only) generics and intermediate virtual methods.

I did consider extracting the loop into a static helper, but that also results in similar virtual dispatch...