### PR TITLE
Added health metrics around trace construction

### DIFF
--- a/communication/src/main/java/datadog/communication/serialization/FlushingBuffer.java
+++ b/communication/src/main/java/datadog/communication/serialization/FlushingBuffer.java
@@ -8,6 +8,7 @@ public final class FlushingBuffer implements StreamingBuffer {
   private final ByteBufferConsumer consumer;
 
   private int messageCount;
+  private int spanCount;
   private int mark;
 
   public FlushingBuffer(int capacity, ByteBufferConsumer consumer) {

--- a/communication/src/main/java/datadog/communication/serialization/FlushingBuffer.java
+++ b/communication/src/main/java/datadog/communication/serialization/FlushingBuffer.java
@@ -8,7 +8,6 @@ public final class FlushingBuffer implements StreamingBuffer {
   private final ByteBufferConsumer consumer;
 
   private int messageCount;
-  private int spanCount;
   private int mark;
 
   public FlushingBuffer(int capacity, ByteBufferConsumer consumer) {

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/PayloadDispatcher.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/PayloadDispatcher.java
@@ -62,7 +62,8 @@ public class PayloadDispatcher implements ByteBufferConsumer {
     // introducing an unbound queue and another thread to do the IO
     // however, we can't block the application threads from here.
     if (null == mapper || !packer.format(trace, mapper)) {
-      healthMetrics.onFailedPublish(trace.get(0).samplingPriority(), trace.size());
+      healthMetrics.onFailedPublish(
+          trace.isEmpty() ? 0 : trace.get(0).samplingPriority(), trace.size());
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/PayloadDispatcher.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/PayloadDispatcher.java
@@ -62,7 +62,7 @@ public class PayloadDispatcher implements ByteBufferConsumer {
     // introducing an unbound queue and another thread to do the IO
     // however, we can't block the application threads from here.
     if (null == mapper || !packer.format(trace, mapper)) {
-      healthMetrics.onFailedPublish(trace.get(0).samplingPriority());
+      healthMetrics.onFailedPublish(trace.get(0).samplingPriority(), trace.size());
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteWriter.java
@@ -138,7 +138,7 @@ public abstract class RemoteWriter implements Writer {
   @Override
   public void close() {
     final boolean flushed = flush();
-    closed = true;
+    closed = true;R
     traceProcessingWorker.close();
     healthMetrics.onShutdown(flushed);
     healthMetrics.close();

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteWriter.java
@@ -140,8 +140,8 @@ public abstract class RemoteWriter implements Writer {
     final boolean flushed = flush();
     closed = true;
     traceProcessingWorker.close();
-    healthMetrics.close();
     healthMetrics.onShutdown(flushed);
+    healthMetrics.close();
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteWriter.java
@@ -106,7 +106,7 @@ public abstract class RemoteWriter implements Writer {
   private void handleDroppedTrace(
       final String reason, final List<DDSpan> trace, final int samplingPriority) {
     log.debug("{}. Counted but dropping trace: {}", reason, trace);
-    healthMetrics.onFailedPublish(samplingPriority);
+    healthMetrics.onFailedPublish(trace.get(0).samplingPriority(), trace.size());
     incrementDropCounts(trace.size());
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteWriter.java
@@ -138,7 +138,7 @@ public abstract class RemoteWriter implements Writer {
   @Override
   public void close() {
     final boolean flushed = flush();
-    closed = true;R
+    closed = true;
     traceProcessingWorker.close();
     healthMetrics.onShutdown(flushed);
     healthMetrics.close();

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteWriter.java
@@ -106,7 +106,8 @@ public abstract class RemoteWriter implements Writer {
   private void handleDroppedTrace(
       final String reason, final List<DDSpan> trace, final int samplingPriority) {
     log.debug("{}. Counted but dropping trace: {}", reason, trace);
-    healthMetrics.onFailedPublish(trace.get(0).samplingPriority(), trace.size());
+    healthMetrics.onFailedPublish(
+        trace.isEmpty() ? 0 : trace.get(0).samplingPriority(), trace.size());
     incrementDropCounts(trace.size());
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/SpanSamplingWorker.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/SpanSamplingWorker.java
@@ -153,7 +153,7 @@ public interface SpanSamplingWorker extends AutoCloseable {
               && (droppingPolicy.active() || !secondaryQueue.offer(unsampledSpans))) {
             if (sampledSpans.isEmpty()) {
               // dropped all spans because none of the spans sampled
-              healthMetrics.onFailedPublish(samplingPriority, trace.size());
+              healthMetrics.onFailedPublish(samplingPriority, unsampledSpans.size());
               log.debug(
                   "Trace is empty after single span sampling. Counted but dropping trace: {}",
                   trace);

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/SpanSamplingWorker.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/SpanSamplingWorker.java
@@ -135,15 +135,17 @@ public interface SpanSamplingWorker extends AutoCloseable {
           for (DDSpan span : trace) {
             if (singleSpanSampler.setSamplingPriority(span)) {
               sampledSpans.add(span);
+              healthMetrics.onSingleSpanSample();
             } else {
               unsampledSpans.add(span);
+              healthMetrics.onSingleSpanUnsampled();
             }
           }
 
           int samplingPriority = trace.get(0).samplingPriority();
           if (sampledSpans.size() > 0 && !primaryQueue.offer(sampledSpans)) {
             // couldn't send sampled spans because the queue is full, count entire trace as dropped
-            healthMetrics.onFailedPublish(samplingPriority);
+            healthMetrics.onFailedPublish(samplingPriority, trace.size());
             log.debug(
                 "Sampled spans written to overfilled buffer after single span sampling. Counted but dropping trace: {}",
                 trace);
@@ -151,7 +153,7 @@ public interface SpanSamplingWorker extends AutoCloseable {
               && (droppingPolicy.active() || !secondaryQueue.offer(unsampledSpans))) {
             if (sampledSpans.isEmpty()) {
               // dropped all spans because none of the spans sampled
-              healthMetrics.onFailedPublish(samplingPriority);
+              healthMetrics.onFailedPublish(samplingPriority, trace.size());
               log.debug(
                   "Trace is empty after single span sampling. Counted but dropping trace: {}",
                   trace);

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -168,6 +168,7 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
     // There is a benign race here where the span added above can get written out by a writer in
     // progress before the count has been incremented. It's being taken care of in the internal
     // write method.
+    healthMetrics.onFinishSpan();
     COMPLETED_SPAN_COUNT.incrementAndGet(this);
     return decrementRefAndMaybeWrite(span == getRootSpan());
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
@@ -27,7 +27,7 @@ public abstract class HealthMetrics implements AutoCloseable {
 
   public void onPublish(final List<DDSpan> trace, final int samplingPriority) {}
 
-  public void onFailedPublish(final int samplingPriority) {}
+  public void onFailedPublish(final int samplingPriority, final int spanCount) {}
 
   public void onPartialPublish(final int numberOfDroppedSpans) {}
 
@@ -37,11 +37,17 @@ public abstract class HealthMetrics implements AutoCloseable {
 
   public void onPartialFlush(final int sizeInBytes) {}
 
+  public void onSingleSpanSample() {}
+
+  public void onSingleSpanUnsampled() {}
+
   public void onSerialize(final int serializedSizeInBytes) {}
 
   public void onFailedSerialize(final List<DDSpan> trace, final Throwable optionalCause) {}
 
   public void onCreateSpan() {}
+
+  public void onFinishSpan() {}
 
   public void onCreateTrace() {}
 
@@ -49,9 +55,17 @@ public abstract class HealthMetrics implements AutoCloseable {
 
   public void onScopeCloseError(int scopeSource) {}
 
+  public void onCaptureContinuation() {}
+
   public void onCancelContinuation() {}
 
   public void onFinishContinuation() {}
+
+  public void onActivateScope() {}
+
+  public void onCloseScope() {}
+
+  public void onScopeStackOverflow() {}
 
   public void onSend(
       final int traceCount, final int sizeInBytes, final RemoteApi.Response response) {}

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
@@ -232,8 +232,10 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
 
   @Override
   public void onFailedSerialize(final List<DDSpan> trace, final Throwable optionalCause) {
-    serialFailedDroppedTraces.inc();
-    serialFailedDroppedSpans.inc(trace != null ? trace.size() : 0);
+    if (trace != null) {
+      serialFailedDroppedTraces.inc();
+      serialFailedDroppedSpans.inc(trace.size());
+    }
   }
 
   @Override
@@ -339,7 +341,6 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
     private static final String[] SAMPLER_KEEP_TAG = new String[] {"priority:sampler_keep"};
     private static final String[] SERIAL_FAILED_TAG = new String[] {"failure:serial"};
     private static final String[] UNSET_TAG = new String[] {"priority:unset"};
-    private static final String[] PUBLISH_FAILED_TAG = new String[] {"failure:publish"};
     private static final String[] SINGLE_SPAN_SAMPLER = new String[] {"sampler:single-span"};
 
     @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
@@ -223,7 +223,7 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
   @Override
   public void onFailedSerialize(final List<DDSpan> trace, final Throwable optionalCause) {
     serialFailedDroppedTraces.inc();
-    serialFailedDroppedSpans.inc(trace.size());
+    serialFailedDroppedSpans.inc(trace != null ? trace.size() : 0);
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
@@ -55,6 +55,7 @@ class ContinuableScope implements AgentScope, AttachableWrapper {
     }
 
     final boolean alive = decrementReferences();
+    scopeManager.healthMetrics.onCloseScope();
     if (!alive) {
       cleanup(scopeStack);
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -103,6 +103,7 @@ public final class ContinuableScopeManager implements AgentScopeManager {
     AbstractContinuation continuation =
         new SingleContinuation(this, span, ScopeSource.INSTRUMENTATION.id());
     continuation.register();
+    healthMetrics.onCaptureContinuation();
     return continuation;
   }
 
@@ -122,6 +123,7 @@ public final class ContinuableScopeManager implements AgentScopeManager {
     // DQH - This check could go before the check above, since depth limit checking is fast
     final int currentDepth = scopeStack.depth();
     if (depthLimit <= currentDepth) {
+      healthMetrics.onScopeStackOverflow();
       log.debug("Scope depth limit exceeded ({}).  Returning NoopScope.", currentDepth);
       return AgentTracer.NoopAgentScope.INSTANCE;
     }
@@ -137,8 +139,8 @@ public final class ContinuableScopeManager implements AgentScopeManager {
                 : DEFAULT_ASYNC_PROPAGATING;
 
     final ContinuableScope scope = new ContinuableScope(this, span, source, asyncPropagation);
-
     scopeStack.push(scope);
+    healthMetrics.onActivateScope();
 
     return scope;
   }
@@ -188,6 +190,7 @@ public final class ContinuableScopeManager implements AgentScopeManager {
 
     final int currentDepth = scopeStack.depth();
     if (depthLimit <= currentDepth) {
+      healthMetrics.onScopeStackOverflow();
       log.debug("Scope depth limit exceeded ({}).  Returning NoopScope.", currentDepth);
       return AgentTracer.NoopAgentScope.INSTANCE;
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
@@ -248,7 +248,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
 
     then:
     // this will be checked during flushing
-    1 * healthMetrics.onFailedPublish(_)
+    1 * healthMetrics.onFailedPublish(_,_)
     1 * healthMetrics.onFlush(_)
     1 * healthMetrics.onShutdown(_)
     1 * healthMetrics.close()
@@ -488,7 +488,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
       onPublish(_, _) >> {
         numPublished.incrementAndGet()
       }
-      onFailedPublish(_) >> {
+      onFailedPublish(_,_) >> {
         numFailedPublish.incrementAndGet()
       }
       onFlush(_) >> {
@@ -592,7 +592,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
       onPublish(_, _) >> {
         numPublished.incrementAndGet()
       }
-      onFailedPublish(_) >> {
+      onFailedPublish(_,_) >> {
         numFailedPublish.incrementAndGet()
       }
       onSend(_, _, _) >> { repCount, sizeInBytes, response ->

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
@@ -137,7 +137,7 @@ class DDAgentWriterTest extends DDCoreSpecification {
 
     then: "monitor is notified of unsuccessful publication"
     1 * worker.publish(_, _, trace) >> publishResult
-    1 * monitor.onFailedPublish(_)
+    1 * monitor.onFailedPublish(_,_)
     0 * _
 
     where:
@@ -149,7 +149,7 @@ class DDAgentWriterTest extends DDCoreSpecification {
     writer.write([])
 
     then: "monitor is notified of unsuccessful publication"
-    1 * monitor.onFailedPublish(_)
+    1 * monitor.onFailedPublish(_,_)
     0 * _
   }
 
@@ -162,7 +162,7 @@ class DDAgentWriterTest extends DDCoreSpecification {
     writer.write(trace)
 
     then:
-    1 * monitor.onFailedPublish(_)
+    1 * monitor.onFailedPublish(_,_)
     0 * _
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
@@ -244,7 +244,7 @@ class DDIntakeWriterCombinedTest extends DDCoreSpecification {
 
     then:
     // this will be checked during flushing
-    1 * healthMetrics.onFailedPublish(_)
+    1 * healthMetrics.onFailedPublish(_,_)
     1 * healthMetrics.onFlush(_)
     1 * healthMetrics.onShutdown(_)
     1 * healthMetrics.close()
@@ -451,7 +451,7 @@ class DDIntakeWriterCombinedTest extends DDCoreSpecification {
       onPublish(_, _) >> {
         numPublished.incrementAndGet()
       }
-      onFailedPublish(_) >> {
+      onFailedPublish(_,_) >> {
         numFailedPublish.incrementAndGet()
       }
       onFlush(_) >> {
@@ -562,7 +562,7 @@ class DDIntakeWriterCombinedTest extends DDCoreSpecification {
       onPublish(_, _) >> {
         numPublished.incrementAndGet()
       }
-      onFailedPublish(_) >> {
+      onFailedPublish(_,_) >> {
         numFailedPublish.incrementAndGet()
       }
       onSend(_, _, _) >> { repCount, sizeInBytes, response ->

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
@@ -246,7 +246,7 @@ class DDIntakeWriterCombinedTest extends DDCoreSpecification {
     // this will be checked during flushing
     1 * healthMetrics.onFailedPublish(_,_)
     1 * healthMetrics.onFlush(_)
-    //2 * healthMetrics.onShutdown(_)
+    1 * healthMetrics.onShutdown(_)
     1 * healthMetrics.close()
     0 * _
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
@@ -246,7 +246,7 @@ class DDIntakeWriterCombinedTest extends DDCoreSpecification {
     // this will be checked during flushing
     1 * healthMetrics.onFailedPublish(_,_)
     1 * healthMetrics.onFlush(_)
-    1 * healthMetrics.onShutdown(_)
+    //2 * healthMetrics.onShutdown(_)
     1 * healthMetrics.close()
     0 * _
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterTest.groovy
@@ -128,7 +128,7 @@ class DDIntakeWriterTest extends DDCoreSpecification{
 
     then: "monitor is notified of unsuccessful publication"
     1 * worker.publish(_, _, trace) >> publishResult
-    1 * healthMetrics.onFailedPublish(_,_)
+    1 * healthMetrics.onFailedPublish(_,1)
     _ * worker.flush(1, TimeUnit.SECONDS)
     0 * _
 
@@ -141,7 +141,7 @@ class DDIntakeWriterTest extends DDCoreSpecification{
     writer.write([])
 
     then: "monitor is notified of unsuccessful publication"
-    1 * healthMetrics.onFailedPublish(_,_)
+    1 * healthMetrics.onFailedPublish(_,0)
     _ * worker.flush(1, TimeUnit.SECONDS)
     0 * _
   }
@@ -155,7 +155,7 @@ class DDIntakeWriterTest extends DDCoreSpecification{
     writer.write(trace)
 
     then:
-    1 * healthMetrics.onFailedPublish(_,_)
+    1 * healthMetrics.onFailedPublish(_,1)
     _ * worker.flush(1, TimeUnit.SECONDS)
     0 * _
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterTest.groovy
@@ -128,7 +128,7 @@ class DDIntakeWriterTest extends DDCoreSpecification{
 
     then: "monitor is notified of unsuccessful publication"
     1 * worker.publish(_, _, trace) >> publishResult
-    1 * healthMetrics.onFailedPublish(_)
+    1 * healthMetrics.onFailedPublish(_,_)
     _ * worker.flush(1, TimeUnit.SECONDS)
     0 * _
 
@@ -141,7 +141,7 @@ class DDIntakeWriterTest extends DDCoreSpecification{
     writer.write([])
 
     then: "monitor is notified of unsuccessful publication"
-    1 * healthMetrics.onFailedPublish(_)
+    1 * healthMetrics.onFailedPublish(_,_)
     _ * worker.flush(1, TimeUnit.SECONDS)
     0 * _
   }
@@ -155,7 +155,7 @@ class DDIntakeWriterTest extends DDCoreSpecification{
     writer.write(trace)
 
     then:
-    1 * healthMetrics.onFailedPublish(_)
+    1 * healthMetrics.onFailedPublish(_,_)
     _ * worker.flush(1, TimeUnit.SECONDS)
     0 * _
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
@@ -119,7 +119,7 @@ class PayloadDispatcherTest extends DDSpecification {
     when:
     dispatcher.addTrace(trace)
     then:
-    1 * healthMetrics.onFailedPublish(PrioritySampling.UNSET)
+    1 * healthMetrics.onFailedPublish(PrioritySampling.UNSET,_)
   }
 
   def "trace and span counts are reset after access"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/SpanSamplingWorkerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/SpanSamplingWorkerTest.groovy
@@ -181,7 +181,7 @@ class SpanSamplingWorkerTest extends DDSpecification {
 
     then:
     1 * healthMetrics.onPublish([span1, span2], PrioritySampling.USER_DROP)
-    0 * healthMetrics.onFailedPublish(_)
+    0 * healthMetrics.onFailedPublish(_,_)
     0 * healthMetrics.onPartialPublish(_)
 
     cleanup:
@@ -225,7 +225,7 @@ class SpanSamplingWorkerTest extends DDSpecification {
     assert secondaryQueue.isEmpty()
 
     then:
-    1 * healthMetrics.onFailedPublish(PrioritySampling.SAMPLER_DROP)
+    1 * healthMetrics.onFailedPublish(PrioritySampling.SAMPLER_DROP,_)
     0 * healthMetrics.onPublish(_, _)
     0 * healthMetrics.onPartialPublish(_)
 
@@ -260,7 +260,7 @@ class SpanSamplingWorkerTest extends DDSpecification {
 
     then:
     1 * healthMetrics.onPublish([span1, span2], PrioritySampling.SAMPLER_DROP)
-    0 * healthMetrics.onFailedPublish(_)
+    0 * healthMetrics.onFailedPublish(_,_)
     0 * healthMetrics.onPartialPublish(_)
 
     cleanup:
@@ -296,7 +296,7 @@ class SpanSamplingWorkerTest extends DDSpecification {
     then:
     1 * healthMetrics.onPublish([span1, span2, span3], PrioritySampling.SAMPLER_DROP)
     0 * healthMetrics.onPartialPublish(_)
-    0 * healthMetrics.onFailedPublish(_)
+    0 * healthMetrics.onFailedPublish(_,_)
 
     cleanup:
     worker.close()
@@ -333,7 +333,7 @@ class SpanSamplingWorkerTest extends DDSpecification {
 
     then:
     1 * healthMetrics.onPartialPublish(2)
-    0 * healthMetrics.onFailedPublish(_)
+    0 * healthMetrics.onFailedPublish(_,_)
     0 * healthMetrics.onPublish(_, _)
 
     cleanup:
@@ -381,7 +381,7 @@ class SpanSamplingWorkerTest extends DDSpecification {
     latch.await(10, TimeUnit.SECONDS)
 
     then:
-    1 * healthMetrics.onFailedPublish(PrioritySampling.SAMPLER_DROP)
+    1 * healthMetrics.onFailedPublish(PrioritySampling.SAMPLER_DROP,_)
     0 * healthMetrics.onPartialPublish(_)
     0 * healthMetrics.onPublish(_, _)
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
@@ -72,7 +72,7 @@ class HealthMetricsTest extends DDSpecification {
     // spotless:on
   }
 
-  def "test onFailedPublish - no USER_KEEP"() {
+  def "test onFailedPublish - no KEEP"() {
     setup:
     def latch = new CountDownLatch(1)
     def healthMetrics = new TracerHealthMetrics(new Latched(statsD, latch), 100, TimeUnit.MILLISECONDS)
@@ -92,7 +92,6 @@ class HealthMetricsTest extends DDSpecification {
 
     where:
     samplingPriority << [
-      PrioritySampling.SAMPLER_KEEP,
       PrioritySampling.USER_DROP,
       PrioritySampling.SAMPLER_DROP,
       PrioritySampling.UNSET
@@ -100,7 +99,7 @@ class HealthMetricsTest extends DDSpecification {
   }
 
   @Flaky
-  def "test onFailedPublish - USER_KEEP"() {
+  def "test onFailedPublish - KEEP"() {
     setup:
     def latch = new CountDownLatch(1)
     def healthMetrics = new TracerHealthMetrics(new Latched(statsD, latch), 100, TimeUnit.MILLISECONDS)
@@ -118,7 +117,7 @@ class HealthMetricsTest extends DDSpecification {
     healthMetrics.close()
 
     where:
-    samplingPriority << [PrioritySampling.USER_KEEP]
+    samplingPriority << [PrioritySampling.SAMPLER_KEEP, PrioritySampling.USER_KEEP]
   }
 
   @Flaky

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
@@ -80,25 +80,28 @@ class HealthMetricsTest extends DDSpecification {
     healthMetrics.start()
 
     when:
-    healthMetrics.onFailedPublish(samplingPriority,1)
-    latch.await(10, TimeUnit.SECONDS)
+    healthMetrics.onFailedPublish(samplingPriority,spanCount)
+    latch.await(2, TimeUnit.SECONDS)
 
     then:
-    1 * statsD.count('queue.dropped.traces', 1, _)
-    1 * statsD.count('queue.dropped.spans', 1, _)
+    1 * statsD.count('queue.dropped.traces', 1, samplingTag)
+    1 * statsD.count('queue.dropped.spans', 1, samplingTag)
     0 * _
 
     cleanup:
     healthMetrics.close()
 
     where:
-    samplingPriority << [
-      PrioritySampling.SAMPLER_KEEP,
-      PrioritySampling.USER_KEEP,
-      PrioritySampling.USER_DROP,
-      PrioritySampling.SAMPLER_DROP,
-      PrioritySampling.UNSET
-    ]
+    // spotless:off
+    samplingPriority              | samplingTag             | spanCount
+    PrioritySampling.SAMPLER_KEEP | "priority:sampler_keep" | 1
+    PrioritySampling.USER_KEEP    | "priority:user_keep"    | 1
+    PrioritySampling.USER_DROP    | "priority:user_drop"    | 1
+    PrioritySampling.SAMPLER_DROP | "priority:sampler_drop" | 1
+    PrioritySampling.UNSET        | "priority:unset"        | 1
+    // spotless:off
+
+
   }
 
   @Flaky
@@ -114,17 +117,19 @@ class HealthMetricsTest extends DDSpecification {
 
     then:
     1 * statsD.count('queue.partial.traces', 1)
-    1 * statsD.count('queue.dropped.spans', droppedSpans, ['priority:sampler_drop'])
+    1 * statsD.count('queue.dropped.spans', droppedSpans, samplingPriority)
     0 * _
 
     cleanup:
     healthMetrics.close()
 
     where:
-    droppedSpans | traces
-    1            | 4
-    42           | 1
-    3            | 5
+    // spotless:off
+    droppedSpans | traces | samplingPriority
+    1            | 4      | ['priority:sampler_drop']
+    42           | 1      | ['priority:sampler_drop']
+    3            | 5      | ['priority:sampler_drop']
+    // spotless:on
   }
 
   def "test onScheduleFlush"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
@@ -79,7 +79,7 @@ class HealthMetricsTest extends DDSpecification {
     healthMetrics.start()
 
     when:
-    healthMetrics.onFailedPublish(samplingPriority)
+    healthMetrics.onFailedPublish(samplingPriority,_)
     latch.await(10, TimeUnit.SECONDS)
 
     then:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
@@ -72,7 +72,8 @@ class HealthMetricsTest extends DDSpecification {
     // spotless:on
   }
 
-  def "test onFailedPublish - no KEEP"() {
+  @Flaky
+  def "test onFailedPublish"() {
     setup:
     def latch = new CountDownLatch(1)
     def healthMetrics = new TracerHealthMetrics(new Latched(statsD, latch), 100, TimeUnit.MILLISECONDS)
@@ -92,32 +93,12 @@ class HealthMetricsTest extends DDSpecification {
 
     where:
     samplingPriority << [
+      PrioritySampling.SAMPLER_KEEP,
+      PrioritySampling.USER_KEEP,
       PrioritySampling.USER_DROP,
       PrioritySampling.SAMPLER_DROP,
       PrioritySampling.UNSET
     ]
-  }
-
-  @Flaky
-  def "test onFailedPublish - KEEP"() {
-    setup:
-    def latch = new CountDownLatch(1)
-    def healthMetrics = new TracerHealthMetrics(new Latched(statsD, latch), 100, TimeUnit.MILLISECONDS)
-    healthMetrics.start()
-
-    when:
-    healthMetrics.onFailedPublish(samplingPriority,1)
-    latch.await(10, TimeUnit.SECONDS)
-
-    then:
-    1 * statsD.count('queue.dropped.traces', 1, _)
-    0 * _
-
-    cleanup:
-    healthMetrics.close()
-
-    where:
-    samplingPriority << [PrioritySampling.SAMPLER_KEEP, PrioritySampling.USER_KEEP]
   }
 
   @Flaky


### PR DESCRIPTION
# What Does This Do
Adds health metrics around trace and span construction:
`queue.dropped.spans` - number of dropped spans tagged by sampling priority
`span.pending.finished` - number of spans that are finished
`span.sampling.sampled` - number of spans sampled by the single span sampler
`span.sampling.unsampled` - number of spans that are considered unsampled by the single span sampler
`scope.activate.count` - number of activated ContinuableScopes
`scope.close.count` - number of closed ContinuableScopes
`scope.error.stack-overflow` - counts the number of times that the Scope depth limit is exceeded
# Motivation
The goal of implementing these metrics is to increase visibility into potential issues in trace/span creation or delivery.

# Additional Notes
