### PR TITLE
Add upper bound for kotlinx-coroutines-core

### DIFF
--- a/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.5/build.gradle
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.5/build.gradle
@@ -41,5 +41,5 @@ dependencies {
   testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$coroutinesVersion"
   testImplementation testFixtures(project(':dd-java-agent:instrumentation:kotlin-coroutines'))
 
-  latestDepTestImplementation group: 'org.jetbrains.kotlinx', name: "kotlinx-coroutines-core", version: '1.+'
+  latestDepTestImplementation group: 'org.jetbrains.kotlinx', name: "kotlinx-coroutines-core", version: '1.6.+'
 }


### PR DESCRIPTION


# What Does This Do

# Motivation
Currently breaks with 1.7-beta
# Additional Notes
