### PR TITLE
Limit latestDep of amazon-sqs-java-messaging-lib to 2.0.x

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/build.gradle
@@ -33,5 +33,5 @@ dependencies {
   testImplementation group: 'com.amazonaws', name: 'amazon-sqs-java-messaging-lib', version: '2.0.0'
 
   latestDepTestImplementation group: 'software.amazon.awssdk', name: 'sqs', version: '+'
-  latestDepTestImplementation group: 'com.amazonaws', name: 'amazon-sqs-java-messaging-lib', version: '2.+'
+  latestDepTestImplementation group: 'com.amazonaws', name: 'amazon-sqs-java-messaging-lib', version: '2.0.+'
 }


### PR DESCRIPTION
(amazon-sqs-java-messaging-lib 2.1.x uses jakarta.jms-api and requires Java 17)