### PR TITLE
Use smoke build cache for check job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,9 +348,9 @@ jobs:
     steps:
       - setup_code
       - restore_dependency_cache:
-          cacheType: lib
+          cacheType: smoke
       - restore_build_cache:
-          cacheType: lib
+          cacheType: smoke
 
       - run:
           name: Check Project


### PR DESCRIPTION


# What Does This Do

# Motivation
This should have a better cache hit rate.
# Additional Notes
