### PR TITLE
Reset vulnerability deduplication every hour

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastSystem.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastSystem.java
@@ -51,7 +51,7 @@ public class IastSystem {
     }
     DEBUG = config.isIastDebugEnabled();
     LOGGER.debug("IAST is starting: debug={}", DEBUG);
-    final Reporter reporter = new Reporter(config);
+    final Reporter reporter = new Reporter(config, AgentTaskScheduler.INSTANCE);
     if (overheadController == null) {
       overheadController = OverheadController.build(config, AgentTaskScheduler.INSTANCE);
     }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
@@ -5,6 +5,7 @@ import com.datadog.iast.model.Location
 import com.datadog.iast.model.Vulnerability
 import com.datadog.iast.model.VulnerabilityBatch
 import com.datadog.iast.model.VulnerabilityType
+import datadog.trace.api.Config
 import datadog.trace.api.internal.TraceSegment
 import datadog.trace.api.gateway.RequestContext
 import datadog.trace.api.gateway.RequestContextSlot
@@ -15,6 +16,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource
 import datadog.trace.test.util.DDSpecification
+import datadog.trace.util.AgentTaskScheduler
 import groovy.json.JsonSlurper
 import spock.lang.Shared
 
@@ -345,7 +347,7 @@ class ReporterTest extends DDSpecification {
     final executors = Executors.newCachedThreadPool()
     final int size = 32
     final latch = new CountDownLatch(size)
-    final predicate = new Reporter.HashBasedDeduplication(size >> 3) // maximum of 4 hashes
+    final predicate = new Reporter.HashBasedDeduplication(size >> 3, null) // maximum of 4 hashes
     final Reporter reporter = new Reporter({ final Vulnerability vul ->
       latch.countDown()
       predicate.test(vul)
@@ -370,6 +372,18 @@ class ReporterTest extends DDSpecification {
     executors.awaitTermination(5, TimeUnit.SECONDS)
     executors.isTerminated()
     batch.vulnerabilities.size() >= 8
+  }
+
+  void 'cache reset is scheduled'() {
+    given:
+    final AgentTaskScheduler scheduler = Mock()
+
+    when:
+    new Reporter(Config.get(), scheduler)
+
+    then: 'there are vulnerabilities reported'
+    1 * scheduler.scheduleAtFixedRate(_, 1, 1, TimeUnit.HOURS)
+    0 * _
   }
 
   private AgentSpan spanWithBatch(final VulnerabilityBatch batch) {


### PR DESCRIPTION
# What Does This Do

Reset vulnerability deduplication every hour. We have a set of vulnerability hashes we've seen before. We clear this every hour to periodically send recurrent vulnerabilities.

# Motivation

Help the backend when assessing exposure windows.

# Additional Notes
