### PR TITLE
Upgrade jmxfetch to 0.47.5 to fix CVE-2022-1471

### DIFF
--- a/dd-java-agent/agent-jmxfetch/build.gradle
+++ b/dd-java-agent/agent-jmxfetch/build.gradle
@@ -11,15 +11,13 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 
 dependencies {
-  api('com.datadoghq:jmxfetch:0.47.0') {
+  api('com.datadoghq:jmxfetch:0.47.5') {
     exclude group: 'org.slf4j', module: 'slf4j-api'
     exclude group: 'org.slf4j', module: 'slf4j-jdk14'
-    exclude group: 'org.yaml', module: 'snakeyaml'
     exclude group: 'com.beust', module: 'jcommander'
   }
   api deps.slf4j
   api project(':internal-api')
-  implementation 'org.yaml:snakeyaml:1.32' // override to mitigate CVE-2022-38752 until jmxfetch is fixed
 }
 
 shadowJar {


### PR DESCRIPTION
# What Does This Do

Upgrades jmx fetch to `0.47.5` to fix [CVE-2022-1471](https://nvd.nist.gov/vuln/detail/CVE-2022-1471)

# Motivation

# Additional Notes
