### PR TITLE
Remove additional probes in ProbeDefinition

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
@@ -82,11 +82,6 @@ public class Snapshot {
       return;
     }
     snapshotStatuses.put(probe.id, new SnapshotStatus(probe.captureSnapshot, true, probe));
-    for (ProbeDetails additionalProbe : probe.additionalProbes) {
-      snapshotStatuses.put(
-          additionalProbe.id,
-          new SnapshotStatus(additionalProbe.captureSnapshot, true, additionalProbe));
-    }
   }
 
   public void setEntry(CapturedContext context) {
@@ -207,9 +202,6 @@ public class Snapshot {
       stack.add(CapturedStackFrame.from(ste));
     }
     summaryBuilder.addStack(stack);
-    for (ProbeDetails additionalProbe : this.probe.additionalProbes) {
-      additionalProbe.summaryBuilder.addStack(stack);
-    }
   }
 
   public enum Kind {
@@ -240,7 +232,6 @@ public class Snapshot {
     private final MethodLocation evaluateAt;
     private final transient boolean captureSnapshot;
     private final DebuggerScript script;
-    private final transient List<ProbeDetails> additionalProbes;
     private final String tags;
     private final transient SummaryBuilder summaryBuilder;
 
@@ -253,8 +244,7 @@ public class Snapshot {
           true,
           null,
           null,
-          new SnapshotSummaryBuilder(location),
-          Collections.emptyList());
+          new SnapshotSummaryBuilder(location));
     }
 
     public ProbeDetails(
@@ -266,35 +256,12 @@ public class Snapshot {
         DebuggerScript<Boolean> script,
         String tags,
         SummaryBuilder summaryBuilder) {
-      this(
-          id,
-          version,
-          location,
-          evaluateAt,
-          captureSnapshot,
-          script,
-          tags,
-          summaryBuilder,
-          Collections.emptyList());
-    }
-
-    public ProbeDetails(
-        String id,
-        int version,
-        ProbeLocation location,
-        MethodLocation evaluateAt,
-        boolean captureSnapshot,
-        DebuggerScript<Boolean> script,
-        String tags,
-        SummaryBuilder summaryBuilder,
-        List<ProbeDetails> additionalProbes) {
       this.id = id;
       this.version = version;
       this.location = location;
       this.evaluateAt = evaluateAt;
       this.captureSnapshot = captureSnapshot;
       this.script = script;
-      this.additionalProbes = additionalProbes;
       this.tags = tags;
       this.summaryBuilder = summaryBuilder;
     }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ClassesToRetransformFinder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ClassesToRetransformFinder.java
@@ -77,10 +77,7 @@ public class ClassesToRetransformFinder {
       } else {
         key = normalizeFilePath(key);
       }
-      LOGGER.debug(
-          "instrumented class changed: {} for probe ids: {}",
-          key,
-          definition.getAllProbeIds().collect(Collectors.toList()));
+      LOGGER.debug("instrumented class changed: {} for probe id: {}", key, definition.getId());
       changedClasses.insert(reverseStr(key));
     }
     for (String typeName : comparer.getChangedBlockedTypes()) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationComparer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationComparer.java
@@ -105,7 +105,7 @@ public class ConfigurationComparer {
         new AllowListHelper(incomingConfiguration.getAllowList());
     DenyListHelper incomingDenyListHelper = new DenyListHelper(incomingConfiguration.getDenyList());
 
-    List<String> changedTypes = new ArrayList();
+    List<String> changedTypes = new ArrayList<>();
 
     for (InstrumentationResult result : instrumentationResults.values()) {
       boolean originalAllowed = true;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
@@ -27,7 +27,7 @@ import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.tree.TypeInsnNode;
 
 /** Common class for generating instrumentation */
-public class Instrumentor {
+public abstract class Instrumentor {
   protected static final String CONSTRUCTOR_NAME = "<init>";
   protected static final String PROBEID_TAG_NAME = "debugger.probeid";
 
@@ -36,6 +36,7 @@ public class Instrumentor {
   protected final ClassNode classNode;
   protected final MethodNode methodNode;
   protected final List<DiagnosticMessage> diagnostics;
+  protected final List<String> probeIds;
   protected final boolean isStatic;
   protected final boolean isLineProbe;
   protected final LineMap lineMap = new LineMap();
@@ -50,12 +51,14 @@ public class Instrumentor {
       ClassLoader classLoader,
       ClassNode classNode,
       MethodNode methodNode,
-      List<DiagnosticMessage> diagnostics) {
+      List<DiagnosticMessage> diagnostics,
+      List<String> probeIds) {
     this.definition = definition;
     this.classLoader = classLoader;
     this.classNode = classNode;
     this.methodNode = methodNode;
     this.diagnostics = diagnostics;
+    this.probeIds = probeIds;
     Where.SourceLine[] sourceLines = definition.getWhere().getSourceLines();
     isLineProbe = sourceLines != null && sourceLines.length > 0;
     isStatic = (methodNode.access & Opcodes.ACC_STATIC) != 0;
@@ -67,6 +70,8 @@ public class Instrumentor {
     }
     localVarsBySlot = extractLocalVariables(argTypes);
   }
+
+  public abstract void instrument();
 
   private LocalVariableNode[] extractLocalVariables(Type[] argTypes) {
     if (methodNode.localVariables == null || methodNode.localVariables.isEmpty()) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/LogInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/LogInstrumentor.java
@@ -59,12 +59,14 @@ public final class LogInstrumentor extends Instrumentor {
       ClassLoader classLoader,
       ClassNode classNode,
       MethodNode methodNode,
-      List<DiagnosticMessage> diagnostics) {
-    super(logProbe, classLoader, classNode, methodNode, diagnostics);
+      List<DiagnosticMessage> diagnostics,
+      List<String> probeIds) {
+    super(logProbe, classLoader, classNode, methodNode, diagnostics, probeIds);
     this.capture = logProbe.getCapture();
     captureFullState = logProbe.isCaptureSnapshot();
   }
 
+  @Override
   public void instrument() {
     if (isLineProbe) {
       fillLineMap();
@@ -319,11 +321,6 @@ public final class LogInstrumentor extends Instrumentor {
   }
 
   private void pushProbesIds(InsnList insnList) {
-    List<String> probeIds = new ArrayList<>();
-    probeIds.add(definition.getId());
-    for (ProbeDefinition def : definition.getAdditionalProbes()) {
-      probeIds.add(def.getId());
-    }
     ldc(insnList, probeIds.size()); // array size
     // stack [int]
     insnList.add(new TypeInsnNode(Opcodes.ANEWARRAY, STRING_TYPE.getInternalName()));

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
@@ -45,11 +45,13 @@ public class MetricInstrumentor extends Instrumentor {
       ClassLoader classLoader,
       ClassNode classNode,
       MethodNode methodNode,
-      List<DiagnosticMessage> diagnostics) {
-    super(metricProbe, classLoader, classNode, methodNode, diagnostics);
+      List<DiagnosticMessage> diagnostics,
+      List<String> probeIds) {
+    super(metricProbe, classLoader, classNode, methodNode, diagnostics, probeIds);
     this.metricProbe = metricProbe;
   }
 
+  @Override
   public void instrument() {
     if (isLineProbe) {
       fillLineMap();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/SpanInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/SpanInstrumentor.java
@@ -27,10 +27,12 @@ public class SpanInstrumentor extends Instrumentor {
       ClassLoader classLoader,
       ClassNode classNode,
       MethodNode methodNode,
-      List<DiagnosticMessage> diagnostics) {
-    super(spanProbe, classLoader, classNode, methodNode, diagnostics);
+      List<DiagnosticMessage> diagnostics,
+      List<String> probeIds) {
+    super(spanProbe, classLoader, classNode, methodNode, diagnostics, probeIds);
   }
 
+  @Override
   public void instrument() {
     if (isLineProbe) {
       fillLineMap();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -321,8 +321,10 @@ public class LogProbe extends ProbeDefinition {
       ClassLoader classLoader,
       ClassNode classNode,
       MethodNode methodNode,
-      List<DiagnosticMessage> diagnostics) {
-    new LogInstrumentor(this, classLoader, classNode, methodNode, diagnostics).instrument();
+      List<DiagnosticMessage> diagnostics,
+      List<String> probeIds) {
+    new LogInstrumentor(this, classLoader, classNode, methodNode, diagnostics, probeIds)
+        .instrument();
   }
 
   @Generated
@@ -344,8 +346,7 @@ public class LogProbe extends ProbeDefinition {
         && Objects.equals(captureSnapshot, that.captureSnapshot)
         && Objects.equals(probeCondition, that.probeCondition)
         && Objects.equals(capture, that.capture)
-        && Objects.equals(sampling, that.sampling)
-        && Objects.equals(additionalProbes, that.additionalProbes);
+        && Objects.equals(sampling, that.sampling);
   }
 
   @Generated
@@ -365,8 +366,7 @@ public class LogProbe extends ProbeDefinition {
             captureSnapshot,
             probeCondition,
             capture,
-            sampling,
-            additionalProbes);
+            sampling);
     result = 31 * result + Arrays.hashCode(tags);
     return result;
   }
@@ -406,8 +406,6 @@ public class LogProbe extends ProbeDefinition {
         + capture
         + ", sampling="
         + sampling
-        + ", additionalProbes="
-        + additionalProbes
         + "} ";
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/MetricProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/MetricProbe.java
@@ -63,8 +63,10 @@ public class MetricProbe extends ProbeDefinition {
       ClassLoader classLoader,
       ClassNode classNode,
       MethodNode methodNode,
-      List<DiagnosticMessage> diagnostics) {
-    new MetricInstrumentor(this, classLoader, classNode, methodNode, diagnostics).instrument();
+      List<DiagnosticMessage> diagnostics,
+      List<String> probeIds) {
+    new MetricInstrumentor(this, classLoader, classNode, methodNode, diagnostics, probeIds)
+        .instrument();
   }
 
   public static Builder builder() {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanProbe.java
@@ -27,8 +27,10 @@ public class SpanProbe extends ProbeDefinition {
       ClassLoader classLoader,
       ClassNode classNode,
       MethodNode methodNode,
-      List<DiagnosticMessage> diagnostics) {
-    new SpanInstrumentor(this, classLoader, classNode, methodNode, diagnostics).instrument();
+      List<DiagnosticMessage> diagnostics,
+      List<String> probeIds) {
+    new SpanInstrumentor(this, classLoader, classNode, methodNode, diagnostics, probeIds)
+        .instrument();
   }
 
   @Generated

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationComparerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationComparerTest.java
@@ -21,6 +21,8 @@ import org.objectweb.asm.tree.MethodNode;
 
 class ConfigurationComparerTest {
   private static final ProbeId PROBE_ID = new ProbeId("beae1807-f3b0-4ea8-a74f-826790c5e6f8", 0);
+  private static final ProbeId PROBE_ID1 = new ProbeId("beae1807-f3b0-4ea8-a74f-826790c5e6f6", 0);
+  private static final ProbeId PROBE_ID2 = new ProbeId("beae1807-f3b0-4ea8-a74f-826790c5e6f7", 0);
   private static final String SERVICE_NAME = "service-name";
 
   @Test
@@ -114,49 +116,43 @@ class ConfigurationComparerTest {
   public void addDuplicate() {
     LogProbe probe =
         LogProbe.builder()
-            .probeId(PROBE_ID)
+            .probeId(PROBE_ID1)
             .where(null, null, null, 1966, "src/main/java/java/lang/String.java")
             .build();
     Configuration singleProbeConfig = createConfig(Collections.singletonList(probe));
     LogProbe duplicatedProbe =
         LogProbe.builder()
-            .probeId(PROBE_ID)
+            .probeId(PROBE_ID2)
             .where(null, null, null, 1966, "src/main/java/java/lang/String.java")
             .build();
-    duplicatedProbe.addAdditionalProbe(probe);
-    Configuration duplicatedProbeConfig = createConfig(Collections.singletonList(duplicatedProbe));
+    Configuration duplicatedProbeConfig = createConfig(Arrays.asList(probe, duplicatedProbe));
     ConfigurationComparer configurationComparer =
         new ConfigurationComparer(singleProbeConfig, duplicatedProbeConfig, emptyMap());
     Assertions.assertTrue(configurationComparer.hasProbeRelatedChanges());
     Assertions.assertFalse(configurationComparer.getAddedDefinitions().isEmpty());
     ProbeDefinition added = configurationComparer.getAddedDefinitions().iterator().next();
     Assertions.assertEquals(duplicatedProbe, added);
-    Assertions.assertFalse(configurationComparer.getRemovedDefinitions().isEmpty());
-    ProbeDefinition removed = configurationComparer.getRemovedDefinitions().iterator().next();
-    Assertions.assertEquals(probe, removed);
+    Assertions.assertTrue(configurationComparer.getRemovedDefinitions().isEmpty());
   }
 
   @Test
   public void removeDuplicate() {
     LogProbe probe =
         LogProbe.builder()
-            .probeId(PROBE_ID)
+            .probeId(PROBE_ID1)
             .where(null, null, null, 1966, "src/main/java/java/lang/String.java")
             .build();
     Configuration singleProbeConfig = createConfig(Collections.singletonList(probe));
     LogProbe duplicatedProbe =
         LogProbe.builder()
-            .probeId(PROBE_ID)
+            .probeId(PROBE_ID2)
             .where(null, null, null, 1966, "src/main/java/java/lang/String.java")
             .build();
-    duplicatedProbe.addAdditionalProbe(probe);
-    Configuration duplicatedProbeConfig = createConfig(Collections.singletonList(duplicatedProbe));
+    Configuration duplicatedProbeConfig = createConfig(Arrays.asList(probe, duplicatedProbe));
     ConfigurationComparer configurationComparer =
         new ConfigurationComparer(duplicatedProbeConfig, singleProbeConfig, emptyMap());
     Assertions.assertTrue(configurationComparer.hasProbeRelatedChanges());
-    Assertions.assertFalse(configurationComparer.getAddedDefinitions().isEmpty());
-    ProbeDefinition added = configurationComparer.getAddedDefinitions().iterator().next();
-    Assertions.assertEquals(probe, added);
+    Assertions.assertTrue(configurationComparer.getAddedDefinitions().isEmpty());
     Assertions.assertFalse(configurationComparer.getRemovedDefinitions().isEmpty());
     ProbeDefinition removed = configurationComparer.getRemovedDefinitions().iterator().next();
     Assertions.assertEquals(duplicatedProbe, removed);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
@@ -158,7 +158,6 @@ public class ConfigurationTest {
     LogProbe snapshotProbe0 = logProbes0.get(0);
     assertEquals("java.lang.String", snapshotProbe0.getWhere().getTypeName());
     assertEquals(ProbeDefinition.MethodLocation.ENTRY, snapshotProbe0.getEvaluateAt());
-    assertEquals(1, snapshotProbe0.getAllProbeIds().count());
     assertEquals(2, snapshotProbe0.getTags().length);
     assertTrue(snapshotProbe0.isCaptureSnapshot());
     assertEquals("tag1:value1", snapshotProbe0.getTags()[0].toString());
@@ -175,8 +174,6 @@ public class ConfigurationTest {
     MetricProbe metricProbe0 = config0.getMetricProbes().iterator().next();
     assertEquals("metric_count", metricProbe0.getMetricName());
     assertEquals(COUNT, metricProbe0.getKind());
-    assertEquals(0, metricProbe0.getAdditionalProbes().size());
-    assertEquals(1, metricProbe0.getAllProbeIds().count());
     // log probe
     assertEquals(2, config0.getLogProbes().size());
     LogProbe logProbe0 = logProbes0.get(1);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
@@ -158,10 +158,7 @@ public class ConfigurationUpdaterTest {
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     assertEquals(2, appliedDefinitions.size());
     assertTrue(appliedDefinitions.containsKey(PROBE_ID.getId()));
-    assertEquals(1, appliedDefinitions.get(PROBE_ID.getId()).getAdditionalProbes().size());
-    assertEquals(
-        PROBE_ID2,
-        appliedDefinitions.get(PROBE_ID.getId()).getAdditionalProbes().get(0).getProbeId());
+    assertTrue(appliedDefinitions.containsKey(PROBE_ID2.getId()));
     verify(probeStatusSink).addReceived(eq(PROBE_ID));
     verify(probeStatusSink).addReceived(eq(PROBE_ID2));
   }
@@ -194,11 +191,8 @@ public class ConfigurationUpdaterTest {
     configurationUpdater.accept(createApp(logProbes));
     appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     assertEquals(2, appliedDefinitions.size());
-    assertEquals(1, appliedDefinitions.get(PROBE_ID.getId()).getAdditionalProbes().size());
-    assertEquals(
-        PROBE_ID2,
-        appliedDefinitions.get(PROBE_ID.getId()).getAdditionalProbes().get(0).getProbeId());
-    verify(probeStatusSink, times(2)).addReceived(eq(PROBE_ID)); // re-installed for PROBE_ID2
+    assertTrue(appliedDefinitions.containsKey(PROBE_ID2.getId()));
+    verify(probeStatusSink).addReceived(eq(PROBE_ID));
     verify(probeStatusSink).addReceived(eq(PROBE_ID2));
   }
 
@@ -222,22 +216,19 @@ public class ConfigurationUpdaterTest {
     verify(inst).getAllLoadedClasses();
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     assertEquals(2, appliedDefinitions.size());
-    assertEquals(1, appliedDefinitions.get(PROBE_ID.getId()).getAdditionalProbes().size());
     assertTrue(appliedDefinitions.containsKey(PROBE_ID.getId()));
-    assertEquals(
-        PROBE_ID2,
-        appliedDefinitions.get(PROBE_ID.getId()).getAdditionalProbes().get(0).getProbeId());
+    assertTrue(appliedDefinitions.containsKey(PROBE_ID2.getId()));
     // phase 2: remove duplicated probe definitions
     logProbes =
         Arrays.asList(
             LogProbe.builder().probeId(PROBE_ID).where("java.lang.String", "concat").build());
     configurationUpdater.accept(createApp(logProbes));
     appliedDefinitions = configurationUpdater.getAppliedDefinitions();
-    assertEquals(2, appliedDefinitions.size());
+    assertEquals(1, appliedDefinitions.size());
     assertTrue(appliedDefinitions.containsKey(PROBE_ID.getId()));
-    assertEquals(0, appliedDefinitions.get(PROBE_ID.getId()).getAdditionalProbes().size());
-    verify(probeStatusSink, times(2)).addReceived(eq(PROBE_ID)); // re-installed for PROBE_ID2
+    verify(probeStatusSink).addReceived(eq(PROBE_ID));
     verify(probeStatusSink).addReceived(eq(PROBE_ID2));
+    verify(probeStatusSink).removeDiagnostics(eq(PROBE_ID2));
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerProductChangesListenerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerProductChangesListenerTest.java
@@ -3,7 +3,6 @@ package com.datadog.debugger.agent;
 import static com.datadog.debugger.util.LogProbeTestHelper.parseTemplate;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.lenient;
 
 import com.datadog.debugger.probe.LogProbe;
@@ -214,11 +213,9 @@ public class DebuggerProductChangesListenerTest {
     acceptLogProbe(listener, logProbe);
     listener.commit(pollingHinter);
     LogProbe receivedProbe = acceptor.getConfiguration().getLogProbes().iterator().next();
-    receivedProbe.addAdditionalProbe(createLogProbe(UUID.randomUUID().toString()));
     listener.commit(pollingHinter);
     LogProbe receivedProbe2 = acceptor.getConfiguration().getLogProbes().iterator().next();
     assertNotSame(receivedProbe, receivedProbe2);
-    assertTrue(receivedProbe2.getAdditionalProbes().isEmpty());
   }
 
   byte[] toContent(Configuration configuration) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/TransformerDefinitionMatcherTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/TransformerDefinitionMatcherTest.java
@@ -32,7 +32,7 @@ public class TransformerDefinitionMatcherTest {
         createMatcher(emptyList(), Arrays.asList(probe), emptyList());
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
     assertEquals(1, probeDefinitions.size());
-    assertEquals(PROBE_ID1.getId(), probeDefinitions.get(0).getId());
+    assertEquals(PROBE_ID1, probeDefinitions.get(0).getProbeId());
   }
 
   @Test
@@ -42,7 +42,7 @@ public class TransformerDefinitionMatcherTest {
         createMatcher(emptyList(), Arrays.asList(probe), emptyList());
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
     assertEquals(1, probeDefinitions.size());
-    assertEquals(PROBE_ID1.getId(), probeDefinitions.get(0).getId());
+    assertEquals(PROBE_ID1, probeDefinitions.get(0).getProbeId());
   }
 
   @Test
@@ -57,7 +57,7 @@ public class TransformerDefinitionMatcherTest {
             String.class.getTypeName(),
             getClassFileBytes(String.class));
     assertEquals(1, probeDefinitions.size());
-    assertEquals(PROBE_ID1.getId(), probeDefinitions.get(0).getId());
+    assertEquals(PROBE_ID1, probeDefinitions.get(0).getProbeId());
   }
 
   @Test
@@ -67,7 +67,7 @@ public class TransformerDefinitionMatcherTest {
         createMatcher(emptyList(), Arrays.asList(probe), emptyList());
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
     assertEquals(1, probeDefinitions.size());
-    assertEquals(PROBE_ID1.getId(), probeDefinitions.get(0).getId());
+    assertEquals(PROBE_ID1, probeDefinitions.get(0).getProbeId());
   }
 
   @Test
@@ -78,7 +78,7 @@ public class TransformerDefinitionMatcherTest {
         createMatcher(emptyList(), Arrays.asList(probe), emptyList());
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
     assertEquals(1, probeDefinitions.size());
-    assertEquals(PROBE_ID1.getId(), probeDefinitions.get(0).getId());
+    assertEquals(PROBE_ID1, probeDefinitions.get(0).getProbeId());
   }
 
   @Test
@@ -88,7 +88,7 @@ public class TransformerDefinitionMatcherTest {
         createMatcher(emptyList(), Arrays.asList(probe), emptyList());
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
     assertEquals(1, probeDefinitions.size());
-    assertEquals(PROBE_ID1.getId(), probeDefinitions.get(0).getId());
+    assertEquals(PROBE_ID1, probeDefinitions.get(0).getProbeId());
   }
 
   @Test
@@ -99,8 +99,8 @@ public class TransformerDefinitionMatcherTest {
         createMatcher(emptyList(), Arrays.asList(probe1, probe2), emptyList());
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
     assertEquals(2, probeDefinitions.size());
-    assertEquals(PROBE_ID1.getId(), probeDefinitions.get(0).getId());
-    assertEquals(PROBE_ID2.getId(), probeDefinitions.get(1).getId());
+    assertEquals(PROBE_ID1, probeDefinitions.get(0).getProbeId());
+    assertEquals(PROBE_ID2, probeDefinitions.get(1).getProbeId());
   }
 
   @Test
@@ -111,8 +111,8 @@ public class TransformerDefinitionMatcherTest {
         createMatcher(emptyList(), Arrays.asList(probe1, probe2), emptyList());
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
     assertEquals(2, probeDefinitions.size());
-    assertEquals(PROBE_ID1.getId(), probeDefinitions.get(0).getId());
-    assertEquals(PROBE_ID2.getId(), probeDefinitions.get(1).getId());
+    assertEquals(PROBE_ID1, probeDefinitions.get(0).getProbeId());
+    assertEquals(PROBE_ID2, probeDefinitions.get(1).getProbeId());
   }
 
   @Test
@@ -123,8 +123,8 @@ public class TransformerDefinitionMatcherTest {
         createMatcher(emptyList(), Arrays.asList(probe1, probe2), emptyList());
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
     assertEquals(2, probeDefinitions.size());
-    assertEquals(PROBE_ID1.getId(), probeDefinitions.get(0).getId());
-    assertEquals(PROBE_ID2.getId(), probeDefinitions.get(1).getId());
+    assertEquals(PROBE_ID1, probeDefinitions.get(0).getProbeId());
+    assertEquals(PROBE_ID2, probeDefinitions.get(1).getProbeId());
   }
 
   @Test
@@ -135,8 +135,8 @@ public class TransformerDefinitionMatcherTest {
         createMatcher(emptyList(), Arrays.asList(probe1, probe2), emptyList());
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
     assertEquals(2, probeDefinitions.size());
-    assertEquals(PROBE_ID1.getId(), probeDefinitions.get(0).getId());
-    assertEquals(PROBE_ID2.getId(), probeDefinitions.get(1).getId());
+    assertEquals(PROBE_ID1, probeDefinitions.get(0).getProbeId());
+    assertEquals(PROBE_ID2, probeDefinitions.get(1).getProbeId());
   }
 
   @Test
@@ -147,8 +147,8 @@ public class TransformerDefinitionMatcherTest {
         createMatcher(Arrays.asList(probe2), Arrays.asList(probe1), emptyList());
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
     assertEquals(2, probeDefinitions.size());
-    assertEquals(PROBE_ID1.getId(), probeDefinitions.get(0).getId());
-    assertEquals(PROBE_ID2.getId(), probeDefinitions.get(1).getId());
+    assertEquals(PROBE_ID1, probeDefinitions.get(0).getProbeId());
+    assertEquals(PROBE_ID2, probeDefinitions.get(1).getProbeId());
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do
Probes are merged by location before applying instrumentation and only the first LogProbe for this location is instrumented passing the duplicated probe ids that will be generated in the instrumented code

# Motivation
Remove the infamous additional probes concept

# Additional Notes
