### PR TITLE
propagate profiling context as auxiliary context in continuations

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -103,6 +103,8 @@ public final class DatadogProfiler {
 
   private final List<String> orderedContextAttributes;
 
+  private final DatadogProfilerContext emptySnapshot = new DatadogProfilerContext(new int[0]);
+
   private DatadogProfiler() throws UnsupportedEnvironmentException {
     this(ConfigProvider.getInstance());
   }
@@ -394,5 +396,12 @@ public final class DatadogProfiler {
       return contextSetter.encode(constant.toString());
     }
     return 0;
+  }
+
+  public DatadogProfilerContext snapshot() {
+    if (orderedContextAttributes.isEmpty()) {
+      return emptySnapshot;
+    }
+    return new DatadogProfilerContext(contextSetter.snapshotTags());
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerContext.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerContext.java
@@ -1,0 +1,28 @@
+package com.datadog.profiling.ddprof;
+
+import static com.datadog.profiling.ddprof.DatadogProfilingIntegration.DDPROF;
+
+import datadog.trace.bootstrap.instrumentation.api.ContinuableContext;
+
+public class DatadogProfilerContext implements ContinuableContext {
+
+  final int[] tags;
+
+  public DatadogProfilerContext(int[] tags) {
+    this.tags = tags;
+  }
+
+  @Override
+  public void activate() {
+    for (int i = 0; i < tags.length; i++) {
+      DDPROF.setContextValue(i, tags[i]);
+    }
+  }
+
+  @Override
+  public void deactivate() {
+    for (int i = 0; i < tags.length; i++) {
+      DDPROF.clearContextValue(i);
+    }
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilingIntegration.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilingIntegration.java
@@ -1,5 +1,6 @@
 package com.datadog.profiling.ddprof;
 
+import datadog.trace.bootstrap.instrumentation.api.ContinuableContext;
 import datadog.trace.bootstrap.instrumentation.api.ProfilerContext;
 import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration;
 
@@ -9,7 +10,7 @@ import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration;
  */
 public class DatadogProfilingIntegration implements ProfilingContextIntegration {
 
-  private static final DatadogProfiler DDPROF = DatadogProfiler.getInstance();
+  static final DatadogProfiler DDPROF = DatadogProfiler.getInstance();
   private static final int SPAN_NAME_INDEX = DDPROF.operationNameOffset();
   private static final boolean WALLCLOCK_ENABLED =
       DatadogProfilerConfig.isWallClockProfilerEnabled();
@@ -51,6 +52,11 @@ public class DatadogProfilingIntegration implements ProfilingContextIntegration 
   @Override
   public void setContext(long rootSpanId, long spanId) {
     DDPROF.setSpanContext(spanId, rootSpanId);
+  }
+
+  @Override
+  public ContinuableContext snapshot() {
+    return DDPROF.snapshot();
   }
 
   @Override

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/test/java/com/datadog/profiling/ddprof/DatadogProfilerTest.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/test/java/com/datadog/profiling/ddprof/DatadogProfilerTest.java
@@ -1,5 +1,6 @@
 package com.datadog.profiling.ddprof;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -110,8 +111,14 @@ class DatadogProfilerTest {
             configProvider(true, true, true, true), new HashSet<>(Arrays.asList("foo", "bar")));
     assertTrue(profiler.setContextValue("foo", "abc"));
     assertTrue(profiler.setContextValue("bar", "abc"));
+    DatadogProfilerContext context = profiler.snapshot();
+    assertEquals(profiler.encode("abc"), context.tags[profiler.offsetOf("foo")]);
+    assertEquals(profiler.encode("abc"), context.tags[profiler.offsetOf("bar")]);
     assertTrue(profiler.setContextValue("foo", "xyz"));
     assertFalse(profiler.setContextValue("xyz", "foo"));
+    context = profiler.snapshot();
+    assertEquals(profiler.encode("xyz"), context.tags[profiler.offsetOf("foo")]);
+    assertEquals(profiler.encode("abc"), context.tags[profiler.offsetOf("bar")]);
   }
 
   private static ConfigProvider configProvider(

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/AbstractContinuation.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/AbstractContinuation.java
@@ -3,6 +3,7 @@ package datadog.trace.core.scopemanager;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTrace;
+import datadog.trace.bootstrap.instrumentation.api.ContinuableContext;
 
 /**
  * This class must not be a nested class of ContinuableScope to avoid an unconstrained chain of
@@ -14,13 +15,18 @@ abstract class AbstractContinuation implements AgentScope.Continuation {
   final AgentSpan spanUnderScope;
   final byte source;
   final AgentTrace trace;
+  final ContinuableContext auxiliaryContext;
 
   public AbstractContinuation(
-      ContinuableScopeManager scopeManager, AgentSpan spanUnderScope, byte source) {
+      ContinuableScopeManager scopeManager,
+      AgentSpan spanUnderScope,
+      byte source,
+      ContinuableContext auxiliaryContext) {
     this.scopeManager = scopeManager;
     this.spanUnderScope = spanUnderScope;
     this.source = source;
     this.trace = spanUnderScope.context().getTrace();
+    this.auxiliaryContext = auxiliaryContext;
   }
 
   AbstractContinuation register() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ConcurrentContinuation.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ConcurrentContinuation.java
@@ -2,6 +2,7 @@ package datadog.trace.core.scopemanager;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.ContinuableContext;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 /**
@@ -23,8 +24,11 @@ final class ConcurrentContinuation extends AbstractContinuation {
       AtomicIntegerFieldUpdater.newUpdater(ConcurrentContinuation.class, "count");
 
   public ConcurrentContinuation(
-      ContinuableScopeManager scopeManager, AgentSpan spanUnderScope, byte source) {
-    super(scopeManager, spanUnderScope, source);
+      ContinuableScopeManager scopeManager,
+      AgentSpan spanUnderScope,
+      byte source,
+      ContinuableContext profilingContext) {
+    super(scopeManager, spanUnderScope, source, profilingContext);
   }
 
   private boolean tryActivate() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
@@ -5,6 +5,7 @@ import datadog.trace.api.scopemanager.ScopeListener;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AttachableWrapper;
+import datadog.trace.bootstrap.instrumentation.api.ContinuableContext;
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import javax.annotation.Nonnull;
@@ -34,6 +35,10 @@ class ContinuableScope implements AgentScope, AttachableWrapper {
     this.span = span;
     this.flags = source;
     this.isAsyncPropagating = isAsyncPropagating;
+  }
+
+  public ContinuableContext auxiliaryContext() {
+    return null;
   }
 
   @Override
@@ -130,7 +135,9 @@ class ContinuableScope implements AgentScope, AttachableWrapper {
   @Override
   public final AbstractContinuation capture() {
     return isAsyncPropagating
-        ? new SingleContinuation(scopeManager, span, source()).register()
+        ? new SingleContinuation(
+                scopeManager, span, source(), scopeManager.captureAuxiliaryContext())
+            .register()
         : null;
   }
 
@@ -142,7 +149,9 @@ class ContinuableScope implements AgentScope, AttachableWrapper {
   @Override
   public final AbstractContinuation captureConcurrent() {
     return isAsyncPropagating
-        ? new ConcurrentContinuation(scopeManager, span, source()).register()
+        ? new ConcurrentContinuation(
+                scopeManager, span, source(), scopeManager.captureAuxiliaryContext())
+            .register()
         : null;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuingScope.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuingScope.java
@@ -1,6 +1,7 @@
 package datadog.trace.core.scopemanager;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.ContinuableContext;
 
 final class ContinuingScope extends ContinuableScope {
   /** Continuation that created this scope. */
@@ -14,6 +15,11 @@ final class ContinuingScope extends ContinuableScope {
       final AbstractContinuation continuation) {
     super(scopeManager, span, source, isAsyncPropagating);
     this.continuation = continuation;
+  }
+
+  @Override
+  public ContinuableContext auxiliaryContext() {
+    return continuation.auxiliaryContext;
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/SingleContinuation.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/SingleContinuation.java
@@ -2,6 +2,7 @@ package datadog.trace.core.scopemanager;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.ContinuableContext;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 /**
@@ -16,8 +17,9 @@ final class SingleContinuation extends AbstractContinuation {
   SingleContinuation(
       final ContinuableScopeManager scopeManager,
       final AgentSpan spanUnderScope,
-      final byte source) {
-    super(scopeManager, spanUnderScope, source);
+      final byte source,
+      final ContinuableContext profilingContext) {
+    super(scopeManager, spanUnderScope, source, profilingContext);
   }
 
   @Override

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeAndContinuationLayoutTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeAndContinuationLayoutTest.groovy
@@ -14,11 +14,11 @@ class ScopeAndContinuationLayoutTest extends DDSpecification {
   }
 
   def "single continuation layout"() {
-    expect: layoutAcceptable(SingleContinuation, 32)
+    expect: layoutAcceptable(SingleContinuation, 40)
   }
 
   def "concurrent continuation layout"() {
-    expect: layoutAcceptable(ConcurrentContinuation, 32)
+    expect: layoutAcceptable(ConcurrentContinuation, 40)
   }
 
   def layoutAcceptable(Class<?> klass, int acceptableSize) {

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -93,6 +93,7 @@ excludedClassesCoverage += [
   // a stub
   "datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration",
   "datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration.NoOp",
+  "datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration.NoOpSnapshot"
 ]
 
 excludedClassesBranchCoverage = [

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ContinuableContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ContinuableContext.java
@@ -1,0 +1,7 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+public interface ContinuableContext {
+  void activate();
+
+  void deactivate();
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ProfilingContextIntegration.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ProfilingContextIntegration.java
@@ -23,6 +23,10 @@ public interface ProfilingContextIntegration extends ProfilingContext {
     return 0;
   }
 
+  default ContinuableContext snapshot() {
+    return NoOpSnapshot.INSTANCE;
+  }
+
   final class NoOp implements ProfilingContextIntegration {
 
     public static final ProfilingContextIntegration INSTANCE =
@@ -56,5 +60,13 @@ public interface ProfilingContextIntegration extends ProfilingContext {
 
     @Override
     public void recordQueueingTime(long duration) {}
+  }
+
+  public static final class NoOpSnapshot implements ContinuableContext {
+    public static final ContinuableContext INSTANCE = new NoOpSnapshot();
+
+    public void activate() {}
+
+    public void deactivate() {}
   }
 }


### PR DESCRIPTION
# What Does This Do

This allows profiling context to get carried along with span context if a span is active when a context switch happens, by snapshotting the tags in our native side table and attaching them to the continuation. This snapshot is modelled as a `ContinuableContext` which can be activated and deactivated, and I have structured the changes to the `ContinuableScopeManager` and `Continuation` classes to allow this to be something more generic than a snapshot of profiling context in the future, so that any context source could be snapshotted and attached to a continuation as auxiliary context.

The aim here is to make profiling context work alongside tracing, and propagating when there is no active span is currently a non-goal because it would require either a much more generic context propagation mechanism or a sibling implementation which operates independently of the tracing scope manager. 

# Motivation

# Additional Notes
