### PR TITLE
naming schema: jms changes

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/MessageConsumerState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/MessageConsumerState.java
@@ -31,7 +31,7 @@ public final class MessageConsumerState {
         this.brokerServiceName = brokerServiceName;
       }
     } else {
-      this.brokerServiceName = "jms";
+      this.brokerServiceName = null;
     }
   }
 

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
@@ -7,6 +7,7 @@ import datadog.trace.api.Functions.Join;
 import datadog.trace.api.Functions.PrefixJoin;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
+import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -27,11 +28,16 @@ public final class JMSDecorator extends MessagingClientDecorator {
   private static final Logger log = LoggerFactory.getLogger(JMSDecorator.class);
 
   public static final CharSequence JMS = UTF8BytesString.create("jms");
-  public static final CharSequence JMS_CONSUME = UTF8BytesString.create("jms.consume");
-  public static final CharSequence JMS_PRODUCE = UTF8BytesString.create("jms.produce");
+  public static final CharSequence JMS_CONSUME =
+      UTF8BytesString.create(
+          SpanNaming.instance().namingSchema().messaging().inboundOperation(JMS.toString()));
+  public static final CharSequence JMS_PRODUCE =
+      UTF8BytesString.create(
+          SpanNaming.instance().namingSchema().messaging().outboundOperation(JMS.toString()));
   public static final CharSequence JMS_DELIVER = UTF8BytesString.create("jms.deliver");
 
-  public static final boolean JMS_LEGACY_TRACING = Config.get().isLegacyTracingEnabled(true, "jms");
+  public static final boolean JMS_LEGACY_TRACING =
+      Config.get().isLegacyTracingEnabled(SpanNaming.instance().version() == 0, "jms");
 
   public static final String JMS_PRODUCED_KEY = "x_datadog_jms_produced";
   public static final String JMS_BATCH_ID_KEY = "x_datadog_jms_batch_id";
@@ -76,7 +82,7 @@ public final class JMSDecorator extends MessagingClientDecorator {
           "",
           Tags.SPAN_KIND_BROKER,
           InternalSpanTypes.MESSAGE_BROKER,
-          null /* service name will be set later on */);
+          SpanNaming.instance().namingSchema().messaging().timeInQueueService(JMS.toString()));
 
   public JMSDecorator(
       String resourcePrefix, String spanKind, CharSequence spanType, String serviceName) {

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/TimeInQueueForkedTest.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/TimeInQueueForkedTest.groovy
@@ -1,6 +1,6 @@
-import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.agent.test.asserts.TraceAssert
+import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.config.GeneralConfig
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
@@ -13,7 +13,7 @@ import javax.jms.Connection
 import javax.jms.Session
 import javax.jms.TextMessage
 
-abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
+abstract class TimeInQueueForkedTestBase extends VersionedNamingTestBase {
   @Shared
   EmbeddedActiveMQBroker broker = new EmbeddedActiveMQBroker()
   @Shared
@@ -38,10 +38,41 @@ abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
   TextMessage message5 = session.createTextMessage(messageText5)
 
   @Override
+  String operation() {
+    null
+  }
+
+  @Override
+  int version() {
+    0
+  }
+
+  @Override
+  String service() {
+    "myService"
+  }
+
+  String operationForProducer() {
+    "jms.produce"
+  }
+
+  String operationForConsumer() {
+    "jms.consume"
+  }
+
+  String serviceForTimeInQueue() {
+    "jms"
+  }
+
+
+  @Override
   protected void configurePreAgent() {
     super.configurePreAgent()
 
-    injectSysConfig("jms.legacy.tracing.enabled", 'false')
+    // test explicit only on v0 since we're also testing that in v1 is implicit
+    if (version() == 0) {
+      injectSysConfig("jms.legacy.tracing.enabled", 'false')
+    }
     injectSysConfig(GeneralConfig.SERVICE_NAME, 'myService')
   }
 
@@ -120,7 +151,7 @@ abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
     consumerSession.close()
 
     where:
-    destination                              | jmsResourceName
+    destination                      | jmsResourceName
     session.createQueue("someQueue") | "Queue someQueue"
     session.createTopic("someTopic") | "Topic someTopic"
     session.createTemporaryQueue()   | "Temporary Queue"
@@ -198,7 +229,7 @@ abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
     consumerSession.close()
 
     where:
-    destination                              | jmsResourceName
+    destination                      | jmsResourceName
     session.createQueue("someQueue") | "Queue someQueue"
     session.createTopic("someTopic") | "Topic someTopic"
     session.createTemporaryQueue()   | "Temporary Queue"
@@ -275,7 +306,7 @@ abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
     consumerSession.close()
 
     where:
-    destination                              | jmsResourceName
+    destination                      | jmsResourceName
     session.createQueue("someQueue") | "Queue someQueue"
     session.createTopic("someTopic") | "Topic someTopic"
     session.createTemporaryQueue()   | "Temporary Queue"
@@ -371,7 +402,7 @@ abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
     consumerSession.close()
 
     where:
-    destination                              | jmsResourceName
+    destination                      | jmsResourceName
     session.createQueue("someQueue") | "Queue someQueue"
     session.createTopic("someTopic") | "Topic someTopic"
     session.createTemporaryQueue()   | "Temporary Queue"
@@ -451,7 +482,7 @@ abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
     consumerSession.close()
 
     where:
-    destination                              | jmsResourceName
+    destination                      | jmsResourceName
     session.createQueue("someQueue") | "Queue someQueue"
     session.createTopic("someTopic") | "Topic someTopic"
     session.createTemporaryQueue()   | "Temporary Queue"
@@ -530,7 +561,7 @@ abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
     consumerSession.close()
 
     where:
-    destination                              | jmsResourceName
+    destination                      | jmsResourceName
     session.createQueue("someQueue") | "Queue someQueue"
     session.createTopic("someTopic") | "Topic someTopic"
     session.createTemporaryQueue()   | "Temporary Queue"
@@ -545,8 +576,8 @@ abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
 
   def producerSpan(TraceAssert traceAssert, String jmsResourceName) {
     return traceAssert.span {
-      serviceName "myService"
-      operationName "jms.produce"
+      serviceName service()
+      operationName operationForProducer()
       resourceName "Produced for $jmsResourceName"
       spanType DDSpanTypes.MESSAGE_PRODUCER
       errored false
@@ -570,8 +601,8 @@ abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
 
   def consumerSpan(TraceAssert traceAssert, String jmsResourceName, DDSpan parentSpan, boolean isTimestampDisabled = false) {
     return traceAssert.span {
-      serviceName "myService"
-      operationName "jms.consume"
+      serviceName service()
+      operationName operationForConsumer()
       resourceName "Consumed from $jmsResourceName"
       spanType DDSpanTypes.MESSAGE_CONSUMER
       errored false
@@ -591,7 +622,7 @@ abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
 
   def timeInQueueSpan(TraceAssert traceAssert, String jmsResourceName, DDSpan parentSpan) {
     return traceAssert.span {
-      serviceName splitByDestination() ? "${jmsResourceName.replaceFirst(/(Queue |Topic )/,'')}" : "jms"
+      serviceName splitByDestination() ? "${jmsResourceName.replaceFirst(/(Queue |Topic )/, '')}" : serviceForTimeInQueue()
       operationName "jms.deliver"
       resourceName "$jmsResourceName"
       spanType DDSpanTypes.MESSAGE_BROKER
@@ -606,12 +637,40 @@ abstract class TimeInQueueForkedTestBase extends AgentTestRunner {
   }
 }
 
-class TimeInQueueForkedTest extends TimeInQueueForkedTestBase {
+abstract class TimeInQueueForkedTest extends TimeInQueueForkedTestBase {
   @Override
   boolean splitByDestination() {
     return false
   }
 }
+
+class TimeInQueueV0ForkedTest extends TimeInQueueForkedTest {
+
+}
+
+class TimeInQueueV1ForkedTest extends TimeInQueueForkedTest {
+  @Override
+  String operationForProducer() {
+    "jms.send"
+  }
+
+  @Override
+  String operationForConsumer() {
+    "jms.process"
+  }
+
+  @Override
+  String serviceForTimeInQueue() {
+    "jms-queue"
+  }
+
+  @Override
+  int version() {
+    1
+  }
+
+}
+
 
 class TimeInQueueSplitByDestinationForkedTest extends TimeInQueueForkedTestBase {
   @Override


### PR DESCRIPTION
# What Does This Do

Changes for v1 naming schema:
* Producer:
  - service: `{{DD_SERVICE}}`
  - operation:  `jms.send`
* Consumer:
  - service: `{{DD_SERVICE}}`
  - operation:  `jms.process`
* Time in queue :
  - service: `jms-queue`
  - operation:  `jms.deliver`

Interactions with other options:
* v1 schema implies legacy tracing disabled by default. However the user can explicitly force the legacy tracing and have service = 'jms' like v0

# Motivation

# Additional Notes
