### PR TITLE
Exclude all classes under 'io.opentelemetry.javaagent' from being traced

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
+++ b/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
@@ -39,6 +39,7 @@
 1 datadog.trace.core.*
 1 io.micrometer.*
 1 io.micronaut.tracing.*
+1 io.opentelemetry.javaagent.*
 1 java.*
 # allow exception profiling instrumentation
 0 java.lang.Throwable


### PR DESCRIPTION
This avoids a ClassCircularityError involving 'io.opentelemetry.javaagent.bootstrap.AgentClassLoader' caused by the Tracer attempting to load the type directly (because it cannot access the class resource)

Since the OTel javaagent contains mostly instrumentation/advice types as well as a shaded copy of OTel classes under a different package (`io.opentelemetry.javaagent.shaded.io.opentelemetry...`) excluding this package should not affect traces of interest.
