### PR TITLE
Harden config map parsing

### DIFF
--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigConverter.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigConverter.java
@@ -133,10 +133,10 @@ final class ConfigConverter {
       nextSpace = nextSpace == -1 ? str.length() : nextSpace;
       // if we have a delimiter after this splitter, then try to move the splitter forward to
       // allow for tags with ':' in them
-      while (nextSplitter != -1 && nextSplitter < nextComma && nextSplitter < nextSpace) {
+      int end = nextComma < str.length() ? nextComma : nextSpace;
+      while (nextSplitter != -1 && nextSplitter < end) {
         nextSplitter = str.indexOf(':', nextSplitter + 1);
       }
-      int end;
       if (nextSplitter == -1) {
         // this is either the end of the string or the next position where the value should be
         // trimmed
@@ -161,7 +161,8 @@ final class ConfigConverter {
         badFormat = key.indexOf(',') != -1;
         if (!badFormat) {
           String value = str.substring(splitter + 1, end).trim();
-          if (!key.isEmpty() && !value.isEmpty()) {
+          badFormat = value.indexOf(' ') != -1;
+          if (!badFormat && !key.isEmpty() && !value.isEmpty()) {
             map.put(key, value);
           }
           splitter = nextSplitter;

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigConverter.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigConverter.java
@@ -120,61 +120,70 @@ final class ConfigConverter {
     return map;
   }
 
+  private static final class BadFormatException extends Exception {
+    public BadFormatException(String message) {
+      super(message);
+    }
+  }
+
   private static void loadMap(Map<String, String> map, String str, String settingName) {
     // we know that the str is trimmed and rely on that there is no leading/trailing whitespace
-    boolean badFormat = false;
-    int start = 0;
-    int splitter = str.indexOf(':', start);
-    while (splitter != -1 && !badFormat) {
-      int nextSplitter = str.indexOf(':', splitter + 1);
-      int nextComma = str.indexOf(',', splitter + 1);
-      nextComma = nextComma == -1 ? str.length() : nextComma;
-      int nextSpace = str.indexOf(' ', splitter + 1);
-      nextSpace = nextSpace == -1 ? str.length() : nextSpace;
-      // if we have a delimiter after this splitter, then try to move the splitter forward to
-      // allow for tags with ':' in them
-      int end = nextComma < str.length() ? nextComma : nextSpace;
-      while (nextSplitter != -1 && nextSplitter < end) {
-        nextSplitter = str.indexOf(':', nextSplitter + 1);
-      }
-      if (nextSplitter == -1) {
-        // this is either the end of the string or the next position where the value should be
-        // trimmed
-        end = nextComma;
-        if (nextComma < str.length() - 1) {
-          // there are non-space characters after the ','
-          badFormat = true;
+    try {
+      int start = 0;
+      int splitter = str.indexOf(':', start);
+      while (splitter != -1) {
+        int nextSplitter = str.indexOf(':', splitter + 1);
+        int nextComma = str.indexOf(',', splitter + 1);
+        nextComma = nextComma == -1 ? str.length() : nextComma;
+        int nextSpace = str.indexOf(' ', splitter + 1);
+        nextSpace = nextSpace == -1 ? str.length() : nextSpace;
+        // if we have a delimiter after this splitter, then try to move the splitter forward to
+        // allow for tags with ':' in them
+        int end = nextComma < str.length() ? nextComma : nextSpace;
+        while (nextSplitter != -1 && nextSplitter < end) {
+          nextSplitter = str.indexOf(':', nextSplitter + 1);
         }
-      } else {
-        if (nextComma < str.length()) {
+        if (nextSplitter == -1) {
+          // this is either the end of the string or the next position where the value should be
+          // trimmed
           end = nextComma;
-        } else if (nextSpace < str.length()) {
-          end = nextSpace;
-        } else {
-          // this should not happen
-          end = str.length();
-          badFormat = true;
-        }
-      }
-      if (!badFormat) {
-        String key = str.substring(start, splitter).trim();
-        badFormat = key.indexOf(',') != -1;
-        if (!badFormat) {
-          String value = str.substring(splitter + 1, end).trim();
-          badFormat = value.indexOf(' ') != -1;
-          if (!badFormat && !key.isEmpty() && !value.isEmpty()) {
-            map.put(key, value);
+          if (nextComma < str.length() - 1) {
+            // there are non-space characters after the ','
+            throw new BadFormatException("Non white space characters after trailing ','");
           }
-          splitter = nextSplitter;
-          start = end + 1;
+        } else {
+          if (nextComma < str.length()) {
+            end = nextComma;
+          } else if (nextSpace < str.length()) {
+            end = nextSpace;
+          } else {
+            // this should not happen
+            throw new BadFormatException("Illegal position of split character ':'");
+          }
         }
+        String key = str.substring(start, splitter).trim();
+        if (key.indexOf(',') != -1) {
+          throw new BadFormatException("Illegal ',' character in key '" + key + "'");
+        }
+        String value = str.substring(splitter + 1, end).trim();
+        if (value.indexOf(' ') != -1) {
+          throw new BadFormatException("Illegal ' ' character in value for key '" + key + "'");
+        }
+        if (!key.isEmpty() && !value.isEmpty()) {
+          map.put(key, value);
+        }
+        splitter = nextSplitter;
+        start = end + 1;
       }
-    }
-    if (badFormat) {
-      log.warn(
-          "Invalid config for {}: '{}'. Must match 'key1:value1,key2:value2' or 'key1:value1 key2:value2'.",
-          settingName,
-          str);
+    } catch (Throwable t) {
+      if (t instanceof BadFormatException) {
+        log.warn(
+            "Invalid config for {}. {}. Must match 'key1:value1,key2:value2' or 'key1:value1 key2:value2'.",
+            settingName,
+            t.getMessage());
+      } else {
+        log.warn("Unexpected exception during config parsing of {}.", settingName, t);
+      }
       map.clear();
     }
   }
@@ -185,68 +194,71 @@ final class ConfigConverter {
       String settingName,
       String defaultPrefix,
       boolean lowercaseKeys) {
-    boolean badFormat = false;
-    defaultPrefix = null == defaultPrefix ? "" : defaultPrefix;
-    if (!defaultPrefix.isEmpty() && !defaultPrefix.endsWith(".")) {
-      defaultPrefix = defaultPrefix + ".";
-    }
-    int start = 0;
-    int len = str.length();
-    char listChar = str.indexOf(',') == -1 ? ' ' : ',';
-    while (!badFormat && start < len) {
-      int end = len;
-      int listPos = str.indexOf(listChar, start);
-      int mapPos = str.indexOf(':', start);
-      int delimiter = listPos == -1 ? mapPos : mapPos == -1 ? listPos : Math.min(listPos, mapPos);
-      if (delimiter == -1) {
-        delimiter = end;
-      } else if (delimiter == mapPos) {
-        // we're in a mapping, so let's find the next part
-        int nextList = str.indexOf(listChar, delimiter + 1);
-        if (mapPos == start) {
-          // can't have an empty key
-          badFormat = true;
-        } else if (nextList != -1) {
-          end = nextList;
-        }
-      } else {
-        // delimiter is at listPos, so set end to delimiter
-        end = delimiter;
+    try {
+      defaultPrefix = null == defaultPrefix ? "" : defaultPrefix;
+      if (!defaultPrefix.isEmpty() && !defaultPrefix.endsWith(".")) {
+        defaultPrefix = defaultPrefix + ".";
       }
+      int start = 0;
+      int len = str.length();
+      char listChar = str.indexOf(',') == -1 ? ' ' : ',';
+      while (start < len) {
+        int end = len;
+        int listPos = str.indexOf(listChar, start);
+        int mapPos = str.indexOf(':', start);
+        int delimiter = listPos == -1 ? mapPos : mapPos == -1 ? listPos : Math.min(listPos, mapPos);
+        if (delimiter == -1) {
+          delimiter = end;
+        } else if (delimiter == mapPos) {
+          // we're in a mapping, so let's find the next part
+          int nextList = str.indexOf(listChar, delimiter + 1);
+          if (mapPos == start) {
+            // can't have an empty key
+            throw new BadFormatException("Illegal empty key at position " + start);
+          } else if (nextList != -1) {
+            end = nextList;
+          }
+        } else {
+          // delimiter is at listPos, so set end to delimiter
+          end = delimiter;
+        }
 
-      if (!badFormat && start != end) {
-        String key = trimmedHeader(str, start, delimiter, lowercaseKeys);
-        if (!key.isEmpty()) {
-          String value;
-          if (delimiter == mapPos) {
-            value = trimmedHeader(str, delimiter + 1, end, false);
-            // tags must start with a letter
-            if (!value.isEmpty() && !Character.isLetter(value.charAt(0))) {
-              value = "";
-              badFormat = true;
-            }
-          } else {
-            if (Character.isLetter(key.charAt(0))) {
-              value = defaultPrefix + normalizedHeaderTag(key);
-            } else {
+        if (start != end) {
+          String key = trimmedHeader(str, start, delimiter, lowercaseKeys);
+          if (!key.isEmpty()) {
+            String value;
+            if (delimiter == mapPos) {
+              value = trimmedHeader(str, delimiter + 1, end, false);
               // tags must start with a letter
-              value = "";
-              badFormat = true;
+              if (!value.isEmpty() && !Character.isLetter(value.charAt(0))) {
+                throw new BadFormatException(
+                    "Illegal tag starting with non letter for key '" + key + "'");
+              }
+            } else {
+              if (Character.isLetter(key.charAt(0))) {
+                value = defaultPrefix + normalizedHeaderTag(key);
+              } else {
+                // tags must start with a letter
+                throw new BadFormatException(
+                    "Illegal key only tag starting with non letter '" + key + "'");
+              }
+            }
+            if (!value.isEmpty()) {
+              map.put(key, value);
             }
           }
-          if (!value.isEmpty()) {
-            map.put(key, value);
-          }
         }
+        start = end + 1;
       }
-      start = end + 1;
-    }
-
-    if (badFormat) {
-      log.warn(
-          "Invalid config for {}: '{}'. Must match '(key:value|key)([ ,](key:value|key))*'.",
-          settingName,
-          str);
+    } catch (Throwable t) {
+      if (t instanceof BadFormatException) {
+        log.warn(
+            "Invalid config for {}. {}. Must match '(key:value|key)([ ,](key:value|key))*'.",
+            settingName,
+            t.getMessage());
+      } else {
+        log.warn("Unexpected exception during config parsing of {}.", settingName, t);
+      }
       map.clear();
     }
   }

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/config/provider/ConfigConverterTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/config/provider/ConfigConverterTest.groovy
@@ -22,4 +22,53 @@ class ConfigConverterTest extends DDSpecification {
     ""          | null
     "0"         | false
   }
+
+  def "parse map properly for #mapString"() {
+    when:
+    def result = ConfigConverter.parseMap(mapString, "test")
+
+    then:
+    result == expected
+
+    where:
+    // spotless:off
+    mapString                                       | expected
+    "a:1, a:2, a:3"                                 | [a: "3"]
+    "a:b,c:d,e:"                                    | [a: "b", c: "d"]
+    // space separated
+    "a:1  a:2  a:3"                                 | [a: "3"]
+    "a:b c:d e:"                                    | [a: "b", c: "d"]
+    // More different string variants:
+    "a:a;"                                          | [a: "a;"]
+    "a:1, a:2, a:3"                                 | [a: "3"]
+    "a:1  a:2  a:3"                                 | [a: "3"]
+    "a:b,c:d,e:"                                    | [a: "b", c: "d"]
+    "a:b c:d e:"                                    | [a: "b", c: "d"]
+    "key 1!:va|ue_1,"                               | ["key 1!": "va|ue_1"]
+    "key 1!:va|ue_1 "                               | ["key 1!": "va|ue_1"]
+    " key1 :value1 ,\t key2:  value2"               | [key1: "value1", key2: "value2"]
+    'a:b, b:c, c:d, d: e'                           | ['a': 'b', 'b': 'c', 'c': 'd', 'd': 'e']
+    "key1 :value1  \t key2:  value2"                | [key1: "value1", key2: "value2"]
+    "dyno:web.1 dynotype:web appname:******"        | ["dyno": "web.1", "dynotype": "web", "appname": "******"]
+    "is:val:id"                                     | [is: "val:id"]
+    "a:b,is:val:id,x:y"                             | [a: "b", is: "val:id", x: "y"]
+    "a:b:c:d"                                       | [a: "b:c:d"]
+    'fooa:barb, foob:barc, fooc: bard, food: bare,' | ['fooa': 'barb', 'foob': 'barc', 'fooc': 'bard', 'food': 'bare']
+    // Illegal
+    "a:"                                            | [:]
+    "a:b,c,d"                                       | [:]
+    "a:b,c,d,k:v"                                   | [:]
+    ""                                              | [:]
+    "1"                                             | [:]
+    "a"                                             | [:]
+    "a,1"                                           | [:]
+    "!a"                                            | [:]
+    "    "                                          | [:]
+    ",,,,"                                          | [:]
+    ":,:,:,:,"                                      | [:]
+    ": : : : "                                      | [:]
+    "::::"                                          | [:]
+    'key1:val1 with_space:and_colon, key2:val2'     | [:]
+    // spotless:on
+  }
 }


### PR DESCRIPTION
# What Does This Do

Hardens the map from string parsing code so it doesn't misstep on values that contain both spaces and colons, i.e. a string like this `key1:val1 with_space:and_colon, key2:val2`. This previously resulted in a substring call with `end` smaller than `start`.

# Motivation

Don't throw `IndexOutOfBoundsException`.

# Additional Notes
