### PR TITLE
[wip] Update jplib to 0.27.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    jplib         : "0.26.0",
+    jplib         : "0.27.0",
     asm           : "9.4"
   ]
 


### PR DESCRIPTION
# What Does This Do
https://github.com/DataDog/java-profiler/releases/tag/v0.27.0

# Motivation
JPLib 0.27.0 is fixing a native memory leak introduced in JPLib 0.15.0

# Additional Notes
