### PR TITLE
Add APM e2e tests in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -787,26 +787,25 @@ jobs:
             cd system-tests
             DD_SITE=datadoghq.com DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APPLICATION_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh APM_TRACING_E2E_SINGLE_SPAN
 
-      # Commented until we make sure it works!
-      # - run:
-      #     name: Upload data to CI Visibility
-      #     command: |
-      #       cd system-tests
-      #       export DD_API_KEY=$SYSTEM_TESTS_CI_API_KEY
-      #       export DD_APP_KEY=$SYSTEM_TESTS_CI_APP_KEY
+      - run:
+          name: Upload data to CI Visibility
+          command: |
+            cd system-tests
+            export DD_API_KEY=$SYSTEM_TESTS_CI_API_KEY
+            export DD_APP_KEY=$SYSTEM_TESTS_CI_APP_KEY
 
-      #       # Causes conflicts with DD_API_KEY and datadog-ci tool
-      #       unset DATADOG_API_KEY
+            # Causes conflicts with DD_API_KEY and datadog-ci tool
+            unset DATADOG_API_KEY
             
-      #       echo "Uploading tests results to CI Visibility"  
-      #       utils/scripts/upload_results_CI_visibility.sh dev java-tracer << pipeline.id >>-<< pipeline.number >>
+            echo "Uploading tests results to CI Visibility"  
+            utils/scripts/upload_results_CI_visibility.sh dev java-tracer << pipeline.id >>-<< pipeline.number >>-e2e
 
-      #       if [[ $CIRCLE_BRANCH == "master" ]]; then
-      #         echo "Updating dashboard from dd-trace-java main branch"
-      #         utils/scripts/update_dashboard_CI_visibility.sh java-tracer << pipeline.id >>-<< pipeline.number >>
-      #       else
-      #         echo "Skipping CI Visibility dashboard update due to it is not a main branch"
-      #       fi
+            if [[ $CIRCLE_BRANCH == "master" ]]; then
+              echo "Updating dashboard from dd-trace-java main branch"
+              utils/scripts/update_dashboard_CI_visibility.sh java-tracer << pipeline.id >>-<< pipeline.number >>-e2e
+            else
+              echo "Skipping CI Visibility dashboard update due to it is not a main branch"
+            fi
 
       - store_artifacts:
           path: system-tests/logs_apm_tracing_e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -777,9 +777,7 @@ jobs:
           no_output_timeout: 5m
           command: |
             cd system-tests
-            unset DATADOG_API_KEY
-
-            DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APPLICATION_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh APM_TRACING_E2E
+            DD_SITE=datadoghq.com DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APPLICATION_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh APM_TRACING_E2E
 
       - run:
           name: Run Single Span tests
@@ -787,9 +785,7 @@ jobs:
           no_output_timeout: 5m
           command: |
             cd system-tests
-            unset DATADOG_API_KEY
-            
-            DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APPLICATION_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh APM_TRACING_E2E_SINGLE_SPAN
+            DD_SITE=datadoghq.com DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APPLICATION_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh APM_TRACING_E2E_SINGLE_SPAN
 
       # Commented until we make sure it works!
       # - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -805,8 +805,12 @@ jobs:
       #       fi
 
       - store_artifacts:
-          path: system-tests/logs
-          destination: logs_java_<< parameters.weblog-variant >>_dev.tar.gz
+          path: system-tests/logs_apm_tracing_e2e
+          destination: logs_apm_tracing_e2e_java_<< parameters.weblog-variant >>_dev.tar.gz
+
+      - store_artifacts:
+          path: system-tests/logs_apm_tracing_e2e_single_span
+          destination: logs_apm_tracing_e2e_single_span_java_<< parameters.weblog-variant >>_dev.tar.gz
 
 build_test_jobs: &build_test_jobs
   - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,10 +17,6 @@ system_test_matrix: &system_test_matrix
   parameters:
     weblog-variant: [ 'spring-boot', 'spring-boot-jetty', 'spring-boot-openliberty', 'spring-boot-3-native', 'jersey-grizzly2', 'resteasy-netty3','ratpack', 'vertx3' ]
 
-system_test_e2e_matrix: &system_test_e2e_matrix
-  parameters:
-    weblog-variant: [ 'spring-boot' ]
-
 agent_integration_tests_modules: &agent_integration_tests_modules "dd-trace-core|communication|internal-api|utils"
 core_modules: &core_modules "dd-java-agent|dd-trace-core|communication|internal-api|telemetry|utils|dd-java-agent/agent-bootstrap|dd-java-agent/agent-installer|dd-java-agent/agent-tooling|dd-java-agent/agent-builder|dd-java-agent/appsec|dd-java-agent/agent-crashtracking"
 instrumentation_modules: &instrumentation_modules "dd-java-agent/instrumentation|dd-java-agent/agent-tooling|dd-java-agent/agent-installer|dd-java-agent/agent-builder|dd-java-agent/agent-bootstrap|dd-java-agent/appsec|dd-java-agent/testing|dd-trace-core|dd-trace-api|internal-api"
@@ -688,6 +684,22 @@ jobs:
             DD_API_KEY=$SYSTEM_TESTS_DD_API_KEY ./run.sh
 
       - run:
+          name: Run APM E2E default tests
+          # Stop the job after 5m to avoid excessive overhead. Will need adjustment as more tests are added.
+          no_output_timeout: 5m
+          command: |
+            cd system-tests
+            DD_SITE=datadoghq.com DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APPLICATION_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh APM_TRACING_E2E
+
+      - run:
+          name: Run APM E2E Single Span tests
+          # Stop the job after 5m to avoid excessive overhead. Will need adjustment as more tests are added.
+          no_output_timeout: 5m
+          command: |
+            cd system-tests
+            DD_SITE=datadoghq.com DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APPLICATION_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh APM_TRACING_E2E_SINGLE_SPAN
+
+      - run:
           name: Upload data to CI Visibility
           command: |
             cd system-tests
@@ -710,6 +722,14 @@ jobs:
       - store_artifacts:
           path: system-tests/logs
           destination: logs_java_<< parameters.weblog-variant >>_dev.tar.gz
+
+      - store_artifacts:
+          path: system-tests/logs_apm_tracing_e2e
+          destination: logs_java_apm_tracing_e2e_<< parameters.weblog-variant >>_dev.tar.gz
+
+      - store_artifacts:
+          path: system-tests/logs_apm_tracing_e2e_single_span
+          destination: logs_java_apm_tracing_e2e_single_span_<< parameters.weblog-variant >>_dev.tar.gz
 
   parametric-tests:
     machine:
@@ -747,73 +767,6 @@ jobs:
             export CLIENTS_ENABLED=java
             python --version
             ./run.sh
-
-  system-tests-e2e:
-    machine:
-      # https://support.circleci.com/hc/en-us/articles/360007324514-How-can-I-use-Docker-volume-mounting-on-CircleCI-
-      image: ubuntu-2004:current
-    resource_class: large
-    parameters:
-      weblog-variant:
-        type: string
-    steps:
-      - setup_system_tests
-
-      - run:
-          name: Copy jar file to system test binaries folder
-          command: |
-            ls -la ~/dd-trace-java/workspace/dd-java-agent/build/libs
-            cp ~/dd-trace-java/workspace/dd-java-agent/build/libs/*.jar system-tests/binaries/
-
-      - run:
-          name: Build
-          command: |
-            cd system-tests
-            ./build.sh java --weblog-variant << parameters.weblog-variant >> 
-
-      - run:
-          name: Run APM E2E default tests
-          # Stop the job after 5m to avoid excessive overhead. Will need adjustment as more tests are added.
-          no_output_timeout: 5m
-          command: |
-            cd system-tests
-            DD_SITE=datadoghq.com DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APPLICATION_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh APM_TRACING_E2E
-
-      - run:
-          name: Run APM E2E Single Span tests
-          # Stop the job after 5m to avoid excessive overhead. Will need adjustment as more tests are added.
-          no_output_timeout: 5m
-          command: |
-            cd system-tests
-            DD_SITE=datadoghq.com DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APPLICATION_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh APM_TRACING_E2E_SINGLE_SPAN
-
-      - run:
-          name: Upload data to CI Visibility
-          command: |
-            cd system-tests
-            export DD_API_KEY=$SYSTEM_TESTS_CI_API_KEY
-            export DD_APP_KEY=$SYSTEM_TESTS_CI_APP_KEY
-
-            # Causes conflicts with DD_API_KEY and datadog-ci tool
-            unset DATADOG_API_KEY
-            
-            echo "Uploading tests results to CI Visibility"  
-            utils/scripts/upload_results_CI_visibility.sh dev java-tracer << pipeline.id >>-<< pipeline.number >>-e2e
-
-            if [[ $CIRCLE_BRANCH == "master" ]]; then
-              echo "Updating dashboard from dd-trace-java main branch"
-              utils/scripts/update_dashboard_CI_visibility.sh java-tracer << pipeline.id >>-<< pipeline.number >>-e2e
-            else
-              echo "Skipping CI Visibility dashboard update due to it is not a main branch"
-            fi
-
-      - store_artifacts:
-          path: system-tests/logs_apm_tracing_e2e
-          destination: logs_apm_tracing_e2e_java_<< parameters.weblog-variant >>_dev.tar.gz
-
-      - store_artifacts:
-          path: system-tests/logs_apm_tracing_e2e_single_span
-          destination: logs_apm_tracing_e2e_single_span_java_<< parameters.weblog-variant >>_dev.tar.gz
 
 build_test_jobs: &build_test_jobs
   - build:
@@ -1112,12 +1065,6 @@ build_test_jobs: &build_test_jobs
   - parametric-tests:
       requires:
         - ok_to_test
-
-  - system-tests-e2e:
-      requires:
-        - ok_to_test
-      matrix:
-          <<: *system_test_e2e_matrix
 
   - fan_in:
       requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -773,12 +773,16 @@ jobs:
 
       - run:
           name: Run APM E2E default tests
+          # Stop the job after 5m to avoid excessive overhead. Will need adjustment as more tests are added.
+          no_output_timeout: 5m
           command: |
             cd system-tests
             DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APP_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh APM_TRACING_E2E
 
       - run:
           name: Run Single Span tests
+          # Stop the job after 5m to avoid excessive overhead. Will need adjustment as more tests are added.
+          no_output_timeout: 5m
           command: |
             cd system-tests
             DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APP_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh APM_TRACING_E2E_SINGLE_SPAN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -780,7 +780,7 @@ jobs:
             DD_SITE=datadoghq.com DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APPLICATION_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh APM_TRACING_E2E
 
       - run:
-          name: Run Single Span tests
+          name: Run APM E2E Single Span tests
           # Stop the job after 5m to avoid excessive overhead. Will need adjustment as more tests are added.
           no_output_timeout: 5m
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -777,6 +777,8 @@ jobs:
           no_output_timeout: 5m
           command: |
             cd system-tests
+            unset DATADOG_API_KEY
+
             DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APPLICATION_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh APM_TRACING_E2E
 
       - run:
@@ -785,6 +787,8 @@ jobs:
           no_output_timeout: 5m
           command: |
             cd system-tests
+            unset DATADOG_API_KEY
+            
             DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APPLICATION_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh APM_TRACING_E2E_SINGLE_SPAN
 
       # Commented until we make sure it works!

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,10 @@ system_test_matrix: &system_test_matrix
   parameters:
     weblog-variant: [ 'spring-boot', 'spring-boot-jetty', 'spring-boot-openliberty', 'spring-boot-3-native', 'jersey-grizzly2', 'resteasy-netty3','ratpack', 'vertx3' ]
 
+system_test_e2e_matrix: &system_test_e2e_matrix
+  parameters:
+    weblog-variant: [ 'spring-boot' ]
+
 agent_integration_tests_modules: &agent_integration_tests_modules "dd-trace-core|communication|internal-api|utils"
 core_modules: &core_modules "dd-java-agent|dd-trace-core|communication|internal-api|telemetry|utils|dd-java-agent/agent-bootstrap|dd-java-agent/agent-installer|dd-java-agent/agent-tooling|dd-java-agent/agent-builder|dd-java-agent/appsec|dd-java-agent/agent-crashtracking"
 instrumentation_modules: &instrumentation_modules "dd-java-agent/instrumentation|dd-java-agent/agent-tooling|dd-java-agent/agent-installer|dd-java-agent/agent-builder|dd-java-agent/agent-bootstrap|dd-java-agent/appsec|dd-java-agent/testing|dd-trace-core|dd-trace-api|internal-api"
@@ -744,6 +748,66 @@ jobs:
             python --version
             ./run.sh
 
+  system-tests-e2e:
+    machine:
+      # https://support.circleci.com/hc/en-us/articles/360007324514-How-can-I-use-Docker-volume-mounting-on-CircleCI-
+      image: ubuntu-2004:current
+    resource_class: large
+    parameters:
+      weblog-variant:
+        type: string
+    steps:
+      - setup_system_tests
+
+      - run:
+          name: Copy jar file to system test binaries folder
+          command: |
+            ls -la ~/dd-trace-java/workspace/dd-java-agent/build/libs
+            cp ~/dd-trace-java/workspace/dd-java-agent/build/libs/*.jar system-tests/binaries/
+
+      - run:
+          name: Build
+          command: |
+            cd system-tests
+            ./build.sh java --weblog-variant << parameters.weblog-variant >> 
+
+      - run:
+          name: Run APM E2E default tests
+          command: |
+            cd system-tests
+            DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APP_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh APM_TRACING_E2E
+
+      - run:
+          name: Run Single Span tests
+          command: |
+            cd system-tests
+            DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APP_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh APM_TRACING_E2E_SINGLE_SPAN
+
+      # Commented until we make sure it works!
+      # - run:
+      #     name: Upload data to CI Visibility
+      #     command: |
+      #       cd system-tests
+      #       export DD_API_KEY=$SYSTEM_TESTS_CI_API_KEY
+      #       export DD_APP_KEY=$SYSTEM_TESTS_CI_APP_KEY
+
+      #       # Causes conflicts with DD_API_KEY and datadog-ci tool
+      #       unset DATADOG_API_KEY
+            
+      #       echo "Uploading tests results to CI Visibility"  
+      #       utils/scripts/upload_results_CI_visibility.sh dev java-tracer << pipeline.id >>-<< pipeline.number >>
+
+      #       if [[ $CIRCLE_BRANCH == "master" ]]; then
+      #         echo "Updating dashboard from dd-trace-java main branch"
+      #         utils/scripts/update_dashboard_CI_visibility.sh java-tracer << pipeline.id >>-<< pipeline.number >>
+      #       else
+      #         echo "Skipping CI Visibility dashboard update due to it is not a main branch"
+      #       fi
+
+      - store_artifacts:
+          path: system-tests/logs
+          destination: logs_java_<< parameters.weblog-variant >>_dev.tar.gz
+
 build_test_jobs: &build_test_jobs
   - build:
       name: build_lib
@@ -1041,6 +1105,12 @@ build_test_jobs: &build_test_jobs
   - parametric-tests:
       requires:
         - ok_to_test
+
+  - system-tests-e2e:
+      requires:
+        - ok_to_test
+      matrix:
+          <<: *system_test_e2e_matrix
 
   - fan_in:
       requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -777,7 +777,7 @@ jobs:
           no_output_timeout: 5m
           command: |
             cd system-tests
-            DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APP_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh APM_TRACING_E2E
+            DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APPLICATION_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh APM_TRACING_E2E
 
       - run:
           name: Run Single Span tests
@@ -785,7 +785,7 @@ jobs:
           no_output_timeout: 5m
           command: |
             cd system-tests
-            DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APP_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh APM_TRACING_E2E_SINGLE_SPAN
+            DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APPLICATION_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh APM_TRACING_E2E_SINGLE_SPAN
 
       # Commented until we make sure it works!
       # - run:


### PR DESCRIPTION
# What Does This Do

This PR enables the APM end-to-end (E2E) tests for the `spring-boot` variant, in CircleCI. All other variants will still run the jobs, but are skipped (in system-tests terms they are expectedly failing).

Once we verify that this works well, we can implement the rest variants too.

- Example run for `spring-boot`: https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/22405/workflows/f98e6efd-9512-4955-82c0-ef02d0fe2668/jobs/621610
  - Check both: `Run APM E2E default tests` and `Run APM E2E Single Span tests` passing!
- Example run for `ratpack `: https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/22405/workflows/f98e6efd-9512-4955-82c0-ef02d0fe2668/jobs/621654
  - Check `Run APM E2E default tests` passing, and `Run APM E2E Single Span tests` expectedly-failing (skipping).

# Motivation

Having fully end-to-end tests, including the APM backend, will allow us to fully test features across the whole pipeline.

# Additional Notes

- More information in ATI-2419