### PR TITLE
Combine class-loader delegation check with 'hasClass' checks

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/GlobalIgnoresMatcher.java
@@ -1,5 +1,7 @@
 package datadog.trace.agent.tooling.bytebuddy.matcher;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.incompatibleClassLoader;
+
 import java.security.ProtectionDomain;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.description.type.TypeDescription;
@@ -28,14 +30,13 @@ public class GlobalIgnoresMatcher implements AgentBuilder.RawMatcher {
       JavaModule module,
       Class<?> classBeingRedefined,
       ProtectionDomain protectionDomain) {
-    if (ClassLoaderMatchers.skipClassLoader(classLoader)) {
-      return true;
-    }
+    // put cheaper name checks first...
     String name = typeDescription.getName();
     return GlobalIgnores.isIgnored(name, skipAdditionalLibraryMatcher)
         || CustomExcludes.isExcluded(name)
         || CodeSourceExcludes.isExcluded(protectionDomain)
-        || ProxyClassIgnores.isIgnored(name);
+        || ProxyClassIgnores.isIgnored(name)
+        || incompatibleClassLoader(classLoader);
   }
 
   @Override

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ClassLoaderMatchers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ClassLoaderMatchers.java
@@ -14,7 +14,6 @@ import java.util.BitSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,37 +28,9 @@ public final class ClassLoaderMatchers {
   private static final boolean HAS_CLASSLOADER_EXCLUDES =
       !InstrumenterConfig.get().getExcludedClassLoaders().isEmpty();
 
-  /* Cache of classloader-instance -> (true|false). True = skip instrumentation. False = safe to instrument. */
-  private static final WeakCache<ClassLoader, Boolean> skipCache = WeakCaches.newWeakCache(64);
-
   /** A private constructor that must not be invoked. */
   private ClassLoaderMatchers() {
     throw new UnsupportedOperationException();
-  }
-
-  public static boolean skipClassLoader(final ClassLoader loader) {
-    if (loader == BOOTSTRAP_CLASSLOADER) {
-      // Don't skip bootstrap loader
-      return false;
-    }
-    if (canSkipClassLoaderByName(loader)) {
-      return true;
-    }
-    Boolean v = skipCache.getIfPresent(loader);
-    if (v != null) {
-      return v;
-    }
-    // when ClassloadingInstrumentation is active, checking delegatesToBootstrap() below is not
-    // required, because ClassloadingInstrumentation forces all class loaders to load all of the
-    // classes in Constants.BOOTSTRAP_PACKAGE_PREFIXES directly from the bootstrap class loader
-    //
-    // however, at this time we don't want to introduce the concept of a required instrumentation,
-    // and we don't want to introduce the concept of the tooling code depending on whether or not
-    // a particular instrumentation is active (mainly because this particular use case doesn't
-    // seem to justify introducing either of these new concepts)
-    v = !delegatesToBootstrap(loader);
-    skipCache.put(loader, v);
-    return v;
   }
 
   public static boolean canSkipClassLoaderByName(final ClassLoader loader) {
@@ -78,6 +49,11 @@ public final class ClassLoaderMatchers {
       return InstrumenterConfig.get().getExcludedClassLoaders().contains(classLoaderName);
     }
     return false;
+  }
+
+  public static boolean incompatibleClassLoader(final ClassLoader loader) {
+    return loader != BOOTSTRAP_CLASSLOADER && hasClassMask(loader) == INCOMPATIBLE_CLASS_LOADER;
+    // note: must use '==' to distinguish INCOMPATIBLE_CLASS_LOADER from NO_CLASS_NAME_MATCHES
   }
 
   /**
@@ -154,19 +130,28 @@ public final class ClassLoaderMatchers {
   /** Cache of classloader-instance -> has-class mask. */
   static final WeakCache<ClassLoader, BitSet> hasClassCache = WeakCaches.newWeakCache(64);
 
+  /** Distinct result used to mark an incompatible classloader that the tracer should skip. */
+  static final BitSet INCOMPATIBLE_CLASS_LOADER = new BitSet();
+
   static final BitSet NO_CLASS_NAME_MATCHES = new BitSet();
 
-  /** Function that generates a has-class mask for a given class-loader. */
-  static final Function<ClassLoader, BitSet> buildHasClassMask =
-      ClassLoaderMatchers::buildHasClassMask;
+  static BitSet hasClassMask(ClassLoader loader) {
+    return hasClassCache.computeIfAbsent(loader, ClassLoaderMatchers::buildHasClassMask);
+  }
 
-  static BitSet buildHasClassMask(ClassLoader cl) {
+  static BitSet buildHasClassMask(ClassLoader loader) {
+    if (!delegatesToBootstrap(loader)) {
+      // when ClassloadingInstrumentation is active this check is not strictly required,
+      // because that instrumentation forces all class loaders to load classes covered by
+      // Constants.BOOTSTRAP_PACKAGE_PREFIXES directly from the bootstrap class loader
+      return INCOMPATIBLE_CLASS_LOADER;
+    }
     PROBING_CLASSLOADER.begin();
     try {
       BitSet hasClassMask = NO_CLASS_NAME_MATCHES;
       for (int hasClassId = hasClassResourceNames.size() - 1; hasClassId >= 0; hasClassId--) {
         try {
-          if (cl.getResource(hasClassResourceNames.get(hasClassId)) != null) {
+          if (loader.getResource(hasClassResourceNames.get(hasClassId)) != null) {
             if (hasClassMask.isEmpty()) {
               hasClassMask = new BitSet(hasClassId + 1);
             }
@@ -190,8 +175,8 @@ public final class ClassLoaderMatchers {
     }
 
     @Override
-    protected boolean doMatch(final ClassLoader cl) {
-      return hasClassCache.computeIfAbsent(cl, buildHasClassMask).get(hasClassId);
+    protected boolean doMatch(final ClassLoader loader) {
+      return hasClassMask(loader).get(hasClassId);
     }
   }
 }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ClassLoaderMatchersTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ClassLoaderMatchersTest.groovy
@@ -12,26 +12,26 @@ class ClassLoaderMatchersTest extends DDSpecification {
     setup:
     final ClassLoader badLoader = new NonDelegatingClassLoader()
     expect:
-    ClassLoaderMatchers.skipClassLoader(badLoader)
+    ClassLoaderMatchers.incompatibleClassLoader(badLoader)
   }
 
   def "skips agent classloader"() {
     setup:
     final ClassLoader agentLoader = new DatadogClassLoader()
     expect:
-    ClassLoaderMatchers.skipClassLoader(agentLoader)
+    ClassLoaderMatchers.incompatibleClassLoader(agentLoader)
   }
 
   def "does not skip empty classloader"() {
     setup:
     final ClassLoader emptyLoader = new ClassLoader() {}
     expect:
-    !ClassLoaderMatchers.skipClassLoader(emptyLoader)
+    !ClassLoaderMatchers.incompatibleClassLoader(emptyLoader)
   }
 
   def "does not skip bootstrap classloader"() {
     expect:
-    !ClassLoaderMatchers.skipClassLoader(null)
+    !ClassLoaderMatchers.incompatibleClassLoader(null)
   }
 
   def "DatadogClassLoader class name is hardcoded in ClassLoaderMatcher"() {


### PR DESCRIPTION
# What Does This Do

Both `DDClassFileTransformer` and its Java9+ equivalent as well as `DDRediscoveryStrategy` already check `canSkipClassLoaderByName` before allowing a transform request to proceed, so we don't need to repeat that particular test in `GlobalIgnoresMatcher`.

That leaves the boot-class-path delegation test. Since we expect every class-loader to pass this test (thanks to `ClassloadingInstrumentation`) we should move this to the end of `GlobalIgnoresMatcher`, where it can act as a final safety net. This also gives us the chance to merge its state with the `hasClass` checks.

Note we use a distinct object to represent an `INCOMPATIBLE_CLASS_LOADER` result, because it avoids having to change the return type or create unnecessary container objects. And since an incompatible class-loader has no `hasClass` matches it's still compatible with previous usage.

# Motivation

Reduces the number of weak caches in the tracer.
