### PR TITLE
W3C trace context extractor/injector

### DIFF
--- a/dd-smoke-tests/springboot-openliberty/snapshots/datadog.smoketest.SpringBootOpenLibertySnapshotTest.nested.snap
+++ b/dd-smoke-tests/springboot-openliberty/snapshots/datadog.smoketest.SpringBootOpenLibertySnapshotTest.nested.snap
@@ -98,7 +98,8 @@
                        "span.kind" "server"
                        "http.method" "GET"
                        "http.route" "/connect/{user}"
-                       "servlet.path" "/connect/92"}
+                       "servlet.path" "/connect/92",
+                       "_dd.p.dm" "-1"}
                "metrics" {"_dd.measured" 1
                           "_sampling_priority_v1" 1
                           "peer.port" 57796

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTraceId.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTraceId.java
@@ -197,6 +197,39 @@ public class DDTraceId {
   }
 
   /**
+   * Returns the zero padded hex representation, in lower case, of the unsigned 64 bit id or the
+   * original. The size will be rounded up to 16 or 32 characters. The hex {@code String} will NOT
+   * be cached.
+   *
+   * @param size the size in characters of the 0 padded String (rounded up to 16 or 32)
+   * @return zero padded hex String
+   */
+  public String toHexStringPaddedOrOriginal(int size) {
+    if (size > 16) {
+      size = 32;
+    } else if (size < 16) {
+      size = 16;
+    }
+    String h = this.hex;
+    if (h == null) {
+      h = DDId.toHexStringPadded(this.id, size);
+    }
+    int len = h.length();
+    if (len == size) {
+      return h;
+    } else if (len > size) {
+      return h.substring((len - 1) - size, len);
+    } else {
+      StringBuilder sb = new StringBuilder(size);
+      for (int i = len; i < size; i++) {
+        sb.append('0');
+      }
+      sb.append(h);
+      return sb.toString();
+    }
+  }
+
+  /**
    * Returns the id as a long representing the bits of the unsigned 64 bit id. This means that
    * values larger than Long.MAX_VALUE will be represented as negative numbers.
    *

--- a/dd-trace-api/src/main/java/datadog/trace/api/TracePropagationStyle.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/TracePropagationStyle.java
@@ -16,6 +16,9 @@ public enum TracePropagationStyle {
   // Amazon X-Ray context propagation style
   // https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader
   XRAY,
+  // W3C trace context propagation style
+  // https://www.w3.org/TR/trace-context-1/
+  TRACECONTEXT,
   // None does not extract or inject
   NONE;
 

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/DDTraceIdTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/DDTraceIdTest.groovy
@@ -185,6 +185,8 @@ class DDTraceIdTest extends DDSpecification {
     if (expectedId) {
       assert ddid == expectedId
       assert ddid.toHexStringOrOriginal() == expectedHex
+      assert ddid.toHexStringPaddedOrOriginal(16) == padHex(16, expectedHex)
+      assert ddid.toHexStringPaddedOrOriginal(32) == padHex(32, expectedHex)
     } else {
       assert !ddid
     }
@@ -234,5 +236,13 @@ class DDTraceIdTest extends DDSpecification {
     1 * random.nextLong() >> { 0 }
     1 * random.nextLong() >> { 11 }
     0 * _
+  }
+
+  static padHex(int size, String hex) {
+    def len = hex.length()
+    if (len >= size) {
+      return hex
+    }
+    return "${"0" * (size - len)}$hex"
   }
 }

--- a/dd-trace-core/src/jmh/java/datadog/trace/core/propagation/PropagationTagsBenchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/propagation/PropagationTagsBenchmark.java
@@ -33,10 +33,15 @@ public class PropagationTagsBenchmark {
    * The parameter is split at '|' and the first element is the propagation tags header type. The
    * rest of the elements are joined with ',' to form the header to be parsed.
    */
-  @Param({"datadog|_dd.p.anytag=value|_dd.p.dm=934086a686-4"})
+  @Param({
+    "datadog|_dd.p.anytag=value|_dd.p.dm=934086a686-4",
+    "w3c|dd=s:1;o:some;t.anytag:value;t.dm:934086a686-4",
+    "w3c|foo=bar|dd=s:1;o:some;t.anytag:value;t.dm:934086a686-4|bar=baz",
+    "w3c|foo=bar|dd=s:1;o:some;t.anytag:value;other:value;t.dm:934086a686-4|bar=baz"
+  })
   String extractHeaderType;
 
-  @Param("datadog")
+  @Param({"datadog", "w3c"})
   String injectHeaderType;
 
   PropagationTags.Factory factory;

--- a/dd-trace-core/src/jmh/java/datadog/trace/core/propagation/PropagationTagsBenchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/propagation/PropagationTagsBenchmark.java
@@ -1,0 +1,67 @@
+package datadog.trace.core.propagation;
+
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import de.thetaphi.forbiddenapis.SuppressForbidden;
+import java.util.Arrays;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 120, timeUnit = SECONDS)
+@Measurement(iterations = 3, time = 120, timeUnit = SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(MICROSECONDS)
+@Fork(value = 1)
+@SuppressForbidden
+public class PropagationTagsBenchmark {
+
+  /**
+   * In order to avoid JMH splitting up the strings, all ',' are replaced by '|' in the parameter.
+   * The parameter is split at '|' and the first element is the propagation tags header type. The
+   * rest of the elements are joined with ',' to form the header to be parsed.
+   */
+  @Param({"datadog|_dd.p.anytag=value|_dd.p.dm=934086a686-4"})
+  String extractHeaderType;
+
+  @Param("datadog")
+  String injectHeaderType;
+
+  PropagationTags.Factory factory;
+  PropagationTags.HeaderType extractHT;
+  PropagationTags.HeaderType injectHT;
+  String header;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    factory = PropagationTags.factory();
+    CharSequence[] parts = extractHeaderType.split("\\|");
+    extractHT = PropagationTags.HeaderType.valueOf(((String) parts[0]).toUpperCase());
+    header = String.join(",", Arrays.stream(parts, 1, parts.length)::iterator);
+    injectHT = PropagationTags.HeaderType.valueOf(injectHeaderType.toUpperCase());
+  }
+
+  @Benchmark
+  public void extractHeader(Blackhole blackhole) {
+    blackhole.consume(factory.fromHeaderValue(extractHT, header));
+  }
+
+  @Benchmark
+  public void extractInjectHeader(Blackhole blackhole) {
+    PropagationTags pt = factory.fromHeaderValue(extractHT, header);
+    blackhole.consume(pt.headerValue(injectHT));
+    blackhole.consume(pt);
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/civisibility/interceptor/CiVisibilityTraceInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/civisibility/interceptor/CiVisibilityTraceInterceptor.java
@@ -37,10 +37,11 @@ public class CiVisibilityTraceInterceptor implements TraceInterceptor {
       return Collections.emptyList();
     }
 
-    // If the trace belongs to a "test", we need to set the origin of all the spans of the trace to
-    // `ciapp-test`.
+    // If the trace belongs to a "test", we need to set the origin to `ciapp-test` and the
+    // `library_version` tag for all spans.
+    firstSpan.context().setOrigin(CIAPP_TEST_ORIGIN);
+    firstSpan.setTag(DDTags.LIBRARY_VERSION_TAG_KEY, DDTraceCoreInfo.VERSION);
     for (MutableSpan span : trace) {
-      ((DDSpan) span).context().setOrigin(CIAPP_TEST_ORIGIN);
       span.setTag(DDTags.LIBRARY_VERSION_TAG_KEY, DDTraceCoreInfo.VERSION);
     }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1254,7 +1254,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       final Map<String, String> baggage;
       final PendingTrace parentTrace;
       final int samplingPriority;
-      final String origin;
+      final CharSequence origin;
       final Map<String, String> coreTags;
       final Map<String, ?> rootSpanTags;
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -40,9 +40,10 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
   protected Map<String, String> tags;
   protected Map<String, String> baggage;
 
-  protected String origin;
+  protected CharSequence origin;
   protected long endToEndStartTime;
   protected boolean valid;
+  protected boolean fullContext;
   protected PropagationTags propagationTags;
 
   private TagContext.HttpHeaders httpHeaders;
@@ -232,6 +233,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
     tags = Collections.emptyMap();
     baggage = Collections.emptyMap();
     valid = true;
+    fullContext = true;
     httpHeaders = null;
     collectIpHeaders =
         this.clientIpWithoutAppSec
@@ -239,9 +241,9 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
     return this;
   }
 
-  TagContext build() {
+  protected TagContext build() {
     if (valid) {
-      if (!DDTraceId.ZERO.equals(traceId)) {
+      if (fullContext && !DDTraceId.ZERO.equals(traceId)) {
         final ExtractedContext context;
         context =
             new ExtractedContext(
@@ -269,6 +271,10 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
 
   protected void invalidateContext() {
     this.valid = false;
+  }
+
+  protected void onlyTagContext() {
+    this.fullContext = false;
   }
 
   protected int defaultSamplingPriority() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
@@ -17,7 +17,7 @@ public class ExtractedContext extends TagContext {
       final DDTraceId traceId,
       final long spanId,
       final int samplingPriority,
-      final String origin,
+      final CharSequence origin,
       final long endToEndStartTime,
       final Map<String, String> baggage,
       final Map<String, String> tags,

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -81,6 +81,9 @@ public class HttpCodec {
         case NONE:
           result.put(style, NoneCodec.INJECTOR);
           break;
+        case TRACECONTEXT:
+          result.put(style, W3CHttpCodec.newInjector(reverseBaggageMapping));
+          break;
         default:
           log.debug("No implementation found to inject propagation style: {}", style);
           break;
@@ -113,6 +116,9 @@ public class HttpCodec {
           break;
         case NONE:
           extractors.add(NoneCodec.EXTRACTOR);
+          break;
+        case TRACECONTEXT:
+          extractors.add(W3CHttpCodec.newExtractor(taggedHeaders, baggageMapping));
           break;
         default:
           log.debug("No implementation found to extract propagation style: {}", style);

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
@@ -34,7 +34,8 @@ public abstract class PropagationTags {
   }
 
   public enum HeaderType {
-    DATADOG;
+    DATADOG,
+    W3C;
 
     private static final int numValues = HeaderType.values().length;
 
@@ -54,6 +55,12 @@ public abstract class PropagationTags {
    * tag doesn't exist. Called on the root span context.
    */
   public abstract void updateTraceSamplingPriority(int samplingPriority, int samplingMechanism);
+
+  public abstract int getSamplingPriority();
+
+  public abstract void updateTraceOrigin(CharSequence origin);
+
+  public abstract CharSequence getOrigin();
 
   /**
    * Constructs a header value that includes valid propagated _dd.p.* tags and possibly a new

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
@@ -5,7 +5,6 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_X_DATADOG_TAGS_MAX_
 import datadog.trace.api.Config;
 import datadog.trace.core.propagation.ptags.PTagsFactory;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -35,7 +34,13 @@ public abstract class PropagationTags {
   }
 
   public enum HeaderType {
-    DATADOG
+    DATADOG;
+
+    private static final int numValues = HeaderType.values().length;
+
+    public static int getNumValues() {
+      return numValues;
+    }
   }
 
   public interface Factory {
@@ -69,13 +74,4 @@ public abstract class PropagationTags {
     fillTagMap(result);
     return result;
   }
-
-  // Internal methods used by the different HeaderType implementations
-  public abstract List<String> tagPairs();
-
-  public abstract int tagsSize();
-
-  public abstract boolean missingDecisionMaker();
-
-  public abstract String decisionMakerTagValue();
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
@@ -3,6 +3,7 @@ package datadog.trace.core.propagation;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_X_DATADOG_TAGS_MAX_LENGTH;
 
 import datadog.trace.api.Config;
+import datadog.trace.core.propagation.ptags.PTagsFactory;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,7 +27,7 @@ public abstract class PropagationTags {
   }
 
   public static PropagationTags.Factory factory(int datadogTagsLimit) {
-    return new PropagationTagsFactory(datadogTagsLimit);
+    return new PTagsFactory(datadogTagsLimit);
   }
 
   public static PropagationTags.Factory factory() {
@@ -70,11 +71,11 @@ public abstract class PropagationTags {
   }
 
   // Internal methods used by the different HeaderType implementations
-  abstract List<String> tagPairs();
+  public abstract List<String> tagPairs();
 
-  abstract int tagsSize();
+  public abstract int tagsSize();
 
-  abstract boolean missingDecisionMaker();
+  public abstract boolean missingDecisionMaker();
 
-  abstract String decisionMakerTagValue();
+  public abstract String decisionMakerTagValue();
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/W3CHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/W3CHttpCodec.java
@@ -1,0 +1,366 @@
+package datadog.trace.core.propagation;
+
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP;
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP;
+import static datadog.trace.core.propagation.HttpCodec.firstHeaderValue;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.DDSpanId;
+import datadog.trace.api.DDTags;
+import datadog.trace.api.DDTraceId;
+import datadog.trace.api.internal.util.HexStringUtils;
+import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.api.sampling.SamplingMechanism;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.bootstrap.instrumentation.api.TagContext;
+import datadog.trace.core.DDSpanContext;
+import java.util.Map;
+import java.util.TreeMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** A codec designed for HTTP transport via headers using W3C traceparent and tracestate headers */
+class W3CHttpCodec {
+  private static final Logger log = LoggerFactory.getLogger(W3CHttpCodec.class);
+
+  static final String TRACE_PARENT_KEY = "traceparent";
+  static final String TRACE_STATE_KEY = "tracestate";
+  static final String OT_BAGGAGE_PREFIX = "ot-baggage-";
+  private static final String E2E_START_KEY = OT_BAGGAGE_PREFIX + DDTags.TRACE_START_TIME;
+
+  private static final int TRACE_PARENT_TID_START = 2 + 1;
+  private static final int TRACE_PARENT_TID_END = TRACE_PARENT_TID_START + 32;
+  private static final int TRACE_PARENT_SID_START = TRACE_PARENT_TID_END + 1;
+  private static final int TRACE_PARENT_SID_END = TRACE_PARENT_SID_START + 16;
+  private static final int TRACE_PARENT_FLAGS_START = TRACE_PARENT_SID_END + 1;
+  private static final int TRACE_PARENT_FLAGS_SAMPLED = 1;
+  private static final int TRACE_PARENT_LENGTH = TRACE_PARENT_FLAGS_START + 2;
+
+  private W3CHttpCodec() {
+    // This class should not be created. This also makes code coverage checks happy.
+  }
+
+  public static HttpCodec.Injector newInjector(Map<String, String> invertedBaggageMapping) {
+    return new Injector(invertedBaggageMapping);
+  }
+
+  private static class Injector implements HttpCodec.Injector {
+
+    private final Map<String, String> invertedBaggageMapping;
+
+    public Injector(Map<String, String> invertedBaggageMapping) {
+      assert invertedBaggageMapping != null;
+      this.invertedBaggageMapping = invertedBaggageMapping;
+    }
+
+    @Override
+    public <C> void inject(
+        final DDSpanContext context, final C carrier, final AgentPropagation.Setter<C> setter) {
+      StringBuilder sb = new StringBuilder(TRACE_PARENT_LENGTH);
+      sb.append("00-");
+      sb.append(context.getTraceId().toHexStringPaddedOrOriginal(32));
+      sb.append("-");
+      sb.append(DDSpanId.toHexStringPadded(context.getSpanId()));
+      sb.append(context.getSamplingPriority() > 0 ? "-01" : "-00");
+      setter.set(carrier, TRACE_PARENT_KEY, sb.toString());
+      String tracestate = context.getPropagationTags().headerValue(PropagationTags.HeaderType.W3C);
+      if (tracestate != null && !tracestate.isEmpty()) {
+        setter.set(carrier, TRACE_STATE_KEY, tracestate);
+      }
+
+      long e2eStart = context.getEndToEndStartTime();
+      if (e2eStart > 0) {
+        setter.set(carrier, E2E_START_KEY, Long.toString(NANOSECONDS.toMillis(e2eStart)));
+      }
+
+      for (final Map.Entry<String, String> entry : context.baggageItems()) {
+        String header = invertedBaggageMapping.get(entry.getKey());
+        header = header != null ? header : OT_BAGGAGE_PREFIX + entry.getKey();
+        setter.set(carrier, header, HttpCodec.encode(entry.getValue()));
+      }
+    }
+  }
+
+  public static HttpCodec.Extractor newExtractor(
+      final Map<String, String> tagMapping, final Map<String, String> baggageMapping) {
+    return newExtractor(tagMapping, baggageMapping, Config.get());
+  }
+
+  public static HttpCodec.Extractor newExtractor(
+      final Map<String, String> tagMapping,
+      final Map<String, String> baggageMapping,
+      final Config config) {
+    return new TagContextExtractor(
+        tagMapping,
+        baggageMapping,
+        new ContextInterpreter.Factory() {
+          @Override
+          protected ContextInterpreter construct(
+              Map<String, String> mapping, Map<String, String> baggageMapping) {
+            return new W3CContextInterpreter(mapping, baggageMapping, config);
+          }
+        });
+  }
+
+  private static class W3CContextInterpreter extends ContextInterpreter {
+
+    private static final int TRACE_PARENT = 0;
+    private static final int TRACE_STATE = 1;
+    private static final int OT_BAGGAGE = 2;
+    private static final int E2E_START = 3;
+    private static final int IGNORE = -1;
+
+    private final PropagationTags.Factory datadogTagsFactory;
+
+    // We need to delay handling of the tracestate header until after traceparent
+    private String tracestateHeader = null;
+    private String traceparentHeader = null;
+
+    private W3CContextInterpreter(
+        Map<String, String> taggedHeaders, Map<String, String> baggageMapping, Config config) {
+      super(taggedHeaders, baggageMapping, config);
+      datadogTagsFactory = PropagationTags.factory(config);
+    }
+
+    @Override
+    public ContextInterpreter reset() {
+      tracestateHeader = null;
+      traceparentHeader = null;
+      return super.reset();
+    }
+
+    @Override
+    public boolean accept(String key, String value) {
+      if (null == key || key.isEmpty()) {
+        return true;
+      }
+      if (LOG_EXTRACT_HEADER_NAMES) {
+        log.debug("Header: {}", key);
+      }
+      String lowerCaseKey = null;
+      int classification = IGNORE;
+      char first = Character.toLowerCase(key.charAt(0));
+      switch (first) {
+        case 'f':
+          if (handledForwarding(key, value)) {
+            return true;
+          }
+          break;
+        case 'o':
+          lowerCaseKey = toLowerCase(key);
+          if (E2E_START_KEY.equals(lowerCaseKey)) {
+            classification = E2E_START;
+          } else if (lowerCaseKey.startsWith(OT_BAGGAGE_PREFIX)) {
+            classification = OT_BAGGAGE;
+          }
+          break;
+        case 't':
+          if (TRACE_PARENT_KEY.equalsIgnoreCase(key)) {
+            classification = TRACE_PARENT;
+          } else if (TRACE_STATE_KEY.equalsIgnoreCase(key)) {
+            classification = TRACE_STATE;
+          }
+          break;
+        case 'u':
+          if (handledUserAgent(key, value)) {
+            return true;
+          }
+          break;
+        case 'x':
+          if (handledXForwarding(key, value)) {
+            return true;
+          }
+          break;
+        default:
+      }
+
+      if (classification != IGNORE) {
+        try {
+          if (null != value) {
+            switch (classification) {
+              case TRACE_PARENT:
+                return storeTraceParent(value);
+              case TRACE_STATE:
+                return storeTraceState(value);
+              case E2E_START:
+                endToEndStartTime = extractEndToEndStartTime(firstHeaderValue(value));
+                break;
+              case OT_BAGGAGE:
+                {
+                  if (baggage.isEmpty()) {
+                    baggage = new TreeMap<>();
+                  }
+                  baggage.put(
+                      lowerCaseKey.substring(OT_BAGGAGE_PREFIX.length()), HttpCodec.decode(value));
+                }
+                break;
+              default:
+            }
+          }
+        } catch (RuntimeException e) {
+          invalidateContext();
+          log.debug("Exception when extracting context", e);
+          return false;
+        }
+      } else {
+        if (handledIpHeaders(key, value)) {
+          return true;
+        }
+        if (handleTags(key, value)) {
+          return true;
+        }
+        handleMappedBaggage(key, value);
+      }
+      return true;
+    }
+
+    private long extractEndToEndStartTime(String value) {
+      try {
+        return MILLISECONDS.toNanos(Long.parseLong(value));
+      } catch (RuntimeException e) {
+        log.debug("Ignoring invalid end-to-end start time {}", value, e);
+        return 0;
+      }
+    }
+
+    private boolean storeTraceParent(String value) {
+      String trimmed = trim(value);
+      if (traceparentHeader != null) {
+        // We should not accept multiple traceparent headers
+        if (log.isDebugEnabled()) {
+          log.debug(
+              "Multiple traceparent headers. Had '{}' and got '{}'", traceparentHeader, trimmed);
+        }
+        onlyTagContext();
+      } else {
+        traceparentHeader = trimmed;
+      }
+      return true;
+    }
+
+    private boolean storeTraceState(String value) {
+      String trimmed = trim(value);
+      if (!trimmed.isEmpty()) {
+        // Yes, this is not efficient for multiple headers, but that is hopefully not common
+        tracestateHeader = tracestateHeader == null ? trimmed : tracestateHeader + "," + trimmed;
+      }
+      return true;
+    }
+
+    /**
+     * We need to delay handling of the W3C headers until the end since tracestate headers should be
+     * concatenated before processed, and only if there is a single valid traceparent header present
+     */
+    @Override
+    protected TagContext build() {
+      // If there is neither a traceparent or a tracestate header, then ignore this
+      if (traceparentHeader == null && tracestateHeader == null) {
+        onlyTagContext();
+      }
+      if (valid && fullContext) {
+        try {
+          if (traceparentHeader == null && tracestateHeader != null) {
+            throw new IllegalStateException(
+                "Found no traceparent header but tracestate header '" + tracestateHeader + "'");
+          }
+          // Now we know that we have at least a traceparent header
+          parseTraceParentHeader(traceparentHeader, this);
+          parseTraceStateHeader(tracestateHeader, this, datadogTagsFactory);
+        } catch (RuntimeException e) {
+          onlyTagContext();
+          log.debug("Exception when building context", e);
+        }
+      }
+      return super.build();
+    }
+
+    static void parseTraceParentHeader(String tp, ContextInterpreter context) {
+      int length = tp == null ? 0 : tp.length();
+      if (length < TRACE_PARENT_LENGTH) {
+        throw new IllegalStateException("The length of traceparent '" + tp + "' is too short");
+      }
+      long version = HexStringUtils.parseUnsignedLongHex(tp, 0, 2, true);
+      if (version == 255) {
+        throw new IllegalStateException("Illegal version number " + tp.substring(0, 2));
+      } else if (version == 0 && length > TRACE_PARENT_LENGTH) {
+        throw new IllegalStateException("The length of traceparent '" + tp + "' is too long");
+      }
+      context.traceId =
+          DDTraceId.fromHexTruncatedWithOriginal(tp, TRACE_PARENT_TID_START, 32, true);
+      if (DDTraceId.ZERO.equals(context.traceId)) {
+        throw new IllegalStateException(
+            "Illegal all zero 64 bit trace id "
+                + tp.substring(TRACE_PARENT_TID_START, TRACE_PARENT_TID_END));
+      }
+      context.spanId = DDSpanId.fromHex(tp, TRACE_PARENT_SID_START, 16, true);
+      if (context.spanId == 0) {
+        throw new IllegalStateException(
+            "Illegal all zero span id "
+                + tp.substring(TRACE_PARENT_SID_START, TRACE_PARENT_SID_END));
+      }
+      if (version != 0 && length > TRACE_PARENT_LENGTH && tp.charAt(TRACE_PARENT_LENGTH) != '-') {
+        throw new IllegalStateException("Illegal character after flags in '" + tp + "'");
+      }
+      long flags = HexStringUtils.parseUnsignedLongHex(tp, TRACE_PARENT_FLAGS_START, 2, true);
+      if ((flags & TRACE_PARENT_FLAGS_SAMPLED) != 0) {
+        context.samplingPriority = SAMPLER_KEEP;
+      } else {
+        context.samplingPriority = SAMPLER_DROP;
+      }
+    }
+
+    static void parseTraceStateHeader(
+        String ts, ContextInterpreter context, PropagationTags.Factory factory) {
+      if (ts == null || ts.isEmpty()) {
+        context.propagationTags = factory.empty();
+      } else {
+        context.propagationTags = factory.fromHeaderValue(PropagationTags.HeaderType.W3C, ts);
+      }
+      int ptagsPriority = context.propagationTags.getSamplingPriority();
+      int contextPriority = context.samplingPriority;
+      if ((contextPriority == SAMPLER_DROP && ptagsPriority > 0)
+          || (contextPriority == SAMPLER_KEEP && ptagsPriority <= 0)
+          || ptagsPriority == PrioritySampling.UNSET) {
+        // Override Datadog sampling priority with W3C one
+        context.propagationTags.updateTraceSamplingPriority(
+            contextPriority, SamplingMechanism.EXTERNAL_OVERRIDE);
+      } else {
+        // Use more detailed Datadog sampling priority in context
+        context.samplingPriority = ptagsPriority;
+      }
+      // Use the origin
+      context.origin = context.propagationTags.getOrigin();
+    }
+
+    private static String trim(String input) {
+      if (input == null) {
+        return "";
+      }
+      final int last = input.length() - 1;
+      if (last == 0) {
+        return input;
+      }
+      int start;
+      for (start = 0; start <= last; start++) {
+        char c = input.charAt(start);
+        if (c != '\t' && c != ' ') {
+          break;
+        }
+      }
+      int end;
+      for (end = last; end > start; end--) {
+        char c = input.charAt(end);
+        if (c != '\t' && c != ' ') {
+          break;
+        }
+      }
+      if (start == 0 && end == last) {
+        return input;
+      } else {
+        return input.substring(start, end + 1);
+      }
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/DatadogPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/DatadogPTagsCodec.java
@@ -1,7 +1,8 @@
-package datadog.trace.core.propagation;
+package datadog.trace.core.propagation.ptags;
 
-import static datadog.trace.core.propagation.PropagationTagsFactory.PROPAGATION_ERROR_TAG_KEY;
+import static datadog.trace.core.propagation.ptags.PTagsFactory.PROPAGATION_ERROR_TAG_KEY;
 
+import datadog.trace.core.propagation.PropagationTags;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -10,9 +11,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Captures configuration required for PropagationTags logic */
-final class DatadogPropagationTagsFactory {
+final class DatadogPTagsCodec {
 
-  private static final Logger log = LoggerFactory.getLogger(DatadogPropagationTagsFactory.class);
+  private static final Logger log = LoggerFactory.getLogger(DatadogPTagsCodec.class);
 
   private static final String ALLOWED_TAG_PREFIX = "_dd.p.";
   private static final String DECISION_MAKER_TAG = ALLOWED_TAG_PREFIX + "dm";
@@ -32,7 +33,7 @@ final class DatadogPropagationTagsFactory {
 
   private final int datadogTagsLimit;
 
-  DatadogPropagationTagsFactory(int datadogTagsLimit) {
+  DatadogPTagsCodec(int datadogTagsLimit) {
     this.datadogTagsLimit = datadogTagsLimit;
   }
 
@@ -54,7 +55,7 @@ final class DatadogPropagationTagsFactory {
    * @return a PropagationTags containing only _dd.p.* tags or an error if the header value is
    *     invalid
    */
-  public PropagationTags fromHeaderValue(PropagationTagsFactory tagsFactory, String value) {
+  public PropagationTags fromHeaderValue(PTagsFactory tagsFactory, String value) {
     if (value == null) {
       return tagsFactory.empty();
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/DatadogPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/DatadogPTagsCodec.java
@@ -1,40 +1,28 @@
 package datadog.trace.core.propagation.ptags;
 
-import static datadog.trace.core.propagation.ptags.PTagsFactory.PROPAGATION_ERROR_TAG_KEY;
-
 import datadog.trace.core.propagation.PropagationTags;
+import datadog.trace.core.propagation.ptags.PTagsFactory.PTags;
+import datadog.trace.core.propagation.ptags.TagElement.Encoding;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
+import java.util.function.IntPredicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Captures configuration required for PropagationTags logic */
-final class DatadogPTagsCodec {
-
+final class DatadogPTagsCodec extends PTagsCodec {
   private static final Logger log = LoggerFactory.getLogger(DatadogPTagsCodec.class);
-
-  private static final String ALLOWED_TAG_PREFIX = "_dd.p.";
-  private static final String DECISION_MAKER_TAG = ALLOWED_TAG_PREFIX + "dm";
-  private static final String UPSTREAM_SERVICES_DEPRECATED_TAG =
-      ALLOWED_TAG_PREFIX + "upstream_services";
-
   private static final String PROPAGATION_ERROR_EXTRACT_MAX_SIZE = "extract_max_size";
-  private static final String PROPAGATION_ERROR_INJECT_MAX_SIZE = "inject_max_size";
-  private static final String PROPAGATION_ERROR_DISABLED = "disabled";
   private static final String PROPAGATION_ERROR_DECODING_ERROR = "decoding_error";
-
   private static final char TAGS_SEPARATOR = ',';
   private static final char TAG_KEY_SEPARATOR = '=';
-
   private static final int MIN_ALLOWED_CHAR = 32;
   private static final int MAX_ALLOWED_CHAR = 126;
 
-  private final int datadogTagsLimit;
+  private final int xDatadogTagsLimit;
 
-  DatadogPTagsCodec(int datadogTagsLimit) {
-    this.datadogTagsLimit = datadogTagsLimit;
+  DatadogPTagsCodec(int xDatadogTagsLimit) {
+    this.xDatadogTagsLimit = xDatadogTagsLimit;
   }
 
   /**
@@ -55,233 +43,136 @@ final class DatadogPTagsCodec {
    * @return a PropagationTags containing only _dd.p.* tags or an error if the header value is
    *     invalid
    */
-  public PropagationTags fromHeaderValue(PTagsFactory tagsFactory, String value) {
+  @Override
+  PropagationTags fromHeaderValue(PTagsFactory tagsFactory, String value) {
     if (value == null) {
       return tagsFactory.empty();
     }
-    if (value.length() > datadogTagsLimit) {
+    if (value.length() > xDatadogTagsLimit) {
       // Incoming x-datadog-tags value length exceeds datadogTagsLimit
       // Set _dd.propagation_error:extract_max_size
       return tagsFactory.createInvalid(PROPAGATION_ERROR_EXTRACT_MAX_SIZE);
     }
 
-    List<String> tagPairs = new ArrayList<>(10);
+    List<TagElement> tagPairs = null;
     int len = value.length();
     int tagPos = 0;
+    TagValue decisionMakerTagValue = null;
     while (tagPos < len) {
-      int tagKeyEndsAt = value.indexOf(TAG_KEY_SEPARATOR, tagPos);
+      int tagKeyEndsAt =
+          validateCharsUntilSeparatorOrEnd(
+              value, tagPos, TAG_KEY_SEPARATOR, DatadogPTagsCodec::isAllowedKeyChar);
       if (tagKeyEndsAt < 0 || tagKeyEndsAt == len) {
-        log.warn(
-            "Invalid datadog tags header value: '{}' tag without a value at {}", value, tagPos);
+        log.warn("Invalid datadog tags header value: '{}' at {}", value, tagPos);
         return tagsFactory.createInvalid(PROPAGATION_ERROR_DECODING_ERROR);
       }
       int tagValuePos = tagKeyEndsAt + 1;
-      int tagValueEndsAt = value.indexOf(TAGS_SEPARATOR, tagKeyEndsAt);
+      int tagValueEndsAt =
+          validateCharsUntilSeparatorOrEnd(
+              value, tagValuePos, TAGS_SEPARATOR, DatadogPTagsCodec::isAllowedValueChar);
       if (tagValueEndsAt < 0) {
-        tagValueEndsAt = len;
-      }
-      String tagKey = value.substring(tagPos, tagKeyEndsAt);
-      String tagValue = value.substring(tagValuePos, tagValueEndsAt);
-      if (!validateTagKey(tagKey)) {
-        log.warn("Invalid datadog tags header value: '{}' invalid tag key at {}", value, tagPos);
+        log.warn("Invalid datadog tags header value: '{}' at {}", value, tagKeyEndsAt);
         return tagsFactory.createInvalid(PROPAGATION_ERROR_DECODING_ERROR);
       }
-      if (tagKey.startsWith(ALLOWED_TAG_PREFIX)
-          && !tagKey.startsWith(UPSTREAM_SERVICES_DEPRECATED_TAG)) {
-        if (!validateTagValue(tagKey, tagValue)) {
-          log.warn(
-              "Invalid datadog tags header value: '{}' invalid tag value at {}",
-              value,
-              tagValuePos);
-          return tagsFactory.createInvalid(PROPAGATION_ERROR_DECODING_ERROR);
+      TagKey tagKey = TagKey.from(Encoding.DATADOG, value, tagPos, tagKeyEndsAt);
+      TagValue tagValue = TagValue.from(Encoding.DATADOG, value, tagValuePos, tagValueEndsAt);
+      if (tagKey != null) {
+        if (!tagKey.equals(UPSTREAM_SERVICES_DEPRECATED_TAG)) {
+          if (!validateTagValue(tagKey, tagValue)) {
+            log.warn(
+                "Invalid datadog tags header value: '{}' invalid tag value at {}",
+                value,
+                tagValuePos);
+            return tagsFactory.createInvalid(PROPAGATION_ERROR_DECODING_ERROR);
+          }
+          if (tagKey.equals(DECISION_MAKER_TAG)) {
+            decisionMakerTagValue = tagValue;
+          } else {
+            if (tagPairs == null) {
+              // This is roughly the size of a two element linked list but can hold six
+              tagPairs = new ArrayList<>(6);
+            }
+            tagPairs.add(tagKey);
+            tagPairs.add(tagValue);
+          }
         }
-        tagPairs.add(tagKey);
-        tagPairs.add(tagValue);
       }
       tagPos = tagValueEndsAt + 1;
     }
-    return tagsFactory.createValid(
-        tagPairs, calcTagsLength(tagPairs), containsTag(tagPairs, DECISION_MAKER_TAG));
+    return tagsFactory.createValid(tagPairs, decisionMakerTagValue);
   }
 
-  String headerValue(PropagationTags propagationTags) {
-    int newSize =
-        countTagSize(
-            propagationTags.tagsSize(),
-            DECISION_MAKER_TAG,
-            propagationTags.decisionMakerTagValue());
-
-    if (newSize > datadogTagsLimit) {
-      // Drop all the tags when the outgoing value length exceeds the configured limit
-      return null;
-    }
-    // No encoding validation here because we don't allow arbitrary tag change
-
-    Iterator<String> it = propagationTags.tagPairs().iterator();
-    StringBuilder sb = new StringBuilder();
-    while (it.hasNext()) {
-      String tagKey = it.next();
-      String tagValue = it.next();
-      appendTag(sb, tagKey, tagValue);
-    }
-    if (propagationTags.missingDecisionMaker() && propagationTags.decisionMakerTagValue() != null) {
-      appendTag(sb, DECISION_MAKER_TAG, propagationTags.decisionMakerTagValue());
-    }
-    return sb.length() > 0 ? sb.toString() : null;
+  @Override
+  protected int estimateHeaderSize(PTags pTags) {
+    return pTags.getXDatadogTagsSize();
   }
 
-  public void fillTagMap(PropagationTags propagationTags, Map<String, String> tagMap) {
-    int newSize =
-        countTagSize(
-            propagationTags.tagsSize(),
-            DECISION_MAKER_TAG,
-            propagationTags.decisionMakerTagValue());
+  @Override
+  protected int appendPrefix(StringBuilder sb, PTags ptags) {
+    // Calculate the tag size here and return it. Don't do anything else since there is no prefix.
+    return ptags.getXDatadogTagsSize();
+  }
 
-    if (newSize > datadogTagsLimit) {
-      // Outgoing x-datadog-tags value length exceeds the configured limit
-      // Set _dd.propagation_error:inject_max_size if the configured limit is greater than zero,
-      // else set _dd.propagation_error:disabled
-      if (datadogTagsLimit == 0) {
-        tagMap.put(PROPAGATION_ERROR_TAG_KEY, PROPAGATION_ERROR_DISABLED);
-      } else {
-        tagMap.put(PROPAGATION_ERROR_TAG_KEY, PROPAGATION_ERROR_INJECT_MAX_SIZE);
+  @Override
+  protected int appendTag(StringBuilder sb, TagElement key, TagElement value, int size) {
+    if (size <= xDatadogTagsLimit) {
+      if (sb.length() > 0) {
+        sb.append(TAGS_SEPARATOR);
       }
-      return;
-    }
-
-    Iterator<String> it = propagationTags.tagPairs().iterator();
-    while (it.hasNext()) {
-      String tagKey = it.next();
-      String tagValue = it.next();
-      tagMap.put(tagKey, tagValue);
-    }
-    if (propagationTags.missingDecisionMaker() && propagationTags.decisionMakerTagValue() != null) {
-      tagMap.put(DECISION_MAKER_TAG, propagationTags.decisionMakerTagValue());
-    }
-  }
-
-  private static boolean containsTag(List<String> tagPairs, String tagName) {
-    for (int i = 0; i < tagPairs.size(); i += 2) {
-      if (tagPairs.get(i).equals(tagName)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private static int calcTagsLength(List<String> tagPairs) {
-    int size = 0;
-    for (String tagPair : tagPairs) {
-      size += tagPair.length();
-      size += 1; // tag or key separator
-    }
-    return size - 1; // exclude last separator
-  }
-
-  private static void appendTag(StringBuilder sb, String tagKey, String tagValue) {
-    if (sb.length() > 0) {
-      sb.append(TAGS_SEPARATOR);
-    }
-    sb.append(tagKey);
-    sb.append(TAG_KEY_SEPARATOR);
-    sb.append(tagValue);
-  }
-
-  private static int countTagSize(int size, String tagKey, String tagValue) {
-    if (tagValue != null) {
-      if (size > 0) {
-        // tag separator
-        size += 1;
-      }
-      size += tagKey.length();
-      // tag key separator
-      size += 1;
-      size += tagValue.length();
+      sb.append(key.forType(Encoding.DATADOG));
+      sb.append(TAG_KEY_SEPARATOR);
+      sb.append(value.forType(Encoding.DATADOG));
     }
     return size;
   }
 
-  private static boolean validateTagKey(String tagKey) {
-    for (int i = 0; i < tagKey.length(); i++) {
-      char c = tagKey.charAt(i);
-      if (!isAllowedKeyChar(c)) {
-        return false;
-      }
-    }
-    return true;
+  @Override
+  protected int appendSuffix(StringBuilder sb, PTags ptags, int size) {
+    return size;
   }
 
-  private static boolean validateTagValue(String tagKey, String tagValue) {
-    for (int i = 0; i < tagValue.length(); i++) {
-      char c = tagValue.charAt(i);
-      if (!isAllowedValueChar(c)) {
-        return false;
-      }
-    }
-    if (tagKey.equals(DECISION_MAKER_TAG) && !validateDecisionMakerTag(tagValue)) {
-      return false;
-    }
-    return true;
+  @Override
+  protected boolean isTooLarge(StringBuilder sb, int size) {
+    return size > xDatadogTagsLimit;
   }
 
-  private static boolean isAllowedKeyChar(char c) {
+  @Override
+  protected boolean isEmpty(StringBuilder sb, int size) {
+    return sb.length() == 0;
+  }
+
+  private static int validateCharsUntilSeparatorOrEnd(
+      String s, int start, char separator, IntPredicate isValid) {
+    int end = s.length();
+    if (start >= end) {
+      return -1;
+    }
+    int pos = start;
+    char c = s.charAt(pos);
+    do {
+      if (!isValid.test(c) || c == separator) {
+        return -1;
+      }
+      pos++;
+      if (pos < end) {
+        c = s.charAt(pos);
+        // It's not allowed to have the separator as the last character so only check
+        // if there is something after the separator
+        if (pos < end - 1 && c == separator) {
+          break;
+        }
+      }
+    } while (pos < end);
+
+    return pos;
+  }
+
+  private static boolean isAllowedKeyChar(int c) {
     // space (MIN_ALLOWED_CHAR) is not allowed
     return c > MIN_ALLOWED_CHAR && c <= MAX_ALLOWED_CHAR && c != TAGS_SEPARATOR;
   }
 
-  private static boolean isAllowedValueChar(char c) {
-    return c >= MIN_ALLOWED_CHAR && c <= MAX_ALLOWED_CHAR && c != TAG_KEY_SEPARATOR;
-  }
-
-  /**
-   * Validates the _dd.p.dm tag format with next eBNF:
-   *
-   * <pre>
-   *   _dd.p.dm = [ service hash ], "-", sampling mechanism;
-   *
-   *   digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
-   *   hexadecimal digit = digit | "a" | "b" | "c" | "d" | "e" | "f" ;
-   *
-   *   service hash = 10 * hexadecimal digit;
-   *   sampling mechanism = digit, { digit };
-   * </pre>
-   */
-  private static boolean validateDecisionMakerTag(String value) {
-    int sepPos = value.indexOf('-');
-    if (sepPos < 0) {
-      // missing separator
-      return false;
-    }
-    if (sepPos != 0 && sepPos != 10) {
-      // invalid service hash length
-      return false;
-    }
-    int samplingMechanismPos = sepPos + 1;
-    int len = value.length();
-    if (samplingMechanismPos == len) {
-      // missing sampling mechanism
-      return false;
-    }
-    for (int i = 0; i < sepPos; i++) {
-      if (!isHexDigit(value.charAt(i))) {
-        // invalid service hash char
-        return false;
-      }
-    }
-    for (int i = samplingMechanismPos; i < len; i++) {
-      if (!isDigit(value.charAt(i))) {
-        // invalid sampling mechanism
-        return false;
-      }
-    }
-    return true;
-  }
-
-  private static boolean isDigit(char c) {
-    return c >= '0' && c <= '9';
-  }
-
-  private static boolean isHexDigit(char c) {
-    return c >= 'a' && c <= 'f' || isDigit(c);
+  private static boolean isAllowedValueChar(int c) {
+    return c >= MIN_ALLOWED_CHAR && c <= MAX_ALLOWED_CHAR;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsCodec.java
@@ -1,0 +1,182 @@
+package datadog.trace.core.propagation.ptags;
+
+import static datadog.trace.core.propagation.ptags.PTagsFactory.PROPAGATION_ERROR_TAG_KEY;
+
+import datadog.trace.core.propagation.PropagationTags;
+import datadog.trace.core.propagation.ptags.PTagsFactory.PTags;
+import datadog.trace.core.propagation.ptags.TagElement.Encoding;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+abstract class PTagsCodec {
+  private static final String PROPAGATION_ERROR_INJECT_MAX_SIZE = "inject_max_size";
+  private static final String PROPAGATION_ERROR_DISABLED = "disabled";
+
+  protected static final TagKey DECISION_MAKER_TAG = TagKey.from("dm");
+  protected static final TagKey UPSTREAM_SERVICES_DEPRECATED_TAG = TagKey.from("upstream_services");
+
+  static String headerValue(PTagsCodec codec, PTags ptags) {
+    int estimate = codec.estimateHeaderSize(ptags);
+    if (estimate == 0) {
+      return "";
+    }
+
+    // No encoding validation here because we don't allow arbitrary tag change
+    StringBuilder sb = new StringBuilder(estimate);
+    int size = codec.appendPrefix(sb, ptags);
+    if (!ptags.isPropagationTagsDisabled()) {
+      if (ptags.getDecisionMakerTagValue() != null) {
+        size = codec.appendTag(sb, DECISION_MAKER_TAG, ptags.getDecisionMakerTagValue(), size);
+      }
+      Iterator<TagElement> it = ptags.getTagPairs().iterator();
+      while (it.hasNext() && !codec.isTooLarge(sb, size)) {
+        TagElement tagKey = it.next();
+        TagElement tagValue = it.next();
+        size = codec.appendTag(sb, tagKey, tagValue, size);
+      }
+    }
+    size = codec.appendSuffix(sb, ptags, size);
+    if (codec.isTooLarge(sb, size)) {
+      return null;
+    } else {
+      return codec.isEmpty(sb, size) ? null : sb.toString();
+    }
+  }
+
+  static void fillTagMap(PTags propagationTags, Map<String, String> tagMap) {
+    int newSize = propagationTags.getXDatadogTagsSize();
+
+    if (newSize > propagationTags.getxDatadogTagsLimit()) {
+      // Outgoing x-datadog-tags value length exceeds the configured limit
+      // Set _dd.propagation_error:inject_max_size if the configured limit is greater than zero,
+      // else set _dd.propagation_error:disabled
+      if (propagationTags.isPropagationTagsDisabled()) {
+        tagMap.put(PROPAGATION_ERROR_TAG_KEY, PROPAGATION_ERROR_DISABLED);
+      } else {
+        tagMap.put(PROPAGATION_ERROR_TAG_KEY, PROPAGATION_ERROR_INJECT_MAX_SIZE);
+      }
+      return;
+    }
+
+    Iterator<TagElement> it = propagationTags.getTagPairs().iterator();
+    while (it.hasNext()) {
+      TagElement tagKey = it.next();
+      TagElement tagValue = it.next();
+      tagMap.put(
+          tagKey.forType(Encoding.DATADOG).toString(),
+          tagValue.forType(Encoding.DATADOG).toString());
+    }
+    if (propagationTags.getDecisionMakerTagValue() != null) {
+      tagMap.put(
+          DECISION_MAKER_TAG.forType(Encoding.DATADOG).toString(),
+          propagationTags.getDecisionMakerTagValue().forType(Encoding.DATADOG).toString());
+    }
+    if (propagationTags.getError() != null) {
+      tagMap.put(PROPAGATION_ERROR_TAG_KEY, propagationTags.getError());
+    }
+  }
+
+  static int calcXDatadogTagsSize(List<TagElement> tagPairs) {
+    int size = 0;
+    int pl = Encoding.DATADOG.getPrefixLength();
+    boolean key = true;
+    for (CharSequence tagPair : tagPairs) {
+      if (key) {
+        size += pl;
+      }
+      key = !key;
+      size += tagPair.length();
+      size += 1; // tag or key separator
+    }
+    return size == 0 ? 0 : size - 1; // exclude last separator
+  }
+
+  static int calcXDatadogTagsSize(int size, TagKey tagKey, TagValue tagValue) {
+    if (tagValue != null) {
+      if (size > 0) {
+        // tag separator
+        size += 1;
+      }
+      size += tagKey.length();
+      // tag key separator
+      size += 1;
+      size += tagValue.length();
+      size += Encoding.DATADOG.getPrefixLength();
+    }
+    return size;
+  }
+
+  abstract PropagationTags fromHeaderValue(PTagsFactory tagsFactory, String value);
+
+  protected abstract int estimateHeaderSize(PTags pTags);
+
+  protected abstract int appendPrefix(StringBuilder sb, PTags ptags);
+
+  protected abstract int appendTag(StringBuilder sb, TagElement key, TagElement value, int size);
+
+  protected abstract int appendSuffix(StringBuilder sb, PTags ptags, int size);
+
+  protected abstract boolean isTooLarge(StringBuilder sb, int size);
+
+  protected abstract boolean isEmpty(StringBuilder sb, int size);
+
+  protected static boolean validateTagValue(TagKey tagKey, TagValue tagValue) {
+    if (tagKey.equals(DECISION_MAKER_TAG) && !validateDecisionMakerTag(tagValue)) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Validates the dm tag format with next eBNF:
+   *
+   * <pre>
+   *   _dd.p.dm = [ service hash ], "-", sampling mechanism;
+   *
+   *   digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
+   *   hexadecimal digit = digit | "a" | "b" | "c" | "d" | "e" | "f" ;
+   *
+   *   service hash = 10 * hexadecimal digit;
+   *   sampling mechanism = digit, { digit };
+   * </pre>
+   */
+  private static boolean validateDecisionMakerTag(TagValue value) {
+    int sepPos = value.indexOf('-');
+    if (sepPos < 0) {
+      // missing separator
+      return false;
+    }
+    if (sepPos != 0 && sepPos != 10) {
+      // invalid service hash length
+      return false;
+    }
+    int samplingMechanismPos = sepPos + 1;
+    int len = value.length();
+    if (samplingMechanismPos == len) {
+      // missing sampling mechanism
+      return false;
+    }
+    for (int i = 0; i < sepPos; i++) {
+      if (!isHexDigit(value.charAt(i))) {
+        // invalid service hash char
+        return false;
+      }
+    }
+    for (int i = samplingMechanismPos; i < len; i++) {
+      if (!isDigit(value.charAt(i))) {
+        // invalid sampling mechanism
+        return false;
+      }
+    }
+    return true;
+  }
+
+  protected static boolean isDigit(char c) {
+    return c >= '0' && c <= '9';
+  }
+
+  protected static boolean isHexDigit(char c) {
+    return c >= 'a' && c <= 'f' || isDigit(c);
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
@@ -1,145 +1,222 @@
 package datadog.trace.core.propagation.ptags;
 
+import static datadog.trace.core.propagation.PropagationTags.HeaderType.DATADOG;
+import static datadog.trace.core.propagation.ptags.PTagsCodec.DECISION_MAKER_TAG;
+
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.core.propagation.PropagationTags;
 import datadog.trace.core.propagation.PropagationTags.HeaderType;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 public class PTagsFactory implements PropagationTags.Factory {
   static final String PROPAGATION_ERROR_TAG_KEY = "_dd.propagation_error";
 
-  private final DatadogPTagsCodec ddFactory;
+  private final EnumMap<HeaderType, PTagsCodec> DEC_ENC_MAP = new EnumMap<>(HeaderType.class);
+
+  private final int xDatadogTagsLimit;
 
   public PTagsFactory(int xDatadogTagsLimit) {
-    ddFactory = new DatadogPTagsCodec(xDatadogTagsLimit);
+    this.xDatadogTagsLimit = xDatadogTagsLimit;
+    DEC_ENC_MAP.put(DATADOG, new DatadogPTagsCodec(xDatadogTagsLimit));
+  }
+
+  boolean isPropagationTagsDisabled() {
+    return xDatadogTagsLimit <= 0;
+  }
+
+  int getxDatadogTagsLimit() {
+    return xDatadogTagsLimit;
+  }
+
+  PTagsCodec getDecoderEncoder(@Nonnull HeaderType headerType) {
+    return DEC_ENC_MAP.get(headerType);
   }
 
   @Override
   public final PropagationTags empty() {
-    return new ValidPropagationTags(Collections.<String>emptyList(), 0, false);
+    return createValid(null, null);
   }
 
   @Override
-  public final PropagationTags fromHeaderValue(HeaderType headerType, String value) {
-    return ddFactory.fromHeaderValue(this, value);
+  public final PropagationTags fromHeaderValue(@Nonnull HeaderType headerType, String value) {
+    return DEC_ENC_MAP.get(headerType).fromHeaderValue(this, value);
   }
 
-  PropagationTags createValid(List<String> tagPairs, int tagSize, boolean hasDecisionMaker) {
-    return new ValidPropagationTags(tagPairs, tagSize, hasDecisionMaker);
+  PropagationTags createValid(List<TagElement> tagPairs, TagValue decisionMakerTagValue) {
+    return new PTags(this, tagPairs, decisionMakerTagValue);
   }
 
   PropagationTags createInvalid(String error) {
-    return new InvalidPropagationTags(error);
+    return new PTagsWithError(this, error);
   }
 
-  // This implementation is used when service propagation is enabled
-  private final class ValidPropagationTags extends PropagationTags {
-    // tags that don't require any modifications and propagated as-is
-    private final List<String> propagatedTagPairs;
-    // pre-calc header size
-    private final int propagatedTagsSize;
+  static class PTags extends PropagationTags {
+    private static final String EMPTY = "";
 
-    private final boolean isDecisionMakerTagMissing;
+    protected final PTagsFactory factory;
+
+    // tags that don't require any modifications and propagated as-is
+    private final List<TagElement> tagPairs;
+
+    private final boolean canChangeDecisionMaker;
 
     // extracted decision maker tag for easier updates
-    private volatile String decisionMakerTagValue;
+    private volatile TagValue decisionMakerTagValue;
 
-    private ValidPropagationTags(List<String> tagPairs, int tagsSize, boolean hasDecisionMaker) {
-      assert tagPairs.size() % 2 == 0;
-      propagatedTagPairs = tagPairs;
-      propagatedTagsSize = tagsSize;
-      isDecisionMakerTagMissing = !hasDecisionMaker;
+    // xDatadogTagsSize of the tagPairs, does not include the decision maker tag
+    private volatile int xDatadogTagsSize = -1;
+
+    private volatile int samplingPriority;
+    private volatile CharSequence origin;
+    private volatile String[] headerCache = null;
+
+    public PTags(PTagsFactory factory, List<TagElement> tagPairs, TagValue decisionMakerTagValue) {
+      this(factory, tagPairs, decisionMakerTagValue, PrioritySampling.UNSET, null);
+    }
+
+    PTags(
+        PTagsFactory factory,
+        List<TagElement> tagPairs,
+        TagValue decisionMakerTagValue,
+        int samplingPriority,
+        CharSequence origin) {
+      assert tagPairs == null || tagPairs.size() % 2 == 0;
+      this.factory = factory;
+      this.tagPairs = tagPairs;
+      this.canChangeDecisionMaker = decisionMakerTagValue == null;
+      this.decisionMakerTagValue = decisionMakerTagValue;
+      this.samplingPriority = samplingPriority;
+      this.origin = origin;
     }
 
     @Override
     public void updateTraceSamplingPriority(int samplingPriority, int samplingMechanism) {
-
-      if (samplingPriority != PrioritySampling.UNSET && isDecisionMakerTagMissing) {
+      if (samplingPriority != PrioritySampling.UNSET && canChangeDecisionMaker) {
+        this.samplingPriority = samplingPriority;
         if (samplingPriority > 0) {
-          // protected against possible SamplingMechanism.UNKNOWN (-1) that doesn't comply with the
+          // Protect against possible SamplingMechanism.UNKNOWN (-1) that doesn't comply with the
           // format
           if (samplingMechanism >= 0) {
-            decisionMakerTagValue = "-" + samplingMechanism;
+            TagValue newDM = TagValue.from("-" + samplingMechanism);
+            if (!newDM.equals(decisionMakerTagValue)) {
+              // This should invalidate any cached datadog header
+              clearCachedHeader(DATADOG);
+            }
+            decisionMakerTagValue = newDM;
           }
         } else {
-          // drop decision maker tag
+          // Drop the decision maker tag
+          if (decisionMakerTagValue != null) {
+            // This should invalidate any cached datadog header
+            clearCachedHeader(DATADOG);
+          }
           decisionMakerTagValue = null;
         }
       }
     }
 
     @Override
+    @SuppressFBWarnings("ES_COMPARING_STRINGS_WITH_EQ")
     public String headerValue(HeaderType headerType) {
-      return ddFactory.headerValue(this);
+      String header = getCachedHeader(headerType);
+      if (header == null) {
+        header = PTagsCodec.headerValue(factory.getDecoderEncoder(headerType), this);
+        if (header != null) {
+          setCachedHeader(headerType, header);
+        } else {
+          // We can still cache the fact that we got back null
+          setCachedHeader(headerType, EMPTY);
+        }
+      }
+      if (header == EMPTY) {
+        return null;
+      }
+      return header;
     }
 
     @Override
     public void fillTagMap(Map<String, String> tagMap) {
-      ddFactory.fillTagMap(this, tagMap);
+      PTagsCodec.fillTagMap(this, tagMap);
     }
 
-    @Override
-    public List<String> tagPairs() {
-      return propagatedTagPairs;
+    private String getCachedHeader(HeaderType headerType) {
+      String[] cache = headerCache;
+      if (cache == null) {
+        return null;
+      }
+      return cache[headerType.ordinal()];
     }
 
-    @Override
-    public int tagsSize() {
-      return propagatedTagsSize;
+    private void setCachedHeader(HeaderType headerType, String header) {
+      String[] cache = headerCache;
+      if (cache == null) {
+        cache = headerCache = new String[HeaderType.getNumValues()];
+      }
+      cache[headerType.ordinal()] = header;
     }
 
-    @Override
-    public boolean missingDecisionMaker() {
-      return isDecisionMakerTagMissing;
+    private void clearCachedHeader(HeaderType headerType) {
+      if (headerType == DATADOG) {
+        invalidateXDatadogTagsSize();
+      }
+      String[] cache = headerCache;
+      if (cache == null) {
+        return;
+      }
+      cache[headerType.ordinal()] = null;
     }
 
-    @Override
-    public String decisionMakerTagValue() {
+    int getxDatadogTagsLimit() {
+      return factory.getxDatadogTagsLimit();
+    }
+
+    boolean isPropagationTagsDisabled() {
+      return factory.isPropagationTagsDisabled();
+    }
+
+    List<TagElement> getTagPairs() {
+      return tagPairs == null ? Collections.emptyList() : tagPairs;
+    }
+
+    private void invalidateXDatadogTagsSize() {
+      this.xDatadogTagsSize = -1;
+    }
+
+    int getXDatadogTagsSize() {
+      int size = xDatadogTagsSize;
+      if (size == -1) {
+        size = PTagsCodec.calcXDatadogTagsSize(getTagPairs());
+        size = PTagsCodec.calcXDatadogTagsSize(size, DECISION_MAKER_TAG, decisionMakerTagValue);
+        xDatadogTagsSize = size;
+      }
+      return size;
+    }
+
+    TagValue getDecisionMakerTagValue() {
       return decisionMakerTagValue;
+    }
+
+    String getError() {
+      return null;
     }
   }
 
-  // This implementation is used for errors and doesn't allow any modifications
-  private static final class InvalidPropagationTags extends PropagationTags {
-    private final String error;
+  static final class PTagsWithError extends PTags {
+    final String error;
 
-    private InvalidPropagationTags(String error) {
+    public PTagsWithError(PTagsFactory factory, String error) {
+      super(factory, null, null, PrioritySampling.UNSET, null);
       this.error = error;
     }
 
     @Override
-    public void updateTraceSamplingPriority(int samplingPriority, int samplingMechanism) {}
-
-    @Override
-    public String headerValue(HeaderType headerType) {
-      return null;
-    }
-
-    @Override
-    public void fillTagMap(Map<String, String> tagMap) {
-      tagMap.put(PROPAGATION_ERROR_TAG_KEY, error);
-    }
-
-    @Override
-    public List<String> tagPairs() {
-      return Collections.emptyList();
-    }
-
-    @Override
-    public int tagsSize() {
-      return 0;
-    }
-
-    @Override
-    public boolean missingDecisionMaker() {
-      return false;
-    }
-
-    @Override
-    public String decisionMakerTagValue() {
-      return null;
+    String getError() {
+      return error;
     }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
@@ -1,18 +1,19 @@
-package datadog.trace.core.propagation;
+package datadog.trace.core.propagation.ptags;
 
 import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.core.propagation.PropagationTags;
 import datadog.trace.core.propagation.PropagationTags.HeaderType;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class PropagationTagsFactory implements PropagationTags.Factory {
+public class PTagsFactory implements PropagationTags.Factory {
   static final String PROPAGATION_ERROR_TAG_KEY = "_dd.propagation_error";
 
-  private final DatadogPropagationTagsFactory ddFactory;
+  private final DatadogPTagsCodec ddFactory;
 
-  PropagationTagsFactory(int xDatadogTagsLimit) {
-    ddFactory = new DatadogPropagationTagsFactory(xDatadogTagsLimit);
+  public PTagsFactory(int xDatadogTagsLimit) {
+    ddFactory = new DatadogPTagsCodec(xDatadogTagsLimit);
   }
 
   @Override
@@ -80,22 +81,22 @@ public class PropagationTagsFactory implements PropagationTags.Factory {
     }
 
     @Override
-    List<String> tagPairs() {
+    public List<String> tagPairs() {
       return propagatedTagPairs;
     }
 
     @Override
-    int tagsSize() {
+    public int tagsSize() {
       return propagatedTagsSize;
     }
 
     @Override
-    boolean missingDecisionMaker() {
+    public boolean missingDecisionMaker() {
       return isDecisionMakerTagMissing;
     }
 
     @Override
-    String decisionMakerTagValue() {
+    public String decisionMakerTagValue() {
       return decisionMakerTagValue;
     }
   }
@@ -122,22 +123,22 @@ public class PropagationTagsFactory implements PropagationTags.Factory {
     }
 
     @Override
-    List<String> tagPairs() {
+    public List<String> tagPairs() {
       return Collections.emptyList();
     }
 
     @Override
-    int tagsSize() {
+    public int tagsSize() {
       return 0;
     }
 
     @Override
-    boolean missingDecisionMaker() {
+    public boolean missingDecisionMaker() {
       return false;
     }
 
     @Override
-    String decisionMakerTagValue() {
+    public String decisionMakerTagValue() {
       return null;
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/TagElement.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/TagElement.java
@@ -1,0 +1,40 @@
+package datadog.trace.core.propagation.ptags;
+
+abstract class TagElement implements CharSequence {
+  public enum Encoding {
+    DATADOG("_dd.p."),
+    W3C("t.");
+
+    private final String prefix;
+
+    Encoding(String prefix) {
+      this.prefix = prefix;
+    }
+
+    public String getPrefix() {
+      return prefix;
+    }
+
+    public int getPrefixLength() {
+      return prefix.length();
+    }
+
+    private static final Encoding[] cachedValues;
+    private static final int numValues;
+
+    static {
+      cachedValues = values();
+      numValues = cachedValues.length;
+    }
+
+    static Encoding[] getCachedValues() {
+      return cachedValues;
+    }
+
+    static int getNumValues() {
+      return numValues;
+    }
+  }
+
+  abstract CharSequence forType(Encoding encoding);
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/TagKey.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/TagKey.java
@@ -1,0 +1,146 @@
+package datadog.trace.core.propagation.ptags;
+
+import datadog.trace.api.cache.DDCaches;
+import datadog.trace.api.cache.DDPartialKeyCache;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class TagKey extends TagElement {
+  private static final Logger log = LoggerFactory.getLogger(TagKey.class);
+  private static final DDPartialKeyCache<String, TagKey> keyCache =
+      DDCaches.newFixedSizePartialKeyCache(64);
+
+  static TagKey from(String s) {
+    if (s == null || isHeaderInvalid(s, 0, s.length(), null)) {
+      if (log.isDebugEnabled()) {
+        log.debug("Invalid header s: {}", s);
+      }
+      return null;
+    }
+    return keyCache.computeIfAbsent(
+        s, 0, s.length(), TagKey::hash, TagKey::compare, TagKey::produce);
+  }
+
+  static TagKey from(Encoding encoding, String s) {
+    if (isHeaderInvalid(encoding, s)) {
+      if (log.isDebugEnabled()) {
+        log.debug("Invalid header h: {} s: {}", encoding, s);
+      }
+      return null;
+    }
+    int pl = encoding.getPrefixLength();
+    return keyCache.computeIfAbsent(
+        s, pl, s.length(), TagKey::hash, TagKey::compare, TagKey::produce);
+  }
+
+  static TagKey from(Encoding encoding, String s, int start, int end) {
+    if (isHeaderInvalid(encoding, s, start, end)) {
+      if (log.isDebugEnabled()) {
+        log.debug("Invalid header h: {} s: {} b: {} e: {}", encoding, s, start, end);
+      }
+      return null;
+    }
+    int pl = encoding.getPrefixLength();
+    return keyCache.computeIfAbsent(
+        s, start + pl, end, TagKey::hash, TagKey::compare, TagKey::produce);
+  }
+
+  private static boolean isHeaderInvalid(Encoding encoding, String s) {
+    if (encoding == null || s == null) {
+      return true;
+    }
+    return isHeaderInvalid(encoding, s, 0, s.length());
+  }
+
+  private static boolean isHeaderInvalid(Encoding encoding, String s, int start, int end) {
+    if (encoding == null || s == null) {
+      return true;
+    }
+    return isHeaderInvalid(s, start, end, encoding.getPrefix());
+  }
+
+  private static boolean isHeaderInvalid(String s, int start, int end, String prefix) {
+    int pl = prefix == null ? 0 : prefix.length();
+    int sl = s.length();
+    return start < 0
+        || end <= 0
+        || (end - start) <= pl
+        || sl <= pl
+        || sl < end
+        || (prefix != null && !s.startsWith(prefix, start));
+  }
+
+  private static int hash(String s, int start, int end) {
+    int h = 0;
+    end = Integer.min(s.length(), end);
+    if (start >= 0 && end > 0) {
+      for (int i = start; i < end; i++) {
+        h = 31 * h + s.charAt(i);
+      }
+    }
+    return h;
+  }
+
+  private static boolean compare(String s, int start, int end, TagKey tagKey) {
+    end = Integer.min(s.length(), end);
+    if (start < 0 || end < 0 || end - start != tagKey.length()) {
+      return false;
+    }
+    boolean eq = true;
+    for (int i = start, j = 0; eq && i < end; i++, j++) {
+      eq = s.charAt(i) == tagKey.charAt(j);
+    }
+    return eq;
+  }
+
+  private static TagKey produce(String s, int hash, int start, int end) {
+    return new TagKey(s, start, end);
+  }
+
+  private final String none;
+  private final String[] keys = new String[Encoding.getNumValues()];
+
+  TagKey(String s, int start, int end) {
+    none = (start == 0 && end == s.length()) ? s : s.substring(start, end);
+    for (Encoding p : Encoding.getCachedValues()) {
+      keys[p.ordinal()] = p.getPrefix() + none;
+    }
+  }
+
+  CharSequence forType(Encoding encoding) {
+    return keys[encoding.ordinal()];
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TagKey tagKey = (TagKey) o;
+    return none.equals(tagKey.none);
+  }
+
+  @Override
+  public int hashCode() {
+    return none.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return none;
+  }
+
+  @Override
+  public int length() {
+    return none.length();
+  }
+
+  @Override
+  public char charAt(int index) {
+    return none.charAt(index);
+  }
+
+  @Override
+  public CharSequence subSequence(int start, int end) {
+    return none.subSequence(start, end);
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/TagValue.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/TagValue.java
@@ -111,7 +111,7 @@ final class TagValue extends TagElement {
     return c;
   }
 
-  private final CharSequence[] values = new String[Encoding.getNumValues()];
+  private final CharSequence[] values = new CharSequence[Encoding.getNumValues()];
   private final int source;
   private final int hash;
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/TagValue.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/TagValue.java
@@ -1,0 +1,216 @@
+package datadog.trace.core.propagation.ptags;
+
+import datadog.trace.api.cache.DDCaches;
+import datadog.trace.api.cache.DDPartialKeyCache;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class TagValue extends TagElement {
+  private static final Logger log = LoggerFactory.getLogger(TagValue.class);
+  private static final DDPartialKeyCache<CharSequence, TagValue> valueCache =
+      DDCaches.newFixedSizePartialKeyCache(128);
+  private static final int DD_SOURCE = Encoding.DATADOG.ordinal();
+
+  static TagValue from(CharSequence s) {
+    return from(Encoding.DATADOG, s);
+  }
+
+  static TagValue from(Encoding encoding, CharSequence s) {
+    return from(encoding, s, s == null ? -1 : 0, s == null ? -1 : s.length());
+  }
+
+  static TagValue from(Encoding encoding, CharSequence s, int start, int end) {
+    if (s == null || isValueInvalid(s, start, end)) {
+      if (log.isDebugEnabled()) {
+        log.debug("Invalid header h: {} s: {} b: {} e: {}", encoding, s, start, end);
+      }
+      return null;
+    }
+    if (encoding == Encoding.W3C) {
+      return valueCache.computeIfAbsent(
+          s, start, end, TagValue::hashW3C, TagValue::compareW3C, TagValue::produceW3C);
+    } else {
+      return valueCache.computeIfAbsent(
+          s, start, end, TagValue::hashDD, TagValue::compareDD, TagValue::produceDD);
+    }
+  }
+
+  private static boolean isValueInvalid(CharSequence s, int start, int end) {
+    return start < 0 || end <= 0 || s.length() < end;
+  }
+
+  private static int hashDD(CharSequence s, int start, int end) {
+    return hash(TagValue::convertDDtoW3C, s, start, end);
+  }
+
+  private static int hashW3C(CharSequence s, int start, int end) {
+    return hash(TagValue::identity, s, start, end);
+  }
+
+  private static int hash(CharConverter converter, CharSequence s, int start, int end) {
+    int h = 0;
+    end = Integer.min(s.length(), end);
+    if (start >= 0 && end > 0) {
+      for (int i = start; i < end; i++) {
+        h = 31 * h + converter.convert(s.charAt(i));
+      }
+    }
+    return h;
+  }
+
+  private static boolean compareDD(CharSequence s, int start, int end, TagValue tagValue) {
+    return compare(TagValue::identity, s, start, end, tagValue);
+  }
+
+  private static boolean compareW3C(CharSequence s, int start, int end, TagValue tagValue) {
+    return compare(TagValue::convertW3CtoDD, s, start, end, tagValue);
+  }
+
+  private static boolean compare(
+      CharConverter converter, CharSequence s, int start, int end, TagValue tagValue) {
+    end = Integer.min(s.length(), end);
+    if (start < 0 || end < 0 || end - start != tagValue.length()) {
+      return false;
+    }
+    boolean eq = true;
+    for (int i = start, j = 0; eq && i < end; i++, j++) {
+      eq = converter.convert(s.charAt(i)) == tagValue.charAt(j);
+    }
+    return eq;
+  }
+
+  private static TagValue produceDD(CharSequence s, int hash, int start, int end) {
+    return new TagValue(Encoding.DATADOG, hash, s, start, end);
+  }
+
+  private static TagValue produceW3C(CharSequence s, int hash, int start, int end) {
+    return new TagValue(Encoding.W3C, hash, s, start, end);
+  }
+
+  private interface CharConverter {
+    char convert(char c);
+  }
+
+  private static char convertDDtoW3C(char c) {
+    if (c == ',' || c == ';' || c == '~') {
+      return '_';
+    } else if (c == '=') {
+      return '~';
+    }
+    return c;
+  }
+
+  private static char identity(char c) {
+    return c;
+  }
+
+  private static char convertW3CtoDD(char c) {
+    if (c == '~') {
+      return '=';
+    }
+    return c;
+  }
+
+  private final CharSequence[] values = new String[Encoding.getNumValues()];
+  private final int source;
+  private final int hash;
+
+  TagValue(Encoding encoding, int hash, CharSequence s, int start, int end) {
+    this.source = encoding.ordinal();
+    this.hash = hash;
+    values[source] =
+        (start == 0 && end == s.length())
+            ? s
+            : new StringBuilder(end - start).append(s, start, end).toString();
+  }
+
+  CharSequence forType(Encoding encoding) {
+    int ordinal = encoding.ordinal();
+    CharSequence cs = values[ordinal];
+    if (cs == null) {
+      CharSequence from = values[source];
+      int len = from.length();
+      CharConverter cc = source == DD_SOURCE ? TagValue::convertDDtoW3C : TagValue::convertW3CtoDD;
+      StringBuilder sb = null;
+      for (int i = 0; i < len; i++) {
+        char c = from.charAt(i);
+        char tc = cc.convert(c);
+        if (tc != c && sb == null) {
+          sb = new StringBuilder(len);
+          sb.append(from, 0, i);
+        }
+        if (sb != null) {
+          sb.append(tc);
+        }
+      }
+      cs = values[ordinal] = sb == null ? from : sb.toString();
+    }
+    return cs;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TagValue ov = (TagValue) o;
+    if (hash != ov.hash) return false;
+    CharSequence cst = values[source];
+    CharSequence cso = ov.values[ov.source];
+    int len = cst.length();
+    if (len != cso.length()) return false;
+    if (source == ov.source) {
+      for (int i = 0; i < len; i++) {
+        if (cst.charAt(i) != cso.charAt(i)) return false;
+      }
+    } else {
+      CharConverter cct = source == DD_SOURCE ? TagValue::identity : TagValue::convertW3CtoDD;
+      CharConverter cco = ov.source == DD_SOURCE ? TagValue::identity : TagValue::convertW3CtoDD;
+      for (int i = 0; i < len; i++) {
+        if (cct.convert(cst.charAt(i)) != cco.convert(cso.charAt(i))) return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    return hash;
+  }
+
+  @Override
+  public String toString() {
+    return values[source].toString();
+  }
+
+  @Override
+  public int length() {
+    return values[source].length();
+  }
+
+  @Override
+  public char charAt(int index) {
+    if (source == DD_SOURCE) {
+      return values[source].charAt(index);
+    } else {
+      return convertW3CtoDD(values[source].charAt(index));
+    }
+  }
+
+  @Override
+  public CharSequence subSequence(int start, int end) {
+    return values[source].subSequence(start, end);
+  }
+
+  public int indexOf(char c) {
+    c = source == DD_SOURCE ? c : convertDDtoW3C(c);
+    CharSequence cs = values[source];
+    int len = cs.length();
+    int index = -1;
+    for (int i = 0; i < len; i++) {
+      if (cs.charAt(i) == c) {
+        index = i;
+      }
+    }
+    return index;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -1,0 +1,685 @@
+package datadog.trace.core.propagation.ptags;
+
+import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.core.propagation.PropagationTags;
+import datadog.trace.core.propagation.ptags.PTagsFactory.PTags;
+import datadog.trace.core.propagation.ptags.TagElement.Encoding;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.IntPredicate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class W3CPTagsCodec extends PTagsCodec {
+  private static final Logger log = LoggerFactory.getLogger(W3CPTagsCodec.class);
+
+  private static final int MAX_HEADER_SIZE = 256;
+  private static final int EMPTY_SIZE = 3; // 'dd='
+  private static final char MEMBER_SEPARATOR = ',';
+  private static final char ELEMENT_SEPARATOR = ';';
+  private static final char KEY_VALUE_SEPARATOR = ':';
+  private static final int MIN_ALLOWED_CHAR = 32;
+  private static final int MAX_ALLOWED_CHAR = 126;
+
+  @Override
+  PropagationTags fromHeaderValue(PTagsFactory tagsFactory, String value) {
+    if (value == null || value.isEmpty()) {
+      return tagsFactory.empty();
+    }
+
+    int len = value.length();
+    // Skip over leading whitespace and empty member list elements
+    int firstMemberStart = findNextMember(value, 0);
+    if (firstMemberStart == len) {
+      return tagsFactory.empty();
+    }
+
+    // Validate the whole tracestate and figure out where the dd member key and value are located
+    int memberStart = firstMemberStart;
+    int ddMemberStart = -1; // dd member start position (inclusive)
+    int ddMemberValueStart = -1; // dd member value start position (inclusive)
+    int ddMemberValueEnd = -1; // dd member value end position including OWS (exclusive)
+    int memberIndex = 0;
+    int ddMemberIndex = -1;
+    while (memberStart < len) {
+      if (memberIndex == 32) {
+        // TODO should we return one with an error?
+        // TODO should we try to pick up the `dd` member anyway?
+        return tagsFactory.empty();
+      }
+      if (ddMemberIndex == -1 && value.startsWith("dd=", memberStart)) {
+        ddMemberStart = memberStart;
+        ddMemberIndex = memberIndex;
+      }
+      // Validate the member key
+      int pos = validateMemberKey(value, memberStart);
+      if (pos < 0) {
+        // TODO should we return one with an error?
+        return tagsFactory.empty();
+      }
+      if (ddMemberValueStart == -1 && ddMemberIndex != -1) {
+        ddMemberValueStart = pos;
+      }
+      pos = validateMemberValue(value, pos);
+      if (pos < 0) {
+        // TODO should we return one with an error?
+        return tagsFactory.empty();
+      }
+      if (ddMemberValueEnd == -1 && ddMemberIndex != -1) {
+        ddMemberValueEnd = pos;
+      }
+      memberStart = findNextMember(value, pos);
+      if (memberStart < 0) {
+        // TODO should we return one with an error?
+        return tagsFactory.empty();
+      }
+      memberIndex++;
+    }
+
+    if (ddMemberIndex == -1) {
+      // There was no dd member, so create an empty one with the _suffix_
+      return empty(tagsFactory, value);
+    }
+
+    List<TagElement> tagPairs = null;
+    int tagPos = ddMemberValueStart;
+    int samplingPriority = PrioritySampling.UNSET;
+    CharSequence origin = null;
+    TagValue decisionMakerTagValue = null;
+    int maxUnknownSize = 0;
+    while (tagPos < ddMemberValueEnd) {
+      int tagKeyEndsAt =
+          validateCharsUntilSeparatorOrEnd(
+              value,
+              tagPos,
+              ddMemberValueEnd,
+              KEY_VALUE_SEPARATOR,
+              false,
+              W3CPTagsCodec::isAllowedKeyChar);
+      if (tagKeyEndsAt < 0 || tagKeyEndsAt == ddMemberValueEnd) {
+        log.warn("Invalid datadog tags header value: '{}' at {}", value, tagPos);
+        // TODO drop parts?
+        return empty(tagsFactory, value, firstMemberStart, ddMemberStart, ddMemberValueEnd);
+      }
+      int tagValuePos = tagKeyEndsAt + 1;
+      int tagValueEndsAt =
+          validateCharsUntilSeparatorOrEnd(
+              value,
+              tagValuePos,
+              ddMemberValueEnd,
+              ELEMENT_SEPARATOR,
+              true,
+              W3CPTagsCodec::isAllowedValueChar);
+      if (tagValueEndsAt < 0) {
+        log.warn("Invalid datadog tags header value: '{}' at {}", value, tagKeyEndsAt);
+        // TODO drop parts?
+        return empty(tagsFactory, value, firstMemberStart, ddMemberStart, ddMemberValueEnd);
+      }
+      int nextTagPos = tagValueEndsAt + 1;
+      if (tagValueEndsAt == ddMemberValueEnd) {
+        tagValueEndsAt = stripTrailingOWC(value, tagValuePos, tagValueEndsAt);
+      }
+      TagKey tagKey = TagKey.from(Encoding.W3C, value, tagPos, tagKeyEndsAt);
+      if (tagKey != null) {
+        TagValue tagValue = TagValue.from(Encoding.W3C, value, tagValuePos, tagValueEndsAt);
+        if (!tagKey.equals(UPSTREAM_SERVICES_DEPRECATED_TAG)) {
+          if (!validateTagValue(tagKey, tagValue)) {
+            log.warn(
+                "Invalid datadog tags header value: '{}' invalid tag value at {}",
+                value,
+                tagValuePos);
+            // TODO drop parts?
+            return empty(tagsFactory, value, firstMemberStart, ddMemberStart, ddMemberValueEnd);
+          }
+          if (tagKey.equals(DECISION_MAKER_TAG)) {
+            decisionMakerTagValue = tagValue;
+          } else {
+            if (tagPairs == null) {
+              // This is roughly the size of a two element linked list but can hold six
+              tagPairs = new ArrayList<>(6);
+            }
+            tagPairs.add(tagKey);
+            tagPairs.add(tagValue);
+          }
+        }
+      } else {
+        // This was not a propagating tag, so check if we know it
+        int keyLength = tagKeyEndsAt - tagPos;
+        char c = value.charAt(tagPos);
+        if (keyLength == 1 && c == 's') {
+          samplingPriority = validateSamplingPriority(value, tagValuePos, tagValueEndsAt);
+        } else if (keyLength == 1 && c == 'o') {
+          origin = TagValue.from(Encoding.W3C, value, tagValuePos, tagValueEndsAt);
+        } else {
+          if (maxUnknownSize != 0) {
+            maxUnknownSize++; // delimiter
+          }
+          maxUnknownSize += (tagValueEndsAt - tagPos);
+        }
+      }
+      tagPos = nextTagPos;
+    }
+    return new W3CPTags(
+        tagsFactory,
+        tagPairs,
+        decisionMakerTagValue,
+        samplingPriority,
+        origin,
+        value,
+        firstMemberStart,
+        ddMemberStart,
+        ddMemberValueEnd,
+        maxUnknownSize);
+  }
+
+  @Override
+  protected int estimateHeaderSize(PTags pTags) {
+    int size = EMPTY_SIZE + 1; // 'dd=' and delimiter;
+    // Yes, this is a bit much, but better safe than sorry
+    size += pTags.getXDatadogTagsSize();
+    if (pTags.getOrigin() != null) {
+      size += pTags.getOrigin().length() + 3; // 'o:' + delimiter
+    }
+    if (pTags.getSamplingPriority() != PrioritySampling.UNSET) {
+      size += 5; // 's:-?[0-9]' + delimiter
+    }
+    if (pTags instanceof W3CPTags) {
+      W3CPTags w3CPTags = (W3CPTags) pTags;
+      size += w3CPTags.maxUnknownSize;
+      if (w3CPTags.ddMemberStart != -1) {
+        size += (w3CPTags.original.length() - (w3CPTags.ddMemberValueEnd - w3CPTags.ddMemberStart));
+      }
+    }
+    return size;
+  }
+
+  @Override
+  protected int appendPrefix(StringBuilder sb, PTags ptags) {
+    sb.append("dd=");
+    if (ptags.getSamplingPriority() != PrioritySampling.UNSET) {
+      sb.append("s:");
+      sb.append(ptags.getSamplingPriority());
+    }
+    CharSequence origin = ptags.getOrigin();
+    if (origin != null) {
+      if (sb.length() > EMPTY_SIZE) {
+        sb.append(';');
+      }
+      sb.append("o:");
+      if (origin instanceof TagValue) {
+        sb.append(((TagValue) origin).forType(Encoding.W3C));
+      } else {
+        sb.append(origin);
+      }
+    }
+    return sb.length();
+  }
+
+  @Override
+  protected int appendTag(StringBuilder sb, TagElement key, TagElement value, int size) {
+    return appendTag(sb, key, value, Encoding.W3C, size);
+  }
+
+  @Override
+  protected int appendSuffix(StringBuilder sb, PTags ptags, int size) {
+    if (size >= MAX_HEADER_SIZE || !(ptags instanceof W3CPTags)) {
+      return size;
+    }
+    W3CPTags w3cPTags = (W3CPTags) ptags;
+    size = cleanUpAndAppendUnknown(sb, w3cPTags, size);
+    if (size == EMPTY_SIZE) {
+      // If we haven't written anything but the 'dd=', then reset the StringBuilder
+      sb.setLength(0);
+      size = 0;
+    }
+    // TODO we need to ensure that there are only 32 segments including our own :(
+    int newSize = cleanUpAndAppendSuffix(sb, w3cPTags, size);
+    if (newSize != size) {
+      // We don't care about the total size in bytes here, but only the fact that we added something
+      // that should be returned
+      size = Math.max(size, EMPTY_SIZE + 1);
+    }
+
+    return size;
+  }
+
+  @Override
+  protected boolean isTooLarge(StringBuilder sb, int size) {
+    return size > MAX_HEADER_SIZE;
+  }
+
+  @Override
+  protected boolean isEmpty(StringBuilder sb, int size) {
+    return size <= EMPTY_SIZE;
+  }
+
+  private int appendTag(
+      StringBuilder sb, TagElement key, TagElement value, Encoding encoding, int size) {
+    if (size >= MAX_HEADER_SIZE) {
+      return size;
+    }
+    int validSize = size;
+    if (size > EMPTY_SIZE) {
+      sb.append(ELEMENT_SEPARATOR);
+      size++;
+    }
+    CharSequence s = key.forType(encoding);
+    sb.append(s);
+    size += s.length();
+    sb.append(KEY_VALUE_SEPARATOR);
+    size++;
+    s = value.forType(encoding);
+    sb.append(s);
+    size += s.length();
+    if (size > MAX_HEADER_SIZE) {
+      sb.setLength(validSize);
+      size = validSize;
+    }
+    return size;
+  }
+
+  private static int validateCharsUntilSeparatorOrEnd(
+      String s, int start, int end, char separator, boolean allowOWC, IntPredicate isValid) {
+    if (start >= end) {
+      return -1;
+    }
+    int pos = start;
+    char c = s.charAt(pos);
+    boolean definitelyOWC = false;
+    do {
+      if (allowOWC && isOWC(c)) {
+        if (c == '\t') {
+          definitelyOWC = true;
+        }
+      } else {
+        if (definitelyOWC || !isValid.test(c) || c == separator) {
+          return -1;
+        }
+      }
+      pos++;
+      if (pos < end) {
+        c = s.charAt(pos);
+        // It's not allowed to have the separator as the last character so only check
+        // if there is something after the separator
+        if (pos < end - 1 && c == separator) {
+          break;
+        }
+      }
+    } while (pos < end);
+
+    return pos;
+  }
+
+  private static boolean isAllowedKeyChar(int c) {
+    // We already know that the segments have been validated against the valid chars for
+    // the general tracestate header
+    return c > MIN_ALLOWED_CHAR && c <= MAX_ALLOWED_CHAR && c != KEY_VALUE_SEPARATOR;
+  }
+
+  private static boolean isAllowedValueChar(int c) {
+    // We already know that the segments have been validated against the valid chars for
+    // the general tracestate header
+    return c >= MIN_ALLOWED_CHAR && c <= MAX_ALLOWED_CHAR;
+  }
+
+  private static int validateSamplingPriority(String original, int start, int end) {
+    try {
+      return parseIntDecimal(original, start, end);
+    } catch (Exception ignored) {
+      return PrioritySampling.UNSET;
+    }
+  }
+
+  // Integer.parseInt(s, start, end, radix) is only available from Java9+, so do it by hand
+  private static int parseIntDecimal(String original, int start, int end)
+      throws NumberFormatException {
+    if (start < 0 || start > end || end > original.length()) {
+      throw new IndexOutOfBoundsException();
+    }
+
+    boolean negative = false;
+    int i = start;
+    int limit = -Integer.MAX_VALUE;
+
+    if (i < end) {
+      int firstChar = original.charAt(i);
+      if (firstChar < '0') {
+        if (firstChar == '-') {
+          negative = true;
+          limit = Integer.MIN_VALUE;
+        } else if (firstChar != '+') {
+          throw new NumberFormatException(original);
+        }
+        i++;
+        if (i == end) {
+          // There needs to be something after the +/-
+          throw new NumberFormatException(original);
+        }
+      }
+      int multmin = limit / 10;
+      int result = 0;
+      while (i < end) {
+        // Accumulating negatively avoids surprises near MAX_VALUE
+        int digit = original.charAt(i) - '0';
+        if (digit < 0 || digit > 9 || result < multmin) {
+          throw new NumberFormatException(original);
+        }
+        result *= 10;
+        if (result < limit + digit) {
+          throw new NumberFormatException(original);
+        }
+        i++;
+        result -= digit;
+      }
+      return negative ? result : -result;
+    } else {
+      throw new NumberFormatException("");
+    }
+  }
+
+  // This is The Fine Specification for the member key https://www.w3.org/TR/trace-context/#key
+  private static int validateMemberKey(String original, int start) {
+    int end = original.length();
+    if (start < 0 || start >= end) {
+      return -1;
+    }
+    boolean multi = false;
+    int length = 1;
+    int pos = start;
+    for (; pos < end; pos++, length++) {
+      if (length > 242) {
+        if (multi) {
+          // We're beyond the length of the allowed tenant id and @ delimiter
+          return -1;
+        } else if (length > 257) {
+          // We're beyond the length of the allowed simple key and = delimiter
+          return -1;
+        }
+      }
+      char c = original.charAt(pos);
+      if (isLcAlpha(c)) {
+        continue;
+      }
+      if (isDigit(c)) {
+        if (length == 1) {
+          multi = true;
+        }
+        continue;
+      }
+      if (length == 1) {
+        // The member key can only start with lower case alpha or a number
+        return -1;
+      }
+      if (isValidExtra(c)) {
+        continue;
+      }
+      if (c == '=') {
+        if (multi) {
+          // If the member key started with a number then it's a multi tenant key and must have an @
+          return -1;
+        } else {
+          pos++;
+          break;
+        }
+      }
+      if (c == '@') {
+        if (length > 242) {
+          // We're beyond the length of the allowed tenant id and @ delimiter
+          return -1;
+        }
+        multi = true;
+        pos++;
+        break;
+      }
+      return -1;
+    }
+
+    if (multi) {
+      // Validate the multi tenant system id part
+      length = 1;
+      for (; pos < end; pos++, length++) {
+        if (length > 15) {
+          // We're beyond the length of the allowed system id and = delimiter
+          return -1;
+        }
+        char c = original.charAt(pos);
+        if (isLcAlpha(c)) {
+          continue;
+        }
+        if (length == 1) {
+          // The system id can only start with lower case alpha
+          return -1;
+        }
+        if (isDigit(c) || isValidExtra(c)) {
+          continue;
+        }
+        if (c == '=') {
+          pos++;
+          break;
+        }
+      }
+    }
+
+    if (pos >= end) {
+      // There needs to be something after the equals sign
+      return -1;
+    }
+
+    return pos;
+  }
+
+  // This is The Fine Specification for the member value https://www.w3.org/TR/trace-context/#value
+  // Please note the wonderful decision to allow ' ' in the value but not let it end with ' ', since
+  // that is indistinguishable from optional whitespace at the end
+  private static int validateMemberValue(String original, int start) {
+    int end = original.length();
+    if (start < 0 || start >= end) {
+      return -1;
+    }
+    int length = 1;
+    int nonOWSLength = 0;
+    int pos = start;
+    boolean inWhiteSpace = false;
+    boolean onlyWhiteSpace = true;
+    boolean moreNonWSAllowed = true;
+    for (; pos < end; pos++, length++) {
+      if (!inWhiteSpace) {
+        nonOWSLength = length - 1;
+      }
+      if (nonOWSLength > 256) {
+        // We're beyond the length of the allowed member value and ',' delimiter
+        return -1;
+      }
+      char c = original.charAt(pos);
+      if (c == ' ') {
+        inWhiteSpace = true;
+        continue;
+      }
+      if (c == '\t') {
+        inWhiteSpace = true;
+        // If we encounter a `\t` then we can't have more normal characters after
+        moreNonWSAllowed = false;
+        continue;
+      }
+      if (c == ',') {
+        break;
+      }
+      if (!moreNonWSAllowed) {
+        return -1;
+      }
+      inWhiteSpace = false;
+      if (isValidMemberValueChar(c)) {
+        onlyWhiteSpace = false;
+        continue;
+      }
+      return -1;
+    }
+    if (onlyWhiteSpace) {
+      return -1;
+    }
+    if (!inWhiteSpace && length > 257) {
+      // We're beyond the length of the allowed member value and ',' delimiter
+      return -1;
+    }
+
+    return pos;
+  }
+
+  private static int findNextMember(String original, int start) {
+    int len = original.length();
+    if (start < 0) {
+      return -1;
+    }
+    if (start >= len) {
+      return len;
+    }
+
+    int pos = start;
+    for (; pos < len; pos++) {
+      char c = original.charAt(pos);
+      if (isOWC(c) || c == ',') {
+        continue;
+      }
+      break;
+    }
+    return pos;
+  }
+
+  private static boolean isLcAlpha(char c) {
+    return c >= 'a' && c <= 'z';
+  }
+
+  private static boolean isValidExtra(char c) {
+    return c == '_' || c == '-' || c == '*' || c == '/';
+  }
+
+  private static boolean isValidMemberValueChar(char c) {
+    return c >= ' ' && c <= '~' && c != ',' && c != '=';
+  }
+
+  private static boolean isOWC(char c) {
+    return c == ' ' || c == '\t';
+  }
+
+  private static int stripTrailingOWC(String original, int start, int end) {
+    char c = original.charAt(--end);
+    while (isOWC(c) && end > start) {
+      c = original.charAt(--end);
+    }
+    return ++end;
+  }
+
+  private static int cleanUpAndAppendUnknown(StringBuilder sb, W3CPTags w3CPTags, int size) {
+    if (w3CPTags.maxUnknownSize == 0
+        || w3CPTags.ddMemberStart == -1
+        || w3CPTags.ddMemberStart >= w3CPTags.ddMemberValueEnd) {
+      return size;
+    }
+    String original = w3CPTags.original;
+    int elementStart = w3CPTags.ddMemberStart + EMPTY_SIZE; // skip over 'dd='
+    int okSize = size;
+    while (elementStart < w3CPTags.ddMemberValueEnd && size < MAX_HEADER_SIZE) {
+      okSize = size;
+      int elementEnd = original.indexOf(ELEMENT_SEPARATOR, elementStart);
+      if (elementEnd < 0) {
+        elementEnd = w3CPTags.ddMemberValueEnd;
+      }
+      if (!original.startsWith(Encoding.W3C.getPrefix(), elementStart)) {
+        char first = original.charAt(elementStart);
+        char second = original.charAt(elementStart + 1);
+        if (second != KEY_VALUE_SEPARATOR || (first != 'o' && first != 's')) {
+          // only append elements that we don't know about or are not tags
+          if (sb.length() > EMPTY_SIZE) {
+            sb.append(ELEMENT_SEPARATOR);
+            size++;
+          }
+          int end = elementEnd;
+          if (end == w3CPTags.ddMemberValueEnd) {
+            end = stripTrailingOWC(original, elementStart, end);
+          }
+          sb.append(original, elementStart, end);
+          size += (end - elementStart);
+        }
+      }
+      elementStart = elementEnd + 1;
+    }
+    if (size > MAX_HEADER_SIZE) {
+      sb.setLength(okSize);
+      size = okSize;
+    }
+    return size;
+  }
+
+  private static int cleanUpAndAppendSuffix(StringBuilder sb, W3CPTags w3CPTags, int size) {
+    String original = w3CPTags.original;
+    int len = original.length();
+    int memberStart = findNextMember(original, 0);
+    while (memberStart < len) {
+      int memberEnd = original.indexOf(MEMBER_SEPARATOR, memberStart);
+      if (memberEnd < 0) {
+        memberEnd = len;
+      }
+      if (memberStart != w3CPTags.ddMemberStart) {
+        if (sb.length() > 0) {
+          sb.append(MEMBER_SEPARATOR);
+          size++;
+        }
+        int end = stripTrailingOWC(original, memberStart, memberEnd);
+        sb.append(original, memberStart, end);
+        size += (end - memberStart);
+      }
+      memberStart = findNextMember(original, memberEnd + 1);
+    }
+    return size;
+  }
+
+  private static W3CPTags empty(PTagsFactory factory, String original) {
+    return empty(factory, original, 0, -1, -1);
+  }
+
+  private static W3CPTags empty(
+      PTagsFactory factory,
+      String original,
+      int firstMemberStart,
+      int ddMemberStart,
+      int ddMemberValueEnd) {
+    return new W3CPTags(
+        factory,
+        null,
+        null,
+        PrioritySampling.UNSET,
+        null,
+        original,
+        firstMemberStart,
+        ddMemberStart,
+        ddMemberValueEnd,
+        0);
+  }
+
+  private static class W3CPTags extends PTags {
+    private final String original;
+    private final int firstMemberStart;
+    private final int ddMemberStart;
+    private final int ddMemberValueEnd;
+    private final int maxUnknownSize;
+
+    public W3CPTags(
+        PTagsFactory factory,
+        List<TagElement> tagPairs,
+        TagValue decisionMakerTagValue,
+        int samplingPriority,
+        CharSequence origin,
+        String original,
+        int firstMemberStart,
+        int ddMemberStart,
+        int ddMemberValueEnd,
+        int maxUnknownSize) {
+      super(factory, tagPairs, decisionMakerTagValue, samplingPriority, origin);
+      this.original = original;
+      this.firstMemberStart = firstMemberStart;
+      this.ddMemberStart = ddMemberStart;
+      this.ddMemberValueEnd = ddMemberValueEnd;
+      this.maxUnknownSize = maxUnknownSize;
+    }
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogPropagationTagsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogPropagationTagsTest.groovy
@@ -2,13 +2,15 @@ package datadog.trace.core.propagation
 
 import datadog.trace.api.Config
 import datadog.trace.core.test.DDCoreSpecification
+import spock.lang.Unroll
 
 import static datadog.trace.api.sampling.PrioritySampling.*
 import static datadog.trace.api.sampling.SamplingMechanism.*
 
 class DatadogPropagationTagsTest extends DDCoreSpecification {
 
-  def createPropagationTagsFromHeaderValue() {
+  @Unroll
+  def "create propagation tags from header value '#headerValue'"() {
     setup:
     def config = Mock(Config)
     config.getxDatadogTagsMaxLength() >> 512
@@ -54,9 +56,9 @@ class DatadogPropagationTagsTest extends DDCoreSpecification {
     "_dd.p.a b=123"                                                                                                              | null                                       | ["_dd.propagation_error": "decoding_error"] // invalid tag key containing space
     "_dd.p.ab =123"                                                                                                              | null                                       | ["_dd.propagation_error": "decoding_error"] // invalid tag key containing space
     "_dd.p. ab=123"                                                                                                              | null                                       | ["_dd.propagation_error": "decoding_error"] // invalid tag key containing space
-    "_dd.p.a=b=1=2"                                                                                                              | null                                       | ["_dd.propagation_error": "decoding_error"] // invalid tag key containing equality
+    "_dd.p.a=b=1=2"                                                                                                              | "_dd.p.a=b=1=2"                            | ["_dd.p.a": "b=1=2"]
     "_dd.p.1ö2=value"                                                                                                            | null                                       | ["_dd.propagation_error": "decoding_error"] // invalid tag key containing not allowed char
-    "_dd.p.ab=1=2"                                                                                                               | null                                       | ["_dd.propagation_error": "decoding_error"] // invalid tag value containing equality
+    "_dd.p.ab=1=2"                                                                                                               | "_dd.p.ab=1=2"                             | ["_dd.p.ab": "1=2"]
     "_dd.p.ab=1ô2"                                                                                                               | null                                       | ["_dd.propagation_error": "decoding_error"] // invalid tag value containing not allowed char
     "_dd.p.dm=934086A686-4"                                                                                                      | null                                       | ["_dd.propagation_error": "decoding_error"] // invalid dm tag value contains invalid char
     "_dd.p.dm=934086a66-4"                                                                                                       | null                                       | ["_dd.propagation_error": "decoding_error"] // invalid dm tag value shorter than 10 chars
@@ -67,7 +69,7 @@ class DatadogPropagationTagsTest extends DDCoreSpecification {
     "_dd.p.dm=934086a665-12b"                                                                                                    | null                                       | ["_dd.propagation_error": "decoding_error"] // invalid dm tag value sampling mechanism contains invalid char
   }
 
-  def updatePropagationTagsSamplingMechanism() {
+  def "update propagation tags sampling mechanism #originalTagSet"() {
     setup:
     def config = Mock(Config)
     config.getxDatadogTagsMaxLength() >> 512
@@ -89,23 +91,23 @@ class DatadogPropagationTagsTest extends DDCoreSpecification {
     "_dd.p.dm=93485302ab-1"                                     | SAMPLER_KEEP | APPSEC     | "_dd.p.dm=93485302ab-1"                                     | ["_dd.p.dm": "93485302ab-1"]
     "_dd.p.dm=934086a686-4,_dd.p.anytag=value"                  | SAMPLER_KEEP | AGENT_RATE | "_dd.p.dm=934086a686-4,_dd.p.anytag=value"                  | ["_dd.p.dm": "934086a686-4", "_dd.p.anytag": "value"]
     "_dd.p.dm=93485302ab-2,_dd.p.anytag=value"                  | SAMPLER_KEEP | APPSEC     | "_dd.p.dm=93485302ab-2,_dd.p.anytag=value"                  | ["_dd.p.dm": "93485302ab-2", "_dd.p.anytag": "value"]
-    "_dd.p.anytag=value,_dd.p.dm=934086a686-4"                  | SAMPLER_KEEP | AGENT_RATE | "_dd.p.anytag=value,_dd.p.dm=934086a686-4"                  | ["_dd.p.anytag": "value", "_dd.p.dm": "934086a686-4"]
-    "_dd.p.anytag=value,_dd.p.dm=93485302ab-2"                  | SAMPLER_KEEP | APPSEC     | "_dd.p.anytag=value,_dd.p.dm=93485302ab-2"                  | ["_dd.p.anytag": "value", "_dd.p.dm": "93485302ab-2"]
-    "_dd.p.anytag=value,_dd.p.dm=934086a686-4,_dd.p.atag=value" | SAMPLER_KEEP | AGENT_RATE | "_dd.p.anytag=value,_dd.p.dm=934086a686-4,_dd.p.atag=value" | ["_dd.p.anytag": "value", "_dd.p.dm": "934086a686-4", "_dd.p.atag": "value"]
-    "_dd.p.anytag=value,_dd.p.dm=93485302ab-2,_dd.p.atag=value" | SAMPLER_KEEP | APPSEC     | "_dd.p.anytag=value,_dd.p.dm=93485302ab-2,_dd.p.atag=value" | ["_dd.p.anytag": "value", "_dd.p.dm": "93485302ab-2", "_dd.p.atag": "value"]
+    "_dd.p.anytag=value,_dd.p.dm=934086a686-4"                  | SAMPLER_KEEP | AGENT_RATE | "_dd.p.dm=934086a686-4,_dd.p.anytag=value"                  | ["_dd.p.anytag": "value", "_dd.p.dm": "934086a686-4"]
+    "_dd.p.anytag=value,_dd.p.dm=93485302ab-2"                  | SAMPLER_KEEP | APPSEC     | "_dd.p.dm=93485302ab-2,_dd.p.anytag=value"                  | ["_dd.p.anytag": "value", "_dd.p.dm": "93485302ab-2"]
+    "_dd.p.anytag=value,_dd.p.dm=934086a686-4,_dd.p.atag=value" | SAMPLER_KEEP | AGENT_RATE | "_dd.p.dm=934086a686-4,_dd.p.anytag=value,_dd.p.atag=value" | ["_dd.p.anytag": "value", "_dd.p.dm": "934086a686-4", "_dd.p.atag": "value"]
+    "_dd.p.anytag=value,_dd.p.dm=93485302ab-2,_dd.p.atag=value" | SAMPLER_KEEP | APPSEC     | "_dd.p.dm=93485302ab-2,_dd.p.anytag=value,_dd.p.atag=value" | ["_dd.p.anytag": "value", "_dd.p.dm": "93485302ab-2", "_dd.p.atag": "value"]
     "_dd.p.dm=93485302ab-2"                                     | USER_DROP    | MANUAL     | "_dd.p.dm=93485302ab-2"                                     | ["_dd.p.dm": "93485302ab-2"]
-    "_dd.p.anytag=value,_dd.p.dm=93485302ab-2"                  | SAMPLER_DROP | MANUAL     | "_dd.p.anytag=value,_dd.p.dm=93485302ab-2"                  | ["_dd.p.anytag": "value", "_dd.p.dm": "93485302ab-2"]
+    "_dd.p.anytag=value,_dd.p.dm=93485302ab-2"                  | SAMPLER_DROP | MANUAL     | "_dd.p.dm=93485302ab-2,_dd.p.anytag=value"                  | ["_dd.p.anytag": "value", "_dd.p.dm": "93485302ab-2"]
     "_dd.p.dm=93485302ab-2,_dd.p.anytag=value"                  | USER_DROP    | MANUAL     | "_dd.p.dm=93485302ab-2,_dd.p.anytag=value"                  | ["_dd.p.dm": "93485302ab-2", "_dd.p.anytag": "value"]
-    "_dd.p.atag=value,_dd.p.dm=93485302ab-2,_dd.p.anytag=value" | USER_DROP    | MANUAL     | "_dd.p.atag=value,_dd.p.dm=93485302ab-2,_dd.p.anytag=value" | ["_dd.p.atag": "value", "_dd.p.dm": "93485302ab-2", "_dd.p.anytag": "value"]
+    "_dd.p.atag=value,_dd.p.dm=93485302ab-2,_dd.p.anytag=value" | USER_DROP    | MANUAL     | "_dd.p.dm=93485302ab-2,_dd.p.atag=value,_dd.p.anytag=value" | ["_dd.p.atag": "value", "_dd.p.dm": "93485302ab-2", "_dd.p.anytag": "value"]
     // propagate sampling mechanism only
     ""                                                          | SAMPLER_KEEP | DEFAULT    | "_dd.p.dm=-0"                                               | ["_dd.p.dm": "-0"]
     ""                                                          | SAMPLER_KEEP | AGENT_RATE | "_dd.p.dm=-1"                                               | ["_dd.p.dm": "-1"]
-    "_dd.p.anytag=value"                                        | USER_KEEP    | MANUAL     | "_dd.p.anytag=value,_dd.p.dm=-4"                            | ["_dd.p.anytag": "value", "_dd.p.dm": "-4"]
+    "_dd.p.anytag=value"                                        | USER_KEEP    | MANUAL     | "_dd.p.dm=-4,_dd.p.anytag=value"                            | ["_dd.p.anytag": "value", "_dd.p.dm": "-4"]
     "_dd.p.anytag=value,_dd.p.atag=value"                       | SAMPLER_DROP | MANUAL     | "_dd.p.anytag=value,_dd.p.atag=value"                       | ["_dd.p.anytag": "value", "_dd.p.atag": "value"]
     // do not set the dm tags when mechanism is UNKNOWN
     "_dd.p.anytag=123"                                          | SAMPLER_KEEP | UNKNOWN    | "_dd.p.anytag=123"                                          | ["_dd.p.anytag": "123"]
     // invalid input
-    ",_dd.p.dm=Value"                                           | SAMPLER_KEEP | AGENT_RATE | null                                                        | ["_dd.propagation_error": "decoding_error"]
+    ",_dd.p.dm=Value"                                           | SAMPLER_KEEP | AGENT_RATE | "_dd.p.dm=-1"                                               | ["_dd.propagation_error": "decoding_error", "_dd.p.dm": "-1"]
   }
 
   def extractionLimitExceeded() {
@@ -118,8 +120,8 @@ class DatadogPropagationTagsTest extends DDCoreSpecification {
     propagationTags.updateTraceSamplingPriority(USER_KEEP, MANUAL)
 
     then:
-    propagationTags.headerValue(PropagationTags.HeaderType.DATADOG) == null
-    propagationTags.createTagMap() == ["_dd.propagation_error": "extract_max_size"]
+    propagationTags.headerValue(PropagationTags.HeaderType.DATADOG) == "_dd.p.dm=-4"
+    propagationTags.createTagMap() == ["_dd.propagation_error": "extract_max_size", "_dd.p.dm": "-4"]
   }
 
   def injectionLimitExceeded() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/W3CHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/W3CHttpExtractorTest.groovy
@@ -1,0 +1,378 @@
+package datadog.trace.core.propagation
+
+import datadog.trace.api.DDSpanId
+import datadog.trace.api.DDTraceId
+import datadog.trace.api.config.TracerConfig
+import datadog.trace.api.sampling.SamplingMechanism
+import datadog.trace.bootstrap.ActiveSubsystems
+import datadog.trace.bootstrap.instrumentation.api.ContextVisitors
+import datadog.trace.bootstrap.instrumentation.api.TagContext
+import datadog.trace.test.util.DDSpecification
+
+import static datadog.trace.api.config.TracerConfig.PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP
+import static datadog.trace.api.sampling.PrioritySampling.USER_DROP
+import static datadog.trace.api.sampling.PrioritySampling.USER_KEEP
+import static datadog.trace.core.propagation.W3CHttpCodec.OT_BAGGAGE_PREFIX
+import static datadog.trace.core.propagation.W3CHttpCodec.TRACE_PARENT_KEY
+import static datadog.trace.core.propagation.W3CHttpCodec.TRACE_STATE_KEY
+
+class W3CHttpExtractorTest extends DDSpecification {
+
+  private static final String TEST_TP_DROP = "00-00000000000000000000000000000001-123456789abcdef0-00"
+  private static final String TEST_TP_KEEP = "00-00000000000000000000000000000001-123456789abcdef0-01"
+  private static final long TEST_SPAN_ID = 1311768467463790320L
+
+  private HttpCodec.Extractor _extractor
+
+  private HttpCodec.Extractor getExtractor() {
+    _extractor ?: (
+      _extractor = W3CHttpCodec.newExtractor(
+      ["SOME_HEADER": "some-tag"],
+      ["SOME_CUSTOM_BAGGAGE_HEADER": "some-baggage", "SOME_CUSTOM_BAGGAGE_HEADER_2": "some-CaseSensitive-baggage"])
+      )
+  }
+
+  boolean origAppSecActive
+
+  void setup() {
+    origAppSecActive = ActiveSubsystems.APPSEC_ACTIVE
+    ActiveSubsystems.APPSEC_ACTIVE = true
+
+    injectSysConfig(PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED, "true")
+  }
+
+  void cleanup() {
+    ActiveSubsystems.APPSEC_ACTIVE = origAppSecActive
+  }
+
+  def "extract traceparent '#traceparent'"() {
+    setup:
+    HashMap<String, String> headers = []
+    String originalTraceId = ""
+    String originalSpanId = ""
+    if (traceparent) {
+      headers.put(W3CHttpCodec.TRACE_PARENT_KEY, traceparent)
+      def parts = traceparent.split('-')
+      originalTraceId = parts[1]
+      originalSpanId = parts[2]
+    }
+
+    when:
+    final ExtractedContext context = extractor.extract(headers, ContextVisitors.stringValuesMap())
+
+    then:
+    if (tpValid) {
+      assert context.traceId == traceId
+      assert context.spanId == spanId
+      assert context.samplingPriority == priority
+      assert context.traceId.toHexStringOrOriginal() == originalTraceId
+      DDSpanId.toHexStringPadded(context.spanId) == originalSpanId
+    } else {
+      assert context == null
+    }
+
+    where:
+    traceparent                                                 | tpValid | traceId       | spanId       | priority
+    null                                                        | false   | null          | null         | null
+    '00-00000000000000000000000000000000-123456789abcdef0-01'   | false   | null          | null         | null
+    '00-123456789abcdef00000000000000000-123456789abcdef0-01'   | false   | null          | null         | null
+    '00-00000000000000000000000000000001-0000000000000000-01'   | false   | null          | null         | null
+    '00-00000000000000000000000000000001-123456789abcdef0-01'   | true    | DDTraceId.ONE | TEST_SPAN_ID | SAMPLER_KEEP
+    '\t00-00000000000000000000000000000001-123456789abcdef0-01' | true    | DDTraceId.ONE | TEST_SPAN_ID | SAMPLER_KEEP
+    '00-00000000000000000000000000000001-123456789abcdef0-01\t' | true    | DDTraceId.ONE | TEST_SPAN_ID | SAMPLER_KEEP
+    ' 00-00000000000000000000000000000001-123456789abcdef0-01 ' | true    | DDTraceId.ONE | TEST_SPAN_ID | SAMPLER_KEEP
+    '00-0000000000000000ffffffffffffffff-ffffffffffffffff-01'   | true    | DDTraceId.MAX | DDSpanId.MAX | SAMPLER_KEEP
+    '00-0000000000000000ffffffffffffffff-ffffffffffffffff-00'   | true    | DDTraceId.MAX | DDSpanId.MAX | SAMPLER_DROP
+    '00-123456789abcdef0ffffffffffffffff-123456789abcdef0-00'   | true    | DDTraceId.MAX | TEST_SPAN_ID | SAMPLER_DROP
+    '00-123456789abcdef0ffffffffffffffFf-123456789abcdef0-00'   | false   | null          | null         | null
+    '00-123456789abcdeF0ffffffffffffffff-123456789abcdef0-00'   | false   | null          | null         | null
+    '00-123456789abcdef0fffffffffFffffff-123456789abcdef0-00'   | false   | null          | null         | null
+    '00-123456789abcdef0ffffffffffffffff-123456789Abcdef0-00'   | false   | null          | null         | null
+    '00-123456789äbcdef0ffffffffffffffff-123456789abcdef0-00'   | false   | null          | null         | null
+    '00-123456789abcdef0ffffffffäfffffff-123456789abcdef0-00'   | false   | null          | null         | null
+    '00-123456789abcdef0ffffffffffffffff-123456789äbcdef0-00'   | false   | null          | null         | null
+    '01-00000000000000000000000000000001-0000000000000001-02'   | true    | DDTraceId.ONE | 1            | SAMPLER_DROP
+    '000-0000000000000000000000000000001-0000000000000001-01'   | false   | null          | null         | null
+    '00-0000000000000000000000000000001 -0000000000000001-01'   | false   | null          | null         | null
+    '00-0000000000000000000000000000001-0000000000000001-01'    | false   | null          | null         | null
+    '00-00000000000000000000000000000001-000000000000001-01'    | false   | null          | null         | null
+    '00-00000000000000000000000000000001-0000000000000001-0'    | false   | null          | null         | null
+    'ff-00000000000000000000000000000001-0000000000000001-00'   | false   | null          | null         | null
+    'fe-00000000000000000000000000000001-0000000000000001-02'   | true    | DDTraceId.ONE | 1            | SAMPLER_DROP
+    '00-00000000000000000000000000000001-0000000000000001-03-0' | false   | null          | null         | null
+    'fe-00000000000000000000000000000001-0000000000000001-02.0' | false   | null          | null         | null
+  }
+
+
+  def "extract traceparent, tracestate, and http headers (#traceparent #tracestate)"() {
+    setup:
+    def headers = [
+      ""                                      : 'empty key',
+      (TRACE_PARENT_KEY.toUpperCase())        : traceparent,
+      (TRACE_STATE_KEY.toUpperCase())         : tracestate,
+      (OT_BAGGAGE_PREFIX.toUpperCase() + 'k1'): 'v1',
+      (OT_BAGGAGE_PREFIX.toUpperCase() + 'k2'): 'v2',
+      SOME_HEADER                             : 'my-interesting-info',
+      SOME_CUSTOM_BAGGAGE_HEADER              : 'my-interesting-baggage-info',
+      SOME_CUSTOM_BAGGAGE_HEADER_2            : 'my-interesting-baggage-info-2',
+    ]
+
+    when:
+    final ExtractedContext context = extractor.extract(headers, ContextVisitors.stringValuesMap())
+
+    then:
+    context.traceId == DDTraceId.ONE
+    context.spanId == TEST_SPAN_ID
+    context.baggage == ['k1'                        : 'v1',
+      'k2'                        : 'v2',
+      'some-baggage'              : 'my-interesting-baggage-info',
+      'some-CaseSensitive-baggage': 'my-interesting-baggage-info-2']
+    context.tags == ['some-tag': 'my-interesting-info']
+    context.samplingPriority == priority
+    if (decisionMaker != null) {
+      assert context.propagationTags.createTagMap() == ['_dd.p.dm': "-$decisionMaker"]
+    } else {
+      assert context.propagationTags.createTagMap() == [:]
+    }
+    if (origin) {
+      assert context.origin.toString() == origin
+    }
+
+    where:
+    traceparent  | tracestate               | priority     | decisionMaker             | origin
+    TEST_TP_KEEP | ''                       | SAMPLER_KEEP | SamplingMechanism.DEFAULT | null
+    TEST_TP_DROP | ''                       | SAMPLER_DROP | null                      | null
+    TEST_TP_KEEP | "dd=s:2;o:some"          | USER_KEEP    | null                      | 'some'
+    TEST_TP_KEEP | "dd=s:2;o:some;t.dm:-4"  | USER_KEEP    | SamplingMechanism.MANUAL  | 'some'
+    TEST_TP_DROP | "dd=s:2;o:some;t.dm:-4"  | SAMPLER_DROP | null                      | 'some'
+    TEST_TP_DROP | "dd=s:-1;o:some"         | USER_DROP    | null                      | 'some'
+    TEST_TP_DROP | "dd=s:-1;o:some;t.dm:-4" | USER_DROP    | SamplingMechanism.MANUAL  | 'some'
+    TEST_TP_KEEP | "dd=s:-1;o:some;t.dm:-4" | SAMPLER_KEEP | SamplingMechanism.DEFAULT | 'some'
+  }
+
+  def "extract header tags with no propagation"() {
+    when:
+    TagContext context = extractor.extract(headers, ContextVisitors.stringValuesMap())
+
+    then:
+    !(context instanceof ExtractedContext)
+    context.getTags() == ['some-tag': 'my-interesting-info']
+
+    where:
+    headers << [[SOME_HEADER: 'my-interesting-info'],]
+  }
+
+  def "extract headers with forwarding"() {
+    when:
+    TagContext context = extractor.extract(tagOnlyCtx, ContextVisitors.stringValuesMap())
+
+    then:
+    context != null
+    !(context instanceof ExtractedContext)
+    context.forwarded == "for=$forwardedIp:$forwardedPort"
+
+    when:
+    context = extractor.extract(fullCtx, ContextVisitors.stringValuesMap())
+
+    then:
+    context instanceof ExtractedContext
+    context.traceId.toLong() == 1
+    context.spanId.toLong() == 2
+    context.forwarded == "for=$forwardedIp:$forwardedPort"
+
+    where:
+    forwardedIp = "1.2.3.4"
+    forwardedPort = "1234"
+    tagOnlyCtx = [
+      'Forwarded' : "for=$forwardedIp:$forwardedPort"
+    ]
+    fullCtx = [
+      (TRACE_PARENT_KEY.toUpperCase())        : '00-00000000000000000000000000000001-0000000000000002-01',
+      'Forwarded' : "for=$forwardedIp:$forwardedPort"
+    ]
+  }
+
+  def "extract headers with x-forwarding"() {
+    setup:
+    String forwardedIp = '1.2.3.4'
+    String forwardedPort = '1234'
+    def tagOnlyCtx = [
+      'X-Forwarded-For' : forwardedIp,
+      'X-Forwarded-Port': forwardedPort
+    ]
+    def fullCtx = [
+      (TRACE_PARENT_KEY.toUpperCase())        : '00-00000000000000000000000000000001-0000000000000002-01',
+      'x-forwarded-for'           : forwardedIp,
+      'x-forwarded-port'          : forwardedPort
+    ]
+
+    when:
+    TagContext context = extractor.extract(tagOnlyCtx, ContextVisitors.stringValuesMap())
+
+    then:
+    context != null
+    context instanceof TagContext
+    context.XForwardedFor == forwardedIp
+    context.XForwardedPort == forwardedPort
+
+    when:
+    context = extractor.extract(fullCtx, ContextVisitors.stringValuesMap())
+
+    then:
+    context instanceof ExtractedContext
+    context.traceId.toLong() == 1
+    context.spanId.toLong() == 2
+    context.XForwardedFor == forwardedIp
+    context.XForwardedPort == forwardedPort
+  }
+
+  def "extract empty headers returns null"() {
+    expect:
+    extractor.extract(["ignored-header": "ignored-value"], ContextVisitors.stringValuesMap()) == null
+  }
+
+  void 'extract headers with ip resolution disabled'() {
+    setup:
+    injectSysConfig(TracerConfig.TRACE_CLIENT_IP_RESOLVER_ENABLED, 'false')
+
+    def tagOnlyCtx = [
+      'X-Forwarded-For': '::1',
+      'User-agent': 'foo/bar',
+    ]
+
+    when:
+    TagContext ctx = extractor.extract(tagOnlyCtx, ContextVisitors.stringValuesMap())
+
+    then:
+    ctx != null
+    ctx.XForwardedFor == null
+    ctx.userAgent == 'foo/bar'
+  }
+
+
+  void 'extract headers with ip resolution disabled — appsec disabled variant'() {
+    setup:
+    ActiveSubsystems.APPSEC_ACTIVE = false
+
+    def tagOnlyCtx = [
+      'X-Forwarded-For': '::1',
+      'User-agent': 'foo/bar',
+    ]
+
+    when:
+    TagContext ctx = extractor.extract(tagOnlyCtx, ContextVisitors.stringValuesMap())
+
+    then:
+    ctx != null
+    ctx.XForwardedFor == null
+  }
+
+  void 'custom IP header collection does not disable standard ip header collection'() {
+    setup:
+    injectSysConfig(TracerConfig.TRACE_CLIENT_IP_HEADER, "my-header")
+
+    def tagOnlyCtx = [
+      'X-Forwarded-For': '::1',
+      'My-Header': '8.8.8.8',
+    ]
+
+    when:
+    def ctx = extractor.extract(tagOnlyCtx, ContextVisitors.stringValuesMap())
+
+    then:
+    ctx != null
+    ctx.XForwardedFor == '::1'
+    ctx.customIpHeader == '8.8.8.8'
+  }
+
+  def "extract http headers with end to end #endToEndStartTime"() {
+    setup:
+    def headers = [
+      ''                                      : 'empty key',
+      (TRACE_PARENT_KEY.toUpperCase())        : '00-00000000000000000000000000000001-123456789abcdef0-01',
+      (OT_BAGGAGE_PREFIX.toUpperCase() + 'k1'): 'v1',
+      (OT_BAGGAGE_PREFIX.toUpperCase() + 't0'): endToEndStartTime,
+      (OT_BAGGAGE_PREFIX.toUpperCase() + 'k2'): 'v2',
+      SOME_HEADER                             : 'my-interesting-info',
+      SOME_CUSTOM_BAGGAGE_HEADER              : 'my-interesting-baggage-info',
+      SOME_CUSTOM_BAGGAGE_HEADER_2            : 'my-interesting-baggage-info-2',
+    ]
+
+    when:
+    final ExtractedContext context = extractor.extract(headers, ContextVisitors.stringValuesMap())
+
+    then:
+    context.traceId == DDTraceId.ONE
+    context.spanId == TEST_SPAN_ID
+    context.baggage == ['k1': 'v1',
+      'k2': 'v2',
+      'some-baggage': 'my-interesting-baggage-info',
+      'some-CaseSensitive-baggage': 'my-interesting-baggage-info-2']
+    context.tags == ['some-tag': 'my-interesting-info']
+    context.endToEndStartTime == endToEndStartTime * 1000000L
+
+    where:
+    endToEndStartTime << [0, 1610001234]
+  }
+
+  def "baggage is mapped on context creation"() {
+    setup:
+    def headers = [
+      (TRACE_PARENT_KEY)                      : traceparent,
+      SOME_CUSTOM_BAGGAGE_HEADER              : 'mappedBaggageValue',
+      (OT_BAGGAGE_PREFIX.toUpperCase() + 'k1'): 'v1',
+      (OT_BAGGAGE_PREFIX.toUpperCase() + 'k2'): 'v2',
+      SOME_ARBITRARY_HEADER                   : 'my-interesting-info',
+    ]
+
+    when:
+    final TagContext context = extractor.extract(headers, ContextVisitors.stringValuesMap())
+
+    then:
+    assert context != null
+    if (tpValid) {
+      assert context.getTraceId() == DDTraceId.ONE
+      assert context.getSpanId()  == 1
+    }
+    context.getBaggage() == [
+      'some-baggage'     : 'mappedBaggageValue',
+      'k1'               : 'v1',
+      'k2'               : 'v2',
+    ]
+
+    where:
+    tpValid | traceparent
+    false   | '00-00000000000000000000000000000000-123456789abcdef0-01'
+    false   | '00-00000000000000000000000000000001-0000000000000000-01'
+    true    | '00-00000000000000000000000000000001-0000000000000001-01'
+  }
+
+  def "extract common http headers"() {
+    setup:
+    def headers = [
+      (HttpCodec.USER_AGENT_KEY): 'some-user-agent',
+      (HttpCodec.X_CLUSTER_CLIENT_IP_KEY): '1.1.1.1',
+      (HttpCodec.X_REAL_IP_KEY): '2.2.2.2',
+      (HttpCodec.CLIENT_IP_KEY): '3.3.3.3',
+      (HttpCodec.TRUE_CLIENT_IP_KEY): '4.4.4.4',
+      (HttpCodec.VIA_KEY): '5.5.5.5',
+      (HttpCodec.FORWARDED_FOR_KEY): '6.6.6.6',
+      (HttpCodec.X_FORWARDED_KEY): '7.7.7.7'
+    ]
+
+    when:
+    final TagContext context = extractor.extract(headers, ContextVisitors.stringValuesMap())
+
+    then:
+    assert context.userAgent == 'some-user-agent'
+    assert context.XClusterClientIp == '1.1.1.1'
+    assert context.XRealIp == '2.2.2.2'
+    assert context.clientIp == '3.3.3.3'
+    assert context.trueClientIp == '4.4.4.4'
+    assert context.via == '5.5.5.5'
+    assert context.forwardedFor == '6.6.6.6'
+    assert context.XForwarded == '7.7.7.7'
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/W3CHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/W3CHttpInjectorTest.groovy
@@ -1,0 +1,174 @@
+package datadog.trace.core.propagation
+
+import datadog.trace.api.DDSpanId
+import datadog.trace.api.DDTraceId
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopPathwayContext
+import datadog.trace.common.writer.ListWriter
+import datadog.trace.core.DDSpanContext
+import datadog.trace.core.test.DDCoreSpecification
+
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP
+import static datadog.trace.api.sampling.PrioritySampling.UNSET
+import static datadog.trace.api.sampling.PrioritySampling.USER_KEEP
+import static datadog.trace.api.sampling.SamplingMechanism.MANUAL
+import static datadog.trace.core.CoreTracer.TRACE_ID_MAX
+import static datadog.trace.core.propagation.W3CHttpCodec.OT_BAGGAGE_PREFIX
+import static datadog.trace.core.propagation.W3CHttpCodec.TRACE_PARENT_KEY
+import static datadog.trace.core.propagation.W3CHttpCodec.TRACE_STATE_KEY
+import static datadog.trace.core.propagation.W3CHttpCodec.newInjector
+
+
+class W3CHttpInjectorTest extends DDCoreSpecification {
+
+  HttpCodec.Injector injector = newInjector(["some-baggage-key":"SOME_CUSTOM_HEADER"])
+
+  def "inject http headers"() {
+    setup:
+    def writer = new ListWriter()
+    def tracer = tracerBuilder().writer(writer).build()
+    final DDSpanContext mockedContext =
+      new DDSpanContext(
+      DDTraceId.from(traceId),
+      DDSpanId.from(spanId),
+      DDSpanId.ZERO,
+      null,
+      "fakeService",
+      "fakeOperation",
+      "fakeResource",
+      samplingPriority,
+      origin,
+      ["k1" : "v1", "k2" : "v2","some-baggage-key": "some-value"],
+      false,
+      "fakeType",
+      0,
+      tracer.pendingTraceFactory.create(DDTraceId.ONE),
+      null,
+      null,
+      NoopPathwayContext.INSTANCE,
+      false,
+      PropagationTags.factory().fromHeaderValue(PropagationTags.HeaderType.DATADOG, tracestate ? "_dd.p.usr=123" : ""))
+    final Map<String, String> carrier = [:]
+    Map<String, String> expected = [
+      (TRACE_PARENT_KEY): buildTraceParent(traceId, spanId, samplingPriority),
+      (OT_BAGGAGE_PREFIX + "k1"): "v1",
+      (OT_BAGGAGE_PREFIX + "k2"): "v2",
+      "SOME_CUSTOM_HEADER": "some-value"
+    ]
+    if (tracestate) {
+      expected.put(TRACE_STATE_KEY, tracestate)
+    }
+
+    when:
+    injector.inject(mockedContext, carrier, MapSetter.INSTANCE)
+
+    then:
+    carrier == expected
+
+    cleanup:
+    tracer.close()
+
+    where:
+    traceId               | spanId                | samplingPriority | origin   | tracestate
+    "1"                   | "2"                   | UNSET            | null     | null
+    "1"                   | "2"                   | SAMPLER_KEEP     | "saipan" | "dd=s:1;o:saipan;t.usr:123"
+    "$TRACE_ID_MAX"       | "${TRACE_ID_MAX - 1}" | UNSET            | "saipan" | "dd=o:saipan;t.usr:123"
+    "${TRACE_ID_MAX - 1}" | "$TRACE_ID_MAX"       | SAMPLER_KEEP     | null     | "dd=s:1;t.usr:123"
+    "${TRACE_ID_MAX - 1}" | "$TRACE_ID_MAX"       | SAMPLER_DROP     | null     | "dd=s:0;t.usr:123"
+  }
+
+  def "inject http headers with end-to-end"() {
+    setup:
+    def writer = new ListWriter()
+    def tracer = tracerBuilder().writer(writer).build()
+    final DDSpanContext mockedContext =
+      new DDSpanContext(
+      DDTraceId.from("1"),
+      DDSpanId.from("2"),
+      DDSpanId.ZERO,
+      null,
+      "fakeService",
+      "fakeOperation",
+      "fakeResource",
+      UNSET,
+      "fakeOrigin",
+      ["k1" : "v1", "k2" : "v2"],
+      false,
+      "fakeType",
+      0,
+      tracer.pendingTraceFactory.create(DDTraceId.ONE),
+      null,
+      null,
+      NoopPathwayContext.INSTANCE,
+      false,
+      PropagationTags.factory().fromHeaderValue(PropagationTags.HeaderType.DATADOG, "_dd.p.dm=-4,_dd.p.anytag=value"))
+
+    mockedContext.beginEndToEnd()
+
+    final Map<String, String> carrier = [:]
+
+    when:
+    injector.inject(mockedContext, carrier, MapSetter.INSTANCE)
+
+    then:
+    carrier == [
+      (TRACE_PARENT_KEY): buildTraceParent('1', '2', UNSET),
+      (TRACE_STATE_KEY): "dd=o:fakeOrigin;t.dm:-4;t.anytag:value",
+      (OT_BAGGAGE_PREFIX + "t0"): "${(long) (mockedContext.endToEndStartTime / 1000000L)}",
+      (OT_BAGGAGE_PREFIX + "k1"): "v1",
+      (OT_BAGGAGE_PREFIX + "k2"): "v2",
+    ]
+
+    cleanup:
+    tracer.close()
+  }
+
+  def "inject the decision maker tag"() {
+    setup:
+    def writer = new ListWriter()
+    def tracer = tracerBuilder().writer(writer).build()
+    final DDSpanContext mockedContext =
+      new DDSpanContext(
+      DDTraceId.from("1"),
+      DDSpanId.from("2"),
+      DDSpanId.ZERO,
+      null,
+      "fakeService",
+      "fakeOperation",
+      "fakeResource",
+      UNSET,
+      "fakeOrigin",
+      ["k1" : "v1", "k2" : "v2"],
+      false,
+      "fakeType",
+      0,
+      tracer.pendingTraceFactory.create(DDTraceId.ONE),
+      null,
+      null,
+      NoopPathwayContext.INSTANCE,
+      false,
+      PropagationTags.factory().empty())
+
+    mockedContext.setSamplingPriority(USER_KEEP, MANUAL)
+
+    final Map<String, String> carrier = [:]
+
+    when:
+    injector.inject(mockedContext, carrier, MapSetter.INSTANCE)
+
+    then:
+    carrier == [
+      (TRACE_PARENT_KEY): buildTraceParent('1', '2', USER_KEEP),
+      (TRACE_STATE_KEY): "dd=s:2;o:fakeOrigin;t.dm:-4",
+      (OT_BAGGAGE_PREFIX + "k1"): "v1",
+      (OT_BAGGAGE_PREFIX + "k2"): "v2",
+    ]
+
+    cleanup:
+    tracer.close()
+  }
+
+  static String buildTraceParent(String traceId, String spanId, int samplingPriority) {
+    return "00-${DDTraceId.from(traceId).toHexStringPadded(32)}-${DDSpanId.toHexStringPadded(DDSpanId.from(spanId))}-${samplingPriority > 0 ? '01': '00'}"
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/W3CPropagationTagsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/W3CPropagationTagsTest.groovy
@@ -1,0 +1,261 @@
+package datadog.trace.core.propagation
+
+import datadog.trace.api.Config
+import datadog.trace.api.sampling.PrioritySampling
+import datadog.trace.api.sampling.SamplingMechanism
+import datadog.trace.core.test.DDCoreSpecification
+
+import static datadog.trace.core.propagation.PropagationTags.HeaderType
+
+class W3CPropagationTagsTest extends DDCoreSpecification {
+
+  def "validate tracestate header limits #headerValue"() {
+    setup:
+    def config = Mock(Config)
+    config.getxDatadogTagsMaxLength() >> 512
+    def propagationTagsFactory = PropagationTags.factory(config)
+
+    when:
+    def propagationTags = propagationTagsFactory.fromHeaderValue(HeaderType.W3C, headerValue)
+
+    then:
+    if (valid) {
+      assert propagationTags.headerValue(HeaderType.W3C) == headerValue.trim()
+    } else {
+      assert propagationTags.headerValue(HeaderType.W3C) == null
+    }
+    // we're not using any dd members in the tests
+    propagationTags.createTagMap() == [:]
+
+    where:
+    headerValue                       | valid
+    null                              | false
+    ''                                | false
+    // check basic key length limit
+    'k' * 251 + '0_-*/=1'             | true
+    'k' * 252 + '0_-*/=1'             | false
+    // check multi key length limit
+    't' * 241 + '@' + 's' * 14 + '=1' | true
+    't' * 242 + '@' + 's' * 14 + '=1' | false
+    't' * 241 + '@' + 's' * 15 + '=1' | false
+    // check value length limit
+    'k=' + 'v' * 256                  | true
+    'k=' + 'v' * 257                  | false
+    // check value length limit with some trailing whitespace
+    'k=' + 'v' * 256 + ' \t \t'       | true
+    'k=' + 'v' * 257 + ' \t \t'       | false
+  }
+
+  def "validate tracestate header valid key contents '#headerChar'"() {
+    setup:
+    def config = Mock(Config)
+    config.getxDatadogTagsMaxLength() >> 512
+    def propagationTagsFactory = PropagationTags.factory(config)
+    def lcAlpha = toLcAlpha(headerChar)
+    def simpleKeyHeader = lcAlpha + headerChar + '_-*/=1'
+    def multiKeyHeader = headerChar + '@' + lcAlpha + headerChar + '_-*/=1'
+
+
+    when:
+    def simpleKeyPT = propagationTagsFactory.fromHeaderValue(HeaderType.W3C, simpleKeyHeader)
+    def multiKeyPT = propagationTagsFactory.fromHeaderValue(HeaderType.W3C, multiKeyHeader)
+
+    then:
+    simpleKeyPT.headerValue(HeaderType.W3C) == simpleKeyHeader
+    multiKeyPT.headerValue(HeaderType.W3C) == multiKeyHeader
+    // we're not using any dd members in the tests
+    simpleKeyPT.createTagMap() == [:]
+    multiKeyPT.createTagMap() == [:]
+
+    where:
+    headerChar << ('a'..'z') + ('0'..'9')
+  }
+
+  def "validate tracestate header invalid key contents '#headerChar'"() {
+    setup:
+    def config = Mock(Config)
+    config.getxDatadogTagsMaxLength() >> 512
+    def propagationTagsFactory = PropagationTags.factory(config)
+    def lcAlpha = toLcAlpha(headerChar)
+    def simpleKeyHeader = lcAlpha + headerChar + '_-*/=1'
+    def multiKeyHeader = lcAlpha + headerChar + '@' + lcAlpha + headerChar + '_-*/=1'
+
+
+    when:
+    def simpleKeyPT = propagationTagsFactory.fromHeaderValue(HeaderType.W3C, simpleKeyHeader)
+    def multiKeyPT = propagationTagsFactory.fromHeaderValue(HeaderType.W3C, multiKeyHeader)
+
+    then:
+    simpleKeyPT.headerValue(HeaderType.W3C) == null
+    multiKeyPT.headerValue(HeaderType.W3C) == null
+    // we're not using any dd members in the tests
+    simpleKeyPT.createTagMap() == [:]
+    multiKeyPT.createTagMap() == [:]
+
+    where:
+    headerChar << (' '..'ÿ') - (('a'..'z') + ('0'..'9') + '_' + '-' + '*' + '/')
+  }
+
+
+  def "validate tracestate header valid value contents '#valueChar'"() {
+    setup:
+    def config = Mock(Config)
+    config.getxDatadogTagsMaxLength() >> 512
+    def propagationTagsFactory = PropagationTags.factory(config)
+    def lcAlpha = toLcAlpha(valueChar)
+    def mostlyOkHeader = lcAlpha + '=' + valueChar
+    def alwaysOkHeader = lcAlpha + '=' + lcAlpha + valueChar + lcAlpha
+
+    when:
+    def mostlyOkPT = propagationTagsFactory.fromHeaderValue(HeaderType.W3C, mostlyOkHeader)
+    def alwaysOkPT = propagationTagsFactory.fromHeaderValue(HeaderType.W3C, alwaysOkHeader)
+
+    then:
+    if (valueChar == ' ') {
+      assert mostlyOkPT.headerValue(HeaderType.W3C) == null
+    } else {
+      assert mostlyOkPT.headerValue(HeaderType.W3C) == mostlyOkHeader
+    }
+    alwaysOkPT.headerValue(HeaderType.W3C) == alwaysOkHeader
+    // we're not using any dd members in the tests
+    mostlyOkPT.createTagMap() == [:]
+    alwaysOkPT.createTagMap() == [:]
+
+    where:
+    valueChar << (' '..'~') - [',', '=']
+  }
+
+  def "validate tracestate header invalid value contents '#valueChar'"() {
+    setup:
+    def config = Mock(Config)
+    config.getxDatadogTagsMaxLength() >> 512
+    def propagationTagsFactory = PropagationTags.factory(config)
+    def lcAlpha = toLcAlpha(valueChar)
+    def alwaysBadHeader = lcAlpha + '=' + lcAlpha + valueChar + lcAlpha
+
+    when:
+    def alwaysBadPT = propagationTagsFactory.fromHeaderValue(HeaderType.W3C, alwaysBadHeader)
+
+    then:
+    alwaysBadPT.headerValue(HeaderType.W3C) == null
+    // we're not using any dd members in the tests
+    alwaysBadPT.createTagMap() == [:]
+
+    where:
+    valueChar << (' '..'ÿ') - ((' '..'~') - [',', '='])
+  }
+
+  def "validate tracestate header number of members #memberCount"() {
+    setup:
+    def config = Mock(Config)
+    config.getxDatadogTagsMaxLength() >> 512
+    def propagationTagsFactory = PropagationTags.factory(config)
+    def header = (1..memberCount).collect { "k$it=v$it" }.join(',')
+
+    when:
+    def headerPT = propagationTagsFactory.fromHeaderValue(HeaderType.W3C, header)
+
+    then:
+    if (memberCount <= 32) {
+      assert headerPT.headerValue(HeaderType.W3C) == header
+    } else {
+      assert headerPT.headerValue(HeaderType.W3C) == null
+    }
+    // we're not using any dd members in the tests
+    headerPT.createTagMap() == [:]
+
+    where:
+    memberCount << (1..37) // some arbitrary number larger than 32
+  }
+
+  def "create propagation tags from header value #headerValue"() {
+    setup:
+    def config = Mock(Config)
+    config.getxDatadogTagsMaxLength() >> 512
+    def propagationTagsFactory = PropagationTags.factory(config)
+
+    when:
+    def propagationTags = propagationTagsFactory.fromHeaderValue(HeaderType.W3C, headerValue)
+
+    then:
+    propagationTags.headerValue(HeaderType.W3C) == expectedHeaderValue
+    propagationTags.createTagMap() == tags
+
+    where:
+    headerValue                                                            | expectedHeaderValue                                  | tags
+    null                                                                   | null                                                 | [:]
+    ''                                                                     | null                                                 | [:]
+    'dd=s:0;t.dm:934086a686-4'                                             | 'dd=s:0;t.dm:934086a686-4'                           | ['_dd.p.dm': '934086a686-4']
+    'other=whatever,dd=s:0;t.dm:934086a686-4'                              | 'dd=s:0;t.dm:934086a686-4,other=whatever'            | ['_dd.p.dm': '934086a686-4']
+    'dd=s:0;t.dm:934086a687-3,other=whatever'                              | 'dd=s:0;t.dm:934086a687-3,other=whatever'            | ['_dd.p.dm': '934086a687-3']
+    'some=thing,dd=s:0;t.dm:934086a687-3,other=whatever'                   | 'dd=s:0;t.dm:934086a687-3,some=thing,other=whatever' | ['_dd.p.dm': '934086a687-3']
+    'some=thing,other=whatever'                                            | 'some=thing,other=whatever'                          | [:]
+    'dd=s:0;o:some;t.dm:934086a686-4'                                      | 'dd=s:0;o:some;t.dm:934086a686-4'                    | ['_dd.p.dm': '934086a686-4']
+    'dd=s:0;x:unknown;t.dm:934086a686-4'                                   | 'dd=s:0;t.dm:934086a686-4;x:unknown'                 | ['_dd.p.dm': '934086a686-4']
+    'other=whatever,dd=s:0;x:unknown;t.dm:934086a686-4'                    | 'dd=s:0;t.dm:934086a686-4;x:unknown,other=whatever'  | ['_dd.p.dm': '934086a686-4']
+    'other=whatever,dd=xyz:unknown;t.dm:934086a686-4'                      | 'dd=t.dm:934086a686-4;xyz:unknown,other=whatever'    | ['_dd.p.dm': '934086a686-4']
+    'other=whatever,dd=t.dm:934086a686-4;xyz:unknown  '                    | 'dd=t.dm:934086a686-4;xyz:unknown,other=whatever'    | ['_dd.p.dm': '934086a686-4']
+    '\tsome=thing \t , dd=s:0;t.dm:934086a687-3\t\t,  other=whatever\t\t ' | 'dd=s:0;t.dm:934086a687-3,some=thing,other=whatever' | ['_dd.p.dm': '934086a687-3']
+    'dd=s:0;t.a:b;t.x:y'                                                   | 'dd=s:0;t.a:b;t.x:y'                                 | ['_dd.p.a': 'b', '_dd.p.x': 'y']
+    'dd=s:0;t.a:b;t.x:y \t'                                                | 'dd=s:0;t.a:b;t.x:y'                                 | ['_dd.p.a': 'b', '_dd.p.x': 'y']
+    'dd=s:0;t.a:b ;t.x:y \t'                                               | 'dd=s:0;t.a:b ;t.x:y'                                | ['_dd.p.a': 'b ', '_dd.p.x': 'y']
+    'dd=s:0;t.a:b \t;t.x:y \t'                                             | null                                                 | [:]
+  }
+
+  def "w3c propagation tags should translate to datadog tags #headerValue"() {
+    setup:
+    def config = Mock(Config)
+    config.getxDatadogTagsMaxLength() >> 512
+    def propagationTagsFactory = PropagationTags.factory(config)
+
+    when:
+    def propagationTags = propagationTagsFactory.fromHeaderValue(HeaderType.W3C, headerValue)
+
+    then:
+    propagationTags.headerValue(HeaderType.DATADOG) == expectedHeaderValue
+    propagationTags.createTagMap() == tags
+
+    where:
+    headerValue                                          | expectedHeaderValue                    | tags
+    'dd=s:0;t.dm:934086a686-4'                           | '_dd.p.dm=934086a686-4'                | ['_dd.p.dm': '934086a686-4']
+    'other=whatever,dd=s:0;t.dm:934086a686-4;t.f:w00t~~' | '_dd.p.dm=934086a686-4,_dd.p.f=w00t==' | ['_dd.p.dm': '934086a686-4', '_dd.p.f': 'w00t==']
+    'some=thing,other=whatever'                          |  null                                  | [:]
+  }
+
+  def "propagation tags should be updated by sampling and origin #headerValue #priority #mechanism #origin"() {
+    setup:
+    def config = Mock(Config)
+    config.getxDatadogTagsMaxLength() >> 512
+    def propagationTagsFactory = PropagationTags.factory(config)
+
+    when:
+    def propagationTags = propagationTagsFactory.fromHeaderValue(HeaderType.W3C, headerValue)
+
+    then:
+    propagationTags.headerValue(HeaderType.W3C) != expectedHeaderValue
+
+    when:
+    propagationTags.updateTraceSamplingPriority(priority, mechanism)
+    propagationTags.updateTraceOrigin(origin)
+
+    then:
+    propagationTags.headerValue(HeaderType.W3C) == expectedHeaderValue
+    propagationTags.createTagMap() == tags
+
+    where:
+    headerValue                       | priority                      | mechanism                           | origin  | expectedHeaderValue                | tags
+    'dd=s:0;o:some;t.dm:934086a686-4' | PrioritySampling.SAMPLER_KEEP | SamplingMechanism.DEFAULT           | "other" | 'dd=s:0;o:other;t.dm:934086a686-4' | ['_dd.p.dm': '934086a686-4']
+    'dd=s:0;o:some;x:unknown'         | PrioritySampling.USER_KEEP    | SamplingMechanism.RULE              | "same"  | 'dd=s:2;o:same;t.dm:-3;x:unknown'  | ['_dd.p.dm': '-3']
+    'dd=s:0;o:some;x:unknown'         | PrioritySampling.USER_DROP    | SamplingMechanism.MANUAL            | null    | 'dd=s:-1;x:unknown'                | [:]
+    'dd=s:0;o:some;t.dm:934086a686-4' | PrioritySampling.SAMPLER_KEEP | SamplingMechanism.EXTERNAL_OVERRIDE | "other" | 'dd=s:1;o:other;t.dm:-0'           | ['_dd.p.dm': '-0']
+    'dd=s:1;o:some;t.dm:934086a686-4' | PrioritySampling.SAMPLER_DROP | SamplingMechanism.EXTERNAL_OVERRIDE | "other" | 'dd=s:0;o:other'                   | [:]
+  }
+
+  static private String toLcAlpha(String cs) {
+    // Argh groovy and characters
+    char c = cs
+    char a = 'a'
+    char z = 'z'
+    "${Character.valueOf((a + (Math.abs(c - a) % (z - a))) as char)}"
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/ptags/TagKeyTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/ptags/TagKeyTest.groovy
@@ -1,0 +1,63 @@
+package datadog.trace.core.propagation.ptags
+
+import datadog.trace.core.test.DDCoreSpecification
+
+import static datadog.trace.core.propagation.ptags.TagElement.Encoding.DATADOG
+import static datadog.trace.core.propagation.ptags.TagElement.Encoding.W3C
+
+class TagKeyTest extends DDCoreSpecification {
+
+
+  def 'tag keys should use cached values when appropriate #seq1 #seq2'() {
+    when:
+    def tk1 = TagKey.from(enc1, seq1)
+    def tk2 = TagKey.from(enc2, seq2)
+
+    then:
+    tk1.forType(enc1) == seq1
+    tk2.forType(enc2) == seq2
+    if (same) {
+      assert tk1.is(tk2)
+      assert tk1.forType(enc2) == seq2
+    } else {
+      assert !tk1.is(tk2)
+    }
+
+    where:
+    seq1          | enc1    | seq2    | enc2     | same
+    '_dd.p.foo1'  | DATADOG | '_dd.p.foo1'  | DATADOG  | true
+    't.foo2'      | W3C     | 't.foo2'      | W3C      | true
+    '_dd.p.foo3'  | DATADOG | 't.foo3'      | W3C      | true
+    't.foo4'      | W3C     | '_dd.p.foo4'  | DATADOG  | true
+    't.foo5~'     | W3C     | '_dd.p.foo5=' | DATADOG  | false
+    '_dd.p.foo6~' | DATADOG | 't.foo6~'     | W3C      | true
+    '_dd.p.foo7~' | DATADOG | 't.foo7='     | W3C      | false
+    '_dd.p.foo81' | DATADOG | 't.foo82'     | W3C      | false
+  }
+
+  def 'tag values should use cached values from sub sequences #seq1 #seq2'() {
+    when:
+    def tv1 = TagKey.from(enc1, seq1, s1, e1)
+    def sub1 = seq1.substring(s1, e1)
+    def tv2 = TagKey.from(enc2, seq2, s2, e2)
+    def sub2 = seq2.substring(s2, e2)
+
+    then:
+    tv1.forType(enc1) == sub1
+    tv2.forType(enc2) == sub2
+    if (same) {
+      assert tv1.is(tv2)
+      assert tv1.forType(enc2) == sub2
+    } else {
+      assert !tv1.is(tv2)
+    }
+
+    where:
+    seq1           | enc1    | s1 | e1 | seq2           | enc2     | s2 | e2 | same
+    'bb_dd.p.bar1' | DATADOG | 2  | 12 | 'r_dd.p.bar1r' | DATADOG  | 1  | 11 | true
+    't.bar2ss'     | W3C     | 0  | 6  | 't_dd.p.bar2t' | DATADOG  | 1  | 11 | true
+    't.bar3~s'     | W3C     | 0  | 7  | 't_dd.p.bar3=' | DATADOG  | 1  | 12 | false
+    't.bar4~s'     | W3C     | 0  | 7  | 'tt.bar4~'     | W3C      | 1  | 8  | true
+    's_dd.p.bar5=' | DATADOG | 1  | 12 | 't.bar5~t'     | W3C      | 0  | 7  | false
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/ptags/TagValueTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/ptags/TagValueTest.groovy
@@ -1,0 +1,66 @@
+package datadog.trace.core.propagation.ptags
+
+import datadog.trace.core.test.DDCoreSpecification
+
+import static datadog.trace.core.propagation.ptags.TagElement.Encoding.DATADOG
+import static datadog.trace.core.propagation.ptags.TagElement.Encoding.W3C
+
+class TagValueTest extends DDCoreSpecification {
+
+
+  def 'tag values should use cached values when appropriate #seq1 #seq2'() {
+    when:
+    def tv1 = TagValue.from(enc1, seq1)
+    def tv2 = TagValue.from(enc2, seq2)
+
+    then:
+    tv1.forType(enc1) == seq1
+    tv2.forType(enc2) == seq2
+    if (same) {
+      assert tv1.is(tv2)
+      assert tv1.forType(enc2) == seq2
+    } else {
+      assert !tv1.is(tv2)
+    }
+
+    where:
+    seq1    | enc1    | seq2    | enc2     | same
+    'foo1'  | DATADOG | 'foo1'  | DATADOG  | true
+    'foo2'  | W3C     | 'foo2'  | W3C      | true
+    'foo3'  | DATADOG | 'foo3'  | W3C      | true
+    'foo4'  | W3C     | 'foo4'  | DATADOG  | true
+    'foo5~' | W3C     | 'foo5=' | DATADOG  | true
+    'foo6=' | DATADOG | 'foo6~' | W3C      | true
+    'foo7~' | DATADOG | 'foo7~' | W3C      | false
+    'foo81' | DATADOG | 'foo82' | W3C      | false
+    'foo9;' | DATADOG | 'foo9_' | W3C      | false
+  }
+
+  def 'tag values should use cached values from sub sequences #seq1 #seq2'() {
+    when:
+    def tv1 = TagValue.from(enc1, seq1, s1, e1)
+    def sub1 = seq1.substring(s1, e1)
+    def tv2 = TagValue.from(enc2, seq2, s2, e2)
+    def sub2 = seq2.substring(s2, e2)
+
+    then:
+    tv1.forType(enc1) == sub1
+    tv2.forType(enc2) == sub2
+    if (same) {
+      assert tv1.is(tv2)
+      assert tv1.forType(enc2) == sub2
+    } else {
+      assert !tv1.is(tv2)
+    }
+
+    where:
+    seq1     | enc1    | s1 | e1 | seq2     | enc2     | s2 | e2 | same
+    'bbbar1' | DATADOG | 2  | 6  | 'rbar1r' | DATADOG  | 1  | 5  | true
+    'bar2ss' | W3C     | 0  | 4  | 'tbar2t' | DATADOG  | 1  | 5  | true
+    'bar3~s' | W3C     | 0  | 5  | 'tbar3=' | DATADOG  | 1  | 6  | true
+    'bar4~s' | W3C     | 0  | 5  | 'tbar4~' | W3C      | 1  | 6  | true
+    'sbar5=' | DATADOG | 1  | 6  | 'bar5~t' | W3C      | 0  | 5  | true
+    'sbar6?' | DATADOG | 1  | 6  | 'bar5!t' | W3C      | 0  | 5  | false
+    'sbar6,' | DATADOG | 1  | 6  | 'bar6_t' | W3C      | 0  | 5  | false
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/cache/DDPartialKeyCache.java
+++ b/internal-api/src/main/java/datadog/trace/api/cache/DDPartialKeyCache.java
@@ -44,6 +44,6 @@ public interface DDPartialKeyCache<K, V> {
 
   @FunctionalInterface
   interface Producer<T, R> {
-    R apply(T t, int m, int n);
+    R apply(T t, int h, int m, int n);
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/cache/FixedSizePartialKeyCache.java
+++ b/internal-api/src/main/java/datadog/trace/api/cache/FixedSizePartialKeyCache.java
@@ -105,7 +105,7 @@ final class FixedSizePartialKeyCache<K, V> implements DDPartialKeyCache<K, V> {
 
   private V produceAndStoreValue(
       Producer<K, ? extends V> producer, int hash, K key, int m, int n, int pos) {
-    V value = producer.apply(key, m, n);
+    V value = producer.apply(key, hash, m, n);
     elements[pos] = new HVElement<>(hash, value);
     return value;
   }

--- a/internal-api/src/main/java/datadog/trace/api/sampling/SamplingMechanism.java
+++ b/internal-api/src/main/java/datadog/trace/api/sampling/SamplingMechanism.java
@@ -21,6 +21,8 @@ public class SamplingMechanism {
   public static final byte REMOTE_USER_RATE = 6;
   /** Span Sampling Rate (single span sampled on account of a span sampling rule) */
   public static final byte SPAN_SAMPLING_RATE = 8;
+  /** Force override sampling decision from external source, like W3C traceparent. */
+  public static final byte EXTERNAL_OVERRIDE = Byte.MIN_VALUE;
 
   public static boolean validateWithSamplingPriority(int mechanism, int priority) {
     switch (mechanism) {
@@ -39,6 +41,9 @@ public class SamplingMechanism {
 
       case APPSEC:
         return priority == PrioritySampling.USER_KEEP;
+
+      case EXTERNAL_OVERRIDE:
+        return false;
     }
     return true;
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
@@ -14,7 +14,7 @@ public class TagContext implements AgentSpan.Context.Extracted {
 
   private static final HttpHeaders EMPTY_HTTP_HEADERS = new HttpHeaders();
 
-  private final String origin;
+  private final CharSequence origin;
   private final Map<String, String> tags;
   private Object requestContextDataAppSec;
   private Object requestContextDataIast;
@@ -32,7 +32,7 @@ public class TagContext implements AgentSpan.Context.Extracted {
   }
 
   public TagContext(
-      final String origin,
+      final CharSequence origin,
       final Map<String, String> tags,
       HttpHeaders httpHeaders,
       final Map<String, String> baggage,
@@ -44,7 +44,7 @@ public class TagContext implements AgentSpan.Context.Extracted {
     this.samplingPriority = samplingPriority;
   }
 
-  public final String getOrigin() {
+  public final CharSequence getOrigin() {
     return origin;
   }
 

--- a/internal-api/src/test/groovy/datadog/trace/api/cache/FixedSizeCacheTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/cache/FixedSizeCacheTest.groovy
@@ -321,7 +321,7 @@ class FixedSizeCacheTest extends DDSpecification {
     }
 
     @Override
-    String apply(TKeyB key, int m, int n) {
+    String apply(TKeyB key, int hash, int m, int n) {
       count.incrementAndGet()
       return "${key.string}_${m}_${n}"
     }

--- a/internal-api/src/test/groovy/datadog/trace/api/sampling/SamplingMechanismTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/sampling/SamplingMechanismTest.groovy
@@ -11,53 +11,59 @@ class SamplingMechanismTest extends Specification {
     validateWithSamplingPriority(mechanism, priority) == valid
 
     where:
-    mechanism        | priority     | valid
-    UNKNOWN          | UNSET        | true
-    UNKNOWN          | SAMPLER_DROP | true
-    UNKNOWN          | SAMPLER_KEEP | true
-    UNKNOWN          | USER_DROP    | true
-    UNKNOWN          | USER_KEEP    | true
+    mechanism         | priority     | valid
+    UNKNOWN           | UNSET        | true
+    UNKNOWN           | SAMPLER_DROP | true
+    UNKNOWN           | SAMPLER_KEEP | true
+    UNKNOWN           | USER_DROP    | true
+    UNKNOWN           | USER_KEEP    | true
 
-    DEFAULT          | UNSET        | false
-    DEFAULT          | SAMPLER_DROP | true
-    DEFAULT          | SAMPLER_KEEP | true
-    DEFAULT          | USER_DROP    | false
-    DEFAULT          | USER_KEEP    | false
+    DEFAULT           | UNSET        | false
+    DEFAULT           | SAMPLER_DROP | true
+    DEFAULT           | SAMPLER_KEEP | true
+    DEFAULT           | USER_DROP    | false
+    DEFAULT           | USER_KEEP    | false
 
-    AGENT_RATE       | UNSET        | false
-    AGENT_RATE       | SAMPLER_DROP | true
-    AGENT_RATE       | SAMPLER_KEEP | true
-    AGENT_RATE       | USER_DROP    | false
-    AGENT_RATE       | USER_KEEP    | false
+    AGENT_RATE        | UNSET        | false
+    AGENT_RATE        | SAMPLER_DROP | true
+    AGENT_RATE        | SAMPLER_KEEP | true
+    AGENT_RATE        | USER_DROP    | false
+    AGENT_RATE        | USER_KEEP    | false
 
-    REMOTE_AUTO_RATE | UNSET        | false
-    REMOTE_AUTO_RATE | SAMPLER_DROP | true
-    REMOTE_AUTO_RATE | SAMPLER_KEEP | true
-    REMOTE_AUTO_RATE | USER_DROP    | false
-    REMOTE_AUTO_RATE | USER_KEEP    | false
+    REMOTE_AUTO_RATE  | UNSET        | false
+    REMOTE_AUTO_RATE  | SAMPLER_DROP | true
+    REMOTE_AUTO_RATE  | SAMPLER_KEEP | true
+    REMOTE_AUTO_RATE  | USER_DROP    | false
+    REMOTE_AUTO_RATE  | USER_KEEP    | false
 
-    RULE             | UNSET        | false
-    RULE             | SAMPLER_DROP | false
-    RULE             | SAMPLER_KEEP | false
-    RULE             | USER_DROP    | true
-    RULE             | USER_KEEP    | true
+    RULE              | UNSET        | false
+    RULE              | SAMPLER_DROP | false
+    RULE              | SAMPLER_KEEP | false
+    RULE              | USER_DROP    | true
+    RULE              | USER_KEEP    | true
 
-    MANUAL           | UNSET        | false
-    MANUAL           | SAMPLER_DROP | false
-    MANUAL           | SAMPLER_KEEP | false
-    MANUAL           | USER_DROP    | true
-    MANUAL           | USER_KEEP    | true
+    MANUAL            | UNSET        | false
+    MANUAL            | SAMPLER_DROP | false
+    MANUAL            | SAMPLER_KEEP | false
+    MANUAL            | USER_DROP    | true
+    MANUAL            | USER_KEEP    | true
 
-    REMOTE_USER_RATE | UNSET        | false
-    REMOTE_USER_RATE | SAMPLER_DROP | false
-    REMOTE_USER_RATE | SAMPLER_KEEP | false
-    REMOTE_USER_RATE | USER_DROP    | true
-    REMOTE_USER_RATE | USER_KEEP    | true
+    REMOTE_USER_RATE  | UNSET        | false
+    REMOTE_USER_RATE  | SAMPLER_DROP | false
+    REMOTE_USER_RATE  | SAMPLER_KEEP | false
+    REMOTE_USER_RATE  | USER_DROP    | true
+    REMOTE_USER_RATE  | USER_KEEP    | true
 
-    APPSEC           | UNSET        | false
-    APPSEC           | SAMPLER_DROP | false
-    APPSEC           | SAMPLER_KEEP | false
-    APPSEC           | USER_DROP    | false
-    APPSEC           | USER_KEEP    | true
+    APPSEC            | UNSET        | false
+    APPSEC            | SAMPLER_DROP | false
+    APPSEC            | SAMPLER_KEEP | false
+    APPSEC            | USER_DROP    | false
+    APPSEC            | USER_KEEP    | true
+
+    EXTERNAL_OVERRIDE | UNSET        | false
+    EXTERNAL_OVERRIDE | SAMPLER_DROP | false
+    EXTERNAL_OVERRIDE | SAMPLER_KEEP | false
+    EXTERNAL_OVERRIDE | USER_DROP    | false
+    EXTERNAL_OVERRIDE | USER_KEEP    | false
   }
 }


### PR DESCRIPTION
# What Does This Do

Implementation of W3C trace context extractor and injector that tries to be as lazy as possible when parsing the `tracestate` header to avoid request overhead for parts that are not used by the Datadog tracer.

# Motivation

Enable better compatibility with other tracers supporting the W3C trace context standard.

# Additional Notes

This PR tries to separate the changes into multiple commits to make review simpler. They are not the most logical, but hopefully better than a single commit.