### PR TITLE
Replace map-based TypeInfoCache with a fixed-sized array approach derived from FixedSizeCache

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/TypeInfoCache.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/TypeInfoCache.java
@@ -1,28 +1,35 @@
 package datadog.trace.agent.tooling.bytebuddy;
 
-import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
 import java.lang.ref.WeakReference;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentMap;
 
 /** Shares type information using a single cache across multiple classloaders. */
 public final class TypeInfoCache<T> {
-  private static final int CONCURRENCY_LEVEL =
-      Math.max(8, Runtime.getRuntime().availableProcessors());
-
-  private final ConcurrentMap<String, SharedTypeInfo<T>> sharedTypeInfo;
-
   public static final URL UNKNOWN_CLASS_FILE = null;
 
-  public TypeInfoCache(int typeCapacity) {
-    sharedTypeInfo =
-        new ConcurrentLinkedHashMap.Builder<String, SharedTypeInfo<T>>()
-            .maximumWeightedCapacity(typeCapacity)
-            .concurrencyLevel(CONCURRENCY_LEVEL)
-            .build();
+  // limit allowed capacities as descriptions are not small
+  private static final int MAX_CAPACITY = 1 << 16;
+  private static final int MIN_CAPACITY = 1 << 4;
+
+  private static final int MAX_HASH_ATTEMPTS = 5;
+
+  private final SharedTypeInfo<T>[] sharedTypeInfo;
+  private final int slotMask;
+
+  @SuppressWarnings("unchecked")
+  public TypeInfoCache(int capacity) {
+    if (capacity < MIN_CAPACITY) {
+      capacity = MIN_CAPACITY;
+    } else if (capacity > MAX_CAPACITY) {
+      capacity = MAX_CAPACITY;
+    }
+    // choose enough slot bits to cover the chosen capacity
+    this.slotMask = 0xFFFFFFFF >>> Integer.numberOfLeadingZeros(capacity - 1);
+    this.sharedTypeInfo = new SharedTypeInfo[slotMask + 1];
   }
 
   /**
@@ -31,8 +38,20 @@ public final class TypeInfoCache<T> {
    * <p>When multiple types exist with the same name only one type will be cached at a time. Callers
    * can compare the originating classloader and class file resource to help disambiguate results.
    */
-  public SharedTypeInfo<T> find(String name) {
-    return sharedTypeInfo.get(name);
+  public SharedTypeInfo<T> find(String className) {
+    int nameHash = className.hashCode();
+    for (int i = 1; true; i++) {
+      SharedTypeInfo<T> value = sharedTypeInfo[slotMask & nameHash];
+      if (null == value) {
+        return null;
+      } else if (className.equals(value.className)) {
+        value.lastUsed = System.currentTimeMillis();
+        return value;
+      } else if (i == MAX_HASH_ATTEMPTS) {
+        return null;
+      }
+      nameHash = rehash(nameHash);
+    }
   }
 
   /**
@@ -40,13 +59,40 @@ public final class TypeInfoCache<T> {
    *
    * @return previously shared information for the named type
    */
-  public SharedTypeInfo<T> share(String name, ClassLoader loader, URL classFile, T typeInfo) {
-    return sharedTypeInfo.put(name, new SharedTypeInfo<>(loaderId(loader), classFile, typeInfo));
+  public SharedTypeInfo<T> share(String className, ClassLoader loader, URL classFile, T typeInfo) {
+    SharedTypeInfo<T> newValue =
+        new SharedTypeInfo<>(className, loaderId(loader), classFile, typeInfo);
+
+    int nameHash = className.hashCode();
+    int slot = slotMask & nameHash;
+
+    long leastUsedTime = Long.MAX_VALUE;
+    int leastUsedSlot = slot;
+
+    for (int i = 1; true; i++) {
+      SharedTypeInfo<T> oldValue = sharedTypeInfo[slot];
+      if (null == oldValue || className.equals(oldValue.className)) {
+        sharedTypeInfo[slot] = newValue;
+        return oldValue;
+      } else if (i == MAX_HASH_ATTEMPTS) {
+        sharedTypeInfo[leastUsedSlot] = newValue; // overwrite least-recently used
+        return null;
+      } else if (oldValue.lastUsed < leastUsedTime) {
+        leastUsedTime = oldValue.lastUsed;
+        leastUsedSlot = slot;
+      }
+      nameHash = rehash(nameHash);
+      slot = slotMask & nameHash;
+    }
   }
 
   /** Clears all type information from the shared cache. */
   public void clear() {
-    sharedTypeInfo.clear();
+    Arrays.fill(sharedTypeInfo, null);
+  }
+
+  private static int rehash(int oldHash) {
+    return Integer.reverseBytes(oldHash * 0x9e3775cd) * 0x9e3775cd;
   }
 
   private static LoaderId loaderId(ClassLoader loader) {
@@ -76,12 +122,17 @@ public final class TypeInfoCache<T> {
   }
 
   /** Wraps type information with the classloader and class file resource it originated from. */
-  public static class SharedTypeInfo<T> {
+  public static final class SharedTypeInfo<T> {
+    final String className;
+
     private final LoaderId loaderId;
     private final URL classFile;
     private final T typeInfo;
 
-    SharedTypeInfo(LoaderId loaderId, URL classFile, T typeInfo) {
+    long lastUsed = System.currentTimeMillis();
+
+    SharedTypeInfo(String className, LoaderId loaderId, URL classFile, T typeInfo) {
+      this.className = className;
       this.loaderId = loaderId;
       this.classFile = classFile;
       this.typeInfo = typeInfo;


### PR DESCRIPTION
Tracks when entries were last used to decide which slot to overwrite when the cache is full - this is necessary to avoid evicting heavily used types from the cache when other less used slots could be evicted.

The LRU approach was tuned to get as close as possible to the behaviour in `ConcurrentLinkedHashMap` while still keeping the simple rehashing approach. The basic idea is to track when each slot was last used so we can choose the least-recently used slot (out of the original and rehashed locations) when the array is full, rather than always choosing the original slot.

After this is merged only one place uses `ConcurrentLinkedHashMap` - the legacy caching strategy which is off by default.