### PR TITLE
naming schema: rabbitmq

### DIFF
--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -13,9 +13,10 @@ import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.EXCHANGE_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.HAS_ROUTING_KEY_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TYPE_TAG;
-import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.AMQP_COMMAND;
 import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.CLIENT_DECORATE;
 import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.CONSUMER_DECORATE;
+import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.OPERATION_AMQP_COMMAND;
+import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.OPERATION_AMQP_OUTBOUND;
 import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.PRODUCER_DECORATE;
 import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.RABBITMQ_LEGACY_TRACING;
 import static datadog.trace.instrumentation.rabbitmq.amqp.TextMapInjectAdapter.SETTER;
@@ -122,7 +123,7 @@ public class RabbitChannelInstrumentation extends Instrumenter.Tracing
 
       final Connection connection = channel.getConnection();
 
-      final AgentSpan span = startSpan(AMQP_COMMAND);
+      final AgentSpan span = startSpan(OPERATION_AMQP_COMMAND);
       span.setResourceName(method);
       CLIENT_DECORATE.setPeerPort(span, connection.getPort());
       CLIENT_DECORATE.afterStart(span);
@@ -159,7 +160,7 @@ public class RabbitChannelInstrumentation extends Instrumenter.Tracing
 
       final Connection connection = channel.getConnection();
 
-      final AgentSpan span = startSpan(AMQP_COMMAND);
+      final AgentSpan span = startSpan(OPERATION_AMQP_OUTBOUND);
       PRODUCER_DECORATE.setPeerPort(span, connection.getPort());
       PRODUCER_DECORATE.afterStart(span);
       PRODUCER_DECORATE.onPeerConnection(span, connection.getAddress());

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitCommandInstrumentation.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitCommandInstrumentation.java
@@ -3,8 +3,9 @@ package datadog.trace.instrumentation.rabbitmq.amqp;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
-import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.AMQP_COMMAND;
 import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.CLIENT_DECORATE;
+import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.OPERATION_AMQP_DELIVER;
+import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.RABBITMQ_AMQP;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 
 import com.google.auto.service.AutoService;
@@ -12,6 +13,7 @@ import com.rabbitmq.client.Command;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -65,7 +67,9 @@ public class RabbitCommandInstrumentation extends Instrumenter.Tracing
       final AgentSpan span = activeSpan();
 
       if (span != null && command.getMethod() != null) {
-        if (span.getSpanName().equals(AMQP_COMMAND)) {
+        // now we have 3 different operations on schema v1
+        if (!span.getSpanName().equals(OPERATION_AMQP_DELIVER.toString())
+            && RABBITMQ_AMQP.equals(span.getTag(Tags.COMPONENT))) {
           CLIENT_DECORATE.onCommand(span, command);
         }
       }

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.rabbitmq.amqp;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.AMQP_COMMAND;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.AMQP_EXCHANGE;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.AMQP_QUEUE;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.AMQP_ROUTING_KEY;
@@ -17,6 +18,7 @@ import com.rabbitmq.client.Command;
 import com.rabbitmq.client.Consumer;
 import com.rabbitmq.client.Envelope;
 import datadog.trace.api.Config;
+import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -32,13 +34,21 @@ import java.util.concurrent.TimeUnit;
 
 public class RabbitDecorator extends MessagingClientDecorator {
 
-  public static final CharSequence AMQP_COMMAND = UTF8BytesString.create("amqp.command");
-  public static final CharSequence AMQP_DELIVER = UTF8BytesString.create("amqp.deliver");
+  public static final CharSequence OPERATION_AMQP_COMMAND = UTF8BytesString.create("amqp.command");
+  public static final CharSequence OPERATION_AMQP_INBOUND =
+      UTF8BytesString.create(
+          SpanNaming.instance().namingSchema().messaging().inboundOperation("amqp"));
+
+  public static final CharSequence OPERATION_AMQP_DELIVER = UTF8BytesString.create("amqp.deliver");
+
+  public static final CharSequence OPERATION_AMQP_OUTBOUND =
+      UTF8BytesString.create(
+          SpanNaming.instance().namingSchema().messaging().outboundOperation("amqp"));
   public static final CharSequence RABBITMQ_AMQP = UTF8BytesString.create("rabbitmq-amqp");
 
   public static final boolean RABBITMQ_LEGACY_TRACING =
-      Config.get().isLegacyTracingEnabled(true, "rabbit", "rabbitmq");
-
+      Config.get()
+          .isLegacyTracingEnabled(SpanNaming.instance().version() == 0, "rabbit", "rabbitmq");
   private static final String LOCAL_SERVICE_NAME =
       RABBITMQ_LEGACY_TRACING ? "rabbitmq" : Config.get().getServiceName();
   public static final RabbitDecorator CLIENT_DECORATE =
@@ -54,7 +64,7 @@ public class RabbitDecorator extends MessagingClientDecorator {
       new RabbitDecorator(
           Tags.SPAN_KIND_BROKER,
           InternalSpanTypes.MESSAGE_BROKER,
-          null /* service name will be set later on */);
+          SpanNaming.instance().namingSchema().messaging().timeInQueueService("rabbitmq"));
 
   private final String spanKind;
   private final CharSequence spanType;
@@ -105,14 +115,14 @@ public class RabbitDecorator extends MessagingClientDecorator {
   public void onGet(final AgentSpan span, final String queue) {
     span.setResourceName("basic.get " + normalizeQueueName(queue));
     // This span is created after the command has returned, so we need to set the tag here
-    span.setTag(AMQP_COMMAND.toString(), "basic.get");
+    span.setTag(AMQP_COMMAND, "basic.get");
     span.setTag(AMQP_QUEUE, queue);
   }
 
   public void onDeliver(final AgentSpan span, final String queue, final Envelope envelope) {
     span.setResourceName("basic.deliver " + normalizeQueueName(queue));
     // This span happens after any AMQP commands so we need to set the tag here
-    span.setTag(AMQP_COMMAND.toString(), "basic.deliver");
+    span.setTag(AMQP_COMMAND, "basic.deliver");
     if (envelope != null) {
       span.setTag(AMQP_EXCHANGE, envelope.getExchange());
       span.setTag(AMQP_ROUTING_KEY, envelope.getRoutingKey());
@@ -125,15 +135,13 @@ public class RabbitDecorator extends MessagingClientDecorator {
     if (!name.equals("basic.publish")) {
       span.setResourceName(name);
     }
-    span.setTag(AMQP_COMMAND.toString(), name);
+    span.setTag(AMQP_COMMAND, name);
   }
 
   public void onTimeInQueue(final AgentSpan span, final String queue, final byte[] body) {
     String normalizedQueueName = normalizeQueueName(queue);
     if (Config.get().isMessageBrokerSplitByDestination()) {
       span.setServiceName(normalizedQueueName);
-    } else {
-      span.setServiceName("rabbitmq");
     }
     span.setResourceName("amqp.deliver " + normalizedQueueName);
     if (null != body) {
@@ -194,7 +202,10 @@ public class RabbitDecorator extends MessagingClientDecorator {
     if (queueStartMillis != 0) {
       queueStartMillis = Math.min(spanStartMillis, queueStartMillis);
       queueSpan =
-          startSpan(AMQP_DELIVER, parentContext, TimeUnit.MILLISECONDS.toMicros(queueStartMillis));
+          startSpan(
+              OPERATION_AMQP_DELIVER,
+              parentContext,
+              TimeUnit.MILLISECONDS.toMicros(queueStartMillis));
       BROKER_DECORATE.afterStart(queueSpan);
       BROKER_DECORATE.onTimeInQueue(queueSpan, queue, body);
       parentContext = queueSpan.context();
@@ -202,7 +213,7 @@ public class RabbitDecorator extends MessagingClientDecorator {
       // The queueSpan will be finished after the inner span has been activated to ensure that the
       // spans are written out together by the TraceStructureWriter when running in strict mode
     }
-    final AgentSpan span = startSpan(AMQP_COMMAND, parentContext, spanStartMicros);
+    final AgentSpan span = startSpan(OPERATION_AMQP_INBOUND, parentContext, spanStartMicros);
 
     if (null != headers) {
       PathwayContext pathwayContext =

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -1,3 +1,8 @@
+import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGATION_DISABLED_EXCHANGES
+import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGATION_DISABLED_QUEUES
+
 import com.rabbitmq.client.AMQP
 import com.rabbitmq.client.AlreadyClosedException
 import com.rabbitmq.client.Channel
@@ -6,8 +11,8 @@ import com.rabbitmq.client.Consumer
 import com.rabbitmq.client.DefaultConsumer
 import com.rabbitmq.client.Envelope
 import com.rabbitmq.client.GetResponse
-import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.asserts.TraceAssert
+import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
@@ -29,12 +34,7 @@ import java.util.concurrent.Phaser
 import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
-import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGATION_DISABLED_EXCHANGES
-import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGATION_DISABLED_QUEUES
-
-abstract class RabbitMQTestBase extends AgentTestRunner {
+abstract class RabbitMQTestBase extends VersionedNamingTestBase {
   @Shared
   def rabbitMQContainer
   @Shared
@@ -92,8 +92,6 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     }
   }
 
-  abstract String expectedServiceName()
-
   abstract boolean hasQueueSpan()
 
   abstract boolean splitByDestination()
@@ -102,6 +100,29 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     false
   }
 
+  String operationForProducer() {
+    "amqp.command"
+  }
+
+  String operationForConsumer() {
+    "amqp.command"
+  }
+
+  String serviceForTimeInQueue() {
+    "rabbitmq"
+  }
+
+
+  @Override
+  int version() {
+    return 0
+  }
+
+
+  @Override
+  String operation() {
+    return "amqp.command"
+  }
 
   def "test rabbit publish/get"() {
     setup:
@@ -123,23 +144,23 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     and:
     assertTraces(2, SORT_TRACES_BY_ID) {
       def publishSpan = null
-      trace(5, true) {
-        publishSpan = span(0)
-        def parentSpan = span(4)
-        rabbitSpan(it, "basic.publish $exchangeName -> $routingKey", false, parentSpan)
-        rabbitSpan(it, "exchange.declare", false, parentSpan)
+      trace(5) {
+        publishSpan = span(1)
+        def parentSpan = span(0)
+        basicSpan(it, "parent")
+        rabbitSpan(it, "basic.publish $exchangeName -> $routingKey", false, parentSpan, operationForProducer())
         rabbitSpan(it, "queue.bind", false, parentSpan)
         rabbitSpan(it, "queue.declare", false, parentSpan)
-        basicSpan(it, "parent")
+        rabbitSpan(it, "exchange.declare", false, parentSpan)
       }
       if (hasQueueSpan()) {
-        trace(2, true) {
-          rabbitSpan(it, "basic.get <generated>", false, span(1))
+        trace(2) {
+          rabbitSpan(it, "basic.get <generated>", false, span(1), operationForConsumer())
           rabbitQueueSpan(it, "amqp.deliver <generated>", true, publishSpan)
         }
       } else {
         trace(1) {
-          rabbitSpan(it, "basic.get <generated>", true, publishSpan)
+          rabbitSpan(it, "basic.get <generated>", true, publishSpan, operationForConsumer())
         }
       }
     }
@@ -184,16 +205,16 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
       }
       trace(1) {
         publishSpan = span(0)
-        rabbitSpan(it, "basic.publish <default> -> <generated>")
+        rabbitSpan(it, "basic.publish <default> -> <generated>", false, null, operationForProducer())
       }
       if (hasQueueSpan()) {
-        trace(2, true) {
-          rabbitSpan(it, "basic.get <generated>", false, span(1))
+        trace(2) {
+          rabbitSpan(it, "basic.get <generated>", false, span(1), operationForConsumer())
           rabbitQueueSpan(it, "amqp.deliver <generated>", true, publishSpan)
         }
       } else {
         trace(1) {
-          rabbitSpan(it, "basic.get <generated>", true, publishSpan)
+          rabbitSpan(it, "basic.get <generated>", true, publishSpan, operationForConsumer())
         }
       }
     }
@@ -272,11 +293,11 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
         def deliverParentSpan = null
         trace(1) {
           deliverParentSpan = span(0)
-          rabbitSpan(it, "basic.publish $exchangeName -> <all>")
+          rabbitSpan(it, "basic.publish $exchangeName -> <all>",false, null, operationForProducer())
         }
         if (hasQueueSpan()) {
-          trace(2, true) {
-            rabbitSpan(it, "basic.deliver $resourceQueueName", false, span(1),
+          trace(2) {
+            rabbitSpan(it, "basic.deliver $resourceQueueName", false, span(1), operationForConsumer(),
               null, null, setTimestamp)
             rabbitQueueSpan(it, "amqp.deliver $resourceQueueName", true, deliverParentSpan)
           }
@@ -284,7 +305,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
           trace(1) {
             // TODO - test with and without feature enabled once Config is easier to control
             rabbitSpan(it, "basic.deliver $resourceQueueName", true, deliverParentSpan,
-              null, null, setTimestamp)
+              operationForConsumer(),null, null, setTimestamp)
           }
         }
       }
@@ -370,19 +391,19 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
       def deliverParentSpan = null
       trace(1) {
         deliverParentSpan = span(0)
-        rabbitSpan(it, "basic.publish $exchangeName -> <all>")
+        rabbitSpan(it, "basic.publish $exchangeName -> <all>",false, null, operationForProducer())
       }
       if (hasQueueSpan()) {
-        trace(2, true) {
-          rabbitSpan(it, "basic.deliver <generated>", false, span(1), error,
-            error.message, false)
+        trace(2) {
+          rabbitSpan(it, "basic.deliver <generated>", false, span(1), operationForConsumer(),
+            error, error.message, false)
           rabbitQueueSpan(it, "amqp.deliver <generated>", true, deliverParentSpan)
         }
       } else {
         trace(1) {
           // TODO - test with and without feature enabled once Config is easier to control
-          rabbitSpan(it, "basic.deliver <generated>", true, deliverParentSpan, error,
-            error.message, false)
+          rabbitSpan(it, "basic.deliver <generated>", true, deliverParentSpan, operationForConsumer(),
+            error, error.message, false)
         }
       }
     }
@@ -417,19 +438,19 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
 
     assertTraces(1, SORT_TRACES_BY_ID) {
       trace(1) {
-        rabbitSpan(it, command, false, null, throwable, errorMsg)
+        rabbitSpan(it, command, false, null, exptectedOperation, throwable, errorMsg)
       }
     }
 
     where:
-    command                 | exception             | errorMsg                                           | closure
-    "exchange.declare"      | IOException           | null                                               | {
+    command                 | exception             | exptectedOperation      | errorMsg                     | closure
+    "exchange.declare"      | IOException           | operation()             | null                         | {
       it.exchangeDeclare("some-exchange", "invalid-type", true)
     }
-    "Channel.basicConsume"  | IllegalStateException | "Invalid configuration: 'queue' must be non-null." | {
+    "Channel.basicConsume"  | IllegalStateException | operation()  | "Invalid configuration: 'queue' must be non-null." | {
       it.basicConsume(null, null)
     }
-    "basic.get <generated>" | IOException           | null                                               | {
+    "basic.get <generated>" | IOException           | operationForConsumer()  | null                                               | {
       it.basicGet("amq.gen-invalid-channel", true)
     }
   }
@@ -458,16 +479,16 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
       def publishSpan = null
       trace(1) {
         publishSpan = span(0)
-        rabbitSpan(it, "basic.publish <default> -> some-routing-queue")
+        rabbitSpan(it, "basic.publish <default> -> some-routing-queue",false, null, operationForProducer())
       }
       if (hasQueueSpan()) {
-        trace(2, true) {
-          rabbitSpan(it, "basic.get ${queue.name}", false, span(1))
+        trace(2) {
+          rabbitSpan(it, "basic.get ${queue.name}", false, span(1), operationForConsumer())
           rabbitQueueSpan(it, "amqp.deliver ${queue.name}", true, publishSpan)
         }
       } else {
         trace(1) {
-          rabbitSpan(it, "basic.get ${queue.name}", true, publishSpan)
+          rabbitSpan(it, "basic.get ${queue.name}", true, publishSpan, operationForConsumer())
         }
       }
     }
@@ -530,7 +551,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
       trace(5) {
         publishSpan = span(1)
         basicSpan(it, "parent")
-        rabbitSpan(it, "basic.publish $exchangeName -> $routingKey", false, span(0))
+        rabbitSpan(it, "basic.publish $exchangeName -> $routingKey", false, span(0), operationForProducer())
         rabbitSpan(it, "queue.bind", false, span(0))
         rabbitSpan(it, "exchange.declare", false, span(0))
         rabbitSpan(it, "queue.declare", false, span(0))
@@ -542,15 +563,15 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
       }
       if (hasQueueSpan() && !noParent) {
         trace(2) {
-          rabbitSpan(it, "basic.$type $queueName", false, span(1))
+          rabbitSpan(it, "basic.$type $queueName", false, span(1), operationForConsumer())
           rabbitQueueSpan(it, "amqp.deliver $queueName", true, publishSpan)
         }
       } else {
         trace(1) {
           if (noParent) {
-            rabbitSpan(it, "basic.$type $queueName")
+            rabbitSpan(it, "basic.$type $queueName", false, null, operationForConsumer())
           } else {
-            rabbitSpan(it, "basic.$type $queueName", true, publishSpan)
+            rabbitSpan(it, "basic.$type $queueName", true, publishSpan, operationForConsumer())
           }
         }
       }
@@ -623,7 +644,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
       trace(5) {
         publishSpan = span(1)
         basicSpan(it, "parent")
-        rabbitSpan(it, "basic.publish $exchangeName -> $routingKey", false, span(0))
+        rabbitSpan(it, "basic.publish $exchangeName -> $routingKey", false, span(0), operationForProducer())
         rabbitSpan(it, "queue.bind", false, span(0))
         rabbitSpan(it, "exchange.declare", false, span(0))
         rabbitSpan(it, "queue.declare", false, span(0))
@@ -634,16 +655,16 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
         }
       }
       if (hasQueueSpan() && !noParent) {
-        trace(2, true) {
-          rabbitSpan(it, "basic.$type $queueName", false, span(1))
+        trace(2) {
+          rabbitSpan(it, "basic.$type $queueName", false, span(1), operationForConsumer())
           rabbitQueueSpan(it, "amqp.deliver $queueName", true, publishSpan)
         }
       } else {
         trace(1) {
           if (noParent) {
-            rabbitSpan(it, "basic.$type $queueName")
+            rabbitSpan(it, "basic.$type $queueName",false, null, operationForConsumer())
           } else {
-            rabbitSpan(it, "basic.$type $queueName", true, publishSpan)
+            rabbitSpan(it, "basic.$type $queueName", true, publishSpan, operationForConsumer())
           }
         }
       }
@@ -679,14 +700,15 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
     String resource,
     Boolean distributedRootSpan = false,
     DDSpan parentSpan = null,
+    String operation = operation(),
     Throwable exception = null,
     String errorMsg = null,
     Boolean expectTimestamp = false
   ) {
     internalRabbitSpan(
       trace,
-      expectedServiceName(),
-      "amqp.command",
+      service(),
+      operation,
       excludesRoutingKeyFromResource() ? resource.replaceAll(" -> .*", "") : resource,
       distributedRootSpan,
       parentSpan,
@@ -707,7 +729,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
   ) {
     internalRabbitSpan(
       trace,
-      splitByDestination() ? resource.replace("amqp.deliver ", "") : "rabbitmq",
+      splitByDestination() ? resource.replace("amqp.deliver ", "") : serviceForTimeInQueue(),
       "amqp.deliver",
       resource,
       distributedRootSpan,
@@ -840,7 +862,7 @@ abstract class RabbitMQTestBase extends AgentTestRunner {
   }
 }
 
-class RabbitMQForkedTest extends RabbitMQTestBase {
+abstract class RabbitMQForkedTest extends RabbitMQTestBase {
   @Override
   void configurePreAgent() {
     super.configurePreAgent()
@@ -849,7 +871,7 @@ class RabbitMQForkedTest extends RabbitMQTestBase {
   }
 
   @Override
-  String expectedServiceName()  {
+  String service()  {
     return "RabbitMQTest"
   }
 
@@ -864,6 +886,33 @@ class RabbitMQForkedTest extends RabbitMQTestBase {
   }
 }
 
+class RabbitMQNamingV0ForkedTest extends RabbitMQForkedTest {
+
+}
+
+class RabbitMQNamingV1ForkedTest extends RabbitMQForkedTest {
+  @Override
+  String operationForProducer() {
+    "amqp.send"
+  }
+
+  @Override
+  String operationForConsumer() {
+    "amqp.process"
+  }
+
+  @Override
+  String serviceForTimeInQueue() {
+    "rabbitmq-queue"
+  }
+
+  @Override
+  int version() {
+    1
+  }
+
+}
+
 class RabbitMQDatastreamsDisabledForkedTest extends RabbitMQTestBase {
   @Override
   void configurePreAgent() {
@@ -873,7 +922,7 @@ class RabbitMQDatastreamsDisabledForkedTest extends RabbitMQTestBase {
   }
 
   @Override
-  String expectedServiceName()  {
+  String service()  {
     return "RabbitMQDatastreamsDisabledForkedTest"
   }
 
@@ -903,7 +952,7 @@ class RabbitMQSplitByDestinationForkedTest extends RabbitMQTestBase {
   }
 
   @Override
-  String expectedServiceName()  {
+  String service()  {
     return "RabbitMQTest"
   }
 
@@ -918,7 +967,7 @@ class RabbitMQSplitByDestinationForkedTest extends RabbitMQTestBase {
   }
 }
 
-class RabbitMQLegacyTracingForkedTest extends RabbitMQTestBase {
+class RabbitMQLegacyTracingV0ForkedTest extends RabbitMQTestBase {
   @Override
   void configurePreAgent() {
     super.configurePreAgent()
@@ -926,7 +975,7 @@ class RabbitMQLegacyTracingForkedTest extends RabbitMQTestBase {
   }
 
   @Override
-  String expectedServiceName() {
+  String service() {
     return "rabbitmq"
   }
 
@@ -941,6 +990,23 @@ class RabbitMQLegacyTracingForkedTest extends RabbitMQTestBase {
   }
 }
 
+class RabbitMQLegacyTracingV1ForkedTest extends RabbitMQLegacyTracingV0ForkedTest {
+  @Override
+  String operationForProducer() {
+    "amqp.send"
+  }
+
+  @Override
+  String operationForConsumer() {
+    "amqp.process"
+  }
+
+  @Override
+  int version() {
+    1
+  }
+}
+
 class RabbitMQRoutingKeyExcludedForkedTest extends RabbitMQTestBase {
   @Override
   void configurePreAgent() {
@@ -951,7 +1017,7 @@ class RabbitMQRoutingKeyExcludedForkedTest extends RabbitMQTestBase {
   }
 
   @Override
-  String expectedServiceName() {
+  String service() {
     return "RabbitMQRoutingKeyExcludedForkedTest"
   }
 

--- a/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
@@ -25,6 +25,13 @@ public interface NamingSchema {
   ForDatabase database();
 
   /**
+   * Get the naming policy for messaging.
+   *
+   * @return a {@link NamingSchema.ForMessaging} instance.
+   */
+  ForMessaging messaging();
+
+  /**
    * Get the naming policy for servers.
    *
    * @return a {@link NamingSchema.ForServer} instance.
@@ -91,6 +98,55 @@ public interface NamingSchema {
      */
     @Nonnull
     String service(@Nonnull String ddService, @Nonnull String databaseType);
+  }
+
+  interface ForMessaging {
+    /**
+     * Calculate the operation name for a messaging consumer span for process operation.
+     *
+     * @param messagingSystem the messaging system (e.g. jms, kafka,..)
+     * @return the operation name
+     */
+    @Nonnull
+    String inboundOperation(@Nonnull String messagingSystem);
+
+    /**
+     * Calculate the service name for a messaging producer span.
+     *
+     * @param ddService the configured service name as set by the user.
+     * @param messagingSystem the messaging system (e.g. jms, kafka, amqp,..)
+     * @return the service name
+     */
+    @Nonnull
+    String inboundService(@Nonnull String ddService, @Nonnull String messagingSystem);
+
+    /**
+     * Calculate the operation name for a messaging producer span.
+     *
+     * @param messagingSystem the messaging system (e.g. jms, kafka, amqp,..)
+     * @return the operation name
+     */
+    @Nonnull
+    String outboundOperation(@Nonnull String messagingSystem);
+
+    /**
+     * Calculate the service name for a messaging producer span.
+     *
+     * @param ddService the configured service name as set by the user.
+     * @param messagingSystem the messaging system (e.g. jms, kafka, amqp,..)
+     * @return the service name
+     */
+    @Nonnull
+    String outboundService(@Nonnull String ddService, @Nonnull String messagingSystem);
+
+    /**
+     * Calculate the service name for a messaging time in queue synthetic span.
+     *
+     * @param messagingSystem the messaging system (e.g. jms, kafka, amqp,..)
+     * @return the service name
+     */
+    @Nonnull
+    String timeInQueueService(@Nonnull String messagingSystem);
   }
 
   interface ForServer {

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/MessagingNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/MessagingNamingV0.java
@@ -1,0 +1,44 @@
+package datadog.trace.api.naming.v0;
+
+import datadog.trace.api.naming.NamingSchema;
+import javax.annotation.Nonnull;
+
+public class MessagingNamingV0 implements NamingSchema.ForMessaging {
+  @Nonnull
+  @Override
+  public String outboundOperation(@Nonnull final String messagingSystem) {
+    if ("amqp".equals(messagingSystem)) {
+      return "amqp.command";
+    }
+    return messagingSystem + ".produce";
+  }
+
+  @Nonnull
+  @Override
+  public String outboundService(
+      @Nonnull final String ddService, @Nonnull final String messagingSystem) {
+    return messagingSystem;
+  }
+
+  @Nonnull
+  @Override
+  public String inboundOperation(@Nonnull final String messagingSystem) {
+    if ("amqp".equals(messagingSystem)) {
+      return "amqp.command";
+    }
+    return messagingSystem + ".consume";
+  }
+
+  @Nonnull
+  @Override
+  public String inboundService(
+      @Nonnull final String ddService, @Nonnull final String messagingSystem) {
+    return messagingSystem;
+  }
+
+  @Override
+  @Nonnull
+  public String timeInQueueService(@Nonnull final String messagingSystem) {
+    return messagingSystem;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/NamingSchemaV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/NamingSchemaV0.java
@@ -6,6 +6,7 @@ public class NamingSchemaV0 implements NamingSchema {
   private final NamingSchema.ForCache cacheNaming = new CacheNamingV0();
   private final NamingSchema.ForClient clientNaming = new ClientNamingV0();
   private final NamingSchema.ForDatabase databaseNaming = new DatabaseNamingV0();
+  private final NamingSchema.ForMessaging messagingNaming = new MessagingNamingV0();
   private final NamingSchema.ForServer serverNaming = new ServerNamingV0();
 
   @Override
@@ -21,6 +22,11 @@ public class NamingSchemaV0 implements NamingSchema {
   @Override
   public ForDatabase database() {
     return databaseNaming;
+  }
+
+  @Override
+  public ForMessaging messaging() {
+    return messagingNaming;
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/MessagingNamingV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/MessagingNamingV1.java
@@ -1,0 +1,37 @@
+package datadog.trace.api.naming.v1;
+
+import datadog.trace.api.naming.NamingSchema;
+import javax.annotation.Nonnull;
+
+public class MessagingNamingV1 implements NamingSchema.ForMessaging {
+
+  @Nonnull
+  @Override
+  public String outboundOperation(@Nonnull String messagingSystem) {
+    return messagingSystem + ".send";
+  }
+
+  @Nonnull
+  @Override
+  public String outboundService(@Nonnull String ddService, @Nonnull String messagingSystem) {
+    return ddService;
+  }
+
+  @Nonnull
+  @Override
+  public String inboundOperation(@Nonnull String messagingSystem) {
+    return messagingSystem + ".process";
+  }
+
+  @Nonnull
+  @Override
+  public String inboundService(@Nonnull String ddService, @Nonnull String messagingSystem) {
+    return ddService;
+  }
+
+  @Override
+  @Nonnull
+  public String timeInQueueService(@Nonnull String messagingSystem) {
+    return messagingSystem + "-queue";
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/NamingSchemaV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/NamingSchemaV1.java
@@ -6,6 +6,7 @@ public class NamingSchemaV1 implements NamingSchema {
   private final NamingSchema.ForCache cacheNaming = new CacheNamingV1();
   private final NamingSchema.ForClient clientNaming = new ClientNamingV1();
   private final NamingSchema.ForDatabase databaseNaming = new DatabaseNamingV1();
+  private final NamingSchema.ForMessaging messagingNaming = new MessagingNamingV1();
   private final NamingSchema.ForServer serverNaming = new ServerNamingV1();
 
   @Override
@@ -21,6 +22,11 @@ public class NamingSchemaV1 implements NamingSchema {
   @Override
   public ForDatabase database() {
     return databaseNaming;
+  }
+
+  @Override
+  public ForMessaging messaging() {
+    return messagingNaming;
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

Changes for v1 naming schema:
* Producer:
  - service: `{{DD_SERVICE}}`
  - operation:  `amqp.send`
* Consumer:
  - service: `{{DD_SERVICE}}`
  - operation:  `amqp.process`
* Time in queue :
  - service: `rabbitmq-queue`
  - operation:  `amqp.deliver`

Interactions with other options:
* v1 schema implies legacy tracing disabled by default. However the user can explicitly force the legacy tracing and have service = 'rabbitmq' like v0

# Motivation

# Additional Notes
