### PR TITLE
service naming: all datastore service is dd_service for v1

### DIFF
--- a/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeAsyncClientTest.groovy
@@ -87,7 +87,7 @@ class AerospikeAsyncClientV1ForkedTest extends AerospikeAsyncClientTest {
 
   @Override
   String service() {
-    return Config.get().getServiceName() + "-aerospike"
+    return Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeClientTest.groovy
+++ b/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeClientTest.groovy
@@ -65,7 +65,7 @@ class AerospikeClientV1ForkedTest extends AerospikeClientTest {
 
   @Override
   String service() {
-    return Config.get().getServiceName() + "-aerospike"
+    return Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
@@ -195,7 +195,7 @@ class CouchbaseAsyncClientV1ForkedTest extends CouchbaseAsyncClientTest {
 
   @Override
   String service() {
-    return Config.get().getServiceName() + "-couchbase"
+    return Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
@@ -137,7 +137,7 @@ class CouchbaseClientV1ForkedTest extends CouchbaseClientTest {
 
   @Override
   String service() {
-    return Config.get().getServiceName() + "-couchbase"
+    return Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/test/groovy/CouchbaseClient31Test.groovy
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/test/groovy/CouchbaseClient31Test.groovy
@@ -441,7 +441,7 @@ class CouchbaseClient31V1ForkedTest extends CouchbaseClient31Test {
 
   @Override
   String service() {
-    return Config.get().getServiceName() + "-couchbase"
+    return Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/test/groovy/CouchbaseClient32Test.groovy
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/test/groovy/CouchbaseClient32Test.groovy
@@ -452,7 +452,7 @@ class CouchbaseClient32V1ForkedTest extends CouchbaseClient32Test {
 
   @Override
   String service() {
-    return Config.get().getServiceName() + "-couchbase"
+    return Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/src/test/groovy/CassandraClientTest.groovy
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/src/test/groovy/CassandraClientTest.groovy
@@ -185,7 +185,7 @@ class CassandraClientV1ForkedTest extends CassandraClientTest {
 
   @Override
   String service() {
-    return Config.get().getServiceName() + "-cassandra"
+    return Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/datastax-cassandra-4/src/test/groovy/CassandraClientTest.groovy
+++ b/dd-java-agent/instrumentation/datastax-cassandra-4/src/test/groovy/CassandraClientTest.groovy
@@ -266,7 +266,7 @@ class CassandraClientV1ForkedTest extends CassandraClientTest {
 
   @Override
   String service() {
-    return Config.get().getServiceName() + "-cassandra"
+    return Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
@@ -148,7 +148,7 @@ class Elasticsearch5RestClientV1ForkedTest extends Elasticsearch5RestClientTest 
 
   @Override
   String service() {
-    return Config.get().getServiceName() + "-elasticsearch"
+    return Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -314,7 +314,7 @@ class Elasticsearch2NodeClientV1ForkedTest extends Elasticsearch2NodeClientTest 
 
   @Override
   String service() {
-    return Config.get().getServiceName() + "-elasticsearch"
+    return Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -376,7 +376,7 @@ class Elasticsearch2TransportClientV1ForkedTest extends Elasticsearch2TransportC
 
   @Override
   String service() {
-    return Config.get().getServiceName() + "-elasticsearch"
+    return Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -327,7 +327,7 @@ class Elasticsearch2SpringRepositoryV1ForkedTest extends Elasticsearch2SpringRep
 
   @Override
   String service() {
-    return datadog.trace.api.Config.get().getServiceName() + "-elasticsearch"
+    return datadog.trace.api.Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -377,7 +377,7 @@ class Elasticsearch2SpringTemplateV1ForkedTest extends Elasticsearch2SpringTempl
 
   @Override
   String service() {
-    return datadog.trace.api.Config.get().getServiceName() + "-elasticsearch"
+    return datadog.trace.api.Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hazelcast-3.6/src/test/groovy/test/hazelcast/v3/HazelcastTest.groovy
+++ b/dd-java-agent/instrumentation/hazelcast-3.6/src/test/groovy/test/hazelcast/v3/HazelcastTest.groovy
@@ -378,7 +378,7 @@ class HazelcastV1ForkedTest extends HazelcastTest {
 
   @Override
   String service() {
-    return datadog.trace.api.Config.get().getServiceName() + "-hazelcast"
+    return datadog.trace.api.Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hazelcast-3.9/src/test/groovy/test/hazelcast/v39/HazelcastTest.groovy
+++ b/dd-java-agent/instrumentation/hazelcast-3.9/src/test/groovy/test/hazelcast/v39/HazelcastTest.groovy
@@ -436,7 +436,7 @@ class HazelcastV1ForkedTest extends HazelcastTest {
 
   @Override
   String service() {
-    return datadog.trace.api.Config.get().getServiceName() + "-hazelcast"
+    return datadog.trace.api.Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/hazelcast-4.0/src/test/groovy/test/hazelcast/v4/HazelcastTest.groovy
+++ b/dd-java-agent/instrumentation/hazelcast-4.0/src/test/groovy/test/hazelcast/v4/HazelcastTest.groovy
@@ -468,7 +468,7 @@ class HazelcastV1ForkedTest extends HazelcastTest {
 
   @Override
   String service() {
-    return datadog.trace.api.Config.get().getServiceName() + "-hazelcast"
+    return datadog.trace.api.Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/ignite-2.0/src/test/groovy/test/AbstractIgniteTest.groovy
+++ b/dd-java-agent/instrumentation/ignite-2.0/src/test/groovy/test/AbstractIgniteTest.groovy
@@ -15,7 +15,7 @@ import spock.lang.Shared
 
 abstract class AbstractIgniteTest extends VersionedNamingTestBase {
   static final String V0_SERVICE = "ignite"
-  static final String V1_SERVICE = Config.get().getServiceName() + "-ignite"
+  static final String V1_SERVICE = Config.get().getServiceName()
   static final String V0_OPERATION = "ignite.cache"
   static final String V1_OPERATION = "ignite.command"
 

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
@@ -187,7 +187,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
           spanType DDSpanTypes.SQL
           childOf span(0)
           errored false
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "java-jdbc-statement"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -255,7 +255,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
           spanType DDSpanTypes.SQL
           childOf span(0)
           errored false
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -309,7 +309,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
           spanType DDSpanTypes.SQL
           childOf span(0)
           errored false
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -363,7 +363,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
           spanType DDSpanTypes.SQL
           childOf span(0)
           errored false
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -473,7 +473,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
           spanType DDSpanTypes.SQL
           childOf span(0)
           errored false
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -541,7 +541,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
           spanType DDSpanTypes.SQL
           childOf span(0)
           errored false
-          topLevel true
+          measured true
           tags {
             if (prepareStatement) {
               "$Tags.COMPONENT" "java-jdbc-prepared_statement"
@@ -659,7 +659,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
           spanType DDSpanTypes.SQL
           childOf span(0)
           errored false
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "java-jdbc-statement"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -726,7 +726,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
           resourceName obfuscatedQuery
           spanType DDSpanTypes.SQL
           errored false
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -831,7 +831,7 @@ class JDBCInstrumentationV1ForkedTest extends JDBCInstrumentationTest {
 
   @Override
   protected String service(String dbType) {
-    return Config.get().getServiceName() + "-${dbType}"
+    return Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
@@ -203,7 +203,7 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
           spanType DDSpanTypes.SQL
           childOf span(0)
           errored false
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "java-jdbc-statement"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -262,7 +262,7 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
           spanType DDSpanTypes.SQL
           childOf span(0)
           errored false
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -320,7 +320,7 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
           spanType DDSpanTypes.SQL
           childOf span(0)
           errored false
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -378,7 +378,7 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
           spanType DDSpanTypes.SQL
           childOf span(0)
           errored false
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -539,7 +539,7 @@ class RemoteJDBCInstrumentationV1ForkedTest extends RemoteJDBCInstrumentationTes
 
   @Override
   protected String service(String dbType) {
-    return Config.get().getServiceName() + "-${remapDbType(dbType)}"
+    return Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jedis-1.4/src/test/groovy/JedisClientTest.groovy
+++ b/dd-java-agent/instrumentation/jedis-1.4/src/test/groovy/JedisClientTest.groovy
@@ -66,7 +66,7 @@ abstract class JedisClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SET"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -185,7 +185,7 @@ class JedisClientV1ForkedTest extends JedisClientTest {
 
   @Override
   String service() {
-    return Config.get().getServiceName() + "-redis"
+    return Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
+++ b/dd-java-agent/instrumentation/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
@@ -65,7 +65,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SET"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -106,7 +106,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "GET"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -133,7 +133,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SET"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -148,7 +148,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "RANDOMKEY"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -325,7 +325,7 @@ class Jedis30ClientV1ForkedTest extends Jedis30ClientTest {
 
   @Override
   String service() {
-    return Config.get().getServiceName() + "-redis"
+    return Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jedis-4.0/src/test/groovy/Jedis40ClientTest.groovy
+++ b/dd-java-agent/instrumentation/jedis-4.0/src/test/groovy/Jedis40ClientTest.groovy
@@ -65,7 +65,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SET"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -106,7 +106,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "GET"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -133,7 +133,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SET"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -148,7 +148,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "RANDOMKEY"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -325,7 +325,7 @@ class Jedis40ClientV1ForkedTest extends Jedis40ClientTest {
 
   @Override
   String service() {
-    return Config.get().getServiceName() + "-redis"
+    return Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4AsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4AsyncClientTest.groovy
@@ -565,7 +565,7 @@ class Lettuce4AsyncClientV1ForkedTest extends Lettuce4AsyncClientTest {
 
   @Override
   String service() {
-    return Config.get().getServiceName() + "-redis"
+    return Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4SyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4SyncClientTest.groovy
@@ -410,7 +410,7 @@ class Lettuce4SyncClientV1ForkedTest extends Lettuce4SyncClientTest {
 
   @Override
   String service() {
-    return Config.get().getServiceName() + "-redis"
+    return Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5AsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5AsyncClientTest.groovy
@@ -570,7 +570,7 @@ class Lettuce5SyncClientV1ForkedTest extends Lettuce5AsyncClientTest {
 
   @Override
   String service() {
-    return Config.get().getServiceName() + "-redis"
+    return Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
@@ -587,7 +587,7 @@ class Lettuce5ReactiveClientV1ForkedTest extends Lettuce5ReactiveClientTest {
 
   @Override
   String service() {
-    return Config.get().getServiceName() + "-redis"
+    return Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5SyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5SyncClientTest.groovy
@@ -412,7 +412,7 @@ class Lettuce5AsyncClientV1ForkedTest extends Lettuce5AsyncClientTest {
 
   @Override
   String service() {
-    return Config.get().getServiceName() + "-redis"
+    return Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/mongo/src/test/groovy/MongoBaseTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/src/test/groovy/MongoBaseTest.groovy
@@ -31,7 +31,7 @@ abstract class MongoBaseTest extends VersionedNamingTestBase {
 
   public static final String V0_SERVICE = "mongo"
   public static final String V0_OPERATION = "mongo.query"
-  public static final String V1_SERVICE = Config.get().getServiceName() + "-mongodb"
+  public static final String V1_SERVICE = Config.get().getServiceName()
   public static final String V1_OPERATION = "mongodb.query"
 
   @Shared
@@ -111,7 +111,7 @@ abstract class MongoBaseTest extends VersionedNamingTestBase {
       } else {
         childOf((DDSpan) parentSpan)
       }
-      topLevel true
+      measured true
       tags {
         "$Tags.COMPONENT" "java-mongo"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT

--- a/dd-java-agent/instrumentation/rediscala-1.8.0/src/test/groovy/RediscalaClientTest.groovy
+++ b/dd-java-agent/instrumentation/rediscala-1.8.0/src/test/groovy/RediscalaClientTest.groovy
@@ -87,7 +87,7 @@ abstract class RediscalaClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "Set"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -173,7 +173,7 @@ class RediscalaClientV1ForkedTest extends RediscalaClientTest {
 
   @Override
   String service() {
-    return Config.get().getServiceName() + "-redis"
+    return Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redisson20/groovy/RedissonClientTest.groovy
+++ b/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redisson20/groovy/RedissonClientTest.groovy
@@ -88,7 +88,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SET"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -129,7 +129,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "GET"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -153,7 +153,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SET"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -194,7 +194,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "INCRBY"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -235,7 +235,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "INCR"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -259,7 +259,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "PUBLISH"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -283,7 +283,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "PFADD"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -310,7 +310,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "PFADD"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -325,7 +325,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "PFCOUNT"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -349,7 +349,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "EVAL"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -373,7 +373,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SADD"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -400,7 +400,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SADD"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -415,7 +415,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SREM"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -439,7 +439,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "RPUSH"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -465,7 +465,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SET"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -495,7 +495,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SET;GET"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -535,7 +535,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SET;SET;GET;RPUSH;RPUSH;LRANGE"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -575,7 +575,7 @@ class RedissonClientV1ForkedTest extends RedissonClientTest {
 
   @Override
   String service() {
-    return datadog.trace.api.Config.get().getServiceName() + "-redis"
+    return datadog.trace.api.Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redisson23/groovy/RedissonClientTest.groovy
+++ b/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redisson23/groovy/RedissonClientTest.groovy
@@ -91,7 +91,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SET"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -132,7 +132,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "GET"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -156,7 +156,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SET"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -197,7 +197,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "INCRBY"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -238,7 +238,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "INCR"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -262,7 +262,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "PUBLISH"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -286,7 +286,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "PFADD"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -313,7 +313,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "PFADD"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -328,7 +328,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "PFCOUNT"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -352,7 +352,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "EVAL"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -376,7 +376,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SADD"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -403,7 +403,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SADD"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -418,7 +418,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SREM"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -442,7 +442,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "RPUSH"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -468,7 +468,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SET"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -498,7 +498,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SET;GET"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -538,7 +538,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SET;SET;GET;RPUSH;RPUSH;LRANGE"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -578,7 +578,7 @@ class RedissonClientV1ForkedTest extends RedissonClientTest {
 
   @Override
   String service() {
-    return datadog.trace.api.Config.get().getServiceName() + "-redis"
+    return datadog.trace.api.Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redissonLatest/groovy/RedissonClientTest.groovy
+++ b/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redissonLatest/groovy/RedissonClientTest.groovy
@@ -82,7 +82,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SET"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -123,7 +123,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "GET"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -147,7 +147,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SET"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -188,7 +188,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "GET"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -229,7 +229,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "INCR"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -253,7 +253,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "PUBLISH"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -277,7 +277,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "PFADD"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -304,7 +304,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "PFADD"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -319,7 +319,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "PFCOUNT"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -343,7 +343,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "EVAL"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -367,7 +367,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SADD"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -394,7 +394,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SADD"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -409,7 +409,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SREM"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -433,7 +433,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "RPUSH"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -459,7 +459,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SET"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -489,7 +489,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SET;GET"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -529,7 +529,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
           operationName operation()
           resourceName "SET;SET;GET;RPUSH;RPUSH;LRANGE"
           spanType DDSpanTypes.REDIS
-          topLevel true
+          measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -568,7 +568,7 @@ class RedissonClientV1ForkedTest extends RedissonClientTest {
 
   @Override
   String service() {
-    return datadog.trace.api.Config.get().getServiceName() + "-redis"
+    return datadog.trace.api.Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/spymemcached-2.12/src/test/groovy/datadog/trace/instrumentation/spymemcached/SpymemcachedTest.groovy
+++ b/dd-java-agent/instrumentation/spymemcached-2.12/src/test/groovy/datadog/trace/instrumentation/spymemcached/SpymemcachedTest.groovy
@@ -676,7 +676,7 @@ abstract class SpymemcachedTest extends VersionedNamingTestBase {
       resourceName resource
       spanType DDSpanTypes.MEMCACHED
       errored(error != null && error != "canceled")
-      topLevel true
+      measured true
       tags {
         "$Tags.COMPONENT" COMPONENT_NAME
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -739,7 +739,7 @@ class SpymemcachedV1ForkedTest extends SpymemcachedTest {
 
   @Override
   String service() {
-    return Config.get().getServiceName() + "-memcached"
+    return Config.get().getServiceName()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/test/groovy/VertxRedisTestBase.groovy
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/test/groovy/VertxRedisTestBase.groovy
@@ -115,7 +115,7 @@ abstract class VertxRedisTestBase extends AgentTestRunner {
       operationName "redis.query"
       resourceName command
       spanType DDSpanTypes.REDIS
-      topLevel true
+      measured true
       tags {
         "$Tags.COMPONENT" "redis-command"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/CacheNamingV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/CacheNamingV1.java
@@ -13,6 +13,6 @@ public class CacheNamingV1 implements NamingSchema.ForCache {
   @Nonnull
   @Override
   public String service(@Nonnull String ddService, @Nonnull String cacheSystem) {
-    return ddService + "-" + cacheSystem;
+    return ddService;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/DatabaseNamingV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/DatabaseNamingV1.java
@@ -28,6 +28,6 @@ public class DatabaseNamingV1 implements NamingSchema.ForDatabase {
   @Nonnull
   @Override
   public String service(@Nonnull String ddService, @Nonnull String databaseType) {
-    return ddService + "-" + normalizeDatabaseType(databaseType);
+    return ddService;
   }
 }


### PR DESCRIPTION
# What Does This Do

In v1 we first named service name as `{{DD_SERVICE}}-{DBMS}` but the requirement changed and we will always use `{{DD_SERVICE}}. 
This PR changes the naming for v1 (all a bunch of tests).

# Motivation

# Additional Notes
