### PR TITLE
bump jplib to 0.26.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    jplib         : "0.24.0",
+    jplib         : "0.26.0",
     asm           : "9.4"
   ]
 


### PR DESCRIPTION
# What Does This Do

Clears out the old slot in the call trace storage hashmap when there are collisions

# Motivation

# Additional Notes
