### PR TITLE
Upgrade jmxfetch to 0.47.5 to fix CVE-2022-1471

### DIFF
--- a/dd-java-agent/agent-jmxfetch/build.gradle
+++ b/dd-java-agent/agent-jmxfetch/build.gradle
@@ -11,15 +11,13 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 
 dependencies {
-  api('com.datadoghq:jmxfetch:0.47.0') {
+  api('com.datadoghq:jmxfetch:0.47.5') {
     exclude group: 'org.slf4j', module: 'slf4j-api'
     exclude group: 'org.slf4j', module: 'slf4j-jdk14'
-    exclude group: 'org.yaml', module: 'snakeyaml'
     exclude group: 'com.beust', module: 'jcommander'
   }
   api deps.slf4j
   api project(':internal-api')
-  implementation 'org.yaml:snakeyaml:1.32' // override to mitigate CVE-2022-38752 until jmxfetch is fixed
 }
 
 shadowJar {

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/build.gradle
@@ -33,5 +33,5 @@ dependencies {
   testImplementation group: 'com.amazonaws', name: 'amazon-sqs-java-messaging-lib', version: '2.0.0'
 
   latestDepTestImplementation group: 'software.amazon.awssdk', name: 'sqs', version: '+'
-  latestDepTestImplementation group: 'com.amazonaws', name: 'amazon-sqs-java-messaging-lib', version: '2.+'
+  latestDepTestImplementation group: 'com.amazonaws', name: 'amazon-sqs-java-messaging-lib', version: '2.0.+'
 }

--- a/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.5/build.gradle
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.5/build.gradle
@@ -41,5 +41,5 @@ dependencies {
   testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$coroutinesVersion"
   testImplementation testFixtures(project(':dd-java-agent:instrumentation:kotlin-coroutines'))
 
-  latestDepTestImplementation group: 'org.jetbrains.kotlinx', name: "kotlinx-coroutines-core", version: '1.+'
+  latestDepTestImplementation group: 'org.jetbrains.kotlinx', name: "kotlinx-coroutines-core", version: '1.6.+'
 }


### PR DESCRIPTION
# What Does This Do

Upgrades jmx fetch to `0.47.5` to fix [CVE-2022-1471](https://nvd.nist.gov/vuln/detail/CVE-2022-1471)

# Motivation

# Additional Notes

Solves #4910 