### PR TITLE
Support fixed-sized weak-key caches

### DIFF
--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -87,6 +87,7 @@ excludedClassesCoverage += [
   "datadog.trace.api.InstrumenterConfig",
   // can't reliably force same identity hash for different instance to cover branch
   "datadog.trace.api.cache.FixedSizeCache.IdentityHash",
+  "datadog.trace.api.cache.FixedSizeWeakKeyCache",
   // Interface with default method
   "datadog.trace.api.StatsDClientManager",
   // a stub

--- a/internal-api/src/main/java/datadog/trace/api/cache/DDCaches.java
+++ b/internal-api/src/main/java/datadog/trace/api/cache/DDCaches.java
@@ -40,6 +40,16 @@ public final class DDCaches {
   }
 
   /**
+   * Specialized fixed-size cache whose keys are weakly referenced. Uses {@link
+   * System#identityHashCode} for key hashing and equality.
+   *
+   * @see #newFixedSizeCache(int)
+   */
+  public static <K, V> DDCache<K, V> newFixedSizeWeakKeyCache(final int capacity) {
+    return new FixedSizeWeakKeyCache<>(capacity);
+  }
+
+  /**
    * Creates a memoization of an association. Useful for creating an association between an
    * implicitly bounded set of keys and values, where the nature of the keys prevents unbounded
    * space usage.

--- a/internal-api/src/main/java/datadog/trace/api/cache/FixedSizeWeakKeyCache.java
+++ b/internal-api/src/main/java/datadog/trace/api/cache/FixedSizeWeakKeyCache.java
@@ -1,0 +1,115 @@
+package datadog.trace.api.cache;
+
+import static datadog.trace.api.cache.FixedSizeCache.calculateSize;
+import static datadog.trace.api.cache.FixedSizeCache.rehash;
+
+import java.lang.ref.WeakReference;
+import java.util.Arrays;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+
+/**
+ * This is a fixed size cache that only has one operation <code>computeIfAbsent</code>, that is used
+ * to retrieve, or store and compute the cached value. Keys are weakly referenced and the cache uses
+ * {@link System#identityHashCode} for key hashing and equality.
+ *
+ * <p>If there is a hash collision, the cache uses double hashing two more times to try to find a
+ * match or an unused slot. Slots whose keys have been garbage collected are considered unused.
+ *
+ * <p>The cache is thread safe, and assumes that the <code>Producer</code> passed into <code>
+ * computeIfAbsent</code> is idempotent, or otherwise you might not get back the value you expect
+ * from a cache lookup.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+final class FixedSizeWeakKeyCache<K, V> implements DDCache<K, V> {
+
+  private final int mask;
+  // This is a cache, so there is no need for volatile, atomics or synchronized.
+  // All race conditions here are benign since you always read or write a full
+  // Element that can not be modified, and eventually other threads will see it
+  // or write the same information at that position, or other information in the
+  // case of a collision.
+  private final WeakPair<K, V>[] elements;
+
+  /**
+   * Creates a <code>FixedSizeWeakKeyCache</code> that can hold up to <code>capacity</code>
+   * elements, if the key hash function has perfect spread.
+   *
+   * @param capacity the maximum number of elements that the cache can hold
+   */
+  @SuppressWarnings("unchecked")
+  FixedSizeWeakKeyCache(int capacity) {
+    int size = calculateSize(capacity);
+    this.elements = new WeakPair[size];
+    this.mask = size - 1;
+  }
+
+  /**
+   * Look up or create and store a value in the cache.
+   *
+   * <p>If there is a hash collision, the method uses double hashing two more times to try to find a
+   * match or an unused slot. If there is no match or empty slot, the first slot is overwritten.
+   *
+   * @param key the key to look up
+   * @param producer how to create a cached value base on the key if the lookup fails
+   * @return the cached or created and stored value
+   */
+  @Override
+  public final V computeIfAbsent(K key, Function<K, ? extends V> producer) {
+    if (key == null) {
+      return null;
+    }
+
+    int hash = System.identityHashCode(key);
+
+    int h = hash;
+    int firstPos = h & mask;
+    V value;
+
+    // try to find a slot or a match 3 times
+    for (int i = 1; true; i++) {
+      int pos = h & mask;
+      WeakPair<K, V> current = elements[pos];
+      if (current == null || null == current.get()) {
+        // we found an empty slot, so store the value there
+        value = produceAndStoreValue(producer, hash, key, pos);
+        break;
+      } else if (hash == current.hash && key.equals(current.get())) {
+        // we found a cached key, so use that value
+        value = current.value;
+        break;
+      } else if (i == 3) {
+        // all 3 slots have been taken, so overwrite the first one
+        value = produceAndStoreValue(producer, hash, key, firstPos);
+        break;
+      }
+      // slot was occupied by someone else, so try another slot
+      h = rehash(h);
+    }
+    return value;
+  }
+
+  @Override
+  public void clear() {
+    Arrays.fill(elements, null);
+  }
+
+  private V produceAndStoreValue(Function<K, ? extends V> producer, int hash, K key, int pos) {
+    V value = producer.apply(key);
+    elements[pos] = new WeakPair<>(key, hash, value);
+    return value;
+  }
+
+  static final class WeakPair<K, V> extends WeakReference<K> {
+    final int hash;
+    final V value;
+
+    WeakPair(K key, int hash, @Nullable V value) {
+      super(key);
+      this.hash = hash;
+      this.value = value;
+    }
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/cache/FixedSizeCacheTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/cache/FixedSizeCacheTest.groovy
@@ -2,9 +2,11 @@ package datadog.trace.api.cache
 
 
 import datadog.trace.test.util.DDSpecification
+import datadog.trace.test.util.GCUtils
 import spock.lang.Shared
 import spock.util.concurrent.AsyncConditions
 
+import java.lang.ref.WeakReference
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.atomic.AtomicInteger
@@ -119,6 +121,46 @@ class FixedSizeCacheTest extends DDSpecification {
     new TKey(1, 1, "1")       | "1_value"      | 2     // create new value for key with different identity
     new TKey(6, 6, "6")       | "6_value"      | 2     // create new value for new key
     null                      | null           | 1     // do nothing
+  }
+
+  def "weak key cache should store and retrieve values"() {
+    setup:
+    def fsCache = DDCaches.newFixedSizeWeakKeyCache(15)
+    def creationCount = new AtomicInteger(0)
+    def tvc = new TVC(creationCount)
+    fsCache.computeIfAbsent(id1, tvc)
+
+    // (only use one key because we can't control the identity hash: more keys might overwrite
+    // an earlier slot if rehashing cycles to the same slots, breaking test assumption that all
+    // the initial keys are allocated to distinct slots)
+
+    expect:
+    fsCache.computeIfAbsent(tk, tvc) == value
+    creationCount.get() == count
+
+    where:
+    tk                        | value          | count
+    id1                       | "one_value"    | 1     // used the cached id1
+    new TKey(1, 1, "1")       | "1_value"      | 2     // create new value for key with different identity
+    new TKey(6, 6, "6")       | "6_value"      | 2     // create new value for new key
+    null                      | null           | 1     // do nothing
+  }
+
+  def "weak key cache does not hold onto key"() {
+    setup:
+    def fsCache = DDCaches.newFixedSizeWeakKeyCache(15)
+    def testHolder = [new Object()]
+    def testRef = new WeakReference(testHolder[0])
+    fsCache.computeIfAbsent(testHolder[0], { "oldValue" })
+
+    expect:
+    "oldValue" == fsCache.computeIfAbsent(testHolder[0], { "newValue" })
+
+    when:
+    testHolder[0] = null
+
+    then:
+    GCUtils.awaitGC(testRef)
   }
 
   def "chm cache should store and retrieve values"() {


### PR DESCRIPTION
# What Does This Do

Adds a new fixed-size `DDCache` implementation where the keys are weakly referenced.

Cache slots whose keys have been GC'd are considered unused when adding new entries.

# Motivation

Provide a smaller alternative to the current `WeakCache` implementation, which is based on `ConcurrentLinkedHashMap` wrapped with  `WeakConcurrentMap`. The map implementation has a large upfront memory cost, even for small caches.

For example, here are the bytes retained by each implementation for a small weak cache:

(The "retained bytes" were calculated by capturing a heap dump and running a heap analysis tool against it. The test class caches the same value under different key instances, and uses the same set of key instances for each implementation. So the retained bytes should approximate the internal overhead of each implementation.)

### WeakCache, capacity=64

| Elements  |  Bytes (retained)  |
| ---------- | ----------------- |
|               0  |                 21,648  |
|               8  |                 22,752  |
|             16  |                  23,712  |
|             32  |                 25,760  |
|             64  |                29,856  |

### FixedSizeWeakKeyCache, capacity=64

| Elements  |  Bytes (retained)  |
| ---------- | ----------------- |
|               0  |                      296  |
|               8  |                      616  |
|             16  |                      936  |
|             32  |                   1,576  |
|             64  |                   2,416  |

For larger caches the fixed-size implementation has a larger upfront cost, but this is still below the map implementation's upfront cost for capacities up to 4096. The fixed-size upfront cost is only larger when the capacity goes above 4096, ie. when the table gets sized at 8192 elements.

Even then the fixed-size cache grows at a slower rate per-value, so it still ends up smaller once 128 elements are cached:

### WeakCache, capacity=8192

| Elements  |  Bytes (retained)  |
| ---------- | ----------------- |
|               0  |                 21,648  |
|             64  |                29,856  |
|           128  |                38,048  |
|           256  |                54,432  |
|        1,024  |               152,736  |
|       4,096  |              545,952  |
|        8,192  |            1,070,240  |

### FixedSizeWeakKeyCache, capacity=8192

| Elements  |  Bytes (retained)  |
| ---------- | ----------------- |
|               0  |                32,808  |
|            64  |                 35,368  |
|           128  |                 37,928  |
|          256  |                 43,048  |
|        1,024  |                 73,768  |
|       4,096  |                191,368  |
|        8,192  |               301,528  |

# Additional Notes

This PR does not replace existing `WeakCache` usage - this will be proposed in a separate PR.

Also note that `ConcurrentLinkedHashMap` +  `WeakConcurrentMap` will still be used for weak context-stores (via a different `WeakMap` API) because that requires unbounded map-like behaviour, not bounded cache behaviour.