### PR TITLE
Fixes to improve OWASP benchmark coverage

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/RequestEndedHandler.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/RequestEndedHandler.java
@@ -29,13 +29,16 @@ public class RequestEndedHandler implements BiFunction<RequestContext, IGSpanInf
     final TraceSegment traceSegment = requestContext.getTraceSegment();
     final IastRequestContext iastRequestContext = IastRequestContext.get(requestContext);
     if (iastRequestContext != null) {
-      ANALYZED.setTagTop(traceSegment);
-      final TaintedObjects taintedObjects = iastRequestContext.getTaintedObjects();
-      if (taintedObjects != null) {
-        taintedObjects.release();
+      try {
+        ANALYZED.setTagTop(traceSegment);
+        final TaintedObjects taintedObjects = iastRequestContext.getTaintedObjects();
+        if (taintedObjects != null) {
+          taintedObjects.release();
+        }
+        telemetry.onRequestEnded(iastRequestContext, traceSegment);
+      } finally {
+        overheadController.releaseRequest();
       }
-      telemetry.onRequestEnded(iastRequestContext, traceSegment);
-      overheadController.releaseRequest();
     } else {
       SKIPPED.setTagTop(traceSegment);
     }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/CommandInjectionModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/CommandInjectionModuleImpl.java
@@ -10,6 +10,7 @@ import datadog.trace.api.iast.sink.CommandInjectionModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.List;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class CommandInjectionModuleImpl extends SinkModuleBase implements CommandInjectionModule {
@@ -26,6 +27,25 @@ public class CommandInjectionModuleImpl extends SinkModuleBase implements Comman
     }
     final TaintedObjects to = ctx.getTaintedObjects();
     checkInjection(span, VulnerabilityType.COMMAND_INJECTION, rangesProviderFor(to, cmdArray));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public void onRuntimeExec(@Nullable final String[] env, @Nonnull final String... command) {
+    if (!canBeTainted(command) && !canBeTainted(env)) {
+      return;
+    }
+    final AgentSpan span = AgentTracer.activeSpan();
+    final IastRequestContext ctx = IastRequestContext.get(span);
+    if (ctx == null) {
+      return;
+    }
+    final TaintedObjects to = ctx.getTaintedObjects();
+    checkInjection(
+        span,
+        VulnerabilityType.COMMAND_INJECTION,
+        rangesProviderFor(to, env),
+        rangesProviderFor(to, command));
   }
 
   @Override

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/LdapInjectionModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/LdapInjectionModuleImpl.java
@@ -9,40 +9,18 @@ import com.datadog.iast.taint.TaintedObjects;
 import datadog.trace.api.iast.sink.LdapInjectionModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import java.util.ArrayList;
-import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class LdapInjectionModuleImpl extends SinkModuleBase implements LdapInjectionModule {
 
+  @SuppressWarnings("unchecked")
   @Override
   public void onDirContextSearch(
       @Nullable final String name,
       @Nonnull final String filterExpr,
       @Nullable final Object[] filterArgs) {
-    List<String> elements = null;
-    if (canBeTainted(name)) {
-      elements = new ArrayList<>();
-      elements.add(name);
-    }
-    if (canBeTainted(filterExpr)) {
-      elements = getElements(elements);
-      elements.add(filterExpr);
-    }
-    if (filterArgs != null) {
-      for (final Object filterArg : filterArgs) {
-        if (filterArg instanceof String) {
-          final String stringArg = (String) filterArg;
-          if (canBeTainted(stringArg)) {
-            elements = getElements(elements);
-            elements.add(stringArg);
-          }
-        }
-      }
-    }
-    if (elements == null || elements.isEmpty()) {
-      LOG.debug("there ara no elements that can be tainted");
+    if (!canBeTainted(name) && !canBeTainted(filterExpr) && filterArgs == null) {
       return;
     }
     final AgentSpan span = AgentTracer.activeSpan();
@@ -52,13 +30,11 @@ public class LdapInjectionModuleImpl extends SinkModuleBase implements LdapInjec
       return;
     }
     final TaintedObjects to = ctx.getTaintedObjects();
-    checkInjection(span, VulnerabilityType.LDAP_INJECTION, rangesProviderFor(to, elements));
-  }
-
-  private static List<String> getElements(@Nullable final List<String> elements) {
-    if (elements == null) {
-      return new ArrayList<>();
-    }
-    return elements;
+    checkInjection(
+        span,
+        VulnerabilityType.LDAP_INJECTION,
+        rangesProviderFor(to, name),
+        rangesProviderFor(to, filterExpr),
+        rangesProviderFor(to, filterArgs));
   }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/Ranges.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/Ranges.java
@@ -69,6 +69,7 @@ public final class Ranges {
     return ranges;
   }
 
+  @SuppressWarnings("unchecked")
   public static <E> RangesProvider<E> rangesProviderFor(
       @Nonnull final TaintedObjects to, @Nullable final E[] items) {
     if (items == null || items.length == 0) {
@@ -77,6 +78,16 @@ public final class Ranges {
     return new ArrayProvider<>(items, to);
   }
 
+  @SuppressWarnings("unchecked")
+  public static <E> RangesProvider<E> rangesProviderFor(
+      @Nonnull final TaintedObjects to, @Nullable final E item) {
+    if (item == null) {
+      return (RangesProvider<E>) EMPTY_PROVIDER;
+    }
+    return new SingleProvider<>(item, to);
+  }
+
+  @SuppressWarnings("unchecked")
   public static <E> RangesProvider<E> rangesProviderFor(
       @Nonnull final TaintedObjects to, @Nullable final List<E> items) {
     if (items == null || items.isEmpty()) {
@@ -206,6 +217,36 @@ public final class Ranges {
     protected abstract int size(@Nonnull final LIST items);
 
     protected abstract E item(@Nonnull final LIST items, final int index);
+  }
+
+  private static class SingleProvider<E> implements RangesProvider<E> {
+    private final E value;
+    private final TaintedObject tainted;
+
+    private SingleProvider(@Nonnull final E value, @Nonnull final TaintedObjects to) {
+      this.value = value;
+      this.tainted = to.get(value);
+    }
+
+    @Override
+    public int rangeCount() {
+      return tainted == null ? 0 : tainted.getRanges().length;
+    }
+
+    @Override
+    public int size() {
+      return 1;
+    }
+
+    @Override
+    public E value(int index) {
+      return index == 0 ? value : null;
+    }
+
+    @Override
+    public Range[] ranges(E value) {
+      return value == this.value && tainted != null ? tainted.getRanges() : null;
+    }
   }
 
   private static class ArrayProvider<E> extends IterableProvider<E, E[]> {

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/TaintedObjects.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/TaintedObjects.java
@@ -1,5 +1,7 @@
 package com.datadog.iast.taint;
 
+import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_MAX_CONCURRENT_REQUESTS;
+
 import com.datadog.iast.IastSystem;
 import com.datadog.iast.model.Range;
 import com.datadog.iast.model.Source;
@@ -40,7 +42,9 @@ public interface TaintedObjects {
   class TaintedObjectsImpl implements TaintedObjects {
 
     private static final ArrayBlockingQueue<TaintedObjectsImpl> pool =
-        new ArrayBlockingQueue<>(Config.get().getIastMaxConcurrentRequests());
+        new ArrayBlockingQueue<>(
+            Math.max(
+                Config.get().getIastMaxConcurrentRequests(), DEFAULT_IAST_MAX_CONCURRENT_REQUESTS));
 
     private final TaintedMap map;
 

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/telemetry/IastTelemetryImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/telemetry/IastTelemetryImpl.java
@@ -44,7 +44,7 @@ public class IastTelemetryImpl implements IastTelemetry {
       final Collection<MetricData> metrics = collector.drainMetrics();
       if (!metrics.isEmpty()) {
         addMetricsToTrace(trace, metrics);
-        IastTelemetryCollector.Holder.GLOBAL.merge(metrics);
+        addMetricsToTelemetry(metrics);
       }
     }
   }
@@ -61,6 +61,13 @@ public class IastTelemetryImpl implements IastTelemetry {
     for (final Map.Entry<IastMetric, Long> entry : flatten.entrySet()) {
       final String tagName = String.format(TRACE_METRIC_PATTERN, entry.getKey().getName());
       trace.setTagTop(tagName, entry.getValue());
+    }
+  }
+
+  private static void addMetricsToTelemetry(final Collection<MetricData> metrics) {
+    boolean added = IastTelemetryCollector.Holder.GLOBAL.merge(metrics);
+    if (!added) {
+      IastTelemetryCollector.LOGGER.debug("Failed to add global metrics after request");
     }
   }
 

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/overhead/OverheadContextTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/overhead/OverheadContextTest.groovy
@@ -4,7 +4,11 @@ import datadog.trace.api.Config
 import datadog.trace.test.util.DDSpecification
 import datadog.trace.util.AgentTaskScheduler
 import com.datadog.iast.overhead.OverheadController.OverheadControllerImpl
+import groovy.transform.CompileDynamic
 
+import static datadog.trace.api.iast.IastDetectionMode.UNLIMITED
+
+@CompileDynamic
 class OverheadContextTest extends DDSpecification {
 
   void 'Can reset global overhead context'() {
@@ -28,7 +32,7 @@ class OverheadContextTest extends DDSpecification {
   void 'Quota is not consumed once it has been exhausted'() {
     given:
     def overheadContext = new OverheadContext()
-    boolean consumed = false
+    boolean consumed
 
     when: 'reduce quota by two'
     consumed = overheadContext.consumeQuota(2)
@@ -43,5 +47,17 @@ class OverheadContextTest extends DDSpecification {
     then: 'available quota still zero'
     !consumed
     overheadContext.getAvailableQuota() == 0
+  }
+
+  void 'Unlimited quota'() {
+    given:
+    final overheadContext = new OverheadContext(UNLIMITED)
+
+    when:
+    final consumed = (1..1_000_000).collect { overheadContext.consumeQuota(1) }
+
+    then:
+    !consumed.any { !it }
+    overheadContext.availableQuota == Integer.MAX_VALUE
   }
 }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/overhead/OverheadControllerTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/overhead/OverheadControllerTest.groovy
@@ -8,6 +8,7 @@ import datadog.trace.api.gateway.RequestContextSlot
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.test.util.DDSpecification
 import datadog.trace.util.AgentTaskScheduler
+import groovy.transform.CompileDynamic
 import spock.lang.Shared
 
 import java.util.concurrent.Callable
@@ -16,6 +17,9 @@ import java.util.concurrent.Executors
 import java.util.concurrent.Future
 import java.util.concurrent.Semaphore
 
+import static datadog.trace.api.iast.IastDetectionMode.UNLIMITED
+
+@CompileDynamic
 class OverheadControllerTest extends DDSpecification {
 
   @Shared
@@ -59,11 +63,11 @@ class OverheadControllerTest extends DDSpecification {
     given: 'Set sampling to 100%'
     def config = Spy(Config.get())
     config.getIastRequestSampling() >> 100
+    def maxRequests = config.iastMaxConcurrentRequests
     def taskSchedler = Stub(AgentTaskScheduler)
     def overheadController = new OverheadControllerImpl(config, taskSchedler)
 
     when: 'Acquire max concurrent requests'
-    def maxRequests = overheadController.maxConcurrentRequests
     assert maxRequests > 0
     def acquired = (1..maxRequests).collect({ overheadController.acquireRequest() })
 
@@ -75,6 +79,21 @@ class OverheadControllerTest extends DDSpecification {
 
     then: 'None of them is acquired'
     extraAcquired.every { !it }
+  }
+
+  void 'Unlimited concurrent requests'() {
+    given: 'Set sampling to 100%'
+    def config = Spy(Config.get())
+    config.getIastRequestSampling() >> 100
+    config.getIastMaxConcurrentRequests() >> UNLIMITED
+    def taskScheduler = Stub(AgentTaskScheduler)
+    def overheadController = new OverheadControllerImpl(config, taskScheduler)
+
+    when: 'Acquire max concurrent requests'
+    def acquired = (1..1_000_000).collect({ overheadController.acquireRequest() })
+
+    then: 'All of them are acquired'
+    acquired.every { it }
   }
 
   void 'getContext defaults to global context if span is null'() {

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/CommandInjectionModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/CommandInjectionModuleTest.groovy
@@ -8,10 +8,12 @@ import datadog.trace.api.gateway.RequestContext
 import datadog.trace.api.gateway.RequestContextSlot
 import datadog.trace.api.iast.sink.CommandInjectionModule
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import groovy.transform.CompileDynamic
 
 import static com.datadog.iast.taint.TaintUtils.addFromTaintFormat
 import static com.datadog.iast.taint.TaintUtils.taintFormat
 
+@CompileDynamic
 class CommandInjectionModuleTest extends IastModuleImplTestBase {
 
   private CommandInjectionModule module
@@ -20,6 +22,8 @@ class CommandInjectionModuleTest extends IastModuleImplTestBase {
 
   private IastRequestContext ctx
 
+  private AgentSpan span
+
   def setup() {
     module = registerDependencies(new CommandInjectionModuleImpl())
     objectHolder = []
@@ -27,26 +31,33 @@ class CommandInjectionModuleTest extends IastModuleImplTestBase {
     final reqCtx = Mock(RequestContext) {
       getData(RequestContextSlot.IAST) >> ctx
     }
-    final span = Mock(AgentSpan) {
+    span = Mock(AgentSpan) {
       getSpanId() >> 123456
       getRequestContext() >> reqCtx
     }
-    tracer.activeSpan() >> span
   }
 
-  void 'iast module detect command injection on process builder start (#command)'(final List<String> command, final String expected) {
+  void 'iast module detect command injection on process builder start (#command)'() {
     setup:
-    final cmd = mapTaintedCommand(command)
+    final cmd = mapTaintedArray(command)
 
     when:
     module.onProcessBuilderStart(cmd)
 
     then:
+    tracer.activeSpan() >> span
     if (expected != null) {
       1 * reporter.report(_, _) >> { args -> assertVulnerability(args[1] as Vulnerability, expected) }
     } else {
       0 * reporter.report(_, _)
     }
+
+    when:
+    module.onProcessBuilderStart(cmd)
+
+    then:
+    tracer.activeSpan() >> null
+    0 * reporter.report(_, _)
 
     where:
     command                    | expected
@@ -57,19 +68,27 @@ class CommandInjectionModuleTest extends IastModuleImplTestBase {
     ['==>ls<==', '==>-lah<=='] | '==>ls<== ==>-lah<=='
   }
 
-  void 'iast module detect command injection on runtime exec (#command)'(final List<String> command, final String expected) {
+  void 'iast module detect command injection on runtime exec (#command)'() {
     setup:
-    final cmd = mapTaintedCommand(command).toArray(new String[0]) as String[]
+    final cmd = mapTaintedArray(command).toArray(new String[0]) as String[]
 
     when:
     module.onRuntimeExec(cmd)
 
     then:
+    tracer.activeSpan() >> span
     if (expected != null) {
       1 * reporter.report(_, _) >> { args -> assertVulnerability(args[1] as Vulnerability, expected) }
     } else {
       0 * reporter.report(_, _)
     }
+
+    when:
+    module.onRuntimeExec(cmd)
+
+    then:
+    tracer.activeSpan() >> null
+    0 * reporter.report(_, _)
 
     where:
     command                    | expected
@@ -80,8 +99,42 @@ class CommandInjectionModuleTest extends IastModuleImplTestBase {
     ['==>ls<==', '==>-lah<=='] | '==>ls<== ==>-lah<=='
   }
 
-  private List<String> mapTaintedCommand(final List<String> command) {
-    return command.collect {
+  void 'iast module detect command injection on runtime exec (#env)'() {
+    setup:
+    final cmd = mapTaintedArray(command).toArray(new String[0]) as String[]
+    final environment = mapTaintedArray(env).toArray(new String[0]) as String[]
+
+    when:
+    module.onRuntimeExec(environment, cmd)
+
+    then:
+    tracer.activeSpan() >> span
+    if (expected != null) {
+      1 * reporter.report(_, _) >> { args -> assertVulnerability(args[1] as Vulnerability, expected) }
+    } else {
+      0 * reporter.report(_, _)
+    }
+
+    when:
+    module.onRuntimeExec(environment, cmd)
+
+    then:
+    tracer.activeSpan() >> null
+    0 * reporter.report(_, _)
+
+    where:
+    command              | env                                                             | expected
+    null                 | null                                                            | null
+    ['ls', '-lah']       | null                                                            | null
+    ['ls', '-lah']       | []                                                              | null
+    ['ls', '-lah']       | ['HAS_VULNERABILITY=false', 'JAVA_HOME=/home/java']             | null
+    ['ls', '-lah']       | ['HAS_VULNERABILITY=false', 'JAVA_HOME===>/home/java<==']       | 'HAS_VULNERABILITY=false JAVA_HOME===>/home/java<== ls -lah'
+    ['ls', '-lah']       | ['HAS_VULNERABILITY===>false<==', 'JAVA_HOME===>/home/java<=='] | 'HAS_VULNERABILITY===>false<== JAVA_HOME===>/home/java<== ls -lah'
+    ['==>ls<==', '-lah'] | ['HAS_VULNERABILITY===>false<==', 'JAVA_HOME===>/home/java<=='] | 'HAS_VULNERABILITY===>false<== JAVA_HOME===>/home/java<== ==>ls<== -lah'
+  }
+
+  private List<String> mapTaintedArray(final List<String> array) {
+    return array.collect {
       final item = addFromTaintFormat(ctx.taintedObjects, it)
       objectHolder.add(item)
       return item

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/NonBlockingSemaphoreTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/NonBlockingSemaphoreTest.groovy
@@ -1,12 +1,14 @@
 package com.datadog.iast.util
 
 import datadog.trace.test.util.DDSpecification
+import groovy.transform.CompileDynamic
 
 import java.util.concurrent.Callable
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
+@CompileDynamic
 class NonBlockingSemaphoreTest extends DDSpecification {
 
   void 'test that the semaphore controls access to a shared resource (#permitCount)'(final int permitCount) {
@@ -89,5 +91,30 @@ class NonBlockingSemaphoreTest extends DDSpecification {
     permitCount | _
     1           | _
     2           | _
+  }
+
+  void 'unlimited semaphore is always available'() {
+    given:
+    final int threads = 100
+    final semaphore = NonBlockingSemaphore.unlimited()
+    final latch = new CountDownLatch(threads)
+    final executors = Executors.newFixedThreadPool(threads)
+
+    when:
+    final acquired = (1..threads).collect {
+      executors.submit({
+        latch.countDown()
+        if (semaphore.acquire()) {
+          TimeUnit.MILLISECONDS.sleep(100)
+          semaphore.release()
+          return 1
+        }
+        return 0
+      } as Callable<Integer>)
+    }.collect { it.get() }.sum()
+
+    then:
+    acquired == threads
+    semaphore.available() == Integer.MAX_VALUE
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
+++ b/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
@@ -247,6 +247,8 @@
 2 org.springframework.instrument.*
 2 org.springframework.jca.*
 2 org.springframework.jdbc.*
+# Need for IAST (Update when JdbcTemplate call sites are ready)
+0 org.springframework.jdbc.core.JdbcTemplate$*
 2 org.springframework.jms.*
 0 org.springframework.jms.listener.*
 2 org.springframework.jmx.*
@@ -256,6 +258,7 @@
 2 org.springframework.objenesis.*
 2 org.springframework.orm.*
 2 org.springframework.remoting.*
+0 org.springframework.samples.*
 2 org.springframework.scripting.*
 2 org.springframework.stereotype.*
 2 org.springframework.transaction.*

--- a/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
@@ -56,9 +56,10 @@
 1 com.esotericsoftware.kryo.*
 1 com.fasterxml.*
 #Need for JsonFactoryCallSite.createParser()
-0 com.fasterxml.jackson.databind.ObjectMapper
+2 com.fasterxml.jackson.databind.ObjectMapper
 1 com.filenet.*
 1 com.github.benmanes.caffeine.*
+1 com.github.jknack.handlebars.*
 1 com.google.*
 1 com.googlecode.*
 1 com.hazelcast.*
@@ -127,6 +128,7 @@
 1 org.apache.*
 1 org.apiguardian.*
 1 org.aspectj.*
+1 org.attoparser.*
 1 org.bson.*
 1 org.clojure.*
 1 org.codehaus.*
@@ -174,13 +176,15 @@
 1 org.renjin.*
 1 org.slf4j.*
 1 org.springdoc.*
-# https://github.com/spring-projects/spring-petclinic
 1 org.springframework.*
-0 org.springframework.web.context.request.*
+# Update when JdbcTemplate call sites are ready
+2 org.springframework.jdbc.core.JdbcTemplate$*
+# https://github.com/spring-projects/spring-petclinic
 0 org.springframework.samples.*
-0 org.springframework.web.util.WebUtils
-#Need for ServletRequestCallSite.getInputStream()
-0 org.springframework.http.server.*
+2 org.springframework.web.context.request.*
+2 org.springframework.web.util.WebUtils
+# Need for ServletRequestCallSite.getInputStream()
+2 org.springframework.http.server.*
 1 org.synchronoss.*
 1 org.terracotta.*
 1 org.testcontainers.*

--- a/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/FileOutputStreamCallSite.java
+++ b/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/FileOutputStreamCallSite.java
@@ -13,7 +13,8 @@ import javax.annotation.Nullable;
 public class FileOutputStreamCallSite {
 
   @CallSite.Before("void java.io.FileOutputStream.<init>(java.lang.String)")
-  public static void beforeConstructor(@CallSite.Argument @Nullable final String path) {
+  @CallSite.Before("void java.io.FileOutputStream.<init>(java.lang.String, boolean)")
+  public static void beforeConstructor(@CallSite.Argument(0) @Nullable final String path) {
     if (path != null) {
       final PathTraversalModule module = InstrumentationBridge.PATH_TRAVERSAL;
       if (module != null) {

--- a/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/FileOutputStreamCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/FileOutputStreamCallSiteTest.groovy
@@ -3,7 +3,9 @@ package datadog.trace.instrumentation.java.io
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.sink.PathTraversalModule
 import foo.bar.TestFileOutputStreamSuite
+import groovy.transform.CompileDynamic
 
+@CompileDynamic
 class FileOutputStreamCallSiteTest extends BaseIoCallSiteTest {
 
   def 'test new file input stream with path'() {
@@ -14,6 +16,20 @@ class FileOutputStreamCallSiteTest extends BaseIoCallSiteTest {
 
     when:
     TestFileOutputStreamSuite.newFileOutputStream(path)
+
+    then:
+    1 * iastModule.onPathTraversal(path)
+    0 * _
+  }
+
+  void 'test new file input stream with path and append'() {
+    setup:
+    PathTraversalModule iastModule = Mock(PathTraversalModule)
+    InstrumentationBridge.registerIastModule(iastModule)
+    final path = newFile('test.txt').toString()
+
+    when:
+    TestFileOutputStreamSuite.newFileOutputStream(path, false)
 
     then:
     1 * iastModule.onPathTraversal(path)

--- a/dd-java-agent/instrumentation/java-io/src/test/java/foo/bar/TestFileOutputStreamSuite.java
+++ b/dd-java-agent/instrumentation/java-io/src/test/java/foo/bar/TestFileOutputStreamSuite.java
@@ -9,4 +9,9 @@ public class TestFileOutputStreamSuite {
       throws FileNotFoundException {
     return new FileOutputStream(path);
   }
+
+  public static FileOutputStream newFileOutputStream(final String path, final boolean append)
+      throws FileNotFoundException {
+    return new FileOutputStream(path, append);
+  }
 }

--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/RuntimeCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/RuntimeCallSite.java
@@ -9,7 +9,6 @@ import datadog.trace.api.iast.sink.CommandInjectionModule;
 import java.io.File;
 import javax.annotation.Nullable;
 
-// TODO deal with the environment
 @Sink(VulnerabilityTypes.COMMAND_INJECTION)
 @CallSite(spi = IastAdvice.class)
 public class RuntimeCallSite {
@@ -50,7 +49,7 @@ public class RuntimeCallSite {
       final CommandInjectionModule module = InstrumentationBridge.COMMAND_INJECTION;
       if (module != null) {
         try {
-          module.onRuntimeExec(command);
+          module.onRuntimeExec(envp, command);
         } catch (final Throwable e) {
           module.onUnexpectedException("beforeExec threw", e);
         }
@@ -67,7 +66,7 @@ public class RuntimeCallSite {
       final CommandInjectionModule module = InstrumentationBridge.COMMAND_INJECTION;
       if (module != null) {
         try {
-          module.onRuntimeExec(cmdArray);
+          module.onRuntimeExec(envp, cmdArray);
         } catch (final Throwable e) {
           module.onUnexpectedException("beforeExec threw", e);
         }
@@ -85,7 +84,7 @@ public class RuntimeCallSite {
       final CommandInjectionModule module = InstrumentationBridge.COMMAND_INJECTION;
       if (module != null) {
         try {
-          module.onRuntimeExec(command);
+          module.onRuntimeExec(envp, command);
         } catch (final Throwable e) {
           module.onUnexpectedException("beforeExec threw", e);
         }
@@ -103,7 +102,7 @@ public class RuntimeCallSite {
       final CommandInjectionModule module = InstrumentationBridge.COMMAND_INJECTION;
       if (module != null) {
         try {
-          module.onRuntimeExec(cmdArray);
+          module.onRuntimeExec(envp, cmdArray);
         } catch (final Throwable e) {
           module.onUnexpectedException("beforeExec threw", e);
         }

--- a/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/RuntimeCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/RuntimeCallSiteTest.groovy
@@ -4,7 +4,9 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.sink.CommandInjectionModule
 import foo.bar.TestRuntimeSuite
+import groovy.transform.CompileDynamic
 
+@CompileDynamic
 class RuntimeCallSiteTest extends AgentTestRunner {
 
   @Override
@@ -40,7 +42,7 @@ class RuntimeCallSiteTest extends AgentTestRunner {
     new TestRuntimeSuite(runtime).exec(command, env)
 
     then:
-    1 * iastModule.onRuntimeExec(command)
+    1 * iastModule.onRuntimeExec(env, command)
     1 * runtime.exec(command, env)
     0 * _
   }
@@ -73,7 +75,7 @@ class RuntimeCallSiteTest extends AgentTestRunner {
     new TestRuntimeSuite(runtime).exec(command, env)
 
     then:
-    1 * iastModule.onRuntimeExec(command)
+    1 * iastModule.onRuntimeExec(env, command)
     1 * runtime.exec(command, env)
     0 * _
   }
@@ -91,7 +93,7 @@ class RuntimeCallSiteTest extends AgentTestRunner {
     new TestRuntimeSuite(runtime).exec(command, env, file)
 
     then:
-    1 * iastModule.onRuntimeExec(command)
+    1 * iastModule.onRuntimeExec(env, command)
     1 * runtime.exec(command, env, file)
     0 * _
   }
@@ -109,7 +111,7 @@ class RuntimeCallSiteTest extends AgentTestRunner {
     new TestRuntimeSuite(runtime).exec(command, env, file)
 
     then:
-    1 * iastModule.onRuntimeExec(command)
+    1 * iastModule.onRuntimeExec(env, command)
     1 * runtime.exec(command, env, file)
     0 * _
   }

--- a/dd-java-agent/instrumentation/javax-naming/src/main/java/datadog/trace/instrumentation/javax/naming/DirContextCallSite.java
+++ b/dd-java-agent/instrumentation/javax-naming/src/main/java/datadog/trace/instrumentation/javax/naming/DirContextCallSite.java
@@ -13,8 +13,11 @@ import javax.naming.directory.SearchControls;
 
 @Sink(VulnerabilityTypes.LDAP_INJECTION)
 @CallSite(spi = IastAdvice.class)
-public class InitialDirContextCallSite {
+// TODO add javax.naming.ldap.InitialLdapContext
+public class DirContextCallSite {
 
+  @CallSite.Before(
+      "javax.naming.NamingEnumeration javax.naming.directory.DirContext.search(java.lang.String, java.lang.String, javax.naming.directory.SearchControls)")
   @CallSite.Before(
       "javax.naming.NamingEnumeration javax.naming.directory.InitialDirContext.search(java.lang.String, java.lang.String, javax.naming.directory.SearchControls)")
   public static void beforeSearch(
@@ -24,6 +27,8 @@ public class InitialDirContextCallSite {
     onDirContextSearch(name, filter, null);
   }
 
+  @CallSite.Before(
+      "javax.naming.NamingEnumeration javax.naming.directory.DirContext.search(java.lang.String, java.lang.String, java.lang.Object[], javax.naming.directory.SearchControls)")
   @CallSite.Before(
       "javax.naming.NamingEnumeration javax.naming.directory.InitialDirContext.search(java.lang.String, java.lang.String, java.lang.Object[], javax.naming.directory.SearchControls)")
   public static void beforeSearch(
@@ -35,6 +40,8 @@ public class InitialDirContextCallSite {
   }
 
   @CallSite.Before(
+      "javax.naming.NamingEnumeration javax.naming.directory.DirContext.search(javax.naming.Name, java.lang.String, javax.naming.directory.SearchControls)")
+  @CallSite.Before(
       "javax.naming.NamingEnumeration javax.naming.directory.InitialDirContext.search(javax.naming.Name, java.lang.String, javax.naming.directory.SearchControls)")
   public static void beforeSearch(
       @CallSite.Argument @Nullable final Name name,
@@ -43,6 +50,8 @@ public class InitialDirContextCallSite {
     onDirContextSearch(null, filter, null);
   }
 
+  @CallSite.Before(
+      "javax.naming.NamingEnumeration javax.naming.directory.DirContext.search(javax.naming.Name, java.lang.String, java.lang.Object[], javax.naming.directory.SearchControls)")
   @CallSite.Before(
       "javax.naming.NamingEnumeration javax.naming.directory.InitialDirContext.search(javax.naming.Name, java.lang.String, java.lang.Object[], javax.naming.directory.SearchControls)")
   public static void beforeSearch(

--- a/dd-java-agent/instrumentation/javax-naming/src/test/groovy/DirContextCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/javax-naming/src/test/groovy/DirContextCallSiteTest.groovy
@@ -1,18 +1,20 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.sink.LdapInjectionModule
+import foo.bar.TestDirContextSuite
 import foo.bar.TestInitialDirContextSuite
+import groovy.transform.CompileDynamic
 
 import javax.naming.Name
 import javax.naming.directory.InitialDirContext
 import javax.naming.directory.SearchControls
 
-class InitialDirContextCallSiteTest extends AgentTestRunner {
-
+@CompileDynamic
+class DirContextCallSiteTest extends AgentTestRunner {
 
   @Override
   protected void configurePreAgent() {
-    injectSysConfig("dd.iast.enabled", "true")
+    injectSysConfig('dd.iast.enabled', 'true')
   }
 
 
@@ -23,16 +25,22 @@ class InitialDirContextCallSiteTest extends AgentTestRunner {
     final cons = Mock(SearchControls)
     final initialDirContext = Mock(InitialDirContext)
     initialDirContext.search(name, filter, cons) >> null
+    final suite = suiteBuilder.call(initialDirContext)
     final iastModule = Mock(LdapInjectionModule)
     InstrumentationBridge.registerIastModule(iastModule)
 
     when:
-    new TestInitialDirContextSuite(initialDirContext).search(name, filter, cons)
+    suite.search(name, filter, cons)
 
     then:
     1 * iastModule.onDirContextSearch(name, filter, null)
     1 * initialDirContext.search(name, filter, cons)
     0 * _
+
+    where:
+    _ | suiteBuilder
+    _ | { InitialDirContext ctx -> new TestDirContextSuite(ctx) }
+    _ | { InitialDirContext ctx -> new TestInitialDirContextSuite(ctx) }
   }
 
   def 'test search(Name, String, SearchControls)'() {
@@ -42,16 +50,22 @@ class InitialDirContextCallSiteTest extends AgentTestRunner {
     final cons = Mock(SearchControls)
     final initialDirContext = Mock(InitialDirContext)
     initialDirContext.search(name, filter, cons) >> null
+    final suite = suiteBuilder.call(initialDirContext)
     final iastModule = Mock(LdapInjectionModule)
     InstrumentationBridge.registerIastModule(iastModule)
 
     when:
-    new TestInitialDirContextSuite(initialDirContext).search(name, filter, cons)
+    suite.search(name, filter, cons)
 
     then:
     1 * iastModule.onDirContextSearch(null, filter, null)
     1 * initialDirContext.search(name, filter, cons)
     0 * _
+
+    where:
+    _ | suiteBuilder
+    _ | { InitialDirContext ctx -> new TestDirContextSuite(ctx) }
+    _ | { InitialDirContext ctx -> new TestInitialDirContextSuite(ctx) }
   }
 
   def 'test search(String, String, Object[], SearchControls)'() {
@@ -62,16 +76,22 @@ class InitialDirContextCallSiteTest extends AgentTestRunner {
     final cons = Mock(SearchControls)
     final initialDirContext = Mock(InitialDirContext)
     initialDirContext.search(name, filter, args, cons) >> null
+    final suite = suiteBuilder.call(initialDirContext)
     final iastModule = Mock(LdapInjectionModule)
     InstrumentationBridge.registerIastModule(iastModule)
 
     when:
-    new TestInitialDirContextSuite(initialDirContext).search(name, filter, args, cons)
+    suite.search(name, filter, args, cons)
 
     then:
     1 * iastModule.onDirContextSearch(name, filter, args)
     1 * initialDirContext.search(name, filter, args, cons)
     0 * _
+
+    where:
+    _ | suiteBuilder
+    _ | { InitialDirContext ctx -> new TestDirContextSuite(ctx) }
+    _ | { InitialDirContext ctx -> new TestInitialDirContextSuite(ctx) }
   }
 
   def 'test search(Name, String, Object[], SearchControls)'() {
@@ -82,15 +102,21 @@ class InitialDirContextCallSiteTest extends AgentTestRunner {
     final cons = Mock(SearchControls)
     final initialDirContext = Mock(InitialDirContext)
     initialDirContext.search(name, filter, args, cons) >> null
+    final suite = suiteBuilder.call(initialDirContext)
     final iastModule = Mock(LdapInjectionModule)
     InstrumentationBridge.registerIastModule(iastModule)
 
     when:
-    new TestInitialDirContextSuite(initialDirContext).search(name, filter, args, cons)
+    suite.search(name, filter, args, cons)
 
     then:
     1 * iastModule.onDirContextSearch(null, filter, args)
     1 * initialDirContext.search(name, filter, args, cons)
     0 * _
+
+    where:
+    _ | suiteBuilder
+    _ | { InitialDirContext ctx -> new TestDirContextSuite(ctx) }
+    _ | { InitialDirContext ctx -> new TestInitialDirContextSuite(ctx) }
   }
 }

--- a/dd-java-agent/instrumentation/javax-naming/src/test/java/foo/bar/DirContextSuite.java
+++ b/dd-java-agent/instrumentation/javax-naming/src/test/java/foo/bar/DirContextSuite.java
@@ -1,0 +1,24 @@
+package foo.bar;
+
+import javax.naming.Name;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+
+public interface DirContextSuite {
+
+  NamingEnumeration<SearchResult> search(
+      final String name, final String filter, final SearchControls cons) throws NamingException;
+
+  NamingEnumeration<SearchResult> search(
+      final Name name, final String filter, final SearchControls cons) throws NamingException;
+
+  NamingEnumeration<SearchResult> search(
+      final String name, final String filter, final Object[] args, final SearchControls cons)
+      throws NamingException;
+
+  NamingEnumeration<SearchResult> search(
+      final Name name, final String filter, final Object[] args, final SearchControls cons)
+      throws NamingException;
+}

--- a/dd-java-agent/instrumentation/javax-naming/src/test/java/foo/bar/TestDirContextSuite.java
+++ b/dd-java-agent/instrumentation/javax-naming/src/test/java/foo/bar/TestDirContextSuite.java
@@ -3,37 +3,37 @@ package foo.bar;
 import javax.naming.Name;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
-import javax.naming.directory.InitialDirContext;
+import javax.naming.directory.DirContext;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TestInitialDirContextSuite implements DirContextSuite {
+public class TestDirContextSuite implements DirContextSuite {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TestInitialDirContextSuite.class);
 
-  private final InitialDirContext ctx;
+  private final DirContext ctx;
 
-  public TestInitialDirContextSuite(final InitialDirContext ctx) {
+  public TestDirContextSuite(final DirContext ctx) {
     this.ctx = ctx;
   }
 
   @Override
   public NamingEnumeration<SearchResult> search(
       final String name, final String filter, final SearchControls cons) throws NamingException {
-    LOGGER.debug("Before InitialDirContext search {} {} {}", name, filter, cons);
+    LOGGER.debug("Before DirContext search {} {} {}", name, filter, cons);
     final NamingEnumeration<SearchResult> result = ctx.search(name, filter, cons);
-    LOGGER.debug("After InitialDirContext search {}", result);
+    LOGGER.debug("After DirContext search {}", result);
     return result;
   }
 
   @Override
   public NamingEnumeration<SearchResult> search(
       final Name name, final String filter, final SearchControls cons) throws NamingException {
-    LOGGER.debug("Before InitialDirContext search {} {} {}", name, filter, cons);
+    LOGGER.debug("Before DirContext search {} {} {}", name, filter, cons);
     final NamingEnumeration<SearchResult> result = ctx.search(name, filter, cons);
-    LOGGER.debug("After InitialDirContext search {}", result);
+    LOGGER.debug("After DirContext search {}", result);
     return result;
   }
 
@@ -41,9 +41,9 @@ public class TestInitialDirContextSuite implements DirContextSuite {
   public NamingEnumeration<SearchResult> search(
       final String name, final String filter, final Object[] args, final SearchControls cons)
       throws NamingException {
-    LOGGER.debug("Before InitialDirContext search {} {} {} {}", name, filter, args, cons);
+    LOGGER.debug("Before DirContext search {} {} {} {}", name, filter, args, cons);
     final NamingEnumeration<SearchResult> result = ctx.search(name, filter, args, cons);
-    LOGGER.debug("After InitialDirContext search {}", result);
+    LOGGER.debug("After DirContext search {}", result);
     return result;
   }
 
@@ -51,9 +51,9 @@ public class TestInitialDirContextSuite implements DirContextSuite {
   public NamingEnumeration<SearchResult> search(
       final Name name, final String filter, final Object[] args, final SearchControls cons)
       throws NamingException {
-    LOGGER.debug("Before InitialDirContext search {} {} {} {}", name, filter, args, cons);
+    LOGGER.debug("Before DirContext search {} {} {} {}", name, filter, args, cons);
     final NamingEnumeration<SearchResult> result = ctx.search(name, filter, args, cons);
-    LOGGER.debug("After InitialDirContext search {}", result);
+    LOGGER.debug("After DirContext search {}", result);
     return result;
   }
 }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/IastStatementCallSite.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/IastStatementCallSite.java
@@ -11,6 +11,7 @@ import datadog.trace.api.iast.sink.SqlInjectionModule;
 @CallSite(spi = IastAdvice.class)
 public class IastStatementCallSite {
 
+  @CallSite.Before("void java.sql.Statement.addBatch(java.lang.String)")
   @CallSite.Before("java.sql.ResultSet java.sql.Statement.executeQuery(java.lang.String)")
   @CallSite.Before("int java.sql.Statement.executeUpdate(java.lang.String)")
   @CallSite.Before("boolean java.sql.Statement.execute(java.lang.String)")

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -93,7 +93,7 @@ public final class ConfigDefaults {
   static final String DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS =
       "^(?:PBEWITH(?:HMACSHA(?:2(?:24ANDAES_(?:128|256)|56ANDAES_(?:128|256))|384ANDAES_(?:128|256)|512ANDAES_(?:128|256)|1ANDAES_(?:128|256))|SHA1AND(?:RC(?:2_(?:128|40)|4_(?:128|40))|DESEDE)|MD5AND(?:TRIPLEDES|DES))|DES(?:EDE(?:WRAP)?)?|BLOWFISH|ARCFOUR|RC2).*$";
 
-  static final boolean DEFAULT_IAST_DEDUPLICATION_ENABLED = true;
+  public static final boolean DEFAULT_IAST_DEDUPLICATION_ENABLED = true;
 
   static final boolean DEFAULT_CIVISIBILITY_ENABLED = false;
   static final boolean DEFAULT_CIVISIBILITY_AGENTLESS_ENABLED = false;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/IastConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/IastConfig.java
@@ -12,6 +12,7 @@ public final class IastConfig {
   public static final String IAST_REQUEST_SAMPLING = "iast.request-sampling";
   public static final String IAST_DEDUPLICATION_ENABLED = "iast.deduplication.enabled";
   public static final String IAST_TELEMETRY_VERBOSITY = "iast.telemetry.verbosity";
+  public static final String IAST_DETECTION_MODE = "iast.detection.mode";
 
   private IastConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/IastDetectionMode.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/IastDetectionMode.java
@@ -1,0 +1,70 @@
+package datadog.trace.api.iast;
+
+import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_DEDUPLICATION_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_MAX_CONCURRENT_REQUESTS;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_REQUEST_SAMPLING;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_VULNERABILITIES_PER_REQUEST;
+import static datadog.trace.api.config.IastConfig.IAST_DEDUPLICATION_ENABLED;
+import static datadog.trace.api.config.IastConfig.IAST_MAX_CONCURRENT_REQUESTS;
+import static datadog.trace.api.config.IastConfig.IAST_REQUEST_SAMPLING;
+import static datadog.trace.api.config.IastConfig.IAST_VULNERABILITIES_PER_REQUEST;
+
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import javax.annotation.Nonnull;
+
+public enum IastDetectionMode {
+  FULL {
+    @Override
+    public int getIastMaxConcurrentRequests(@Nonnull final ConfigProvider config) {
+      return UNLIMITED;
+    }
+
+    @Override
+    public int getIastVulnerabilitiesPerRequest(@Nonnull final ConfigProvider config) {
+      return UNLIMITED;
+    }
+
+    @Override
+    public float getIastRequestSampling(@Nonnull final ConfigProvider config) {
+      return 100;
+    }
+
+    @Override
+    public boolean isIastDeduplicationEnabled(@Nonnull final ConfigProvider config) {
+      return false;
+    }
+  },
+
+  DEFAULT {
+    @Override
+    public int getIastMaxConcurrentRequests(@Nonnull final ConfigProvider config) {
+      return config.getInteger(IAST_MAX_CONCURRENT_REQUESTS, DEFAULT_IAST_MAX_CONCURRENT_REQUESTS);
+    }
+
+    @Override
+    public int getIastVulnerabilitiesPerRequest(@Nonnull final ConfigProvider config) {
+      return config.getInteger(
+          IAST_VULNERABILITIES_PER_REQUEST, DEFAULT_IAST_VULNERABILITIES_PER_REQUEST);
+    }
+
+    @Override
+    public float getIastRequestSampling(@Nonnull final ConfigProvider config) {
+      return config.getFloat(IAST_REQUEST_SAMPLING, DEFAULT_IAST_REQUEST_SAMPLING);
+    }
+
+    @Override
+    public boolean isIastDeduplicationEnabled(@Nonnull final ConfigProvider config) {
+      return config.getBoolean(IAST_DEDUPLICATION_ENABLED, DEFAULT_IAST_DEDUPLICATION_ENABLED);
+    }
+  };
+
+  public static final int UNLIMITED = Integer.MIN_VALUE;
+
+  public abstract int getIastMaxConcurrentRequests(@Nonnull ConfigProvider config);
+
+  public abstract int getIastVulnerabilitiesPerRequest(@Nonnull ConfigProvider config);
+
+  public abstract float getIastRequestSampling(@Nonnull ConfigProvider config);
+
+  public abstract boolean isIastDeduplicationEnabled(@Nonnull ConfigProvider config);
+}

--- a/internal-api/src/main/java/datadog/trace/api/iast/sink/CommandInjectionModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/sink/CommandInjectionModule.java
@@ -3,10 +3,13 @@ package datadog.trace.api.iast.sink;
 import datadog.trace.api.iast.IastModule;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public interface CommandInjectionModule extends IastModule {
 
   void onRuntimeExec(@Nonnull String... command);
+
+  void onRuntimeExec(@Nullable String[] env, @Nonnull String... command);
 
   void onProcessBuilderStart(@Nonnull List<String> command);
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/telemetry/IastTelemetryCollectorImpl.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/telemetry/IastTelemetryCollectorImpl.java
@@ -20,15 +20,17 @@ public class IastTelemetryCollectorImpl implements IastTelemetryCollector {
   }
 
   @Override
-  public void addMetric(final IastMetric metric, final long value, final String tag) {
-    getOrCreateHandler(metric).add(value, tag);
+  public boolean addMetric(final IastMetric metric, final long value, final String tag) {
+    return getOrCreateHandler(metric).add(value, tag);
   }
 
   @Override
-  public void merge(final Collection<MetricData> metrics) {
+  public boolean merge(final Collection<MetricData> metrics) {
+    boolean result = true;
     for (final MetricData data : metrics) {
-      getOrCreateHandler(data.getMetric()).merge(data);
+      result &= getOrCreateHandler(data.getMetric()).merge(data);
     }
+    return result;
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/api/iast/telemetry/NoOpTelemetryCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/telemetry/NoOpTelemetryCollector.java
@@ -7,10 +7,14 @@ import java.util.Collection;
 public class NoOpTelemetryCollector implements IastTelemetryCollector {
 
   @Override
-  public void addMetric(final IastMetric metric, final long value, final String tag) {}
+  public boolean addMetric(final IastMetric metric, final long value, final String tag) {
+    return true;
+  }
 
   @Override
-  public void merge(Collection<MetricData> metrics) {}
+  public boolean merge(Collection<MetricData> metrics) {
+    return true;
+  }
 
   @Override
   public Collection<MetricData> drainMetrics() {

--- a/internal-api/src/test/groovy/datadog/trace/api/iast/IastDetectionModeTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/iast/IastDetectionModeTest.groovy
@@ -1,0 +1,76 @@
+package datadog.trace.api.iast
+
+import datadog.trace.api.ConfigDefaults
+import datadog.trace.bootstrap.config.provider.ConfigProvider
+import groovy.transform.CompileDynamic
+import spock.lang.Specification
+
+import static datadog.trace.api.iast.IastDetectionMode.UNLIMITED
+
+@CompileDynamic
+class IastDetectionModeTest extends Specification {
+
+  void 'test max concurrent requests'() {
+    given:
+    final config = ConfigProvider.getInstance()
+
+    when:
+    final result = mode.getIastMaxConcurrentRequests(config)
+
+    then:
+    result == expected
+
+    where:
+    mode                      | expected
+    IastDetectionMode.FULL    | UNLIMITED
+    IastDetectionMode.DEFAULT | ConfigDefaults.DEFAULT_IAST_MAX_CONCURRENT_REQUESTS
+  }
+
+  void 'test vulnerabilities per requests'() {
+    given:
+    final config = ConfigProvider.getInstance()
+
+    when:
+    final result = mode.getIastVulnerabilitiesPerRequest(config)
+
+    then:
+    result == expected
+
+    where:
+    mode                      | expected
+    IastDetectionMode.FULL    | UNLIMITED
+    IastDetectionMode.DEFAULT | ConfigDefaults.DEFAULT_IAST_VULNERABILITIES_PER_REQUEST
+  }
+
+  void 'test sampling'() {
+    given:
+    final config = ConfigProvider.getInstance()
+
+    when:
+    final result = mode.getIastRequestSampling(config)
+
+    then:
+    result == expected
+
+    where:
+    mode                      | expected
+    IastDetectionMode.FULL    | 100
+    IastDetectionMode.DEFAULT | ConfigDefaults.DEFAULT_IAST_REQUEST_SAMPLING
+  }
+
+  void 'test deduplication'() {
+    given:
+    final config = ConfigProvider.getInstance()
+
+    when:
+    final result = mode.isIastDeduplicationEnabled(config)
+
+    then:
+    result == expected
+
+    where:
+    mode                      | expected
+    IastDetectionMode.FULL    | false
+    IastDetectionMode.DEFAULT | ConfigDefaults.DEFAULT_IAST_DEDUPLICATION_ENABLED
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/iast/telemetry/IastMetricHandlerTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/iast/telemetry/IastMetricHandlerTest.groovy
@@ -168,7 +168,7 @@ class IastMetricHandlerTest extends Specification {
     final value = 5
     final iastMetric = IastMetric.EXECUTED_PROPAGATION
     final delegate = Mock(IastTelemetryCollector)
-    final handler = new IastMetricHandler.DelegatingHandler(iastMetric, delegate)
+    final handler = IastMetricHandler.delegating(iastMetric, delegate)
 
     when:
     testHandler(handler, times, value)


### PR DESCRIPTION
# What Does This Do
* Adds a few missing call sites required for the OWASP benchmark.
* Improved command injection detection.
* Adds a new config property `-Ddd.iast.detection.mode=FULL` that removes sampling and all limits regarding vulnerabilities

# Motivation
We were missing some call sites in order to increase our current coverage in the OWASP benchmark, this PR adds some of them to increase the value.

# Additional Notes
