### PR TITLE
Fix matching source filename with different paths

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/TransformerDefinitionMatcher.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/TransformerDefinitionMatcher.java
@@ -25,10 +25,7 @@ public class TransformerDefinitionMatcher {
 
   public TransformerDefinitionMatcher(Configuration configuration) {
     this.definitionsByClass = buildDefinitionsMap(configuration.getDefinitions());
-    populateDefinitionFileNamesMap(
-        configuration.getDefinitions(),
-        definitionsBySimpleFileNames,
-        definitionsByQualifiedFileNames);
+    populateDefinitionFileNamesMap(configuration.getDefinitions());
     this.definitionFileNames = buildDefinitionFileNamesTrie(definitionsByQualifiedFileNames);
   }
 
@@ -56,22 +53,17 @@ public class TransformerDefinitionMatcher {
     return map;
   }
 
-  private void populateDefinitionFileNamesMap(
-      Collection<ProbeDefinition> definitions,
-      Map<String, List<ProbeDefinition>> definitionsBySimpleFileNames,
-      Map<String, List<ProbeDefinition>> definitionsByQualifiedFileNames) {
+  private void populateDefinitionFileNamesMap(Collection<ProbeDefinition> definitions) {
     for (ProbeDefinition definition : definitions) {
       String fileName = definition.getWhere().getSourceFile();
       if (fileName == null) {
         continue;
       }
-      Map<String, List<ProbeDefinition>> resultMap =
+      Map<String, List<ProbeDefinition>> targetMap =
           fileName.indexOf('/') != -1
               ? definitionsByQualifiedFileNames
               : definitionsBySimpleFileNames;
-      List<ProbeDefinition> definitionByFileName =
-          resultMap.computeIfAbsent("/" + fileName, key -> new ArrayList<>());
-      definitionByFileName.add(definition);
+      targetMap.computeIfAbsent("/" + fileName, key -> new ArrayList<>()).add(definition);
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/TransformerDefinitionMatcher.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/TransformerDefinitionMatcher.java
@@ -18,15 +18,18 @@ public class TransformerDefinitionMatcher {
   private static final Logger LOG = LoggerFactory.getLogger(TransformerDefinitionMatcher.class);
 
   private final Map<String, List<ProbeDefinition>> definitionsByClass;
-  private final Map<String, List<ProbeDefinition>> definitionsByFileNames;
+  private final Map<String, List<ProbeDefinition>> definitionsBySimpleFileNames = new HashMap<>();
+  private final Map<String, List<ProbeDefinition>> definitionsByQualifiedFileNames =
+      new HashMap<>();
   private final Trie definitionFileNames;
-  private final Trie definitionsDirectories;
 
   public TransformerDefinitionMatcher(Configuration configuration) {
     this.definitionsByClass = buildDefinitionsMap(configuration.getDefinitions());
-    this.definitionsByFileNames = buildDefinitionFileNamesMap(configuration.getDefinitions());
-    this.definitionFileNames = buildDefinitionFileNamesTrie(definitionsByFileNames);
-    this.definitionsDirectories = buildDefinitionsDirTrie(configuration.getDefinitions());
+    populateDefinitionFileNamesMap(
+        configuration.getDefinitions(),
+        definitionsBySimpleFileNames,
+        definitionsByQualifiedFileNames);
+    this.definitionFileNames = buildDefinitionFileNamesTrie(definitionsByQualifiedFileNames);
   }
 
   private Map<String, List<ProbeDefinition>> buildDefinitionsMap(
@@ -53,19 +56,23 @@ public class TransformerDefinitionMatcher {
     return map;
   }
 
-  private Map<String, List<ProbeDefinition>> buildDefinitionFileNamesMap(
-      Collection<ProbeDefinition> definitions) {
-    Map<String, List<ProbeDefinition>> resultMap = new HashMap<>();
+  private void populateDefinitionFileNamesMap(
+      Collection<ProbeDefinition> definitions,
+      Map<String, List<ProbeDefinition>> definitionsBySimpleFileNames,
+      Map<String, List<ProbeDefinition>> definitionsByQualifiedFileNames) {
     for (ProbeDefinition definition : definitions) {
       String fileName = definition.getWhere().getSourceFile();
       if (fileName == null) {
         continue;
       }
+      Map<String, List<ProbeDefinition>> resultMap =
+          fileName.indexOf('/') != -1
+              ? definitionsByQualifiedFileNames
+              : definitionsBySimpleFileNames;
       List<ProbeDefinition> definitionByFileName =
           resultMap.computeIfAbsent("/" + fileName, key -> new ArrayList<>());
       definitionByFileName.add(definition);
     }
-    return resultMap;
   }
 
   private Trie buildDefinitionFileNamesTrie(
@@ -77,20 +84,6 @@ public class TransformerDefinitionMatcher {
       resultTrie.insert(reverseStr(sourceFile));
     }
     return resultTrie;
-  }
-
-  private Trie buildDefinitionsDirTrie(Collection<ProbeDefinition> definitions) {
-    Trie trie = new Trie();
-    for (ProbeDefinition definition : definitions) {
-      String fileName = definition.getWhere().getSourceFile();
-      if (fileName == null) {
-        continue;
-      }
-      int idx = fileName.lastIndexOf('/');
-      String dir = idx > -1 ? fileName.substring(0, idx) : fileName;
-      trie.insert(reverseStr(dir));
-    }
-    return trie;
   }
 
   public boolean isEmpty() {
@@ -149,17 +142,24 @@ public class TransformerDefinitionMatcher {
       sb.append(reversedPackageName);
     }
     String reversedFileName = sb.toString();
-    String fullFileName = reverseStr(definitionFileNames.getStringStartingWith(reversedFileName));
-    if (fullFileName == null) {
-      fullFileName = reverseStr(definitionFileNames.getStringStartingWith(reversedSourceFileName));
+    List<ProbeDefinition> bySourceFileDefinitions = new ArrayList<>();
+    // try match qualified filenames
+    Collection<String> matchingFileNames =
+        definitionFileNames.getStringsStartingWith(reversedFileName);
+    if (!matchingFileNames.isEmpty()) {
+      for (String matchingFileName : matchingFileNames) {
+        List<ProbeDefinition> definitions =
+            definitionsByQualifiedFileNames.get(reverseStr(matchingFileName));
+        if (definitions != null) {
+          bySourceFileDefinitions.addAll(definitions);
+        }
+      }
     }
-    if (fullFileName == null) {
-      return Collections.emptyList();
+    // try match simple filenames
+    List<ProbeDefinition> definitions = definitionsBySimpleFileNames.get("/" + sourceFileName);
+    if (definitions != null) {
+      bySourceFileDefinitions.addAll(definitions);
     }
-    List<ProbeDefinition> bySourceFileDefinitions = definitionsByFileNames.get(fullFileName);
-    if (bySourceFileDefinitions != null) {
-      return bySourceFileDefinitions;
-    }
-    return Collections.emptyList();
+    return bySourceFileDefinitions;
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/Trie.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/Trie.java
@@ -1,7 +1,10 @@
 package com.datadog.debugger.agent;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 // TODO This naive implementation should be improved
@@ -83,6 +86,29 @@ public class Trie {
       node = node.children.values().iterator().next();
     }
     return node.str;
+  }
+
+  /**
+   * @param prefix prefix to search into the trie
+   * @return all the strings that matches the given prefix
+   */
+  public Collection<String> getStringsStartingWith(String prefix) {
+    TrieNode node = searchNode(prefix, false);
+    if (node == null) {
+      return Collections.emptyList();
+    }
+    List<String> result = new ArrayList<>();
+    traverse(node, result);
+    return result;
+  }
+
+  private void traverse(TrieNode currentNode, List<String> result) {
+    if (currentNode.str != null) {
+      result.add(currentNode.str);
+    }
+    for (TrieNode nextNode : currentNode.children.values()) {
+      traverse(nextNode, result);
+    }
   }
 
   /**

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/Trie.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/Trie.java
@@ -90,7 +90,7 @@ public class Trie {
 
   /**
    * @param prefix prefix to search into the trie
-   * @return all the strings that matches the given prefix
+   * @return all the strings that match the given prefix
    */
   public Collection<String> getStringsStartingWith(String prefix) {
     TrieNode node = searchNode(prefix, false);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/TransformerDefinitionMatcherTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/TransformerDefinitionMatcherTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 public class TransformerDefinitionMatcherTest {
   private static final ProbeId PROBE_ID1 = new ProbeId("beae1807-f3b0-4ea8-a74f-826790c5e6f6", 0);
   private static final ProbeId PROBE_ID2 = new ProbeId("beae1807-f3b0-4ea8-a74f-826790c5e6f7", 0);
+  private static final ProbeId PROBE_ID3 = new ProbeId("beae1807-f3b0-4ea8-a74f-826790c5e6f8", 0);
   private static final String SERVICE_NAME = "service-name";
 
   @Test
@@ -158,6 +159,20 @@ public class TransformerDefinitionMatcherTest {
         createMatcher(emptyList(), Arrays.asList(probe1), emptyList());
     List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
     assertEquals(0, probeDefinitions.size());
+  }
+
+  @Test
+  public void mixedSourceFileName() {
+    LogProbe probe1 = createProbe(PROBE_ID1, "src/main/java/java/lang/String.java", 23);
+    LogProbe probe2 = createProbe(PROBE_ID2, "myproject/src/main/java/java/lang/String.java", 42);
+    LogProbe probe3 = createProbe(PROBE_ID3, "String.java", 11);
+    TransformerDefinitionMatcher matcher =
+        createMatcher(emptyList(), Arrays.asList(probe1, probe2, probe3), emptyList());
+    List<ProbeDefinition> probeDefinitions = match(matcher, String.class);
+    assertEquals(3, probeDefinitions.size());
+    assertEquals(PROBE_ID1.getId(), probeDefinitions.get(0).getId());
+    assertEquals(PROBE_ID2.getId(), probeDefinitions.get(1).getId());
+    assertEquals(PROBE_ID3.getId(), probeDefinitions.get(2).getId());
   }
 
   private TransformerDefinitionMatcher createMatcher(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/TrieTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/TrieTest.java
@@ -2,6 +2,7 @@ package com.datadog.debugger.agent;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Collection;
 import org.junit.jupiter.api.Test;
 
 public class TrieTest {
@@ -46,6 +47,19 @@ public class TrieTest {
     trie.insert("abcde");
     trie.insert("abcfe");
     assertNull(trie.getStringStartingWith("abc"));
+  }
+
+  @Test
+  public void getStringsStartingWith() {
+    Trie trie = new Trie();
+    trie.insert("java.Main");
+    trie.insert("java.Main/debugger/datadog/com/java/main/src");
+    trie.insert("java.Main/debugger/datadog/com/java/main/src/myproject");
+    trie.insert("java.Configuration/config/debugger/datadog/com/java/main/src");
+    Collection<String> strings = trie.getStringsStartingWith("java.Main/debugger/datadog/com");
+    assertEquals(2, strings.size());
+    assertTrue(strings.contains("java.Main/debugger/datadog/com/java/main/src"));
+    assertTrue(strings.contains("java.Main/debugger/datadog/com/java/main/src/myproject"));
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do
Separate matching for qualified filenames and simple filenames collect all definitions matching the prefix and not just one as path could be different outside the prefix

# Motivation
issue with multiple probe having different path for the same source code ex: `VetController.java` & `org/springframework/samples/petclinic/vet/VetController.java`

# Additional Notes
