### PR TITLE
Support using the Java tracer with both -javaagent and -jar at the same time

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -43,7 +43,9 @@ import java.lang.instrument.Instrumentation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.UndeclaredThrowableException;
+import java.net.MalformedURLException;
 import java.net.URL;
+import java.security.CodeSource;
 import java.util.EnumSet;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -301,13 +303,25 @@ public class Agent {
     }
   }
 
-  public static synchronized Class<?> installAgentCLI(final URL agentJarURL) throws Exception {
+  public static synchronized Class<?> installAgentCLI() throws Exception {
     if (null == AGENT_CLASSLOADER) {
       // in CLI mode we skip installation of instrumentation because we're not running as an agent
       // we still create the agent classloader so we can install the tracer and query integrations
-      createAgentClassloader(agentJarURL);
+      CodeSource codeSource = Agent.class.getProtectionDomain().getCodeSource();
+      if (codeSource == null || codeSource.getLocation() == null) {
+        throw new MalformedURLException("Could not get jar location from code source");
+      }
+      createAgentClassloader(codeSource.getLocation());
     }
     return AGENT_CLASSLOADER.loadClass("datadog.trace.agent.tooling.AgentCLI");
+  }
+
+  /** Used by AgentCLI to send sample traces from the command-line. */
+  public static void startDatadogTracer() throws Exception {
+    Class<?> scoClass =
+        AGENT_CLASSLOADER.loadClass("datadog.communication.ddagent.SharedCommunicationObjects");
+    installDatadogTracer(scoClass, scoClass.getConstructor().newInstance());
+    startJmx(); // send runtime metrics along with the traces
   }
 
   private static void registerLogManagerCallback(final ClassLoadCallBack callback) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentCLI.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentCLI.java
@@ -53,8 +53,8 @@ public final class AgentCLI {
    * @param count how many traces to send, negative means send forever
    * @param interval the interval (in seconds) to wait for each trace
    */
-  public static void sendSampleTraces(final int count, final double interval) {
-    Agent.start(null, Agent.class.getProtectionDomain().getCodeSource().getLocation());
+  public static void sendSampleTraces(final int count, final double interval) throws Exception {
+    Agent.startDatadogTracer();
 
     int numTraces = 0;
     while (++numTraces <= count || count < 0) {

--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentJar.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentJar.java
@@ -3,10 +3,7 @@ package datadog.trace.bootstrap;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.security.CodeSource;
 import java.util.Arrays;
 
 /** Entry point when running the agent as a sample application with -jar. */
@@ -119,13 +116,7 @@ public final class AgentJar {
   }
 
   private static Class<?> installAgentCLI() throws Exception {
-    CodeSource codeSource = thisClass.getProtectionDomain().getCodeSource();
-    if (codeSource == null || codeSource.getLocation() == null) {
-      throw new MalformedURLException("Could not get jar location from code source");
-    }
-
-    return (Class<?>)
-        agentClass.getMethod("installAgentCLI", URL.class).invoke(null, codeSource.getLocation());
+    return (Class<?>) agentClass.getMethod("installAgentCLI").invoke(null);
   }
 
   private static void printAgentVersion() {


### PR DESCRIPTION
# What Does This Do

Cleans up how we load classes via the CLI to avoid checking the code source location unless we really need it.
For example, if the agent classloader is already installed then we don't need the tracer's code source location.

# Motivation

 This avoids a potential exception when `dd-java-agent` is used with both `-javaagent` and `-jar` at the same time.

(The original exception occurred because the code source location of `AgentJar` became `null` after we added `dd-java-agent` to the boot-class-path - determining that we're running `dd-java-agent` with `-jar` from `premain` turns out to be non-trivial, it was easier to adjust the code so `dd-java-agent` can work in both places.)
