### PR TITLE
Improve Open Telemetry tracer API instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelContext.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelContext.java
@@ -9,18 +9,23 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public class OtelContext implements Context {
   private static final String OTEL_CONTEXT_SPAN_KEY = "opentelemetry-trace-span-key";
+  private static final String DATADOG_CONTEXT_ROOT_SPAN_KEY = "datadog-root-span-key";
 
-  private final Span span;
+  private final Span currentSpan;
+  private final Span rootSpan;
 
-  public OtelContext(Span span) {
-    this.span = span;
+  public OtelContext(Span currentSpan, Span rootSpan) {
+    this.currentSpan = currentSpan;
+    this.rootSpan = rootSpan;
   }
 
   @Nullable
   @Override
   public <V> V get(ContextKey<V> key) {
     if (OTEL_CONTEXT_SPAN_KEY.equals(key.toString())) {
-      return (V) this.span;
+      return (V) this.currentSpan;
+    } else if (DATADOG_CONTEXT_ROOT_SPAN_KEY.equals(key.toString())) {
+      return (V) this.rootSpan;
     }
     return null;
   }
@@ -28,7 +33,9 @@ public class OtelContext implements Context {
   @Override
   public <V> Context with(ContextKey<V> k1, V v1) {
     if (OTEL_CONTEXT_SPAN_KEY.equals(k1.toString())) {
-      return new OtelContext((Span) v1);
+      return new OtelContext((Span) v1, this.rootSpan);
+    } else if (DATADOG_CONTEXT_ROOT_SPAN_KEY.equals(k1.toString())) {
+      return new OtelContext(this.currentSpan, (Span) v1);
     }
     return this;
   }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelSpanBuilder.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelSpanBuilder.java
@@ -36,6 +36,7 @@ public class OtelSpanBuilder implements SpanBuilder {
   @Override
   public SpanBuilder setNoParent() {
     this.delegate.asChildOf(null);
+    this.delegate.ignoreActiveSpan();
     return this;
   }
 

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
@@ -380,7 +380,7 @@ class OpenTelemetry14Test extends AgentTestRunner {
     def otelParentSpan = tracer.spanBuilder("some-name").startSpan()
 
     when:
-    otelParentSpan.makeCurrent()
+    def otelParentScope = otelParentSpan.makeCurrent()
     def activeSpan = TEST_TRACER.activeSpan()
 
     then:
@@ -389,7 +389,7 @@ class OpenTelemetry14Test extends AgentTestRunner {
 
     when:
     def ddChildSpan = TEST_TRACER.startSpan("other-name")
-    TEST_TRACER.activateSpan(ddChildSpan, MANUAL)
+    def ddChildScope = TEST_TRACER.activateSpan(ddChildSpan, MANUAL)
     def current = Span.current()
 
     then:
@@ -397,7 +397,7 @@ class OpenTelemetry14Test extends AgentTestRunner {
 
     when:
     def otelGrandChildSpan = tracer.spanBuilder("another-name").startSpan()
-    otelGrandChildSpan.makeCurrent()
+    def otelGrandChildScope= otelGrandChildSpan.makeCurrent()
     activeSpan = TEST_TRACER.activeSpan()
 
     then:
@@ -405,8 +405,11 @@ class OpenTelemetry14Test extends AgentTestRunner {
     DDSpanId.toHexString(activeSpan.spanId) == otelGrandChildSpan.getSpanContext().spanId
 
     when:
+    otelGrandChildScope.close()
     otelGrandChildSpan.end()
+    ddChildScope.close()
     ddChildSpan.finish()
+    otelParentScope.close()
     otelParentSpan.end()
 
     then:

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
@@ -2,6 +2,7 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.instrumentation.opentelemetry14.OtelContext
 import datadog.trace.instrumentation.opentelemetry14.OtelSpan
 import datadog.trace.instrumentation.opentelemetry14.OtelSpanBuilder
 import datadog.trace.instrumentation.opentelemetry14.OtelTracer
@@ -10,6 +11,7 @@ import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.context.Context
+import io.opentelemetry.context.ContextKey
 import spock.lang.Subject
 
 import static datadog.trace.bootstrap.instrumentation.api.ScopeSource.MANUAL
@@ -424,5 +426,42 @@ class OpenTelemetry14Test extends AgentTestRunner {
         }
       }
     }
+  }
+
+  def "test context spans retrieval"() {
+    setup:
+    def parentSpan = tracer.spanBuilder("some-name").startSpan()
+    def parentScope = parentSpan.makeCurrent()
+    def currentSpanKey = ContextKey.named(OtelContext.OTEL_CONTEXT_SPAN_KEY)
+    def rootSpanKey = ContextKey.named(OtelContext.DATADOG_CONTEXT_ROOT_SPAN_KEY)
+
+    when:
+    def current = Context.current()
+
+    then:
+    current.get(currentSpanKey) == parentSpan
+    current.get(rootSpanKey) == parentSpan
+
+    when:
+    def childSpan = tracer.spanBuilder("other-name").startSpan()
+    def childScope = childSpan.makeCurrent()
+    current = Context.current()
+
+    then:
+    current.get(currentSpanKey) == childSpan
+    current.get(rootSpanKey) == parentSpan
+
+    when:
+    childScope.close()
+    childSpan.end()
+    current = Context.current()
+
+    then:
+    current.get(currentSpanKey) == parentSpan
+    current.get(rootSpanKey) == parentSpan
+
+    cleanup:
+    parentScope.close()
+    parentSpan.end()
   }
 }


### PR DESCRIPTION
# What Does This Do

This PR follows the original experimental support #4669 to fix new trace creation and bring root span retrieval from `Context`.

# Motivation

Open Telemetry API does not provide a way to get local root span.
This change introduce a such feature using a custom `ContextKey`.

```java
ContextKey rootSpanKey = ContextKey.named("datadog-root-span-key");
Span rootSpan = Context.current().get(rootSpanKey);
```

Please note:
* The `Context` instance is immutable so its (current and root) spans will be snapshot during the `Context.current()` call.
* Setting attributes for the root span is not guaranteed as the root span might no more be eligible for modification.

# Additional Notes

Check the full discussion about those changes from #4935 
