### PR TITLE
Revert "Upgrade to jplib 0.22.0"

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -34,7 +34,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    jplib         : "0.22.0",
+    jplib         : "0.20.0",
     asm           : "9.4"
   ]
 


### PR DESCRIPTION
Reverts DataDog/dd-trace-java#4859

There are some changes I don't feel confident releasing in this upgrade