### PR TITLE
ZIO 2.0 instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/zio/build.gradle
+++ b/dd-java-agent/instrumentation/zio/build.gradle
@@ -1,0 +1,1 @@
+apply from: "$rootDir/gradle/java.gradle"

--- a/dd-java-agent/instrumentation/zio/zio-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/zio/zio-2.0/build.gradle
@@ -1,0 +1,48 @@
+def zioVersion = '2.0.0'
+def scalaVersion = '2.12'
+
+muzzle {
+  pass {
+    group = 'dev.zio'
+    module = "zio_2.12"
+    versions = "[$zioVersion,)"
+    assertInverse = true
+  }
+  pass {
+    group = 'dev.zio'
+    module = "zio_2.13"
+    versions = "[$zioVersion,)"
+    assertInverse = true
+  }
+  pass {
+    group = 'dev.zio'
+    module = "zio_3"
+    versions = "[$zioVersion,)"
+    assertInverse = true
+  }
+}
+
+apply from: "$rootDir/gradle/java.gradle"
+apply from: "$rootDir/gradle/test-with-scala.gradle"
+
+apply plugin: 'org.unbroken-dome.test-sets'
+
+testSets {
+  latestDepTest {
+    dirName = 'test'
+  }
+}
+
+tasks.named("compileLatestDepTestGroovy").configure {
+  dependsOn "compileLatestDepTestScala"
+  classpath += files(compileLatestDepTestScala.destinationDirectory)
+}
+
+dependencies {
+  compileOnly group: 'dev.zio', name: "zio_$scalaVersion", version: zioVersion
+
+  testImplementation deps.scala
+  testImplementation group: 'dev.zio', name: "zio_$scalaVersion", version: zioVersion
+
+  latestDepTestImplementation group: 'dev.zio', name: "zio_$scalaVersion", version: '+'
+}

--- a/dd-java-agent/instrumentation/zio/zio-2.0/src/main/java/datadog/trace/instrumentation/zio/v2_0/FiberContext.java
+++ b/dd-java-agent/instrumentation/zio/zio-2.0/src/main/java/datadog/trace/instrumentation/zio/v2_0/FiberContext.java
@@ -1,0 +1,70 @@
+package datadog.trace.instrumentation.zio.v2_0;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.ScopeState;
+
+public class FiberContext {
+
+  private final ScopeState state;
+  private AgentScope.Continuation continuation;
+  private AgentScope scope;
+  private ScopeState oldState;
+
+  private FiberContext(ScopeState state, AgentScope.Continuation continuation) {
+    this.state = state;
+    this.continuation = continuation;
+    this.scope = null;
+    this.oldState = null;
+  }
+
+  public static FiberContext create() {
+    final ScopeState state = AgentTracer.get().newScopeState();
+    final AgentScope scope = AgentTracer.get().activeScope();
+    final AgentScope.Continuation continuation;
+
+    if (scope != null && scope.isAsyncPropagating()) {
+      continuation = scope.capture();
+    } else {
+      continuation = null;
+    }
+
+    return new FiberContext(state, continuation);
+  }
+
+  public void onEnd() {
+    if (this.scope != null) {
+      this.scope.close();
+      this.scope = null;
+    }
+
+    if (this.continuation != null) {
+      this.continuation.cancel();
+      this.continuation = null;
+    }
+
+    if (this.oldState != null) {
+      this.oldState.activate();
+      this.oldState = null;
+    }
+  }
+
+  public void onSuspend() {
+    if (this.oldState != null) {
+      this.oldState.activate();
+      this.oldState = null;
+    }
+  }
+
+  public void onResume() {
+    this.oldState = AgentTracer.get().newScopeState();
+    this.oldState.fetchFromActive();
+
+    this.state.activate();
+
+    if (this.continuation != null && this.scope == null) {
+      this.scope = this.continuation.activate();
+      this.continuation = null;
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/zio/zio-2.0/src/main/java/datadog/trace/instrumentation/zio/v2_0/TracingSupervisor.java
+++ b/dd-java-agent/instrumentation/zio/zio-2.0/src/main/java/datadog/trace/instrumentation/zio/v2_0/TracingSupervisor.java
@@ -1,0 +1,58 @@
+package datadog.trace.instrumentation.zio.v2_0;
+
+import datadog.trace.bootstrap.ContextStore;
+import scala.Option;
+import zio.Exit;
+import zio.Fiber;
+import zio.Supervisor;
+import zio.Unsafe;
+import zio.ZEnvironment;
+import zio.ZIO;
+import zio.ZIO$;
+
+@SuppressWarnings("unchecked")
+public final class TracingSupervisor extends Supervisor<Object> {
+
+  @SuppressWarnings("rawtypes")
+  private final ContextStore<Fiber.Runtime, FiberContext> contextStore;
+
+  @SuppressWarnings("rawtypes")
+  public TracingSupervisor(ContextStore<Fiber.Runtime, FiberContext> contextStore) {
+    this.contextStore = contextStore;
+  }
+
+  @Override
+  @SuppressWarnings("rawtypes")
+  public ZIO value(Object trace) {
+    return ZIO$.MODULE$.unit();
+  }
+
+  @Override
+  public <R, E, A_> void onStart(
+      ZEnvironment<R> environment,
+      ZIO<R, E, A_> effect,
+      Option<Fiber.Runtime<Object, Object>> parent,
+      Fiber.Runtime<E, A_> fiber,
+      Unsafe unsafe) {
+    FiberContext context = FiberContext.create();
+    contextStore.put(fiber, context);
+  }
+
+  @Override
+  public <R, E, A_> void onEnd(Exit<E, A_> value, Fiber.Runtime<E, A_> fiber, Unsafe unsafe) {
+    FiberContext context = contextStore.get(fiber);
+    if (context != null) context.onEnd();
+  }
+
+  @Override
+  public <E, A_> void onSuspend(Fiber.Runtime<E, A_> fiber, Unsafe unsafe) {
+    FiberContext context = contextStore.get(fiber);
+    if (context != null) context.onSuspend();
+  }
+
+  @Override
+  public <E, A_> void onResume(Fiber.Runtime<E, A_> fiber, Unsafe unsafe) {
+    FiberContext context = contextStore.get(fiber);
+    if (context != null) context.onResume();
+  }
+}

--- a/dd-java-agent/instrumentation/zio/zio-2.0/src/main/java/datadog/trace/instrumentation/zio/v2_0/ZioRuntimeInstrumentation.java
+++ b/dd-java-agent/instrumentation/zio/zio-2.0/src/main/java/datadog/trace/instrumentation/zio/v2_0/ZioRuntimeInstrumentation.java
@@ -1,0 +1,59 @@
+package datadog.trace.instrumentation.zio.v2_0;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.InstrumentationContext;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+import zio.Fiber;
+import zio.Supervisor;
+
+@AutoService(Instrumenter.class)
+public class ZioRuntimeInstrumentation extends Instrumenter.Tracing
+    implements Instrumenter.ForSingleType {
+
+  public ZioRuntimeInstrumentation() {
+    super("zio.experimental");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "zio.Runtime$";
+  }
+
+  @Override
+  protected final boolean defaultEnabled() {
+    return false;
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod().and(named("defaultSupervisor")), getClass().getName() + "$DefaultSupervisor");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {packageName + ".FiberContext", packageName + ".TracingSupervisor"};
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return singletonMap("zio.Fiber$Runtime", packageName + ".FiberContext");
+  }
+
+  public static final class DefaultSupervisor {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onExit(@Advice.Return(readOnly = false) Supervisor<?> supervisor) {
+      @SuppressWarnings("rawtypes")
+      ContextStore<Fiber.Runtime, FiberContext> contextStore =
+          InstrumentationContext.get(Fiber.Runtime.class, FiberContext.class);
+      supervisor = supervisor.$plus$plus(new TracingSupervisor(contextStore));
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/zio/zio-2.0/src/test/groovy/ZioRuntimeInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/zio/zio-2.0/src/test/groovy/ZioRuntimeInstrumentationTest.groovy
@@ -1,0 +1,159 @@
+import datadog.trace.agent.test.AgentTestRunner
+
+class ZioRuntimeInstrumentationTest extends AgentTestRunner {
+
+  @Override
+  void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("dd.integration.zio.experimental.enabled", "true")
+  }
+
+  def "trace is propagated to child fiber"() {
+    setup:
+    fixture().runNestedFibers()
+
+    expect:
+    assertTraces(1) {
+      trace(2, true) {
+        span(0) {
+          operationName "fiber_1_span_1"
+          parent()
+        }
+        span(1) {
+          operationName "fiber_2_span_1"
+          childOf(span(0))
+        }
+      }
+    }
+  }
+
+  def "trace is preserved when fiber is interrupted"() {
+    setup:
+    fixture().runInterruptedFiber()
+
+    expect:
+    assertTraces(1) {
+      trace(2, true) {
+        span(0) {
+          operationName "fiber_1_span_1"
+          parent()
+        }
+        span(1) {
+          operationName "fiber_2_span_1"
+          childOf(span(0))
+        }
+      }
+    }
+  }
+
+  def "synchronized fibers do not interfere with each other's traces"() {
+    setup:
+    fixture().runSynchronizedFibers()
+
+    expect:
+    assertTraces(2, SORT_TRACES_BY_NAMES) {
+      trace(2, true) {
+        span(0) {
+          operationName "fiber_1_span_1"
+          parent()
+        }
+        span(1) {
+          operationName "fiber_1_span_2"
+          childOf(span(0))
+        }
+      }
+      trace(2, true) {
+        span(0) {
+          operationName "fiber_2_span_1"
+          parent()
+        }
+        span(1) {
+          operationName "fiber_2_span_2"
+          childOf(span(0))
+        }
+      }
+    }
+  }
+
+  def "concurrent fibers do not interfere with each other's traces"() {
+    setup:
+    fixture().runConcurrentFibers()
+
+    expect:
+    assertTraces(3, SORT_TRACES_BY_NAMES) {
+      trace(2, true) {
+        span(0) {
+          operationName "fiber_1_span_1"
+          parent()
+        }
+        span(1) {
+          operationName "fiber_1_span_2"
+          childOf(span(0))
+        }
+      }
+      trace(2, true) {
+        span(0) {
+          operationName "fiber_2_span_1"
+          parent()
+        }
+        span(1) {
+          operationName "fiber_2_span_2"
+          childOf(span(0))
+        }
+      }
+      trace(2, true) {
+        span(0) {
+          operationName "fiber_3_span_1"
+          parent()
+        }
+        span(1) {
+          operationName "fiber_3_span_2"
+          childOf(span(0))
+        }
+      }
+    }
+  }
+
+  def "sequential fibers do not interfere with each other's traces"() {
+    setup:
+    fixture().runSequentialFibers()
+
+    expect:
+    assertTraces(3, SORT_TRACES_BY_NAMES) {
+      trace(2, true) {
+        span(0) {
+          operationName "fiber_1_span_1"
+          parent()
+        }
+        span(1) {
+          operationName "fiber_1_span_2"
+          childOf(span(0))
+        }
+      }
+      trace(2, true) {
+        span(0) {
+          operationName "fiber_2_span_1"
+          parent()
+        }
+        span(1) {
+          operationName "fiber_2_span_2"
+          childOf(span(0))
+        }
+      }
+      trace(2, true) {
+        span(0) {
+          operationName "fiber_3_span_1"
+          parent()
+        }
+        span(1) {
+          operationName "fiber_3_span_2"
+          childOf(span(0))
+        }
+      }
+    }
+  }
+
+  def fixture() {
+    ZioTestFixtures$.MODULE$
+  }
+}

--- a/dd-java-agent/instrumentation/zio/zio-2.0/src/test/scala/ZioTestFixtures.scala
+++ b/dd-java-agent/instrumentation/zio/zio-2.0/src/test/scala/ZioTestFixtures.scala
@@ -1,0 +1,157 @@
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import datadog.trace.bootstrap.instrumentation.api.ScopeSource.INSTRUMENTATION
+import zio._
+
+import java.util.concurrent.Executors
+
+object ZioTestFixtures {
+
+  def runNestedFibers(): Unit =
+    run {
+      childSpan("fiber_1_span_1") {
+        for {
+          child <- childSpan("fiber_2_span_1")(ZIO.unit).fork
+          _ <- child.join
+        } yield ()
+      }
+    }
+
+  def runInterruptedFiber(): Unit =
+    run {
+      for {
+        childStarted <- Promise.make[Nothing, Unit]
+        _ <- childSpan("fiber_1_span_1") {
+          for {
+            child <- childSpan("fiber_2_span_1") {
+              childStarted.succeed(()) *>
+                ZIO.never
+            }.fork
+            _ <- childStarted.await
+            _ <- child.interrupt
+          } yield ()
+        }
+      } yield ()
+    }
+
+  def runSynchronizedFibers(): Unit = {
+    def runFiber(
+        fiberNumber: Int,
+        onStart: UIO[Unit],
+        onEnd: UIO[Unit]
+    ): ZIO[Any, Nothing, Any] =
+      childSpan(s"fiber_${fiberNumber}_span_1") {
+        onStart *>
+          childSpan(s"fiber_${fiberNumber}_span_2") {
+            onEnd
+          }
+      }
+
+    run {
+      for {
+        fiber1Started <- Promise.make[Nothing, Unit]
+        fiber2Done <- Promise.make[Nothing, Unit]
+
+        fiber1 <- runFiber(
+          fiberNumber = 1,
+          onStart = fiber1Started.succeed(()) *> fiber2Done.await,
+          onEnd = ZIO.unit
+        ).fork
+
+        fiber2 <- runFiber(
+          fiberNumber = 2,
+          onStart = fiber1Started.await,
+          onEnd = fiber2Done.succeed(()).unit
+        ).fork
+
+        _ <- Fiber.joinAll(List(fiber1, fiber2))
+      } yield ()
+    }
+  }
+
+  def runConcurrentFibers(): Unit = {
+    def runFiber(
+        fiberNumber: Int,
+        start: Promise[Nothing, Unit]
+    ): ZIO[Any, Nothing, Unit] = {
+      start.await *>
+        childSpan(s"fiber_${fiberNumber}_span_1") {
+          ZIO.yieldNow *>
+            childSpan(s"fiber_${fiberNumber}_span_2") {
+              ZIO.yieldNow
+            }
+        }
+    }
+
+    run {
+      for {
+        start <- Promise.make[Nothing, Unit]
+        fiber1 <- runFiber(1, start).fork
+        fiber2 <- runFiber(2, start).fork
+        fiber3 <- runFiber(3, start).fork
+        _ <- start.succeed(())
+        _ <- Fiber.joinAll(List(fiber1, fiber2, fiber3))
+      } yield ()
+    }
+  }
+
+  def runSequentialFibers(): Unit = {
+    def runFiber(fiberNumber: Int): ZIO[Any, Nothing, Unit] = {
+      childSpan(s"fiber_${fiberNumber}_span_1") {
+        childSpan(s"fiber_${fiberNumber}_span_2") {
+          ZIO.unit
+        }
+      }
+    }
+
+    run {
+      for {
+        fiber1 <- runFiber(1).fork
+        _ <- fiber1.join
+        fiber2 <- runFiber(2).fork
+        _ <- fiber2.join
+        fiber3 <- runFiber(3).fork
+        _ <- fiber3.join
+      } yield ()
+    }
+  }
+
+  private def childSpan(opName: String)(op: UIO[Unit]): UIO[Unit] =
+    ZIO.scoped {
+      for {
+        scope <- ZIO.scope
+        ddSpan <- ZIO.succeed(
+          AgentTracer
+            .get()
+            .buildSpan(opName)
+            .withResourceName("zio-test")
+            .start()
+        )
+        ddScope <- ZIO.succeed(
+          AgentTracer.get().activateSpan(ddSpan, INSTRUMENTATION)
+        )
+        _ <- scope.addFinalizer(ZIO.succeed(ddScope.close()))
+        _ <- scope.addFinalizer(ZIO.succeed(ddSpan.finish()))
+        _ <- op
+      } yield ()
+    }
+
+  private def run[A](zio: ZIO[Any, Nothing, A]): Unit = {
+    val executor = Executors.newSingleThreadExecutor()
+    val zioExecutor = Executor.fromJavaExecutor(executor)
+    val layer =
+      Runtime.setExecutor(zioExecutor) >>>
+        Runtime.setBlockingExecutor(zioExecutor)
+    try {
+      Unsafe.unsafe { implicit unsafe =>
+        Runtime.unsafe
+          .fromLayer(layer)
+          .unsafe
+          .run(zio)
+          .getOrThrowFiberFailure()
+      }
+    } finally {
+      executor.shutdownNow()
+    }
+  }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -358,6 +358,8 @@ include ':dd-java-agent:instrumentation:vertx-web-3.4'
 include ':dd-java-agent:instrumentation:vertx-web-3.5'
 include ':dd-java-agent:instrumentation:vertx-web-4.0'
 include ':dd-java-agent:instrumentation:redisson-2.0.0'
+include ':dd-java-agent:instrumentation:zio'
+include ':dd-java-agent:instrumentation:zio:zio-2.0'
 
 // benchmark
 include ':dd-java-agent:benchmark'


### PR DESCRIPTION
# What Does This Do

Adds instrumentation for  [ZIO 2.0](https://zio.dev/).

# Motivation

ZIO is a popular Scala library for asynchronous and concurrent programming. Its runtime uses green threads (fibers) which breaks instrumentation because scope state is stored in `ThreadLocal` variable. This PR takes care of synchronizing scope state between fibers and JVM threads on which they are executed.

Implementation was tested on a [non-trivial distributed application](https://github.com/dmytr/zio-otel-instrumentation/tree/6de68991ac932473f1d7d8b3151e9cf84e494900).
