### PR TITLE
Report evaluation error inline in message

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
@@ -597,7 +597,9 @@ public class Snapshot {
 
     private void checkUndefined(String expr, Object target, String name, String msg) {
       if (target == Values.UNDEFINED_OBJECT) {
-        addEvaluationError(expr, msg + name);
+        String errorMsg = msg + name;
+        addEvaluationError(expr, errorMsg);
+        throw new RuntimeException(errorMsg);
       }
     }
 
@@ -851,6 +853,9 @@ public class Snapshot {
         if (!script.execute(capture)) {
           return false;
         }
+      } catch (RuntimeException ex) {
+        LOG.debug("Evaluation error: ", ex);
+        return false;
       } finally {
         LOG.debug("Script for probe[{}] evaluated in {}ns", probeId, (System.nanoTime() - startTs));
       }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IndexExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IndexExpression.java
@@ -37,6 +37,7 @@ public class IndexExpression implements ValueExpression<Value<?>> {
       }
     } catch (IllegalArgumentException ex) {
       valueRefResolver.addEvaluationError(PrettyPrintVisitor.print(this), ex.getMessage());
+      throw ex;
     }
 
     return result;

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
@@ -13,9 +13,11 @@ import com.squareup.moshi.Moshi;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import okio.Okio;
 import org.junit.jupiter.api.Test;
@@ -29,14 +31,23 @@ public class ProbeConditionTest {
     ProbeCondition probeCondition = load("/test_conditional_01.json");
 
     Collection<String> tags = Arrays.asList("hello", "world", "ko");
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("tags", tags);
+    fields.put("field", 10);
+    class Obj {
+      List<String> field2 = new ArrayList<>();
+    }
     ValueReferenceResolver ctx =
-        RefResolverHelper.createResolver(null, null, singletonMap("tags", tags));
+        RefResolverHelper.createResolver(singletonMap("this", new Obj()), null, fields);
 
     assertTrue(probeCondition.execute(ctx));
 
     Collection<String> tags2 = Arrays.asList("hey", "world", "ko");
+    fields = new HashMap<>();
+    fields.put("tags", tags2);
+    fields.put("field", 10);
     ValueReferenceResolver ctx2 =
-        RefResolverHelper.createResolver(null, null, singletonMap("tags", tags2));
+        RefResolverHelper.createResolver(singletonMap("this", new Obj()), null, fields);
     assertFalse(probeCondition.execute(ctx2));
   }
 
@@ -61,7 +72,9 @@ public class ProbeConditionTest {
             singletonMap("this", new Obj2()),
             singletonMap("container", new Container("world")),
             null);
-    assertFalse(probeCondition.execute(ctx2));
+    RuntimeException runtimeException =
+        assertThrows(RuntimeException.class, () -> probeCondition.execute(ctx2));
+    assertEquals("Cannot dereference to field: container", runtimeException.getMessage());
   }
 
   @Test
@@ -70,8 +83,10 @@ public class ProbeConditionTest {
     class Obj {
       int intField1 = 42;
     }
+    Obj obj = new Obj();
     ValueReferenceResolver ctx =
-        RefResolverHelper.createResolver(singletonMap("this", new Obj()), null, null);
+        RefResolverHelper.createResolver(
+            singletonMap("this", obj), null, singletonMap("intField1", obj.intField1));
     assertTrue(probeCondition.execute(ctx));
   }
 

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/GetMemberExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/GetMemberExpressionTest.java
@@ -37,4 +37,10 @@ class GetMemberExpressionTest {
     assertEquals(root.getB(), val.getValue());
     assertEquals("ref.ref.b", print(expr));
   }
+
+  @Test
+  void getMemberUndefined() {
+    GetMemberExpression expr = new GetMemberExpression(ValueExpression.UNDEFINED, "size");
+    assertEquals(Value.undefined(), expr.evaluate(RefResolverHelper.createResolver(this)));
+  }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/HasAllExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/HasAllExpressionTest.java
@@ -4,6 +4,7 @@ import static com.datadog.debugger.el.DSL.*;
 import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.datadog.debugger.el.RefResolverHelper;
@@ -110,8 +111,11 @@ class HasAllExpressionTest {
     GetMemberExpression fldRef = getMember(ref(ValueReferences.ITERATOR_REF), "testField");
     ValueRefExpression itRef = ref(ValueReferences.ITERATOR_REF);
 
-    expression = all(targetExpression, eq(fldRef, value(10)));
-    assertFalse(expression.evaluate(ctx));
+    RuntimeException runtimeException =
+        assertThrows(
+            RuntimeException.class,
+            () -> all(targetExpression, eq(fldRef, value(10))).evaluate(ctx));
+    assertEquals("Cannot dereference to field: testField", runtimeException.getMessage());
 
     expression = all(targetExpression, eq(itRef, value("hello")));
     assertFalse(expression.evaluate(ctx));
@@ -134,8 +138,11 @@ class HasAllExpressionTest {
     ValueRefExpression fldRef = ref(ValueReferences.ITERATOR_REF + "testField");
     ValueRefExpression itRef = ref(ValueReferences.ITERATOR_REF);
 
-    expression = all(targetExpression, eq(fldRef, value(10)));
-    assertFalse(expression.evaluate(ctx));
+    RuntimeException runtimeException =
+        assertThrows(
+            RuntimeException.class,
+            () -> all(targetExpression, eq(fldRef, value(10))).evaluate(ctx));
+    assertEquals("Cannot find synthetic var: ittestField", runtimeException.getMessage());
 
     expression = all(targetExpression, eq(itRef, value("hello")));
     assertFalse(expression.evaluate(ctx));

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ValueRefExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ValueRefExpressionTest.java
@@ -9,7 +9,6 @@ import com.datadog.debugger.el.RefResolverHelper;
 import com.datadog.debugger.el.Value;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.ValueReferences;
-import datadog.trace.bootstrap.debugger.el.Values;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -42,9 +41,15 @@ class ValueRefExpressionTest {
     assertFalse(isEmpty.evaluate(ctx));
     assertEquals("isEmpty(b)", print(isEmpty));
 
-    assertTrue(isEmptyInvalid.evaluate(ctx));
-    assertFalse(and(isEmptyInvalid, isEmpty).evaluate(ctx));
-    assertTrue(or(isEmptyInvalid, isEmpty).evaluate(ctx));
+    RuntimeException runtimeException =
+        assertThrows(RuntimeException.class, () -> isEmptyInvalid.evaluate(ctx));
+    assertEquals("Cannot find symbol: x", runtimeException.getMessage());
+    runtimeException =
+        assertThrows(RuntimeException.class, () -> and(isEmptyInvalid, isEmpty).evaluate(ctx));
+    assertEquals("Cannot find symbol: x", runtimeException.getMessage());
+    runtimeException =
+        assertThrows(RuntimeException.class, () -> or(isEmptyInvalid, isEmpty).evaluate(ctx));
+    assertEquals("Cannot find symbol: x", runtimeException.getMessage());
     assertEquals("isEmpty(x)", print(isEmptyInvalid));
   }
 
@@ -69,8 +74,8 @@ class ValueRefExpressionTest {
     Map<String, Object> exts = new HashMap<>();
     exts.put(ValueReferences.RETURN_EXTENSION_NAME, returnVal);
     exts.put(ValueReferences.DURATION_EXTENSION_NAME, duration);
-    ValueReferenceResolver resolver = RefResolverHelper.createResolver(null, null, values);
-    resolver = resolver.withExtensions(exts);
+    ValueReferenceResolver resolver =
+        RefResolverHelper.createResolver(null, null, values).withExtensions(exts);
 
     ValueRefExpression expression = DSL.ref(ValueReferences.DURATION_REF);
     assertEquals(duration, expression.evaluate(resolver).getValue());
@@ -88,8 +93,10 @@ class ValueRefExpressionTest {
     assertEquals(
         (long) i, expression.evaluate(resolver).getValue()); // int value is widened to long
     assertEquals("i", print(expression));
-    expression = DSL.ref(ValueReferences.synthetic("invalid"));
-    assertEquals(Values.UNDEFINED_OBJECT, expression.evaluate(resolver).getValue());
-    assertEquals("@invalid", print(expression));
+    ValueRefExpression invalidExpression = ref(ValueReferences.synthetic("invalid"));
+    RuntimeException runtimeException =
+        assertThrows(RuntimeException.class, () -> invalidExpression.evaluate(resolver).getValue());
+    assertEquals("Cannot find synthetic var: invalid", runtimeException.getMessage());
+    assertEquals("@invalid", print(invalidExpression));
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/LogMessageTemplateSummaryBuilder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/LogMessageTemplateSummaryBuilder.java
@@ -70,13 +70,17 @@ public class LogMessageTemplateSummaryBuilder implements SummaryBuilder {
         sb.append(segment.getStr());
       } else {
         if (parsedExr != null) {
-          Value<?> result = parsedExr.execute(entry);
-          if (result.isUndefined()) {
-            sb.append(result.getValue());
-          } else if (result.isNull()) {
-            sb.append("null");
-          } else {
-            serializeValue(sb, segment.getParsedExpr().getDsl(), result.getValue());
+          try {
+            Value<?> result = parsedExr.execute(entry);
+            if (result.isUndefined()) {
+              sb.append(result.getValue());
+            } else if (result.isNull()) {
+              sb.append("null");
+            } else {
+              serializeValue(sb, segment.getParsedExpr().getDsl(), result.getValue());
+            }
+          } catch (RuntimeException ex) {
+            sb.append("{").append(ex.getMessage()).append("}");
           }
         }
       }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogMessageTemplateSummaryBuilderTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogMessageTemplateSummaryBuilderTest.java
@@ -48,7 +48,7 @@ class LogMessageTemplateSummaryBuilderTest {
     LogProbe probe = createLogProbe("{arg}");
     LogMessageTemplateSummaryBuilder summaryBuilder = new LogMessageTemplateSummaryBuilder(probe);
     summaryBuilder.addEntry(new Snapshot.CapturedContext());
-    assertEquals("UNDEFINED", summaryBuilder.build());
+    assertEquals("{Cannot find symbol: arg}", summaryBuilder.build());
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -263,7 +263,8 @@ public class LogProbesInstrumentationTest {
     Assertions.assertEquals(3, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCapturesNull(snapshot);
-    assertEquals("this is log line with local var=UNDEFINED", snapshot.buildSummary());
+    assertEquals(
+        "this is log line with local var={Cannot find symbol: var42}", snapshot.buildSummary());
     assertEquals(1, snapshot.getEvaluationErrors().size());
     assertEquals("var42", snapshot.getEvaluationErrors().get(0).getExpr());
     assertEquals("Cannot find symbol: var42", snapshot.getEvaluationErrors().get(0).getMessage());
@@ -280,7 +281,9 @@ public class LogProbesInstrumentationTest {
     Assertions.assertEquals(143, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCapturesNull(snapshot);
-    assertEquals("this is log line with field=UNDEFINED", snapshot.buildSummary());
+    assertEquals(
+        "this is log line with field={Cannot dereference to field: intValue}",
+        snapshot.buildSummary());
     assertEquals(1, snapshot.getEvaluationErrors().size());
     assertEquals("intValue", snapshot.getEvaluationErrors().get(0).getExpr());
     assertEquals(
@@ -298,7 +301,9 @@ public class LogProbesInstrumentationTest {
     int result = Reflect.on(testClass).call("main", "f").get();
     Assertions.assertEquals(42, result);
     Snapshot snapshot = assertOneSnapshot(listener);
-    assertEquals("this is log line with element of list=UNDEFINED", snapshot.buildSummary());
+    assertEquals(
+        "this is log line with element of list={index[10] out of bounds: [0-3]}",
+        snapshot.buildSummary());
     assertEquals(1, snapshot.getEvaluationErrors().size());
     assertEquals("strList[10]", snapshot.getEvaluationErrors().get(0).getExpr());
     assertEquals(
@@ -360,7 +365,8 @@ public class LogProbesInstrumentationTest {
     assertEquals(LOG_ID2, snapshot1.getProbe().getId());
     assertNotNull(snapshot1.getCaptures().getEntry());
     assertNotNull(snapshot1.getCaptures().getReturn());
-    assertEquals("this is log line #2 with arg=UNDEFINED", snapshot1.buildSummary());
+    assertEquals(
+        "this is log line #2 with arg={Cannot find symbol: typoArg}", snapshot1.buildSummary());
     assertEquals(1, snapshot1.getEvaluationErrors().size());
     assertEquals(
         "Cannot find symbol: typoArg", snapshot1.getEvaluationErrors().get(0).getMessage());
@@ -376,7 +382,8 @@ public class LogProbesInstrumentationTest {
     assertEquals(LOG_ID1, snapshot0.getProbe().getId());
     assertNotNull(snapshot0.getCaptures().getEntry());
     assertNotNull(snapshot0.getCaptures().getReturn());
-    assertEquals("this is log line #1 with arg=UNDEFINED", snapshot0.buildSummary());
+    assertEquals(
+        "this is log line #1 with arg={Cannot find symbol: typoArg}", snapshot0.buildSummary());
     assertEquals(1, snapshot0.getEvaluationErrors().size());
     assertEquals(
         "Cannot find symbol: typoArg", snapshot0.getEvaluationErrors().get(0).getMessage());
@@ -398,7 +405,8 @@ public class LogProbesInstrumentationTest {
     assertEquals(LOG_ID1, snapshot0.getProbe().getId());
     assertNotNull(snapshot0.getCaptures().getEntry());
     assertNotNull(snapshot0.getCaptures().getReturn());
-    assertEquals("this is log line #1 with arg=UNDEFINED", snapshot0.buildSummary());
+    assertEquals(
+        "this is log line #1 with arg={Cannot find symbol: typoArg1}", snapshot0.buildSummary());
     assertEquals(1, snapshot0.getEvaluationErrors().size());
     assertEquals(
         "Cannot find symbol: typoArg1", snapshot0.getEvaluationErrors().get(0).getMessage());
@@ -406,7 +414,8 @@ public class LogProbesInstrumentationTest {
     assertEquals(LOG_ID2, snapshot1.getProbe().getId());
     assertNotNull(snapshot1.getCaptures().getEntry());
     assertNotNull(snapshot1.getCaptures().getReturn());
-    assertEquals("this is log line #2 with arg=UNDEFINED", snapshot1.buildSummary());
+    assertEquals(
+        "this is log line #2 with arg={Cannot find symbol: typoArg2}", snapshot1.buildSummary());
     assertEquals(1, snapshot1.getEvaluationErrors().size());
     assertEquals(
         "Cannot find symbol: typoArg2", snapshot1.getEvaluationErrors().get(0).getMessage());


### PR DESCRIPTION
# What Does This Do
instead of reporting UNDEFINED we put the the evaluation error message in curly braces:
ex: this is a log line with arg={Cannot find symbol: var42}

# Motivation
Having evaluation error message directly into the log message

# Additional Notes
