### PR TITLE
Call site instrumentation for request#getQueryString()

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/SourceType.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/SourceType.java
@@ -18,6 +18,7 @@ public final class SourceType {
   public static final byte REQUEST_COOKIE_DOMAIN = 8;
   public static final byte REQUEST_COOKIE_PATH = 9;
   public static final byte REQUEST_BODY = 10;
+  public static final byte REQUEST_QUERY = 11;
 
   public static String toString(final byte sourceType) {
     switch (sourceType) {
@@ -41,6 +42,8 @@ public final class SourceType {
         return SourceTypes.REQUEST_COOKIE_PATH;
       case REQUEST_BODY:
         return SourceTypes.REQUEST_BODY;
+      case REQUEST_QUERY:
+        return SourceTypes.REQUEST_QUERY;
       default:
         return null;
     }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
@@ -145,4 +145,18 @@ public class WebModuleImpl implements WebModule {
     taintedObjects.taintInputString(
         cookieValue, new Source(SourceType.REQUEST_COOKIE_VALUE, cookieName, cookieValue));
   }
+
+  @Override
+  public void onQueryString(@Nullable final String queryString) {
+    if (!canBeTainted(queryString)) {
+      return;
+    }
+    final IastRequestContext ctx = IastRequestContext.get();
+    if (ctx == null) {
+      return;
+    }
+    final TaintedObjects taintedObjects = ctx.getTaintedObjects();
+    taintedObjects.taintInputString(
+        queryString, new Source(SourceType.REQUEST_QUERY, null, queryString));
+  }
 }

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
@@ -125,4 +125,20 @@ public class HttpServletRequestCallSite {
     }
     return cookies;
   }
+
+  @Source(SourceTypes.REQUEST_QUERY)
+  @CallSite.After("java.lang.String javax.servlet.http.HttpServletRequest.getQueryString()")
+  @CallSite.After("java.lang.String javax.servlet.http.HttpServletRequestWrapper.getQueryString()")
+  public static String afterGetQueryString(
+      @CallSite.This final HttpServletRequest self, @CallSite.Return final String queryString) {
+    final WebModule module = InstrumentationBridge.WEB;
+    if (module != null) {
+      try {
+        module.onQueryString(queryString);
+      } catch (final Throwable e) {
+        module.onUnexpectedException("afterGetQueryString threw", e);
+      }
+    }
+    return queryString;
+  }
 }

--- a/dd-java-agent/instrumentation/servlet/src/test/java/datadog/smoketest/controller/TestHttpServletRequestCallSiteSuite.java
+++ b/dd-java-agent/instrumentation/servlet/src/test/java/datadog/smoketest/controller/TestHttpServletRequestCallSiteSuite.java
@@ -27,4 +27,8 @@ public class TestHttpServletRequestCallSiteSuite {
   public Cookie[] getCookies() {
     return request.getCookies();
   }
+
+  public String getQueryString() {
+    return request.getQueryString();
+  }
 }

--- a/dd-smoke-tests/spring-boot-2.6-webmvc/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/spring-boot-2.6-webmvc/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -104,6 +104,11 @@ public class IastWebController {
         + testBean.getValue();
   }
 
+  @GetMapping("/query_string")
+  public String queryString(final HttpServletRequest request) {
+    return "QueryString is: " + request.getQueryString();
+  }
+
   private void withProcess(final Operation<Process> op) {
     Process process = null;
     try {

--- a/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -110,6 +110,11 @@ public class IastWebController {
         + testBean.getValue();
   }
 
+  @GetMapping("/query_string")
+  public String queryString(final HttpServletRequest request) {
+    return "QueryString is: " + request.getQueryString();
+  }
+
   private void withProcess(final Operation<Process> op) {
     Process process = null;
     try {

--- a/internal-api/src/main/java/datadog/trace/api/iast/model/SourceTypes.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/model/SourceTypes.java
@@ -14,4 +14,5 @@ public abstract class SourceTypes {
   public static final String REQUEST_COOKIE_DOMAIN = "http.request.cookie.domain";
   public static final String REQUEST_COOKIE_PATH = "http.request.cookie.path";
   public static final String REQUEST_BODY = "http.request.body";
+  public static final String REQUEST_QUERY = "http.request.query";
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
@@ -24,6 +24,8 @@ public interface WebModule extends IastModule {
 
   void onHeaderValue(@Nullable String headerName, @Nullable String headerValue);
 
+  void onQueryString(@Nullable String queryString);
+
   <COOKIE> void onCookies(@Nullable COOKIE[] cookies);
 
   <COOKIE> void onCookieGetter(


### PR DESCRIPTION
# What Does This Do
Add required call sites for the `HttpServletRequest#getQueryString()` method to taint the query string value.

# Motivation
The data coming from the `HttpServletRequest#getQueryString()` method is under the control of the user and should be considered as unstrusted.

# Additional Notes
