### PR TITLE
upgrade jplib to 0.21.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -34,7 +34,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    jplib         : "0.19.0",
+    jplib         : "0.21.0",
     asm           : "9.4"
   ]
 


### PR DESCRIPTION
# What Does This Do

Picks up fixes to avoid unwinding stacks when the ZGC load barrier slow path is active.

# Motivation

# Additional Notes
