### PR TITLE
Fix failing muzzle classloader tests on CI

### DIFF
--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -163,19 +163,13 @@ class MuzzlePlugin implements Plugin<Project> {
                    |</testsuite>\n""".stripMargin()
   }
 
-  static FileCollection createMuzzleClassPath(Project project, Project bootstrapProject, String muzzleTaskName) {
+  static FileCollection createMuzzleClassPath(Project project, String muzzleTaskName) {
     FileCollection cp = project.files()
     project.getLogger().info("Creating classpath for $muzzleTaskName")
-    // add project jars first so we can test different dd-trace-api versions
     if ('muzzle' == muzzleTaskName) {
       cp += project.configurations.compileClasspath
     } else {
       cp += project.configurations.getByName(muzzleTaskName)
-    }
-    for (SourceSet sourceSet: bootstrapProject.sourceSets) {
-      if (sourceSet.name.startsWith('main')) {
-        cp += sourceSet.runtimeClasspath
-      }
     }
     if (project.getLogger().isInfoEnabled()) {
       cp.forEach { project.getLogger().info("-- $it") }
@@ -544,7 +538,7 @@ abstract class MuzzleTask extends DefaultTask {
       parameters.bootstrapClassPath.setFrom(bootstrapProject.sourceSets.main.runtimeClasspath as FileCollection)
       parameters.toolingClassPath.setFrom(toolingProject.sourceSets.main.runtimeClasspath as FileCollection)
       parameters.instrumentationClassPath.setFrom(instrumentationProject.sourceSets.main.runtimeClasspath as FileCollection)
-      parameters.testApplicationClassPath.setFrom(MuzzlePlugin.createMuzzleClassPath(instrumentationProject, bootstrapProject, name))
+      parameters.testApplicationClassPath.setFrom(MuzzlePlugin.createMuzzleClassPath(instrumentationProject, name))
       if (muzzleDirective) {
         parameters.assertPass.set(muzzleDirective.assertPass)
         parameters.muzzleDirective.set(muzzleDirective.name ?: muzzleDirective.module)

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceCreator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceCreator.java
@@ -465,10 +465,6 @@ public class ReferenceCreator extends ClassVisitor {
     if (dottedName.startsWith("org.slf4j.")) {
       return true;
     }
-    // trace-annotation's muzzle check relies on this annotation type
-    if (dottedName.equals("datadog.trace.api.Trace")) {
-      return false;
-    }
     for (String prefix : Constants.BOOTSTRAP_PACKAGE_PREFIXES) {
       if (dottedName.startsWith(prefix)) {
         return true;

--- a/dd-java-agent/instrumentation/trace-annotation/build.gradle
+++ b/dd-java-agent/instrumentation/trace-annotation/build.gradle
@@ -1,13 +1,4 @@
 
-muzzle {
-  pass {
-    group = "com.datadoghq"
-    module = "dd-trace-api"
-    versions = "[0.31.0,]"
-    assertInverse = true
-  }
-}
-
 apply from: "$rootDir/gradle/java.gradle"
 
 dependencies {

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAdvice.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAdvice.java
@@ -1,43 +1,17 @@
 package datadog.trace.instrumentation.trace_annotation;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.trace_annotation.TraceDecorator.DECORATE;
 
-import datadog.trace.api.Trace;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.lang.reflect.Method;
 import net.bytebuddy.asm.Advice;
 
 public class TraceAdvice {
-  private static final String DEFAULT_OPERATION_NAME = "trace.annotation";
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static AgentScope onEnter(@Advice.Origin final Method method) {
-    final Trace traceAnnotation = method.getAnnotation(Trace.class);
-    CharSequence operationName = traceAnnotation == null ? null : traceAnnotation.operationName();
-
-    if (operationName == null || operationName.length() == 0) {
-      if (DECORATE.useLegacyOperationName()) {
-        operationName = DEFAULT_OPERATION_NAME;
-      } else {
-        operationName = DECORATE.spanNameForMethod(method);
-      }
-    }
-
-    final AgentSpan span = startSpan(operationName);
-
-    CharSequence resourceName = traceAnnotation == null ? null : traceAnnotation.resourceName();
-    if (resourceName == null || resourceName.length() == 0) {
-      resourceName = DECORATE.spanNameForMethod(method);
-    }
-    span.setResourceName(resourceName);
-    DECORATE.afterStart(span);
-
-    final AgentScope scope = activateSpan(span);
-    scope.setAsyncPropagation(true);
-    return scope;
+    return activateSpan(DECORATE.startMethodSpan(method));
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceDecorator.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceDecorator.java
@@ -1,15 +1,23 @@
 package datadog.trace.instrumentation.trace_annotation;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+
 import datadog.trace.api.InstrumenterConfig;
+import datadog.trace.api.Trace;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
+import java.lang.reflect.Method;
 
 public class TraceDecorator extends BaseDecorator {
   public static TraceDecorator DECORATE = new TraceDecorator();
 
   private static final boolean useLegacyOperationName =
       InstrumenterConfig.get().isLegacyInstrumentationEnabled(true, "trace.annotations");
+
   private static final CharSequence TRACE = UTF8BytesString.create("trace");
+
+  private static final String DEFAULT_OPERATION_NAME = "trace.annotation";
 
   @Override
   protected String[] instrumentationNames() {
@@ -29,5 +37,38 @@ public class TraceDecorator extends BaseDecorator {
 
   public boolean useLegacyOperationName() {
     return useLegacyOperationName;
+  }
+
+  public AgentSpan startMethodSpan(Method method) {
+    CharSequence operationName = null;
+    CharSequence resourceName = null;
+
+    Trace traceAnnotation = method.getAnnotation(Trace.class);
+    if (null != traceAnnotation) {
+      operationName = traceAnnotation.operationName();
+      try {
+        resourceName = traceAnnotation.resourceName();
+      } catch (Throwable ignore) {
+        // dd-trace-api < 0.31.0 on classpath
+      }
+    }
+
+    if (operationName == null || operationName.length() == 0) {
+      if (DECORATE.useLegacyOperationName()) {
+        operationName = DEFAULT_OPERATION_NAME;
+      } else {
+        operationName = DECORATE.spanNameForMethod(method);
+      }
+    }
+
+    if (resourceName == null || resourceName.length() == 0) {
+      resourceName = DECORATE.spanNameForMethod(method);
+    }
+
+    AgentSpan span = startSpan(operationName);
+    DECORATE.afterStart(span);
+    span.setResourceName(resourceName);
+
+    return span;
   }
 }


### PR DESCRIPTION
Now that the boot delegation check has been merged with the class-loader state, the muzzle plugin must ensure the test and instrumentation class-paths share the same boot class-loader.

As part of fixing this I had to pull in a related fix to `trace-annotation` that makes it compatible with very old versions of the `@Trace` annotation. This means we can drop some special handling in the Muzzle Plugin that put some bootstrap related classes  at a different point in the generated class-path, just to allow an artificial muzzle check that would not really apply in practice.