### PR TITLE
Change graphql query text to be tagged with graphql.source

### DIFF
--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/main/java/datadog/trace/instrumentation/graphqljava/ExecutionInstrumentationContext.java
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/main/java/datadog/trace/instrumentation/graphqljava/ExecutionInstrumentationContext.java
@@ -32,7 +32,7 @@ public class ExecutionInstrumentationContext extends SimpleInstrumentationContex
         requestSpan.setError(true);
       }
     }
-    requestSpan.setTag("graphql.query", state.getQuery());
+    requestSpan.setTag("graphql.source", state.getQuery());
     DECORATE.beforeFinish(requestSpan);
     requestSpan.finish();
   }

--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLTest.groovy
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLTest.groovy
@@ -1,5 +1,3 @@
-import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring
-
 import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.Trace
@@ -15,6 +13,8 @@ import graphql.schema.idl.SchemaParser
 import spock.lang.Shared
 
 import java.nio.charset.StandardCharsets
+
+import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring
 
 abstract class GraphQLTest extends VersionedNamingTestBase {
   @Shared
@@ -107,7 +107,7 @@ abstract class GraphQLTest extends VersionedNamingTestBase {
           parent()
           tags {
             "$Tags.COMPONENT" "graphql-java"
-            "graphql.query" expectedQuery
+            "graphql.source" expectedQuery
             "graphql.operation.name" "findBookById"
             defaultTags()
           }
@@ -227,7 +227,7 @@ abstract class GraphQLTest extends VersionedNamingTestBase {
           parent()
           tags {
             "$Tags.COMPONENT" "graphql-java"
-            "graphql.query" expectedQuery
+            "graphql.source" expectedQuery
             "graphql.operation.name" null
             "error.message" { it.contains("Field 'title' in type 'Book' is undefined") }
             "error.message" { it.contains("(and 1 more errors)") }
@@ -286,7 +286,7 @@ abstract class GraphQLTest extends VersionedNamingTestBase {
           parent()
           tags {
             "$Tags.COMPONENT" "graphql-java"
-            "graphql.query" query
+            "graphql.source" query
             "graphql.operation.name" null
             "error.message" { it.toLowerCase().startsWith("invalid syntax") }
             defaultTags()
@@ -341,7 +341,7 @@ abstract class GraphQLTest extends VersionedNamingTestBase {
           parent()
           tags {
             "$Tags.COMPONENT" "graphql-java"
-            "graphql.query" expectedQuery
+            "graphql.source" expectedQuery
             "graphql.operation.name" "findBookById"
             "error.message" "Exception while fetching data (/bookById/cover) : TEST"
             defaultTags()


### PR DESCRIPTION
# What Does This Do

Fixes: https://github.com/DataDog/dd-trace-java/issues/4961

# Motivation

- Align with dd-trace-js behavior for instrumenting graphql operation query [link](https://github.com/DataDog/dd-trace-js/blob/08b0c7fc6254a185afd2f2ad63743254f1f969c9/packages/datadog-plugin-graphql/src/parse.js#L23) 
- Provide richer display in traces within Datadog UI

# Additional Notes

Before:
<img width="881" alt="Screenshot 2023-03-25 at 12 02 22 PM" src="https://user-images.githubusercontent.com/467023/227732640-cc7132e6-e7b3-4d12-9299-858bf7e4dd44.png">


After:
<img width="887" alt="Screenshot 2023-03-25 at 12 01 09 PM" src="https://user-images.githubusercontent.com/467023/227732669-95f7e956-b177-4c64-bdea-019275d44ffe.png">


