### PR TITLE
Support retrieving context-stores by class name

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InstrumentationContext.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/InstrumentationContext.java
@@ -26,4 +26,15 @@ public class InstrumentationContext {
     throw new RuntimeException(
         "Calls to this method will be rewritten by Instrumentation Context Provider (e.g. FieldBackedProvider)");
   }
+
+  /**
+   * Find a {@link ContextStore} instance for given key class name and context class name.
+   *
+   * @apiNote This is a fallback for when the key/context are only available as string constants at
+   *     compile time, in all other situations prefer the method that accepts class literals
+   */
+  public static <K, C> ContextStore<K, C> get(final String keyClass, final String contextClass) {
+    throw new RuntimeException(
+        "Calls to this method will be rewritten by Instrumentation Context Provider (e.g. FieldBackedProvider)");
+  }
 }

--- a/dd-java-agent/testing/src/test/groovy/context/FieldInjectionForkedTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/context/FieldInjectionForkedTest.groovy
@@ -99,9 +99,11 @@ class FieldInjectionForkedTest extends AgentTestRunner {
   def "get/put test"() {
     when:
     instance1.putContextCount(10)
+    instance1.putContextCount2(10)
 
     then:
     instance1.getContextCount() == 10
+    instance1.getContextCount2() == 10
 
     where:
     instance1                     | _

--- a/dd-java-agent/testing/src/test/java/context/FieldInjectionTestInstrumentation.java
+++ b/dd-java-agent/testing/src/test/java/context/FieldInjectionTestInstrumentation.java
@@ -38,6 +38,8 @@ public class FieldInjectionTestInstrumentation extends Instrumenter.Tracing
         named("incrementContextCount"), StoreAndIncrementApiUsageAdvice.class.getName());
     transformation.applyAdvice(named("getContextCount"), GetApiUsageAdvice.class.getName());
     transformation.applyAdvice(named("putContextCount"), PutApiUsageAdvice.class.getName());
+    transformation.applyAdvice(named("getContextCount2"), GetApiUsageAdvice2.class.getName());
+    transformation.applyAdvice(named("putContextCount2"), PutApiUsageAdvice2.class.getName());
     transformation.applyAdvice(
         named("incorrectKeyClassUsage"), IncorrectKeyClassContextApiUsageAdvice.class.getName());
     transformation.applyAdvice(
@@ -117,6 +119,32 @@ public class FieldInjectionTestInstrumentation extends Instrumenter.Tracing
     }
   }
 
+  public static class GetApiUsageAdvice2 {
+    @Advice.OnMethodExit
+    public static void methodExit(
+        @Advice.This final Object thiz, @Advice.Return(readOnly = false) int contextCount) {
+      final ContextStore<Object, Context> contextStore =
+          InstrumentationContext.get(
+              "context.FieldInjectionTestInstrumentation$KeyClass",
+              "context.FieldInjectionTestInstrumentation$Context");
+      contextCount = contextStore.get(thiz).count;
+    }
+  }
+
+  public static class PutApiUsageAdvice2 {
+    @Advice.OnMethodExit
+    public static void methodExit(
+        @Advice.This final Object thiz, @Advice.Argument(0) final int value) {
+      final ContextStore<Object, Context> contextStore =
+          InstrumentationContext.get(
+              "context.FieldInjectionTestInstrumentation$KeyClass",
+              "context.FieldInjectionTestInstrumentation$Context");
+      final Context context = new Context();
+      context.count = value;
+      contextStore.put(thiz, context);
+    }
+  }
+
   public static class IncorrectKeyClassContextApiUsageAdvice {
     @Advice.OnMethodExit
     public static void methodExit() {
@@ -167,6 +195,15 @@ public class FieldInjectionTestInstrumentation extends Instrumenter.Tracing
     }
 
     public void putContextCount(final int value) {
+      // implementation replaced with test instrumentation
+    }
+
+    public int getContextCount2() {
+      // implementation replaced with test instrumentation
+      return -1;
+    }
+
+    public void putContextCount2(final int value) {
       // implementation replaced with test instrumentation
     }
   }


### PR DESCRIPTION
# Motivation

This is for situations where the key/context are only available as string constants at compile time, ie. it is difficult to arrange access to the class literals (for example when the dependency is not available on Maven central)
