### PR TITLE
add service name and resource name to profiling context

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -149,10 +149,13 @@ public final class DatadogProfiler {
     if (isWallClockProfilerEnabled(configProvider)) {
       profilingModes.add(WALL);
     }
-    this.orderedContextAttributes = new ArrayList<>(contextAttributes);
+    this.orderedContextAttributes = new ArrayList<>();
     if (isSpanNameContextAttributeEnabled(configProvider)) {
-      orderedContextAttributes.add(0, "operation");
+      orderedContextAttributes.add("resource");
+      orderedContextAttributes.add("operation");
+      orderedContextAttributes.add("service");
     }
+    orderedContextAttributes.addAll(contextAttributes);
     this.contextSetter = new ContextSetter(profiler, orderedContextAttributes);
     try {
       // sanity test - force load Datadog profiler to catch it not being available early
@@ -327,6 +330,14 @@ public final class DatadogProfiler {
 
   public int operationNameOffset() {
     return offsetOf("operation");
+  }
+
+  public int serviceNameOffset() {
+    return offsetOf("service");
+  }
+
+  public int resourceNameOffset() {
+    return offsetOf("resource");
   }
 
   public int offsetOf(String attribute) {

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilingIntegration.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilingIntegration.java
@@ -11,6 +11,10 @@ public class DatadogProfilingIntegration implements ProfilingContextIntegration 
 
   private static final DatadogProfiler DDPROF = DatadogProfiler.getInstance();
   private static final int SPAN_NAME_INDEX = DDPROF.operationNameOffset();
+
+  private static final int RESOURCE_NAME_INDEX = DDPROF.resourceNameOffset();
+
+  private static final int SERVICE_NAME_INDEX = DDPROF.serviceNameOffset();
   private static final boolean WALLCLOCK_ENABLED =
       DatadogProfilerConfig.isWallClockProfilerEnabled();
 
@@ -39,13 +43,17 @@ public class DatadogProfilingIntegration implements ProfilingContextIntegration 
   @Override
   public void setContext(ProfilerContext profilerContext) {
     DDPROF.setSpanContext(profilerContext.getSpanId(), profilerContext.getRootSpanId());
+    DDPROF.setContextValue(RESOURCE_NAME_INDEX, profilerContext.getEncodedResourceName());
     DDPROF.setContextValue(SPAN_NAME_INDEX, profilerContext.getEncodedOperationName());
+    DDPROF.setContextValue(SERVICE_NAME_INDEX, profilerContext.getEncodedServiceName());
   }
 
   @Override
   public void clearContext() {
     DDPROF.clearSpanContext();
+    DDPROF.clearContextValue(RESOURCE_NAME_INDEX);
     DDPROF.clearContextValue(SPAN_NAME_INDEX);
+    DDPROF.clearContextValue(SERVICE_NAME_INDEX);
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -137,6 +137,8 @@ public class DDSpanContext
   private final ProfilingContextIntegration profilingContextIntegration;
 
   private volatile int encodedOperationName;
+  private volatile int encodedResourceName;
+  private volatile int encodedServiceName;
 
   public DDSpanContext(
       final DDTraceId traceId,
@@ -229,9 +231,16 @@ public class DDSpanContext
     final int capacity = Math.max((tagsSize <= 0 ? 3 : (tagsSize + 1)) * 4 / 3, 8);
     this.unsafeTags = new HashMap<>(capacity);
 
+    // must set this before setting the service and resource names below
+    this.profilingContextIntegration = profilingContextIntegration;
+    // as fast as we can try to make this operation, we still might need to activate/deactivate
+    // contexts at alarming rates in unpredictable async applications, so we'll try
+    // to get away with doing this just once per span
+    this.encodedOperationName = profilingContextIntegration.encode(operationName);
+
     setServiceName(serviceName);
     this.operationName = operationName;
-    this.resourceName = resourceName;
+    setResourceName(resourceName, ResourceNamePriorities.DEFAULT);
     this.errorFlag = errorFlag;
     this.spanType = spanType;
 
@@ -252,11 +261,6 @@ public class DDSpanContext
     if (samplingPriority != PrioritySampling.UNSET) {
       setSamplingPriority(samplingPriority, SamplingMechanism.UNKNOWN);
     }
-    this.profilingContextIntegration = profilingContextIntegration;
-    // as fast as we can try to make this operation, we still might need to activate/deactivate
-    // contexts at alarming rates in unpredictable async applications, so we'll try
-    // to get away with doing this just once per span
-    this.encodedOperationName = profilingContextIntegration.encode(operationName);
   }
 
   @Override
@@ -283,6 +287,16 @@ public class DDSpanContext
     return encodedOperationName;
   }
 
+  @Override
+  public int getEncodedServiceName() {
+    return encodedServiceName;
+  }
+
+  @Override
+  public int getEncodedResourceName() {
+    return encodedResourceName;
+  }
+
   public String getServiceName() {
     return serviceName;
   }
@@ -290,6 +304,9 @@ public class DDSpanContext
   public void setServiceName(final String serviceName) {
     this.serviceName = trace.getTracer().mapServiceName(serviceName);
     this.topLevel = isTopLevel(parentServiceName, this.serviceName);
+    if (this.serviceName != null) {
+      this.encodedServiceName = profilingContextIntegration.encode(this.serviceName);
+    }
   }
 
   // TODO this logic is inconsistent with hasResourceName
@@ -312,6 +329,7 @@ public class DDSpanContext
     if (priority >= this.resourceNamePriority) {
       this.resourceNamePriority = priority;
       this.resourceName = resourceName;
+      this.encodedResourceName = profilingContextIntegration.encode(resourceName);
     }
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -555,6 +555,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     1 * profilingContext.onAttach()
     1 * profilingContext.encode("foo")
     1 * profilingContext.encode("bar")
+    _ * profilingContext._
     0 * _
 
     when:
@@ -595,6 +596,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     1 * profilingContext.onAttach()
     1 * profilingContext.setContext(_)
     1 * profilingContext.encode("foo")
+    _ * profilingContext._
     0 * _
 
     when:
@@ -608,6 +610,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     assertEvents([ACTIVATE, ACTIVATE])
     1 * profilingContext.setContext(_)
     1 * profilingContext.encode("bar")
+    _ * profilingContext._
     0 * _
 
     when:
@@ -621,6 +624,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     assertEvents([ACTIVATE, ACTIVATE, ACTIVATE])
     1 * profilingContext.setContext(_)
     1 * profilingContext.encode("quux")
+    _ * profilingContext._
     0 * _
 
     when:
@@ -705,6 +709,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     assertEvents([ACTIVATE, ACTIVATE])
     1 * profilingContext.setContext(_)
     1 * profilingContext.encode("quux")
+    _ * profilingContext._
     0 * _
 
     when:

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ProfilerContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ProfilerContext.java
@@ -8,4 +8,8 @@ public interface ProfilerContext {
   long getRootSpanId();
 
   int getEncodedOperationName();
+
+  int getEncodedServiceName();
+
+  int getEncodedResourceName();
 }


### PR DESCRIPTION
# What Does This Do

Adds service and resource name tags to profile events (e.g. cpu, wall, allocation).

# Motivation

# Additional Notes
