### PR TITLE
A setting to remove http resource name trailing slash

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -145,5 +145,7 @@ public final class ConfigDefaults {
 
   public static final int DEFAULT_TRACE_X_DATADOG_TAGS_MAX_LENGTH = 512;
 
+  static final boolean DEFAULT_TRACE_HTTP_RESOURCE_REMOVE_TRAILING_SLASH = false;
+
   private ConfigDefaults() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -52,6 +52,8 @@ public final class TracerConfig {
   public static final String REQUEST_HEADER_TAGS = "trace.request_header.tags";
   public static final String RESPONSE_HEADER_TAGS = "trace.response_header.tags";
   public static final String BAGGAGE_MAPPING = "trace.header.baggage";
+  public static final String TRACE_HTTP_RESOURCE_REMOVE_TRAILING_SLASH =
+      "trace.http.resource.remove-trailing-slash";
   public static final String TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING =
       "trace.http.server.path-resource-name-mapping";
   public static final String TRACE_HTTP_CLIENT_PATH_RESOURCE_NAME_MAPPING =

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -70,6 +70,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_TELEMETRY_HEARTBEAT_INTER
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_PORT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_V05_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_ANALYTICS_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_HTTP_RESOURCE_REMOVE_TRAILING_SLASH;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_RATE_LIMIT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_REPORT_HOSTNAME;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_RESOLVER_ENABLED;
@@ -283,6 +284,7 @@ import static datadog.trace.api.config.TracerConfig.TRACE_ANALYTICS_ENABLED;
 import static datadog.trace.api.config.TracerConfig.TRACE_CLIENT_IP_HEADER;
 import static datadog.trace.api.config.TracerConfig.TRACE_CLIENT_IP_RESOLVER_ENABLED;
 import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_CLIENT_PATH_RESOURCE_NAME_MAPPING;
+import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_RESOURCE_REMOVE_TRAILING_SLASH;
 import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING;
 import static datadog.trace.api.config.TracerConfig.TRACE_PROPAGATION_STYLE;
 import static datadog.trace.api.config.TracerConfig.TRACE_PROPAGATION_STYLE_EXTRACT;
@@ -428,6 +430,7 @@ public class Config {
   private final boolean httpServerRouteBasedNaming;
   private final Map<String, String> httpServerPathResourceNameMapping;
   private final Map<String, String> httpClientPathResourceNameMapping;
+  private final boolean httpResourceRemoveTrailingSlash;
   private final boolean httpClientTagQueryString;
   private final boolean httpClientSplitByDomain;
   private final boolean dbClientSplitByInstance;
@@ -834,6 +837,11 @@ public class Config {
 
     httpClientPathResourceNameMapping =
         configProvider.getOrderedMap(TRACE_HTTP_CLIENT_PATH_RESOURCE_NAME_MAPPING);
+
+    httpResourceRemoveTrailingSlash =
+        configProvider.getBoolean(
+            TRACE_HTTP_RESOURCE_REMOVE_TRAILING_SLASH,
+            DEFAULT_TRACE_HTTP_RESOURCE_REMOVE_TRAILING_SLASH);
 
     httpServerErrorStatuses =
         configProvider.getIntegerRange(
@@ -1535,6 +1543,10 @@ public class Config {
 
   public Map<String, String> getHttpClientPathResourceNameMapping() {
     return httpClientPathResourceNameMapping;
+  }
+
+  public boolean getHttpResourceRemoveTrailingSlash() {
+    return httpResourceRemoveTrailingSlash;
   }
 
   public BitSet getHttpServerErrorStatuses() {
@@ -2966,6 +2978,8 @@ public class Config {
         + httpClientTagQueryString
         + ", httpClientSplitByDomain="
         + httpClientSplitByDomain
+        + ", httpResourceRemoveTrailingSlash"
+        + httpResourceRemoveTrailingSlash
         + ", dbClientSplitByInstance="
         + dbClientSplitByInstance
         + ", dbClientSplitByInstanceTypeSuffix="

--- a/internal-api/src/main/java/datadog/trace/api/normalize/HttpResourceNames.java
+++ b/internal-api/src/main/java/datadog/trace/api/normalize/HttpResourceNames.java
@@ -34,6 +34,7 @@ public class HttpResourceNames {
 
   private final AntPatternHttpPathNormalizer serverAntPatternHttpPathNormalizer;
   private final AntPatternHttpPathNormalizer clientAntPatternHttpPathNormalizer;
+  private final boolean removeTrailingSlash;
 
   private static HttpResourceNames instance() {
     if (null == INSTANCE) {
@@ -47,6 +48,7 @@ public class HttpResourceNames {
         new AntPatternHttpPathNormalizer(Config.get().getHttpServerPathResourceNameMapping());
     clientAntPatternHttpPathNormalizer =
         new AntPatternHttpPathNormalizer(Config.get().getHttpClientPathResourceNameMapping());
+    removeTrailingSlash = Config.get().getHttpResourceRemoveTrailingSlash();
   }
 
   public static AgentSpan setForServer(
@@ -91,6 +93,12 @@ public class HttpResourceNames {
   }
 
   public static CharSequence join(CharSequence method, CharSequence path) {
+    if (instance().removeTrailingSlash
+        && path != null
+        && path.length() > 1
+        && path.charAt(path.length() - 1) == '/') {
+      path = path.subSequence(0, path.length() - 1);
+    }
     return JOINER_CACHE.computeIfAbsent(Pair.of(method, path), JOINER);
   }
 }

--- a/internal-api/src/test/groovy/datadog/trace/api/normalize/HttpResourceNamesTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/normalize/HttpResourceNamesTest.groovy
@@ -6,6 +6,7 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString
 import datadog.trace.test.util.DDSpecification
 
 import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_CLIENT_PATH_RESOURCE_NAME_MAPPING
+import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_RESOURCE_REMOVE_TRAILING_SLASH
 import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING
 
 class HttpResourceNamesTest extends DDSpecification {
@@ -15,7 +16,7 @@ class HttpResourceNamesTest extends DDSpecification {
 
   def "uses the simple normalizer for servers by default"() {
     given:
-    def span =  Mock(AgentSpan)
+    def span = Mock(AgentSpan)
 
     when:
     HttpResourceNames.setForServer(span, "GET", "/asdf/1234", false)
@@ -27,7 +28,7 @@ class HttpResourceNamesTest extends DDSpecification {
   def "uses the ant matching normalizer for servers when configured to"() {
     setup:
     injectSysConfig(TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING, "/asdf/*:/test")
-    def span =  Mock(AgentSpan)
+    def span = Mock(AgentSpan)
 
     when:
     HttpResourceNames.setForServer(span, "GET", "/asdf/1234", false)
@@ -38,7 +39,7 @@ class HttpResourceNamesTest extends DDSpecification {
 
   def "uses the simple normalizer for clients by default"() {
     given:
-    def span =  Mock(AgentSpan)
+    def span = Mock(AgentSpan)
 
     when:
     HttpResourceNames.setForClient(span, "GET", "/asdf/1234", false)
@@ -50,7 +51,7 @@ class HttpResourceNamesTest extends DDSpecification {
   def "uses the ant matching normalizer for clients when configured to"() {
     setup:
     injectSysConfig(TRACE_HTTP_CLIENT_PATH_RESOURCE_NAME_MAPPING, "/asdf/*:/test")
-    def span =  Mock(AgentSpan)
+    def span = Mock(AgentSpan)
 
     when:
     HttpResourceNames.setForClient(span, "GET", "/asdf/1234", false)
@@ -59,7 +60,7 @@ class HttpResourceNamesTest extends DDSpecification {
     1 * span.setResourceName(UTF8BytesString.create("GET /test"), ResourceNamePriorities.HTTP_CLIENT_CONFIG_PATTERN_MATCH)
   }
 
-  def "works as expected" () {
+  def "works as expected"() {
     when:
     def resourceName = HttpResourceNames.join(method, path)
 
@@ -67,9 +68,37 @@ class HttpResourceNamesTest extends DDSpecification {
     resourceName.toString() == expected
 
     where:
-    method | path | expected
-    "GET"  | "/test" | "GET /test"
-    null   | "/test" | "/test"
-    "GET"  | null    | "/"
+    method | path        | expected
+    "GET"  | "/test"     | "GET /test"
+    null   | "/test"     | "/test"
+    "GET"  | null        | "/"
+    "GET"  | ""          | "GET "
+    "GET"  | "/"         | "GET /"
+    "GET"  | "//"        | "GET //"
+    "GET"  | "/foo/bar"  | "GET /foo/bar"
+    "GET"  | "/foo/bar/" | "GET /foo/bar/"
+  }
+
+  def "remove trailing slash"() {
+    setup:
+    injectSysConfig(TRACE_HTTP_RESOURCE_REMOVE_TRAILING_SLASH, "true")
+
+    when:
+    def resourceName = HttpResourceNames.join(method, path)
+
+    then:
+    resourceName.toString() == expected
+
+    where:
+    method | path        | expected
+    "GET"  | "/foo/bar/" | "GET /foo/bar"
+    "GET"  | "/test"     | "GET /test"
+    "GET"  | "/test/"    | "GET /test"
+    null   | "/test"     | "/test"
+    null   | "/test/"    | "/test"
+    "GET"  | null        | "/"
+    "GET"  | ""          | "GET "
+    "GET"  | "/"         | "GET /"
+    "GET"  | "//"        | "GET /"
   }
 }

--- a/internal-api/src/test/groovy/datadog/trace/api/normalize/HttpResourceNamesTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/normalize/HttpResourceNamesTest.groovy
@@ -12,6 +12,7 @@ import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_SERVER_PATH_RESOU
 class HttpResourceNamesTest extends DDSpecification {
   def setup() {
     HttpResourceNames.INSTANCE = null
+    HttpResourceNames.JOINER_CACHE.clear()
   }
 
   def "uses the simple normalizer for servers by default"() {


### PR DESCRIPTION
# What Does This Do

Adds a setting to remove a trailing slash from the http resource name.

# Motivation

Datadog treats otherwise identical http path resources with and without a trailing slash as two different resource. This addition will help to instruct Java Tracer to group them into one resource by removing a trailing slash.

# Additional Notes

FRAPMS-1972

This change supersedes #4870