### PR TITLE
Peer service for client and precursors

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/rmi/RmiClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/rmi/RmiClientDecorator.java
@@ -1,9 +1,14 @@
 package datadog.trace.bootstrap.instrumentation.rmi;
 
+import datadog.trace.api.cache.DDCache;
+import datadog.trace.api.cache.DDCaches;
 import datadog.trace.api.naming.SpanNaming;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.ClientDecorator;
+import java.lang.reflect.Method;
 
 public class RmiClientDecorator extends ClientDecorator {
   public static final CharSequence RMI_INVOKE =
@@ -11,6 +16,9 @@ public class RmiClientDecorator extends ClientDecorator {
           SpanNaming.instance().namingSchema().client().operationForProtocol("rmi"));
   public static final CharSequence RMI_CLIENT = UTF8BytesString.create("rmi-client");
   public static final RmiClientDecorator DECORATE = new RmiClientDecorator();
+
+  private static final DDCache<Method, CharSequence> METHOD_CACHE =
+      DDCaches.newFixedSizeIdentityCache(32);
 
   @Override
   protected String[] instrumentationNames() {
@@ -30,5 +38,13 @@ public class RmiClientDecorator extends ClientDecorator {
   @Override
   protected String service() {
     return null;
+  }
+
+  public AgentSpan onMethodInvocation(final AgentSpan span, final Method method) {
+    span.setResourceName(spanNameForMethod(method));
+    span.setTag(
+        Tags.RPC_SERVICE,
+        METHOD_CACHE.computeIfAbsent(method, m -> m.getDeclaringClass().getName()));
+    return span;
   }
 }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientDecorator.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientDecorator.java
@@ -10,6 +10,7 @@ import datadog.trace.api.GenericClassValue;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.ClientDecorator;
 import io.grpc.MethodDescriptor;
@@ -93,7 +94,8 @@ public class GrpcClientDecorator extends ClientDecorator {
     AgentSpan span =
         startSpan(OPERATION_NAME)
             .setTag("request.type", requestMessageType(method))
-            .setTag("response.type", responseMessageType(method));
+            .setTag("response.type", responseMessageType(method))
+            .setTag(Tags.RPC_SERVICE, method.getServiceName());
     span.setResourceName(method.getFullMethodName());
     return afterStart(span);
   }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
@@ -152,6 +152,7 @@ abstract class GrpcStreamingTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "grpc-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.RPC_SERVICE" "example.Greeter"
             "status.code" "OK"
             "request.type" "example.Helloworld\$Response"
             "response.type" "example.Helloworld\$Response"

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -145,6 +145,7 @@ abstract class GrpcTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "grpc-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.RPC_SERVICE" "example.Greeter"
             "status.code" "OK"
             "request.type" "example.Helloworld\$Request"
             "response.type" "example.Helloworld\$Response"
@@ -283,6 +284,7 @@ abstract class GrpcTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "grpc-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.RPC_SERVICE" "example.Greeter"
             "status.code" "${status.code.name()}"
             "status.description" description
             "request.type" "example.Helloworld\$Request"
@@ -383,6 +385,7 @@ abstract class GrpcTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "grpc-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.RPC_SERVICE" "example.Greeter"
             "status.code" "UNKNOWN"
             "request.type" "example.Helloworld\$Request"
             "response.type" "example.Helloworld\$Response"
@@ -570,6 +573,7 @@ abstract class GrpcTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "grpc-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.RPC_SERVICE" "example.Greeter"
             "status.code" "OK"
             "request.type" "example.Helloworld\$Request"
             "response.type" "example.Helloworld\$Response"

--- a/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/client/RmiClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/client/RmiClientInstrumentation.java
@@ -54,9 +54,8 @@ public final class RmiClientInstrumentation extends Instrumenter.Tracing
         return null;
       }
       final AgentSpan span = startSpan(RMI_INVOKE);
-      span.setResourceName(DECORATE.spanNameForMethod(method));
-
       DECORATE.afterStart(span);
+      DECORATE.onMethodInvocation(span, method);
       return activateSpan(span);
     }
 

--- a/dd-java-agent/instrumentation/rmi/src/test/groovy/RmiTest.groovy
+++ b/dd-java-agent/instrumentation/rmi/src/test/groovy/RmiTest.groovy
@@ -63,6 +63,7 @@ abstract class RmiTest extends VersionedNamingTestBase {
 
           tags {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.RPC_SERVICE" "rmi.app.Greeter"
             "$Tags.COMPONENT" "rmi-client"
             defaultTags()
           }
@@ -144,6 +145,7 @@ abstract class RmiTest extends VersionedNamingTestBase {
 
           tags {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.RPC_SERVICE" "rmi.app.Greeter"
             "$Tags.COMPONENT" "rmi-client"
             errorTags(RuntimeException, String)
             defaultTags()
@@ -198,6 +200,7 @@ abstract class RmiTest extends VersionedNamingTestBase {
           tags {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.COMPONENT" "rmi-client"
+            "$Tags.RPC_SERVICE" "rmi.app.Greeter"
             defaultTags()
           }
         }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
@@ -48,9 +48,12 @@ class TagsAssert {
     assertedTags.add("_sample_rate")
     assertedTags.add(DDTags.PID_TAG)
     assertedTags.add(DDTags.SCHEMA_VERSION_TAG_KEY)
+    assertedTags.add(Tags.NET_PEER_NAME)
+
 
     assert tags["thread.name"] != null
     assert tags["thread.id"] != null
+    assert tags["peer.hostname"] == tags["net.peer.name"]
 
     // FIXME: DQH - Too much conditional logic?  Maybe create specialized methods for client & server cases
 
@@ -71,6 +74,16 @@ class TagsAssert {
       assert tags[DDTags.LANGUAGE_TAG_KEY] == DDTags.LANGUAGE_TAG_VALUE
     } else {
       assert tags[DDTags.LANGUAGE_TAG_KEY] == null
+    }
+    boolean shouldSetPeerService = tags[Tags.SPAN_KIND] == Tags.SPAN_KIND_CLIENT
+    if (SpanNaming.instance().namingSchema().supportsPeerService() && shouldSetPeerService) {
+      assertedTags.add(Tags.PEER_SERVICE)
+      assertedTags.add(DDTags.PEER_SERVICE_SOURCE)
+      assert tags[Tags.PEER_SERVICE] != null
+      assert tags[Tags.PEER_SERVICE] == tags[tags[DDTags.PEER_SERVICE_SOURCE]]
+    } else {
+      assert tags[Tags.PEER_SERVICE] == null
+      assert tags[DDTags.PEER_SERVICE_SOURCE] == null
     }
   }
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -44,4 +44,5 @@ public class DDTags {
   public static final String MEASURED = "_dd.measured";
   public static final String PID_TAG = "process_id";
   public static final String SCHEMA_VERSION_TAG_KEY = "_dd.trace_span_attribute_schema";
+  public static final String PEER_SERVICE_SOURCE = "_dd.peer.service.source";
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -558,7 +558,10 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     this.dataStreamsMonitoring.start();
 
     this.tagInterceptor =
-        null == tagInterceptor ? new TagInterceptor(new RuleFlags(config)) : tagInterceptor;
+        null == tagInterceptor
+            ? new TagInterceptor(
+                new RuleFlags(config), (span, tag, value) -> span.unsafeSetTag(tag, value))
+            : tagInterceptor;
 
     if (config.isCiVisibilityEnabled()) {
       addTraceInterceptor(CiVisibilityTraceInterceptor.INSTANCE);

--- a/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
@@ -46,6 +46,13 @@ public interface NamingSchema {
    */
   ForServer server();
 
+  /**
+   * Whenever the schema versions supports `peer.service` tag
+   *
+   * @return
+   */
+  boolean supportsPeerService();
+
   interface ForCache {
     /**
      * Calculate the operation name for a cache span.

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/NamingSchemaV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/NamingSchemaV0.java
@@ -39,4 +39,9 @@ public class NamingSchemaV0 implements NamingSchema {
   public ForServer server() {
     return serverNaming;
   }
+
+  @Override
+  public boolean supportsPeerService() {
+    return false;
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/NamingSchemaV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/NamingSchemaV1.java
@@ -39,4 +39,9 @@ public class NamingSchemaV1 implements NamingSchema {
   public ForServer server() {
     return serverNaming;
   }
+
+  @Override
+  public boolean supportsPeerService() {
+    return true;
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
@@ -29,6 +29,8 @@ public class Tags {
   public static final String PEER_SERVICE = "peer.service";
   public static final String PEER_HOSTNAME = "peer.hostname";
   public static final String PEER_PORT = "peer.port";
+  public static final String NET_PEER_NAME = "net.peer.name";
+  public static final String RPC_SERVICE = "rpc.service";
   public static final String SAMPLING_PRIORITY = "sampling.priority";
   public static final String SPAN_KIND = "span.kind";
   public static final String COMPONENT = "component";
@@ -39,7 +41,6 @@ public class Tags {
   public static final String DB_OPERATION = "db.operation";
   public static final String DB_STATEMENT = "db.statement";
   public static final String MESSAGE_BUS_DESTINATION = "message_bus.destination";
-
   public static final String TEST_MODULE = "test.module";
   public static final String TEST_BUNDLE = "test.bundle";
   public static final String TEST_SUITE = "test.suite";


### PR DESCRIPTION
# What Does This Do

Implement `peer.service` tag logic for span kind client spans.

Peer service can be:
* Set by the user: in this case it takes precedence to automatic calculation
* Automatically calculated (value derived from other tags)

Calculation logic is (higher in the list, higher in priority):
* `rpc.service` for grpc and rmi
* `db.instance` for databases
* `net.peer.name` as generic fallback

the three above are called precursors since they also need to be set. two of the three are missing hence added:
* `rpc.service`: is the fully qualified name (without method) of the service being called. Added only to client spans (not server for now)
* `net.peer.name`: is the OTEL alias for `peer.hostname`

Once the `peer.service` value is set we also have to know it's provenance. For this we set the tag `_dd.peer.service.source` having as value the tag name which has served as source to calculate peer service.

# Motivation

# Additional Notes
