### PR TITLE
Update client ip resolver

### DIFF
--- a/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
@@ -25,7 +25,7 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
     def request = new Request.Builder()
       .url(url)
       .addHeader("User-Agent", "Arachni/v1")
-      .addHeader("Forwarded", 'for="[::ffff:1.2.3.4]"')
+      .addHeader("X-Forwarded", 'for="[::ffff:1.2.3.4]"')
       .build()
     def response = client.newCall(request).execute()
     def responseBodyStr = response.body().string()

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -1,11 +1,13 @@
 package datadog.trace.core.propagation;
 
-import static datadog.trace.core.propagation.HttpCodec.CLIENT_IP_KEY;
+import static datadog.trace.core.propagation.HttpCodec.CF_CONNECTING_IP_KEY;
+import static datadog.trace.core.propagation.HttpCodec.CF_CONNECTING_IP_V6_KEY;
+import static datadog.trace.core.propagation.HttpCodec.FASTLY_CLIENT_IP_KEY;
 import static datadog.trace.core.propagation.HttpCodec.FORWARDED_FOR_KEY;
 import static datadog.trace.core.propagation.HttpCodec.FORWARDED_KEY;
 import static datadog.trace.core.propagation.HttpCodec.TRUE_CLIENT_IP_KEY;
 import static datadog.trace.core.propagation.HttpCodec.USER_AGENT_KEY;
-import static datadog.trace.core.propagation.HttpCodec.VIA_KEY;
+import static datadog.trace.core.propagation.HttpCodec.X_CLIENT_IP_KEY;
 import static datadog.trace.core.propagation.HttpCodec.X_CLUSTER_CLIENT_IP_KEY;
 import static datadog.trace.core.propagation.HttpCodec.X_FORWARDED_FOR_KEY;
 import static datadog.trace.core.propagation.HttpCodec.X_FORWARDED_HOST_KEY;
@@ -175,20 +177,27 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
         getHeaders().xRealIp = value;
         return true;
       }
-      if (CLIENT_IP_KEY.equalsIgnoreCase(key)) {
-        getHeaders().clientIp = value;
+      if (X_CLIENT_IP_KEY.equalsIgnoreCase(key)) {
+        getHeaders().xClientIp = value;
         return true;
       }
       if (TRUE_CLIENT_IP_KEY.equalsIgnoreCase(key)) {
         getHeaders().trueClientIp = value;
         return true;
       }
-    }
-
-    if (VIA_KEY.equalsIgnoreCase(key)) {
-      getHeaders().via = value;
+      if (FASTLY_CLIENT_IP_KEY.equalsIgnoreCase(key)) {
+        getHeaders().fastlyClientIp = value;
+        return true;
+      }
+      if (CF_CONNECTING_IP_KEY.equalsIgnoreCase(key)) {
+        getHeaders().cfConnectingIp = value;
+        return true;
+      }
+    } else if (CF_CONNECTING_IP_V6_KEY.equalsIgnoreCase(key)) {
+      getHeaders().cfConnectingIpv6 = value;
       return true;
     }
+
     return false;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -30,12 +30,14 @@ public class HttpCodec {
   static final String X_FORWARDED_PORT_KEY = "x-forwarded-port";
 
   // other headers which may contain real ip
-  static final String CLIENT_IP_KEY = "client-ip";
+  static final String X_CLIENT_IP_KEY = "x-client-ip";
   static final String TRUE_CLIENT_IP_KEY = "true-client-ip";
   static final String X_CLUSTER_CLIENT_IP_KEY = "x-cluster-client-ip";
   static final String X_REAL_IP_KEY = "x-real-ip";
   static final String USER_AGENT_KEY = "user-agent";
-  static final String VIA_KEY = "via";
+  static final String FASTLY_CLIENT_IP_KEY = "fastly-client-ip";
+  static final String CF_CONNECTING_IP_KEY = "cf-connecting-ip";
+  static final String CF_CONNECTING_IP_V6_KEY = "cf-connecting-ipv6";
 
   public interface Injector {
     <C> void inject(

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpExtractorTest.groovy
@@ -352,11 +352,13 @@ class B3HttpExtractorTest extends DDSpecification {
       (HttpCodec.USER_AGENT_KEY): 'some-user-agent',
       (HttpCodec.X_CLUSTER_CLIENT_IP_KEY): '1.1.1.1',
       (HttpCodec.X_REAL_IP_KEY): '2.2.2.2',
-      (HttpCodec.CLIENT_IP_KEY): '3.3.3.3',
+      (HttpCodec.X_CLIENT_IP_KEY): '3.3.3.3',
       (HttpCodec.TRUE_CLIENT_IP_KEY): '4.4.4.4',
-      (HttpCodec.VIA_KEY): '5.5.5.5',
-      (HttpCodec.FORWARDED_FOR_KEY): '6.6.6.6',
-      (HttpCodec.X_FORWARDED_KEY): '7.7.7.7'
+      (HttpCodec.FORWARDED_FOR_KEY): '5.5.5.5',
+      (HttpCodec.X_FORWARDED_KEY): '6.6.6.6',
+      (HttpCodec.FASTLY_CLIENT_IP_KEY): '7.7.7.7',
+      (HttpCodec.CF_CONNECTING_IP_KEY): '8.8.8.8',
+      (HttpCodec.CF_CONNECTING_IP_V6_KEY): '9.9.9.9',
     ]
 
     when:
@@ -366,10 +368,12 @@ class B3HttpExtractorTest extends DDSpecification {
     assert context.userAgent == 'some-user-agent'
     assert context.XClusterClientIp == '1.1.1.1'
     assert context.XRealIp == '2.2.2.2'
-    assert context.clientIp == '3.3.3.3'
+    assert context.XClientIp == '3.3.3.3'
     assert context.trueClientIp == '4.4.4.4'
-    assert context.via == '5.5.5.5'
-    assert context.forwardedFor == '6.6.6.6'
-    assert context.XForwarded == '7.7.7.7'
+    assert context.forwardedFor == '5.5.5.5'
+    assert context.XForwarded == '6.6.6.6'
+    assert context.fastlyClientIp == '7.7.7.7'
+    assert context.cfConnectingIp == '8.8.8.8'
+    assert context.cfConnectingIpv6 == '9.9.9.9'
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpExtractorTest.groovy
@@ -383,11 +383,13 @@ class DatadogHttpExtractorTest extends DDSpecification {
       (HttpCodec.USER_AGENT_KEY): 'some-user-agent',
       (HttpCodec.X_CLUSTER_CLIENT_IP_KEY): '1.1.1.1',
       (HttpCodec.X_REAL_IP_KEY): '2.2.2.2',
-      (HttpCodec.CLIENT_IP_KEY): '3.3.3.3',
+      (HttpCodec.X_CLIENT_IP_KEY): '3.3.3.3',
       (HttpCodec.TRUE_CLIENT_IP_KEY): '4.4.4.4',
-      (HttpCodec.VIA_KEY): '5.5.5.5',
-      (HttpCodec.FORWARDED_FOR_KEY): '6.6.6.6',
-      (HttpCodec.X_FORWARDED_KEY): '7.7.7.7'
+      (HttpCodec.FORWARDED_FOR_KEY): '5.5.5.5',
+      (HttpCodec.X_FORWARDED_KEY): '6.6.6.6',
+      (HttpCodec.FASTLY_CLIENT_IP_KEY): '7.7.7.7',
+      (HttpCodec.CF_CONNECTING_IP_KEY): '8.8.8.8',
+      (HttpCodec.CF_CONNECTING_IP_V6_KEY): '9.9.9.9',
     ]
 
     when:
@@ -397,10 +399,12 @@ class DatadogHttpExtractorTest extends DDSpecification {
     assert context.userAgent == 'some-user-agent'
     assert context.XClusterClientIp == '1.1.1.1'
     assert context.XRealIp == '2.2.2.2'
-    assert context.clientIp == '3.3.3.3'
+    assert context.XClientIp == '3.3.3.3'
     assert context.trueClientIp == '4.4.4.4'
-    assert context.via == '5.5.5.5'
-    assert context.forwardedFor == '6.6.6.6'
-    assert context.XForwarded == '7.7.7.7'
+    assert context.forwardedFor == '5.5.5.5'
+    assert context.XForwarded == '6.6.6.6'
+    assert context.fastlyClientIp == '7.7.7.7'
+    assert context.cfConnectingIp == '8.8.8.8'
+    assert context.cfConnectingIpv6 == '9.9.9.9'
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
@@ -289,11 +289,13 @@ class HaystackHttpExtractorTest extends DDSpecification {
       (HttpCodec.USER_AGENT_KEY): 'some-user-agent',
       (HttpCodec.X_CLUSTER_CLIENT_IP_KEY): '1.1.1.1',
       (HttpCodec.X_REAL_IP_KEY): '2.2.2.2',
-      (HttpCodec.CLIENT_IP_KEY): '3.3.3.3',
+      (HttpCodec.X_CLIENT_IP_KEY): '3.3.3.3',
       (HttpCodec.TRUE_CLIENT_IP_KEY): '4.4.4.4',
-      (HttpCodec.VIA_KEY): '5.5.5.5',
-      (HttpCodec.FORWARDED_FOR_KEY): '6.6.6.6',
-      (HttpCodec.X_FORWARDED_KEY): '7.7.7.7'
+      (HttpCodec.FORWARDED_FOR_KEY): '5.5.5.5',
+      (HttpCodec.X_FORWARDED_KEY): '6.6.6.6',
+      (HttpCodec.FASTLY_CLIENT_IP_KEY): '7.7.7.7',
+      (HttpCodec.CF_CONNECTING_IP_KEY): '8.8.8.8',
+      (HttpCodec.CF_CONNECTING_IP_V6_KEY): '9.9.9.9',
     ]
 
     when:
@@ -303,10 +305,12 @@ class HaystackHttpExtractorTest extends DDSpecification {
     assert context.userAgent == 'some-user-agent'
     assert context.XClusterClientIp == '1.1.1.1'
     assert context.XRealIp == '2.2.2.2'
-    assert context.clientIp == '3.3.3.3'
+    assert context.XClientIp == '3.3.3.3'
     assert context.trueClientIp == '4.4.4.4'
-    assert context.via == '5.5.5.5'
-    assert context.forwardedFor == '6.6.6.6'
-    assert context.XForwarded == '7.7.7.7'
+    assert context.forwardedFor == '5.5.5.5'
+    assert context.XForwarded == '6.6.6.6'
+    assert context.fastlyClientIp == '7.7.7.7'
+    assert context.cfConnectingIp == '8.8.8.8'
+    assert context.cfConnectingIpv6 == '9.9.9.9'
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/W3CHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/W3CHttpExtractorTest.groovy
@@ -355,11 +355,13 @@ class W3CHttpExtractorTest extends DDSpecification {
       (HttpCodec.USER_AGENT_KEY): 'some-user-agent',
       (HttpCodec.X_CLUSTER_CLIENT_IP_KEY): '1.1.1.1',
       (HttpCodec.X_REAL_IP_KEY): '2.2.2.2',
-      (HttpCodec.CLIENT_IP_KEY): '3.3.3.3',
+      (HttpCodec.X_CLIENT_IP_KEY): '3.3.3.3',
       (HttpCodec.TRUE_CLIENT_IP_KEY): '4.4.4.4',
-      (HttpCodec.VIA_KEY): '5.5.5.5',
-      (HttpCodec.FORWARDED_FOR_KEY): '6.6.6.6',
-      (HttpCodec.X_FORWARDED_KEY): '7.7.7.7'
+      (HttpCodec.FORWARDED_FOR_KEY): '5.5.5.5',
+      (HttpCodec.X_FORWARDED_KEY): '6.6.6.6',
+      (HttpCodec.FASTLY_CLIENT_IP_KEY): '7.7.7.7',
+      (HttpCodec.CF_CONNECTING_IP_KEY): '8.8.8.8',
+      (HttpCodec.CF_CONNECTING_IP_V6_KEY): '9.9.9.9',
     ]
 
     when:
@@ -369,10 +371,12 @@ class W3CHttpExtractorTest extends DDSpecification {
     assert context.userAgent == 'some-user-agent'
     assert context.XClusterClientIp == '1.1.1.1'
     assert context.XRealIp == '2.2.2.2'
-    assert context.clientIp == '3.3.3.3'
+    assert context.XClientIp == '3.3.3.3'
     assert context.trueClientIp == '4.4.4.4'
-    assert context.via == '5.5.5.5'
-    assert context.forwardedFor == '6.6.6.6'
-    assert context.XForwarded == '7.7.7.7'
+    assert context.forwardedFor == '5.5.5.5'
+    assert context.XForwarded == '6.6.6.6'
+    assert context.fastlyClientIp == '7.7.7.7'
+    assert context.cfConnectingIp == '8.8.8.8'
+    assert context.cfConnectingIpv6 == '9.9.9.9'
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/XRayHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/XRayHttpExtractorTest.groovy
@@ -244,11 +244,13 @@ class XRayHttpExtractorTest extends DDSpecification {
       (HttpCodec.USER_AGENT_KEY): 'some-user-agent',
       (HttpCodec.X_CLUSTER_CLIENT_IP_KEY): '1.1.1.1',
       (HttpCodec.X_REAL_IP_KEY): '2.2.2.2',
-      (HttpCodec.CLIENT_IP_KEY): '3.3.3.3',
+      (HttpCodec.X_CLIENT_IP_KEY): '3.3.3.3',
       (HttpCodec.TRUE_CLIENT_IP_KEY): '4.4.4.4',
-      (HttpCodec.VIA_KEY): '5.5.5.5',
-      (HttpCodec.FORWARDED_FOR_KEY): '6.6.6.6',
-      (HttpCodec.X_FORWARDED_KEY): '7.7.7.7'
+      (HttpCodec.FORWARDED_FOR_KEY): '5.5.5.5',
+      (HttpCodec.X_FORWARDED_KEY): '6.6.6.6',
+      (HttpCodec.FASTLY_CLIENT_IP_KEY): '7.7.7.7',
+      (HttpCodec.CF_CONNECTING_IP_KEY): '8.8.8.8',
+      (HttpCodec.CF_CONNECTING_IP_V6_KEY): '9.9.9.9',
     ]
 
     when:
@@ -258,10 +260,12 @@ class XRayHttpExtractorTest extends DDSpecification {
     assert context.userAgent == 'some-user-agent'
     assert context.XClusterClientIp == '1.1.1.1'
     assert context.XRealIp == '2.2.2.2'
-    assert context.clientIp == '3.3.3.3'
+    assert context.XClientIp == '3.3.3.3'
     assert context.trueClientIp == '4.4.4.4'
-    assert context.via == '5.5.5.5'
-    assert context.forwardedFor == '6.6.6.6'
-    assert context.XForwarded == '7.7.7.7'
+    assert context.forwardedFor == '5.5.5.5'
+    assert context.XForwarded == '6.6.6.6'
+    assert context.fastlyClientIp == '7.7.7.7'
+    assert context.cfConnectingIp == '8.8.8.8'
+    assert context.cfConnectingIpv6 == '9.9.9.9'
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -142,6 +142,12 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo {
     interface Extracted extends Context {
       String getForwarded();
 
+      String getFastlyClientIp();
+
+      String getCfConnectingIp();
+
+      String getCfConnectingIpv6();
+
       String getXForwardedProto();
 
       String getXForwardedHost();
@@ -158,11 +164,9 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo {
 
       String getXRealIp();
 
-      String getClientIp();
+      String getXClientIp();
 
       String getUserAgent();
-
-      String getVia();
 
       String getTrueClientIp();
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -823,6 +823,21 @@ public class AgentTracer {
     }
 
     @Override
+    public String getFastlyClientIp() {
+      return null;
+    }
+
+    @Override
+    public String getCfConnectingIp() {
+      return null;
+    }
+
+    @Override
+    public String getCfConnectingIpv6() {
+      return null;
+    }
+
+    @Override
     public String getXForwardedProto() {
       return null;
     }
@@ -863,17 +878,12 @@ public class AgentTracer {
     }
 
     @Override
-    public String getClientIp() {
+    public String getXClientIp() {
       return null;
     }
 
     @Override
     public String getUserAgent() {
-      return null;
-    }
-
-    @Override
-    public String getVia() {
       return null;
     }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
@@ -54,6 +54,21 @@ public class TagContext implements AgentSpan.Context.Extracted {
   }
 
   @Override
+  public String getFastlyClientIp() {
+    return httpHeaders.fastlyClientIp;
+  }
+
+  @Override
+  public String getCfConnectingIp() {
+    return httpHeaders.cfConnectingIp;
+  }
+
+  @Override
+  public String getCfConnectingIpv6() {
+    return httpHeaders.cfConnectingIpv6;
+  }
+
+  @Override
   public String getXForwardedProto() {
     return httpHeaders.xForwardedProto;
   }
@@ -94,18 +109,13 @@ public class TagContext implements AgentSpan.Context.Extracted {
   }
 
   @Override
-  public String getClientIp() {
-    return httpHeaders.clientIp;
+  public String getXClientIp() {
+    return httpHeaders.xClientIp;
   }
 
   @Override
   public String getUserAgent() {
     return httpHeaders.userAgent;
-  }
-
-  @Override
-  public String getVia() {
-    return httpHeaders.via;
   }
 
   @Override
@@ -174,18 +184,20 @@ public class TagContext implements AgentSpan.Context.Extracted {
   }
 
   public static class HttpHeaders {
-    public String forwardedFor;
+    public String fastlyClientIp;
+    public String cfConnectingIp;
+    public String cfConnectingIpv6;
     public String xForwarded;
     public String forwarded;
     public String xForwardedProto;
     public String xForwardedHost;
     public String xForwardedPort;
     public String xForwardedFor;
+    public String forwardedFor;
     public String xClusterClientIp;
     public String xRealIp;
-    public String clientIp;
+    public String xClientIp;
     public String userAgent;
-    public String via;
     public String trueClientIp;
     public String customIpHeader;
   }


### PR DESCRIPTION
Update behavior to match the changes in the spec. The differences are:

* Forwarded and Via are not to be used anymore.
* Client-ip is changed to X-Client-Ip.
* Added Fast-client-ip, Cf-connecting-ip and Cf-connecting-ipv6
* We report only the first public ip found in the headers.
* We don't report that there are multiple tags presents anymore.
