### PR TITLE
Parallelized test jobs in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ system_test_matrix: &system_test_matrix
 agent_integration_tests_modules: &agent_integration_tests_modules "dd-trace-core|communication|internal-api|utils"
 core_modules: &core_modules "dd-java-agent|dd-trace-core|communication|internal-api|telemetry|utils|dd-java-agent/agent-bootstrap|dd-java-agent/agent-installer|dd-java-agent/agent-tooling|dd-java-agent/agent-builder|dd-java-agent/appsec|dd-java-agent/agent-crashtracking"
 instrumentation_modules: &instrumentation_modules "dd-java-agent/instrumentation|dd-java-agent/agent-tooling|dd-java-agent/agent-installer|dd-java-agent/agent-builder|dd-java-agent/agent-bootstrap|dd-java-agent/appsec|dd-java-agent/testing|dd-trace-core|dd-trace-api|internal-api"
-iast_modules: &iast_modules "dd-java-agent/agent-iast|internal-api|utils/test-utils"
 debugger_modules: &debugger_modules "dd-java-agent/agent-debugger|dd-java-agent/agent-bootstrap|dd-java-agent/agent-builder|internal-api|communication|dd-trace-core"
 profiling_modules: &profiling_modules "dd-java-agent/agent-profiling"
 
@@ -95,7 +94,7 @@ commands:
           version: 20.10.18
           # DLC shares Docker layers across jobs (at an extra cost).
           # But its time to setup (~1min) exceeds the time required to prefetch all images we use.
-          docker_layer_caching: true
+          docker_layer_caching: false
 
       - run:
           name: Prepare testcontainers environment
@@ -452,6 +451,9 @@ jobs:
       stage:
         type: string
         default: ""
+      parallelism:
+        type: integer
+        default: 1
       maxWorkers:
         type: integer
         default: 2
@@ -463,6 +465,8 @@ jobs:
         default: false
       cacheType:
         type: string
+
+    parallelism: << parameters.parallelism >>
 
     steps:
       - setup_code
@@ -497,6 +501,7 @@ jobs:
             ./gradlew
             << parameters.gradleTarget >>
             << parameters.gradleParameters >>
+            -PtaskPartitionCount=${CIRCLE_NODE_TOTAL} -PtaskPartition=${CIRCLE_NODE_INDEX}
             <<# parameters.testJvm >>-PtestJvm=<< parameters.testJvm >><</ parameters.testJvm >>
             << pipeline.parameters.gradle_flags >>
             --max-workers=<< parameters.maxWorkers >>
@@ -823,7 +828,7 @@ build_test_jobs: &build_test_jobs
       requires:
         - ok_to_test
 
-  - xlarge_tests:
+  - tests:
       requires:
         - ok_to_test
       name: z_test_<< matrix.testJvm >>_base
@@ -832,11 +837,12 @@ build_test_jobs: &build_test_jobs
       gradleParameters: "-PskipFlakyTests -PskipInstTests -PskipSmokeTests -PskipProfilingTests"
       stage: core
       cacheType: base
-      maxWorkers: 6
+      parallelism: 4
+      maxWorkers: 4
       matrix:
         <<: *test_matrix
 
-  - xlarge_tests:
+  - tests:
       requires:
         - ok_to_test
       name: z_test_8_base
@@ -845,7 +851,8 @@ build_test_jobs: &build_test_jobs
       gradleParameters: "-PskipFlakyTests -PskipInstTests -PskipSmokeTests -PskipProfilingTests"
       stage: core
       cacheType: base
-      maxWorkers: 6
+      parallelism: 4
+      maxWorkers: 4
       testJvm: "8"
 
   - xlarge_tests:
@@ -857,7 +864,8 @@ build_test_jobs: &build_test_jobs
       triggeredBy: *instrumentation_modules
       stage: instrumentation
       cacheType: inst
-      maxWorkers: 8
+      parallelism: 4
+      maxWorkers: 4
       matrix:
         <<: *test_matrix
 
@@ -870,7 +878,8 @@ build_test_jobs: &build_test_jobs
       triggeredBy: *instrumentation_modules
       stage: instrumentation
       cacheType: inst
-      maxWorkers: 8
+      parallelism: 4
+      maxWorkers: 4
       testJvm: "8"
 
   - xlarge_tests:
@@ -883,10 +892,11 @@ build_test_jobs: &build_test_jobs
       triggeredBy: *instrumentation_modules
       stage: instrumentation
       cacheType: latestdep
-      maxWorkers: 8
+      parallelism: 4
+      maxWorkers: 4
       testJvm: "8"
 
-  - huge_tests:
+  - tests:
       requires:
         - ok_to_test
       name: z_test_8_flaky_base
@@ -896,10 +906,11 @@ build_test_jobs: &build_test_jobs
       triggeredBy: *core_modules
       stage: core
       cacheType: base
+      parallelism: 4
       maxWorkers: 4
       testJvm: "8"
 
-  - tests:
+  - xlarge_tests:
       requires:
         - ok_to_test
       name: z_test_8_flaky_inst
@@ -909,6 +920,7 @@ build_test_jobs: &build_test_jobs
       triggeredBy: *instrumentation_modules
       stage: instrumentation
       cacheType: inst
+      parallelism: 2
       maxWorkers: 4
       testJvm: "8"
 
@@ -921,6 +933,7 @@ build_test_jobs: &build_test_jobs
       continueOnFailure: true
       stage: smoke
       cacheType: smoke
+      parallelism: 4
       maxWorkers: 4
       testJvm: "8"
 
@@ -940,19 +953,6 @@ build_test_jobs: &build_test_jobs
   - tests:
       requires:
         - ok_to_test
-      maxWorkers: 4
-      name: test_<< matrix.testJvm >>_iast
-      gradleTarget: ":dd-java-agent:agent-iast:test"
-      gradleParameters: "-PskipFlakyTests"
-      triggeredBy: *iast_modules
-      stage: iast
-      cacheType: base
-      matrix:
-        <<: *profiling_test_matrix
-
-  - tests:
-      requires:
-        - ok_to_test
       name: test_<< matrix.testJvm >>_debugger
       maxWorkers: 4
       gradleTarget: ":debuggerTest"
@@ -963,7 +963,7 @@ build_test_jobs: &build_test_jobs
       matrix:
         <<: *profiling_test_matrix
 
-  - huge_tests:
+  - tests:
       requires:
         - ok_to_test
       name: z_test_<< matrix.testJvm >>_smoke
@@ -971,11 +971,12 @@ build_test_jobs: &build_test_jobs
       gradleParameters: "-PskipFlakyTests"
       stage: smoke
       cacheType: smoke
-      maxWorkers: 8
+      parallelism: 4
+      maxWorkers: 3
       matrix:
         <<: *test_matrix
 
-  - huge_tests:
+  - tests:
       requires:
         - ok_to_test
       name: test_semeru11_smoke
@@ -983,10 +984,11 @@ build_test_jobs: &build_test_jobs
       gradleParameters: "-PskipFlakyTests"
       stage: smoke
       cacheType: smoke
-      maxWorkers: 8
+      parallelism: 4
+      maxWorkers: 3
       testJvm: "semeru11"
 
-  - huge_tests:
+  - tests:
       requires:
         - ok_to_test
       name: test_semeru17_smoke
@@ -994,10 +996,11 @@ build_test_jobs: &build_test_jobs
       gradleParameters: "-PskipFlakyTests"
       stage: smoke
       cacheType: smoke
-      maxWorkers: 8
+      parallelism: 4
+      maxWorkers: 3
       testJvm: "semeru17"
 
-  - xlarge_tests:
+  - tests:
       requires:
         - ok_to_test
       name: test_graalvm11_smoke
@@ -1006,7 +1009,7 @@ build_test_jobs: &build_test_jobs
       cacheType: smoke
       testJvm: "graalvm11"
 
-  - xlarge_tests:
+  - tests:
       requires:
         - ok_to_test
       name: test_graalvm17_smoke
@@ -1016,7 +1019,7 @@ build_test_jobs: &build_test_jobs
       testJvm: "graalvm17"
 
 
-  - huge_tests:
+  - tests:
       requires:
         - ok_to_test
       name: z_test_8_smoke
@@ -1024,7 +1027,8 @@ build_test_jobs: &build_test_jobs
       gradleParameters: "-PskipFlakyTests"
       stage: smoke
       cacheType: smoke
-      maxWorkers: 8
+      parallelism: 4
+      maxWorkers: 3
       testJvm: "8"
 
   - fan_in:
@@ -1102,18 +1106,6 @@ build_test_jobs: &build_test_jobs
       name: debugger
       stage: debugger
 
-  - fan_in:
-      requires:
-        - test_published_artifacts
-        - test_8_iast
-        - test_oracle8_iast
-        - test_zulu8_iast
-        - test_zulu11_iast
-        - test_11_iast
-        - test_17_iast
-      name: iast
-      stage: iast
-
   # This job requires all the jobs needed for a successful build, so GitHub only needs to enforce this one,
   # and it will be simpler to require different JVM versions for different branches and old releases
   - fan_in:
@@ -1129,7 +1121,6 @@ build_test_jobs: &build_test_jobs
         - test_semeru17_smoke
         - test_zulu8
         - profiling
-        - iast
         - debugger
       name: required
       stage: required

--- a/build.gradle
+++ b/build.gradle
@@ -148,11 +148,25 @@ allprojects {
   }
 }
 
+allprojects { project ->
+  project.ext {
+    activePartition = true
+  }
+  final boolean shouldUseTaskPartitions = project.rootProject.hasProperty("taskPartitionCount") && project.rootProject.hasProperty("taskPartition")
+  if (shouldUseTaskPartitions) {
+    final int taskPartitionCount = project.rootProject.property("taskPartitionCount") as int
+    final int taskPartition = project.rootProject.property("taskPartition") as int
+    final currentTaskPartition = project.path.hashCode() % taskPartitionCount
+    project.setProperty("activePartition", currentTaskPartition == taskPartition)
+  }
+}
+
+
 def testAggregate(String taskName, includePrefixes, excludePrefixes) {
   tasks.register(taskName) { aggTest ->
     subprojects { subproject ->
-      println(subproject.path)
-      if (includePrefixes.any { subproject.path.startsWith(it) } && !excludePrefixes.any { subproject.path.startsWith(it) }) {
+      if (subproject.property("activePartition") && includePrefixes.any { subproject.path.startsWith(it) } && !excludePrefixes.any { subproject.path.startsWith(it) }) {
+        println(subproject.path)
         def testTask = subproject.tasks.findByName("test")
         if (testTask != null) {
           aggTest.dependsOn(testTask)

--- a/gradle/configure_tests.gradle
+++ b/gradle/configure_tests.gradle
@@ -83,3 +83,11 @@ project.afterEvaluate {
     }
   }
 }
+
+if (!project.property("activePartition")) {
+  project.afterEvaluate {
+    tasks.withType(Test).configureEach {
+      enabled = false
+    }
+  }
+}


### PR DESCRIPTION
# What Does This Do
Parallelized test jobs in CI:

* Use Circle CI job parallelism for tests: https://circleci.com/docs/parallelism-faster-jobs/
* Partition test tasks at gradle level using CIRCLE_NODE_TOTAL and CIRCLE_NODE_INDEX. See https://circleci.com/docs/parallelism-faster-jobs/#using-environment-variables-to-split-tests
* Adjust [resource class](https://circleci.com/product/features/resource-classes/) for test jobs: moved all to `large` (4 CPU, 8 GB), some where previously `xlarge` and `2xlarge`. Adjust number of gradle workers and parallelism accordingly.
* Disable Docker layer caching: cheaper, faster setup.
* Fold IAST jobs back to `base` tests.

# Motivation

Make pipelines faster.

# Additional Notes
* Replaces https://github.com/DataDog/dd-trace-java/pull/4694 and https://github.com/DataDog/dd-trace-java/pull/4659
* Includes https://github.com/DataDog/dd-trace-java/pull/4668