### PR TITLE
Build-time instrumenting toolchain support

### DIFF
--- a/buildSrc/src/main/groovy/InstrumentingPlugin.groovy
+++ b/buildSrc/src/main/groovy/InstrumentingPlugin.groovy
@@ -1,0 +1,75 @@
+import net.bytebuddy.ClassFileVersion
+import net.bytebuddy.build.EntryPoint
+import net.bytebuddy.build.Plugin
+import net.bytebuddy.description.type.TypeDescription
+import net.bytebuddy.dynamic.ClassFileLocator
+import net.bytebuddy.dynamic.scaffold.inline.MethodNameTransformer.Suffixing
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * Performs build-time instrumentation of classes, called indirectly from InstrumentPlugin.
+ * (This is the byte-buddy side of the task; InstrumentPlugin contains the Gradle pieces.)
+ */
+class InstrumentingPlugin {
+  static final Logger log = LoggerFactory.getLogger(InstrumentingPlugin.class)
+
+  static void instrumentClasses(
+    String[] plugins, ClassLoader instrumentingLoader, File sourceDirectory, File targetDirectory)
+    throws Exception {
+
+    ClassLoader tccl = Thread.currentThread().getContextClassLoader()
+    try {
+      Thread.currentThread().setContextClassLoader(instrumentingLoader)
+
+      List<Plugin.Factory> factories = new ArrayList<>()
+      for (String plugin : plugins) {
+        try {
+          Class<Plugin> pluginClass = (Class<Plugin>) instrumentingLoader.loadClass(plugin)
+          Plugin loadedPlugin = pluginClass.getConstructor(File.class).newInstance(targetDirectory)
+          factories.add(new Plugin.Factory.Simple(loadedPlugin))
+        } catch (Throwable throwable) {
+          throw new IllegalStateException("Cannot resolve plugin: " + plugin, throwable)
+        }
+      }
+
+      Plugin.Engine.Source source = new Plugin.Engine.Source.ForFolder(sourceDirectory)
+      Plugin.Engine.Target target = new Plugin.Engine.Target.ForFolder(targetDirectory)
+
+      Plugin.Engine engine =
+        Plugin.Engine.Default.of(
+          EntryPoint.Default.REBASE, ClassFileVersion.ofThisVm(), Suffixing.withRandomSuffix())
+
+      Plugin.Engine.Summary summary =
+        engine
+          .with(Plugin.Engine.PoolStrategy.Default.FAST)
+          .with(ClassFileLocator.ForClassLoader.of(instrumentingLoader))
+          .with(new LoggingAdapter())
+          .withErrorHandlers(
+            Plugin.Engine.ErrorHandler.Enforcing.ALL_TYPES_RESOLVED,
+            Plugin.Engine.ErrorHandler.Enforcing.NO_LIVE_INITIALIZERS,
+            Plugin.Engine.ErrorHandler.Failing.FAIL_LAST)
+          .with(Plugin.Engine.Dispatcher.ForSerialTransformation.Factory.INSTANCE)
+          .apply(source, target, factories)
+
+      if (!summary.getFailed().isEmpty()) {
+        throw new IllegalStateException("Failed to transform: " + summary.getFailed())
+      }
+    } catch (Throwable e) {
+      Thread.currentThread().setContextClassLoader(tccl)
+      throw e
+    }
+  }
+
+  static class LoggingAdapter extends Plugin.Engine.Listener.Adapter {
+    @Override
+    void onTransformation(TypeDescription typeDescription, List<Plugin> plugins) {
+      log.debug("Transformed {} using {}", typeDescription, plugins)
+    }
+
+    @Override
+    void onError(TypeDescription typeDescription, Plugin plugin, Throwable throwable) {
+      log.warn("Failed to transform {} using {}", typeDescription, plugin, throwable)
+    }
+  }
+}

--- a/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
+++ b/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
@@ -95,7 +95,7 @@ class InstrumentPluginTest extends Specification {
       .withTestKitDir(new File(buildDir, '.gradle-test-kit'))  // workaround in case the global test-kit cache becomes corrupted
       .withDebug(true)                                         // avoids starting daemon which can leave undeleted files post-cleanup
       .withProjectDir(buildDir)
-      .withArguments('build')
+      .withArguments('build', '--stacktrace')
       .withPluginClasspath()
       .forwardOutput()
       .build()

--- a/dd-java-agent/agent-tooling/build.gradle
+++ b/dd-java-agent/agent-tooling/build.gradle
@@ -23,11 +23,10 @@ sourceSets {
 }
 
 configurations {
-  // classpath used by the instrumentation muzzle plugin
-  instrumentationMuzzle {
+  instrumentPluginClasspath {
     canBeConsumed = true
     canBeResolved = false
-    extendsFrom implementation
+    extendsFrom runtimeElements
   }
 
   test_java11Implementation {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGenerator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGenerator.java
@@ -58,8 +58,8 @@ public class MuzzleGenerator implements AsmVisitorWrapper {
     try {
       instrumenter =
           (Instrumenter.Default)
-              MuzzleGenerator.class
-                  .getClassLoader()
+              Thread.currentThread()
+                  .getContextClassLoader()
                   .loadClass(instrumentedType.getName())
                   .getConstructor()
                   .newInstance();
@@ -83,12 +83,11 @@ public class MuzzleGenerator implements AsmVisitorWrapper {
     final Map<String, Reference> references = new LinkedHashMap<>();
     final Set<String> adviceClasses = new HashSet<>();
     instrumenter.adviceTransformations((matcher, name) -> adviceClasses.add(name));
+    ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
     for (String adviceClass : adviceClasses) {
       if (referenceSources.add(adviceClass)) {
         for (Map.Entry<String, Reference> entry :
-            ReferenceCreator.createReferencesFrom(
-                    adviceClass, ReferenceMatcher.class.getClassLoader())
-                .entrySet()) {
+            ReferenceCreator.createReferencesFrom(adviceClass, contextClassLoader).entrySet()) {
           Reference toMerge = references.get(entry.getKey());
           if (null == toMerge) {
             references.put(entry.getKey(), entry.getValue());

--- a/dd-java-agent/instrumentation/build.gradle
+++ b/dd-java-agent/instrumentation/build.gradle
@@ -22,8 +22,7 @@ subprojects { Project subProj ->
   apply plugin: 'muzzle'
 
   configurations {
-    // classpath used by the instrumentation muzzle plugin
-    instrumentationMuzzle {
+    instrumentPluginClasspath {
       visible = false
       canBeConsumed = false
       canBeResolved = true
@@ -70,7 +69,7 @@ subprojects { Project subProj ->
       testAnnotationProcessor deps.autoserviceProcessor
       testCompileOnly deps.autoserviceAnnotation
 
-      instrumentationMuzzle project(path: ':dd-java-agent:agent-tooling', configuration: 'instrumentationMuzzle')
+      instrumentPluginClasspath project(path: ':dd-java-agent:agent-tooling', configuration: 'instrumentPluginClasspath')
     }
 
     subProj.tasks.withType(Test).configureEach { subTask ->


### PR DESCRIPTION
# What Does This Do

Runs build-time instrumentation tasks on the appropriate Java version

# Motivation

Certain build-time instrumentation tasks, such as generation of muzzle references, need to run on the appropriate Java version - otherwise some bytecode references will not be resolvable. This is a companion PR to #4913  