### PR TITLE
Enable ddprof allocation profiling for JDK 11+ by default

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
@@ -38,6 +38,7 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILE
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED_DEFAULT;
 
+import datadog.trace.api.Platform;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import java.lang.management.ManagementFactory;
 import java.util.Collections;
@@ -131,7 +132,8 @@ public class DatadogProfilerConfig {
     return getBoolean(
         configProvider,
         PROFILING_DATADOG_PROFILER_ALLOC_ENABLED,
-        PROFILING_DATADOG_PROFILER_ALLOC_ENABLED_DEFAULT);
+        PROFILING_DATADOG_PROFILER_ALLOC_ENABLED_DEFAULT
+            || (Platform.isJavaVersionAtLeast(11) && !Platform.isJ9()));
   }
 
   public static boolean isAllocationProfilingEnabled() {

--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/JFRBasedProfilingIntegrationTest.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/JFRBasedProfilingIntegrationTest.java
@@ -576,6 +576,9 @@ class JFRBasedProfilingIntegrationTest {
     }
     if (asyncProfilerEnabled) {
       verifyDatadogEventsNotCorrupt(events);
+      assertEquals(
+          Platform.isJavaVersionAtLeast(11),
+          events.apply(ItemFilters.type("datadog.ObjectSample")).hasItems());
     }
 
     // check exception events


### PR DESCRIPTION
# What Does This Do
This modifies the default value of the ddprof based allocation profiling enablement.
The allocation profiling in the DD java profiler lib is now ready to be used as default when possible. This means that when `ddprof` is enabled (either manually or automatically) and we are running on JDK 11+ the ddprof allocation profiling will be activated.

It is still possible to manually disable by config as well as enable for systems where we don't enable it automatically if users are feeling adventurous.

# Motivation
Make the ddprof allocation profiling automatically available where possible.

# Additional Notes
