### PR TITLE
Remove not needed cookie call sites

### DIFF
--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/source/WebModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/source/WebModuleTest.groovy
@@ -259,14 +259,8 @@ class WebModuleTest extends IastModuleImplTestBase {
     value     | sourceTypeValue                   | isCookieTainted
     "name"    | SourceTypes.REQUEST_COOKIE_NAME    | true
     "value"   | SourceTypes.REQUEST_COOKIE_VALUE   | true
-    "comment" | SourceTypes.REQUEST_COOKIE_COMMENT | true
-    "domain"  | SourceTypes.REQUEST_COOKIE_DOMAIN  | true
-    "path"    | SourceTypes.REQUEST_COOKIE_PATH    | true
     "name"    | SourceTypes.REQUEST_COOKIE_NAME    | false
     "value"   | SourceTypes.REQUEST_COOKIE_VALUE   | false
-    "comment" | SourceTypes.REQUEST_COOKIE_COMMENT | false
-    "domain"  | SourceTypes.REQUEST_COOKIE_DOMAIN  | false
-    "path"    | SourceTypes.REQUEST_COOKIE_PATH    | false
   }
 
   void 'test onGetInputStream without span'() {

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/CookieCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/CookieCallSite.java
@@ -18,7 +18,7 @@ public class CookieCallSite {
     final WebModule module = InstrumentationBridge.WEB;
     if (module != null) {
       try {
-        module.onCookieGetter(self, self.getName(), result, (byte) 5);
+        module.onCookieGetter(self, self.getName(), result, SourceTypes.REQUEST_COOKIE_NAME);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterGetName threw", e);
       }
@@ -33,54 +33,9 @@ public class CookieCallSite {
     final WebModule module = InstrumentationBridge.WEB;
     if (module != null) {
       try {
-        module.onCookieGetter(self, self.getName(), result, (byte) 6);
+        module.onCookieGetter(self, self.getName(), result, SourceTypes.REQUEST_COOKIE_VALUE);
       } catch (final Throwable e) {
         module.onUnexpectedException("getValue threw", e);
-      }
-    }
-    return result;
-  }
-
-  @Source(SourceTypes.REQUEST_COOKIE_COMMENT_STRING)
-  @CallSite.After("java.lang.String javax.servlet.http.Cookie.getComment()")
-  public static String afterGetComment(
-      @CallSite.This final Cookie self, @CallSite.Return final String result) {
-    final WebModule module = InstrumentationBridge.WEB;
-    if (module != null) {
-      try {
-        module.onCookieGetter(self, self.getName(), result, (byte) 7);
-      } catch (final Throwable e) {
-        module.onUnexpectedException("getComment threw", e);
-      }
-    }
-    return result;
-  }
-
-  @Source(SourceTypes.REQUEST_COOKIE_DOMAIN_STRING)
-  @CallSite.After("java.lang.String javax.servlet.http.Cookie.getDomain()")
-  public static String afterGetDomain(
-      @CallSite.This final Cookie self, @CallSite.Return final String result) {
-    final WebModule module = InstrumentationBridge.WEB;
-    if (module != null) {
-      try {
-        module.onCookieGetter(self, self.getName(), result, (byte) 8);
-      } catch (final Throwable e) {
-        module.onUnexpectedException("afterGetDomain threw", e);
-      }
-    }
-    return result;
-  }
-
-  @Source(SourceTypes.REQUEST_COOKIE_PATH_STRING)
-  @CallSite.After("java.lang.String javax.servlet.http.Cookie.getPath()")
-  public static String afterGetPath(
-      @CallSite.This final Cookie self, @CallSite.Return final String result) {
-    final WebModule module = InstrumentationBridge.WEB;
-    if (module != null) {
-      try {
-        module.onCookieGetter(self, self.getName(), result, (byte) 9);
-      } catch (final Throwable e) {
-        module.onUnexpectedException("afterGetPath threw", e);
       }
     }
     return result;

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/CookieCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/CookieCallSiteTest.groovy
@@ -1,88 +1,46 @@
 import datadog.smoketest.controller.CookieTestSuite
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.SourceTypes
 import datadog.trace.api.iast.source.WebModule
+import groovy.transform.CompileDynamic
 
+@CompileDynamic
 class CookieCallSiteTest extends AgentTestRunner {
 
   private static final String NAME = 'name'
   private static final String VALUE = 'value'
-  private static final String COMMENT = 'comment'
-  private static final String DOMAIN = 'domain'
-  private static final String PATH = 'path'
 
   @Override
   protected void configurePreAgent() {
     injectSysConfig("dd.iast.enabled", "true")
   }
 
-  def 'test getName'() {
+  void 'test getName'() {
     setup:
     final iastModule = Mock(WebModule)
     InstrumentationBridge.registerIastModule(iastModule)
-    final cookieTestSuite = new CookieTestSuite(NAME, VALUE, COMMENT, DOMAIN, PATH)
+    final cookieTestSuite = new CookieTestSuite(NAME, VALUE)
 
     when:
     final result = cookieTestSuite.getName()
 
     then:
     result == NAME
-    1 * iastModule.onCookieGetter(cookieTestSuite.getCookie(), NAME, NAME, ((byte) 5).byteValue())
+    1 * iastModule.onCookieGetter(cookieTestSuite.getCookie(), NAME, NAME, SourceTypes.REQUEST_COOKIE_NAME)
   }
 
-  def 'test getValue'() {
+  void 'test getValue'() {
     setup:
     final iastModule = Mock(WebModule)
     InstrumentationBridge.registerIastModule(iastModule)
-    final cookieTestSuite = new CookieTestSuite(NAME, VALUE, COMMENT, DOMAIN, PATH)
+    final cookieTestSuite = new CookieTestSuite(NAME, VALUE)
 
     when:
     final result = cookieTestSuite.getValue()
 
     then:
     result == VALUE
-    1 * iastModule.onCookieGetter(cookieTestSuite.getCookie(), NAME, VALUE, ((byte) 6).byteValue())
-  }
-
-  def 'test getComment'() {
-    setup:
-    final iastModule = Mock(WebModule)
-    InstrumentationBridge.registerIastModule(iastModule)
-    final cookieTestSuite = new CookieTestSuite(NAME, VALUE, COMMENT, DOMAIN, PATH)
-
-    when:
-    final result = cookieTestSuite.getComment()
-
-    then:
-    result == COMMENT
-    1 * iastModule.onCookieGetter(cookieTestSuite.getCookie(), NAME, COMMENT, ((byte) 7).byteValue())
-  }
-
-  def 'test getDomain'() {
-    setup:
-    final iastModule = Mock(WebModule)
-    InstrumentationBridge.registerIastModule(iastModule)
-    final cookieTestSuite = new CookieTestSuite(NAME, VALUE, COMMENT, DOMAIN, PATH)
-
-    when:
-    final result = cookieTestSuite.getDomain()
-
-    then:
-    result == DOMAIN
-    1 * iastModule.onCookieGetter(cookieTestSuite.getCookie(), NAME, DOMAIN, ((byte) 8).byteValue())
-  }
-
-  def 'test getPath'() {
-    setup:
-    final iastModule = Mock(WebModule)
-    InstrumentationBridge.registerIastModule(iastModule)
-    final cookieTestSuite = new CookieTestSuite(NAME, VALUE, COMMENT, DOMAIN, PATH)
-
-    when:
-    final result = cookieTestSuite.getPath()
-
-    then:
-    result == PATH
-    1 * iastModule.onCookieGetter(cookieTestSuite.getCookie(), NAME, PATH, ((byte) 9).byteValue())
+    1 * iastModule.onCookieGetter(cookieTestSuite.getCookie(), NAME, VALUE, SourceTypes.REQUEST_COOKIE_VALUE)
   }
 }

--- a/dd-java-agent/instrumentation/servlet/src/test/java/datadog/smoketest/controller/CookieTestSuite.java
+++ b/dd-java-agent/instrumentation/servlet/src/test/java/datadog/smoketest/controller/CookieTestSuite.java
@@ -6,16 +6,8 @@ public class CookieTestSuite {
 
   private Cookie cookie;
 
-  public CookieTestSuite(
-      final String name,
-      final String value,
-      final String comment,
-      final String domain,
-      final String path) {
+  public CookieTestSuite(final String name, final String value) {
     cookie = new Cookie(name, value);
-    cookie.setComment(comment);
-    cookie.setDomain(domain);
-    cookie.setPath(path);
   }
 
   public String getName() {
@@ -24,18 +16,6 @@ public class CookieTestSuite {
 
   public String getValue() {
     return cookie.getValue();
-  }
-
-  public String getComment() {
-    return cookie.getComment();
-  }
-
-  public String getDomain() {
-    return cookie.getDomain();
-  }
-
-  public String getPath() {
-    return cookie.getPath();
   }
 
   public Cookie getCookie() {

--- a/dd-smoke-tests/spring-boot-2.6-webmvc/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/spring-boot-2.6-webmvc/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -6,6 +6,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.websocket.server.PathParam;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -107,6 +108,12 @@ public class IastWebController {
   @GetMapping("/query_string")
   public String queryString(final HttpServletRequest request) {
     return "QueryString is: " + request.getQueryString();
+  }
+
+  @GetMapping("/cookie")
+  public String cookie(final HttpServletRequest request) {
+    final Cookie cookie = request.getCookies()[0];
+    return "Cookie is: " + cookie.getName() + "=" + cookie.getValue();
   }
 
   private void withProcess(final Operation<Process> op) {

--- a/dd-smoke-tests/spring-boot-2.6-webmvc/src/test/groovy/IastSpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/spring-boot-2.6-webmvc/src/test/groovy/IastSpringBootSmokeTest.groovy
@@ -301,6 +301,26 @@ class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
     }
   }
 
+  void 'request cookie propagation'() {
+    given:
+    final url = "http://localhost:${httpPort}/cookie"
+    final request = new Request.Builder().url(url).header('Cookie', 'name=value').get().build()
+
+    when:
+    client.newCall(request).execute()
+
+    then:
+    hasTainted { tainted ->
+      tainted.value == 'name' &&
+        tainted.ranges[0].source.origin == 'http.request.cookie.name'
+    }
+    hasTainted { tainted ->
+      tainted.value == 'value' &&
+        tainted.ranges[0].source.name == 'name' &&
+        tainted.ranges[0].source.origin == 'http.request.cookie.value'
+    }
+  }
+
   private static Function<DecodedSpan, Boolean> hasMetric(final String name, final Object value) {
     return new Function<DecodedSpan, Boolean>() {
         @Override

--- a/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -6,6 +6,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.websocket.server.PathParam;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -113,6 +114,12 @@ public class IastWebController {
   @GetMapping("/query_string")
   public String queryString(final HttpServletRequest request) {
     return "QueryString is: " + request.getQueryString();
+  }
+
+  @GetMapping("/cookie")
+  public String cookie(final HttpServletRequest request) {
+    final Cookie cookie = request.getCookies()[0];
+    return "Cookie is: " + cookie.getName() + "=" + cookie.getValue();
   }
 
   private void withProcess(final Operation<Process> op) {

--- a/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
@@ -304,6 +304,26 @@ class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
     }
   }
 
+  void 'request cookie propagation'() {
+    given:
+    final url = "http://localhost:${httpPort}/cookie"
+    final request = new Request.Builder().url(url).header('Cookie', 'name=value').get().build()
+
+    when:
+    client.newCall(request).execute()
+
+    then:
+    hasTainted { tainted ->
+      tainted.value == 'name' &&
+        tainted.ranges[0].source.origin == 'http.request.cookie.name'
+    }
+    hasTainted { tainted ->
+      tainted.value == 'value' &&
+        tainted.ranges[0].source.name == 'name' &&
+        tainted.ranges[0].source.origin == 'http.request.cookie.value'
+    }
+  }
+
   private static Function<DecodedSpan, Boolean> hasMetric(final String name, final Object value) {
     return { span -> value == span.metrics.get(name) }
   }

--- a/internal-api/src/main/java/datadog/trace/api/iast/SourceTypes.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/SourceTypes.java
@@ -18,15 +18,9 @@ public abstract class SourceTypes {
   public static final String REQUEST_COOKIE_NAME_STRING = "http.request.cookie.name";
   public static final byte REQUEST_COOKIE_VALUE = 6;
   public static final String REQUEST_COOKIE_VALUE_STRING = "http.request.cookie.value";
-  public static final byte REQUEST_COOKIE_COMMENT = 7;
-  public static final String REQUEST_COOKIE_COMMENT_STRING = "http.request.cookie.comment";
-  public static final byte REQUEST_COOKIE_DOMAIN = 8;
-  public static final String REQUEST_COOKIE_DOMAIN_STRING = "http.request.cookie.domain";
-  public static final byte REQUEST_COOKIE_PATH = 9;
-  public static final String REQUEST_COOKIE_PATH_STRING = "http.request.cookie.path";
-  public static final byte REQUEST_BODY = 10;
+  public static final byte REQUEST_BODY = 7;
   public static final String REQUEST_BODY_STRING = "http.request.body";
-  public static final byte REQUEST_QUERY = 11;
+  public static final byte REQUEST_QUERY = 8;
   public static final String REQUEST_QUERY_STRING = "http.request.query";
 
   public static String toString(final byte sourceType) {
@@ -43,12 +37,6 @@ public abstract class SourceTypes {
         return SourceTypes.REQUEST_COOKIE_NAME_STRING;
       case SourceTypes.REQUEST_COOKIE_VALUE:
         return SourceTypes.REQUEST_COOKIE_VALUE_STRING;
-      case SourceTypes.REQUEST_COOKIE_COMMENT:
-        return SourceTypes.REQUEST_COOKIE_COMMENT_STRING;
-      case SourceTypes.REQUEST_COOKIE_DOMAIN:
-        return SourceTypes.REQUEST_COOKIE_DOMAIN_STRING;
-      case SourceTypes.REQUEST_COOKIE_PATH:
-        return SourceTypes.REQUEST_COOKIE_PATH_STRING;
       case SourceTypes.REQUEST_BODY:
         return SourceTypes.REQUEST_BODY_STRING;
       case SourceTypes.REQUEST_QUERY:

--- a/internal-api/src/test/groovy/datadog/trace/api/iast/SourceTypesTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/iast/SourceTypesTest.groovy
@@ -22,9 +22,6 @@ class SourceTypesTest extends DDSpecification {
     SourceTypes.REQUEST_HEADER_NAME     | SourceTypes.REQUEST_HEADER_NAME_STRING
     SourceTypes.REQUEST_COOKIE_NAME     | SourceTypes.REQUEST_COOKIE_NAME_STRING
     SourceTypes.REQUEST_COOKIE_VALUE    | SourceTypes.REQUEST_COOKIE_VALUE_STRING
-    SourceTypes.REQUEST_COOKIE_COMMENT  | SourceTypes.REQUEST_COOKIE_COMMENT_STRING
-    SourceTypes.REQUEST_COOKIE_DOMAIN   | SourceTypes.REQUEST_COOKIE_DOMAIN_STRING
-    SourceTypes.REQUEST_COOKIE_PATH     | SourceTypes.REQUEST_COOKIE_PATH_STRING
     SourceTypes.REQUEST_BODY            | SourceTypes.REQUEST_BODY_STRING
     SourceTypes.REQUEST_QUERY           | SourceTypes.REQUEST_QUERY_STRING
   }


### PR DESCRIPTION
# What Does This Do
Remove cookie related call sites that are part of the response but not the request

# Motivation
The cookie header can only contain a list of key/value tuples: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cookie 

# Additional Notes
