### PR TITLE
naming schema: synapse server

### DIFF
--- a/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerDecorator.java
+++ b/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerDecorator.java
@@ -19,12 +19,11 @@ import org.apache.http.nio.NHttpConnection;
 
 public final class SynapseServerDecorator
     extends HttpServerDecorator<HttpRequest, NHttpConnection, HttpResponse, HttpRequest> {
-  public static final SynapseServerDecorator DECORATE = new SynapseServerDecorator();
-
-  public static final CharSequence SYNAPSE_REQUEST = UTF8BytesString.create("synapse.request");
-  public static final CharSequence LEGACY_SYNAPSE_REQUEST = UTF8BytesString.create("http.request");
   public static final CharSequence SYNAPSE_SERVER = UTF8BytesString.create("synapse-server");
-
+  public static final SynapseServerDecorator DECORATE = new SynapseServerDecorator();
+  private static final CharSequence SYNAPSE_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
+  private static final CharSequence LEGACY_SYNAPSE_REQUEST = UTF8BytesString.create("http.request");
   public static final String SYNAPSE_SPAN_KEY = "dd.trace.synapse.span";
   public static final String SYNAPSE_CONTINUATION_KEY = "dd.trace.synapse.continuation";
 

--- a/dd-java-agent/instrumentation/synapse-3/src/test/groovy/datadog/trace/instrumentation/synapse3/SynapseTest.groovy
+++ b/dd-java-agent/instrumentation/synapse-3/src/test/groovy/datadog/trace/instrumentation/synapse3/SynapseTest.groovy
@@ -94,6 +94,8 @@ abstract class SynapseTest extends VersionedNamingTestBase {
     return address.getPort()
   }
 
+  abstract String expectedServerOperation()
+
   def cleanupSpec() {
     server.shutdown()
 
@@ -230,7 +232,7 @@ abstract class SynapseTest extends VersionedNamingTestBase {
   def serverSpan(TraceAssert trace, int index, String method, int statusCode, String query = null, Object parentSpan = null, boolean distributedRootSpan = false, boolean legacyOperationName = false) {
     trace.span {
       serviceName expectedServiceName()
-      operationName legacyOperationName ? "http.request" : "synapse.request"
+      operationName legacyOperationName ? "http.request" : expectedServerOperation()
       resourceName "${method} /services/SimpleStockQuoteService"
       spanType DDSpanTypes.HTTP_SERVER
       errored statusCode >= 500
@@ -259,7 +261,7 @@ abstract class SynapseTest extends VersionedNamingTestBase {
   def proxySpan(TraceAssert trace, int index, String method, int statusCode, Object parentSpan = null) {
     trace.span {
       serviceName expectedServiceName()
-      operationName "synapse.request"
+      operationName expectedServerOperation()
       resourceName "${method} /services/StockQuoteProxy"
       spanType DDSpanTypes.HTTP_SERVER
       errored statusCode >= 500
@@ -311,8 +313,17 @@ abstract class SynapseTest extends VersionedNamingTestBase {
 
 class SynapseV0ForkedTest extends SynapseTest implements TestingGenericHttpNamingConventions.ClientV0 {
 
+
+  @Override
+  String expectedServerOperation() {
+    return "synapse.request"
+  }
 }
 
 class SynapseV1ForkedTest extends SynapseTest implements TestingGenericHttpNamingConventions.ClientV1 {
 
+  @Override
+  String expectedServerOperation() {
+    return "http.server.request"
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/ServerNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/ServerNamingV0.java
@@ -34,6 +34,9 @@ public class ServerNamingV0 implements NamingSchema.ForServer {
       case "restlet-http-server":
         prefix = "restlet-http";
         break;
+      case "synapse-server":
+        prefix = "synapse";
+        break;
       default:
         prefix = "servlet";
         break;


### PR DESCRIPTION
# What Does This Do

v1 naming changes for  synapse server:
* operation: `http.server.request`

# Motivation

# Additional Notes
