### PR TITLE
Docker base image on release Fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -217,7 +217,7 @@ tracer-base-image-release:
   rules:
     - if: '$POPULATE_CACHE'
       when: never
-    - if: '$CI_COMMIT_BRANCH == "master" && $CI_COMMIT_TAG =~ /^v1\..*/'
+    - if: '$CI_COMMIT_TAG =~ /^v1\..*/'
       when: on_success
   dependencies:
   - build


### PR DESCRIPTION
# What Does This Do
Currently we are generating latest_snapshot docker image when we push to master branch 
But we are not generating latest (release) when we generate new version/tag. 
This PR fix that problem.

# Motivation

# Additional Notes
