### PR TITLE
Add padding to B3 propagation headers

### DIFF
--- a/dd-trace-core/src/jmh/java/datadog/trace/core/propagation/InjectorBenchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/propagation/InjectorBenchmark.java
@@ -95,7 +95,7 @@ public class InjectorBenchmark {
     System.setProperty("dd.propagation.style.extract", propagations.toString());
     injector =
         HttpCodec.createInjector(
-            Config.get().getTracePropagationStylesToInject(), Collections.emptyMap());
+            Config.get(), Config.get().getTracePropagationStylesToInject(), Collections.emptyMap());
 
     traceId = DDTraceId.from("12345");
     spanId = DDSpanId.from("23456");

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -381,7 +381,9 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       instrumentationGateway(new InstrumentationGateway());
       injector(
           HttpCodec.createInjector(
-              config.getTracePropagationStylesToInject(), invertMap(config.getBaggageMapping())));
+              config,
+              config.getTracePropagationStylesToInject(),
+              invertMap(config.getBaggageMapping())));
       extractor(
           HttpCodec.createExtractor(
               config, config.getRequestHeaderTags(), config.getBaggageMapping()));
@@ -580,7 +582,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     this.callbackProviderIast = instrumentationGateway.getCallbackProvider(RequestContextSlot.IAST);
     this.universalCallbackProvider = instrumentationGateway.getUniversalCallbackProvider();
 
-    injectors = HttpCodec.allInjectorsFor(invertMap(baggageMapping));
+    injectors = HttpCodec.allInjectorsFor(config, invertMap(baggageMapping));
 
     shutdownCallback = new ShutdownHook(this);
     try {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/B3HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/B3HttpCodec.java
@@ -9,6 +9,7 @@ import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.core.DDSpanContext;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -34,26 +35,49 @@ class B3HttpCodec {
     // This class should not be created. This also makes code coverage checks happy.
   }
 
-  public static final HttpCodec.Injector INJECTOR =
-      new HttpCodec.Injector() {
-        @Override
-        public <C> void inject(
-            DDSpanContext context, C carrier, AgentPropagation.Setter<C> setter) {
-          SINGLE_INJECTOR.inject(context, carrier, setter);
-          MULTI_INJECTOR.inject(context, carrier, setter);
-        }
-      };
+  public static HttpCodec.Injector newCombinedInjector(boolean paddingEnabled) {
+    return new HttpCodec.CompoundInjector(
+        Arrays.asList(newSingleInjector(paddingEnabled), newMultiInjector(paddingEnabled)));
+  }
 
-  public static final HttpCodec.Injector MULTI_INJECTOR = new B3MultiInjector();
+  public static HttpCodec.Injector newMultiInjector(boolean paddingEnalbed) {
+    return new B3MultiInjector(paddingEnalbed);
+  }
 
-  public static final HttpCodec.Injector SINGLE_INJECTOR = new B3SingleInjector();
+  public static HttpCodec.Injector newSingleInjector(boolean paddingEnabled) {
+    return new B3SingleInjector(paddingEnabled);
+  }
 
-  private static class B3MultiInjector implements HttpCodec.Injector {
+  private abstract static class B3Injector implements HttpCodec.Injector {
+    private final boolean paddingEnabled;
+
+    public B3Injector(boolean paddingEnabled) {
+      this.paddingEnabled = paddingEnabled;
+    }
+
+    protected final String getTraceId(DDSpanContext context) {
+      return paddingEnabled
+          ? context.getTraceId().toHexStringPaddedOrOriginal(32)
+          : context.getTraceId().toHexStringOrOriginal();
+    }
+
+    protected final String getSpanId(DDSpanContext context) {
+      return paddingEnabled
+          ? DDSpanId.toHexStringPadded(context.getSpanId())
+          : DDSpanId.toHexString(context.getSpanId());
+    }
+  }
+
+  private static final class B3MultiInjector extends B3Injector {
+    public B3MultiInjector(boolean paddingEnabled) {
+      super(paddingEnabled);
+    }
+
     @Override
     public <C> void inject(
         final DDSpanContext context, final C carrier, final AgentPropagation.Setter<C> setter) {
-      final String injectedTraceId = context.getTraceId().toHexStringOrOriginal();
-      final String injectedSpanId = DDSpanId.toHexString(context.getSpanId());
+      final String injectedTraceId = getTraceId(context);
+      final String injectedSpanId = getSpanId(context);
       setter.set(carrier, TRACE_ID_KEY, injectedTraceId);
       setter.set(carrier, SPAN_ID_KEY, injectedSpanId);
       if (context.lockSamplingPriority()) {
@@ -61,26 +85,35 @@ class B3HttpCodec {
             convertSamplingPriority(context.getSamplingPriority());
         setter.set(carrier, SAMPLING_PRIORITY_KEY, injectedSamplingPriority);
       }
-      log.debug("{} - B3 parent context injected - {}", context.getTraceId(), injectedTraceId);
+      log.debug(
+          "{} - B3 parent context injected - {} {}",
+          context.getTraceId(),
+          injectedTraceId,
+          injectedSpanId);
     }
   }
 
-  private static class B3SingleInjector implements HttpCodec.Injector {
+  private static final class B3SingleInjector extends B3Injector {
+    public B3SingleInjector(boolean paddingEnabled) {
+      super(paddingEnabled);
+    }
+
     @Override
     public <C> void inject(
         final DDSpanContext context, final C carrier, final AgentPropagation.Setter<C> setter) {
-      final String injectedTraceId = context.getTraceId().toHexStringOrOriginal();
-      final String injectedSpanId = DDSpanId.toHexString(context.getSpanId());
-      final StringBuilder injectedB3Id = new StringBuilder(100);
-      injectedB3Id.append(injectedTraceId).append('-').append(injectedSpanId);
+      final String injectedTraceId = getTraceId(context);
+      final String injectedSpanId = getSpanId(context);
+      final StringBuilder injectedB3IdBuilder = new StringBuilder(100);
+      injectedB3IdBuilder.append(injectedTraceId).append('-').append(injectedSpanId);
 
       if (context.lockSamplingPriority()) {
         final String injectedSamplingPriority =
             convertSamplingPriority(context.getSamplingPriority());
-        injectedB3Id.append('-').append(injectedSamplingPriority);
+        injectedB3IdBuilder.append('-').append(injectedSamplingPriority);
       }
-      setter.set(carrier, B3_KEY, injectedB3Id.toString());
-      log.debug("{} - B3 parent context injected - {}", context.getTraceId(), injectedTraceId);
+      String injectedB3Id = injectedB3IdBuilder.toString();
+      setter.set(carrier, B3_KEY, injectedB3Id);
+      log.debug("{} - B3 parent context injected - {}", context.getTraceId(), injectedB3Id);
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -49,19 +49,24 @@ public class HttpCodec {
   }
 
   public static Injector createInjector(
-      Set<TracePropagationStyle> styles, Map<String, String> invertedBaggageMapping) {
+      Config config,
+      Set<TracePropagationStyle> styles,
+      Map<String, String> invertedBaggageMapping) {
     ArrayList<Injector> injectors =
-        new ArrayList<>(createInjectors(styles, invertedBaggageMapping).values());
+        new ArrayList<>(createInjectors(config, styles, invertedBaggageMapping).values());
     return new CompoundInjector(injectors);
   }
 
   public static Map<TracePropagationStyle, Injector> allInjectorsFor(
-      Map<String, String> reverseBaggageMapping) {
-    return createInjectors(EnumSet.allOf(TracePropagationStyle.class), reverseBaggageMapping);
+      Config config, Map<String, String> reverseBaggageMapping) {
+    return createInjectors(
+        config, EnumSet.allOf(TracePropagationStyle.class), reverseBaggageMapping);
   }
 
   private static Map<TracePropagationStyle, Injector> createInjectors(
-      Set<TracePropagationStyle> propagationStyles, Map<String, String> reverseBaggageMapping) {
+      Config config,
+      Set<TracePropagationStyle> propagationStyles,
+      Map<String, String> reverseBaggageMapping) {
     EnumMap<TracePropagationStyle, Injector> result = new EnumMap<>(TracePropagationStyle.class);
     for (TracePropagationStyle style : propagationStyles) {
       switch (style) {
@@ -69,10 +74,14 @@ public class HttpCodec {
           result.put(style, DatadogHttpCodec.newInjector(reverseBaggageMapping));
           break;
         case B3SINGLE:
-          result.put(style, B3HttpCodec.SINGLE_INJECTOR);
+          result.put(
+              style,
+              B3HttpCodec.newSingleInjector(config.isTracePropagationStyleB3PaddingEnabled()));
           break;
         case B3MULTI:
-          result.put(style, B3HttpCodec.MULTI_INJECTOR);
+          result.put(
+              style,
+              B3HttpCodec.newMultiInjector(config.isTracePropagationStyleB3PaddingEnabled()));
           break;
         case HAYSTACK:
           result.put(style, HaystackHttpCodec.newInjector(reverseBaggageMapping));

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpInjectorTest.groovy
@@ -3,9 +3,10 @@ package datadog.trace.core.propagation
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTraceId
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopPathwayContext
+import datadog.trace.core.CoreTracer
+import datadog.trace.test.util.StringUtils
 
 import static datadog.trace.api.sampling.PrioritySampling.*
-import static datadog.trace.api.sampling.SamplingMechanism.*
 import datadog.trace.bootstrap.instrumentation.api.TagContext
 import datadog.trace.bootstrap.instrumentation.api.ContextVisitors
 import datadog.trace.common.writer.ListWriter
@@ -17,19 +18,106 @@ import static datadog.trace.core.propagation.B3HttpCodec.B3_KEY
 import static datadog.trace.core.propagation.B3HttpCodec.SAMPLING_PRIORITY_KEY
 import static datadog.trace.core.propagation.B3HttpCodec.SPAN_ID_KEY
 import static datadog.trace.core.propagation.B3HttpCodec.TRACE_ID_KEY
+import static datadog.trace.test.util.StringUtils.trimHex
 
 class B3HttpInjectorTest extends DDCoreSpecification {
 
-  HttpCodec.Injector injector = B3HttpCodec.INJECTOR
+  boolean tracePropagationB3Padding() {
+    return false
+  }
+
+  String idOrPadded(BigInteger id, int size) {
+    return idOrPadded(id.toString(16), size)
+  }
+
+  String idOrPadded(String id, int size) {
+    if (!tracePropagationB3Padding()) {
+      return id.toLowerCase()
+    }
+    return StringUtils.padHexLower(id, size)
+  }
 
   def "inject http headers"() {
     setup:
+    HttpCodec.Injector injector = B3HttpCodec.newCombinedInjector(tracePropagationB3Padding())
     def writer = new ListWriter()
     def tracer = tracerBuilder().writer(writer).build()
-    final DDSpanContext mockedContext =
-      new DDSpanContext(
-      DDTraceId.from("$traceId"),
-      DDSpanId.from("$spanId"),
+    final DDSpanContext mockedContext = mockedContext(tracer, DDTraceId.from("$traceId"), DDSpanId.from("$spanId"), samplingPriority)
+    final Map<String, String> carrier = Mock()
+
+    when:
+    injector.inject(mockedContext, carrier, MapSetter.INSTANCE)
+
+    then:
+    1 * carrier.put(TRACE_ID_KEY, idOrPadded(traceId, 32))
+    1 * carrier.put(SPAN_ID_KEY, idOrPadded(spanId, 16))
+    if (expectedSamplingPriority != null) {
+      1 * carrier.put(SAMPLING_PRIORITY_KEY, "$expectedSamplingPriority")
+      1 * carrier.put(B3_KEY, idOrPadded(traceId, 32) + "-" + idOrPadded(spanId, 16) + "-$expectedSamplingPriority")
+    } else {
+      1 * carrier.put(B3_KEY, idOrPadded(traceId, 32) + "-" + idOrPadded(spanId, 16))
+    }
+    0 * _
+
+    cleanup:
+    tracer.close()
+
+    where:
+    traceId          | spanId           | samplingPriority | expectedSamplingPriority
+    1G               | 2G               | UNSET            | null
+    2G               | 3G               | SAMPLER_KEEP     | SAMPLER_KEEP
+    4G               | 5G               | SAMPLER_DROP     | SAMPLER_DROP
+    5G               | 6G               | USER_KEEP        | SAMPLER_KEEP
+    6G               | 7G               | USER_DROP        | SAMPLER_DROP
+    TRACE_ID_MAX     | TRACE_ID_MAX - 1 | UNSET            | null
+    TRACE_ID_MAX - 1 | TRACE_ID_MAX     | SAMPLER_KEEP     | SAMPLER_KEEP
+  }
+
+  def "inject http headers with extracted original"() {
+    setup:
+    HttpCodec.Injector injector = B3HttpCodec.newCombinedInjector(tracePropagationB3Padding())
+    def writer = new ListWriter()
+    def tracer = tracerBuilder().writer(writer).build()
+    def headers = [
+      (TRACE_ID_KEY.toUpperCase()): traceId,
+      (SPAN_ID_KEY.toUpperCase()) : spanId,
+    ]
+    HttpCodec.Extractor extractor = B3HttpCodec.newExtractor(Collections.emptyMap(),Collections.emptyMap())
+    final TagContext context = extractor.extract(headers, ContextVisitors.stringValuesMap())
+    final DDSpanContext mockedContext = mockedContext(tracer, context)
+    final Map<String, String> carrier = Mock()
+
+    when:
+    injector.inject(mockedContext, carrier, MapSetter.INSTANCE)
+
+    then:
+    1 * carrier.put(TRACE_ID_KEY, idOrPadded(traceId, 32))
+    1 * carrier.put(SPAN_ID_KEY, idOrPadded(trimHex(spanId), 16))
+    1 * carrier.put(B3_KEY, idOrPadded(traceId, 32) + "-" + idOrPadded(trimHex(spanId), 16))
+    0 * _
+
+    cleanup:
+    tracer.close()
+
+    where:
+    traceId                            | spanId
+    "00001"                            | "00001"
+    "463ac35c9f6413ad"                 | "463ac35c9f6413ad"
+    "463ac35c9f6413ad48485a3953bb6124" | "1"
+    "f" * 16                           | "1"
+    "a" * 16 + "f" * 16                | "1"
+    "1"                                | "f" * 16
+    "1"                                | "000" + "f" * 16
+  }
+
+  static DDSpanContext mockedContext(CoreTracer tracer, TagContext context) {
+    return mockedContext(tracer, context.traceId, context.spanId, UNSET)
+  }
+
+  static DDSpanContext mockedContext(CoreTracer tracer, DDTraceId traceId, long spanId, int samplingPriority) {
+    return new DDSpanContext(
+      traceId,
+      spanId,
       DDSpanId.ZERO,
       null,
       "fakeService",
@@ -47,102 +135,12 @@ class B3HttpInjectorTest extends DDCoreSpecification {
       NoopPathwayContext.INSTANCE,
       false,
       PropagationTags.factory().empty())
-
-    final Map<String, String> carrier = Mock()
-
-    when:
-    injector.inject(mockedContext, carrier, MapSetter.INSTANCE)
-
-    then:
-    1 * carrier.put(TRACE_ID_KEY, traceId.toString(16).toLowerCase())
-    1 * carrier.put(SPAN_ID_KEY, spanId.toString(16).toLowerCase())
-    if (expectedSamplingPriority != null) {
-      1 * carrier.put(SAMPLING_PRIORITY_KEY, "$expectedSamplingPriority")
-      1 * carrier.put(B3_KEY, traceId.toString(16).toLowerCase() + "-" + spanId.toString(16).toLowerCase() + "-$expectedSamplingPriority")
-    } else {
-      1 * carrier.put(B3_KEY, traceId.toString(16).toLowerCase() + "-" + spanId.toString(16).toLowerCase())
-    }
-    0 * _
-
-    cleanup:
-    tracer.close()
-
-    where:
-    traceId          | spanId           | samplingPriority | samplingMechanism | expectedSamplingPriority
-    1G               | 2G               | UNSET            | UNKNOWN           | null
-    2G               | 3G               | SAMPLER_KEEP     | DEFAULT           | SAMPLER_KEEP
-    4G               | 5G               | SAMPLER_DROP     | DEFAULT           | SAMPLER_DROP
-    5G               | 6G               | USER_KEEP        | MANUAL            | SAMPLER_KEEP
-    6G               | 7G               | USER_DROP        | MANUAL            | SAMPLER_DROP
-    TRACE_ID_MAX     | TRACE_ID_MAX - 1 | UNSET            | UNKNOWN           | null
-    TRACE_ID_MAX - 1 | TRACE_ID_MAX     | SAMPLER_KEEP     | DEFAULT           | SAMPLER_KEEP
   }
+}
 
-  def "inject http headers with extracted original"() {
-    setup:
-    def writer = new ListWriter()
-    def tracer = tracerBuilder().writer(writer).build()
-    def headers = [
-      (TRACE_ID_KEY.toUpperCase()): traceId,
-      (SPAN_ID_KEY.toUpperCase()) : spanId,
-    ]
-    HttpCodec.Extractor extractor = B3HttpCodec.newExtractor(Collections.emptyMap(),Collections.emptyMap())
-    final TagContext context = extractor.extract(headers, ContextVisitors.stringValuesMap())
-    final DDSpanContext mockedContext =
-      new DDSpanContext(
-      context.traceId,
-      context.spanId,
-      DDSpanId.ZERO,
-      null,
-      "fakeService",
-      "fakeOperation",
-      "fakeResource",
-      UNSET,
-      "fakeOrigin",
-      ["k1": "v1", "k2": "v2"],
-      false,
-      "fakeType",
-      0,
-      tracer.pendingTraceFactory.create(DDTraceId.ONE),
-      null,
-      null,
-      NoopPathwayContext.INSTANCE,
-      false,
-      PropagationTags.factory().empty())
-    final Map<String, String> carrier = Mock()
-
-    when:
-    injector.inject(mockedContext, carrier, MapSetter.INSTANCE)
-
-    then:
-    1 * carrier.put(TRACE_ID_KEY, traceId)
-    1 * carrier.put(SPAN_ID_KEY, trimmed(spanId))
-    1 * carrier.put(B3_KEY, traceId + "-" + trimmed(spanId))
-    0 * _
-
-    cleanup:
-    tracer.close()
-
-    where:
-    traceId                            | spanId
-    "00001"                            | "00001"
-    "463ac35c9f6413ad"                 | "463ac35c9f6413ad"
-    "463ac35c9f6413ad48485a3953bb6124" | "1"
-    "f" * 16                           | "1"
-    "a" * 16 + "f" * 16                | "1"
-    "1"                                | "f" * 16
-    "1"                                | "000" + "f" * 16
-  }
-
-  String trimmed(String hex) {
-    int length = hex.length()
-    int i = 0
-    while (i < length  && hex.charAt(i) == '0') {
-      i++
-    }
-    if (i == length) {
-      return "0"
-    }
-    return hex.substring(i, length)
+class B3HttpInjectorLegacyTest extends B3HttpInjectorTest {
+  @Override
+  boolean tracePropagationB3Padding() {
+    return true
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpInjectorTest.groovy
@@ -3,9 +3,10 @@ package datadog.trace.core.propagation
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTraceId
+import datadog.trace.core.CoreTracer
+import datadog.trace.test.util.StringUtils
 
 import static datadog.trace.api.sampling.PrioritySampling.*
-import static datadog.trace.api.sampling.SamplingMechanism.*
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopPathwayContext
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.DDSpanContext
@@ -18,40 +19,37 @@ import static datadog.trace.core.propagation.B3HttpCodec.B3_KEY
 
 class HttpInjectorTest extends DDCoreSpecification {
 
+  boolean tracePropagationB3Padding() {
+    return false
+  }
+
+  String idOrPadded(DDTraceId id) {
+    return idOrPadded(id.toHexString(), 32)
+  }
+
+  String idOrPadded(long id) {
+    return idOrPadded(DDSpanId.toHexString(id), 16)
+  }
+
+  String idOrPadded(String id, int size) {
+    if (!tracePropagationB3Padding()) {
+      return id.toLowerCase()
+    }
+    return StringUtils.padHexLower(id, size)
+  }
+
   def "inject http headers using #styles"() {
     setup:
     Config config = Mock(Config) {
       getTracePropagationStylesToInject() >> styles
+      isTracePropagationStyleB3PaddingEnabled() >> tracePropagationB3Padding()
     }
-    HttpCodec.Injector injector = HttpCodec.createInjector(config.getTracePropagationStylesToInject(), [:])
-
+    HttpCodec.Injector injector = HttpCodec.createInjector(config, config.getTracePropagationStylesToInject(), [:])
     def traceId = DDTraceId.ONE
     def spanId = 2
-
     def writer = new ListWriter()
     def tracer = tracerBuilder().writer(writer).build()
-    final DDSpanContext mockedContext =
-      new DDSpanContext(
-      traceId,
-      spanId,
-      DDSpanId.ZERO,
-      null,
-      "fakeService",
-      "fakeOperation",
-      "fakeResource",
-      samplingPriority,
-      origin,
-      ["k1": "v1", "k2": "v2"],
-      false,
-      "fakeType",
-      0,
-      tracer.pendingTraceFactory.create(DDTraceId.ONE),
-      null,
-      null,
-      NoopPathwayContext.INSTANCE,
-      false,
-      PropagationTags.factory().fromHeaderValue(PropagationTags.HeaderType.DATADOG, "_dd.p.usr=123"))
-
+    final DDSpanContext mockedContext = mockedContext(tracer, traceId, spanId, samplingPriority, origin, ["k1": "v1", "k2": "v2"])
     final Map<String, String> carrier = Mock()
 
     when:
@@ -72,17 +70,17 @@ class HttpInjectorTest extends DDCoreSpecification {
       1 * carrier.put('x-datadog-tags', '_dd.p.usr=123')
     }
     if (styles.contains(B3MULTI)) {
-      1 * carrier.put(B3HttpCodec.TRACE_ID_KEY, traceId.toString())
-      1 * carrier.put(B3HttpCodec.SPAN_ID_KEY, spanId.toString())
+      1 * carrier.put(B3HttpCodec.TRACE_ID_KEY, idOrPadded(traceId))
+      1 * carrier.put(B3HttpCodec.SPAN_ID_KEY, idOrPadded(spanId))
       if (samplingPriority != UNSET) {
         1 * carrier.put(B3HttpCodec.SAMPLING_PRIORITY_KEY, "1")
       }
     }
     if (styles.contains(B3SINGLE)) {
       if (samplingPriority != UNSET) {
-        1 * carrier.put(B3_KEY, traceId.toString() + "-" + spanId.toString() + "-1")
+        1 * carrier.put(B3_KEY, idOrPadded(traceId) + "-" + idOrPadded(spanId) + "-1")
       } else {
-        1 * carrier.put(B3_KEY, traceId.toString() + "-" + spanId.toString())
+        1 * carrier.put(B3_KEY, idOrPadded(traceId) + "-" + idOrPadded(spanId))
       }
     }
     0 * _
@@ -92,57 +90,38 @@ class HttpInjectorTest extends DDCoreSpecification {
 
     where:
     // spotless:off
-    styles                       | samplingPriority | samplingMechanism | origin
-    [DATADOG, B3SINGLE]          | UNSET            | UNKNOWN           | null
-    [DATADOG, B3SINGLE]          | SAMPLER_KEEP     | DEFAULT           | "saipan"
-    [DATADOG]                    | UNSET            | UNKNOWN           | null
-    [DATADOG]                    | SAMPLER_KEEP     | DEFAULT           | "saipan"
-    [B3SINGLE]                   | UNSET            | UNKNOWN           | null
-    [B3SINGLE]                   | SAMPLER_KEEP     | DEFAULT           | "saipan"
-    [B3SINGLE, DATADOG]          | SAMPLER_KEEP     | DEFAULT           | "saipan"
-    [DATADOG, B3MULTI, B3SINGLE] | UNSET            | UNKNOWN           | null
-    [DATADOG, B3MULTI, B3SINGLE] | SAMPLER_KEEP     | DEFAULT           | "saipan"
-    [DATADOG, B3MULTI]           | UNSET            | UNKNOWN           | null
-    [DATADOG, B3MULTI]           | SAMPLER_KEEP     | DEFAULT           | "saipan"
-    [B3MULTI]                    | UNSET            | UNKNOWN           | null
-    [B3MULTI]                    | SAMPLER_KEEP     | DEFAULT           | "saipan"
-    [B3MULTI, DATADOG]           | SAMPLER_KEEP     | DEFAULT           | "saipan"
+    styles                       | samplingPriority | origin
+    [DATADOG, B3SINGLE]          | UNSET            | null
+    [DATADOG, B3SINGLE]          | SAMPLER_KEEP     | "saipan"
+    [DATADOG]                    | UNSET            | null
+    [DATADOG]                    | SAMPLER_KEEP     | "saipan"
+    [B3SINGLE]                   | UNSET            | null
+    [B3SINGLE]                   | SAMPLER_KEEP     | "saipan"
+    [B3SINGLE, DATADOG]          | SAMPLER_KEEP     | "saipan"
+    [DATADOG, B3MULTI, B3SINGLE] | UNSET            | null
+    [DATADOG, B3MULTI, B3SINGLE] | SAMPLER_KEEP     | "saipan"
+    [DATADOG, B3MULTI]           | UNSET            | null
+    [DATADOG, B3MULTI]           | SAMPLER_KEEP     | "saipan"
+    [B3MULTI]                    | UNSET            | null
+    [B3MULTI]                    | SAMPLER_KEEP     | "saipan"
+    [B3MULTI, DATADOG]           | SAMPLER_KEEP     | "saipan"
     // spotless:on
   }
 
   def "inject http headers using #style"() {
     setup:
+    Config config = Mock(Config) {
+      isTracePropagationStyleB3PaddingEnabled() >> tracePropagationB3Padding()
+    }
+    def injector = HttpCodec.createInjector(config, [style].toSet(), ["some-baggage-item": "SOME_HEADER"],)
     def traceId = DDTraceId.ONE
     def spanId = 2
-
     def writer = new ListWriter()
     def tracer = tracerBuilder().writer(writer).build()
-    final DDSpanContext mockedContext =
-      new DDSpanContext(
-      traceId,
-      spanId,
-      DDSpanId.ZERO,
-      null,
-      "fakeService",
-      "fakeOperation",
-      "fakeResource",
-      samplingPriority,
-      origin,
-      ["k1": "v1", "k2": "v2","some-baggage-item":"some-baggage-value"],
-      false,
-      "fakeType",
-      0,
-      tracer.pendingTraceFactory.create(DDTraceId.ONE),
-      null,
-      null,
-      NoopPathwayContext.INSTANCE,
-      false,
-      PropagationTags.factory().fromHeaderValue(PropagationTags.HeaderType.DATADOG, "_dd.p.usr=123"))
-
+    final DDSpanContext mockedContext = mockedContext(tracer, traceId, spanId, samplingPriority, origin, ["k1": "v1", "k2": "v2","some-baggage-item":"some-baggage-value"])
     final Map<String, String> carrier = Mock()
 
     when:
-    def injector = HttpCodec.createInjector([style].toSet(), ["some-baggage-item": "SOME_HEADER"],)
     injector.inject(mockedContext, carrier, MapSetter.INSTANCE)
 
     then:
@@ -160,16 +139,16 @@ class HttpInjectorTest extends DDCoreSpecification {
       }
       1 * carrier.put('x-datadog-tags', '_dd.p.usr=123')
     } else if (style == B3MULTI) {
-      1 * carrier.put(B3HttpCodec.TRACE_ID_KEY, traceId.toString())
-      1 * carrier.put(B3HttpCodec.SPAN_ID_KEY, spanId.toString())
+      1 * carrier.put(B3HttpCodec.TRACE_ID_KEY, idOrPadded(traceId))
+      1 * carrier.put(B3HttpCodec.SPAN_ID_KEY, idOrPadded(spanId))
       if (samplingPriority != UNSET) {
         1 * carrier.put(B3HttpCodec.SAMPLING_PRIORITY_KEY, "1")
       }
     } else if (style == B3SINGLE) {
       if (samplingPriority != UNSET) {
-        1 * carrier.put(B3_KEY, traceId.toString() + "-" + spanId.toString() + "-1")
+        1 * carrier.put(B3_KEY, idOrPadded(traceId) + "-" + idOrPadded(spanId) + "-1")
       } else {
-        1 * carrier.put(B3_KEY, traceId.toString() + "-" + spanId.toString())
+        1 * carrier.put(B3_KEY, idOrPadded(traceId) + "-" + idOrPadded(spanId))
       }
     }
     0 * _
@@ -179,16 +158,46 @@ class HttpInjectorTest extends DDCoreSpecification {
 
     where:
     // spotless:off
-    style    | samplingPriority | samplingMechanism | origin
-    DATADOG  | UNSET            | UNKNOWN           | null
-    DATADOG  | SAMPLER_KEEP     | DEFAULT           | null
-    DATADOG  | SAMPLER_KEEP     | DEFAULT           | "saipan"
-    B3SINGLE | UNSET            | UNKNOWN           | null
-    B3SINGLE | SAMPLER_KEEP     | DEFAULT           | null
-    B3SINGLE | SAMPLER_KEEP     | DEFAULT           | "saipan"
-    B3MULTI  | UNSET            | UNKNOWN           | null
-    B3MULTI  | SAMPLER_KEEP     | DEFAULT           | null
-    B3MULTI  | SAMPLER_KEEP     | DEFAULT           | "saipan"
+    style    | samplingPriority | origin
+    DATADOG  | UNSET            | null
+    DATADOG  | SAMPLER_KEEP     | null
+    DATADOG  | SAMPLER_KEEP     | "saipan"
+    B3SINGLE | UNSET            | null
+    B3SINGLE | SAMPLER_KEEP     | null
+    B3SINGLE | SAMPLER_KEEP     | "saipan"
+    B3MULTI  | UNSET            | null
+    B3MULTI  | SAMPLER_KEEP     | null
+    B3MULTI  | SAMPLER_KEEP     | "saipan"
     // spotless:on
+  }
+
+  static DDSpanContext mockedContext(CoreTracer tracer, DDTraceId traceId, long spanId, int samplingPriority, String origin, Map<String, String> baggage) {
+    return new DDSpanContext(
+      traceId,
+      spanId,
+      DDSpanId.ZERO,
+      null,
+      "fakeService",
+      "fakeOperation",
+      "fakeResource",
+      samplingPriority,
+      origin,
+      baggage,
+      false,
+      "fakeType",
+      0,
+      tracer.pendingTraceFactory.create(DDTraceId.ONE),
+      null,
+      null,
+      NoopPathwayContext.INSTANCE,
+      false,
+      PropagationTags.factory().fromHeaderValue(PropagationTags.HeaderType.DATADOG, "_dd.p.usr=123"))
+  }
+}
+
+class HttpInjectorB3PaddingTest extends HttpInjectorTest {
+  @Override
+  boolean tracePropagationB3Padding() {
+    return true
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -441,6 +441,7 @@ public class Config {
   private final boolean logExtractHeaderNames;
   private final Set<PropagationStyle> propagationStylesToExtract;
   private final Set<PropagationStyle> propagationStylesToInject;
+  private final boolean tracePropagationStyleB3PaddingEnabled;
   private final Set<TracePropagationStyle> tracePropagationStylesToExtract;
   private final Set<TracePropagationStyle> tracePropagationStylesToInject;
   private final int clockSyncPeriod;
@@ -901,6 +902,8 @@ public class Config {
             PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED,
             DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED);
 
+    tracePropagationStyleB3PaddingEnabled =
+        isEnabled(true, TRACE_PROPAGATION_STYLE, ".b3.padding.enabled");
     {
       // The dd.propagation.style.(extract|inject) settings have been deprecated in
       // favor of dd.trace.propagation.style(|.extract|.inject) settings.
@@ -1623,6 +1626,10 @@ public class Config {
   @Deprecated
   public Set<PropagationStyle> getPropagationStylesToInject() {
     return propagationStylesToInject;
+  }
+
+  public boolean isTracePropagationStyleB3PaddingEnabled() {
+    return tracePropagationStyleB3PaddingEnabled;
   }
 
   public Set<TracePropagationStyle> getTracePropagationStylesToExtract() {

--- a/utils/test-utils/src/main/groovy/datadog/trace/test/util/StringUtils.groovy
+++ b/utils/test-utils/src/main/groovy/datadog/trace/test/util/StringUtils.groovy
@@ -1,0 +1,25 @@
+package datadog.trace.test.util
+
+class StringUtils {
+
+  static String padHexLower(String hex, int size) {
+    hex = hex.toLowerCase()
+    int left = size - hex.length()
+    if (size > 0) {
+      return "${'0' * left}${hex}"
+    }
+    return hex
+  }
+
+  static String trimHex(String hex) {
+    int length = hex.length()
+    int i = 0
+    while (i < length  && hex.charAt(i) == '0') {
+      i++
+    }
+    if (i == length) {
+      return "0"
+    }
+    return hex.substring(i, length)
+  }
+}


### PR DESCRIPTION
# What Does This Do

Adds padding to B3 propagation headers to be compliant with other tracers behavior.

# Motivation

# Additional Notes

This behavior can be turned off by the setting the java property `-Ddd.trace.propagation.style.b3.padding.enabled=false` or the environment variable `DD_TRACE_PROPAGATION_STYLE_B3_PADDING_ENABLED=false`