### PR TITLE
Fix spring-native smoke tests

### DIFF
--- a/dd-smoke-tests/spring-native/application/build.gradle
+++ b/dd-smoke-tests/spring-native/application/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'org.springframework.boot' version '2.7.1'
   id 'io.spring.dependency-management' version '1.0.12.RELEASE'
-  id 'org.springframework.experimental.aot' version '0.12.3-20230103.090922-1'
+  id 'org.springframework.experimental.aot' version '0.12.2'
   id 'java'
   id 'application'
 }
@@ -16,7 +16,7 @@ application {
 
 repositories {
   mavenCentral()
-  maven { url 'https://repo.spring.io/snapshot' }
+  maven { url 'https://repo.spring.io/milestone' }
 }
 
 dependencies {

--- a/dd-smoke-tests/spring-native/application/settings.gradle
+++ b/dd-smoke-tests/spring-native/application/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
   repositories {
     gradlePluginPortal()
-    maven { url 'https://repo.spring.io/snapshot' }
+    maven { url 'https://repo.spring.io/milestone' }
   }
 }
 


### PR DESCRIPTION
Switch over to Spring's `milestone` repository which now has a version of `org.springframework.experimental/spring-aot-gradle-plugin` we can use. This is just a temporary fix until we update these smoke tests to use the Spring 6 / Spring-Boot 3 native tooling.