### PR TITLE
graphql: Set resource name to operation name (or query when anonymous) to make…

### DIFF
--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/main/java/datadog/trace/instrumentation/graphqljava/GraphQLInstrumentation.java
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/main/java/datadog/trace/instrumentation/graphqljava/GraphQLInstrumentation.java
@@ -99,7 +99,8 @@ public final class GraphQLInstrumentation extends SimpleInstrumentation {
     String operationName = operationDefinition.getName();
 
     requestSpan.setTag("graphql.operation.name", operationName);
-
+    String resourceName = operationName != null ? operationName : state.getQuery();
+    requestSpan.setResourceName(resourceName);
     return SimpleInstrumentationContext.noOp();
   }
 

--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLTest.groovy
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLTest.groovy
@@ -100,7 +100,7 @@ abstract class GraphQLTest extends VersionedNamingTestBase {
       trace(7) {
         span {
           operationName operation()
-          resourceName operation()
+          resourceName "findBookById"
           spanType DDSpanTypes.GRAPHQL
           errored false
           measured true
@@ -334,7 +334,7 @@ abstract class GraphQLTest extends VersionedNamingTestBase {
       trace(6) {
         span {
           operationName operation()
-          resourceName operation()
+          resourceName "findBookById"
           spanType DDSpanTypes.GRAPHQL
           errored true
           measured true


### PR DESCRIPTION
… Datadog resource view extremely useful for GraphQL requests

# What Does This Do
Resolves: https://github.com/DataDog/dd-trace-java/issues/4210
https://help.datadoghq.com/hc/en-us/requests/1003318

# Motivation
Having much richer and useful Datadog Resource View for graphql requests.  Performance characteristics vary widely across operations, but are much more likely to similar and SLOs will likely be aligned based on the operation being executed.

https://www.apollographql.com/docs/react/data/operation-best-practices/#name-all-operations

Platforms like Apollo Studio leverage operation names to group and measure performance using operation-level metrics.

# Additional Notes
