### PR TITLE
Avoid ClassNotFoundException when resteasy-spring attempts to process tracer-related beans

### DIFF
--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/BeanDefinitionRepairer.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/BeanDefinitionRepairer.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.springweb;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 
 /**
@@ -12,6 +13,11 @@ public final class BeanDefinitionRepairer {
 
   public static void register(Class<?> beanClass) {
     ddBeanClasses.put(beanClass.getName(), beanClass);
+  }
+
+  public static boolean isDatadogBean(BeanDefinition beanDefinition) {
+    String className = beanDefinition.getBeanClassName();
+    return null != className && null != ddBeanClasses.get(className);
   }
 
   public static void repair(RootBeanDefinition beanDefinition) {

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/BeanDefinitionRepairer.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/BeanDefinitionRepairer.java
@@ -17,7 +17,7 @@ public final class BeanDefinitionRepairer {
 
   public static boolean isDatadogBean(BeanDefinition beanDefinition) {
     String className = beanDefinition.getBeanClassName();
-    return null != className && null != ddBeanClasses.get(className);
+    return null != className && ddBeanClasses.containsKey(className);
   }
 
   public static void repair(RootBeanDefinition beanDefinition) {

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringBeanProcessorInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringBeanProcessorInstrumentation.java
@@ -28,6 +28,11 @@ public class SpringBeanProcessorInstrumentation extends Instrumenter.Tracing
   }
 
   @Override
+  public String[] helperClassNames() {
+    return new String[] {packageName + ".BeanDefinitionRepairer"};
+  }
+
+  @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(
         isMethod()
@@ -45,8 +50,7 @@ public class SpringBeanProcessorInstrumentation extends Instrumenter.Tracing
   public static class SkipBeanClassAdvice {
     @Advice.OnMethodEnter(skipOn = Advice.OnNonDefaultValue.class, suppress = Throwable.class)
     public static Class<?> onEnter(@Advice.Argument(3) final BeanDefinition beanDefinition) {
-      if ("datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter"
-          .equals(beanDefinition.getBeanClassName())) {
+      if (BeanDefinitionRepairer.isDatadogBean(beanDefinition)) {
         return Object.class; // skip the original method and return this value instead
       } else {
         return null; // continue on to call the original method and return its value


### PR DESCRIPTION
This replaces the previous workaround which was limited to listing tracer beans by name.

After #4543 we now have a single place to track and resolve these beans, so re-use that here.