### PR TITLE
Upgrade to jplib 0.22.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -34,7 +34,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    jplib         : "0.20.0",
+    jplib         : "0.22.0",
     asm           : "9.4"
   ]
 


### PR DESCRIPTION
# What Does This Do

Includes a revised fix to handle sampling the ZGC load barrier

# Motivation

# Additional Notes
