### PR TITLE
Register that moshi needs reflective access to adapters in TraceSamplingRules/SpanSamplingRules

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/resources/META-INF/native-image/com.datadoghq/dd-java-agent/reflect-config.json
+++ b/dd-java-agent/agent-bootstrap/src/main/resources/META-INF/native-image/com.datadoghq/dd-java-agent/reflect-config.json
@@ -30,6 +30,18 @@
     ]
   },
   {
+    "name" : "datadog.trace.agent.common.sampling.SpanSamplingRules$RuleAdapter",
+    "methods": [
+      {"name": "fromJson"}
+    ]
+  },
+  {
+    "name" : "datadog.trace.agent.common.sampling.TraceSamplingRules$RuleAdapter",
+    "methods": [
+      {"name": "fromJson"}
+    ]
+  },
+  {
     "name" : "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter",
     "methods": [
       {"name": "<init>", "parameterTypes": []}

--- a/dd-smoke-tests/spring-native/src/test/groovy/SpringNativeWebmvcIntegrationTest.groovy
+++ b/dd-smoke-tests/spring-native/src/test/groovy/SpringNativeWebmvcIntegrationTest.groovy
@@ -12,6 +12,9 @@ class SpringNativeWebmvcIntegrationTest extends AbstractServerSmokeTest {
     command.addAll(nativeJavaProperties)
     command.addAll((String[]) [
       "-Ddd.writer.type=MultiWriter:TraceStructureWriter:${output.getAbsolutePath()},DDAgentWriter",
+      // trigger use of moshi for parsing sampling rules
+      "-Ddd.trace.sampling.rules=[]",
+      "-Ddd.span.sampling.rules=[]",
       "--server.port=${httpPort}"
     ])
     ProcessBuilder processBuilder = new ProcessBuilder(command)


### PR DESCRIPTION
and update the `spring-native` smoke-test to trigger the use of moshi for parsing sampling rules