### PR TITLE
naming schema: kafka changes

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
@@ -10,6 +10,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.Functions;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
+import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -20,12 +21,17 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.record.TimestampType;
 
 public class KafkaDecorator extends MessagingClientDecorator {
+  private static final String KAFKA = "kafka";
   public static final CharSequence JAVA_KAFKA = UTF8BytesString.create("java-kafka");
-  public static final CharSequence KAFKA_CONSUME = UTF8BytesString.create("kafka.consume");
-  public static final CharSequence KAFKA_PRODUCE = UTF8BytesString.create("kafka.produce");
+  public static final CharSequence KAFKA_CONSUME =
+      UTF8BytesString.create(
+          SpanNaming.instance().namingSchema().messaging().inboundOperation(KAFKA));
+  public static final CharSequence KAFKA_PRODUCE =
+      UTF8BytesString.create(
+          SpanNaming.instance().namingSchema().messaging().outboundOperation(KAFKA));
   public static final CharSequence KAFKA_DELIVER = UTF8BytesString.create("kafka.deliver");
   public static final boolean KAFKA_LEGACY_TRACING =
-      Config.get().isLegacyTracingEnabled(true, "kafka");
+      Config.get().isLegacyTracingEnabled(SpanNaming.instance().version() == 0, KAFKA);
 
   public static final String KAFKA_PRODUCED_KEY = "x_datadog_kafka_produced";
   private final String spanKind;
@@ -54,7 +60,7 @@ public class KafkaDecorator extends MessagingClientDecorator {
       new KafkaDecorator(
           Tags.SPAN_KIND_BROKER,
           InternalSpanTypes.MESSAGE_BROKER,
-          null /* service name will be set later on */);
+          SpanNaming.instance().namingSchema().messaging().timeInQueueService(KAFKA));
 
   protected KafkaDecorator(String spanKind, CharSequence spanType, String serviceName) {
     this.spanKind = spanKind;
@@ -112,8 +118,6 @@ public class KafkaDecorator extends MessagingClientDecorator {
       span.setResourceName(topic);
       if (Config.get().isMessageBrokerSplitByDestination()) {
         span.setServiceName(topic);
-      } else {
-        span.setServiceName("kafka");
       }
     }
   }

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsDecorator.java
@@ -8,6 +8,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.Functions;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
+import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -18,12 +19,15 @@ import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.processor.internals.StampedRecord;
 
 public class KafkaStreamsDecorator extends MessagingClientDecorator {
+  private static final String KAFKA = "kafka";
   public static final CharSequence JAVA_KAFKA = UTF8BytesString.create("java-kafka-streams");
-  public static final CharSequence KAFKA_CONSUME = UTF8BytesString.create("kafka.consume");
+  public static final CharSequence KAFKA_CONSUME =
+      UTF8BytesString.create(
+          SpanNaming.instance().namingSchema().messaging().inboundOperation(KAFKA));
   public static final CharSequence KAFKA_DELIVER = UTF8BytesString.create("kafka.deliver");
 
   public static final boolean KAFKA_LEGACY_TRACING =
-      Config.get().isLegacyTracingEnabled(true, "kafka");
+      Config.get().isLegacyTracingEnabled(SpanNaming.instance().version() == 0, KAFKA);
 
   public static final String KAFKA_PRODUCED_KEY = "x_datadog_kafka_produced";
 
@@ -46,7 +50,7 @@ public class KafkaStreamsDecorator extends MessagingClientDecorator {
       new KafkaStreamsDecorator(
           Tags.SPAN_KIND_BROKER,
           InternalSpanTypes.MESSAGE_BROKER,
-          null /* service name will be set later on */);
+          SpanNaming.instance().namingSchema().messaging().timeInQueueService(KAFKA));
 
   protected KafkaStreamsDecorator(String spanKind, CharSequence spanType, String serviceName) {
     this.spanKind = spanKind;
@@ -121,8 +125,6 @@ public class KafkaStreamsDecorator extends MessagingClientDecorator {
     span.setResourceName(topic);
     if (Config.get().isMessageBrokerSplitByDestination()) {
       span.setServiceName(topic);
-    } else {
-      span.setServiceName("kafka");
     }
   }
 }

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTestBase.groovy
@@ -1,4 +1,4 @@
-import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -20,21 +20,19 @@ import org.springframework.kafka.listener.config.ContainerProperties
 import org.springframework.kafka.test.rule.KafkaEmbedded
 import org.springframework.kafka.test.utils.ContainerTestUtils
 import org.springframework.kafka.test.utils.KafkaTestUtils
-import spock.lang.Shared
 import spock.lang.Ignore
+import spock.lang.Shared
 
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 
-abstract class KafkaStreamsTestBase extends AgentTestRunner {
+abstract class KafkaStreamsTestBase extends VersionedNamingTestBase {
   static final STREAM_PENDING = "test.pending"
   static final STREAM_PROCESSED = "test.processed"
 
   @Shared
   @ClassRule
   KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true, 1, STREAM_PENDING, STREAM_PROCESSED)
-
-  abstract String expectedServiceName()
 
   abstract boolean hasQueueSpan()
 
@@ -44,6 +42,29 @@ abstract class KafkaStreamsTestBase extends AgentTestRunner {
   protected boolean isDataStreamsEnabled() {
     return true
   }
+
+  @Override
+  int version() {
+    0
+  }
+
+  @Override
+  String operation() {
+    return null
+  }
+
+  String operationForProducer() {
+    "kafka.produce"
+  }
+
+  String operationForConsumer() {
+    "kafka.consume"
+  }
+
+  String serviceForTimeInQueue() {
+    "kafka"
+  }
+
 
   @Ignore("Repeatedly fails with the wrong parent span https://github.com/DataDog/dd-trace-java/issues/3865")
   def "test kafka produce and consume with streams in-between"() {
@@ -126,8 +147,8 @@ abstract class KafkaStreamsTestBase extends AgentTestRunner {
         // PRODUCER span 0
         span {
           firstProducerSpan = it.span
-          serviceName expectedServiceName()
-          operationName "kafka.produce"
+          serviceName service()
+          operationName operationForProducer()
           resourceName "Produce Topic $STREAM_PENDING"
           spanType "queue"
           errored false
@@ -149,7 +170,7 @@ abstract class KafkaStreamsTestBase extends AgentTestRunner {
         if (hasQueueSpan) {
           span {
             firstQueueSpan = it.span
-            serviceName splitByDestination() ? "$STREAM_PENDING" : "kafka"
+            serviceName splitByDestination() ? "$STREAM_PENDING" : serviceForTimeInQueue()
             operationName "kafka.deliver"
             resourceName "$STREAM_PENDING"
             spanType "queue"
@@ -166,8 +187,8 @@ abstract class KafkaStreamsTestBase extends AgentTestRunner {
 
         // STREAMING span 0
         span {
-          serviceName expectedServiceName()
-          operationName "kafka.consume"
+          serviceName service()
+          operationName operationForConsumer()
           resourceName "Consume Topic $STREAM_PENDING"
           spanType "queue"
           errored false
@@ -191,8 +212,8 @@ abstract class KafkaStreamsTestBase extends AgentTestRunner {
         // STREAMING span 1
         span {
           secondProducerSpan = it.span
-          serviceName expectedServiceName()
-          operationName "kafka.produce"
+          serviceName service()
+          operationName operationForProducer()
           resourceName "Produce Topic $STREAM_PROCESSED"
           spanType "queue"
           errored false
@@ -215,7 +236,7 @@ abstract class KafkaStreamsTestBase extends AgentTestRunner {
         if (hasQueueSpan) {
           span {
             secondQueueSpan = it.span
-            serviceName splitByDestination() ? "$STREAM_PROCESSED" : "kafka"
+            serviceName splitByDestination() ? "$STREAM_PROCESSED" : serviceForTimeInQueue()
             operationName "kafka.deliver"
             resourceName "$STREAM_PROCESSED"
             spanType "queue"
@@ -232,8 +253,8 @@ abstract class KafkaStreamsTestBase extends AgentTestRunner {
 
         // CONSUMER span 0
         span {
-          serviceName expectedServiceName()
-          operationName "kafka.consume"
+          serviceName service()
+          operationName operationForConsumer()
           resourceName "Consume Topic $STREAM_PROCESSED"
           spanType "queue"
           errored false
@@ -300,16 +321,15 @@ abstract class KafkaStreamsTestBase extends AgentTestRunner {
   }
 }
 
-class KafkaStreamsForkedTest extends KafkaStreamsTestBase {
+abstract class KafkaStreamsForkedTest extends KafkaStreamsTestBase {
   @Override
   void configurePreAgent() {
     super.configurePreAgent()
     injectSysConfig("dd.service", "KafkaStreamsTest")
-    injectSysConfig("dd.kafka.legacy.tracing.enabled", "false")
   }
 
   @Override
-  String expectedServiceName()  {
+  String service()  {
     return "KafkaStreamsTest"
   }
 
@@ -321,6 +341,32 @@ class KafkaStreamsForkedTest extends KafkaStreamsTestBase {
   @Override
   boolean splitByDestination() {
     return false
+  }
+}
+
+class KafkaStreamsV0ForkedTest extends KafkaStreamsForkedTest {
+
+}
+
+class KafkaStreamsV1ForkedTest extends KafkaStreamsForkedTest {
+  @Override
+  int version() {
+    1
+  }
+
+  @Override
+  String operationForProducer() {
+    "kafka.send"
+  }
+
+  @Override
+  String operationForConsumer() {
+    return "kafka.process"
+  }
+
+  @Override
+  String serviceForTimeInQueue() {
+    "kafka-queue"
   }
 }
 
@@ -334,7 +380,7 @@ class KafkaStreamsSplitByDestinationForkedTest extends KafkaStreamsTestBase {
   }
 
   @Override
-  String expectedServiceName()  {
+  String service()  {
     return "KafkaStreamsTest"
   }
 
@@ -349,16 +395,12 @@ class KafkaStreamsSplitByDestinationForkedTest extends KafkaStreamsTestBase {
   }
 }
 
-class KafkaStreamsLegacyTracingForkedTest extends KafkaStreamsTestBase {
+abstract class KafkaStreamsLegacyTracingForkedTest extends KafkaStreamsTestBase {
   @Override
   void configurePreAgent() {
     super.configurePreAgent()
+    injectSysConfig("dd.service", "KafkaStreamsLegacyTracingTest")
     injectSysConfig("dd.kafka.legacy.tracing.enabled", "true")
-  }
-
-  @Override
-  String expectedServiceName() {
-    return "kafka"
   }
 
   @Override
@@ -371,6 +413,33 @@ class KafkaStreamsLegacyTracingForkedTest extends KafkaStreamsTestBase {
     return false
   }
 }
+class KafkaStreamsLegacyTracingV0ForkedTest extends KafkaStreamsLegacyTracingForkedTest {
+  @Override
+  String service() {
+    "kafka"
+  }
+}
+
+class KafkaStreamsLegacyTracingV1ForkedTest extends KafkaStreamsLegacyTracingForkedTest {
+  @Override
+  String service() {
+    "KafkaStreamsLegacyTracingTest"
+  }
+  @Override
+  String operationForProducer() {
+    "kafka.send"
+  }
+
+  @Override
+  String operationForConsumer() {
+    return "kafka.process"
+  }
+
+  @Override
+  String serviceForTimeInQueue() {
+    "kafka-queue"
+  }
+}
 
 class KafkaStreamsDataStreamsDisabledForkedTest extends KafkaStreamsTestBase {
   @Override
@@ -381,7 +450,7 @@ class KafkaStreamsDataStreamsDisabledForkedTest extends KafkaStreamsTestBase {
   }
 
   @Override
-  String expectedServiceName()  {
+  String service()  {
     return "KafkaStreamsDataStreamsDisabledForkedTest"
   }
 


### PR DESCRIPTION
# What Does This Do

Changes for v1 naming schema:
* Producer:
  - service: `{{DD_SERVICE}}`
  - operation:  `kafka.send`
* Consumer:
  - service: `{{DD_SERVICE}}`
  - operation:  `kafka.process`
* Time in queue :
  - service: `kafka-queue`
  - operation:  `kafka.deliver`

Interactions with other options:
* v1 schema implies legacy tracing disabled by default. However the user can explicitly force the legacy tracing and have service = 'kafka' like v0

# Motivation

# Additional Notes
