### PR TITLE
Fix Java version parsing for pre-releases

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/Platform.java
+++ b/internal-api/src/main/java/datadog/trace/api/Platform.java
@@ -1,6 +1,5 @@
 package datadog.trace.api;
 
-import datadog.trace.util.Strings;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
@@ -103,7 +102,11 @@ public final class Platform {
   }
 
   private static Version parseJavaVersion(String javaVersion) {
-    javaVersion = Strings.replace(javaVersion, "-ea", "");
+    // Remove pre-release part, usually -ea
+    final int indexOfDash = javaVersion.indexOf('-');
+    if (indexOfDash >= 0) {
+      javaVersion = javaVersion.substring(0, indexOfDash);
+    }
 
     int major = 0;
     int minor = 0;

--- a/internal-api/src/test/groovy/datadog/trace/api/PlatformTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/PlatformTest.groovy
@@ -74,6 +74,7 @@ class PlatformTest extends DDSpecification {
     "16.0.1"    | 16    | 0     | 1
     "11.0.9.1+1"| 11    | 0     | 9
     "11.0.6+10" | 11    | 0     | 6
+    "17.0.4-x"  | 17    | 0     | 4
   }
 
   def "test parse #version is at least #major, #minor, and #update"() {


### PR DESCRIPTION
# What Does This Do
Removes any pre-release suffix before parsing versions.

# Motivation
We supported the -ea suffix, but according to the standard, it can be any string.

# Additional Notes
Solves https://github.com/DataDog/dd-trace-java/issues/4875
