### PR TITLE
Add software.amazon and com.mongodb to exclusions

### DIFF
--- a/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
@@ -69,6 +69,7 @@
 1 com.jprofiler.*
 1 com.lowagie.*
 1 com.mchange.*
+1 com.mongodb.*
 1 com.mysql.*
 1 com.neo4j.*
 1 com.netscape.*
@@ -190,6 +191,7 @@
 1 org.xnio.*
 1 org.yaml.*
 1 reactor.*
+1 software.amazon.awssdk.*
 1 springfox.*
 1 tech.jhipster.*
 1 weblogic.*
@@ -197,6 +199,6 @@
 
 # --------- testing ----------------
 
+1 org.gradle.*
 1 org.spockframework.*
 1 worker.org.gradle.*
-1 org.gradle.*

--- a/dd-java-agent/instrumentation/iast-instrumenter/src/test/groovy/IastExclusionTrieTest.groovy
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/test/groovy/IastExclusionTrieTest.groovy
@@ -1,11 +1,17 @@
 import datadog.trace.instrumentation.iastinstrumenter.IastExclusionTrie
 import datadog.trace.test.util.DDSpecification
+import groovy.transform.CompileDynamic
 import spock.lang.Unroll
 
+@CompileDynamic
 class IastExclusionTrieTest extends DDSpecification {
 
+  private static final int EXCLUDED = 1
+  private static final int BYPASSED = 0
+  private static final int INCLUDED = -1
+
   @Unroll
-  def 'Test that #name should be included? #expected'(final String name, final int expected) {
+  void 'Test that #name should be included? #expected'(final String name, final int expected) {
     when:
     final result = IastExclusionTrie.apply(name)
 
@@ -14,14 +20,16 @@ class IastExclusionTrieTest extends DDSpecification {
 
     where:
     name                                                | expected
-    String.name                                         | 1
-    'io.vertx.core.json.JsonArray'                      | 1
-    'io.vertx.demo.Test'                                | 0
-    'org.springframework.core.env.Environment'          | 1
-    'org.springframework.samples.petclinic.owner.Owner' | 0
-    'org.owasp.encoder.Encode'                          | 1
-    'org.owasp.webgoat.server.StartWebGoat'             | 0
-    'my.package.name.Test'                              | -1
-    'com.test.Demo'                                     | -1
+    String.name                                         | EXCLUDED
+    'io.vertx.core.json.JsonArray'                      | EXCLUDED
+    'io.vertx.demo.Test'                                | BYPASSED
+    'org.springframework.core.env.Environment'          | EXCLUDED
+    'org.springframework.samples.petclinic.owner.Owner' | BYPASSED
+    'org.owasp.encoder.Encode'                          | EXCLUDED
+    'org.owasp.webgoat.server.StartWebGoat'             | BYPASSED
+    'my.package.name.Test'                              | INCLUDED
+    'com.test.Demo'                                     | INCLUDED
+    'software.amazon.awssdk.core.checksums.Md5Checksum' | EXCLUDED
+    'com.mongodb.internal.HexUtils'                     | EXCLUDED
   }
 }


### PR DESCRIPTION
# What Does This Do
Include two new packages that need to be excluded:

- com.mongodb
- software.amazon.awssdk

# Motivation

We are reporting vulnerabilities on those libraries that are not custom code, and can be considered false positives (weak hash on MD5 usage).

# Additional Notes
