### PR TITLE
New mapping rule for adding trailing slash to the http resource path

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/http/AntPatternPathNormalizer.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/http/AntPatternPathNormalizer.java
@@ -16,6 +16,8 @@ final class AntPatternPathNormalizer extends PathNormalizer {
   /** Used to preserve original value as is when it's mapped to this value. */
   private static final String KEEP_AS_IS = "*";
 
+  private static final String ADD_TRAILING_SLASH = "*/";
+
   private final Map<String, String> resourceNameMatchers;
   private final AntPathMatcher matcher = new AntPathMatcher();
 
@@ -26,10 +28,16 @@ final class AntPatternPathNormalizer extends PathNormalizer {
         public String apply(String path) {
           for (Map.Entry<String, String> resourceNameMatcher : resourceNameMatchers.entrySet()) {
             if (matcher.match(resourceNameMatcher.getKey(), path)) {
-              if (KEEP_AS_IS.equals(resourceNameMatcher.getValue())) {
+              String value = resourceNameMatcher.getValue();
+              if (KEEP_AS_IS.equals(value)) {
                 return path;
+              } else if (ADD_TRAILING_SLASH.equals(value)) {
+                if (path.endsWith("/")) {
+                  return path;
+                }
+                return path + "/";
               }
-              return resourceNameMatcher.getValue();
+              return value;
             }
           }
           return null;

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/http/AntPatternPathNormalizerTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/http/AntPatternPathNormalizerTest.groovy
@@ -111,4 +111,24 @@ class AntPatternPathNormalizerTest extends DDSpecification {
     "/test/foo/bar/baz.html" | "/test/foo/bar/baz.html"
     "/dev/foo/bar/baz.html"  | "dev"
   }
+
+  def "add trailing slash"() {
+    given:
+    def matchers = [
+      "/test/**": "*/",
+    ]
+    AntPatternPathNormalizer normalizer = new AntPatternPathNormalizer(matchers)
+
+    when:
+    String result = normalizer.normalize(path)
+
+    then:
+    result == normalizedPath
+
+    where:
+    path         | normalizedPath
+    "/test/foo/" | "/test/foo/"
+    "/test/foo"  | "/test/foo/"
+    "/dev/foo"   | null
+  }
 }


### PR DESCRIPTION
# What Does This Do

Adds a path mapping rule to force adding trailing slash by adding a special mapping value `*/`.
With this change it's possible to define TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING and TRACE_HTTP_CLIENT_PATH_RESOURCE_NAME_MAPPING rules that will force adding a trailing slash if missing.
E.g. next rules will force adding trailing slash for all resource that match `/test/**`
```json
[
      "/test/**": "*/",
]
```
so, `/test/foo` will be changed to `/test/foo/`.

# Motivation

Datadog treats otherwise identical http path resources with and without a trailing slash as two different resource. This addition will help to instruct Java Tracer to group them into one resource.

# Additional Notes

FRAPMS-1972
