### PR TITLE
Setup python 3.9 for system tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,10 +233,15 @@ commands:
           cacheType: lib
 
       - run:
+          # TODO: removes this step once host-in-runner is merged on system tests
           name: Install good version of docker-compose
           command: |
             sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
             sudo chmod +x /usr/local/bin/docker-compose
+
+      - run:
+          name: Install python 3.9
+          command: sudo apt-get install python3.9-venv
 
       - run:
           name: versions


### PR DESCRIPTION
# What Does This Do

This PR installs python 3.9 for system tests jobs

# Motivation

System test executor will run on the host rather than inside a container (see https://github.com/DataDog/system-tests/pull/958). It will allow users to do step-by-step debugging, and will allow to unify architecture with parametric tests.

# Additional Notes

As now, the change will do nothing but installing python 3.9 on system tests job. Once the PR on system repo will be merge, it'll work silently (and we'll be able to remove the installation of docker compose, not required anymore).