### PR TITLE
Size limit for DSM payloads

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1106,7 +1106,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   private static DataStreamsMonitoring createDataStreamsMonitoring(
       Config config, SharedCommunicationObjects sharedCommunicationObjects, TimeSource timeSource) {
     if (config.isDataStreamsEnabled()) {
-      return new DefaultDataStreamsMonitoring(config, sharedCommunicationObjects, timeSource, 512 * 1024 * 10);
+      return new DefaultDataStreamsMonitoring(
+          config, sharedCommunicationObjects, timeSource, 512 * 1024 * 10);
     } else {
       log.debug("Data streams monitoring not enabled.");
       return new NoopDataStreamsMonitoring();

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1106,7 +1106,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   private static DataStreamsMonitoring createDataStreamsMonitoring(
       Config config, SharedCommunicationObjects sharedCommunicationObjects, TimeSource timeSource) {
     if (config.isDataStreamsEnabled()) {
-      return new DefaultDataStreamsMonitoring(config, sharedCommunicationObjects, timeSource);
+      return new DefaultDataStreamsMonitoring(config, sharedCommunicationObjects, timeSource, 512 * 1024 * 10);
     } else {
       log.debug("Data streams monitoring not enabled.");
       return new NoopDataStreamsMonitoring();

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
@@ -59,7 +59,7 @@ public class DefaultDataStreamsMonitoring
   private volatile boolean supportsDataStreams = false;
 
   public DefaultDataStreamsMonitoring(
-      Config config, SharedCommunicationObjects sharedCommunicationObjects, TimeSource timeSource) {
+      Config config, SharedCommunicationObjects sharedCommunicationObjects, TimeSource timeSource, long payloadSizeLimit) {
     this(
         new OkHttpSink(
             sharedCommunicationObjects.okHttpClient,
@@ -70,18 +70,19 @@ public class DefaultDataStreamsMonitoring
             Collections.<String, String>emptyMap()),
         sharedCommunicationObjects.featuresDiscovery(config),
         timeSource,
-        config);
+        config,
+        payloadSizeLimit);
   }
 
   public DefaultDataStreamsMonitoring(
-      Sink sink, DDAgentFeaturesDiscovery features, TimeSource timeSource, Config config) {
+      Sink sink, DDAgentFeaturesDiscovery features, TimeSource timeSource, Config config, long payloadSizeLimit) {
     this(
         sink,
         features,
         timeSource,
         config.getWellKnownTags(),
         new MsgPackDatastreamsPayloadWriter(
-            sink, config.getWellKnownTags(), DDTraceCoreInfo.VERSION, config.getPrimaryTag()),
+            sink, config.getWellKnownTags(), DDTraceCoreInfo.VERSION, config.getPrimaryTag(), payloadSizeLimit),
         DEFAULT_BUCKET_DURATION_NANOS);
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
@@ -59,7 +59,10 @@ public class DefaultDataStreamsMonitoring
   private volatile boolean supportsDataStreams = false;
 
   public DefaultDataStreamsMonitoring(
-      Config config, SharedCommunicationObjects sharedCommunicationObjects, TimeSource timeSource, long payloadSizeLimit) {
+      Config config,
+      SharedCommunicationObjects sharedCommunicationObjects,
+      TimeSource timeSource,
+      long payloadSizeLimit) {
     this(
         new OkHttpSink(
             sharedCommunicationObjects.okHttpClient,
@@ -75,14 +78,22 @@ public class DefaultDataStreamsMonitoring
   }
 
   public DefaultDataStreamsMonitoring(
-      Sink sink, DDAgentFeaturesDiscovery features, TimeSource timeSource, Config config, long payloadSizeLimit) {
+      Sink sink,
+      DDAgentFeaturesDiscovery features,
+      TimeSource timeSource,
+      Config config,
+      long payloadSizeLimit) {
     this(
         sink,
         features,
         timeSource,
         config.getWellKnownTags(),
         new MsgPackDatastreamsPayloadWriter(
-            sink, config.getWellKnownTags(), DDTraceCoreInfo.VERSION, config.getPrimaryTag(), payloadSizeLimit),
+            sink,
+            config.getWellKnownTags(),
+            DDTraceCoreInfo.VERSION,
+            config.getPrimaryTag(),
+            payloadSizeLimit),
         DEFAULT_BUCKET_DURATION_NANOS);
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/MsgPackDatastreamsPayloadWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/MsgPackDatastreamsPayloadWriter.java
@@ -42,7 +42,11 @@ public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter
   private final long payloadSizeLimit;
 
   public MsgPackDatastreamsPayloadWriter(
-      Sink sink, WellKnownTags wellKnownTags, String tracerVersion, String primaryTag, long payloadSizeLimit) {
+      Sink sink,
+      WellKnownTags wellKnownTags,
+      String tracerVersion,
+      String primaryTag,
+      long payloadSizeLimit) {
     buffer = new GrowableBuffer(INITIAL_CAPACITY);
     writer = new MsgPackWriter(buffer);
     this.sink = sink;
@@ -63,16 +67,17 @@ public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter
 
     for (StatsGroup group : bucket.getGroups()) {
       // hash + parent hash + sketches + tags
-      size += group.getPathwayLatency().serializedSize() +
-          group.getEdgeLatency().serializedSize() +
-          Long.BYTES * 2;
-      for (String tag: group.getEdgeTags()) {
+      size +=
+          group.getPathwayLatency().serializedSize()
+              + group.getEdgeLatency().serializedSize()
+              + Long.BYTES * 2;
+      for (String tag : group.getEdgeTags()) {
         size += tag.length() * charSize;
       }
     }
 
-    for (Map.Entry<List<String>, Long> backlogEntry: bucket.getBacklogs()) {
-      for (String tag: backlogEntry.getKey()) {
+    for (Map.Entry<List<String>, Long> backlogEntry : bucket.getBacklogs()) {
+      for (String tag : backlogEntry.getKey()) {
         size += tag.length() * charSize + Long.BYTES;
       }
     }
@@ -137,7 +142,7 @@ public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter
     long size = 0;
     List<StatsBucket> payloads = new ArrayList<>();
 
-    for (StatsBucket bucket: data) {
+    for (StatsBucket bucket : data) {
       long nextSize = getApproximateBucketSize(bucket);
       if (size > 0 && size + nextSize > payloadSizeLimit) {
         write(payloads);


### PR DESCRIPTION
# What Does This Do
This PR enables splitting DSM payloads based on an approximated bucket size. This helps ensuring that the data sent from the tracer can be accepted by the backend. 
