### PR TITLE
upgrade jplib to 0.24.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    jplib         : "0.20.0",
+    jplib         : "0.24.0",
     asm           : "9.4"
   ]
 


### PR DESCRIPTION
# What Does This Do

* Robust detection of ZGC load barrier
* Clear thread set when dumping the profile to avoid an ever growing thread constant pool when the application creates and renames lots of threads

# Motivation

# Additional Notes
