### PR TITLE
Fix GraphQL tests by excluding graphql-java v13.0

### DIFF
--- a/dd-java-agent/instrumentation/graphql-java-14.0/build.gradle
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/build.gradle
@@ -3,14 +3,13 @@ muzzle {
   pass {
     group = "com.graphql-java"
     module = 'graphql-java'
-    //TODO: rename module to graphql-java-13.0 as it now supported
-    versions = '[13.0,2018)' // exclude dates as version numbers
+    versions = '[14.0,2018)' // exclude dates as version numbers
     // earlier versions are missing some classes and will require separate instrumentation
   }
   fail {
     group = "com.graphql-java"
     module = 'graphql-java'
-    versions = '[1.2,13.0)'
+    versions = '[1.2,14.0)'
   }
 }
 
@@ -24,8 +23,8 @@ testSets {
 }
 
 dependencies {
-  compileOnly group: 'com.graphql-java', name: 'graphql-java', version: '13.0'
-  testImplementation group: 'com.graphql-java', name: 'graphql-java', version: '13.0'
+  compileOnly group: 'com.graphql-java', name: 'graphql-java', version: '14.0'
+  testImplementation group: 'com.graphql-java', name: 'graphql-java', version: '14.0'
 
   testImplementation project(':dd-java-agent:instrumentation:trace-annotation')
 

--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/main/java/datadog.trace.instrumentation.graphqljava/GraphQLJavaInstrumentation.java
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/main/java/datadog.trace.instrumentation.graphqljava/GraphQLJavaInstrumentation.java
@@ -7,7 +7,7 @@ import static net.bytebuddy.matcher.ElementMatchers.returns;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import graphql.analysis.QueryTraverser;
+import graphql.execution.ValueUnboxer;
 import graphql.execution.instrumentation.Instrumentation;
 import net.bytebuddy.asm.Advice;
 
@@ -60,9 +60,9 @@ public class GraphQLJavaInstrumentation extends Instrumenter.Tracing
       instrumentation = GraphQLInstrumentation.install(instrumentation);
     }
 
-    public static void muzzleCheck(QueryTraverser queryTraverser) {
-      // Class renamed in 13.0
-      queryTraverser.newQueryTraverser();
+    public static void muzzleCheck() {
+      // Class introduced in 15.0
+      ValueUnboxer value = ValueUnboxer.DEFAULT;
     }
   }
 }


### PR DESCRIPTION
# What Does This Do

Excludes graphql-java 13.x from instrumentation to make tests pass.

# Motivation

I mistakenly [included v13](https://github.com/DataDog/dd-trace-java/pull/4663/commits/79f1a50036eca929e37b93e0e3062bb3aa746675) as supported version but it's not correct. 

# Additional Notes

N/A
