### PR TITLE
naming schema: graphql

### DIFF
--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/main/java/datadog/trace/instrumentation/graphqljava/GraphQLDecorator.java
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/main/java/datadog/trace/instrumentation/graphqljava/GraphQLDecorator.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.graphqljava;
 
+import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -7,12 +8,12 @@ import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
 
 public class GraphQLDecorator extends BaseDecorator {
   public static final GraphQLDecorator DECORATE = new GraphQLDecorator();
-
-  public static final CharSequence GRAPHQL_REQUEST = UTF8BytesString.create("graphql.request");
+  public static final CharSequence GRAPHQL_REQUEST =
+      UTF8BytesString.create(
+          SpanNaming.instance().namingSchema().server().operationForProtocol("graphql"));
   public static final CharSequence GRAPHQL_PARSING = UTF8BytesString.create("graphql.parsing");
   public static final CharSequence GRAPHQL_VALIDATION =
       UTF8BytesString.create("graphql.validation");
-
   public static final CharSequence GRAPHQL_JAVA = UTF8BytesString.create("graphql-java");
 
   @Override

--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLTest.groovy
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLTest.groovy
@@ -1,4 +1,6 @@
-import datadog.trace.agent.test.AgentTestRunner
+import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring
+
+import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.Trace
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -10,13 +12,13 @@ import graphql.schema.GraphQLSchema
 import graphql.schema.idl.RuntimeWiring
 import graphql.schema.idl.SchemaGenerator
 import graphql.schema.idl.SchemaParser
+import spock.lang.Shared
 
 import java.nio.charset.StandardCharsets
 
-import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring
-
-class GraphQLTest extends AgentTestRunner {
-  private GraphQL graphql
+abstract class GraphQLTest extends VersionedNamingTestBase {
+  @Shared
+  GraphQL graphql
 
   @Override
   def setup() {
@@ -88,8 +90,8 @@ class GraphQLTest extends AgentTestRunner {
     assertTraces(1) {
       trace(6) {
         span {
-          operationName "graphql.request"
-          resourceName "graphql.request"
+          operationName operation()
+          resourceName operation()
           spanType DDSpanTypes.GRAPHQL
           errored false
           measured true
@@ -192,8 +194,8 @@ class GraphQLTest extends AgentTestRunner {
     assertTraces(1) {
       trace(3) {
         span {
-          operationName "graphql.request"
-          resourceName "graphql.request"
+          operationName operation()
+          resourceName operation()
           spanType DDSpanTypes.GRAPHQL
           errored true
           measured true
@@ -251,8 +253,8 @@ class GraphQLTest extends AgentTestRunner {
     assertTraces(1) {
       trace(2) {
         span {
-          operationName "graphql.request"
-          resourceName "graphql.request"
+          operationName operation()
+          resourceName operation()
           spanType DDSpanTypes.GRAPHQL
           errored true
           measured true
@@ -306,8 +308,8 @@ class GraphQLTest extends AgentTestRunner {
     assertTraces(1) {
       trace(6) {
         span {
-          operationName "graphql.request"
-          resourceName "graphql.request"
+          operationName operation()
+          resourceName operation()
           spanType DDSpanTypes.GRAPHQL
           errored true
           measured true
@@ -387,5 +389,41 @@ class GraphQLTest extends AgentTestRunner {
         }
       }
     }
+  }
+}
+
+class GraphQLV0ForkedTest extends GraphQLTest {
+
+  @Override
+  int version() {
+    0
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "graphql.request"
+  }
+}
+
+class GraphQLV1ForkedTest extends GraphQLTest {
+
+  @Override
+  int version() {
+    1
+  }
+
+  @Override
+  String service() {
+    return null
+  }
+
+  @Override
+  String operation() {
+    return "graphql.server.request"
   }
 }


### PR DESCRIPTION
# What Does This Do

v1 naming schema changes for graphql (request only):
* operation: `graphql.server.request`

Note: the resource name will also change on v1 to `graphql.server.request` since the decorator does not set any and thus defaulting to operation name.

# Motivation

# Additional Notes
