### PR TITLE
Update Groovy and Spock versions

### DIFF
--- a/communication/build.gradle
+++ b/communication/build.gradle
@@ -14,7 +14,7 @@ dependencies {
   implementation group: 'com.datadoghq', name: 'java-dogstatsd-client', version: "${versions.dogstatsd}"
 
   testImplementation project(':utils:test-utils')
-  testImplementation deps.junit4
+  testImplementation deps.junit5
   testImplementation deps.truth
   testImplementation deps.bytebuddy
   testImplementation group: 'org.msgpack', name: 'msgpack-core', version: '0.8.20'

--- a/communication/src/test/groovy/datadog/communication/http/RejectingExecutorServiceTest.groovy
+++ b/communication/src/test/groovy/datadog/communication/http/RejectingExecutorServiceTest.groovy
@@ -1,6 +1,6 @@
 package datadog.communication.http
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.RejectedExecutionException

--- a/communication/src/test/groovy/datadog/communication/http/SafeRequestBuilderTest.groovy
+++ b/communication/src/test/groovy/datadog/communication/http/SafeRequestBuilderTest.groovy
@@ -2,16 +2,17 @@ package datadog.communication.http
 
 import com.google.common.truth.Truth
 import okhttp3.Request
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 
 class SafeRequestBuilderTest {
   Request.Builder testBuilder = new Request.Builder()
+
   @Test
-  void "test adding bad header"(){
+  void "test adding bad header"() {
     def name = 'bad'
     def password = 'very-secret-password'
-    IllegalArgumentException ex = Assert.assertThrows(IllegalArgumentException, {
+    IllegalArgumentException ex = Assertions.assertThrows(IllegalArgumentException, {
       testBuilder.url("http:localhost").addHeader(name, "$password\n")
     })
     Truth.assertThat(ex).hasMessageThat().contains(name)
@@ -21,7 +22,7 @@ class SafeRequestBuilderTest {
   void "test adding bad header2"(){
     def name = '\u0019'
     def password = 'very-secret-password'
-    IllegalArgumentException ex = Assert.assertThrows(IllegalArgumentException, {
+    IllegalArgumentException ex = Assertions.assertThrows(IllegalArgumentException, {
       testBuilder.url("http:localhost").addHeader(name, "\u0080$password")
     })
     Truth.assertThat(ex).hasMessageThat().contains(name)

--- a/communication/src/test/groovy/datadog/communication/monitor/DisabledMonitoringTest.groovy
+++ b/communication/src/test/groovy/datadog/communication/monitor/DisabledMonitoringTest.groovy
@@ -1,6 +1,6 @@
 package datadog.communication.monitor
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class DisabledMonitoringTest {
   Monitoring disabledMonitoring = Monitoring.DISABLED

--- a/communication/src/test/groovy/datadog/communication/monitor/NoopCounterTest.groovy
+++ b/communication/src/test/groovy/datadog/communication/monitor/NoopCounterTest.groovy
@@ -1,6 +1,6 @@
 package datadog.communication.monitor
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class NoopCounterTest {
   Counter noopCounter = NoOpCounter.NO_OP

--- a/communication/src/test/groovy/datadog/communication/serialization/FlushingBufferTest.java
+++ b/communication/src/test/groovy/datadog/communication/serialization/FlushingBufferTest.java
@@ -1,8 +1,8 @@
 package datadog.communication.serialization;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FlushingBufferTest {
 

--- a/communication/src/test/java/datadog/communication/serialization/GrowableBufferTest.java
+++ b/communication/src/test/java/datadog/communication/serialization/GrowableBufferTest.java
@@ -1,11 +1,11 @@
 package datadog.communication.serialization;
 
 import static groovy.util.GroovyTestCase.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.ByteBuffer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GrowableBufferTest {
 

--- a/communication/src/test/java/datadog/communication/serialization/IntPackingTest.java
+++ b/communication/src/test/java/datadog/communication/serialization/IntPackingTest.java
@@ -1,28 +1,19 @@
 package datadog.communication.serialization;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import datadog.communication.serialization.msgpack.MsgPackWriter;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.ThreadLocalRandom;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.msgpack.core.MessagePack;
 import org.msgpack.core.MessageUnpacker;
 
-@RunWith(Parameterized.class)
 public class IntPackingTest {
 
-  private final long[] input;
-
-  public IntPackingTest(long[] input) {
-    this.input = input;
-  }
-
-  @Parameterized.Parameters
   public static Object[][] inputs() {
     return new Object[][] {
       {
@@ -101,8 +92,9 @@ public class IntPackingTest {
     return random;
   }
 
-  @Test
-  public void packLongs() {
+  @ParameterizedTest
+  @MethodSource("inputs")
+  public void packLongs(long[] input) {
     ByteBuffer buffer = ByteBuffer.allocate(input.length * 9 + 10);
     MessageFormatter messageFormatter =
         new MsgPackWriter(
@@ -117,15 +109,16 @@ public class IntPackingTest {
                       assertEquals(i, unpacker.unpackLong());
                     }
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(input, (x, w) -> w.writeObject(x, null));
     messageFormatter.flush();
   }
 
-  @Test
-  public void packInts() {
+  @ParameterizedTest
+  @MethodSource("inputs")
+  public void packInts(long[] input) {
     final int[] asInts = new int[input.length];
     for (int i = 0; i < input.length; ++i) {
       asInts[i] = (int) input[i];
@@ -143,7 +136,7 @@ public class IntPackingTest {
                       assertEquals(i, unpacker.unpackInt());
                     }
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
 

--- a/communication/src/test/java/datadog/communication/serialization/SmokeTest.java
+++ b/communication/src/test/java/datadog/communication/serialization/SmokeTest.java
@@ -1,7 +1,7 @@
 package datadog.communication.serialization;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import datadog.communication.serialization.msgpack.MsgPackWriter;
 import java.io.IOException;
@@ -13,8 +13,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.msgpack.core.MessagePack;
 import org.msgpack.core.MessageUnpacker;
 
@@ -99,7 +99,7 @@ public class SmokeTest {
                       }
                     }
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     packer.format(

--- a/communication/src/test/java/datadog/communication/serialization/msgpack/MsgPackWriterTest.java
+++ b/communication/src/test/java/datadog/communication/serialization/msgpack/MsgPackWriterTest.java
@@ -1,6 +1,9 @@
 package datadog.communication.serialization.msgpack;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import datadog.communication.serialization.ByteBufferConsumer;
 import datadog.communication.serialization.Codec;
@@ -19,8 +22,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.msgpack.core.MessagePack;
 import org.msgpack.core.MessageUnpacker;
 
@@ -47,11 +50,11 @@ public class MsgPackWriterTest {
             newBuffer(
                 2 + 25, // enough space for a 25 element string and its 2 byte header
                 (messageCount, buffer) -> {}));
-    assertTrue("data fits in buffer", packer.format("abcdefghijklmnopqrstuvwxy", mapper));
+    assertTrue(packer.format("abcdefghijklmnopqrstuvwxy", mapper), "data fits in buffer");
     assertFalse(
-        "data doesn't fit in finite buffer", packer.format("abcdefghijklmnopqrstuvwxyz", mapper));
+        packer.format("abcdefghijklmnopqrstuvwxyz", mapper), "data doesn't fit in finite buffer");
     assertTrue(
-        "data fits in buffer after overflow", packer.format("abcdefghijklmnopqrstuvwxy", mapper));
+        packer.format("abcdefghijklmnopqrstuvwxy", mapper), "data fits in buffer after overflow");
   }
 
   @Test
@@ -68,15 +71,15 @@ public class MsgPackWriterTest {
                     try {
                       flushed.add(unpacker.unpackString());
                     } catch (Exception error) {
-                      Assert.fail(error.getMessage());
+                      Assertions.fail(error.getMessage());
                     }
                   }
                 }));
-    assertTrue("data fits in buffer", packer.format("abcdefghijklm", mapper));
+    assertTrue(packer.format("abcdefghijklm", mapper), "data fits in buffer");
     assertTrue(
-        "data fits in empty buffer but triggers flush", packer.format("nopqrstuvwxyz", mapper));
+        packer.format("nopqrstuvwxyz", mapper), "data fits in empty buffer but triggers flush");
     assertTrue(
-        "data fits in buffer after overflow", packer.format("abcdefghijklmnopqrstuvwxy", mapper));
+        packer.format("abcdefghijklmnopqrstuvwxy", mapper), "data fits in buffer after overflow");
     assertEquals(2, flushed.size());
     assertEquals("abcdefghijklm", flushed.get(0));
     assertEquals("nopqrstuvwxyz", flushed.get(1));
@@ -115,7 +118,7 @@ public class MsgPackWriterTest {
                     assertEquals(4, length);
                     assertArrayEquals(data, unpacker.readPayload(length));
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(
@@ -136,7 +139,7 @@ public class MsgPackWriterTest {
                     assertArrayEquals(
                         unpacker.readPayload(6), "foobar".getBytes(StandardCharsets.UTF_8));
                   } catch (IOException e) {
-                    fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     writer.writeBinary("foobar".getBytes(StandardCharsets.UTF_8));
@@ -156,7 +159,7 @@ public class MsgPackWriterTest {
                     assertEquals(4, length);
                     assertArrayEquals(data, unpacker.readPayload(length));
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(data, (ba, writable) -> writable.writeObject(ba, null));
@@ -177,7 +180,7 @@ public class MsgPackWriterTest {
                     assertEquals(4, length);
                     assertArrayEquals(data, unpacker.readPayload(length));
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(ByteBuffer.wrap(data), (bb, writable) -> writable.writeBinary(bb));
@@ -198,7 +201,7 @@ public class MsgPackWriterTest {
                     assertEquals(4, length);
                     assertArrayEquals(data, unpacker.readPayload(length));
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(
@@ -217,7 +220,7 @@ public class MsgPackWriterTest {
                   try {
                     unpacker.unpackNil();
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(null, (x, w) -> w.writeObject(x, null));
@@ -235,7 +238,7 @@ public class MsgPackWriterTest {
                   try {
                     assertTrue(unpacker.unpackBoolean());
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(true, (x, w) -> w.writeObject(x, null));
@@ -253,7 +256,7 @@ public class MsgPackWriterTest {
                   try {
                     assertTrue(unpacker.unpackBoolean());
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(true, (x, w) -> w.writeBoolean(x));
@@ -272,7 +275,7 @@ public class MsgPackWriterTest {
                   try {
                     assertEquals(data.doubleValue(), unpacker.unpackDouble(), 0);
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(data, (Mapper<Number>) (x, w) -> w.writeObject(x, null));
@@ -291,7 +294,7 @@ public class MsgPackWriterTest {
                   try {
                     assertEquals(data, unpacker.unpackString());
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(data.toCharArray(), (x, w) -> w.writeObject(x, null));
@@ -310,7 +313,7 @@ public class MsgPackWriterTest {
                   try {
                     assertEquals("xyz", unpacker.unpackString());
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(utf8BytesString, (x, w) -> w.writeObject(x, null));
@@ -332,7 +335,7 @@ public class MsgPackWriterTest {
                       assertEquals(datum, unpacker.unpackBoolean());
                     }
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(data, (x, w) -> w.writeObject(x, null));
@@ -354,7 +357,7 @@ public class MsgPackWriterTest {
                       assertEquals(datum, unpacker.unpackFloat(), 0.001);
                     }
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(data, (x, w) -> w.writeObject(x, null));
@@ -376,7 +379,7 @@ public class MsgPackWriterTest {
                       assertEquals(datum, unpacker.unpackDouble(), 0.001);
                     }
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(data, (x, w) -> w.writeObject(x, null));
@@ -398,7 +401,7 @@ public class MsgPackWriterTest {
                       assertEquals(datum, unpacker.unpackLong());
                     }
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(data, (x, w) -> w.writeObject(x, null));
@@ -420,7 +423,7 @@ public class MsgPackWriterTest {
                       assertEquals(datum, unpacker.unpackInt());
                     }
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(data, (x, w) -> w.writeObject(x, null));
@@ -442,7 +445,7 @@ public class MsgPackWriterTest {
                       assertEquals(datum, unpacker.unpackInt());
                     }
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(data, (x, w) -> w.writeObject(x, null));
@@ -461,7 +464,7 @@ public class MsgPackWriterTest {
                   try {
                     assertEquals(data, unpacker.unpackLong());
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(data, (x, w) -> w.writeObject(x, null));
@@ -481,7 +484,7 @@ public class MsgPackWriterTest {
                     assertEquals(data, unpacker.unpackLong());
                     assertEquals(data, unpacker.unpackLong());
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(
@@ -505,7 +508,7 @@ public class MsgPackWriterTest {
                   try {
                     assertEquals(data, unpacker.unpackInt());
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(data, (x, w) -> w.writeObject(x, null));
@@ -524,7 +527,7 @@ public class MsgPackWriterTest {
                   try {
                     assertEquals(data, unpacker.unpackInt());
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(data, (x, w) -> w.writeInt(x));
@@ -543,7 +546,7 @@ public class MsgPackWriterTest {
                   try {
                     assertEquals(data, unpacker.unpackInt());
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(data, (x, w) -> w.writeObject(x, null));
@@ -562,7 +565,7 @@ public class MsgPackWriterTest {
                   try {
                     assertEquals(data.toString(), unpacker.unpackString());
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(data, (x, w) -> w.writeObject(x, null));
@@ -583,7 +586,7 @@ public class MsgPackWriterTest {
                     assertEquals(data[0].toString(), unpacker.unpackString());
                     assertEquals(data[1].toString(), unpacker.unpackString());
                   } catch (IOException e) {
-                    Assert.fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     messageFormatter.format(data, (x, w) -> w.writeObject(x, null));
@@ -603,7 +606,7 @@ public class MsgPackWriterTest {
                     assertEquals(unpacker.unpackString(), "foobár");
                     assertEquals(unpacker.unpackString(), "foobár");
                   } catch (IOException e) {
-                    fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     writer.writeObjectString(value, null);
@@ -622,7 +625,7 @@ public class MsgPackWriterTest {
                     unpacker.unpackNil();
                     unpacker.unpackNil();
                   } catch (IOException e) {
-                    fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     writer.writeObjectString(null, null);
@@ -648,7 +651,7 @@ public class MsgPackWriterTest {
                     assertEquals(unpacker.unpackString(), "foobár");
                     assertEquals(unpacker.unpackString(), "foobàr");
                   } catch (IOException e) {
-                    fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     writer.writeObjectString(value, null);
@@ -666,7 +669,7 @@ public class MsgPackWriterTest {
                   try {
                     assertEquals(unpacker.unpackString(), "foobár");
                   } catch (IOException e) {
-                    fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     CharBuffer charSeq = CharBuffer.wrap("foobár");
@@ -684,7 +687,7 @@ public class MsgPackWriterTest {
                   try {
                     assertEquals(unpacker.unpackString(), "foobár");
                   } catch (IOException e) {
-                    fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     writer.writeString("", s -> "foobár".getBytes(StandardCharsets.UTF_8));
@@ -704,7 +707,7 @@ public class MsgPackWriterTest {
                     assertEquals(unpacker.unpackArrayHeader(), 0x10000);
                     assertEquals(unpacker.unpackArrayHeader(), 1);
                   } catch (IOException e) {
-                    fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     writer.startArray(1);
@@ -726,7 +729,7 @@ public class MsgPackWriterTest {
                     assertEquals(unpacker.unpackMapHeader(), 0xFFFF);
                     assertEquals(unpacker.unpackMapHeader(), 0x10000);
                   } catch (IOException e) {
-                    fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     writer.startMap(1);
@@ -747,7 +750,7 @@ public class MsgPackWriterTest {
                     assertEquals(unpacker.unpackRawStringHeader(), 0xFFFF);
                     assertEquals(unpacker.unpackRawStringHeader(), 0x10000);
                   } catch (IOException e) {
-                    fail(e.getMessage());
+                    Assertions.fail(e.getMessage());
                   }
                 }));
     writer.writeStringHeader(1);

--- a/dd-java-agent/agent-crashtracking/build.gradle
+++ b/dd-java-agent/agent-crashtracking/build.gradle
@@ -1,8 +1,3 @@
-// Set properties before any plugins get loaded
-ext {
-  enableJunitPlatform = true
-}
-
 apply from: "$rootDir/gradle/java.gradle"
 
 // FIXME: Improve test coverage.

--- a/dd-java-agent/agent-debugger/build.gradle
+++ b/dd-java-agent/agent-debugger/build.gradle
@@ -2,11 +2,6 @@ plugins {
   id "com.github.johnrengelman.shadow"
 }
 
-// Set properties before any plugins get loaded
-ext {
-  enableJunitPlatform = true
-}
-
 apply from: "$rootDir/gradle/java.gradle"
 // We do not publish separate jar, but having version file is useful
 apply from: "$rootDir/gradle/version.gradle"

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/build.gradle
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/build.gradle
@@ -1,8 +1,3 @@
-// Set properties before any plugins get loaded
-ext {
-  enableJunitPlatform = true
-}
-
 apply from: "$rootDir/gradle/java.gradle"
 // We do not publish separate jar, but having version file is useful
 apply from: "$rootDir/gradle/version.gradle"

--- a/dd-java-agent/agent-debugger/debugger-el/build.gradle
+++ b/dd-java-agent/agent-debugger/debugger-el/build.gradle
@@ -1,7 +1,3 @@
-ext {
-  enableJunitPlatform = true
-}
-
 apply from: "$rootDir/gradle/java.gradle"
 // We do not publish separate jar, but having version file is useful
 apply from: "$rootDir/gradle/version.gradle"

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/AllowListHelperTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/AllowListHelperTest.java
@@ -3,7 +3,7 @@ package com.datadog.debugger.agent;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class AllowListHelperTest {
@@ -11,19 +11,19 @@ public class AllowListHelperTest {
   @Test
   public void allowAll() {
     AllowListHelper allowListHelper = new AllowListHelper(null);
-    Assert.assertTrue(allowListHelper.isAllowed("foo"));
+    Assertions.assertTrue(allowListHelper.isAllowed("foo"));
     allowListHelper = create(Collections.emptyList(), Collections.emptyList());
-    Assert.assertTrue(allowListHelper.isAllowed("foo"));
+    Assertions.assertTrue(allowListHelper.isAllowed("foo"));
   }
 
   @Test
   public void simple() {
     AllowListHelper allowListHelper =
         create(Arrays.asList("com.datadog"), Arrays.asList("java.util.HashMap"));
-    Assert.assertTrue(allowListHelper.isAllowed(AllowListHelper.class.getTypeName()));
-    Assert.assertTrue(allowListHelper.isAllowed("java.util.HashMap"));
-    Assert.assertFalse(allowListHelper.isAllowed("org.junit.jupiter.api.Test"));
-    Assert.assertFalse(allowListHelper.isAllowed("java.util.ArrayList"));
+    Assertions.assertTrue(allowListHelper.isAllowed(AllowListHelper.class.getTypeName()));
+    Assertions.assertTrue(allowListHelper.isAllowed("java.util.HashMap"));
+    Assertions.assertFalse(allowListHelper.isAllowed("org.junit.jupiter.api.Test"));
+    Assertions.assertFalse(allowListHelper.isAllowed("java.util.ArrayList"));
   }
 
   private static AllowListHelper create(List<String> packagePrefixes, List<String> classes) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -62,8 +62,8 @@ import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler;
 import org.jetbrains.kotlin.config.Services;
 import org.joor.Reflect;
 import org.joor.ReflectException;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -98,8 +98,8 @@ public class CapturedSnapshotTest {
         installSingleProbe(CLASS_NAME, "foobar", null);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "2").get();
-    Assert.assertEquals(2, result);
-    Assert.assertEquals(
+    Assertions.assertEquals(2, result);
+    Assertions.assertEquals(
         "Cannot find method CapturedSnapshot01::foobar",
         listener.errors.get(PROBE_ID).get(0).getMessage());
   }
@@ -111,13 +111,13 @@ public class CapturedSnapshotTest {
         installSingleProbe(CLASS_NAME, "main", "int (java.lang.String)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
+    Assertions.assertEquals(3, result);
     Snapshot snapshot = assertOneSnapshot(listener);
-    Assert.assertNotNull(snapshot.getCaptures().getEntry());
-    Assert.assertNotNull(snapshot.getCaptures().getReturn());
+    Assertions.assertNotNull(snapshot.getCaptures().getEntry());
+    Assertions.assertNotNull(snapshot.getCaptures().getReturn());
     assertCaptureArgs(snapshot.getCaptures().getEntry(), "arg", "java.lang.String", "1");
     assertCaptureArgs(snapshot.getCaptures().getReturn(), "arg", "java.lang.String", "1");
-    Assert.assertTrue(snapshot.retrieveDuration() > 0);
+    Assertions.assertTrue(snapshot.retrieveDuration() > 0);
   }
 
   @Test
@@ -127,11 +127,11 @@ public class CapturedSnapshotTest {
         installSingleProbe(CLASS_NAME, "main", "int (java.lang.String)", "8");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
+    Assertions.assertEquals(3, result);
     Snapshot snapshot = assertOneSnapshot(listener);
-    Assert.assertNull(snapshot.getCaptures().getEntry());
-    Assert.assertNull(snapshot.getCaptures().getReturn());
-    Assert.assertEquals(1, snapshot.getCaptures().getLines().size());
+    Assertions.assertNull(snapshot.getCaptures().getEntry());
+    Assertions.assertNull(snapshot.getCaptures().getReturn());
+    Assertions.assertEquals(1, snapshot.getCaptures().getLines().size());
     assertCaptureArgs(snapshot.getCaptures().getLines().get(8), "arg", "java.lang.String", "1");
     assertCaptureLocals(snapshot.getCaptures().getLines().get(8), "var1", "int", "1");
   }
@@ -144,10 +144,10 @@ public class CapturedSnapshotTest {
     DebuggerContext.init(listener, (id, clazz) -> null, null);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
-    Assert.assertEquals(1, listener.snapshots.size());
+    Assertions.assertEquals(3, result);
+    Assertions.assertEquals(1, listener.snapshots.size());
     Snapshot snapshot = listener.snapshots.get(0);
-    Assert.assertEquals(Snapshot.ProbeDetails.UNKNOWN.getId(), snapshot.getProbe().getId());
+    Assertions.assertEquals(Snapshot.ProbeDetails.UNKNOWN.getId(), snapshot.getProbe().getId());
   }
 
   @Test
@@ -157,7 +157,7 @@ public class CapturedSnapshotTest {
         installSingleProbe(CLASS_NAME, "<init>", "(String, Object)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assert.assertEquals(42, result);
+    Assertions.assertEquals(42, result);
     assertOneSnapshot(listener);
   }
 
@@ -168,7 +168,7 @@ public class CapturedSnapshotTest {
         installSingleProbe(CLASS_NAME, "<init>", "()");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assert.assertEquals(42, result);
+    Assertions.assertEquals(42, result);
     assertOneSnapshot(listener);
   }
 
@@ -178,7 +178,7 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener =
         installSingleProbe(CLASS_NAME, "<init>", "()");
     Class<?> testClass = Class.forName(CLASS_NAME);
-    Assert.assertNotNull(testClass);
+    Assertions.assertNotNull(testClass);
     testClass.newInstance();
     assertOneSnapshot(listener);
   }
@@ -190,7 +190,7 @@ public class CapturedSnapshotTest {
         installSingleProbe(CLASS_NAME, "<init>", "(Throwable)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "init").get();
-    Assert.assertEquals(42, result);
+    Assertions.assertEquals(42, result);
     assertOneSnapshot(listener);
   }
 
@@ -201,7 +201,7 @@ public class CapturedSnapshotTest {
         installSingleProbe(CLASS_NAME, "<init>", "(int)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assert.assertEquals(42, result);
+    Assertions.assertEquals(42, result);
     Snapshot snapshot = assertOneSnapshot(listener);
   }
 
@@ -212,7 +212,7 @@ public class CapturedSnapshotTest {
         installSingleProbe(CLASS_NAME, "<init>", "(int, int, int)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assert.assertEquals(42, result);
+    Assertions.assertEquals(42, result);
     Snapshot snapshot = assertOneSnapshot(listener);
   }
 
@@ -223,14 +223,14 @@ public class CapturedSnapshotTest {
         installSingleProbe(CLASS_NAME + "$Inherited", "<init>", null);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assert.assertEquals(42, result);
+    Assertions.assertEquals(42, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCaptureFields(
         snapshot.getCaptures().getEntry(), "obj2", "java.lang.Object", (String) null);
     Snapshot.CapturedValue obj2 = snapshot.getCaptures().getReturn().getFields().get("obj2");
     Map<String, Snapshot.CapturedValue> fields = getFields(obj2);
-    Assert.assertEquals(24, fields.get("intValue").getValue());
-    Assert.assertEquals(3.14, fields.get("doubleValue").getValue());
+    Assertions.assertEquals(24, fields.get("intValue").getValue());
+    Assertions.assertEquals(3.14, fields.get("doubleValue").getValue());
   }
 
   @Test
@@ -243,7 +243,7 @@ public class CapturedSnapshotTest {
             createProbe(PROBE_ID2, CLASS_NAME, "<init>", "(String, long, String)"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     long result = Reflect.on(testClass).call("main", "").get();
-    Assert.assertEquals(4_000_000_001L, result);
+    Assertions.assertEquals(4_000_000_001L, result);
     assertSnapshots(listener, 2, PROBE_ID2, PROBE_ID1);
   }
 
@@ -257,7 +257,7 @@ public class CapturedSnapshotTest {
             createProbe(PROBE_ID2, CLASS_NAME, "f2", "(int)"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assert.assertEquals(48, result);
+    Assertions.assertEquals(48, result);
     List<Snapshot> snapshots = assertSnapshots(listener, 2, PROBE_ID1, PROBE_ID2);
     Snapshot snapshot0 = snapshots.get(0);
     assertCaptureArgs(snapshot0.getCaptures().getEntry(), "value", "int", "31");
@@ -276,7 +276,7 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, probe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assert.assertEquals(48, result);
+    Assertions.assertEquals(48, result);
     List<Snapshot> snapshots = assertSnapshots(listener, 2, PROBE_ID1, PROBE_ID2);
     Snapshot snapshot0 = snapshots.get(0);
     assertCaptureArgs(snapshot0.getCaptures().getEntry(), "value", "int", "31");
@@ -290,9 +290,9 @@ public class CapturedSnapshotTest {
       DebuggerTransformerTest.TestSnapshotListener listener,
       int expectedCount,
       String... probeIds) {
-    Assert.assertEquals(expectedCount, listener.snapshots.size());
+    Assertions.assertEquals(expectedCount, listener.snapshots.size());
     for (int i = 0; i < probeIds.length; i++) {
-      Assert.assertEquals(probeIds[i], listener.snapshots.get(i).getProbe().getId());
+      Assertions.assertEquals(probeIds[i], listener.snapshots.get(i).getProbe().getId());
     }
     return listener.snapshots;
   }
@@ -304,7 +304,7 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, "f", "()"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assert.assertEquals(42, result);
+    Assertions.assertEquals(42, result);
     assertOneSnapshot(listener);
   }
 
@@ -320,7 +320,7 @@ public class CapturedSnapshotTest {
                 PROBE_ID, CLASS_NAME, "synchronizedBlock", "(int)", LINE_START + "-" + LINE_END));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "synchronizedBlock").get();
-    Assert.assertEquals(76, result);
+    Assertions.assertEquals(76, result);
     List<Snapshot> snapshots = assertSnapshots(listener, 10);
     int count = 31;
     for (int i = 0; i < 10; i++) {
@@ -347,11 +347,11 @@ public class CapturedSnapshotTest {
                 PROBE_ID, CLASS_NAME, "synchronizedBlock", "(int)", LINE_START + "-" + LINE_END));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "synchronizedBlock").get();
-    Assert.assertEquals(76, result);
+    Assertions.assertEquals(76, result);
     Snapshot snapshot = assertOneSnapshot(listener);
-    Assert.assertNull(snapshot.getCaptures().getEntry());
-    Assert.assertNull(snapshot.getCaptures().getReturn());
-    Assert.assertEquals(2, snapshot.getCaptures().getLines().size());
+    Assertions.assertNull(snapshot.getCaptures().getEntry());
+    Assertions.assertNull(snapshot.getCaptures().getReturn());
+    Assertions.assertEquals(2, snapshot.getCaptures().getLines().size());
     assertCaptureLocals(snapshot.getCaptures().getLines().get(LINE_START), "count", "int", "31");
     assertCaptureLocals(snapshot.getCaptures().getLines().get(LINE_END), "count", "int", "76");
   }
@@ -363,13 +363,13 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, CLASS_NAME + ".java", 4));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assert.assertEquals(48, result);
+    Assertions.assertEquals(48, result);
     Snapshot snapshot = assertOneSnapshot(listener);
-    Assert.assertNull(snapshot.getCaptures().getEntry());
-    Assert.assertNull(snapshot.getCaptures().getReturn());
-    Assert.assertEquals(1, snapshot.getCaptures().getLines().size());
-    Assert.assertEquals(CLASS_NAME, snapshot.getProbe().getLocation().getType());
-    Assert.assertEquals("f1", snapshot.getProbe().getLocation().getMethod());
+    Assertions.assertNull(snapshot.getCaptures().getEntry());
+    Assertions.assertNull(snapshot.getCaptures().getReturn());
+    Assertions.assertEquals(1, snapshot.getCaptures().getLines().size());
+    Assertions.assertEquals(CLASS_NAME, snapshot.getProbe().getLocation().getType());
+    Assertions.assertEquals("f1", snapshot.getProbe().getLocation().getMethod());
     assertCaptureArgs(snapshot.getCaptures().getLines().get(4), "value", "int", "31");
   }
 
@@ -380,13 +380,13 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, "CapturedSnapshot10.java", 11));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "2").get();
-    Assert.assertEquals(2, result);
+    Assertions.assertEquals(2, result);
     Snapshot snapshot = assertOneSnapshot(listener);
-    Assert.assertNull(snapshot.getCaptures().getEntry());
-    Assert.assertNull(snapshot.getCaptures().getReturn());
-    Assert.assertEquals(1, snapshot.getCaptures().getLines().size());
-    Assert.assertEquals(CLASS_NAME, snapshot.getProbe().getLocation().getType());
-    Assert.assertEquals("main", snapshot.getProbe().getLocation().getMethod());
+    Assertions.assertNull(snapshot.getCaptures().getEntry());
+    Assertions.assertNull(snapshot.getCaptures().getReturn());
+    Assertions.assertEquals(1, snapshot.getCaptures().getLines().size());
+    Assertions.assertEquals(CLASS_NAME, snapshot.getProbe().getLocation().getType());
+    Assertions.assertEquals("main", snapshot.getProbe().getLocation().getMethod());
     assertCaptureLocals(snapshot.getCaptures().getLines().get(11), "var1", "int", "1");
   }
 
@@ -400,13 +400,13 @@ public class CapturedSnapshotTest {
             createSourceFileProbe(PROBE_ID, "src/main/java/" + DIR_CLASS_NAME + ".java", 11));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "2").get();
-    Assert.assertEquals(2, result);
+    Assertions.assertEquals(2, result);
     Snapshot snapshot = assertOneSnapshot(listener);
-    Assert.assertNull(snapshot.getCaptures().getEntry());
-    Assert.assertNull(snapshot.getCaptures().getReturn());
-    Assert.assertEquals(1, snapshot.getCaptures().getLines().size());
-    Assert.assertEquals(CLASS_NAME, snapshot.getProbe().getLocation().getType());
-    Assert.assertEquals("main", snapshot.getProbe().getLocation().getMethod());
+    Assertions.assertNull(snapshot.getCaptures().getEntry());
+    Assertions.assertNull(snapshot.getCaptures().getReturn());
+    Assertions.assertEquals(1, snapshot.getCaptures().getLines().size());
+    Assertions.assertEquals(CLASS_NAME, snapshot.getProbe().getLocation().getType());
+    Assertions.assertEquals("main", snapshot.getProbe().getLocation().getMethod());
     assertCaptureArgs(snapshot.getCaptures().getLines().get(11), "arg", "java.lang.String", "2");
   }
 
@@ -420,14 +420,14 @@ public class CapturedSnapshotTest {
             createSourceFileProbe(PROBE_ID, "src/main/java/" + DIR_CLASS_NAME + ".java", 21));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(42 * 42, result);
+    Assertions.assertEquals(42 * 42, result);
     Snapshot snapshot = assertOneSnapshot(listener);
-    Assert.assertNull(snapshot.getCaptures().getEntry());
-    Assert.assertNull(snapshot.getCaptures().getReturn());
-    Assert.assertEquals(1, snapshot.getCaptures().getLines().size());
-    Assert.assertEquals(
+    Assertions.assertNull(snapshot.getCaptures().getEntry());
+    Assertions.assertNull(snapshot.getCaptures().getReturn());
+    Assertions.assertEquals(1, snapshot.getCaptures().getLines().size());
+    Assertions.assertEquals(
         "com.datadog.debugger.TopLevel01", snapshot.getProbe().getLocation().getType());
-    Assert.assertEquals("process", snapshot.getProbe().getLocation().getMethod());
+    Assertions.assertEquals("process", snapshot.getProbe().getLocation().getMethod());
     assertCaptureArgs(snapshot.getCaptures().getLines().get(21), "arg", "int", "42");
   }
 
@@ -442,21 +442,21 @@ public class CapturedSnapshotTest {
             createProbe(PROBE_ID2, CLASS_NAME, "main", null));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "2").get();
-    Assert.assertEquals(2, result);
+    Assertions.assertEquals(2, result);
     List<Snapshot> snapshots = assertSnapshots(listener, 2, PROBE_ID1, PROBE_ID2);
     Snapshot snapshot0 = snapshots.get(0);
-    Assert.assertNull(snapshot0.getCaptures().getEntry());
-    Assert.assertNull(snapshot0.getCaptures().getReturn());
-    Assert.assertEquals(1, snapshot0.getCaptures().getLines().size());
-    Assert.assertEquals(
+    Assertions.assertNull(snapshot0.getCaptures().getEntry());
+    Assertions.assertNull(snapshot0.getCaptures().getReturn());
+    Assertions.assertEquals(1, snapshot0.getCaptures().getLines().size());
+    Assertions.assertEquals(
         "com.datadog.debugger.CapturedSnapshot11", snapshot0.getProbe().getLocation().getType());
-    Assert.assertEquals("main", snapshot0.getProbe().getLocation().getMethod());
+    Assertions.assertEquals("main", snapshot0.getProbe().getLocation().getMethod());
     assertCaptureArgs(snapshot0.getCaptures().getLines().get(10), "arg", "java.lang.String", "2");
     assertCaptureLocals(snapshot0.getCaptures().getLines().get(10), "var1", "int", "1");
     Snapshot snapshot1 = snapshots.get(1);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "com.datadog.debugger.CapturedSnapshot11", snapshot1.getProbe().getLocation().getType());
-    Assert.assertEquals("main", snapshot1.getProbe().getLocation().getMethod());
+    Assertions.assertEquals("main", snapshot1.getProbe().getLocation().getMethod());
     assertCaptureArgs(snapshot1.getCaptures().getEntry(), "arg", "java.lang.String", "2");
     assertCaptureReturnValue(snapshot1.getCaptures().getReturn(), "int", "2");
   }
@@ -470,13 +470,13 @@ public class CapturedSnapshotTest {
     String source = getFixtureContent("/" + FILE_NAME);
     Class<?> testClass = ScalaHelper.compileAndLoad(source, CLASS_NAME, FILE_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assert.assertEquals(48, result);
+    Assertions.assertEquals(48, result);
     Snapshot snapshot = assertOneSnapshot(listener);
-    Assert.assertNull(snapshot.getCaptures().getEntry());
-    Assert.assertNull(snapshot.getCaptures().getReturn());
-    Assert.assertEquals(1, snapshot.getCaptures().getLines().size());
-    Assert.assertEquals(CLASS_NAME, snapshot.getProbe().getLocation().getType());
-    Assert.assertEquals("f1", snapshot.getProbe().getLocation().getMethod());
+    Assertions.assertNull(snapshot.getCaptures().getEntry());
+    Assertions.assertNull(snapshot.getCaptures().getReturn());
+    Assertions.assertEquals(1, snapshot.getCaptures().getLines().size());
+    Assertions.assertEquals(CLASS_NAME, snapshot.getProbe().getLocation().getType());
+    Assertions.assertEquals("f1", snapshot.getProbe().getLocation().getMethod());
     assertCaptureArgs(snapshot.getCaptures().getLines().get(3), "value", "int", "31");
   }
 
@@ -489,13 +489,13 @@ public class CapturedSnapshotTest {
     GroovyClassLoader groovyClassLoader = new GroovyClassLoader();
     Class<?> testClass = groovyClassLoader.parseClass(source);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assert.assertEquals(48, result);
+    Assertions.assertEquals(48, result);
     Snapshot snapshot = assertOneSnapshot(listener);
-    Assert.assertNull(snapshot.getCaptures().getEntry());
-    Assert.assertNull(snapshot.getCaptures().getReturn());
-    Assert.assertEquals(1, snapshot.getCaptures().getLines().size());
-    Assert.assertEquals(CLASS_NAME, snapshot.getProbe().getLocation().getType());
-    Assert.assertEquals("f1", snapshot.getProbe().getLocation().getMethod());
+    Assertions.assertNull(snapshot.getCaptures().getEntry());
+    Assertions.assertNull(snapshot.getCaptures().getReturn());
+    Assertions.assertEquals(1, snapshot.getCaptures().getLines().size());
+    Assertions.assertEquals(CLASS_NAME, snapshot.getProbe().getLocation().getType());
+    Assertions.assertEquals("f1", snapshot.getProbe().getLocation().getMethod());
     assertCaptureArgs(snapshot.getCaptures().getLines().get(4), "value", "int", "31");
   }
 
@@ -505,19 +505,19 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener =
         installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, CLASS_NAME + ".kt", 4));
     URL resource = CapturedSnapshotTest.class.getResource("/" + CLASS_NAME + ".kt");
-    Assert.assertNotNull(resource);
+    Assertions.assertNotNull(resource);
     List<File> filesToDelete = new ArrayList<>();
     Class<?> testClass = KotlinHelper.compileAndLoad(CLASS_NAME, resource.getFile(), filesToDelete);
     try {
       Object companion = Reflect.on(testClass).get("Companion");
       int result = Reflect.on(companion).call("main", "").get();
-      Assert.assertEquals(48, result);
+      Assertions.assertEquals(48, result);
       Snapshot snapshot = assertOneSnapshot(listener);
-      Assert.assertNull(snapshot.getCaptures().getEntry());
-      Assert.assertNull(snapshot.getCaptures().getReturn());
-      Assert.assertEquals(1, snapshot.getCaptures().getLines().size());
-      Assert.assertEquals(CLASS_NAME, snapshot.getProbe().getLocation().getType());
-      Assert.assertEquals("f1", snapshot.getProbe().getLocation().getMethod());
+      Assertions.assertNull(snapshot.getCaptures().getEntry());
+      Assertions.assertNull(snapshot.getCaptures().getReturn());
+      Assertions.assertEquals(1, snapshot.getCaptures().getLines().size());
+      Assertions.assertEquals(CLASS_NAME, snapshot.getProbe().getLocation().getType());
+      Assertions.assertEquals("f1", snapshot.getProbe().getLocation().getMethod());
       assertCaptureArgs(snapshot.getCaptures().getLines().get(4), "value", "int", "31");
     } finally {
       filesToDelete.forEach(File::delete);
@@ -535,7 +535,7 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, simpleDataProbe, compositeDataProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assert.assertEquals(143, result);
+    Assertions.assertEquals(143, result);
     List<Snapshot> snapshots = assertSnapshots(listener, 2, PROBE_ID1, PROBE_ID2);
     Snapshot simpleSnapshot = snapshots.get(0);
     Map<String, String> expectedSimpleFields = new HashMap<>();
@@ -567,20 +567,20 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, compositeDataProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assert.assertEquals(143, result);
+    Assertions.assertEquals(143, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     Snapshot.CapturedValue returnValue =
         snapshot.getCaptures().getReturn().getLocals().get("@return");
     Map<String, Snapshot.CapturedValue> fields = getFields(returnValue);
-    Assert.assertTrue(fields.containsKey("nullsd"));
-    Assert.assertTrue(fields.containsKey("l1"));
+    Assertions.assertTrue(fields.containsKey("nullsd"));
+    Assertions.assertTrue(fields.containsKey("l1"));
     Snapshot.CapturedValue s1 = fields.get("s1");
     Map<String, Snapshot.CapturedValue> s1Fields =
         (Map<String, Snapshot.CapturedValue>) s1.getValue();
-    Assert.assertEquals("101", String.valueOf(s1Fields.get("intValue").getValue()));
-    Assert.assertEquals("foo1", s1Fields.get("strValue").getValue());
-    Assert.assertEquals("null", String.valueOf(s1Fields.get("listValue").getValue()));
-    Assert.assertEquals(
+    Assertions.assertEquals("101", String.valueOf(s1Fields.get("intValue").getValue()));
+    Assertions.assertEquals("foo1", s1Fields.get("strValue").getValue());
+    Assertions.assertEquals("null", String.valueOf(s1Fields.get("listValue").getValue()));
+    Assertions.assertEquals(
         DEPTH_REASON, String.valueOf(s1Fields.get("listValue").getNotCapturedReason()));
   }
 
@@ -593,7 +593,7 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, simpleDataProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assert.assertEquals(143, result);
+    Assertions.assertEquals(143, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     Map<String, String> expectedFields = new HashMap<>();
     expectedFields.put("intValue", "42");
@@ -612,13 +612,14 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, simpleDataProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assert.assertEquals(143, result);
+    Assertions.assertEquals(143, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     Snapshot.CapturedValue simpleData =
         snapshot.getCaptures().getReturn().getLocals().get("simpleData");
     Map<String, Snapshot.CapturedValue> fields = getFields(simpleData);
-    Assert.assertEquals(1, fields.size());
-    Assert.assertEquals(DEPTH_REASON, fields.get("@" + NOT_CAPTURED_REASON).getNotCapturedReason());
+    Assertions.assertEquals(1, fields.size());
+    Assertions.assertEquals(
+        DEPTH_REASON, fields.get("@" + NOT_CAPTURED_REASON).getNotCapturedReason());
   }
 
   @Test
@@ -630,13 +631,13 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, simpleDataProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assert.assertEquals(143, result);
+    Assertions.assertEquals(143, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     Snapshot.CapturedValue simpleData =
         snapshot.getCaptures().getReturn().getLocals().get("simpleData");
     Map<String, Snapshot.CapturedValue> simpleDataFields = getFields(simpleData);
-    Assert.assertEquals(1, simpleDataFields.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, simpleDataFields.size());
+    Assertions.assertEquals(
         DEPTH_REASON, simpleDataFields.get("@" + NOT_CAPTURED_REASON).getNotCapturedReason());
   }
 
@@ -649,15 +650,15 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, simpleDataProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assert.assertEquals(143, result);
+    Assertions.assertEquals(143, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     Snapshot.CapturedValue simpleData =
         snapshot.getCaptures().getReturn().getLocals().get("simpleData");
     Map<String, Snapshot.CapturedValue> simpleDataFields = getFields(simpleData);
-    Assert.assertEquals(3, simpleDataFields.size());
-    Assert.assertEquals("foo", simpleDataFields.get("strValue").getValue());
-    Assert.assertEquals(42, simpleDataFields.get("intValue").getValue());
-    Assert.assertEquals(DEPTH_REASON, simpleDataFields.get("listValue").getNotCapturedReason());
+    Assertions.assertEquals(3, simpleDataFields.size());
+    Assertions.assertEquals("foo", simpleDataFields.get("strValue").getValue());
+    Assertions.assertEquals(42, simpleDataFields.get("intValue").getValue());
+    Assertions.assertEquals(DEPTH_REASON, simpleDataFields.get("listValue").getNotCapturedReason());
   }
 
   @Test
@@ -670,33 +671,33 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, compositeDataProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assert.assertEquals(143, result);
+    Assertions.assertEquals(143, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     Snapshot.CapturedValue returnValue =
         snapshot.getCaptures().getReturn().getLocals().get("@return");
-    Assert.assertEquals("CapturedSnapshot04$CompositeData", returnValue.getType());
+    Assertions.assertEquals("CapturedSnapshot04$CompositeData", returnValue.getType());
     Map<String, Snapshot.CapturedValue> fields = getFields(returnValue);
-    Assert.assertEquals(3, fields.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(3, fields.size());
+    Assertions.assertEquals(
         FIELD_COUNT_REASON, fields.get("@" + NOT_CAPTURED_REASON).getNotCapturedReason());
     Map<String, Snapshot.CapturedValue> s1Fields =
         (Map<String, Snapshot.CapturedValue>) fields.get("s1").getValue();
-    Assert.assertEquals("foo1", s1Fields.get("strValue").getValue());
-    Assert.assertEquals(101, s1Fields.get("intValue").getValue());
+    Assertions.assertEquals("foo1", s1Fields.get("strValue").getValue());
+    Assertions.assertEquals(101, s1Fields.get("intValue").getValue());
     Map<String, Snapshot.CapturedValue> s2Fields =
         (Map<String, Snapshot.CapturedValue>) fields.get("s2").getValue();
-    Assert.assertEquals("foo2", s2Fields.get("strValue").getValue());
-    Assert.assertEquals(202, s2Fields.get("intValue").getValue());
+    Assertions.assertEquals("foo2", s2Fields.get("strValue").getValue());
+    Assertions.assertEquals(202, s2Fields.get("intValue").getValue());
 
     Snapshot.CapturedValue compositeData =
         snapshot.getCaptures().getReturn().getLocals().get("compositeData");
     Map<String, Snapshot.CapturedValue> compositeDataFields = getFields(compositeData);
-    Assert.assertEquals(3, compositeDataFields.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(3, compositeDataFields.size());
+    Assertions.assertEquals(
         FIELD_COUNT_REASON,
         compositeDataFields.get("@" + NOT_CAPTURED_REASON).getNotCapturedReason());
-    Assert.assertTrue(compositeDataFields.containsKey("s1"));
-    Assert.assertTrue(compositeDataFields.containsKey("s2"));
+    Assertions.assertTrue(compositeDataFields.containsKey("s1"));
+    Assertions.assertTrue(compositeDataFields.containsKey("s2"));
   }
 
   @Test
@@ -708,9 +709,9 @@ public class CapturedSnapshotTest {
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     try {
       Reflect.on(testClass).call("main", "triggerUncaughtException").get();
-      Assert.fail("should not reach this code");
+      Assertions.fail("should not reach this code");
     } catch (ReflectException ex) {
-      Assert.assertEquals("oops", ex.getCause().getCause().getMessage());
+      Assertions.assertEquals("oops", ex.getCause().getCause().getMessage());
     }
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCaptureThrowable(
@@ -729,7 +730,7 @@ public class CapturedSnapshotTest {
             CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, "triggerCaughtException", "()"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "triggerCaughtException").get();
-    Assert.assertEquals(42, result);
+    Assertions.assertEquals(42, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCaptureThrowable(
         snapshot.getCaptures().getCaughtExceptions().get(0),
@@ -754,9 +755,9 @@ public class CapturedSnapshotTest {
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     for (int i = 0; i < 100; i++) {
       int result = Reflect.on(testClass).call("main", "1").get();
-      Assert.assertEquals(3, result);
+      Assertions.assertEquals(3, result);
     }
-    Assert.assertTrue(listener.snapshots.size() < 20);
+    Assertions.assertTrue(listener.snapshots.size() < 20);
   }
 
   @Test
@@ -774,10 +775,10 @@ public class CapturedSnapshotTest {
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     for (int i = 0; i < 100; i++) {
       int result = Reflect.on(testClass).call("main", "").get();
-      Assert.assertEquals(48, result);
+      Assertions.assertEquals(48, result);
     }
-    Assert.assertTrue(
-        "actual snapshots: " + listener.snapshots.size(), listener.snapshots.size() < 20);
+    Assertions.assertTrue(
+        listener.snapshots.size() < 20, "actual snapshots: " + listener.snapshots.size());
   }
 
   @Test
@@ -810,9 +811,9 @@ public class CapturedSnapshotTest {
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     for (int i = 0; i < 100; i++) {
       int result = Reflect.on(testClass).call("main", String.valueOf(i)).get();
-      Assert.assertTrue((i == 2 && result == 2) || result == 3);
+      Assertions.assertTrue((i == 2 && result == 2) || result == 3);
     }
-    Assert.assertEquals(1, listener.snapshots.size());
+    Assertions.assertEquals(1, listener.snapshots.size());
     assertCaptureArgs(
         listener.snapshots.get(0).getCaptures().getReturn(), "arg", "java.lang.String", "5");
   }
@@ -829,8 +830,8 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "0").get();
-    Assert.assertEquals(3, result);
-    Assert.assertEquals(0, listener.snapshots.size());
+    Assertions.assertEquals(3, result);
+    Assertions.assertEquals(0, listener.snapshots.size());
   }
 
   @Test
@@ -851,12 +852,13 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(1, listener.snapshots.size());
+    Assertions.assertEquals(1, listener.snapshots.size());
     List<Snapshot.EvaluationError> evaluationErrors =
         listener.snapshots.get(0).getEvaluationErrors();
-    Assert.assertEquals(1, evaluationErrors.size());
-    Assert.assertEquals("fld", evaluationErrors.get(0).getExpr());
-    Assert.assertEquals("Cannot dereference to field: fld", evaluationErrors.get(0).getMessage());
+    Assertions.assertEquals(1, evaluationErrors.size());
+    Assertions.assertEquals("fld", evaluationErrors.get(0).getExpr());
+    Assertions.assertEquals(
+        "Cannot dereference to field: fld", evaluationErrors.get(0).getMessage());
   }
 
   @Test
@@ -913,8 +915,8 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, probe1);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
-    Assert.assertEquals(expectedSnapshots, listener.snapshots.size());
+    Assertions.assertEquals(3, result);
+    Assertions.assertEquals(expectedSnapshots, listener.snapshots.size());
     return listener.snapshots;
   }
 
@@ -932,9 +934,10 @@ public class CapturedSnapshotTest {
     ProbeCondition condition2 = new ProbeCondition(DSL.when(DSL.FALSE), "false");
     List<Snapshot> snapshots = doMergedProbeConditions(condition1, condition2, 1);
     List<Snapshot.EvaluationError> evaluationErrors = snapshots.get(0).getEvaluationErrors();
-    Assert.assertEquals(1, evaluationErrors.size());
-    Assert.assertEquals("fld", evaluationErrors.get(0).getExpr());
-    Assert.assertEquals("Cannot dereference to field: fld", evaluationErrors.get(0).getMessage());
+    Assertions.assertEquals(1, evaluationErrors.size());
+    Assertions.assertEquals("fld", evaluationErrors.get(0).getExpr());
+    Assertions.assertEquals(
+        "Cannot dereference to field: fld", evaluationErrors.get(0).getMessage());
   }
 
   @Test
@@ -951,10 +954,11 @@ public class CapturedSnapshotTest {
     ProbeCondition condition2 = new ProbeCondition(DSL.when(DSL.TRUE), "true");
     List<Snapshot> snapshots = doMergedProbeConditions(condition1, condition2, 2);
     List<Snapshot.EvaluationError> evaluationErrors = snapshots.get(0).getEvaluationErrors();
-    Assert.assertEquals(1, evaluationErrors.size());
-    Assert.assertEquals("fld", evaluationErrors.get(0).getExpr());
-    Assert.assertEquals("Cannot dereference to field: fld", evaluationErrors.get(0).getMessage());
-    Assert.assertNull(snapshots.get(1).getEvaluationErrors());
+    Assertions.assertEquals(1, evaluationErrors.size());
+    Assertions.assertEquals("fld", evaluationErrors.get(0).getExpr());
+    Assertions.assertEquals(
+        "Cannot dereference to field: fld", evaluationErrors.get(0).getMessage());
+    Assertions.assertNull(snapshots.get(1).getEvaluationErrors());
   }
 
   @Test
@@ -971,9 +975,10 @@ public class CapturedSnapshotTest {
             "nullTyped.fld.fld.msg == 'hello'");
     List<Snapshot> snapshots = doMergedProbeConditions(condition1, condition2, 1);
     List<Snapshot.EvaluationError> evaluationErrors = snapshots.get(0).getEvaluationErrors();
-    Assert.assertEquals(1, evaluationErrors.size());
-    Assert.assertEquals("fld", evaluationErrors.get(0).getExpr());
-    Assert.assertEquals("Cannot dereference to field: fld", evaluationErrors.get(0).getMessage());
+    Assertions.assertEquals(1, evaluationErrors.size());
+    Assertions.assertEquals("fld", evaluationErrors.get(0).getExpr());
+    Assertions.assertEquals(
+        "Cannot dereference to field: fld", evaluationErrors.get(0).getMessage());
   }
 
   @Test
@@ -989,11 +994,12 @@ public class CapturedSnapshotTest {
                     DSL.value("hello"))),
             "nullTyped.fld.fld.msg == 'hello'");
     List<Snapshot> snapshots = doMergedProbeConditions(condition1, condition2, 2);
-    Assert.assertNull(snapshots.get(0).getEvaluationErrors());
+    Assertions.assertNull(snapshots.get(0).getEvaluationErrors());
     List<Snapshot.EvaluationError> evaluationErrors = snapshots.get(1).getEvaluationErrors();
-    Assert.assertEquals(1, evaluationErrors.size());
-    Assert.assertEquals("fld", evaluationErrors.get(0).getExpr());
-    Assert.assertEquals("Cannot dereference to field: fld", evaluationErrors.get(0).getMessage());
+    Assertions.assertEquals(1, evaluationErrors.size());
+    Assertions.assertEquals("fld", evaluationErrors.get(0).getExpr());
+    Assertions.assertEquals(
+        "Cannot dereference to field: fld", evaluationErrors.get(0).getMessage());
   }
 
   @Test
@@ -1015,10 +1021,10 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, probe1);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
-    Assert.assertEquals(2, listener.snapshots.size());
-    Assert.assertNull(listener.snapshots.get(0).getEvaluationErrors());
-    Assert.assertNull(listener.snapshots.get(1).getEvaluationErrors());
+    Assertions.assertEquals(3, result);
+    Assertions.assertEquals(2, listener.snapshots.size());
+    Assertions.assertNull(listener.snapshots.get(0).getEvaluationErrors());
+    Assertions.assertNull(listener.snapshots.get(1).getEvaluationErrors());
   }
 
   @Test
@@ -1028,7 +1034,7 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, "f", "()"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assert.assertEquals(42, result);
+    Assertions.assertEquals(42, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCaptureFieldCount(snapshot.getCaptures().getEntry(), 5);
     assertCaptureFields(snapshot.getCaptures().getEntry(), "intValue", "int", "24");
@@ -1062,7 +1068,7 @@ public class CapturedSnapshotTest {
         installProbes(INHERITED_CLASS_NAME, createProbe(PROBE_ID, INHERITED_CLASS_NAME, "f", "()"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "inherited").get();
-    Assert.assertEquals(42, result);
+    Assertions.assertEquals(42, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     // Only Declared fields in the current class are captured, not inherited fields
     assertCaptureFieldCount(snapshot.getCaptures().getEntry(), 2);
@@ -1083,10 +1089,10 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, null, null, "33"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "static", "email@address").get();
-    Assert.assertEquals(8, result);
+    Assertions.assertEquals(8, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     Snapshot.CapturedContext context = snapshot.getCaptures().getLines().get(33);
-    Assert.assertNotNull(context);
+    Assertions.assertNotNull(context);
     assertCaptureLocals(context, "idx", "int", "5");
   }
 
@@ -1100,10 +1106,10 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, null, null, "44"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "capturing", "email@address").get();
-    Assert.assertEquals(8, result);
+    Assertions.assertEquals(8, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     Snapshot.CapturedContext context = snapshot.getCaptures().getLines().get(44);
-    Assert.assertNotNull(context);
+    Assertions.assertNotNull(context);
     assertCaptureLocals(context, "idx", "int", "5");
     assertCaptureFields(context, "strValue", "java.lang.String", "email@address");
   }
@@ -1127,12 +1133,12 @@ public class CapturedSnapshotTest {
         snapshot.getCaptures().getEntry().getArguments();
     // it's important there is no null key in this map, as Jackson is not happy about it
     // it's means here that argument names are not resolved correctly
-    Assert.assertFalse(arguments.containsKey(null));
-    Assert.assertEquals(4, arguments.size());
-    Assert.assertTrue(arguments.containsKey("this"));
-    Assert.assertTrue(arguments.containsKey("apiKey"));
-    Assert.assertTrue(arguments.containsKey("uriInfo"));
-    Assert.assertTrue(arguments.containsKey("value"));
+    Assertions.assertFalse(arguments.containsKey(null));
+    Assertions.assertEquals(4, arguments.size());
+    Assertions.assertTrue(arguments.containsKey("this"));
+    Assertions.assertTrue(arguments.containsKey("apiKey"));
+    Assertions.assertTrue(arguments.containsKey("uriInfo"));
+    Assertions.assertTrue(arguments.containsKey("value"));
   }
 
   @Test
@@ -1144,11 +1150,11 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, nativeMethodProbe, abstractMethodProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assert.assertEquals(1, result);
-    Assert.assertEquals(
+    Assertions.assertEquals(1, result);
+    Assertions.assertEquals(
         "Cannot instrument an abstract or native method",
         listener.errors.get(PROBE_ID1).get(0).getMessage());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Cannot instrument an abstract or native method",
         listener.errors.get(PROBE_ID2).get(0).getMessage());
   }
@@ -1165,7 +1171,7 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener =
         installProbes(CLASS_NAME, abstractMethodProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
-    Assert.assertNotNull(testClass);
+    Assertions.assertNotNull(testClass);
   }
 
   @Test
@@ -1175,7 +1181,7 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, "overload", null));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assert.assertEquals(63, result);
+    Assertions.assertEquals(63, result);
     List<Snapshot> snapshots = assertSnapshots(listener, 4, PROBE_ID, PROBE_ID, PROBE_ID, PROBE_ID);
     assertCaptureReturnValue(snapshots.get(0).getCaptures().getReturn(), "int", "42");
     assertCaptureArgs(snapshots.get(1).getCaptures().getEntry(), "s", "java.lang.String", "1");
@@ -1191,7 +1197,7 @@ public class CapturedSnapshotTest {
     Map<String, byte[]> classFileBuffers = compile(CLASS_NAME, SourceCompiler.DebugInfo.NONE);
     Class<?> testClass = loadClass(CLASS_NAME, classFileBuffers);
     int result = Reflect.on(testClass).call("main", "2").get();
-    Assert.assertEquals(48, result);
+    Assertions.assertEquals(48, result);
     assertOneSnapshot(listener);
   }
 
@@ -1208,10 +1214,10 @@ public class CapturedSnapshotTest {
       instr.removeTransformer(currentTransformer);
     }
     int result = Reflect.on(testClass).call("main", "2").get();
-    Assert.assertEquals(2, result);
-    Assert.assertEquals(1, listener.snapshots.size());
+    Assertions.assertEquals(2, result);
+    Assertions.assertEquals(1, listener.snapshots.size());
     Snapshot snapshot = listener.snapshots.get(0);
-    Assert.assertEquals(Snapshot.ProbeDetails.ITW_PROBE_ID, snapshot.getProbe().getId());
+    Assertions.assertEquals(Snapshot.ProbeDetails.ITW_PROBE_ID, snapshot.getProbe().getId());
   }
 
   @ParameterizedTest
@@ -1229,8 +1235,8 @@ public class CapturedSnapshotTest {
       instr.removeTransformer(currentTransformer);
     }
     int result = Reflect.on(testClass).call("main", "2").get();
-    Assert.assertEquals(2, result);
-    Assert.assertEquals(0, listener.snapshots.size());
+    Assertions.assertEquals(2, result);
+    Assertions.assertEquals(0, listener.snapshots.size());
   }
 
   @Test
@@ -1240,7 +1246,7 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, "processWithArg", null));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "2").get();
-    Assert.assertEquals(50, result);
+    Assertions.assertEquals(50, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCaptureArgs(snapshot.getCaptures().getEntry(), "obj", "java.lang.Integer", "42");
     assertCaptureFields(
@@ -1256,7 +1262,7 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, null, null, "14"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "2").get();
-    Assert.assertEquals(42, result);
+    Assertions.assertEquals(42, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     Map<String, String> expectedFields = new HashMap<>();
     expectedFields.put("detailMessage", "For input string: \"a\"");
@@ -1279,7 +1285,7 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
+    Assertions.assertEquals(3, result);
     assertOneSnapshot(listener);
   }
 
@@ -1296,7 +1302,7 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
+    Assertions.assertEquals(3, result);
     assertOneSnapshot(listener);
   }
 
@@ -1313,10 +1319,10 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
-    Assert.assertEquals(0, listener.snapshots.size());
-    Assert.assertTrue(listener.skipped);
-    Assert.assertEquals(DebuggerContext.SkipCause.CONDITION, listener.cause);
+    Assertions.assertEquals(3, result);
+    Assertions.assertEquals(0, listener.snapshots.size());
+    Assertions.assertTrue(listener.skipped);
+    Assertions.assertEquals(DebuggerContext.SkipCause.CONDITION, listener.cause);
   }
 
   private DebuggerTransformerTest.TestSnapshotListener setupInstrumentTheWorldTransformer(
@@ -1349,9 +1355,9 @@ public class CapturedSnapshotTest {
   }
 
   private Snapshot assertOneSnapshot(DebuggerTransformerTest.TestSnapshotListener listener) {
-    Assert.assertEquals(1, listener.snapshots.size());
+    Assertions.assertEquals(1, listener.snapshots.size());
     Snapshot snapshot = listener.snapshots.get(0);
-    Assert.assertEquals(PROBE_ID, snapshot.getProbe().getId());
+    Assertions.assertEquals(PROBE_ID, snapshot.getProbe().getId());
     return snapshot;
   }
 
@@ -1401,7 +1407,7 @@ public class CapturedSnapshotTest {
       String expectedClassName,
       Collection<LogProbe> logProbes,
       Map<String, InstrumentationResult> instrumentationResults) {
-    Assert.assertEquals(expectedClassName, callingClass.getName());
+    Assertions.assertEquals(expectedClassName, callingClass.getName());
     for (LogProbe probe : logProbes) {
       if (probe.getId().equals(id)) {
         String typeName = probe.getWhere().getTypeName();
@@ -1458,15 +1464,15 @@ public class CapturedSnapshotTest {
   private void assertCaptureArgs(
       Snapshot.CapturedContext context, String name, String typeName, String value) {
     Snapshot.CapturedValue capturedValue = context.getArguments().get(name);
-    Assert.assertEquals(typeName, capturedValue.getType());
-    Assert.assertEquals(value, getValue(capturedValue));
+    Assertions.assertEquals(typeName, capturedValue.getType());
+    Assertions.assertEquals(value, getValue(capturedValue));
   }
 
   private void assertCaptureLocals(
       Snapshot.CapturedContext context, String name, String typeName, String value) {
     Snapshot.CapturedValue localVar = context.getLocals().get(name);
-    Assert.assertEquals(typeName, localVar.getType());
-    Assert.assertEquals(value, getValue(localVar));
+    Assertions.assertEquals(typeName, localVar.getType());
+    Assertions.assertEquals(value, getValue(localVar));
   }
 
   private void assertCaptureLocals(
@@ -1475,16 +1481,16 @@ public class CapturedSnapshotTest {
       String typeName,
       Map<String, String> expectedFields) {
     Snapshot.CapturedValue localVar = context.getLocals().get(name);
-    Assert.assertEquals(typeName, localVar.getType());
+    Assertions.assertEquals(typeName, localVar.getType());
     Map<String, Snapshot.CapturedValue> fields = getFields(localVar);
     for (Map.Entry<String, String> entry : expectedFields.entrySet()) {
-      Assert.assertTrue(fields.containsKey(entry.getKey()));
+      Assertions.assertTrue(fields.containsKey(entry.getKey()));
       Snapshot.CapturedValue fieldCapturedValue = fields.get(entry.getKey());
       if (fieldCapturedValue.getNotCapturedReason() != null) {
-        Assert.assertEquals(
+        Assertions.assertEquals(
             entry.getValue(), String.valueOf(fieldCapturedValue.getNotCapturedReason()));
       } else {
-        Assert.assertEquals(entry.getValue(), String.valueOf(fieldCapturedValue.getValue()));
+        Assertions.assertEquals(entry.getValue(), String.valueOf(fieldCapturedValue.getValue()));
       }
     }
   }
@@ -1492,20 +1498,20 @@ public class CapturedSnapshotTest {
   private void assertCaptureFields(
       Snapshot.CapturedContext context, String name, String typeName, String value) {
     Snapshot.CapturedValue field = context.getFields().get(name);
-    Assert.assertEquals(typeName, field.getType());
-    Assert.assertEquals(value, getValue(field));
+    Assertions.assertEquals(typeName, field.getType());
+    Assertions.assertEquals(value, getValue(field));
   }
 
   private void assertCaptureFields(
       Snapshot.CapturedContext context, String name, String typeName, Collection<?> collection) {
     Snapshot.CapturedValue field = context.getFields().get(name);
-    Assert.assertEquals(typeName, field.getType());
+    Assertions.assertEquals(typeName, field.getType());
     Iterator<?> iterator = collection.iterator();
     for (Object obj : getCollection(field)) {
       if (iterator.hasNext()) {
-        Assert.assertEquals(iterator.next(), obj);
+        Assertions.assertEquals(iterator.next(), obj);
       } else {
-        Assert.fail("not same number of elements");
+        Assertions.fail("not same number of elements");
       }
     }
   }
@@ -1516,39 +1522,39 @@ public class CapturedSnapshotTest {
       String typeName,
       Map<Object, Object> expectedMap) {
     Snapshot.CapturedValue field = context.getFields().get(name);
-    Assert.assertEquals(typeName, field.getType());
+    Assertions.assertEquals(typeName, field.getType());
     Map<Object, Object> map = getMap(field);
-    Assert.assertEquals(expectedMap.size(), map.size());
+    Assertions.assertEquals(expectedMap.size(), map.size());
     for (Map.Entry<Object, Object> entry : map.entrySet()) {
-      Assert.assertTrue(expectedMap.containsKey(entry.getKey()));
-      Assert.assertEquals(expectedMap.get(entry.getKey()), entry.getValue());
+      Assertions.assertTrue(expectedMap.containsKey(entry.getKey()));
+      Assertions.assertEquals(expectedMap.get(entry.getKey()), entry.getValue());
     }
   }
 
   private void assertCaptureFieldCount(Snapshot.CapturedContext context, int expectedFieldCount) {
-    Assert.assertEquals(expectedFieldCount, context.getFields().size());
+    Assertions.assertEquals(expectedFieldCount, context.getFields().size());
   }
 
   private void assertCaptureReturnValue(
       Snapshot.CapturedContext context, String typeName, String value) {
     Snapshot.CapturedValue returnValue = context.getLocals().get("@return");
-    Assert.assertEquals(typeName, returnValue.getType());
-    Assert.assertEquals(value, getValue(returnValue));
+    Assertions.assertEquals(typeName, returnValue.getType());
+    Assertions.assertEquals(value, getValue(returnValue));
   }
 
   private void assertCaptureReturnValue(
       Snapshot.CapturedContext context, String typeName, Map<String, String> expectedFields) {
     Snapshot.CapturedValue returnValue = context.getLocals().get("@return");
-    Assert.assertEquals(typeName, returnValue.getType());
+    Assertions.assertEquals(typeName, returnValue.getType());
     Map<String, Snapshot.CapturedValue> fields = getFields(returnValue);
     for (Map.Entry<String, String> entry : expectedFields.entrySet()) {
-      Assert.assertTrue(fields.containsKey(entry.getKey()));
+      Assertions.assertTrue(fields.containsKey(entry.getKey()));
       Snapshot.CapturedValue fieldCapturedValue = fields.get(entry.getKey());
       if (fieldCapturedValue.getNotCapturedReason() != null) {
-        Assert.assertEquals(
+        Assertions.assertEquals(
             entry.getValue(), String.valueOf(fieldCapturedValue.getNotCapturedReason()));
       } else {
-        Assert.assertEquals(entry.getValue(), String.valueOf(fieldCapturedValue.getValue()));
+        Assertions.assertEquals(entry.getValue(), String.valueOf(fieldCapturedValue.getValue()));
       }
     }
   }
@@ -1569,13 +1575,13 @@ public class CapturedSnapshotTest {
       String message,
       String methodName,
       int lineNumber) {
-    Assert.assertNotNull(throwable);
-    Assert.assertEquals(typeName, throwable.getType());
-    Assert.assertEquals(message, throwable.getMessage());
-    Assert.assertNotNull(throwable.getStacktrace());
-    Assert.assertFalse(throwable.getStacktrace().isEmpty());
-    Assert.assertEquals(methodName, throwable.getStacktrace().get(0).getFunction());
-    Assert.assertEquals(lineNumber, throwable.getStacktrace().get(0).getLineNumber());
+    Assertions.assertNotNull(throwable);
+    Assertions.assertEquals(typeName, throwable.getType());
+    Assertions.assertEquals(message, throwable.getMessage());
+    Assertions.assertNotNull(throwable.getStacktrace());
+    Assertions.assertFalse(throwable.getStacktrace().isEmpty());
+    Assertions.assertEquals(methodName, throwable.getStacktrace().get(0).getFunction());
+    Assertions.assertEquals(lineNumber, throwable.getStacktrace().get(0).getLineNumber());
   }
 
   private static String getValue(Snapshot.CapturedValue capturedValue) {
@@ -1616,19 +1622,19 @@ public class CapturedSnapshotTest {
       Map<String, Object> capturedValueMap = GENERIC_ADAPTER.fromJson(capturedValue.getStrValue());
       List<Object> elements = (List<Object>) capturedValueMap.get("elements");
       if (elements == null) {
-        Assert.fail("not a collection");
+        Assertions.fail("not a collection");
       }
       List<Object> result = new ArrayList<>();
       for (Object obj : elements) {
         Map<String, Object> element = (Map<String, Object>) obj;
         String type = (String) element.get("type");
         if (type == null) {
-          Assert.fail("no type for element");
+          Assertions.fail("no type for element");
         }
         if (SerializerWithLimits.isPrimitive(type)) {
           result.add(element.get("value"));
         } else {
-          Assert.fail("not implemented");
+          Assertions.fail("not implemented");
         }
       }
       return result;
@@ -1643,7 +1649,7 @@ public class CapturedSnapshotTest {
       Map<String, Object> capturedValueMap = GENERIC_ADAPTER.fromJson(capturedValue.getStrValue());
       List<Object> entries = (List<Object>) capturedValueMap.get("entries");
       if (entries == null) {
-        Assert.fail("not a map");
+        Assertions.fail("not a map");
       }
       Map<Object, Object> result = new HashMap<>();
       for (Object obj : entries) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerProductChangesListenerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerProductChangesListenerTest.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.UUID;
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -60,7 +59,7 @@ public class DebuggerProductChangesListenerTest {
         new DebuggerProductChangesListener(tracerConfig, acceptor);
     listener.commit(pollingHinter);
 
-    Assert.assertEquals(emptyConfig, acceptor.getConfiguration());
+    Assertions.assertEquals(emptyConfig, acceptor.getConfiguration());
   }
 
   @Test
@@ -79,7 +78,7 @@ public class DebuggerProductChangesListenerTest {
     acceptConfig(listener, config, UUID.randomUUID().toString());
     listener.commit(pollingHinter);
 
-    Assert.assertEquals(config, acceptor.getConfiguration());
+    Assertions.assertEquals(config, acceptor.getConfiguration());
   }
 
   @Test
@@ -103,7 +102,7 @@ public class DebuggerProductChangesListenerTest {
 
     listener.commit(pollingHinter);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Configuration.builder().setService(SERVICE_NAME).build(), acceptor.getConfiguration());
   }
 
@@ -120,19 +119,19 @@ public class DebuggerProductChangesListenerTest {
 
     acceptMetricProbe(listener, metricProbe);
     listener.commit(pollingHinter);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Configuration.builder().setService(SERVICE_NAME).add(metricProbe).build(),
         acceptor.getConfiguration());
 
     acceptLogProbe(listener, logProbe);
     listener.commit(pollingHinter);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Configuration.builder().setService(SERVICE_NAME).add(metricProbe).add(logProbe).build(),
         acceptor.getConfiguration());
 
     acceptSpanProbe(listener, spanProbe);
     listener.commit(pollingHinter);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Configuration.builder()
             .setService(SERVICE_NAME)
             .add(metricProbe)
@@ -143,19 +142,19 @@ public class DebuggerProductChangesListenerTest {
 
     removeMetricProbe(listener, metricProbe);
     listener.commit(pollingHinter);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Configuration.builder().setService(SERVICE_NAME).add(logProbe).add(spanProbe).build(),
         acceptor.getConfiguration());
 
     removeLogProbe(listener, logProbe);
     listener.commit(pollingHinter);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Configuration.builder().setService(SERVICE_NAME).add(spanProbe).build(),
         acceptor.getConfiguration());
 
     removeSpanProbe(listener, spanProbe);
     listener.commit(pollingHinter);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Configuration.builder().setService(SERVICE_NAME).build(), acceptor.getConfiguration());
   }
 
@@ -186,11 +185,12 @@ public class DebuggerProductChangesListenerTest {
     listener.commit(pollingHinter);
     Configuration expectedConfig =
         Configuration.builder().add(config).add(logProbeWithSnapshot).build();
-    Assert.assertEquals(expectedConfig.getService(), acceptor.getConfiguration().getService());
-    Assert.assertEquals(
+    Assertions.assertEquals(expectedConfig.getService(), acceptor.getConfiguration().getService());
+    Assertions.assertEquals(
         expectedConfig.getMetricProbes(), acceptor.getConfiguration().getMetricProbes());
-    Assert.assertTrue(acceptor.getConfiguration().getLogProbes().contains(logProbeWithSnapshot));
-    Assert.assertTrue(acceptor.getConfiguration().getLogProbes().contains(logProbe));
+    Assertions.assertTrue(
+        acceptor.getConfiguration().getLogProbes().contains(logProbeWithSnapshot));
+    Assertions.assertTrue(acceptor.getConfiguration().getLogProbes().contains(logProbe));
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
@@ -52,8 +52,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import net.bytebuddy.agent.ByteBuddyAgent;
 import org.joor.Reflect;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -97,7 +97,7 @@ public class DebuggerTransformerTest {
 
     @Override
     public void addSnapshot(Snapshot snapshot) {
-      this.snapshots.add(snapshot);
+      snapshots.add(snapshot);
     }
 
     @Override
@@ -114,7 +114,7 @@ public class DebuggerTransformerTest {
     TrackingClassFileTransformer(String targetClassName, LogProbe probe, byte[][] codeOutput) {
       assertTrue(codeOutput != null && codeOutput.length == 2);
       this.targetClassName = targetClassName;
-      this.delegate =
+      delegate =
           new DebuggerTransformer(
               Config.get(),
               new Configuration(SERVICE_NAME, Collections.singletonList(probe)),
@@ -230,10 +230,10 @@ public class DebuggerTransformerTest {
         ArrayList.class,
         null,
         getClassFileBytes(ArrayList.class));
-    Assert.assertTrue(instrumentedClassFile.exists());
-    Assert.assertTrue(origClassFile.exists());
-    Assert.assertTrue(instrumentedClassFile.delete());
-    Assert.assertTrue(origClassFile.delete());
+    Assertions.assertTrue(instrumentedClassFile.exists());
+    Assertions.assertTrue(origClassFile.exists());
+    Assertions.assertTrue(instrumentedClassFile.delete());
+    Assertions.assertTrue(origClassFile.delete());
   }
 
   @Test
@@ -272,7 +272,7 @@ public class DebuggerTransformerTest {
               probeInfo.clazz,
               null,
               getClassFileBytes(probeInfo.clazz));
-      Assert.assertNotNull(newClassBuffer);
+      Assertions.assertNotNull(newClassBuffer);
     }
     byte[] newClassBuffer =
         debuggerTransformer.transform(
@@ -281,7 +281,7 @@ public class DebuggerTransformerTest {
             HashSet.class,
             null,
             getClassFileBytes(HashSet.class));
-    Assert.assertNull(newClassBuffer);
+    Assertions.assertNull(newClassBuffer);
   }
 
   static class ProbeTestInfo {
@@ -326,7 +326,7 @@ public class DebuggerTransformerTest {
             String.class,
             null,
             getClassFileBytes(String.class));
-    Assert.assertNull(newClassBuffer);
+    Assertions.assertNull(newClassBuffer);
     newClassBuffer =
         debuggerTransformer.transform(
             ClassLoader.getSystemClassLoader(),
@@ -334,7 +334,7 @@ public class DebuggerTransformerTest {
             HashMap.class,
             null,
             getClassFileBytes(HashMap.class));
-    Assert.assertNull(newClassBuffer);
+    Assertions.assertNull(newClassBuffer);
   }
 
   @Test
@@ -360,11 +360,11 @@ public class DebuggerTransformerTest {
             String.class,
             null,
             getClassFileBytes(String.class));
-    Assert.assertNull(newClassBuffer);
-    Assert.assertNotNull(lastResult.get());
-    Assert.assertTrue(lastResult.get().isBlocked());
-    Assert.assertFalse(lastResult.get().isInstalled());
-    Assert.assertEquals("java.lang.String", lastResult.get().getTypeName());
+    Assertions.assertNull(newClassBuffer);
+    Assertions.assertNotNull(lastResult.get());
+    Assertions.assertTrue(lastResult.get().isBlocked());
+    Assertions.assertFalse(lastResult.get().isInstalled());
+    Assertions.assertEquals("java.lang.String", lastResult.get().getTypeName());
   }
 
   @Test
@@ -384,11 +384,11 @@ public class DebuggerTransformerTest {
             null, // classBeingRedefined
             null,
             getClassFileBytes(ArrayList.class));
-    Assert.assertNotNull(newClassBuffer);
-    Assert.assertNotNull(lastResult.get());
-    Assert.assertFalse(lastResult.get().isBlocked());
-    Assert.assertTrue(lastResult.get().isInstalled());
-    Assert.assertEquals("java.util.ArrayList", lastResult.get().getTypeName());
+    Assertions.assertNotNull(newClassBuffer);
+    Assertions.assertNotNull(lastResult.get());
+    Assertions.assertFalse(lastResult.get().isBlocked());
+    Assertions.assertTrue(lastResult.get().isInstalled());
+    Assertions.assertEquals("java.util.ArrayList", lastResult.get().getTypeName());
   }
 
   @ParameterizedTest(
@@ -670,7 +670,7 @@ public class DebuggerTransformerTest {
   }
 
   private static void assertTransformation(byte[] original, byte[] transformed) {
-    Assert.assertNotNull(transformed);
+    Assertions.assertNotNull(transformed);
     String diff = diff(asmify(transformed), asmify(original));
     // make sure the instrumentation actually changed anything
     assertFalse(diff.isEmpty());

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DenyListHelperTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DenyListHelperTest.java
@@ -1,6 +1,6 @@
 package com.datadog.debugger.agent;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class DenyListHelperTest {
@@ -8,13 +8,13 @@ public class DenyListHelperTest {
   @Test
   public void isDeniedClass() {
     DenyListHelper denyListHelper = new DenyListHelper(null);
-    Assert.assertTrue(denyListHelper.isDenied("java.lang.String"));
-    Assert.assertTrue(denyListHelper.isDenied("java.lang.Object"));
-    Assert.assertTrue(denyListHelper.isDenied("java.security.Security"));
-    Assert.assertTrue(denyListHelper.isDenied("javax.security.auth.AuthPermission"));
-    Assert.assertFalse(denyListHelper.isDenied("java.util.List"));
-    Assert.assertFalse(denyListHelper.isDenied("List"));
-    Assert.assertFalse(denyListHelper.isDenied(null));
-    Assert.assertFalse(denyListHelper.isDenied(""));
+    Assertions.assertTrue(denyListHelper.isDenied("java.lang.String"));
+    Assertions.assertTrue(denyListHelper.isDenied("java.lang.Object"));
+    Assertions.assertTrue(denyListHelper.isDenied("java.security.Security"));
+    Assertions.assertTrue(denyListHelper.isDenied("javax.security.auth.AuthPermission"));
+    Assertions.assertFalse(denyListHelper.isDenied("java.util.List"));
+    Assertions.assertFalse(denyListHelper.isDenied("List"));
+    Assertions.assertFalse(denyListHelper.isDenied(null));
+    Assertions.assertFalse(denyListHelper.isDenied(""));
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -29,8 +29,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import net.bytebuddy.agent.ByteBuddyAgent;
 import org.joor.Reflect;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class LogProbesInstrumentationTest {
@@ -57,7 +57,7 @@ public class LogProbesInstrumentationTest {
         installSingleProbe("this is log line", CLASS_NAME, "main", "int (java.lang.String)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
+    Assertions.assertEquals(3, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCapturesNull(snapshot);
     assertEquals("this is log line", snapshot.buildSummary());
@@ -71,7 +71,7 @@ public class LogProbesInstrumentationTest {
             "this is log line with arg={arg}", CLASS_NAME, "main", "int (java.lang.String)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
+    Assertions.assertEquals(3, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCapturesNull(snapshot);
     assertEquals("this is log line with arg=1", snapshot.buildSummary());
@@ -92,7 +92,7 @@ public class LogProbesInstrumentationTest {
     DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, probe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
+    Assertions.assertEquals(3, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCapturesNull(snapshot);
     assertEquals("this is log line with return=3", snapshot.buildSummary());
@@ -119,8 +119,8 @@ public class LogProbesInstrumentationTest {
     DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbe1);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
-    Assert.assertEquals(2, listener.snapshots.size());
+    Assertions.assertEquals(3, result);
+    Assertions.assertEquals(2, listener.snapshots.size());
     Snapshot snapshot0 = listener.snapshots.get(0);
     assertCapturesNull(snapshot0);
     assertEquals("this is log line #1 with arg=1", snapshot0.buildSummary());
@@ -184,8 +184,8 @@ public class LogProbesInstrumentationTest {
     DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbe1);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
-    Assert.assertEquals(2, listener.snapshots.size());
+    Assertions.assertEquals(3, result);
+    Assertions.assertEquals(2, listener.snapshots.size());
     return listener.snapshots;
   }
 
@@ -196,7 +196,7 @@ public class LogProbesInstrumentationTest {
         installSingleProbe("this is log line", CLASS_NAME, null, null, "9");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
+    Assertions.assertEquals(3, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCapturesNull(snapshot);
     assertEquals("this is log line", snapshot.buildSummary());
@@ -209,7 +209,7 @@ public class LogProbesInstrumentationTest {
         installSingleProbe("this is log line with local var={var1}", CLASS_NAME, null, null, "9");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
+    Assertions.assertEquals(3, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCapturesNull(snapshot);
     assertEquals("this is log line with local var=3", snapshot.buildSummary());
@@ -227,7 +227,7 @@ public class LogProbesInstrumentationTest {
             "25");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(143, result);
+    Assertions.assertEquals(143, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCapturesNull(snapshot);
     assertEquals("nullObject=null sdata=foo cdata=101", snapshot.buildSummary());
@@ -245,7 +245,7 @@ public class LogProbesInstrumentationTest {
             "9");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
+    Assertions.assertEquals(3, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCapturesNull(snapshot);
     assertEquals(
@@ -259,7 +259,7 @@ public class LogProbesInstrumentationTest {
         installSingleProbe("this is log line with local var={var42}", CLASS_NAME, null, null, "9");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
+    Assertions.assertEquals(3, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCapturesNull(snapshot);
     assertEquals("this is log line with local var=UNDEFINED", snapshot.buildSummary());
@@ -276,7 +276,7 @@ public class LogProbesInstrumentationTest {
             "this is log line with field={nullObject.intValue}", CLASS_NAME, null, null, "25");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assert.assertEquals(143, result);
+    Assertions.assertEquals(143, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCapturesNull(snapshot);
     assertEquals("this is log line with field=UNDEFINED", snapshot.buildSummary());
@@ -295,7 +295,7 @@ public class LogProbesInstrumentationTest {
             "this is log line with element of list={strList[10]}", CLASS_NAME, null, null, "24");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assert.assertEquals(42, result);
+    Assertions.assertEquals(42, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertEquals("this is log line with element of list=UNDEFINED", snapshot.buildSummary());
     assertEquals(1, snapshot.getEvaluationErrors().size());
@@ -311,7 +311,7 @@ public class LogProbesInstrumentationTest {
         installSingleProbe("this is log line for this={this}", CLASS_NAME, null, null, "24");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assert.assertEquals(42, result);
+    Assertions.assertEquals(42, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertEquals(
         "this is log line for this={STATIC_STR=strStatic, intValue=48, doubleValue=3.14, strValue=done, strList=..., ...}",
@@ -333,13 +333,13 @@ public class LogProbesInstrumentationTest {
     DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "5").get();
-    Assert.assertEquals(3, result);
-    Assert.assertEquals(1, listener.snapshots.size());
+    Assertions.assertEquals(3, result);
+    Assertions.assertEquals(1, listener.snapshots.size());
     Snapshot snapshot = listener.snapshots.get(0);
-    Assert.assertNotNull(snapshot.getCaptures().getEntry());
-    Assert.assertEquals(2, snapshot.getCaptures().getEntry().getArguments().size());
-    Assert.assertEquals(1, snapshot.getEvaluationErrors().size());
-    Assert.assertEquals(
+    Assertions.assertNotNull(snapshot.getCaptures().getEntry());
+    Assertions.assertEquals(2, snapshot.getCaptures().getEntry().getArguments().size());
+    Assertions.assertEquals(1, snapshot.getEvaluationErrors().size());
+    Assertions.assertEquals(
         "Cannot find symbol: typoArg", snapshot.getEvaluationErrors().get(0).getMessage());
   }
 
@@ -427,8 +427,8 @@ public class LogProbesInstrumentationTest {
     DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbe1);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
-    Assert.assertEquals(2, listener.snapshots.size());
+    Assertions.assertEquals(3, result);
+    Assertions.assertEquals(2, listener.snapshots.size());
     return listener.snapshots;
   }
 
@@ -510,7 +510,7 @@ public class LogProbesInstrumentationTest {
       String expectedClassName,
       Collection<LogProbe> logProbes,
       Map<String, InstrumentationResult> instrumentationResults) {
-    Assert.assertEquals(expectedClassName, callingClass.getName());
+    Assertions.assertEquals(expectedClassName, callingClass.getName());
     for (LogProbe probe : logProbes) {
       if (probe.getId().equals(id)) {
         String typeName = probe.getWhere().getTypeName();
@@ -557,17 +557,17 @@ public class LogProbesInstrumentationTest {
   }
 
   private Snapshot assertOneSnapshot(DebuggerTransformerTest.TestSnapshotListener listener) {
-    Assert.assertFalse("Snapshot skipped because " + listener.cause, listener.skipped);
-    Assert.assertEquals(1, listener.snapshots.size());
+    Assertions.assertFalse(listener.skipped, "Snapshot skipped because " + listener.cause);
+    Assertions.assertEquals(1, listener.snapshots.size());
     Snapshot snapshot = listener.snapshots.get(0);
-    Assert.assertEquals(LOG_ID, snapshot.getProbe().getId());
+    Assertions.assertEquals(LOG_ID, snapshot.getProbe().getId());
     return snapshot;
   }
 
   private void assertCapturesNull(Snapshot snapshot) {
-    Assert.assertNull(snapshot.getCaptures().getEntry());
-    Assert.assertNull(snapshot.getCaptures().getReturn());
-    Assert.assertNull(snapshot.getCaptures().getLines());
-    Assert.assertNull(snapshot.getCaptures().getCaughtExceptions());
+    Assertions.assertNull(snapshot.getCaptures().getEntry());
+    Assertions.assertNull(snapshot.getCaptures().getReturn());
+    Assertions.assertNull(snapshot.getCaptures().getLines());
+    Assertions.assertNull(snapshot.getCaptures().getCaughtExceptions());
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
@@ -26,8 +26,8 @@ import java.util.List;
 import java.util.Map;
 import net.bytebuddy.agent.ByteBuddyAgent;
 import org.joor.Reflect;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class MetricProbesInstrumentationTest {
@@ -58,10 +58,10 @@ public class MetricProbesInstrumentationTest {
         installSingleMetric(METRIC_NAME, COUNT, CLASS_NAME, "main", "int (java.lang.String)", null);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
-    Assert.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(1, listener.counters.get(METRIC_NAME).longValue());
-    Assert.assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
+    Assertions.assertEquals(3, result);
+    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(1, listener.counters.get(METRIC_NAME).longValue());
+    Assertions.assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
   @Test
@@ -79,10 +79,10 @@ public class MetricProbesInstrumentationTest {
             new String[] {"tag1:foo1", "tag2:foo2"});
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
-    Assert.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(1, listener.counters.get(METRIC_NAME).longValue());
-    Assert.assertArrayEquals(
+    Assertions.assertEquals(3, result);
+    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(1, listener.counters.get(METRIC_NAME).longValue());
+    Assertions.assertArrayEquals(
         new String[] {"tag1:foo1", "tag2:foo2", METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
@@ -100,9 +100,9 @@ public class MetricProbesInstrumentationTest {
             new ValueScript(DSL.value(42L), "42"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
-    Assert.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(42, listener.counters.get(METRIC_NAME).longValue());
+    Assertions.assertEquals(3, result);
+    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(42, listener.counters.get(METRIC_NAME).longValue());
   }
 
   @Test
@@ -119,9 +119,9 @@ public class MetricProbesInstrumentationTest {
             new ValueScript(DSL.value(42.0), "42.0"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
-    Assert.assertFalse(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(
+    Assertions.assertEquals(3, result);
+    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(
         "Unsupported literal: 42.0 type: java.lang.Double, expect integral type (int, long).",
         mockSink.getCurrentDiagnostics().get(0).getMessage());
   }
@@ -140,9 +140,9 @@ public class MetricProbesInstrumentationTest {
             new ValueScript(DSL.ref("value"), "value"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
-    Assert.assertFalse(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(
+    Assertions.assertEquals(3, result);
+    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(
         "Cannot resolve symbol value", mockSink.getCurrentDiagnostics().get(0).getMessage());
   }
 
@@ -160,9 +160,9 @@ public class MetricProbesInstrumentationTest {
             new ValueScript(DSL.ref("value"), "value"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(48, result);
-    Assert.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(31, listener.counters.get(METRIC_NAME).longValue());
+    Assertions.assertEquals(48, result);
+    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(31, listener.counters.get(METRIC_NAME).longValue());
   }
 
   @Test
@@ -179,10 +179,10 @@ public class MetricProbesInstrumentationTest {
             new ValueScript(DSL.ref("value"), "value"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(48, result);
-    Assert.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(31, listener.counters.get(METRIC_NAME).longValue());
-    Assert.assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
+    Assertions.assertEquals(48, result);
+    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(31, listener.counters.get(METRIC_NAME).longValue());
+    Assertions.assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
   @Test
@@ -200,7 +200,7 @@ public class MetricProbesInstrumentationTest {
             new String[] {"tag1:foo1"});
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertArrayEquals(new String[] {"tag1:foo1", METRIC_PROBEID_TAG}, listener.lastTags);
+    Assertions.assertArrayEquals(new String[] {"tag1:foo1", METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
   @Test
@@ -217,10 +217,10 @@ public class MetricProbesInstrumentationTest {
             new ValueScript(DSL.ref("value"), "value"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(48, result);
-    Assert.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(31, listener.counters.get(METRIC_NAME).longValue());
-    Assert.assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
+    Assertions.assertEquals(48, result);
+    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(31, listener.counters.get(METRIC_NAME).longValue());
+    Assertions.assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
   @Test
@@ -239,10 +239,10 @@ public class MetricProbesInstrumentationTest {
             new String[] {"tag1:foo1"});
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(48, result);
-    Assert.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(31, listener.counters.get(METRIC_NAME).longValue());
-    Assert.assertArrayEquals(new String[] {"tag1:foo1", METRIC_PROBEID_TAG}, listener.lastTags);
+    Assertions.assertEquals(48, result);
+    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(31, listener.counters.get(METRIC_NAME).longValue());
+    Assertions.assertArrayEquals(new String[] {"tag1:foo1", METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
   @Test
@@ -260,9 +260,9 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(48, result);
-    Assert.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(31, listener.counters.get(METRIC_NAME).longValue());
+    Assertions.assertEquals(48, result);
+    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(31, listener.counters.get(METRIC_NAME).longValue());
   }
 
   @Test
@@ -279,9 +279,9 @@ public class MetricProbesInstrumentationTest {
             new ValueScript(DSL.ref("foo"), "foo"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(48, result);
-    Assert.assertFalse(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(
+    Assertions.assertEquals(48, result);
+    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(
         "Cannot resolve symbol foo", mockSink.getCurrentDiagnostics().get(0).getMessage());
   }
 
@@ -299,9 +299,9 @@ public class MetricProbesInstrumentationTest {
             new ValueScript(DSL.ref("arg"), "arg"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(48, result);
-    Assert.assertFalse(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(
+    Assertions.assertEquals(48, result);
+    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(
         "Incompatible type for expression: java.lang.String with expected type: long",
         mockSink.getCurrentDiagnostics().get(0).getMessage());
   }
@@ -316,9 +316,9 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
-    Assert.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(3, listener.counters.get(METRIC_NAME).longValue());
+    Assertions.assertEquals(3, result);
+    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(3, listener.counters.get(METRIC_NAME).longValue());
   }
 
   @Test
@@ -331,9 +331,9 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
-    Assert.assertFalse(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(
+    Assertions.assertEquals(3, result);
+    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(
         "Cannot resolve symbol foo", mockSink.getCurrentDiagnostics().get(0).getMessage());
   }
 
@@ -347,9 +347,9 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
-    Assert.assertFalse(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(
+    Assertions.assertEquals(3, result);
+    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(
         "Incompatible type for expression: java.lang.String with expected type: long",
         mockSink.getCurrentDiagnostics().get(0).getMessage());
   }
@@ -369,9 +369,9 @@ public class MetricProbesInstrumentationTest {
 
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assert.assertEquals(42, result);
-    Assert.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(24, listener.counters.get(METRIC_NAME).longValue());
+    Assertions.assertEquals(42, result);
+    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(24, listener.counters.get(METRIC_NAME).longValue());
   }
 
   @Test
@@ -389,9 +389,9 @@ public class MetricProbesInstrumentationTest {
 
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assert.assertEquals(42, result);
-    Assert.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(24, listener.counters.get(METRIC_NAME).longValue());
+    Assertions.assertEquals(42, result);
+    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(24, listener.counters.get(METRIC_NAME).longValue());
   }
 
   @Test
@@ -409,9 +409,9 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assert.assertEquals(42, result);
-    Assert.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(48, listener.counters.get(METRIC_NAME).longValue());
+    Assertions.assertEquals(42, result);
+    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(48, listener.counters.get(METRIC_NAME).longValue());
   }
 
   @Test
@@ -440,11 +440,11 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe1, metricProbe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assert.assertEquals(143, result);
-    Assert.assertTrue(listener.counters.containsKey(METRIC_NAME1));
-    Assert.assertTrue(listener.counters.containsKey(METRIC_NAME2));
-    Assert.assertEquals(42, listener.counters.get(METRIC_NAME1).longValue());
-    Assert.assertEquals(101, listener.counters.get(METRIC_NAME2).longValue());
+    Assertions.assertEquals(143, result);
+    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME1));
+    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME2));
+    Assertions.assertEquals(42, listener.counters.get(METRIC_NAME1).longValue());
+    Assertions.assertEquals(101, listener.counters.get(METRIC_NAME2).longValue());
   }
 
   @Test
@@ -474,10 +474,10 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe1, metricProbe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assert.assertEquals(143, result);
-    Assert.assertFalse(listener.counters.containsKey(METRIC_NAME1));
-    Assert.assertFalse(listener.counters.containsKey(METRIC_NAME2));
-    Assert.assertTrue(mockSink.getCurrentDiagnostics().isEmpty());
+    Assertions.assertEquals(143, result);
+    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME1));
+    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME2));
+    Assertions.assertTrue(mockSink.getCurrentDiagnostics().isEmpty());
   }
 
   @Test
@@ -506,12 +506,12 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe1, metricProbe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assert.assertEquals(143, result);
-    Assert.assertFalse(listener.counters.containsKey(METRIC_NAME1));
-    Assert.assertFalse(listener.counters.containsKey(METRIC_NAME2));
-    Assert.assertEquals(
+    Assertions.assertEquals(143, result);
+    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME1));
+    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME2));
+    Assertions.assertEquals(
         "Cannot resolve field foovalue", mockSink.getCurrentDiagnostics().get(0).getMessage());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Cannot resolve field foovalue", mockSink.getCurrentDiagnostics().get(1).getMessage());
   }
 
@@ -541,13 +541,13 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe1, metricProbe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assert.assertEquals(143, result);
-    Assert.assertFalse(listener.counters.containsKey(METRIC_NAME1));
-    Assert.assertFalse(listener.counters.containsKey(METRIC_NAME2));
-    Assert.assertEquals(
+    Assertions.assertEquals(143, result);
+    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME1));
+    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME2));
+    Assertions.assertEquals(
         "Incompatible type for expression: java.lang.String with expected type: long",
         mockSink.getCurrentDiagnostics().get(0).getMessage());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Incompatible type for expression: java.lang.String with expected type: long",
         mockSink.getCurrentDiagnostics().get(1).getMessage());
   }
@@ -567,9 +567,9 @@ public class MetricProbesInstrumentationTest {
 
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assert.assertEquals(42, result);
-    Assert.assertFalse(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(
+    Assertions.assertEquals(42, result);
+    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(
         "Cannot resolve symbol fooValue", mockSink.getCurrentDiagnostics().get(0).getMessage());
   }
 
@@ -588,9 +588,9 @@ public class MetricProbesInstrumentationTest {
 
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assert.assertEquals(42, result);
-    Assert.assertFalse(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(
+    Assertions.assertEquals(42, result);
+    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(
         "Incompatible type for expression: java.lang.String with expected type: long",
         mockSink.getCurrentDiagnostics().get(0).getMessage());
   }
@@ -604,9 +604,9 @@ public class MetricProbesInstrumentationTest {
             METRIC_NAME, COUNT, CLASS_NAME, "main", "int (java.lang.String)", null, null, "8");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
-    Assert.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(1, listener.counters.get(METRIC_NAME).longValue());
+    Assertions.assertEquals(3, result);
+    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(1, listener.counters.get(METRIC_NAME).longValue());
   }
 
   @Test
@@ -618,11 +618,11 @@ public class MetricProbesInstrumentationTest {
             METRIC_NAME, COUNT, CLASS_NAME, "main", "int (java.lang.String)", null, null, "4-8");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assert.assertEquals(3, result);
-    Assert.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(2, listener.counters.get(METRIC_NAME).longValue());
+    Assertions.assertEquals(3, result);
+    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(2, listener.counters.get(METRIC_NAME).longValue());
     result = Reflect.on(testClass).call("main", "2").get();
-    Assert.assertEquals(3, listener.counters.get(METRIC_NAME).longValue());
+    Assertions.assertEquals(3, listener.counters.get(METRIC_NAME).longValue());
   }
 
   @Test
@@ -638,9 +638,9 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assert.assertEquals(42, result);
-    Assert.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(24, listener.counters.get(METRIC_NAME).longValue());
+    Assertions.assertEquals(42, result);
+    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(24, listener.counters.get(METRIC_NAME).longValue());
   }
 
   @Test
@@ -656,9 +656,9 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assert.assertEquals(42, result);
-    Assert.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assert.assertEquals(48, listener.counters.get(METRIC_NAME).longValue());
+    Assertions.assertEquals(42, result);
+    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
+    Assertions.assertEquals(48, listener.counters.get(METRIC_NAME).longValue());
   }
 
   private MetricForwarderListener installSingleMetric(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnJre;
@@ -74,10 +74,10 @@ public class SnapshotSerializationTest {
 
     Snapshot deserializedSnapshot = adapter.fromJson(buffer);
     Snapshot.ProbeLocation location = deserializedSnapshot.getProbe().getLocation();
-    Assert.assertEquals(PROBE_LOCATION.getType(), location.getType());
-    Assert.assertEquals(PROBE_LOCATION.getFile(), location.getFile());
-    Assert.assertEquals(PROBE_LOCATION.getMethod(), location.getMethod());
-    Assert.assertEquals(PROBE_LOCATION.getLines(), location.getLines());
+    Assertions.assertEquals(PROBE_LOCATION.getType(), location.getType());
+    Assertions.assertEquals(PROBE_LOCATION.getFile(), location.getFile());
+    Assertions.assertEquals(PROBE_LOCATION.getMethod(), location.getMethod());
+    Assertions.assertEquals(PROBE_LOCATION.getLines(), location.getLines());
   }
 
   @Test
@@ -103,36 +103,36 @@ public class SnapshotSerializationTest {
     String snapshotRegex =
         getFixtureContent(SINK_FIXTURE_PREFIX + "/snapshotCapturedValueRegex.txt");
     snapshotRegex = snapshotRegex.replaceAll("\\n", "");
-    Assert.assertTrue(buffer, buffer.matches(snapshotRegex));
+    Assertions.assertTrue(buffer.matches(snapshotRegex), buffer);
     Snapshot deserializedSnapshot = adapter.fromJson(buffer);
     Map<String, Snapshot.CapturedValue> fields =
         deserializedSnapshot.getCaptures().getReturn().getFields();
-    Assert.assertEquals(3, fields.size());
+    Assertions.assertEquals(3, fields.size());
     normalValuedField = fields.get("normalValuedField");
-    Assert.assertEquals("foobar", normalValuedField.getValue());
-    Assert.assertEquals(String.class.getTypeName(), normalValuedField.getType());
-    Assert.assertNull(normalValuedField.getNotCapturedReason());
+    Assertions.assertEquals("foobar", normalValuedField.getValue());
+    Assertions.assertEquals(String.class.getTypeName(), normalValuedField.getType());
+    Assertions.assertNull(normalValuedField.getNotCapturedReason());
     normalNullField = fields.get("normalNullField");
-    Assert.assertNull(normalNullField.getValue());
-    Assert.assertEquals(String.class.getTypeName(), normalNullField.getType());
-    Assert.assertNull(normalNullField.getNotCapturedReason());
+    Assertions.assertNull(normalNullField.getValue());
+    Assertions.assertEquals(String.class.getTypeName(), normalNullField.getType());
+    Assertions.assertNull(normalNullField.getNotCapturedReason());
     notCapturedField = fields.get("notCapturedField");
     Map<String, Snapshot.CapturedValue> notCapturedFields =
         (Map<String, Snapshot.CapturedValue>) notCapturedField.getValue();
     Snapshot.CapturedValue processLoadTicks = notCapturedFields.get("processLoadTicks");
-    Assert.assertTrue(
+    Assertions.assertTrue(
         processLoadTicks
             .getNotCapturedReason()
             .startsWith(
                 "java.lang.reflect.InaccessibleObjectException: Unable to make field private com.sun.management.internal.OperatingSystemImpl$ContainerCpuTicks com.sun.management.internal.OperatingSystemImpl.processLoadTicks accessible: module jdk.management does not \"opens com.sun.management.internal\" to unnamed module @"));
     Snapshot.CapturedValue systemLoadTicks = notCapturedFields.get("systemLoadTicks");
-    Assert.assertTrue(
+    Assertions.assertTrue(
         systemLoadTicks
             .getNotCapturedReason()
             .startsWith(
                 "java.lang.reflect.InaccessibleObjectException: Unable to make field private com.sun.management.internal.OperatingSystemImpl$ContainerCpuTicks com.sun.management.internal.OperatingSystemImpl.systemLoadTicks accessible: module jdk.management does not \"opens com.sun.management.internal\" to unnamed module @"));
     Snapshot.CapturedValue containerMetrics = notCapturedFields.get("containerMetrics");
-    Assert.assertTrue(
+    Assertions.assertTrue(
         containerMetrics
             .getNotCapturedReason()
             .startsWith(
@@ -157,7 +157,7 @@ public class SnapshotSerializationTest {
     Snapshot deserializedSnapshot = adapter.fromJson(buffer);
     List<CapturedStackFrame> stacktrace =
         deserializedSnapshot.getCaptures().getCaughtExceptions().get(0).getStacktrace();
-    Assert.assertEquals(3, stacktrace.size());
+    Assertions.assertEquals(3, stacktrace.size());
     assertCapturedFrame(stacktrace.get(0), "f1", 12);
     assertCapturedFrame(stacktrace.get(1), "f2", 23);
     assertCapturedFrame(stacktrace.get(2), "f3", 34);
@@ -182,12 +182,12 @@ public class SnapshotSerializationTest {
     Snapshot deserializedSnapshot = adapter.fromJson(buffer);
     Snapshot.CapturedContext entry = deserializedSnapshot.getCaptures().getEntry();
     Snapshot.CapturedContext exit = deserializedSnapshot.getCaptures().getReturn();
-    Assert.assertEquals(1, entry.getFields().size());
-    Assert.assertEquals(42, entry.getFields().get("fieldInt").getValue());
-    Assert.assertEquals(1, exit.getFields().size());
-    Assert.assertEquals(42, exit.getFields().get("fieldInt").getValue());
-    Assert.assertEquals(1, exit.getLocals().size());
-    Assert.assertEquals("foo", exit.getLocals().get("@return").getValue());
+    Assertions.assertEquals(1, entry.getFields().size());
+    Assertions.assertEquals(42, entry.getFields().get("fieldInt").getValue());
+    Assertions.assertEquals(1, exit.getFields().size());
+    Assertions.assertEquals(42, exit.getFields().get("fieldInt").getValue());
+    Assertions.assertEquals(1, exit.getLocals().size());
+    Assertions.assertEquals("foo", exit.getLocals().get("@return").getValue());
   }
 
   @Test
@@ -203,10 +203,10 @@ public class SnapshotSerializationTest {
 
     Snapshot deserializedSnapshot = adapter.fromJson(buffer);
     Map<Integer, Snapshot.CapturedContext> lines = deserializedSnapshot.getCaptures().getLines();
-    Assert.assertEquals(1, lines.size());
+    Assertions.assertEquals(1, lines.size());
     Map<String, Snapshot.CapturedValue> lineFields = lines.get(24).getFields();
-    Assert.assertEquals(1, lineFields.size());
-    Assert.assertEquals(42, lineFields.get("fieldInt").getValue());
+    Assertions.assertEquals(1, lineFields.size());
+    Assertions.assertEquals(42, lineFields.get("fieldInt").getValue());
   }
 
   @Test
@@ -232,8 +232,8 @@ public class SnapshotSerializationTest {
     String buffer = adapter.toJson(snapshot);
 
     Snapshot deserializedSnapshot = adapter.fromJson(buffer);
-    Assert.assertTrue(deserializedSnapshot.getProbe().getScript() instanceof ProbeCondition);
-    Assert.assertEquals(
+    Assertions.assertTrue(deserializedSnapshot.getProbe().getScript() instanceof ProbeCondition);
+    Assertions.assertEquals(
         "n > 0", ((ProbeCondition) deserializedSnapshot.getProbe().getScript()).getDslExpression());
   }
 
@@ -366,7 +366,7 @@ public class SnapshotSerializationTest {
     Map<String, Object> localObjFieldsMap = (Map<String, Object>) localObjMap.get(FIELDS);
     Map<String, Object> complexClasses =
         (Map<String, Object>) localObjFieldsMap.get("complexClasses");
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "com.datadog.debugger.agent.SnapshotSerializationTest$ComplexClass[]",
         complexClasses.get(TYPE));
   }
@@ -435,7 +435,7 @@ public class SnapshotSerializationTest {
     assertPrimitiveValue(thisFields, "nullField", ComplexClass.class.getTypeName(), null);
     assertPrimitiveValue(thisFields, "intField", "int", "42");
     Map<String, Object> objField = (Map<String, Object>) thisFields.get("objField");
-    Assert.assertEquals(ComplexClass.class.getTypeName(), objField.get("type"));
+    Assertions.assertEquals(ComplexClass.class.getTypeName(), objField.get("type"));
     Map<String, Object> objFieldFields = (Map<String, Object>) objField.get(FIELDS);
     assertPrimitiveValue(objFieldFields, "complexIntField", "int", "21");
     assertPrimitiveValue(objFieldFields, "complexStrField", String.class.getTypeName(), "bar");
@@ -449,7 +449,7 @@ public class SnapshotSerializationTest {
     Map<String, Object> locals = (Map<String, Object>) returnJson.get(LOCALS);
     assertPrimitiveValue(locals, "intLocal", "int", "42");
     Map<String, Object> objLocal = (Map<String, Object>) locals.get("objLocal");
-    Assert.assertEquals(ComplexClass.class.getTypeName(), objLocal.get(TYPE));
+    Assertions.assertEquals(ComplexClass.class.getTypeName(), objLocal.get(TYPE));
     Map<String, Object> objLocalFields = (Map<String, Object>) objLocal.get(FIELDS);
     assertPrimitiveValue(objLocalFields, "complexIntField", "int", "21");
     assertPrimitiveValue(objLocalFields, "complexStrField", String.class.getTypeName(), "bar");
@@ -469,13 +469,13 @@ public class SnapshotSerializationTest {
     assertPrimitiveValue(thisFields, "nullField", ComplexClass.class.getTypeName(), null);
     assertPrimitiveValue(thisFields, "intField", "int", "42");
     Map<String, Object> objField = (Map<String, Object>) thisFields.get("objField");
-    Assert.assertEquals(ComplexClass.class.getTypeName(), objField.get(TYPE));
+    Assertions.assertEquals(ComplexClass.class.getTypeName(), objField.get(TYPE));
     Map<String, Object> objFieldFields = (Map<String, Object>) objField.get(FIELDS);
     assertPrimitiveValue(objFieldFields, "complexIntField", "int", "21");
     assertPrimitiveValue(objFieldFields, "complexStrField", String.class.getTypeName(), "bar");
     Map<String, Object> complexObjField =
         (Map<String, Object>) objFieldFields.get("complexObjField");
-    Assert.assertEquals(AnotherClass.class.getTypeName(), complexObjField.get(TYPE));
+    Assertions.assertEquals(AnotherClass.class.getTypeName(), complexObjField.get(TYPE));
     Map<String, Object> complexObjFieldFields = (Map<String, Object>) complexObjField.get(FIELDS);
     assertPrimitiveValue(complexObjFieldFields, "anotherIntField", "int", "11");
     assertPrimitiveValue(
@@ -486,13 +486,13 @@ public class SnapshotSerializationTest {
     Map<String, Object> locals = (Map<String, Object>) returnJson.get(LOCALS);
     assertPrimitiveValue(locals, "intLocal", "int", "42");
     Map<String, Object> objLocal = (Map<String, Object>) locals.get("objLocal");
-    Assert.assertEquals(ComplexClass.class.getTypeName(), objLocal.get("type"));
+    Assertions.assertEquals(ComplexClass.class.getTypeName(), objLocal.get("type"));
     Map<String, Object> objLocalFields = (Map<String, Object>) objLocal.get(FIELDS);
     assertPrimitiveValue(objLocalFields, "complexIntField", "int", "21");
     assertPrimitiveValue(objLocalFields, "complexStrField", String.class.getTypeName(), "bar");
     Map<String, Object> localComplexObjField =
         (Map<String, Object>) objLocalFields.get("complexObjField");
-    Assert.assertEquals(AnotherClass.class.getTypeName(), localComplexObjField.get(TYPE));
+    Assertions.assertEquals(AnotherClass.class.getTypeName(), localComplexObjField.get(TYPE));
     Map<String, Object> localComplexObjFieldFields =
         (Map<String, Object>) localComplexObjField.get(FIELDS);
     assertPrimitiveValue(localComplexObjFieldFields, "anotherIntField", "int", "11");
@@ -514,56 +514,56 @@ public class SnapshotSerializationTest {
   public void collectionSize0() throws IOException {
     Map<String, Object> thisArgFields = doCollectionSize(0);
     assertNotCaptured(thisArgFields, "intArrayField", "int[]", COLLECTION_SIZE_REASON);
-    Assert.assertEquals(0, getNbElements(thisArgFields, "intArrayField"));
+    Assertions.assertEquals(0, getNbElements(thisArgFields, "intArrayField"));
     assertNotCaptured(
         thisArgFields, "strArrayField", String[].class.getTypeName(), COLLECTION_SIZE_REASON);
-    Assert.assertEquals(0, getNbElements(thisArgFields, "strArrayField"));
+    Assertions.assertEquals(0, getNbElements(thisArgFields, "strArrayField"));
     assertNotCaptured(
         thisArgFields, "objArrayField", Object[].class.getTypeName(), COLLECTION_SIZE_REASON);
-    Assert.assertEquals(0, getNbElements(thisArgFields, "objArrayField"));
+    Assertions.assertEquals(0, getNbElements(thisArgFields, "objArrayField"));
     assertNotCaptured(
         thisArgFields, "listField", ArrayList.class.getTypeName(), COLLECTION_SIZE_REASON);
-    Assert.assertEquals(0, getNbElements(thisArgFields, "listField"));
+    Assertions.assertEquals(0, getNbElements(thisArgFields, "listField"));
     assertNotCaptured(
         thisArgFields, "mapField", HashMap.class.getTypeName(), COLLECTION_SIZE_REASON);
-    Assert.assertEquals(0, getNbEntries(thisArgFields, "mapField"));
+    Assertions.assertEquals(0, getNbEntries(thisArgFields, "mapField"));
   }
 
   @Test
   public void collectionSize3() throws IOException {
     Map<String, Object> thisArgFields = doCollectionSize(3);
     assertNotCaptured(thisArgFields, "intArrayField", "int[]", COLLECTION_SIZE_REASON);
-    Assert.assertEquals(3, getNbElements(thisArgFields, "intArrayField"));
+    Assertions.assertEquals(3, getNbElements(thisArgFields, "intArrayField"));
     assertArrayItem(thisArgFields, "intArrayField", "0", "1", "2");
     assertNotCaptured(
         thisArgFields, "strArrayField", String[].class.getTypeName(), COLLECTION_SIZE_REASON);
-    Assert.assertEquals(3, getNbElements(thisArgFields, "strArrayField"));
+    Assertions.assertEquals(3, getNbElements(thisArgFields, "strArrayField"));
     assertArrayItem(thisArgFields, "strArrayField", "foo0", "foo1", "foo2");
     assertNotCaptured(
         thisArgFields, "objArrayField", Object[].class.getTypeName(), COLLECTION_SIZE_REASON);
-    Assert.assertEquals(3, getNbElements(thisArgFields, "objArrayField"));
+    Assertions.assertEquals(3, getNbElements(thisArgFields, "objArrayField"));
     List<Object> objArrayElements = getArrayElements(thisArgFields, "objArrayField");
     assertComplexClass(objArrayElements.get(0), ComplexClass.class.getTypeName());
     assertComplexClass(objArrayElements.get(1), ComplexClass.class.getTypeName());
     assertComplexClass(objArrayElements.get(2), ComplexClass.class.getTypeName());
     assertNotCaptured(
         thisArgFields, "listField", ArrayList.class.getTypeName(), COLLECTION_SIZE_REASON);
-    Assert.assertEquals(3, getNbElements(thisArgFields, "listField"));
+    Assertions.assertEquals(3, getNbElements(thisArgFields, "listField"));
     assertArrayItem(thisArgFields, "listField", "foo0", "foo1", "foo2");
     assertNotCaptured(
         thisArgFields, "mapField", HashMap.class.getTypeName(), COLLECTION_SIZE_REASON);
-    Assert.assertEquals(3, getNbEntries(thisArgFields, "mapField"));
+    Assertions.assertEquals(3, getNbEntries(thisArgFields, "mapField"));
   }
 
   @Test
   public void collectionSize100() throws IOException {
     Map<String, Object> thisArgFields = doCollectionSize(100);
     assertNotCaptured(thisArgFields, "intArrayField", "int[]", null);
-    Assert.assertEquals(10, getNbElements(thisArgFields, "intArrayField"));
+    Assertions.assertEquals(10, getNbElements(thisArgFields, "intArrayField"));
     assertArrayItem(
         thisArgFields, "intArrayField", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
     assertNotCaptured(thisArgFields, "strArrayField", String[].class.getTypeName(), null);
-    Assert.assertEquals(10, getNbElements(thisArgFields, "strArrayField"));
+    Assertions.assertEquals(10, getNbElements(thisArgFields, "strArrayField"));
     assertArrayItem(
         thisArgFields,
         "strArrayField",
@@ -578,13 +578,13 @@ public class SnapshotSerializationTest {
         "foo8",
         "foo9");
     assertNotCaptured(thisArgFields, "objArrayField", Object[].class.getTypeName(), null);
-    Assert.assertEquals(10, getNbElements(thisArgFields, "objArrayField"));
+    Assertions.assertEquals(10, getNbElements(thisArgFields, "objArrayField"));
     List<Object> objArrayElements = getArrayElements(thisArgFields, "objArrayField");
     assertComplexClass(objArrayElements.get(0), ComplexClass.class.getTypeName());
     assertComplexClass(objArrayElements.get(4), ComplexClass.class.getTypeName());
     assertComplexClass(objArrayElements.get(9), ComplexClass.class.getTypeName());
     assertNotCaptured(thisArgFields, "listField", ArrayList.class.getTypeName(), null);
-    Assert.assertEquals(10, getNbElements(thisArgFields, "listField"));
+    Assertions.assertEquals(10, getNbElements(thisArgFields, "listField"));
     assertArrayItem(
         thisArgFields,
         "listField",
@@ -599,7 +599,7 @@ public class SnapshotSerializationTest {
         "foo8",
         "foo9");
     assertNotCaptured(thisArgFields, "mapField", HashMap.class.getTypeName(), null);
-    Assert.assertEquals(10, getNbEntries(thisArgFields, "mapField"));
+    Assertions.assertEquals(10, getNbEntries(thisArgFields, "mapField"));
     assertMapItems(
         thisArgFields,
         "mapField",
@@ -647,7 +647,7 @@ public class SnapshotSerializationTest {
     assertNotCaptured(thisArgFields, "strMap", HashMap.class.getTypeName(), COLLECTION_SIZE_REASON);
     Map<String, Object> field = (Map<String, Object>) thisArgFields.get("strMap");
     List<Object> entries = (List<Object>) field.get(ENTRIES);
-    Assert.assertEquals(3, entries.size());
+    Assertions.assertEquals(3, entries.size());
     assertSize(thisArgFields, "strMap", "10");
   }
 
@@ -717,14 +717,14 @@ public class SnapshotSerializationTest {
   public void capturesAdapterNull() {
     MoshiSnapshotHelper.CapturesAdapter capturesAdapter =
         new MoshiSnapshotHelper.CapturesAdapter(new Moshi.Builder().build(), null);
-    Assert.assertEquals("null", capturesAdapter.toJson(null));
+    Assertions.assertEquals("null", capturesAdapter.toJson(null));
   }
 
   @Test
   public void capturedValueAdapterNull() {
     MoshiSnapshotHelper.CapturedValueAdapter capturedValueAdapter =
         new MoshiSnapshotHelper.CapturedValueAdapter();
-    Assert.assertEquals("null", capturedValueAdapter.toJson(null));
+    Assertions.assertEquals("null", capturedValueAdapter.toJson(null));
   }
 
   private Map<String, Object> doLength(int maxLength) throws IOException {
@@ -738,22 +738,22 @@ public class SnapshotSerializationTest {
   @Test
   public void fieldCount0() throws IOException {
     Map<String, Object> thisArg = doFieldCount(0);
-    Assert.assertEquals(0, ((Map<String, Snapshot.CapturedValue>) thisArg.get(FIELDS)).size());
-    Assert.assertEquals(FIELD_COUNT_REASON, thisArg.get(NOT_CAPTURED_REASON));
+    Assertions.assertEquals(0, ((Map<String, Snapshot.CapturedValue>) thisArg.get(FIELDS)).size());
+    Assertions.assertEquals(FIELD_COUNT_REASON, thisArg.get(NOT_CAPTURED_REASON));
   }
 
   @Test
   public void fieldCount3() throws IOException {
     Map<String, Object> thisArg = doFieldCount(3);
-    Assert.assertEquals(3, ((Map<String, Snapshot.CapturedValue>) thisArg.get(FIELDS)).size());
-    Assert.assertEquals(FIELD_COUNT_REASON, thisArg.get(NOT_CAPTURED_REASON));
+    Assertions.assertEquals(3, ((Map<String, Snapshot.CapturedValue>) thisArg.get(FIELDS)).size());
+    Assertions.assertEquals(FIELD_COUNT_REASON, thisArg.get(NOT_CAPTURED_REASON));
   }
 
   @Test
   public void fieldCount20() throws IOException {
     Map<String, Object> thisArg = doFieldCount(20);
-    Assert.assertEquals(4, ((Map<String, Snapshot.CapturedValue>) thisArg.get(FIELDS)).size());
-    Assert.assertNull(thisArg.get(NOT_CAPTURED_REASON));
+    Assertions.assertEquals(4, ((Map<String, Snapshot.CapturedValue>) thisArg.get(FIELDS)).size());
+    Assertions.assertNull(thisArg.get(NOT_CAPTURED_REASON));
   }
 
   private Map<String, Object> doFieldCount(int maxFieldCount) throws IOException {
@@ -766,8 +766,8 @@ public class SnapshotSerializationTest {
 
   private void assertComplexClass(Object obj, String type) {
     Map<String, Object> objMap = (Map<String, Object>) obj;
-    Assert.assertEquals(type, objMap.get(TYPE));
-    Assert.assertTrue(objMap.containsKey(FIELDS));
+    Assertions.assertEquals(type, objMap.get(TYPE));
+    Assertions.assertTrue(objMap.containsKey(FIELDS));
   }
 
   private int getNbElements(Map<String, Object> item, String name) {
@@ -784,7 +784,7 @@ public class SnapshotSerializationTest {
     List<Object> elements = getArrayElements(item, name);
     for (int i = 0; i < values.length; i++) {
       Map<String, Object> elem = (Map<String, Object>) elements.get(i);
-      Assert.assertEquals(values[i], elem.get(VALUE));
+      Assertions.assertEquals(values[i], elem.get(VALUE));
     }
   }
 
@@ -801,7 +801,7 @@ public class SnapshotSerializationTest {
   private void assertMapItems(Map<String, Object> item, String name, String... expectedValues) {
     Map<String, Object> field = (Map<String, Object>) item.get(name);
     List<Object> entries = (List<Object>) field.get(ENTRIES);
-    Assert.assertEquals(expectedValues.length / 2, entries.size());
+    Assertions.assertEquals(expectedValues.length / 2, entries.size());
     int index = 0;
     Map<String, String> tmpMap = new HashMap<>();
     for (Object obj : entries) {
@@ -814,38 +814,38 @@ public class SnapshotSerializationTest {
     while (index < expectedValues.length) {
       String key = expectedValues[index++];
       String value = expectedValues[index++];
-      Assert.assertTrue(tmpMap.containsKey(key));
-      Assert.assertEquals(value, tmpMap.get(key));
+      Assertions.assertTrue(tmpMap.containsKey(key));
+      Assertions.assertEquals(value, tmpMap.get(key));
     }
   }
 
   private void assertNotCaptured(
       Map<String, Object> item, String name, String type, String reason) {
     Map<String, Object> obj = (Map<String, Object>) item.get(name);
-    Assert.assertEquals(type, obj.get(TYPE));
-    Assert.assertEquals(reason, obj.get(NOT_CAPTURED_REASON));
+    Assertions.assertEquals(type, obj.get(TYPE));
+    Assertions.assertEquals(reason, obj.get(NOT_CAPTURED_REASON));
   }
 
   private void assertTruncated(
       Map<String, Object> item, String name, String type, String truncated) {
     Map<String, Object> obj = (Map<String, Object>) item.get(name);
-    Assert.assertEquals(type, obj.get(TYPE));
-    Assert.assertEquals(truncated, String.valueOf(obj.get(TRUNCATED)));
+    Assertions.assertEquals(type, obj.get(TYPE));
+    Assertions.assertEquals(truncated, String.valueOf(obj.get(TRUNCATED)));
   }
 
   private void assertSize(Map<String, Object> item, String name, String size) {
     Map<String, Object> obj = (Map<String, Object>) item.get(name);
-    Assert.assertEquals(size, String.valueOf(obj.get(SIZE)));
+    Assertions.assertEquals(size, String.valueOf(obj.get(SIZE)));
   }
 
   private void assertPrimitiveValue(
       Map<String, Object> item, String name, String type, String value) {
     Map<String, Object> prim = (Map<String, Object>) item.get(name);
-    Assert.assertEquals(type, prim.get(TYPE));
+    Assertions.assertEquals(type, prim.get(TYPE));
     if (value != null) {
-      Assert.assertEquals(value, String.valueOf(prim.get(VALUE)));
+      Assertions.assertEquals(value, String.valueOf(prim.get(VALUE)));
     } else {
-      Assert.assertEquals(true, prim.get(IS_NULL));
+      Assertions.assertEquals(true, prim.get(IS_NULL));
     }
   }
 
@@ -1065,9 +1065,9 @@ public class SnapshotSerializationTest {
 
   private void assertCapturedFrame(
       CapturedStackFrame capturedStackFrame, String methodName, int lineNumber) {
-    Assert.assertNull(capturedStackFrame.getFileName());
-    Assert.assertEquals(methodName, capturedStackFrame.getFunction());
-    Assert.assertEquals(lineNumber, capturedStackFrame.getLineNumber());
+    Assertions.assertNull(capturedStackFrame.getFileName());
+    Assertions.assertEquals(methodName, capturedStackFrame.getFunction());
+    Assertions.assertEquals(lineNumber, capturedStackFrame.getLineNumber());
   }
 
   private Snapshot createSnapshot() {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/TypeNameHelperTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/TypeNameHelperTest.java
@@ -1,17 +1,17 @@
 package com.datadog.debugger.agent;
 
 import java.util.Map;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TypeNameHelperTest {
 
   @Test
   public void extractSimpleName() {
-    Assert.assertEquals("String", TypeNameHelper.extractSimpleName(String.class));
-    Assert.assertEquals(
+    Assertions.assertEquals("String", TypeNameHelper.extractSimpleName(String.class));
+    Assertions.assertEquals(
         "String", TypeNameHelper.extractSimpleNameFromName(String.class.getTypeName()));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Entry", TypeNameHelper.extractSimpleNameFromName(Map.Entry.class.getTypeName()));
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/instrumentation/LineMapTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/instrumentation/LineMapTest.java
@@ -1,6 +1,6 @@
 package com.datadog.debugger.instrumentation;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.tree.LabelNode;
 import org.objectweb.asm.tree.LineNumberNode;
@@ -18,8 +18,8 @@ public class LineMapTest {
   void isEmptyReturnTrue() {
     LineMap map = new LineMap();
 
-    Assert.assertEquals(true, map.isEmpty());
-    Assert.assertEquals(null, map.getLineLabel(2));
+    Assertions.assertEquals(true, map.isEmpty());
+    Assertions.assertEquals(null, map.getLineLabel(2));
   }
 
   @Test
@@ -29,13 +29,13 @@ public class LineMapTest {
     LabelNode line2 = addLine(map, 2);
     LabelNode line5 = addLine(map, 5);
 
-    Assert.assertEquals(line1, map.getLineLabel(0));
-    Assert.assertEquals(line1, map.getLineLabel(1));
-    Assert.assertEquals(line2, map.getLineLabel(2));
-    Assert.assertEquals(line5, map.getLineLabel(3));
-    Assert.assertEquals(line5, map.getLineLabel(4));
-    Assert.assertEquals(line5, map.getLineLabel(5));
-    Assert.assertEquals(null, map.getLineLabel(6));
+    Assertions.assertEquals(line1, map.getLineLabel(0));
+    Assertions.assertEquals(line1, map.getLineLabel(1));
+    Assertions.assertEquals(line2, map.getLineLabel(2));
+    Assertions.assertEquals(line5, map.getLineLabel(3));
+    Assertions.assertEquals(line5, map.getLineLabel(4));
+    Assertions.assertEquals(line5, map.getLineLabel(5));
+    Assertions.assertEquals(null, map.getLineLabel(6));
   }
 
   @Test
@@ -46,9 +46,9 @@ public class LineMapTest {
     map.addLine(new LineNumberNode(1, line1));
     LabelNode line5 = addLine(map, 5);
 
-    Assert.assertEquals(line1, map.getLineLabel(0));
-    Assert.assertEquals(line1, map.getLineLabel(1));
-    Assert.assertEquals(line2, map.getLineLabel(2));
+    Assertions.assertEquals(line1, map.getLineLabel(0));
+    Assertions.assertEquals(line1, map.getLineLabel(1));
+    Assertions.assertEquals(line2, map.getLineLabel(2));
   }
 
   @Test
@@ -57,7 +57,7 @@ public class LineMapTest {
     LabelNode line1 = addLine(map, 1);
     LabelNode line1b = addLine(map, 1);
 
-    Assert.assertEquals(line1b, map.getLineLabel(0));
-    Assert.assertEquals(line1b, map.getLineLabel(1));
+    Assertions.assertEquals(line1b, map.getLineLabel(0));
+    Assertions.assertEquals(line1b, map.getLineLabel(1));
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/instrumentation/TypesTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/instrumentation/TypesTest.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.instrumentation;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.objectweb.asm.Opcodes.AALOAD;
 import static org.objectweb.asm.Opcodes.AASTORE;
 import static org.objectweb.asm.Opcodes.BALOAD;
@@ -19,7 +20,7 @@ import static org.objectweb.asm.Opcodes.SALOAD;
 import static org.objectweb.asm.Opcodes.SASTORE;
 
 import java.util.stream.Stream;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -84,7 +85,7 @@ class TypesTest {
   @ParameterizedTest
   @MethodSource("provideGetArrayType")
   void testGetArrayType(Class<?> clazz, int opcode) {
-    Assert.assertEquals(Type.getType(clazz), Types.getArrayType(opcode));
+    Assertions.assertEquals(Type.getType(clazz), Types.getArrayType(opcode));
   }
 
   private static Stream<Arguments> provideGetArrayType() {
@@ -110,7 +111,7 @@ class TypesTest {
   @ParameterizedTest
   @MethodSource("provideGetElementType")
   void testGetElementType(Class<?> clazz, int opcode) {
-    Assert.assertEquals(Type.getType(clazz), Types.getElementType(opcode));
+    Assertions.assertEquals(Type.getType(clazz), Types.getElementType(opcode));
   }
 
   private static Stream<Arguments> provideGetElementType() {
@@ -136,7 +137,7 @@ class TypesTest {
   @ParameterizedTest
   @MethodSource("provideGetFrameItemType")
   void testGetFrameItemType(Class<?> clazz, Object opcode) {
-    Assert.assertEquals(Type.getType(clazz), Types.getFrameItemType(opcode));
+    Assertions.assertEquals(Type.getType(clazz), Types.getFrameItemType(opcode));
   }
 
   private static Stream<Arguments> provideGetFrameItemType() {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
@@ -1,9 +1,11 @@
 package com.datadog.debugger.probe;
 
 import static com.datadog.debugger.util.LogProbeTestHelper.parseTemplate;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class LogProbeTest {
@@ -14,16 +16,16 @@ public class LogProbeTest {
   public void testCapture() {
     LogProbe.Builder builder = createLog(null);
     LogProbe snapshotProbe = builder.capture(1, 420, 255, 20).build();
-    Assert.assertEquals(1, snapshotProbe.getCapture().getMaxReferenceDepth());
-    Assert.assertEquals(420, snapshotProbe.getCapture().getMaxCollectionSize());
-    Assert.assertEquals(255, snapshotProbe.getCapture().getMaxLength());
+    Assertions.assertEquals(1, snapshotProbe.getCapture().getMaxReferenceDepth());
+    Assertions.assertEquals(420, snapshotProbe.getCapture().getMaxCollectionSize());
+    Assertions.assertEquals(255, snapshotProbe.getCapture().getMaxLength());
   }
 
   @Test
   public void testSampling() {
     LogProbe.Builder builder = createLog(null);
     LogProbe snapshotProbe = builder.sampling(0.25).build();
-    Assert.assertEquals(0.25, snapshotProbe.getSampling().getSnapshotsPerSecond(), 0.01);
+    Assertions.assertEquals(0.25, snapshotProbe.getSampling().getSnapshotsPerSecond(), 0.01);
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/MetricProbeTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/MetricProbeTest.java
@@ -2,7 +2,7 @@ package com.datadog.debugger.probe;
 
 import com.datadog.debugger.el.DSL;
 import com.datadog.debugger.el.ValueScript;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class MetricProbeTest {
@@ -18,10 +18,10 @@ public class MetricProbeTest {
             .kind(MetricProbe.MetricKind.COUNT)
             .metricName("datadog.debugger.calls")
             .build();
-    Assert.assertEquals("toString()", metric.getWhere().getMethodName());
-    Assert.assertEquals("5-7", metric.getWhere().getLines()[0]);
-    Assert.assertEquals(MetricProbe.MetricKind.COUNT, metric.getKind());
-    Assert.assertEquals("datadog.debugger.calls", metric.getMetricName());
+    Assertions.assertEquals("toString()", metric.getWhere().getMethodName());
+    Assertions.assertEquals("5-7", metric.getWhere().getLines()[0]);
+    Assertions.assertEquals(MetricProbe.MetricKind.COUNT, metric.getKind());
+    Assertions.assertEquals("datadog.debugger.calls", metric.getMetricName());
   }
 
   @Test
@@ -34,9 +34,9 @@ public class MetricProbeTest {
             .metricName("datadog.debugger.calls")
             .tags("tag1:foo1", "tag2:foo2")
             .build();
-    Assert.assertEquals(2, metric.getTags().length);
-    Assert.assertEquals("foo1", metric.getTagMap().get("tag1"));
-    Assert.assertEquals("foo2", metric.getTagMap().get("tag2"));
+    Assertions.assertEquals(2, metric.getTags().length);
+    Assertions.assertEquals("foo1", metric.getTagMap().get("tag1"));
+    Assertions.assertEquals("foo2", metric.getTagMap().get("tag2"));
   }
 
   @Test
@@ -56,7 +56,7 @@ public class MetricProbeTest {
             .metricName("datadog.debugger.calls")
             .valueScript(new ValueScript(DSL.value(42), "42"))
             .build();
-    Assert.assertEquals(metric1, metric2);
+    Assertions.assertEquals(metric1, metric2);
   }
 
   @Test
@@ -76,7 +76,7 @@ public class MetricProbeTest {
             .metricName("datadog.debugger.calls")
             .valueScript(new ValueScript(DSL.ref("arg"), "arg"))
             .build();
-    Assert.assertEquals(metric1, metric2);
+    Assertions.assertEquals(metric1, metric2);
   }
 
   private MetricProbe.Builder createMetric() {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/ProbeDefinitionTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/ProbeDefinitionTest.java
@@ -1,6 +1,6 @@
 package com.datadog.debugger.probe;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class ProbeDefinitionTest {
@@ -10,29 +10,29 @@ public class ProbeDefinitionTest {
   public void tags() {
     String[] tags = new String[] {"tag1:foo1", "tag2:foo2", "tag3"};
     ProbeDefinition snapshotProbe = LogProbe.builder().probeId(PROBE_ID).tags(tags).build();
-    Assert.assertEquals("foo1", snapshotProbe.getTagMap().get("tag1"));
-    Assert.assertEquals("foo2", snapshotProbe.getTagMap().get("tag2"));
-    Assert.assertNull(snapshotProbe.getTagMap().get("tag3"));
-    Assert.assertNotNull(snapshotProbe.getTags());
-    Assert.assertEquals(3, snapshotProbe.getTags().length);
-    Assert.assertEquals("tag1:foo1", snapshotProbe.getTags()[0].toString());
-    Assert.assertEquals("tag2:foo2", snapshotProbe.getTags()[1].toString());
-    Assert.assertEquals("tag3", snapshotProbe.getTags()[2].toString());
-    Assert.assertEquals("tag1:foo1,tag2:foo2,tag3", snapshotProbe.concatTags());
+    Assertions.assertEquals("foo1", snapshotProbe.getTagMap().get("tag1"));
+    Assertions.assertEquals("foo2", snapshotProbe.getTagMap().get("tag2"));
+    Assertions.assertNull(snapshotProbe.getTagMap().get("tag3"));
+    Assertions.assertNotNull(snapshotProbe.getTags());
+    Assertions.assertEquals(3, snapshotProbe.getTags().length);
+    Assertions.assertEquals("tag1:foo1", snapshotProbe.getTags()[0].toString());
+    Assertions.assertEquals("tag2:foo2", snapshotProbe.getTags()[1].toString());
+    Assertions.assertEquals("tag3", snapshotProbe.getTags()[2].toString());
+    Assertions.assertEquals("tag1:foo1,tag2:foo2,tag3", snapshotProbe.concatTags());
   }
 
   @Test
   public void noTags() {
     ProbeDefinition snapshotProbe = LogProbe.builder().probeId(PROBE_ID).build();
-    Assert.assertNull(snapshotProbe.getTags());
-    Assert.assertNull(snapshotProbe.concatTags());
+    Assertions.assertNull(snapshotProbe.getTags());
+    Assertions.assertNull(snapshotProbe.concatTags());
   }
 
   @Test
   public void emptyTags() {
     ProbeDefinition snapshotProbe =
         LogProbe.builder().probeId(PROBE_ID).tags(new String[] {}).build();
-    Assert.assertEquals(0, snapshotProbe.getTags().length);
-    Assert.assertEquals("", snapshotProbe.concatTags());
+    Assertions.assertEquals(0, snapshotProbe.getTags().length);
+    Assertions.assertEquals("", snapshotProbe.concatTags());
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/WhereTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/WhereTest.java
@@ -3,7 +3,7 @@ package com.datadog.debugger.probe;
 import com.datadog.debugger.util.MoshiHelper;
 import com.squareup.moshi.JsonAdapter;
 import java.io.IOException;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class WhereTest {
@@ -12,11 +12,11 @@ public class WhereTest {
     Where where =
         new Where(
             "java.lang.Object", "toString()", "java.lang.String ()", new String[] {"5-7"}, null);
-    Assert.assertTrue(where.isSignatureMatching("java.lang.String ()"));
+    Assertions.assertTrue(where.isSignatureMatching("java.lang.String ()"));
     String[] lines = where.getLines();
-    Assert.assertNotNull(lines);
-    Assert.assertEquals(1, lines.length);
-    Assert.assertEquals("5-7", lines[0]);
+    Assertions.assertNotNull(lines);
+    Assertions.assertEquals(1, lines.length);
+    Assertions.assertEquals("5-7", lines[0]);
   }
 
   @Test
@@ -28,12 +28,12 @@ public class WhereTest {
             "java.lang.String ()",
             new String[] {"12-25", "42-45"},
             null);
-    Assert.assertTrue(where.isSignatureMatching("java.lang.String ()"));
+    Assertions.assertTrue(where.isSignatureMatching("java.lang.String ()"));
     String[] lines = where.getLines();
-    Assert.assertNotNull(lines);
-    Assert.assertEquals(2, lines.length);
-    Assert.assertEquals("12-25", lines[0]);
-    Assert.assertEquals("42-45", lines[1]);
+    Assertions.assertNotNull(lines);
+    Assertions.assertEquals(2, lines.length);
+    Assertions.assertEquals("12-25", lines[0]);
+    Assertions.assertEquals("42-45", lines[1]);
   }
 
   @Test
@@ -41,11 +41,11 @@ public class WhereTest {
     Where where =
         new Where(
             "java.lang.Object", "toString()", "java.lang.String ()", new String[] {"12"}, null);
-    Assert.assertTrue(where.isSignatureMatching("java.lang.String ()"));
+    Assertions.assertTrue(where.isSignatureMatching("java.lang.String ()"));
     String[] lines = where.getLines();
-    Assert.assertNotNull(lines);
-    Assert.assertEquals(1, lines.length);
-    Assert.assertEquals("12", lines[0]);
+    Assertions.assertNotNull(lines);
+    Assertions.assertEquals(1, lines.length);
+    Assertions.assertEquals("12", lines[0]);
   }
 
   @Test
@@ -57,9 +57,9 @@ public class WhereTest {
             "java.lang.String ()",
             (Where.SourceLine[]) null,
             null);
-    Assert.assertTrue(where.isSignatureMatching("java.lang.String ()"));
+    Assertions.assertTrue(where.isSignatureMatching("java.lang.String ()"));
     String[] lines = where.getLines();
-    Assert.assertNull(lines);
+    Assertions.assertNull(lines);
   }
 
   @Test
@@ -69,27 +69,27 @@ public class WhereTest {
 
     String linesJson = "[\"12\",\"40-42\"]";
     Where.SourceLine[] lines = adapter.fromJson(linesJson);
-    Assert.assertEquals(2, lines.length);
-    Assert.assertEquals(new Where.SourceLine(12), lines[0]);
-    Assert.assertEquals(new Where.SourceLine(40, 42), lines[1]);
-    Assert.assertEquals(linesJson, adapter.toJson(lines));
+    Assertions.assertEquals(2, lines.length);
+    Assertions.assertEquals(new Where.SourceLine(12), lines[0]);
+    Assertions.assertEquals(new Where.SourceLine(40, 42), lines[1]);
+    Assertions.assertEquals(linesJson, adapter.toJson(lines));
   }
 
   @Test
   public void methodMatching() {
     Where where = new Where("String", "substring", "(int,int)", new String[0], null);
-    Assert.assertTrue(where.isMethodMatching("substring", "(II)Ljava/lang/String;"));
+    Assertions.assertTrue(where.isMethodMatching("substring", "(II)Ljava/lang/String;"));
     where = new Where("String", "replaceAll", "(String,String)", new String[0], null);
-    Assert.assertTrue(
+    Assertions.assertTrue(
         where.isMethodMatching(
             "replaceAll", "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;"));
     where = new Where("HashMap", "<init>", "(Map)", new String[0], null);
-    Assert.assertTrue(where.isMethodMatching("<init>", "(Ljava/util/Map;)V"));
+    Assertions.assertTrue(where.isMethodMatching("<init>", "(Ljava/util/Map;)V"));
     where = new Where("ArrayList", "removeIf", "(Predicate)", new String[0], null);
-    Assert.assertTrue(where.isMethodMatching("removeIf", "(Ljava/util/function/Predicate;)Z"));
+    Assertions.assertTrue(where.isMethodMatching("removeIf", "(Ljava/util/function/Predicate;)Z"));
     where = new Where("String", "concat", "", new String[0], null);
-    Assert.assertTrue(where.isMethodMatching("concat", "String (String)"));
+    Assertions.assertTrue(where.isMethodMatching("concat", "String (String)"));
     where = new Where("String", "concat", " \t", new String[0], null);
-    Assert.assertTrue(where.isMethodMatching("concat", "String (String)"));
+    Assertions.assertTrue(where.isMethodMatching("concat", "String (String)"));
   }
 }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/overhead/OverheadControllerTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/overhead/OverheadControllerTest.groovy
@@ -10,7 +10,11 @@ import datadog.trace.test.util.DDSpecification
 import datadog.trace.util.AgentTaskScheduler
 import spock.lang.Shared
 
-import java.util.concurrent.*
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.Semaphore
 
 class OverheadControllerTest extends DDSpecification {
 
@@ -206,15 +210,15 @@ class OverheadControllerTest extends DDSpecification {
         return results
       } as Callable<Boolean[]>)
     }
-    def results = futures.collect({
+    def futuresResults = futures.collect({
       it.get()
     })
 
     then:
     // At least one request ran.
-    results.flatten().any { it }
+    futuresResults.flatten().any { it }
     // At least one request did not run.
-    results.flatten().any { !it }
+    futuresResults.flatten().any { !it }
     // In the final state, there is no consumed available request.
     overheadController.availableRequests.available() == Config.get().getIastMaxConcurrentRequests()
 

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/StringModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/StringModuleTest.groovy
@@ -26,7 +26,7 @@ class StringModuleTest extends IastModuleImplTestBase {
     objectHolder = []
   }
 
-  void 'onStringBuilderAppend null or empty (#builder, #param)'(StringBuilder builder, final String param) {
+  void 'onStringBuilderAppend null or empty (#builder, #param)'() {
     given:
     final result = builder?.append(param)
 
@@ -42,7 +42,7 @@ class StringModuleTest extends IastModuleImplTestBase {
     sb('')  | ''
   }
 
-  void 'onStringBuilderAppend without span (#builder, #param)'(StringBuilder builder, final String param, final int mockCalls) {
+  void 'onStringBuilderAppend without span (#builder, #param)'() {
     given:
     final result = builder?.append(param)
 
@@ -59,7 +59,7 @@ class StringModuleTest extends IastModuleImplTestBase {
     sb('3') | '4'   | 1
   }
 
-  void 'onStringBuilderAppend (#builder, #param)'(StringBuilder builder, String param, final int mockCalls, final String expected) {
+  void 'onStringBuilderAppend (#builder, #param)'() {
     given:
     final span = Mock(AgentSpan)
     tracer.activeSpan() >> span
@@ -110,7 +110,7 @@ class StringModuleTest extends IastModuleImplTestBase {
     sb('1==>234<==5==>678<==9') | 'a==>bcd<==e==>fgh<==i' | 1         | '1==>234<==5==>678<==9a==>bcd<==e==>fgh<==i'
   }
 
-  void 'onStringBuilderInit null or empty (#builder, #param)'(StringBuilder builder, final String param) {
+  void 'onStringBuilderInit null or empty (#builder, #param)'() {
     given:
     final result = builder?.append(param)
 
@@ -126,7 +126,7 @@ class StringModuleTest extends IastModuleImplTestBase {
     sb('')  | ''
   }
 
-  void 'onStringBuilderInit without span (#builder, #param)'(StringBuilder builder, final String param, final int mockCalls) {
+  void 'onStringBuilderInit without span (#builder, #param)'() {
     given:
     final result = builder?.append(param)
 
@@ -143,7 +143,7 @@ class StringModuleTest extends IastModuleImplTestBase {
     sb()    | '4'   | 1
   }
 
-  void 'onStringBuilderInit (#builder, #param)'(StringBuilder builder, String param, final int mockCalls, final String expected) {
+  void 'onStringBuilderInit (#builder, #param)'() {
     given:
     final span = Mock(AgentSpan)
     tracer.activeSpan() >> span
@@ -203,7 +203,7 @@ class StringModuleTest extends IastModuleImplTestBase {
     0 * _
   }
 
-  void 'onStringBuilderToString (#builder)'(StringBuilder builder, final String expected) {
+  void 'onStringBuilderToString (#builder)'() {
     given:
     final span = Mock(AgentSpan)
     tracer.activeSpan() >> span
@@ -657,7 +657,7 @@ class StringModuleTest extends IastModuleImplTestBase {
     ]                                                                                                                    | "stringParam1,stringParam2,stringParam3:==>taintedString<==, ==>taintedString<==, ==>taintedString<=="
   }
 
-  void 'onStringRepeat that can not be tainted (#self, #count)'(final String self, final int count, final String expected) {
+  void 'onStringRepeat that can not be tainted (#self, #count)'() {
     when:
     module.onStringRepeat(self, count, expected)
 
@@ -691,7 +691,7 @@ class StringModuleTest extends IastModuleImplTestBase {
     "abc" | 2     | 'abcabc' | 1
   }
 
-  void 'onStringRepeat (#self, #count, #result)'() {
+  void 'onStringRepeat (#self, #count)'() {
     given:
     final span = Mock(AgentSpan)
     tracer.activeSpan() >> span

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/PathTraversalModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/PathTraversalModuleTest.groovy
@@ -79,7 +79,7 @@ class PathTraversalModuleTest extends IastModuleImplTestBase {
     '/==>var<==' | "/==>var<=="
   }
 
-  void 'iast module detects path traversal with String (#parent, #child)'(final String first, final String rest, final String expected) {
+  void 'iast module detects path traversal with String (#first, #rest)'() {
     setup:
     final parent = mapTainted(first)
     final children = mapTainted(rest)

--- a/dd-java-agent/agent-profiling/build.gradle
+++ b/dd-java-agent/agent-profiling/build.gradle
@@ -2,11 +2,6 @@ plugins {
   id "com.github.johnrengelman.shadow"
 }
 
-// Set properties before any plugins get loaded
-ext {
-  enableJunitPlatform = true
-}
-
 apply from: "$rootDir/gradle/java.gradle"
 
 dependencies {

--- a/dd-java-agent/agent-tooling/build.gradle
+++ b/dd-java-agent/agent-tooling/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'me.champeau.jmh'
+  id 'java-test-fixtures'
 }
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/tries.gradle"

--- a/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/test/HelperClass.java
+++ b/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/test/HelperClass.java
@@ -1,4 +1,0 @@
-package datadog.trace.agent.test;
-
-/** Used by {@link HelperInjectionTest}. Must not be loaded outside of that test. */
-public class HelperClass {}

--- a/dd-java-agent/agent-tooling/src/testFixtures/java/datadog/trace/agent/test/HelperClass.java
+++ b/dd-java-agent/agent-tooling/src/testFixtures/java/datadog/trace/agent/test/HelperClass.java
@@ -1,0 +1,8 @@
+package datadog.trace.agent.test;
+
+/**
+ * Used by {@link datadog.trace.agent.test.HelperInjectionTest}. Must not be loaded outside of that
+ * test. This class is placed inside testFixtures source set to prevent tests' classloader from
+ * eagerly loading it
+ */
+public class HelperClass {}

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWS1ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/AWS1ClientTest.groovy
@@ -162,8 +162,8 @@ class AWS1ClientTest extends AgentTestRunner {
 
     where:
     service      | operation           | ddService      | method | path                  | client                                                                                                                                             | call                                                                            | additionalTags                    | body
-    "S3"         | "CreateBucket"      | "java-aws-sdk" | "PUT"  | "/testbucket/"        | AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true).withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build() | { client -> client.createBucket("testbucket") }                                 | ["aws.bucket.name": "testbucket"] | ""
-    "S3"         | "GetObject"         | "java-aws-sdk" | "GET"  | "/someBucket/someKey" | AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true).withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build() | { client -> client.getObject("someBucket", "someKey") }                         | ["aws.bucket.name": "someBucket"] | ""
+    "S3"         | "CreateBucket"      | "java-aws-sdk" | "PUT"  | "/testbucket/"        | AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true).withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build() | { c -> c.createBucket("testbucket") }                                           | ["aws.bucket.name": "testbucket"] | ""
+    "S3"         | "GetObject"         | "java-aws-sdk" | "GET"  | "/someBucket/someKey" | AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true).withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build() | { c -> c.getObject("someBucket", "someKey") }                                   | ["aws.bucket.name": "someBucket"] | ""
     "DynamoDBv2" | "CreateTable"       | "java-aws-sdk" | "POST" | "/"                   | AmazonDynamoDBClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                            | { c -> c.createTable(new CreateTableRequest("sometable", null)) }               | ["aws.table.name": "sometable"]   | ""
     "Kinesis"    | "DeleteStream"      | "java-aws-sdk" | "POST" | "/"                   | AmazonKinesisClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                             | { c -> c.deleteStream(new DeleteStreamRequest().withStreamName("somestream")) } | ["aws.stream.name": "somestream"] | ""
     "SQS"        | "CreateQueue"       | "java-aws-sdk" | "POST" | "/"                   | AmazonSQSClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                                 | { c -> c.createQueue(new CreateQueueRequest("somequeue")) }                     | ["aws.queue.name": "somequeue"]   | """
@@ -190,14 +190,14 @@ class AWS1ClientTest extends AgentTestRunner {
             <ResponseMetadata><RequestId>d74b8436-ae13-5ab4-a9ff-ce54dfea72a0</RequestId></ResponseMetadata>
         </PublishResponse>
       """
-    "EC2"        | "AllocateAddress"   | "java-aws-sdk" | "POST" | "/"                   | AmazonEC2ClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                                 | { client -> client.allocateAddress() }                                          | [:]                               | """
+    "EC2"        | "AllocateAddress"   | "java-aws-sdk" | "POST" | "/"                   | AmazonEC2ClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                                 | { c -> c.allocateAddress() }                                                    | [:]                               | """
         <AllocateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
            <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
            <publicIp>192.0.2.1</publicIp>
            <domain>standard</domain>
         </AllocateAddressResponse>
       """
-    "RDS"        | "DeleteOptionGroup" | "java-aws-sdk" | "POST" | "/"                   | AmazonRDSClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                                 | { client -> client.deleteOptionGroup(new DeleteOptionGroupRequest()) }          | [:]                               | """
+    "RDS"        | "DeleteOptionGroup" | "java-aws-sdk" | "POST" | "/"                   | AmazonRDSClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                                 | { c -> c.deleteOptionGroup(new DeleteOptionGroupRequest()) }                    | [:]                               | """
         <DeleteOptionGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
           <ResponseMetadata>
             <RequestId>0ac9cda2-bbf4-11d3-f92b-31fa5e8dbc99</RequestId>
@@ -249,7 +249,7 @@ class AWS1ClientTest extends AgentTestRunner {
 
     where:
     service | operation   | method | url                  | call                                                    | additionalTags                    | body | client
-    "S3"    | "GetObject" | "GET"  | "someBucket/someKey" | { client -> client.getObject("someBucket", "someKey") } | ["aws.bucket.name": "someBucket"] | ""   | new AmazonS3Client(CREDENTIALS_PROVIDER_CHAIN, new ClientConfiguration().withRetryPolicy(PredefinedRetryPolicies.getDefaultRetryPolicyWithCustomMaxRetries(0))).withEndpoint("http://localhost:${UNUSABLE_PORT}")
+    "S3" | "GetObject" | "GET" | "someBucket/someKey" | { c -> c.getObject("someBucket", "someKey") } | ["aws.bucket.name": "someBucket"] | "" | new AmazonS3Client(CREDENTIALS_PROVIDER_CHAIN, new ClientConfiguration().withRetryPolicy(PredefinedRetryPolicies.getDefaultRetryPolicyWithCustomMaxRetries(0))).withEndpoint("http://localhost:${UNUSABLE_PORT}")
   }
 
   def "naughty request handler doesn't break the trace"() {

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/LegacyAWS1ClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test/groovy/LegacyAWS1ClientForkedTest.groovy
@@ -188,8 +188,8 @@ class LegacyAWS1ClientForkedTest extends AgentTestRunner {
 
     where:
     service      | operation           | ddService      | method | path                  | client                                                                                                                                             | call                                                                            | additionalTags                    | body
-    "S3"         | "CreateBucket"      | "java-aws-sdk" | "PUT"  | "/testbucket/"        | AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true).withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build() | { client -> client.createBucket("testbucket") }                                 | ["aws.bucket.name": "testbucket"] | ""
-    "S3"         | "GetObject"         | "java-aws-sdk" | "GET"  | "/someBucket/someKey" | AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true).withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build() | { client -> client.getObject("someBucket", "someKey") }                         | ["aws.bucket.name": "someBucket"] | ""
+    "S3"         | "CreateBucket"      | "java-aws-sdk" | "PUT"  | "/testbucket/"        | AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true).withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build() | { c -> c.createBucket("testbucket") }                                           | ["aws.bucket.name": "testbucket"] | ""
+    "S3"         | "GetObject"         | "java-aws-sdk" | "GET"  | "/someBucket/someKey" | AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true).withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build() | { c -> c.getObject("someBucket", "someKey") }                                   | ["aws.bucket.name": "someBucket"] | ""
     "DynamoDBv2" | "CreateTable"       | "java-aws-sdk" | "POST" | "/"                   | AmazonDynamoDBClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                            | { c -> c.createTable(new CreateTableRequest("sometable", null)) }               | ["aws.table.name": "sometable"]   | ""
     "Kinesis"    | "DeleteStream"      | "java-aws-sdk" | "POST" | "/"                   | AmazonKinesisClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                             | { c -> c.deleteStream(new DeleteStreamRequest().withStreamName("somestream")) } | ["aws.stream.name": "somestream"] | ""
     "SQS"        | "CreateQueue"       | "java-aws-sdk" | "POST" | "/"                   | AmazonSQSClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                                 | { c -> c.createQueue(new CreateQueueRequest("somequeue")) }                     | ["aws.queue.name": "somequeue"]   | """
@@ -216,14 +216,14 @@ class LegacyAWS1ClientForkedTest extends AgentTestRunner {
             <ResponseMetadata><RequestId>d74b8436-ae13-5ab4-a9ff-ce54dfea72a0</RequestId></ResponseMetadata>
         </PublishResponse>
       """
-    "EC2"        | "AllocateAddress"   | "java-aws-sdk" | "POST" | "/"                   | AmazonEC2ClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                                 | { client -> client.allocateAddress() }                                          | [:]                               | """
+    "EC2"        | "AllocateAddress"   | "java-aws-sdk" | "POST" | "/"                   | AmazonEC2ClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                                 | { c -> c.allocateAddress() }                                                    | [:]                               | """
         <AllocateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
            <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
            <publicIp>192.0.2.1</publicIp>
            <domain>standard</domain>
         </AllocateAddressResponse>
       """
-    "RDS"        | "DeleteOptionGroup" | "java-aws-sdk" | "POST" | "/"                   | AmazonRDSClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                                 | { client -> client.deleteOptionGroup(new DeleteOptionGroupRequest()) }          | [:]                               | """
+    "RDS"        | "DeleteOptionGroup" | "java-aws-sdk" | "POST" | "/"                   | AmazonRDSClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                                 | { c -> c.deleteOptionGroup(new DeleteOptionGroupRequest()) }                    | [:]                               | """
         <DeleteOptionGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
           <ResponseMetadata>
             <RequestId>0ac9cda2-bbf4-11d3-f92b-31fa5e8dbc99</RequestId>
@@ -293,7 +293,7 @@ class LegacyAWS1ClientForkedTest extends AgentTestRunner {
 
     where:
     service | operation   | method | url                  | call                                                    | additionalTags                    | body | client
-    "S3"    | "GetObject" | "GET"  | "someBucket/someKey" | { client -> client.getObject("someBucket", "someKey") } | ["aws.bucket.name": "someBucket"] | ""   | new AmazonS3Client(CREDENTIALS_PROVIDER_CHAIN, new ClientConfiguration().withRetryPolicy(PredefinedRetryPolicies.getDefaultRetryPolicyWithCustomMaxRetries(0))).withEndpoint("http://localhost:${UNUSABLE_PORT}")
+    "S3" | "GetObject" | "GET" | "someBucket/someKey" | { c -> c.getObject("someBucket", "someKey") } | ["aws.bucket.name": "someBucket"] | "" | new AmazonS3Client(CREDENTIALS_PROVIDER_CHAIN, new ClientConfiguration().withRetryPolicy(PredefinedRetryPolicies.getDefaultRetryPolicyWithCustomMaxRetries(0))).withEndpoint("http://localhost:${UNUSABLE_PORT}")
   }
 
   def "naughty request handler doesn't break the trace"() {

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWS0ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/AWS0ClientTest.groovy
@@ -121,17 +121,17 @@ class AWS0ClientTest extends AgentTestRunner {
     server.lastRequest.headers.get("x-datadog-parent-id") == null
 
     where:
-    service | operation           | method | path                  | handlerCount | client                                                                      | additionalTags                    | call                                                                                                                                   | body
-    "S3"    | "CreateBucket"      | "PUT"  | "/testbucket/"        | 1            | new AmazonS3Client().withEndpoint("http://localhost:$server.address.port")  | ["aws.bucket.name": "testbucket"] | { client -> client.setS3ClientOptions(S3ClientOptions.builder().setPathStyleAccess(true).build()); client.createBucket("testbucket") } | ""
-    "S3"    | "GetObject"         | "GET"  | "/someBucket/someKey" | 1            | new AmazonS3Client().withEndpoint("http://localhost:$server.address.port")  | ["aws.bucket.name": "someBucket"] | { client -> client.getObject("someBucket", "someKey") }                                                                                | ""
-    "EC2"   | "AllocateAddress"   | "POST" | "/"                   | 4            | new AmazonEC2Client().withEndpoint("http://localhost:$server.address.port") | [:]                               | { client -> client.allocateAddress() }                                                                                                 | """
+    service | operation           | method | path                  | handlerCount | client                                                                      | additionalTags                    | call                                                                                                                         | body
+    "S3"    | "CreateBucket"      | "PUT"  | "/testbucket/"        | 1            | new AmazonS3Client().withEndpoint("http://localhost:$server.address.port")  | ["aws.bucket.name": "testbucket"] | { c -> c.setS3ClientOptions(S3ClientOptions.builder().setPathStyleAccess(true).build()); client.createBucket("testbucket") } | ""
+    "S3"    | "GetObject"         | "GET"  | "/someBucket/someKey" | 1            | new AmazonS3Client().withEndpoint("http://localhost:$server.address.port")  | ["aws.bucket.name": "someBucket"] | { c -> c.getObject("someBucket", "someKey") }                                                                                | ""
+    "EC2"   | "AllocateAddress"   | "POST" | "/"                   | 4            | new AmazonEC2Client().withEndpoint("http://localhost:$server.address.port") | [:]                               | { c -> c.allocateAddress() }                                                                                                 | """
             <AllocateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
                <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
                <publicIp>192.0.2.1</publicIp>
                <domain>standard</domain>
             </AllocateAddressResponse>
             """
-    "RDS"   | "DeleteOptionGroup" | "POST" | "/"                   | 1            | new AmazonRDSClient().withEndpoint("http://localhost:$server.address.port") | [:]                               | { client -> client.deleteOptionGroup(new DeleteOptionGroupRequest()) }                                                                 | """
+    "RDS"   | "DeleteOptionGroup" | "POST" | "/"                   | 1            | new AmazonRDSClient().withEndpoint("http://localhost:$server.address.port") | [:]                               | { c -> c.deleteOptionGroup(new DeleteOptionGroupRequest()) }                                                                 | """
         <DeleteOptionGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
           <ResponseMetadata>
             <RequestId>0ac9cda2-bbf4-11d3-f92b-31fa5e8dbc99</RequestId>
@@ -183,7 +183,7 @@ class AWS0ClientTest extends AgentTestRunner {
 
     where:
     service | operation   | method | url                  | call                                                    | additionalTags                    | body | client
-    "S3"    | "GetObject" | "GET"  | "someBucket/someKey" | { client -> client.getObject("someBucket", "someKey") } | ["aws.bucket.name": "someBucket"] | ""   | new AmazonS3Client(CREDENTIALS_PROVIDER_CHAIN, new ClientConfiguration().withRetryPolicy(PredefinedRetryPolicies.getDefaultRetryPolicyWithCustomMaxRetries(0))).withEndpoint("http://localhost:${UNUSABLE_PORT}")
+    "S3" | "GetObject" | "GET" | "someBucket/someKey" | { c -> c.getObject("someBucket", "someKey") } | ["aws.bucket.name": "someBucket"] | "" | new AmazonS3Client(CREDENTIALS_PROVIDER_CHAIN, new ClientConfiguration().withRetryPolicy(PredefinedRetryPolicies.getDefaultRetryPolicyWithCustomMaxRetries(0))).withEndpoint("http://localhost:${UNUSABLE_PORT}")
   }
 
   def "naughty request handler doesn't break the trace"() {

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/LegacyAWS0ClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/test_before_1_11_106/groovy/LegacyAWS0ClientForkedTest.groovy
@@ -147,17 +147,17 @@ class LegacyAWS0ClientForkedTest extends AgentTestRunner {
     server.lastRequest.headers.get("x-datadog-parent-id") == null
 
     where:
-    service | operation           | method | path                  | handlerCount | client                                                                      | additionalTags                    | call                                                                                                                                   | body
-    "S3"    | "CreateBucket"      | "PUT"  | "/testbucket/"        | 1            | new AmazonS3Client().withEndpoint("http://localhost:$server.address.port")  | ["aws.bucket.name": "testbucket"] | { client -> client.setS3ClientOptions(S3ClientOptions.builder().setPathStyleAccess(true).build()); client.createBucket("testbucket") } | ""
-    "S3"    | "GetObject"         | "GET"  | "/someBucket/someKey" | 1            | new AmazonS3Client().withEndpoint("http://localhost:$server.address.port")  | ["aws.bucket.name": "someBucket"] | { client -> client.getObject("someBucket", "someKey") }                                                                                | ""
-    "EC2"   | "AllocateAddress"   | "POST" | "/"                   | 4            | new AmazonEC2Client().withEndpoint("http://localhost:$server.address.port") | [:]                               | { client -> client.allocateAddress() }                                                                                                 | """
+    service | operation           | method | path                  | handlerCount | client                                                                      | additionalTags                    | call                                                                                                                         | body
+    "S3"    | "CreateBucket"      | "PUT"  | "/testbucket/"        | 1            | new AmazonS3Client().withEndpoint("http://localhost:$server.address.port")  | ["aws.bucket.name": "testbucket"] | { c -> c.setS3ClientOptions(S3ClientOptions.builder().setPathStyleAccess(true).build()); client.createBucket("testbucket") } | ""
+    "S3"    | "GetObject"         | "GET"  | "/someBucket/someKey" | 1            | new AmazonS3Client().withEndpoint("http://localhost:$server.address.port")  | ["aws.bucket.name": "someBucket"] | { c -> c.getObject("someBucket", "someKey") }                                                                                | ""
+    "EC2"   | "AllocateAddress"   | "POST" | "/"                   | 4            | new AmazonEC2Client().withEndpoint("http://localhost:$server.address.port") | [:]                               | { c -> c.allocateAddress() }                                                                                                 | """
             <AllocateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
                <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
                <publicIp>192.0.2.1</publicIp>
                <domain>standard</domain>
             </AllocateAddressResponse>
             """
-    "RDS"   | "DeleteOptionGroup" | "POST" | "/"                   | 1            | new AmazonRDSClient().withEndpoint("http://localhost:$server.address.port") | [:]                               | { client -> client.deleteOptionGroup(new DeleteOptionGroupRequest()) }                                                                 | """
+    "RDS"   | "DeleteOptionGroup" | "POST" | "/"                   | 1            | new AmazonRDSClient().withEndpoint("http://localhost:$server.address.port") | [:]                               | { c -> c.deleteOptionGroup(new DeleteOptionGroupRequest()) }                                                                 | """
         <DeleteOptionGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
           <ResponseMetadata>
             <RequestId>0ac9cda2-bbf4-11d3-f92b-31fa5e8dbc99</RequestId>
@@ -227,7 +227,7 @@ class LegacyAWS0ClientForkedTest extends AgentTestRunner {
 
     where:
     service | operation   | method | url                  | call                                                    | additionalTags                    | body | client
-    "S3"    | "GetObject" | "GET"  | "someBucket/someKey" | { client -> client.getObject("someBucket", "someKey") } | ["aws.bucket.name": "someBucket"] | ""   | new AmazonS3Client(CREDENTIALS_PROVIDER_CHAIN, new ClientConfiguration().withRetryPolicy(PredefinedRetryPolicies.getDefaultRetryPolicyWithCustomMaxRetries(0))).withEndpoint("http://localhost:${UNUSABLE_PORT}")
+    "S3" | "GetObject" | "GET" | "someBucket/someKey" | { c -> c.getObject("someBucket", "someKey") } | ["aws.bucket.name": "someBucket"] | "" | new AmazonS3Client(CREDENTIALS_PROVIDER_CHAIN, new ClientConfiguration().withRetryPolicy(PredefinedRetryPolicies.getDefaultRetryPolicyWithCustomMaxRetries(0))).withEndpoint("http://localhost:${UNUSABLE_PORT}")
   }
 
   def "naughty request handler doesn't break the trace"() {

--- a/dd-java-agent/instrumentation/build.gradle
+++ b/dd-java-agent/instrumentation/build.gradle
@@ -74,6 +74,19 @@ subprojects { Project subProj ->
     }
 
     subProj.tasks.withType(Test).configureEach { subTask ->
+      // SpockRunner that we use to run agent tests cannot be properly ported to JUnit 5,
+      // since the framework does not provide the hooks / extension points
+      // that can be used to shadow the tested class.
+
+      // In order to mitigate this, SpockRunner extends JUnitPlatform,
+      // which is a JUnit 4 runner that allows executing JUnit 5 tests in a JUnit 4 environment
+      // (i.e. running them as JUnit 4 tests).
+
+      // So even though Spock 2 tests run on top of JUnit 5,
+      // we execute them in "compatibility mode" so that SpockRunner could shadow the test class
+      // See https://junit.org/junit5/docs/current/user-guide/#running-tests-junit-platform-runner for more details.
+      useJUnit()
+
       onlyIf { !project.rootProject.hasProperty("skipInstTests") }
 
       if (subTask.name == 'latestDepTest') {

--- a/dd-java-agent/instrumentation/exception-profiling/build.gradle
+++ b/dd-java-agent/instrumentation/exception-profiling/build.gradle
@@ -5,7 +5,6 @@ ext {
   // By default tests with be compiled for `minJavaVersionForTests` version,
   // but in this case we would like to avoid this since we would like to run with ZULU8
   skipSettingTestJavaVersion = true
-  enableJunitPlatform = true
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-java-agent/instrumentation/grizzly-2/build.gradle
+++ b/dd-java-agent/instrumentation/grizzly-2/build.gradle
@@ -31,3 +31,8 @@ dependencies {
   latestDepTestImplementation group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: '2.+'
   latestDepTestImplementation group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: '2.+'
 }
+
+configurations.testRuntimeClasspath {
+  // jersey-container-grizzly2-http transitively imports its own set repackaged asm classes
+  exclude group: 'org.ow2.asm'
+}

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
@@ -97,7 +97,7 @@ abstract class GrpcStreamingTest extends VersionedNamingTestBase {
     GreeterGrpc.GreeterStub client = GreeterGrpc.newStub(channel).withWaitForReady()
 
     when:
-    def observer = client.conversation(new StreamObserver<Helloworld.Response>() {
+    def streamObserver = client.conversation(new StreamObserver<Helloworld.Response>() {
         @Override
         void onNext(Helloworld.Response value) {
           if (TEST_TRACER.activeScope().isAsyncPropagating()) {
@@ -126,9 +126,9 @@ abstract class GrpcStreamingTest extends VersionedNamingTestBase {
 
     clientRange.each {
       def message = Helloworld.Response.newBuilder().setMessage("call $it").build()
-      observer.onNext(message)
+      streamObserver.onNext(message)
     }
-    observer.onCompleted()
+    streamObserver.onCompleted()
 
     then:
     error.get() == null

--- a/dd-java-agent/instrumentation/java-lang/java-lang-9/src/test/groovy/datadog/trace/instrumentation/java/lang/invoke/StringConcatFactoryCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-lang/java-lang-9/src/test/groovy/datadog/trace/instrumentation/java/lang/invoke/StringConcatFactoryCallSiteTest.groovy
@@ -184,14 +184,14 @@ class StringConcatFactoryCallSiteTest extends AgentTestRunner {
     0 * _
 
     where:
-    method                                                                 | expectedResult           | expectedArgs
-    { it -> stringPlusWithPrimitive('Hello World! in ', (int) 2023) }      | 'Hello World! in 2023'   | ['Hello World! in ', '2023']
-    { it -> stringPlusWithPrimitive('Give me a number : ', (byte) 5) }     | 'Give me a number : 5'   | ['Give me a number : ', '5']
-    { it -> stringPlusWithPrimitive('Give me a number : ', (short) 5) }    | 'Give me a number : 5'   | ['Give me a number : ', '5']
-    { it -> stringPlusWithPrimitive('Are you mad? ', (boolean) false) }    | 'Are you mad? false'     | ['Are you mad? ', 'false']
-    { it -> stringPlusWithPrimitive('Give me a letter : ', (char) 'c') }   | 'Give me a letter : c'   | ['Give me a letter : ', 'c']
-    { it -> stringPlusWithPrimitive('Hello World! in ', (long) 2023) }     | 'Hello World! in 2023'   | ['Hello World! in ', '2023']
-    { it -> stringPlusWithPrimitive('Hello World! in ', (float) 2023.0) }  | 'Hello World! in 2023.0' | ['Hello World! in ', '2023.0']
-    { it -> stringPlusWithPrimitive('Hello World! in ', (double) 2023.0) } | 'Hello World! in 2023.0' | ['Hello World! in ', '2023.0']
+    expectedResult           | expectedArgs                   | method
+    'Hello World! in 2023'   | ['Hello World! in ', '2023']   | { it -> stringPlusWithPrimitive('Hello World! in ', (int) 2023) }
+    'Give me a number : 5'   | ['Give me a number : ', '5']   | { it -> stringPlusWithPrimitive('Give me a number : ', (byte) 5) }
+    'Give me a number : 5'   | ['Give me a number : ', '5']   | { it -> stringPlusWithPrimitive('Give me a number : ', (short) 5) }
+    'Are you mad? false'     | ['Are you mad? ', 'false']     | { it -> stringPlusWithPrimitive('Are you mad? ', (boolean) false) }
+    'Give me a letter : c'   | ['Give me a letter : ', 'c']   | { it -> stringPlusWithPrimitive('Give me a letter : ', (char) 'c') }
+    'Hello World! in 2023'   | ['Hello World! in ', '2023']   | { it -> stringPlusWithPrimitive('Hello World! in ', (long) 2023) }
+    'Hello World! in 2023.0' | ['Hello World! in ', '2023.0'] | { it -> stringPlusWithPrimitive('Hello World! in ', (float) 2023.0) }
+    'Hello World! in 2023.0' | ['Hello World! in ', '2023.0'] | { it -> stringPlusWithPrimitive('Hello World! in ', (double) 2023.0) }
   }
 }

--- a/dd-java-agent/instrumentation/junit-4.10/build.gradle
+++ b/dd-java-agent/instrumentation/junit-4.10/build.gradle
@@ -12,9 +12,11 @@ muzzle {
 dependencies {
   compileOnly group: 'junit', name: 'junit', version: '4.10'
 
+  // version used below is not the minimum one that we support,
+  // but the tests need to use it in order to be compliant with Spock 2.0
   testImplementation(group: 'junit', name: 'junit') {
     version {
-      strictly '4.10'
+      strictly '4.11'
     }
   }
 }

--- a/dd-java-agent/instrumentation/junit-5.3/build.gradle
+++ b/dd-java-agent/instrumentation/junit-5.3/build.gradle
@@ -20,19 +20,26 @@ dependencies {
   compileOnly group: 'org.junit.platform', name: 'junit-platform-launcher', version: "$platformVersion"
   compileOnly group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: "$jupiterVersion"
 
+  // versions used below are not the minimum ones that we support,
+  // but the tests need to use them in order to be compliant with Spock 2.0
+  testImplementation(group: 'org.junit.platform', name: 'junit-platform-launcher') {
+    version {
+      strictly '1.7.2'
+    }
+  }
   testImplementation(group: 'org.junit.platform', name: 'junit-platform-engine') {
     version {
-      strictly platformVersion
+      strictly '1.7.2'
     }
   }
   testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter-engine') {
     version {
-      strictly jupiterVersion
+      strictly '5.8.2'
     }
   }
   testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter-params') {
     version {
-      strictly jupiterVersion
+      strictly '5.8.2'
     }
   }
 }

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/TracingListener.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.platform.engine.TestEngine;
 import org.junit.platform.engine.TestExecutionResult;
@@ -208,6 +209,10 @@ public class TracingListener implements TestExecutionListener {
   private String getVersions(final TestPlan testPlan) {
     StringBuilder versions = new StringBuilder();
     for (TestIdentifier root : testPlan.getRoots()) {
+      Set<TestIdentifier> rootChildren = testPlan.getChildren(root);
+      if (rootChildren.isEmpty()) {
+        continue;
+      }
       String version = getVersion(root);
       if (version != null) {
         if (versions.length() > 0) {

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.base.TestFrameworkTest
+import datadog.trace.api.DisableTestTrace
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.bootstrap.instrumentation.civisibility.TestEventsHandler
 import datadog.trace.instrumentation.junit5.JUnit5Decorator
@@ -30,6 +31,7 @@ import org.opentest4j.AssertionFailedError
 
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
 
+@DisableTestTrace(reason = "avoid self-tracing")
 class JUnit5Test extends TestFrameworkTest {
 
   def "test success generate spans"() {
@@ -475,7 +477,7 @@ class JUnit5Test extends TestFrameworkTest {
 
   @Override
   String expectedTestFrameworkVersion() {
-    return "5.3.0"
+    return "5.8.2"
   }
 
   @Override

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/build.gradle
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/build.gradle
@@ -24,7 +24,6 @@ dependencies {
   testImplementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.2.3'
   testImplementation group: 'org.assertj', name: 'assertj-core', version: '2.9.+'
   testImplementation group: 'org.mockito', name: 'mockito-core', version: '2.19.0'
-  testImplementation deps.guava
 
   // Include latest version of kafka itself along with latest version of client libs.
   // This seems to help with jar compatibility hell.
@@ -34,4 +33,9 @@ dependencies {
   latestDepTestImplementation group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '2.+'
   latestDepTestImplementation group: 'org.assertj', name: 'assertj-core', version: '3.19.+'
   latestDepTestImplementation deps.guava
+}
+
+configurations.testRuntimeClasspath {
+  // spock-core depends on assertj version that is not compatible with kafka-clients
+  resolutionStrategy.force 'org.assertj:assertj-core:2.9.1'
 }

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/build.gradle
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/build.gradle
@@ -28,7 +28,6 @@ dependencies {
   testImplementation group: 'org.assertj', name: 'assertj-core', version: '2.9.+'
   testImplementation group: 'org.mockito', name: 'mockito-core', version: '2.19.0'
 
-
   // Include latest version of kafka itself along with latest version of client libs.
   // This seems to help with jar compatibility hell.
   latestDepTestImplementation group: 'org.apache.kafka', name: 'kafka_2.13', version: '2.+'
@@ -38,4 +37,9 @@ dependencies {
   latestDepTestImplementation group: 'org.springframework.kafka', name: 'spring-kafka', version: '2.7+'
   latestDepTestImplementation group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '2.7+'
   latestDepTestImplementation group: 'org.assertj', name: 'assertj-core', version: '3.+'
+}
+
+configurations.testRuntimeClasspath {
+  // spock-core depends on assertj version that is not compatible with kafka-streams
+  resolutionStrategy.force 'org.assertj:assertj-core:2.9.1'
 }

--- a/dd-java-agent/instrumentation/spring-cloud-zuul-2/build.gradle
+++ b/dd-java-agent/instrumentation/spring-cloud-zuul-2/build.gradle
@@ -30,10 +30,25 @@ dependencies {
   // These two version sets are compatible together:
   testImplementation enforcedPlatform('org.springframework.boot:spring-boot-dependencies:2.3.5.RELEASE') {
     exclude group: 'net.bytebuddy', module: 'byte-buddy' // we don't want this shared dependency pinned
+    // exclude transitive Groovy and JUnit since they're too old
+    // and conflict with the ones that Spock uses
+    exclude group: 'org.codehaus.groovy'
+    exclude group: 'org.junit'
+    exclude group: 'org.junit.jupiter'
+    exclude group: 'org.junit.platform'
+    exclude group: 'org.junit.vintage'
   }
   testImplementation enforcedPlatform('org.springframework.cloud:spring-cloud-netflix-dependencies:2.2.6.RELEASE')
 
-  testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
+  testImplementation(group: 'org.springframework.boot', name: 'spring-boot-starter-test') {
+    // exclude transitive Groovy and JUnit since they're too old
+    // and conflict with the ones that Spock uses
+    exclude group: 'org.codehaus.groovy'
+    exclude group: 'org.junit'
+    exclude group: 'org.junit.jupiter'
+    exclude group: 'org.junit.platform'
+    exclude group: 'org.junit.vintage'
+  }
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
   testImplementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-zuul'
   testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicHandlerMapping.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicHandlerMapping.groovy
@@ -1,6 +1,6 @@
 package test.dynamic
 
-import org.junit.Assert
+import org.junit.jupiter.api.Assertions
 import org.springframework.context.ApplicationContext
 import org.springframework.web.context.request.RequestContextHolder
 import org.springframework.web.method.HandlerMethod
@@ -18,7 +18,7 @@ class DynamicHandlerMapping extends AbstractHandlerMapping {
     try {
       RequestContextHolder.currentRequestAttributes()
     } catch (Exception e) {
-      Assert.fail(e.getMessage())
+      Assertions.fail(e.getMessage())
     }
     ApplicationContext applicationContext = this.getApplicationContext()
     DynamicRoutingConfig routingConfig = applicationContext

--- a/dd-java-agent/testing/build.gradle
+++ b/dd-java-agent/testing/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 
   api deps.groovy
 
-  implementation 'org.junit.platform:junit-platform-runner:1.7.2'
+  implementation 'org.junit.platform:junit-platform-runner:1.9.0'
 
   testImplementation project(':utils:test-utils')
   testImplementation project(':dd-java-agent:instrumentation:trace-annotation')

--- a/dd-java-agent/testing/build.gradle
+++ b/dd-java-agent/testing/build.gradle
@@ -46,6 +46,8 @@ dependencies {
 
   api deps.groovy
 
+  implementation 'org.junit.platform:junit-platform-runner:1.7.2'
+
   testImplementation project(':utils:test-utils')
   testImplementation project(':dd-java-agent:instrumentation:trace-annotation')
 
@@ -56,4 +58,19 @@ dependencies {
   // We have autoservices defined in test subtree, looks like we need this to be able to properly rebuild this
   testAnnotationProcessor deps.autoserviceProcessor
   testCompileOnly deps.autoserviceAnnotation
+}
+
+tasks.withType(Test).configureEach {
+  // SpockRunner that we use to run agent tests cannot be properly ported to JUnit 5,
+  // since the framework does not provide the hooks / extension points
+  // that can be used to shadow the tested class.
+
+  // In order to mitigate this, SpockRunner extends JUnitPlatform,
+  // which is a JUnit 4 runner that allows executing JUnit 5 tests in a JUnit 4 environment
+  // (i.e. running them as JUnit 4 tests).
+
+  // So even though Spock 2 tests run on top of JUnit 5,
+  // we execute them in "compatibility mode" so that SpockRunner could shadow the test class
+  // See https://junit.org/junit5/docs/current/user-guide/#running-tests-junit-platform-runner for more details.
+  useJUnit()
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/SpockRunner.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/SpockRunner.java
@@ -14,9 +14,8 @@ import java.util.TreeSet;
 import java.util.jar.JarFile;
 import net.bytebuddy.agent.ByteBuddyAgent;
 import net.bytebuddy.dynamic.ClassFileLocator;
+import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.notification.RunNotifier;
-import org.junit.runners.model.InitializationError;
-import org.spockframework.runtime.Sputnik;
 
 /**
  * Runs a spock test in an agent-friendly way.
@@ -25,7 +24,7 @@ import org.spockframework.runtime.Sputnik;
  *   <li>Adds agent bootstrap classes to bootstrap classpath.
  * </ul>
  */
-public class SpockRunner extends Sputnik {
+public class SpockRunner extends JUnitPlatform {
   /**
    * An exact copy of {@link datadog.trace.bootstrap.Constants#BOOTSTRAP_PACKAGE_PREFIXES}.
    *
@@ -69,12 +68,12 @@ public class SpockRunner extends Sputnik {
   private final InstrumentationClassLoader customLoader;
 
   public SpockRunner(final Class<?> clazz)
-      throws InitializationError, NoSuchFieldException, SecurityException, IllegalArgumentException,
+      throws NoSuchFieldException, SecurityException, IllegalArgumentException,
           IllegalAccessException {
     super(shadowTestClass(clazz));
     assertNoBootstrapClassesInTestClass(clazz);
     // access the classloader created in shadowTestClass above
-    final Field clazzField = Sputnik.class.getDeclaredField("clazz");
+    final Field clazzField = JUnitPlatform.class.getDeclaredField("testClass");
     try {
       clazzField.setAccessible(true);
       customLoader =

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -38,31 +38,32 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import spock.lang.Unroll
 
+import javax.annotation.Nonnull
 import java.util.function.BiFunction
 import java.util.function.Function
 import java.util.function.Supplier
-import javax.annotation.Nonnull
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_JSON
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_URLENCODED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.CREATED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.CREATED_IS
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.CUSTOM_EXCEPTION
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_BOTH
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_BOTH
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_QUERY
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.TIMEOUT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.TIMEOUT_ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.UNKNOWN
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_RAW_QUERY_STRING
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_RAW_RESOURCE
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_TAG_QUERY_STRING
@@ -74,7 +75,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScop
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.get
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan
-import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.SERVER_PATHWAY_EDGE_TAGS
 import static org.junit.Assume.assumeTrue
 
@@ -1475,10 +1475,10 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     assumeTrue(testUserBlocking())
     Blocking.blockingService = bs
 
-    def request = request(USER_BLOCK, 'GET', null)
+    def testRequest = request(USER_BLOCK, 'GET', null)
       .addHeader('Accept', 'application/json')
       .build()
-    def response = client.newCall(request).execute()
+    def response = client.newCall(testRequest).execute()
 
     expect:
     response.code() == USER_BLOCK.status

--- a/dd-java-agent/testing/src/test/groovy/server/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/server/HttpServerTest.groovy
@@ -64,11 +64,11 @@ class HttpServerTest extends AgentTestRunner {
       .url("$server.address")
       .get()
       .build()
-    def response = client.newCall(request).execute()
+    def clientResponse = client.newCall(request).execute()
 
     then:
-    response.code() == 404
-    response.body().string().contains("<title>Error 404 </title>")
+    clientResponse.code() == 404
+    clientResponse.body().string().contains("<title>Error 404 </title>")
 
     cleanup:
     server.stop()
@@ -97,20 +97,20 @@ class HttpServerTest extends AgentTestRunner {
     }
 
     when:
-    def request = new Request.Builder()
+    def clientRequest = new Request.Builder()
       .url("$server.address/$path")
 
     if (method == "get") {
-      request."$method"()
+      clientRequest."$method"()
     } else {
-      request."$method"(body())
+      clientRequest."$method"(body())
     }
 
-    def response = client.newCall(request.build()).execute()
+    def clientResponse = client.newCall(clientRequest.build()).execute()
 
     then:
-    response.code() == 200
-    response.body().string().trim() == "/$path response"
+    clientResponse.code() == 200
+    clientResponse.body().string().trim() == "/$path response"
 
     cleanup:
     server.stop()
@@ -154,11 +154,11 @@ class HttpServerTest extends AgentTestRunner {
       request."$method"()
     }
 
-    def response = client.newCall(request.build()).execute()
+    def clientResponse = client.newCall(request.build()).execute()
 
     then:
-    response.code() == code
-    response.body().string().trim() == "$resp"
+    clientResponse.code() == code
+    clientResponse.body().string().trim() == "$resp"
     server.lastRequest.contentType == contentType
     server.lastRequest.text.empty == !hasContent
 
@@ -189,11 +189,11 @@ class HttpServerTest extends AgentTestRunner {
       .header(headerKey, headerValue)
       .build()
 
-    def response = client.newCall(request).execute()
+    def clientResponse = client.newCall(request).execute()
 
     then:
-    response.code() == 200
-    response.body().string().trim() == ""
+    clientResponse.code() == 200
+    clientResponse.body().string().trim() == ""
 
     server.lastRequest.contentType == null
     server.lastRequest.headers.get(headerKey) == headerValue
@@ -245,11 +245,11 @@ class HttpServerTest extends AgentTestRunner {
       .url("$server.address/redirect")
       .get()
       .build()
-    def response = client.newCall(request).execute()
+    def clientResponse = client.newCall(request).execute()
 
     then:
-    response.code() == code
-    response.body().string() == body
+    clientResponse.code() == code
+    clientResponse.body().string() == body
 
     cleanup:
     server.stop()
@@ -276,11 +276,11 @@ class HttpServerTest extends AgentTestRunner {
       .head()
       .build()
 
-    def response = client.newCall(request).execute()
+    def clientResponse = client.newCall(request).execute()
 
     then:
-    response.code() == 200
-    response.body().string().trim() == ""
+    clientResponse.code() == 200
+    clientResponse.body().string().trim() == ""
 
     cleanup:
     server.stop()
@@ -303,11 +303,11 @@ class HttpServerTest extends AgentTestRunner {
       .get()
       .build()
 
-    def response = client.newCall(request).execute()
+    def clientResponse = client.newCall(request).execute()
 
     then:
-    response.code() == 200
-    response.body().string().trim() == "done"
+    clientResponse.code() == 200
+    clientResponse.body().string().trim() == "done"
 
     assertTraces(1) {
       server.distributedRequestTrace(it)
@@ -335,13 +335,13 @@ class HttpServerTest extends AgentTestRunner {
       .get()
       .build()
 
-    def response = runUnderTrace("parent") {
+    def clientResponse = runUnderTrace("parent") {
       client.newCall(request).execute()
     }
 
     then:
-    response.code() == 200
-    response.body().string().trim() == "done"
+    clientResponse.code() == 200
+    clientResponse.body().string().trim() == "done"
 
     assertTraces(1) {
       trace(1) {
@@ -371,11 +371,11 @@ class HttpServerTest extends AgentTestRunner {
       .get()
       .build()
 
-    def response = client.newCall(request).execute()
+    def clientResponse = client.newCall(request).execute()
 
     then:
-    response.code() == 200
-    response.body().string().trim() == "done"
+    clientResponse.code() == 200
+    clientResponse.body().string().trim() == "done"
 
     // parent<->child relation can't be tested because okhttp isnt traced here
     assertTraces(1) {
@@ -404,11 +404,11 @@ class HttpServerTest extends AgentTestRunner {
       .get()
       .build()
 
-    def response = client.newCall(request).execute()
+    def clientResponse = client.newCall(request).execute()
 
     then:
-    response.code() == 500
-    response.message().startsWith("assert !req.orig.handled")
+    clientResponse.code() == 500
+    clientResponse.message().startsWith("assert !req.orig.handled")
 
     cleanup:
     server.stop()
@@ -430,11 +430,11 @@ class HttpServerTest extends AgentTestRunner {
       .get()
       .build()
 
-    def response = client.newCall(request).execute()
+    def clientResponse = client.newCall(request).execute()
 
     then:
-    response.code() == 500
-    response.message().startsWith("assert body != null?")
+    clientResponse.code() == 500
+    clientResponse.message().startsWith("assert body != null?")
 
     cleanup:
     server.stop()

--- a/dd-smoke-tests/debugger-integration-tests/build.gradle
+++ b/dd-smoke-tests/debugger-integration-tests/build.gradle
@@ -2,10 +2,6 @@ plugins {
   id "com.github.johnrengelman.shadow"
 }
 
-ext {
-  enableJunitPlatform = true
-}
-
 apply from: "$rootDir/gradle/java.gradle"
 
 description = 'Debugger Integration Tests.'

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ServerDebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ServerDebuggerIntegrationTest.java
@@ -27,8 +27,8 @@ import okhttp3.Response;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -47,6 +47,7 @@ public class ServerDebuggerIntegrationTest extends BaseIntegrationTest {
   private HttpUrl controlUrl;
   private OkHttpClient httpClient = new OkHttpClient();
 
+  @Override
   @BeforeEach
   void setup(TestInfo testInfo) throws Exception {
     super.setup(testInfo);
@@ -56,6 +57,7 @@ public class ServerDebuggerIntegrationTest extends BaseIntegrationTest {
     controlUrl = controlServer.url(CONTROL_URL);
   }
 
+  @Override
   @AfterEach
   void teardown() throws Exception {
     super.teardown();
@@ -214,8 +216,8 @@ public class ServerDebuggerIntegrationTest extends BaseIntegrationTest {
     statuses.put(diagnostics.getStatus(), diagnostics);
     diagnostics = retrieveProbeStatusRequest().getDiagnostics();
     statuses.put(diagnostics.getStatus(), diagnostics);
-    Assert.assertTrue(statuses.containsKey(ProbeStatus.Status.RECEIVED));
-    Assert.assertEquals(
+    Assertions.assertTrue(statuses.containsKey(ProbeStatus.Status.RECEIVED));
+    Assertions.assertEquals(
         "Cannot find method datadog/smoketest/debugger/ServerDebuggerTestApplication::unknownMethodName",
         statuses.get(ProbeStatus.Status.ERROR).getException().getMessage());
   }

--- a/dd-smoke-tests/profiling-integration-tests/build.gradle
+++ b/dd-smoke-tests/profiling-integration-tests/build.gradle
@@ -3,7 +3,6 @@ plugins {
 }
 
 ext {
-  enableJunitPlatform = true
   excludeJdk = ['IBM8']
 }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/civisibility/writer/ddintake/CiTestCycleMapperV1PayloadTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/civisibility/writer/ddintake/CiTestCycleMapperV1PayloadTest.groovy
@@ -11,7 +11,7 @@ import datadog.trace.common.writer.Payload
 import datadog.trace.common.writer.TraceGenerator
 import datadog.trace.core.DDSpanContext
 import datadog.trace.test.util.DDSpecification
-import org.junit.Assert
+import org.junit.jupiter.api.Assertions
 import org.msgpack.core.MessageFormat
 import org.msgpack.core.MessagePack
 import org.msgpack.core.MessageUnpacker
@@ -23,9 +23,9 @@ import java.nio.channels.WritableByteChannel
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.DD_MEASURED
 import static datadog.trace.common.writer.TraceGenerator.generateRandomSpan
 import static datadog.trace.common.writer.TraceGenerator.generateRandomTraces
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertFalse
-import static org.junit.Assert.assertNotNull
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.msgpack.core.MessageFormat.FLOAT32
 import static org.msgpack.core.MessageFormat.FLOAT64
 import static org.msgpack.core.MessageFormat.INT16
@@ -326,7 +326,7 @@ class CiTestCycleMapperV1PayloadTest extends DDSpecification {
                 n = unpacker.unpackDouble()
                 break
               default:
-                Assert.fail("Unexpected type in metrics values: " + format)
+                Assertions.fail("Unexpected type in metrics values: " + format)
             }
             if (DD_MEASURED.toString() == key) {
               assert ((n == 1) && expectedSpan.isMeasured()) || !expectedSpan.isMeasured()
@@ -368,7 +368,7 @@ class CiTestCycleMapperV1PayloadTest extends DDSpecification {
           }
         }
       } catch (IOException e) {
-        Assert.fail(e.getMessage())
+        Assertions.fail(e.getMessage())
       } finally {
         mapper.reset()
         captured.position(0)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentApiTest.groovy
@@ -2,7 +2,12 @@ package datadog.trace.common.writer
 
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
+import datadog.communication.ddagent.DDAgentFeaturesDiscovery
+import datadog.communication.http.OkHttpUtils
 import datadog.communication.monitor.Monitoring
+import datadog.communication.serialization.ByteBufferConsumer
+import datadog.communication.serialization.FlushingBuffer
+import datadog.communication.serialization.msgpack.MsgPackWriter
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTraceId
 import datadog.trace.api.StatsDClient
@@ -11,17 +16,11 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopPathwayContex
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.common.sampling.RateByServiceTraceSampler
 import datadog.trace.common.writer.ddagent.DDAgentApi
-import datadog.communication.ddagent.DDAgentFeaturesDiscovery
-
 import datadog.trace.common.writer.ddagent.TraceMapperV0_4
 import datadog.trace.common.writer.ddagent.TraceMapperV0_5
 import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext
-import datadog.communication.http.OkHttpUtils
 import datadog.trace.core.monitor.MonitoringImpl
-import datadog.communication.serialization.ByteBufferConsumer
-import datadog.communication.serialization.FlushingBuffer
-import datadog.communication.serialization.msgpack.MsgPackWriter
 import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.core.test.DDCoreSpecification
 import okhttp3.HttpUrl
@@ -29,6 +28,7 @@ import okhttp3.OkHttpClient
 import org.msgpack.jackson.dataformat.MessagePackFactory
 import spock.lang.Shared
 import spock.lang.Timeout
+
 import java.nio.ByteBuffer
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
@@ -96,9 +96,9 @@ class DDAgentApiTest extends DDCoreSpecification {
     def client = createAgentApi(agent.address.toString())[1]
     Payload payload = prepareTraces("v0.3/traces", [])
     expect:
-    def response = client.sendSerializedTraces(payload)
-    !response.success()
-    response.status() == 404
+    def clientResponse = client.sendSerializedTraces(payload)
+    !clientResponse.success()
+    clientResponse.status() == 404
     agent.getLastRequest().path == "/v0.3/traces"
 
     cleanup:

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/TraceProcessingWorkerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/TraceProcessingWorkerTest.groovy
@@ -17,7 +17,7 @@ import static datadog.trace.api.sampling.PrioritySampling.UNSET
 import static datadog.trace.api.sampling.PrioritySampling.USER_DROP
 import static datadog.trace.api.sampling.PrioritySampling.USER_KEEP
 import static datadog.trace.common.writer.ddagent.Prioritization.FAST_LANE
-import static datadog.trace.common.writer.ddagent.PrioritizationStrategy.PublishResult.*
+import static datadog.trace.common.writer.ddagent.PrioritizationStrategy.PublishResult.ENQUEUED_FOR_SERIALIZATION
 
 class TraceProcessingWorkerTest extends DDSpecification {
 
@@ -232,8 +232,8 @@ class TraceProcessingWorkerTest extends DDSpecification {
     AtomicInteger acceptedSpanCount = new AtomicInteger()
     PayloadDispatcher countingDispatcher = Mock(PayloadDispatcher)
     countingDispatcher.addTrace(_) >> {
-      List trace = it[0]
-      acceptedSpanCount.getAndAdd(trace.size())
+      List traceList = it[0]
+      acceptedSpanCount.getAndAdd(traceList.size())
       acceptedCount.getAndIncrement()
     }
     AtomicInteger sampledSpansCount = new AtomicInteger()
@@ -308,8 +308,8 @@ class TraceProcessingWorkerTest extends DDSpecification {
     AtomicInteger spansCount = new AtomicInteger()
     PayloadDispatcher countingDispatcher = Mock(PayloadDispatcher)
     countingDispatcher.addTrace(_) >> {
-      List trace = it[0]
-      spansCount.getAndAdd(trace.size())
+      List traceList = it[0]
+      spansCount.getAndAdd(traceList.size())
       chunksCount.getAndIncrement()
     }
     AtomicInteger sampledSpansCount = new AtomicInteger()

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperV04PayloadTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperV04PayloadTest.groovy
@@ -9,7 +9,7 @@ import datadog.trace.common.writer.Payload
 import datadog.trace.common.writer.TraceGenerator
 import datadog.trace.core.DDSpanContext
 import datadog.trace.test.util.DDSpecification
-import org.junit.Assert
+import org.junit.jupiter.api.Assertions
 import org.msgpack.core.MessageFormat
 import org.msgpack.core.MessagePack
 import org.msgpack.core.MessageUnpacker
@@ -19,9 +19,20 @@ import java.nio.channels.WritableByteChannel
 
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.DD_MEASURED
 import static datadog.trace.common.writer.TraceGenerator.generateRandomTraces
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertFalse
-import static org.msgpack.core.MessageFormat.*
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.msgpack.core.MessageFormat.FLOAT32
+import static org.msgpack.core.MessageFormat.FLOAT64
+import static org.msgpack.core.MessageFormat.INT16
+import static org.msgpack.core.MessageFormat.INT32
+import static org.msgpack.core.MessageFormat.INT64
+import static org.msgpack.core.MessageFormat.INT8
+import static org.msgpack.core.MessageFormat.NEGFIXINT
+import static org.msgpack.core.MessageFormat.POSFIXINT
+import static org.msgpack.core.MessageFormat.UINT16
+import static org.msgpack.core.MessageFormat.UINT32
+import static org.msgpack.core.MessageFormat.UINT64
+import static org.msgpack.core.MessageFormat.UINT8
 
 class TraceMapperV04PayloadTest extends DDSpecification {
 
@@ -163,7 +174,7 @@ class TraceMapperV04PayloadTest extends DDSpecification {
                   n = unpacker.unpackDouble()
                   break
                 default:
-                  Assert.fail("Unexpected type in metrics values: " + format)
+                  Assertions.fail("Unexpected type in metrics values: " + format)
               }
               if (DD_MEASURED.toString() == key) {
                 assert ((n == 1) && expectedSpan.isMeasured()) || !expectedSpan.isMeasured()
@@ -208,7 +219,7 @@ class TraceMapperV04PayloadTest extends DDSpecification {
           }
         }
       } catch (IOException e) {
-        Assert.fail(e.getMessage())
+        Assertions.fail(e.getMessage())
       } finally {
         mapper.reset()
         captured.position(0)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDEvpProxyApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDEvpProxyApiTest.groovy
@@ -56,9 +56,9 @@ class DDEvpProxyApiTest extends DDCoreSpecification {
     def payload = prepareTraces(trackType, [])
 
     expect:
-    def response = client.sendSerializedTraces(payload)
-    response.success()
-    response.status() == 200
+    def clientResponse = client.sendSerializedTraces(payload)
+    clientResponse.success()
+    clientResponse.status() == 200
     agentEvpProxy.getLastRequest().path == path
     agentEvpProxy.getLastRequest().getHeader(DDEvpProxyApi.DD_EVP_SUBDOMAIN_HEADER) == intakeSubdomain
 
@@ -91,9 +91,9 @@ class DDEvpProxyApiTest extends DDCoreSpecification {
     def payload = prepareTraces(trackType, [])
 
     expect:
-    def response = client.sendSerializedTraces(payload)
-    response.success()
-    response.status() == 200
+    def clientResponse = client.sendSerializedTraces(payload)
+    clientResponse.success()
+    clientResponse.status() == 200
     agentEvpProxy.getLastRequest().path == path
     agentEvpProxy.getLastRequest().getHeader(DDEvpProxyApi.DD_EVP_SUBDOMAIN_HEADER) == intakeSubdomain
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDIntakeApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDIntakeApiTest.groovy
@@ -55,9 +55,9 @@ class DDIntakeApiTest extends DDCoreSpecification {
     def payload = prepareTraces(trackType, [])
 
     expect:
-    def response = client.sendSerializedTraces(payload)
-    response.success()
-    response.status() == 200
+    def clientResponse = client.sendSerializedTraces(payload)
+    clientResponse.success()
+    clientResponse.status() == 200
     intake.getLastRequest().path == path
 
     cleanup:
@@ -89,9 +89,9 @@ class DDIntakeApiTest extends DDCoreSpecification {
     def payload = prepareTraces(trackType, [])
 
     expect:
-    def response = client.sendSerializedTraces(payload)
-    response.success()
-    response.status() == 200
+    def clientResponse = client.sendSerializedTraces(payload)
+    clientResponse.success()
+    clientResponse.status() == 200
     intake.getLastRequest().path == path
 
     cleanup:
@@ -123,9 +123,9 @@ class DDIntakeApiTest extends DDCoreSpecification {
     def payload = prepareTraces(trackType, [])
 
     expect:
-    def response = client.sendSerializedTraces(payload)
-    response.success()
-    response.status() == 200
+    def clientResponse = client.sendSerializedTraces(payload)
+    clientResponse.success()
+    clientResponse.status() == 200
     intake.getLastRequest().path == path
 
     cleanup:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DefaultDataStreamsMonitoringTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DefaultDataStreamsMonitoringTest.groovy
@@ -400,7 +400,7 @@ class DefaultDataStreamsMonitoringTest extends DDCoreSpecification {
     given:
     def conditions = new PollingConditions(timeout: 1)
     boolean supportsDataStreaming = false
-    def features = Stub(DDAgentFeaturesDiscovery) {
+    def features = Mock(DDAgentFeaturesDiscovery) {
       supportsDataStreams() >> { return supportsDataStreaming }
     }
     def timeSource = new ControllableTimeSource()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/CounterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/CounterTest.groovy
@@ -5,7 +5,6 @@ import datadog.communication.monitor.Monitoring
 import datadog.communication.monitor.NoOpCounter
 import datadog.trace.api.StatsDClient
 import datadog.trace.test.util.DDSpecification
-import org.junit.Assert
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 
@@ -50,7 +49,7 @@ class CounterTest extends DDSpecification {
       counter.increment(1)
       counter.incrementErrorCount("cause", 1)
     } catch (Throwable t) {
-      Assert.fail(t.getMessage())
+      Assertions.fail(t.getMessage())
     }
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/TimingTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/TimingTest.groovy
@@ -5,7 +5,7 @@ import datadog.communication.monitor.NoOpRecording
 import datadog.communication.monitor.Recording
 import datadog.trace.api.StatsDClient
 import datadog.trace.test.util.DDSpecification
-import org.junit.Assert
+import org.junit.jupiter.api.Assertions
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 
@@ -81,7 +81,7 @@ class TimingTest extends DDSpecification {
       recording.start().stop()
       recording.reset()
     } catch (Throwable t) {
-      Assert.fail(t.getMessage())
+      Assertions.fail(t.getMessage())
     }
 
     where:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerDepthTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerDepthTest.groovy
@@ -18,8 +18,8 @@ class ScopeManagerDepthTest extends DDCoreSpecification {
     when: "fill up the scope stack"
     AgentScope scope = null
     for (int i = 0; i < depth; i++) {
-      def span = tracer.buildSpan("test").start()
-      scope = tracer.activateSpan(span)
+      def testSpan = tracer.buildSpan("test").start()
+      scope = tracer.activateSpan(testSpan)
       assert scope instanceof ContinuableScope
     }
 
@@ -59,8 +59,8 @@ class ScopeManagerDepthTest extends DDCoreSpecification {
     when: "fill up the scope stack"
     AgentScope scope = null
     for (int i = 0; i < defaultLimit; i++) {
-      def span = tracer.buildSpan("test").start()
-      scope = tracer.activateSpan(span)
+      def testSpan = tracer.buildSpan("test").start()
+      scope = tracer.activateSpan(testSpan)
       assert scope instanceof ContinuableScope
     }
 

--- a/dd-trace-core/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/DDApiIntegrationTest.groovy
@@ -9,7 +9,6 @@ import datadog.trace.common.writer.Payload
 import datadog.trace.common.writer.RemoteApi
 import datadog.trace.common.writer.RemoteResponseListener
 import datadog.trace.common.writer.ddagent.DDAgentApi
-
 import datadog.trace.common.writer.ddagent.TraceMapper
 import datadog.trace.common.writer.ddagent.TraceMapperV0_4
 import datadog.trace.common.writer.ddagent.TraceMapperV0_5
@@ -195,7 +194,7 @@ class DDApiIntegrationTest extends DDSpecification {
     // spotless:on
   }
 
-  def "Sending traces to unix domain socket succeeds (test #test)"() {
+  def "Sending traces to unix domain socket succeeds (enableV05 #enableV05)"() {
     setup:
     beforeTest(enableV05)
     expect:

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/DefaultLogHandlerTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/DefaultLogHandlerTest.groovy
@@ -22,17 +22,17 @@ class DefaultLogHandlerTest extends DDSpecification {
     final DDSpan span = tracer.buildSpan("op name").withServiceName("foo").start()
     final String errorMessage = "errorMessage"
     final String differentMessage = "differentMessage"
-    final Throwable throwable = new Throwable(errorMessage)
+    final Throwable error = new Throwable(errorMessage)
     final Map<String, ?> fields = new HashMap<>()
-    fields.put(Fields.ERROR_OBJECT, throwable)
+    fields.put(Fields.ERROR_OBJECT, error)
     fields.put(Fields.MESSAGE, differentMessage)
 
     when:
     underTest.log(fields, span)
 
     then:
-    span.getTags().get(DDTags.ERROR_MSG) == throwable.getMessage()
-    span.getTags().get(DDTags.ERROR_TYPE) == throwable.getClass().getName()
+    span.getTags().get(DDTags.ERROR_MSG) == error.getMessage()
+    span.getTags().get(DDTags.ERROR_TYPE) == error.getClass().getName()
   }
 
   def "handles correctly the error passed in the fields when called with timestamp"() {
@@ -41,17 +41,17 @@ class DefaultLogHandlerTest extends DDSpecification {
     final DDSpan span = tracer.buildSpan("op name").withServiceName("foo").start()
     final String errorMessage = "errorMessage"
     final String differentMessage = "differentMessage"
-    final Throwable throwable = new Throwable(errorMessage)
+    final Throwable error = new Throwable(errorMessage)
     final Map<String, ?> fields = new HashMap<>()
-    fields.put(Fields.ERROR_OBJECT, throwable)
+    fields.put(Fields.ERROR_OBJECT, error)
     fields.put(Fields.MESSAGE, differentMessage)
 
     when:
     underTest.log(System.currentTimeMillis(), fields, span)
 
     then:
-    span.getTags().get(DDTags.ERROR_MSG) == throwable.getMessage()
-    span.getTags().get(DDTags.ERROR_TYPE) == throwable.getClass().getName()
+    span.getTags().get(DDTags.ERROR_MSG) == error.getMessage()
+    span.getTags().get(DDTags.ERROR_TYPE) == error.getClass().getName()
   }
 
   def "handles correctly the message passed in the fields but the span is not an error"() {

--- a/gradle/configure_tests.gradle
+++ b/gradle/configure_tests.gradle
@@ -14,6 +14,7 @@ def testTimeoutDuration = Duration.of(9, ChronoUnit.MINUTES)
 
 // Go through the Test tasks and configure them
 tasks.withType(Test).configureEach {
+  // Use JUnit 5 to run tests
   useJUnitPlatform()
 
   // All tests must complete within 15 minutes.
@@ -65,7 +66,7 @@ tasks.withType(Test).configureEach {
 // Setup flaky tests jobs. Done in afterEvaluate so that it applies to latestDepTest.
 project.afterEvaluate {
   tasks.withType(Test).configureEach {
-    // JUnit 5 support
+    // Flaky tests management for JUnit 5
     testFramework {
       if (project.rootProject.hasProperty("skipFlakyTests")) {
         excludeTags "flaky"
@@ -74,7 +75,7 @@ project.afterEvaluate {
       }
     }
 
-    // Spock support
+    // Flaky tests management for Spock
     if (project.rootProject.hasProperty("skipFlakyTests")) {
       jvmArgs += ["-Drun.flaky.tests=false"]
     } else if (project.rootProject.hasProperty("runFlakyTests")) {

--- a/gradle/configure_tests.gradle
+++ b/gradle/configure_tests.gradle
@@ -14,9 +14,7 @@ def testTimeoutDuration = Duration.of(9, ChronoUnit.MINUTES)
 
 // Go through the Test tasks and configure them
 tasks.withType(Test).configureEach {
-  if (project.findProperty("enableJunitPlatform") == true) {
-    useJUnitPlatform()
-  }
+  useJUnitPlatform()
 
   // All tests must complete within 15 minutes.
   // This value is quite big because with lower values (3 mins) we were experiencing large number of false positives
@@ -68,13 +66,11 @@ tasks.withType(Test).configureEach {
 project.afterEvaluate {
   tasks.withType(Test).configureEach {
     // JUnit 5 support
-    if (project.findProperty("enableJunitPlatform") == true) {
-      useJUnitPlatform {
-        if (project.rootProject.hasProperty("skipFlakyTests")) {
-          excludeTags "flaky"
-        } else if (project.rootProject.hasProperty("runFlakyTests")) {
-          includeTags "flaky"
-        }
+    testFramework {
+      if (project.rootProject.hasProperty("skipFlakyTests")) {
+        excludeTags "flaky"
+      } else if (project.rootProject.hasProperty("runFlakyTests")) {
+        includeTags "flaky"
       }
     }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,5 +1,5 @@
 final class CachedData {
-  static groovyVer = "2.5.21"
+  static groovyVer = "3.0.10"
   static spockGroovyVer = groovyVer.replaceAll(/\.\d+$/, '')
 
   static versions = [
@@ -10,10 +10,9 @@ final class CachedData {
     okhttp_legacy : "[3.0,3.12.12]", // 3.12.x is last version to support Java7)
     okio          : "1.16.0",
 
-    spock         : "1.3-groovy-$spockGroovyVer",
+    spock         : "2.1-groovy-$spockGroovyVer",
     groovy        : groovyVer,
-    junit4        : "4.13.2",
-    junit5        : "5.8.1",
+    junit5        : "5.9.2",
     logback       : "1.2.3",
     bytebuddy     : "1.12.22",
     scala         : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)
@@ -61,11 +60,10 @@ final class CachedData {
 
     spock                : [
       "org.spockframework:spock-core:${versions.spock}",
-      // Used by Spock for mocking:
-      "org.objenesis:objenesis:2.6" // Last version to support Java7
+      "org.spockframework:spock-junit4:${versions.spock}",
+      "org.objenesis:objenesis:3.3" // Used by Spock for mocking:
     ],
     groovy               : "org.codehaus.groovy:groovy-all:${versions.groovy}",
-    junit4               : "junit:junit:${versions.junit4}",
     junit5               : [
       "org.junit.jupiter:junit-jupiter:${versions.junit5}",
       "org.junit.jupiter:junit-jupiter-params:${versions.junit5}"

--- a/gradle/java_deps.gradle
+++ b/gradle/java_deps.gradle
@@ -4,5 +4,4 @@ dependencies {
   testImplementation deps.spock
   testImplementation deps.groovy
   testImplementation deps.testLogging
-  testImplementation group: 'info.solidsoft.spock', name: 'spock-global-unroll', version: '0.5.1'
 }

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -5,7 +5,6 @@ plugins {
 ext {
   // need access to sun.misc.SharedSecrets
   skipSettingCompilerRelease = true
-  enableJunitPlatform = true
 }
 
 // sun.misc.SharedSecrets is gone in later versions
@@ -116,7 +115,7 @@ dependencies {
   api "com.datadoghq:dd-javac-plugin-client:0.1.1"
 
   testImplementation project(":utils:test-utils")
-  testImplementation("org.assertj:assertj-core:2.9.1")
+  testImplementation("org.assertj:assertj-core:3.20.2")
   testImplementation deps.junit5
   testImplementation("org.junit.vintage:junit-vintage-engine:${versions.junit5}")
   testImplementation deps.commonsMath

--- a/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
@@ -15,8 +15,8 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.assertj.core.api.ThrowableAssert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class InstrumentationGatewayTest {
 
@@ -28,7 +28,7 @@ public class InstrumentationGatewayTest {
   private Callback callback;
   private Events<Object> events;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     gateway = new InstrumentationGateway();
     ss = gateway.getSubscriptionService(RequestContextSlot.APPSEC);
@@ -177,7 +177,7 @@ public class InstrumentationGatewayTest {
     cbp.getCallback(events.responseHeader()).accept(null, null, null);
     ss.registerCallback(events.responseHeaderDone(), callback.function);
     cbp.getCallback(events.responseHeaderDone()).apply(null);
-    assertThat(this.callback.count).isEqualTo(Events.MAX_EVENTS);
+    assertThat(callback.count).isEqualTo(Events.MAX_EVENTS);
   }
 
   @Test
@@ -381,9 +381,9 @@ public class InstrumentationGatewayTest {
     public Callback(RequestContext ctxt, Flow<Void> flow) {
       this.ctxt = ctxt;
       this.flow = flow;
-      this.function =
+      function =
           input -> {
-            this.count++;
+            count++;
             return flow;
           };
     }
@@ -449,7 +449,7 @@ public class InstrumentationGatewayTest {
 
     private final Function<RequestContext, Flow<Void>> function =
         input -> {
-          this.count++;
+          count++;
           throw new IllegalArgumentException();
         };
 

--- a/internal-api/src/test/java/datadog/trace/util/TagsHelperTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/TagsHelperTest.java
@@ -3,7 +3,7 @@ package datadog.trace.util;
 import static org.junit.Assert.assertEquals;
 
 import java.nio.charset.StandardCharsets;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TagsHelperTest {
 

--- a/telemetry/src/test/java/datadog/telemetry/dependency/DependencyServiceImplTests.java
+++ b/telemetry/src/test/java/datadog/telemetry/dependency/DependencyServiceImplTests.java
@@ -24,8 +24,8 @@ import org.jboss.vfs.TempFileProvider;
 import org.jboss.vfs.VFS;
 import org.jboss.vfs.VirtualFile;
 import org.jboss.vfs.VirtualFileAssembly;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class DependencyServiceImplTests {
 
@@ -33,7 +33,7 @@ public class DependencyServiceImplTests {
   Closeable assemblyHandle;
   TempFileProvider tempFileProvider;
 
-  @After
+  @AfterEach
   public void teardown() throws IOException {
     if (assemblyHandle != null) {
       assemblyHandle.close();

--- a/utils/container-utils/src/test/groovy/ServerlessInfoTest.groovy
+++ b/utils/container-utils/src/test/groovy/ServerlessInfoTest.groovy
@@ -1,11 +1,7 @@
 import datadog.common.container.ServerlessInfo
 import datadog.trace.test.util.DDSpecification
-import org.junit.Rule
-import org.junit.contrib.java.lang.system.EnvironmentVariables
 
 class ServerlessInfoTest extends DDSpecification {
-  @Rule
-  public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
 
   def "test serverless detection"() {
     given:

--- a/utils/test-agent-utils/decoder/build.gradle
+++ b/utils/test-agent-utils/decoder/build.gradle
@@ -7,6 +7,6 @@ ext {
 
 dependencies {
   implementation group: 'org.msgpack', name: 'msgpack-core', version: '0.8.24'
-  testImplementation deps.junit4
+  testImplementation deps.junit5
   testImplementation deps.truth
 }

--- a/utils/test-agent-utils/decoder/src/test/java/datadog/trace/test/agent/decoder/DecoderTest.java
+++ b/utils/test-agent-utils/decoder/src/test/java/datadog/trace/test/agent/decoder/DecoderTest.java
@@ -10,7 +10,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DecoderTest {
 
@@ -107,7 +107,7 @@ public class DecoderTest {
   }
 
   private byte[] readResourceFile(String resourceName) throws IOException {
-    Path path = new File(this.getClass().getResource(resourceName).getFile()).toPath();
+    Path path = new File(getClass().getResource(resourceName).getFile()).toPath();
     return Files.readAllBytes(path);
   }
 


### PR DESCRIPTION
# What Does This Do
Updates Groovy version (2.5 -> 3.0) and Spock version (1.3 -> 2.1).
Migrates all tests that used to run on JUnit 4 to JUnit 5.

# Motivation
Our current version of Spock is 1.3.
It only support Groovy 2.x, which has some drawbacks:
* our Gradle version uses Groovy 3.0.10, as the result `gradleTestKit()` cannot be used due to dependency conflicts
* Groovy 2 has some annoying bugs (e.g. https://issues.apache.org/jira/browse/GROOVY-10137)

# Additional Notes
`SpockRunner` that we use to run instrumentation tests cannot be properly ported to JUnit 5, since the framework does not provide the hooks / extension points that can be used to shadow the tested class (see [Introduce extension API for providing a custom ClassLoader (e.g. for Powermock)](https://github.com/junit-team/junit5/issues/201)).

In order to mitigate this, `SpockRunner` was changed to extend `JUnitPlatform`, which is a JUnit 4 runner that allows executing JUnit 5 tests in a JUnit 4 environment (i.e. running them as JUnit 4 tests).

So even though Spock 2 tests run on top of JUnit 5, we execute them in "compatibility mode" so that `SpockRunner` could shadow the test class (see [SputnikRunner removed](https://spockframework.org/spock/docs/2.3/all_in_one.html#_sputnik_runner_removed_an_alternative) for more details).
