### PR TITLE
reduce the number of noisy log statements

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-auxiliary-ddprof/src/main/java/com/datadog/profiling/auxiliary/ddprof/AuxiliaryDatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-auxiliary-ddprof/src/main/java/com/datadog/profiling/auxiliary/ddprof/AuxiliaryDatadogProfiler.java
@@ -77,8 +77,6 @@ final class AuxiliaryDatadogProfiler implements AuxiliaryImplementation {
     } catch (Throwable t) {
       if (log.isDebugEnabled()) {
         log.warn("Exception occurred while attempting to emit config event", t);
-      } else {
-        log.warn("Exception occurred while attempting to emit config event: {}", t.toString());
       }
     }
   }

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecording.java
@@ -68,14 +68,14 @@ public class OpenJdkOngoingRecording implements OngoingRecording {
         case CPU:
           {
             // CPU execution profiling will take over these events
-            log.info("Disabling built-in CPU profiling events");
+            log.debug("Disabling built-in CPU profiling events");
             recording.disable("jdk.ExecutionSample");
             recording.disable("jdk.NativeMethodSample");
             break;
           }
         case WALL:
           {
-            log.info("Disabling built-in wall-time tracing events");
+            log.debug("Disabling built-in wall-time tracing events");
             recording.disable("jdk.JavaMonitorWait");
             recording.disable("jdk.ThreadPark");
             recording.disable("jdk.ThreadSleep");
@@ -84,7 +84,7 @@ public class OpenJdkOngoingRecording implements OngoingRecording {
         case ALLOCATION:
           {
             // allocation profiling will take over these events
-            log.info("Disabling built-in allocation profiling events");
+            log.debug("Disabling built-in allocation profiling events");
             recording.disable("jdk.ObjectAllocationOutsideTLAB");
             recording.disable("jdk.ObjectAllocationInNewTLAB");
             recording.disable("jdk.ObjectAllocationSample");
@@ -93,7 +93,7 @@ public class OpenJdkOngoingRecording implements OngoingRecording {
         case MEMLEAK:
           {
             // memleak profiling will take over these events
-            log.info("Disabling built-in memory leak profiling events");
+            log.debug("Disabling built-in memory leak profiling events");
             recording.disable("jdk.OldObjectSample");
             break;
           }

--- a/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/JfrMBeanHelper.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/JfrMBeanHelper.java
@@ -393,7 +393,7 @@ final class JfrMBeanHelper {
         }
       default:
         {
-          log.warn(
+          log.debug(
               "Unsupported time unit: {}. Assuming {}", valueUnit[1], defaultTimeUnit.toString());
           return Duration.of(value, defaultTimeUnit);
         }
@@ -457,7 +457,7 @@ final class JfrMBeanHelper {
     try {
       return ObjectName.getInstance(objectName);
     } catch (MalformedObjectNameException e) {
-      log.warn("Invalid object name: {}", objectName);
+      log.debug("Invalid object name: {}", objectName);
     }
     return null;
   }

--- a/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkOngoingRecording.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-oracle/src/main/java/com/datadog/profiling/controller/oracle/OracleJdkOngoingRecording.java
@@ -81,7 +81,7 @@ public class OracleJdkOngoingRecording implements OngoingRecording {
     try {
       helper.closeRecording(recordingId);
     } catch (IOException e) {
-      log.warn("Unable to close recording {}", name, e);
+      log.debug("Unable to close recording {}", name, e);
     }
   }
 

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -349,7 +349,7 @@ public final class DatadogProfiler {
       try {
         profiler.setContext(spanId, rootSpanId);
       } catch (IllegalStateException e) {
-        log.warn("Failed to clear context", e);
+        log.debug("Failed to clear context", e);
       }
     }
   }
@@ -359,7 +359,7 @@ public final class DatadogProfiler {
       try {
         profiler.setContext(0L, 0L);
       } catch (IllegalStateException e) {
-        log.warn("Failed to set context", e);
+        log.debug("Failed to set context", e);
       }
     }
   }

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
@@ -361,7 +361,7 @@ public final class ProfileUploader {
     } catch (final InterruptedException e) {
       // Note: this should only happen in main thread right before exiting, so eating up interrupted
       // state should be fine.
-      log.warn("Wait for executor shutdown interrupted");
+      log.debug("Wait for executor shutdown interrupted");
     }
     client.connectionPool().evictAll();
   }


### PR DESCRIPTION
# What Does This Do

Changes log statements which indicate that something unexpected has happened but do not constitute a loss of functionality to debug to avoid alarming users.

# Motivation

# Additional Notes
