### PR TITLE
Fix test-case spans to always be root spans

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/civisibility/TestEventsHandler.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/civisibility/TestEventsHandler.java
@@ -189,7 +189,7 @@ public class TestEventsHandler {
       return;
     }
 
-    final AgentSpan span = startSpan(testDecorator.component() + ".test");
+    final AgentSpan span = startSpan(testDecorator.component() + ".test", null);
     final AgentScope scope = activateSpan(span);
     scope.setAsyncPropagation(true);
 
@@ -248,7 +248,7 @@ public class TestEventsHandler {
       return;
     }
 
-    final AgentSpan span = startSpan("junit.test");
+    final AgentSpan span = startSpan("junit.test", null);
     final AgentScope scope = activateSpan(span);
 
     testDecorator.afterTestStart(

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
@@ -1,3 +1,4 @@
+import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.agent.test.base.TestFrameworkTest
 import datadog.trace.api.DisableTestTrace
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -31,13 +32,17 @@ class JUnit4Test extends TestFrameworkTest {
     runner.run(TestSucceed)
 
     expect:
-    assertTraces(1) {
-      trace(3, true) {
-        long testModuleId = testModuleSpan(it, 1, TestEventsHandler.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSucceed", TestEventsHandler.TEST_PASS)
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSucceed", TestEventsHandler.TEST_PASS)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
       }
-    }
+    })
   }
 
   def "test inheritance generates spans"() {
@@ -45,13 +50,17 @@ class JUnit4Test extends TestFrameworkTest {
     runner.run(TestInheritance)
 
     expect:
-    assertTraces(1) {
-      trace(3, true) {
-        long testModuleId = testModuleSpan(it, 1, TestEventsHandler.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestInheritance", TestEventsHandler.TEST_PASS)
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestInheritance", TestEventsHandler.TEST_PASS)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestInheritance", "test_succeed", TestEventsHandler.TEST_PASS)
       }
-    }
+    })
   }
 
   def "test failed generates spans"() {
@@ -63,13 +72,17 @@ class JUnit4Test extends TestFrameworkTest {
     }
 
     expect:
-    assertTraces(1) {
-      trace(3, true) {
-        long testModuleId = testModuleSpan(it, 1, TestEventsHandler.TEST_FAIL)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestFailed", TestEventsHandler.TEST_FAIL)
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_FAIL)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestFailed", TestEventsHandler.TEST_FAIL)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailed", "test_failed", TestEventsHandler.TEST_FAIL, null, exception)
       }
-    }
+    })
 
     where:
     exception = new AssertionError()
@@ -84,13 +97,17 @@ class JUnit4Test extends TestFrameworkTest {
     }
 
     expect:
-    assertTraces(1) {
-      trace(3, true) {
-        long testModuleId = testModuleSpan(it, 1, TestEventsHandler.TEST_FAIL)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestError", TestEventsHandler.TEST_FAIL)
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_FAIL)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestError", TestEventsHandler.TEST_FAIL)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestError", "test_error", TestEventsHandler.TEST_FAIL, null, exception)
       }
-    }
+    })
 
     where:
     exception = new IllegalArgumentException("This exception is an example")
@@ -101,13 +118,17 @@ class JUnit4Test extends TestFrameworkTest {
     runner.run(TestSkipped)
 
     expect:
-    assertTraces(1) {
-      trace(3, true) {
-        long testModuleId = testModuleSpan(it, 1, TestEventsHandler.TEST_SKIP)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSkipped", TestEventsHandler.TEST_SKIP)
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_SKIP)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSkipped", TestEventsHandler.TEST_SKIP)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSkipped", "test_skipped", TestEventsHandler.TEST_SKIP, testTags, null, true)
       }
-    }
+    })
 
     where:
     testTags = [(Tags.TEST_SKIP_REASON): "Ignore reason in test"]
@@ -118,14 +139,20 @@ class JUnit4Test extends TestFrameworkTest {
     runner.run(TestSkippedClass)
 
     expect:
-    assertTraces(1) {
-      trace(4, true) {
-        long testModuleId = testModuleSpan(it, 2, TestEventsHandler.TEST_SKIP)
-        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestSkippedClass", TestEventsHandler.TEST_SKIP, testTags, null)
-        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestSkippedClass", "test_class_skipped", TestEventsHandler.TEST_SKIP, testTags, null, true)
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_SKIP)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSkippedClass", TestEventsHandler.TEST_SKIP, testTags, null)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSkippedClass", "test_class_another_skipped", TestEventsHandler.TEST_SKIP, testTags, null, true)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSkippedClass", "test_class_skipped", TestEventsHandler.TEST_SKIP, testTags, null, true)
+      }
+    })
 
     where:
     testTags = [(Tags.TEST_SKIP_REASON): "Ignore reason in class"]
@@ -136,14 +163,20 @@ class JUnit4Test extends TestFrameworkTest {
     runner.run(TestSucceedAndSkipped)
 
     expect:
-    assertTraces(1) {
-      trace(4, true) {
-        long testModuleId = testModuleSpan(it, 2, TestEventsHandler.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestSucceedAndSkipped", TestEventsHandler.TEST_PASS)
-        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceedAndSkipped", "test_skipped", TestEventsHandler.TEST_SKIP, testTags, null, true)
-        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestSucceedAndSkipped", "test_succeed", TestEventsHandler.TEST_PASS)
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSucceedAndSkipped", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceedAndSkipped", "test_skipped", TestEventsHandler.TEST_SKIP, testTags, null, true)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceedAndSkipped", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+    })
 
     where:
     testTags = [(Tags.TEST_SKIP_REASON): "Ignore reason in test"]
@@ -154,15 +187,23 @@ class JUnit4Test extends TestFrameworkTest {
     runner.run(TestFailedAndSucceed)
 
     expect:
-    assertTraces(1) {
-      trace(5, true) {
-        long testModuleId = testModuleSpan(it, 3, TestEventsHandler.TEST_FAIL)
-        long testSuiteId = testSuiteSpan(it, 4, testModuleId, testModuleId, "org.example.TestFailedAndSucceed", TestEventsHandler.TEST_FAIL)
-        testSpan(it, 2, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
-        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_failed", TestEventsHandler.TEST_FAIL, null, exception)
+    ListWriterAssert.assertTraces(TEST_WRITER, 4, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_FAIL)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestFailedAndSucceed", TestEventsHandler.TEST_FAIL)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_another_succeed", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_failed", TestEventsHandler.TEST_FAIL, null, exception)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+    })
 
     where:
     exception = new AssertionError()
@@ -173,14 +214,20 @@ class JUnit4Test extends TestFrameworkTest {
     runner.run(TestFailedSuiteTearDown)
 
     expect:
-    assertTraces(1) {
-      trace(4, true) {
-        long testModuleId = testModuleSpan(it, 2, TestEventsHandler.TEST_FAIL)
-        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestFailedSuiteTearDown", TestEventsHandler.TEST_FAIL, null, exception)
-        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestFailedSuiteTearDown", "test_succeed", TestEventsHandler.TEST_PASS)
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_FAIL)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestFailedSuiteTearDown", TestEventsHandler.TEST_FAIL, null, exception)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedSuiteTearDown", "test_another_succeed", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedSuiteTearDown", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+    })
 
     where:
     exception = new RuntimeException("suite tear down failed")
@@ -191,12 +238,12 @@ class JUnit4Test extends TestFrameworkTest {
     runner.run(TestFailedSuiteSetup)
 
     expect:
-    assertTraces(1) {
+    ListWriterAssert.assertTraces(TEST_WRITER, 1, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
       trace(2, true) {
         long testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_FAIL)
         testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestFailedSuiteSetup", TestEventsHandler.TEST_FAIL, null, exception)
       }
-    }
+    })
 
     where:
     exception = new RuntimeException("suite set up failed")
@@ -207,13 +254,17 @@ class JUnit4Test extends TestFrameworkTest {
     runner.run(TestAssumption)
 
     expect:
-    assertTraces(1) {
-      trace(3, true) {
-        long testModuleId = testModuleSpan(it, 1, TestEventsHandler.TEST_SKIP)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestAssumption", TestEventsHandler.TEST_SKIP)
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_SKIP)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestAssumption", TestEventsHandler.TEST_SKIP)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestAssumption", "test_fail_assumption", TestEventsHandler.TEST_SKIP, testTags)
       }
-    }
+    })
 
     where:
     testTags = [(Tags.TEST_SKIP_REASON): "got: <false>, expected: is <true>"]
@@ -224,17 +275,21 @@ class JUnit4Test extends TestFrameworkTest {
     runner.run(TestSucceedWithCategories)
 
     expect:
-    assertTraces(1) {
-      trace(3, true) {
-        long testModuleId = testModuleSpan(it, 1, TestEventsHandler.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSucceedWithCategories",
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSucceedWithCategories",
           TestEventsHandler.TEST_PASS, null, null, false,
           ["org.example.Slow", "org.example.Flaky"])
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceedWithCategories", "test_succeed",
           TestEventsHandler.TEST_PASS, null, null, false,
           ["org.example.Slow", "org.example.Flaky", "org.example.End2End", "org.example.Browser"])
       }
-    }
+    })
   }
 
   def "test assumption failure during suite setup"() {
@@ -242,13 +297,17 @@ class JUnit4Test extends TestFrameworkTest {
     runner.run(TestSuiteSetUpAssumption)
 
     expect:
-    assertTraces(1) {
-      trace(3, true) {
-        long testModuleId = testModuleSpan(it, 1, TestEventsHandler.TEST_SKIP)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSuiteSetUpAssumption", TestEventsHandler.TEST_SKIP)
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_SKIP)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSuiteSetUpAssumption", TestEventsHandler.TEST_SKIP)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSuiteSetUpAssumption", "test_succeed", TestEventsHandler.TEST_SKIP, null, null, true)
       }
-    }
+    })
   }
 
   def "test assumption failure in a multi-test-case suite"() {
@@ -256,14 +315,20 @@ class JUnit4Test extends TestFrameworkTest {
     runner.run(TestAssumptionAndSucceed)
 
     expect:
-    assertTraces(1) {
-      trace(4, true) {
-        long testModuleId = testModuleSpan(it, 2, TestEventsHandler.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestAssumptionAndSucceed", TestEventsHandler.TEST_PASS)
-        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestAssumptionAndSucceed", "test_fail_assumption", TestEventsHandler.TEST_SKIP, testTags)
-        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestAssumptionAndSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestAssumptionAndSucceed", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestAssumptionAndSucceed", "test_fail_assumption", TestEventsHandler.TEST_SKIP, testTags)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestAssumptionAndSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+    })
 
     where:
     testTags = [(Tags.TEST_SKIP_REASON): "got: <false>, expected: is <true>"]
@@ -274,18 +339,25 @@ class JUnit4Test extends TestFrameworkTest {
     runner.run(TestSucceed, TestSucceedAndSkipped)
 
     expect:
-    assertTraces(1) {
-      trace(6, true) {
-        long testModuleId = testModuleSpan(it, 3, TestEventsHandler.TEST_PASS)
-
-        long firstSuiteId = testSuiteSpan(it, 4, testModuleId, testModuleId, "org.example.TestSucceed", TestEventsHandler.TEST_PASS)
-        testSpan(it, 0, testModuleId, firstSuiteId, "org.example.TestSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
-
-        long secondSuiteId = testSuiteSpan(it, 5, testModuleId, testModuleId, "org.example.TestSucceedAndSkipped", TestEventsHandler.TEST_PASS)
-        testSpan(it, 1, testModuleId, secondSuiteId, "org.example.TestSucceedAndSkipped", "test_skipped", TestEventsHandler.TEST_SKIP, testTags, null, true)
-        testSpan(it, 2, testModuleId, secondSuiteId, "org.example.TestSucceedAndSkipped", "test_succeed", TestEventsHandler.TEST_PASS)
+    ListWriterAssert.assertTraces(TEST_WRITER, 4, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long firstSuiteId
+      long secondSuiteId
+      trace(3, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        firstSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSucceed", TestEventsHandler.TEST_PASS)
+        secondSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSucceedAndSkipped", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, firstSuiteId, "org.example.TestSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, secondSuiteId, "org.example.TestSucceedAndSkipped", "test_skipped", TestEventsHandler.TEST_SKIP, testTags, null, true)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, secondSuiteId, "org.example.TestSucceedAndSkipped", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+    })
 
     where:
     testTags = [(Tags.TEST_SKIP_REASON): "Ignore reason in test"]
@@ -296,19 +368,28 @@ class JUnit4Test extends TestFrameworkTest {
     runner.run(TestSucceed, TestFailedAndSucceed)
 
     expect:
-    assertTraces(1) {
-      trace(7, true) {
-        long testModuleId = testModuleSpan(it, 4, TestEventsHandler.TEST_FAIL)
-
-        long firstSuiteId = testSuiteSpan(it, 6, testModuleId, testModuleId, "org.example.TestSucceed", TestEventsHandler.TEST_PASS)
-        testSpan(it, 3, testModuleId, firstSuiteId, "org.example.TestSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
-
-        long secondSuiteId = testSuiteSpan(it, 5, testModuleId, testModuleId, "org.example.TestFailedAndSucceed", TestEventsHandler.TEST_FAIL)
-        testSpan(it, 2, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
-        testSpan(it, 1, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_failed", TestEventsHandler.TEST_FAIL, null, exception)
+    ListWriterAssert.assertTraces(TEST_WRITER, 5, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long firstSuiteId
+      long secondSuiteId
+      trace(3, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_FAIL)
+        firstSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSucceed", TestEventsHandler.TEST_PASS)
+        secondSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestFailedAndSucceed", TestEventsHandler.TEST_FAIL)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_another_succeed", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_failed", TestEventsHandler.TEST_FAIL, null, exception)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, firstSuiteId, "org.example.TestSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+    })
 
     where:
     exception = new AssertionError()
@@ -318,14 +399,20 @@ class JUnit4Test extends TestFrameworkTest {
     setup:
     runner.run(TestParameterized)
 
-    assertTraces(1) {
-      trace(4, true) {
-        long testModuleId = testModuleSpan(it, 2, TestEventsHandler.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestParameterized", TestEventsHandler.TEST_PASS)
-        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestParameterized", "parameterized_test_succeed", TestEventsHandler.TEST_PASS, testTags_1)
-        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestParameterized", "parameterized_test_succeed", TestEventsHandler.TEST_PASS, testTags_0)
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestParameterized", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestParameterized", "parameterized_test_succeed", TestEventsHandler.TEST_PASS, testTags_0)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestParameterized", "parameterized_test_succeed", TestEventsHandler.TEST_PASS, testTags_1)
+      }
+    })
 
     where:
     testTags_0 = [(Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"parameterized_test_succeed[0]"}}']

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
@@ -1,3 +1,4 @@
+import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.agent.test.base.TestFrameworkTest
 import datadog.trace.api.DisableTestTrace
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -39,13 +40,17 @@ class JUnit5Test extends TestFrameworkTest {
     runTestClasses(TestSucceed)
 
     expect:
-    assertTraces(1) {
-      trace(3, true) {
-        long testModuleId = testModuleSpan(it, 1, TestEventsHandler.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSucceed", TestEventsHandler.TEST_PASS)
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSucceed", TestEventsHandler.TEST_PASS)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
       }
-    }
+    })
   }
 
   def "test inheritance generates spans"() {
@@ -53,13 +58,17 @@ class JUnit5Test extends TestFrameworkTest {
     runTestClasses(TestInheritance)
 
     expect:
-    assertTraces(1) {
-      trace(3, true) {
-        long testModuleId = testModuleSpan(it, 1, TestEventsHandler.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestInheritance", TestEventsHandler.TEST_PASS)
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestInheritance", TestEventsHandler.TEST_PASS)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestInheritance", "test_succeed", TestEventsHandler.TEST_PASS)
       }
-    }
+    })
   }
 
   def "test parameterized generates spans"() {
@@ -67,14 +76,20 @@ class JUnit5Test extends TestFrameworkTest {
     runTestClasses(TestParameterized)
 
     expect:
-    assertTraces(1) {
-      trace(4, true) {
-        long testModuleId = testModuleSpan(it, 2, TestEventsHandler.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestParameterized", TestEventsHandler.TEST_PASS)
-        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestParameterized", "test_parameterized", TestEventsHandler.TEST_PASS, testTags_1)
-        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestParameterized", "test_parameterized", TestEventsHandler.TEST_PASS, testTags_0)
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestParameterized", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestParameterized", "test_parameterized", TestEventsHandler.TEST_PASS, testTags_0)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestParameterized", "test_parameterized", TestEventsHandler.TEST_PASS, testTags_1)
+      }
+    })
 
     where:
     testTags_0 = [(Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"[1] 0, 0, 0, some:\\\"parameter\\\""}}']
@@ -86,14 +101,20 @@ class JUnit5Test extends TestFrameworkTest {
     runTestClasses(TestRepeated)
 
     expect:
-    assertTraces(1) {
-      trace(4, true) {
-        long testModuleId = testModuleSpan(it, 2, TestEventsHandler.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestRepeated", TestEventsHandler.TEST_PASS)
-        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestRepeated", "test_repeated", TestEventsHandler.TEST_PASS)
-        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestRepeated", "test_repeated", TestEventsHandler.TEST_PASS)
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestRepeated", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestRepeated", "test_repeated", TestEventsHandler.TEST_PASS)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestRepeated", "test_repeated", TestEventsHandler.TEST_PASS)
+      }
+    })
   }
 
   def "test template generates spans"() {
@@ -101,14 +122,20 @@ class JUnit5Test extends TestFrameworkTest {
     runTestClasses(TestTemplate)
 
     expect:
-    assertTraces(1) {
-      trace(4, true) {
-        long testModuleId = testModuleSpan(it, 2, TestEventsHandler.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestTemplate", TestEventsHandler.TEST_PASS)
-        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestTemplate", "test_template", TestEventsHandler.TEST_PASS, testTags_1)
-        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestTemplate", "test_template", TestEventsHandler.TEST_PASS, testTags_0)
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestTemplate", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestTemplate", "test_template", TestEventsHandler.TEST_PASS, testTags_0)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestTemplate", "test_template", TestEventsHandler.TEST_PASS, testTags_1)
+      }
+    })
 
     where:
     testTags_0 = [(Tags.TEST_PARAMETERS): "{\"metadata\":{\"test_name\":\"test_template_1\"}}"]
@@ -120,14 +147,20 @@ class JUnit5Test extends TestFrameworkTest {
     runTestClasses(TestFactory)
 
     expect:
-    assertTraces(1) {
-      trace(4, true) {
-        long testModuleId = testModuleSpan(it, 2, TestEventsHandler.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestFactory", TestEventsHandler.TEST_PASS)
-        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFactory", "test_factory", TestEventsHandler.TEST_PASS)
-        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestFactory", "test_factory", TestEventsHandler.TEST_PASS)
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestFactory", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFactory", "test_factory", TestEventsHandler.TEST_PASS)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFactory", "test_factory", TestEventsHandler.TEST_PASS)
+      }
+    })
   }
 
   def "test failed generates spans"() {
@@ -135,13 +168,17 @@ class JUnit5Test extends TestFrameworkTest {
     runTestClassesSuppressingExceptions(TestFailed)
 
     expect:
-    assertTraces(1) {
-      trace(3, true) {
-        long testModuleId = testModuleSpan(it, 1, TestEventsHandler.TEST_FAIL)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestFailed", TestEventsHandler.TEST_FAIL)
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_FAIL)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestFailed", TestEventsHandler.TEST_FAIL)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailed", "test_failed", TestEventsHandler.TEST_FAIL, null, exception)
       }
-    }
+    })
 
     where:
     exception = new AssertionFailedError("expected: <true> but was: <false>")
@@ -152,13 +189,17 @@ class JUnit5Test extends TestFrameworkTest {
     runTestClassesSuppressingExceptions(TestError)
 
     expect:
-    assertTraces(1) {
-      trace(3, true) {
-        long testModuleId = testModuleSpan(it, 1, TestEventsHandler.TEST_FAIL)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestError", TestEventsHandler.TEST_FAIL)
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_FAIL)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestError", TestEventsHandler.TEST_FAIL)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestError", "test_error", TestEventsHandler.TEST_FAIL, null, exception)
       }
-    }
+    })
 
     where:
     exception = new IllegalArgumentException("This exception is an example")
@@ -169,13 +210,17 @@ class JUnit5Test extends TestFrameworkTest {
     runTestClasses(TestSkipped)
 
     expect:
-    assertTraces(1) {
-      trace(3, true) {
-        long testModuleId = testModuleSpan(it, 1, TestEventsHandler.TEST_SKIP)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSkipped", TestEventsHandler.TEST_SKIP)
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_SKIP)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSkipped", TestEventsHandler.TEST_SKIP)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSkipped", "test_skipped", TestEventsHandler.TEST_SKIP, testTags, null, true)
       }
-    }
+    })
 
     where:
     testTags = [(Tags.TEST_SKIP_REASON): "Ignore reason in test"]
@@ -186,16 +231,26 @@ class JUnit5Test extends TestFrameworkTest {
     runTestClasses(TestSkippedClass)
 
     expect:
-    assertTraces(1) {
-      trace(6, true) {
-        long testModuleId = testModuleSpan(it, 4, TestEventsHandler.TEST_SKIP)
-        long testSuiteId = testSuiteSpan(it, 5, testModuleId, testModuleId, "org.example.TestSkippedClass", TestEventsHandler.TEST_SKIP, testTags)
-        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSkippedClass", "test_case_skipped", TestEventsHandler.TEST_SKIP, testTags, null, true)
-        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestSkippedClass", "test_factory_skipped", TestEventsHandler.TEST_SKIP, testTags, null, true)
-        testSpan(it, 2, testModuleId, testSuiteId, "org.example.TestSkippedClass", "test_parameterized_skipped", TestEventsHandler.TEST_SKIP, parameterizedTestTags, null, true)
-        testSpan(it, 3, testModuleId, testSuiteId, "org.example.TestSkippedClass", "test_repeated_skipped", TestEventsHandler.TEST_SKIP, testTags, null, true)
+    ListWriterAssert.assertTraces(TEST_WRITER, 5, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_SKIP)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSkippedClass", TestEventsHandler.TEST_SKIP, testTags)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSkippedClass", "test_case_skipped", TestEventsHandler.TEST_SKIP, testTags, null, true)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSkippedClass", "test_factory_skipped", TestEventsHandler.TEST_SKIP, testTags, null, true)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSkippedClass", "test_parameterized_skipped", TestEventsHandler.TEST_SKIP, parameterizedTestTags, null, true)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSkippedClass", "test_repeated_skipped", TestEventsHandler.TEST_SKIP, testTags, null, true)
+      }
+    })
 
     where:
     testTags = [(Tags.TEST_SKIP_REASON): "Ignore reason in class"]
@@ -207,13 +262,17 @@ class JUnit5Test extends TestFrameworkTest {
     runTestClasses(TestAssumption)
 
     expect:
-    assertTraces(1) {
-      trace(3, true) {
-        long testModuleId = testModuleSpan(it, 1, TestEventsHandler.TEST_SKIP)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestAssumption", TestEventsHandler.TEST_SKIP)
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_SKIP)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestAssumption", TestEventsHandler.TEST_SKIP)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestAssumption", "test_fail_assumption", TestEventsHandler.TEST_SKIP, testTags)
       }
-    }
+    })
 
     where:
     testTags = [(Tags.TEST_SKIP_REASON): "Assumption failed: assumption is not true"]
@@ -224,13 +283,17 @@ class JUnit5Test extends TestFrameworkTest {
     runTestClasses(TestAssumptionLegacy)
 
     expect:
-    assertTraces(1) {
-      trace(3, true) {
-        long testModuleId = testModuleSpan(it, 1, TestEventsHandler.TEST_SKIP)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestAssumptionLegacy", TestEventsHandler.TEST_SKIP)
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_SKIP)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestAssumptionLegacy", TestEventsHandler.TEST_SKIP)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestAssumptionLegacy", "test_fail_assumption_legacy", TestEventsHandler.TEST_SKIP, testTags)
       }
-    }
+    })
 
     where:
     testTags = [(Tags.TEST_SKIP_REASON): "assumption is not fulfilled"]
@@ -241,14 +304,20 @@ class JUnit5Test extends TestFrameworkTest {
     runTestClasses(TestSucceedAndSkipped)
 
     expect:
-    assertTraces(1) {
-      trace(4, true) {
-        long testModuleId = testModuleSpan(it, 2, TestEventsHandler.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestSucceedAndSkipped", TestEventsHandler.TEST_PASS)
-        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceedAndSkipped", "test_skipped", TestEventsHandler.TEST_SKIP, testTags, null, true)
-        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestSucceedAndSkipped", "test_succeed", TestEventsHandler.TEST_PASS)
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSucceedAndSkipped", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceedAndSkipped", "test_skipped", TestEventsHandler.TEST_SKIP, testTags, null, true)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceedAndSkipped", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+    })
 
     where:
     testTags = [(Tags.TEST_SKIP_REASON): "Ignore reason in test"]
@@ -259,15 +328,23 @@ class JUnit5Test extends TestFrameworkTest {
     runTestClasses(TestFailedAndSucceed)
 
     expect:
-    assertTraces(1) {
-      trace(5, true) {
-        long testModuleId = testModuleSpan(it, 3, TestEventsHandler.TEST_FAIL)
-        long testSuiteId = testSuiteSpan(it, 4, testModuleId, testModuleId, "org.example.TestFailedAndSucceed", TestEventsHandler.TEST_FAIL)
-        testSpan(it, 2, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
-        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_failed", TestEventsHandler.TEST_FAIL, null, exception)
+    ListWriterAssert.assertTraces(TEST_WRITER, 4, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_FAIL)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestFailedAndSucceed", TestEventsHandler.TEST_FAIL)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_another_succeed", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_failed", TestEventsHandler.TEST_FAIL, null, exception)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+    })
 
     where:
     exception = new AssertionFailedError("expected: <true> but was: <false>")
@@ -278,14 +355,20 @@ class JUnit5Test extends TestFrameworkTest {
     runTestClasses(TestFailedSuiteTearDown)
 
     expect:
-    assertTraces(1) {
-      trace(4, true) {
-        long testModuleId = testModuleSpan(it, 2, TestEventsHandler.TEST_FAIL)
-        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestFailedSuiteTearDown", TestEventsHandler.TEST_FAIL, null, exception)
-        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestFailedSuiteTearDown", "test_succeed", TestEventsHandler.TEST_PASS)
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_FAIL)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestFailedSuiteTearDown", TestEventsHandler.TEST_FAIL, null, exception)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedSuiteTearDown", "test_another_succeed", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedSuiteTearDown", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+    })
 
     where:
     exception = new RuntimeException("suite tear down failed")
@@ -296,12 +379,12 @@ class JUnit5Test extends TestFrameworkTest {
     runTestClasses(TestFailedSuiteSetup)
 
     expect:
-    assertTraces(1) {
+    ListWriterAssert.assertTraces(TEST_WRITER, 1, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
       trace(2, true) {
         long testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_FAIL)
         testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestFailedSuiteSetup", TestEventsHandler.TEST_FAIL, null, exception)
       }
-    }
+    })
 
     where:
     exception = new RuntimeException("suite set up failed")
@@ -312,17 +395,21 @@ class JUnit5Test extends TestFrameworkTest {
     runTestClasses(TestSucceedWithCategories)
 
     expect:
-    assertTraces(1) {
-      trace(3, true) {
-        long testModuleId = testModuleSpan(it, 1, TestEventsHandler.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSucceedWithCategories",
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSucceedWithCategories",
           TestEventsHandler.TEST_PASS, null, null, false,
           ["Slow", "Flaky"])
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceedWithCategories", "test_succeed",
           TestEventsHandler.TEST_PASS, null, null, false,
           ["End2end", "Browser", "Slow", "Flaky"])
       }
-    }
+    })
   }
 
   def "test assumption failure during suite setup"() {
@@ -330,13 +417,17 @@ class JUnit5Test extends TestFrameworkTest {
     runTestClasses(TestSuiteSetUpAssumption)
 
     expect:
-    assertTraces(1) {
-      trace(3, true) {
-        long testModuleId = testModuleSpan(it, 1, TestEventsHandler.TEST_SKIP)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSuiteSetUpAssumption", TestEventsHandler.TEST_SKIP, testTags)
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_SKIP)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSuiteSetUpAssumption", TestEventsHandler.TEST_SKIP, testTags)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSuiteSetUpAssumption", "test_succeed", TestEventsHandler.TEST_SKIP, testTags, null, true)
       }
-    }
+    })
 
     where:
     testTags = [(Tags.TEST_SKIP_REASON): "Assumption failed: assumption is not true"]
@@ -347,14 +438,20 @@ class JUnit5Test extends TestFrameworkTest {
     runTestClasses(TestAssumptionAndSucceed)
 
     expect:
-    assertTraces(1) {
-      trace(4, true) {
-        long testModuleId = testModuleSpan(it, 2, TestEventsHandler.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestAssumptionAndSucceed", TestEventsHandler.TEST_PASS)
-        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestAssumptionAndSucceed", "test_fail_assumption", TestEventsHandler.TEST_SKIP, testTags)
-        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestAssumptionAndSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestAssumptionAndSucceed", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestAssumptionAndSucceed", "test_fail_assumption", TestEventsHandler.TEST_SKIP, testTags)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestAssumptionAndSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+    })
 
     where:
     testTags = [(Tags.TEST_SKIP_REASON): "Assumption failed: assumption is not true"]
@@ -365,18 +462,25 @@ class JUnit5Test extends TestFrameworkTest {
     runTestClasses(TestSucceed, TestSucceedAndSkipped)
 
     expect:
-    assertTraces(1) {
-      trace(6, true) {
-        long testModuleId = testModuleSpan(it, 3, TestEventsHandler.TEST_PASS)
-
-        long firstSuiteId = testSuiteSpan(it, 4, testModuleId, testModuleId, "org.example.TestSucceed", TestEventsHandler.TEST_PASS)
-        testSpan(it, 0, testModuleId, firstSuiteId, "org.example.TestSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
-
-        long secondSuiteId = testSuiteSpan(it, 5, testModuleId, testModuleId, "org.example.TestSucceedAndSkipped", TestEventsHandler.TEST_PASS)
-        testSpan(it, 1, testModuleId, secondSuiteId, "org.example.TestSucceedAndSkipped", "test_skipped", TestEventsHandler.TEST_SKIP, testTags, null, true)
-        testSpan(it, 2, testModuleId, secondSuiteId, "org.example.TestSucceedAndSkipped", "test_succeed", TestEventsHandler.TEST_PASS)
+    ListWriterAssert.assertTraces(TEST_WRITER, 4, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long firstSuiteId
+      long secondSuiteId
+      trace(3, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        firstSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSucceed", TestEventsHandler.TEST_PASS)
+        secondSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSucceedAndSkipped", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, firstSuiteId, "org.example.TestSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, secondSuiteId, "org.example.TestSucceedAndSkipped", "test_skipped", TestEventsHandler.TEST_SKIP, testTags, null, true)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, secondSuiteId, "org.example.TestSucceedAndSkipped", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+    })
 
     where:
     testTags = [(Tags.TEST_SKIP_REASON): "Ignore reason in test"]
@@ -387,19 +491,28 @@ class JUnit5Test extends TestFrameworkTest {
     runTestClasses(TestSucceed, TestFailedAndSucceed)
 
     expect:
-    assertTraces(1) {
-      trace(7, true) {
-        long testModuleId = testModuleSpan(it, 4, TestEventsHandler.TEST_FAIL)
-
-        long firstSuiteId = testSuiteSpan(it, 6, testModuleId, testModuleId, "org.example.TestSucceed", TestEventsHandler.TEST_PASS)
-        testSpan(it, 3, testModuleId, firstSuiteId, "org.example.TestSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
-
-        long secondSuiteId = testSuiteSpan(it, 5, testModuleId, testModuleId, "org.example.TestFailedAndSucceed", TestEventsHandler.TEST_FAIL)
-        testSpan(it, 2, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
-        testSpan(it, 1, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_failed", TestEventsHandler.TEST_FAIL, null, exception)
+    ListWriterAssert.assertTraces(TEST_WRITER, 5, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long firstSuiteId
+      long secondSuiteId
+      trace(3, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_FAIL)
+        firstSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSucceed", TestEventsHandler.TEST_PASS)
+        secondSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestFailedAndSucceed", TestEventsHandler.TEST_FAIL)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_another_succeed", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_failed", TestEventsHandler.TEST_FAIL, null, exception)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, firstSuiteId, "org.example.TestSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+    })
 
     where:
     exception = new AssertionFailedError("expected: <true> but was: <false>")
@@ -410,17 +523,22 @@ class JUnit5Test extends TestFrameworkTest {
     runTestClasses(TestSucceedNested)
 
     expect:
-    assertTraces(1) {
-      trace(5, true) {
-        long testModuleId = testModuleSpan(it, 2, TestEventsHandler.TEST_PASS)
-
-        long topLevelSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestSucceedNested", TestEventsHandler.TEST_PASS)
-        testSpan(it, 1, testModuleId, topLevelSuiteId, "org.example.TestSucceedNested", "test_succeed", TestEventsHandler.TEST_PASS)
-
-        long nestedSuiteId = testSuiteSpan(it, 4, topLevelSuiteId, testModuleId, 'org.example.TestSucceedNested$NestedSuite', TestEventsHandler.TEST_PASS)
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long topLevelSuiteId
+      long nestedSuiteId
+      trace(3, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        topLevelSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSucceedNested", TestEventsHandler.TEST_PASS)
+        nestedSuiteId = testSuiteSpan(it, 2, topLevelSuiteId, testModuleId, 'org.example.TestSucceedNested$NestedSuite', TestEventsHandler.TEST_PASS)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, nestedSuiteId, 'org.example.TestSucceedNested$NestedSuite', "test_succeed_nested", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, topLevelSuiteId, "org.example.TestSucceedNested", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+    })
   }
 
   def "test nested skipped suites"() {
@@ -428,17 +546,22 @@ class JUnit5Test extends TestFrameworkTest {
     runTestClasses(TestSkippedNested)
 
     expect:
-    assertTraces(1) {
-      trace(5, true) {
-        long testModuleId = testModuleSpan(it, 2, TestEventsHandler.TEST_SKIP)
-
-        long topLevelSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestSkippedNested", TestEventsHandler.TEST_SKIP, testTags)
-        testSpan(it, 1, testModuleId, topLevelSuiteId, "org.example.TestSkippedNested", "test_succeed", TestEventsHandler.TEST_SKIP, testTags, null, true)
-
-        long nestedSuiteId = testSuiteSpan(it, 4, topLevelSuiteId, testModuleId, 'org.example.TestSkippedNested$NestedSuite', TestEventsHandler.TEST_SKIP, testTags)
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long topLevelSuiteId
+      long nestedSuiteId
+      trace(3, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_SKIP)
+        topLevelSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSkippedNested", TestEventsHandler.TEST_SKIP, testTags)
+        nestedSuiteId = testSuiteSpan(it, 2, topLevelSuiteId, testModuleId, 'org.example.TestSkippedNested$NestedSuite', TestEventsHandler.TEST_SKIP, testTags)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, nestedSuiteId, 'org.example.TestSkippedNested$NestedSuite', "test_succeed_nested", TestEventsHandler.TEST_SKIP, testTags, null, true)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, topLevelSuiteId, "org.example.TestSkippedNested", "test_succeed", TestEventsHandler.TEST_SKIP, testTags, null, true)
+      }
+    })
 
     where:
     testTags = [(Tags.TEST_SKIP_REASON): "Ignore reason in class"]

--- a/dd-java-agent/instrumentation/testng/src/testFixtures/groovy/datadog/trace/instrumentation/testng/TestNGTest.groovy
+++ b/dd-java-agent/instrumentation/testng/src/testFixtures/groovy/datadog/trace/instrumentation/testng/TestNGTest.groovy
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.testng
 
+import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.agent.test.base.TestFrameworkTest
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.bootstrap.instrumentation.civisibility.TestEventsHandler
@@ -32,13 +33,17 @@ abstract class TestNGTest extends TestFrameworkTest {
     testNG.run()
 
     expect:
-    assertTraces(1) {
-      trace(3, true) {
-        long testModuleId = testModuleSpan(it, 1, TestEventsHandler.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSucceed", TestEventsHandler.TEST_PASS)
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSucceed", TestEventsHandler.TEST_PASS)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
       }
-    }
+    })
   }
 
   def "test inheritance generates spans"() {
@@ -49,13 +54,17 @@ abstract class TestNGTest extends TestFrameworkTest {
     testNG.run()
 
     expect:
-    assertTraces(1) {
-      trace(3, true) {
-        long testModuleId = testModuleSpan(it, 1, TestEventsHandler.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestInheritance", TestEventsHandler.TEST_PASS)
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestInheritance", TestEventsHandler.TEST_PASS)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestInheritance", "test_succeed", TestEventsHandler.TEST_PASS)
       }
-    }
+    })
   }
 
   def "test failed generates spans"() {
@@ -70,13 +79,17 @@ abstract class TestNGTest extends TestFrameworkTest {
     }
 
     expect:
-    assertTraces(1) {
-      trace(3, true) {
-        long testModuleId = testModuleSpan(it, 1, TestEventsHandler.TEST_FAIL)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestFailed", TestEventsHandler.TEST_FAIL)
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_FAIL)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestFailed", TestEventsHandler.TEST_FAIL)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailed", "test_failed", TestEventsHandler.TEST_FAIL, null, exception)
       }
-    }
+    })
 
     where:
     exception = new AssertionError(assertionErrorMessage(), null)
@@ -94,17 +107,29 @@ abstract class TestNGTest extends TestFrameworkTest {
     }
 
     expect:
-    assertTraces(1) {
-      trace(7, true) {
-        long testModuleId = testModuleSpan(it, 5, TestEventsHandler.TEST_FAIL)
-        long testSuiteId = testSuiteSpan(it, 6, testModuleId, testModuleId, "org.example.TestFailedWithSuccessPercentage", TestEventsHandler.TEST_FAIL)
-        testSpan(it, 3, testModuleId, testSuiteId, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestEventsHandler.TEST_FAIL, null, exception)
-        testSpan(it, 4, testModuleId, testSuiteId, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestEventsHandler.TEST_FAIL, null, exception)
-        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestEventsHandler.TEST_PASS)
-        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestEventsHandler.TEST_PASS)
-        testSpan(it, 2, testModuleId, testSuiteId, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestEventsHandler.TEST_PASS)
+    ListWriterAssert.assertTraces(TEST_WRITER, 6, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_FAIL)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestFailedWithSuccessPercentage", TestEventsHandler.TEST_FAIL)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestEventsHandler.TEST_FAIL, null, exception)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestEventsHandler.TEST_FAIL, null, exception)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestEventsHandler.TEST_PASS)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestEventsHandler.TEST_PASS)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedWithSuccessPercentage", "test_failed_with_success_percentage", TestEventsHandler.TEST_PASS)
+      }
+    })
 
     where:
     exception = new AssertionError(assertionErrorMessage(), null)
@@ -118,13 +143,17 @@ abstract class TestNGTest extends TestFrameworkTest {
     testNG.run()
 
     expect:
-    assertTraces(1) {
-      trace(3, true) {
-        long testModuleId = testModuleSpan(it, 1, TestEventsHandler.TEST_FAIL)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestError", TestEventsHandler.TEST_FAIL)
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_FAIL)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestError", TestEventsHandler.TEST_FAIL)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestError", "test_error", TestEventsHandler.TEST_FAIL, null, exception)
       }
-    }
+    })
 
     where:
     exception = new IllegalArgumentException("This exception is an example")
@@ -138,13 +167,17 @@ abstract class TestNGTest extends TestFrameworkTest {
     testNG.run()
 
     expect:
-    assertTraces(1) {
-      trace(3, true) {
-        long testModuleId = testModuleSpan(it, 1, TestEventsHandler.TEST_SKIP)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSkipped", TestEventsHandler.TEST_SKIP)
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_SKIP)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSkipped", TestEventsHandler.TEST_SKIP)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSkipped", "test_skipped", TestEventsHandler.TEST_SKIP, testTags)
       }
-    }
+    })
 
     where:
     testTags = [(Tags.TEST_SKIP_REASON): "Ignore reason in test"]
@@ -158,14 +191,20 @@ abstract class TestNGTest extends TestFrameworkTest {
     testNG.run()
 
     expect:
-    assertTraces(1) {
-      trace(4, true) {
-        long testModuleId = testModuleSpan(it, 2, TestEventsHandler.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestParameterized", TestEventsHandler.TEST_PASS)
-        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestParameterized", "parameterized_test_succeed", TestEventsHandler.TEST_PASS, testTags_1)
-        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestParameterized", "parameterized_test_succeed", TestEventsHandler.TEST_PASS, testTags_0)
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestParameterized", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestParameterized", "parameterized_test_succeed", TestEventsHandler.TEST_PASS, testTags_0)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestParameterized", "parameterized_test_succeed", TestEventsHandler.TEST_PASS, testTags_1)
+      }
+    })
 
     where:
     testTags_0 = [(Tags.TEST_PARAMETERS): '{"arguments":{"0":"hello","1":"true"}}']
@@ -180,15 +219,19 @@ abstract class TestNGTest extends TestFrameworkTest {
     testNG.run()
 
     expect:
-    assertTraces(1) {
-      trace(3, true) {
-        long testModuleId = testModuleSpan(it, 1, TestEventsHandler.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSucceedGroups", TestEventsHandler.TEST_PASS,
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSucceedGroups", TestEventsHandler.TEST_PASS,
           null, null, false, ["classGroup", "parentGroup"])
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceedGroups", "test_succeed", TestEventsHandler.TEST_PASS,
           null, null, false, ["classGroup", "testCaseGroup", "parentGroup"])
       }
-    }
+    })
   }
 
   def "test class skipped generated spans"() {
@@ -199,14 +242,20 @@ abstract class TestNGTest extends TestFrameworkTest {
     testNG.run()
 
     expect:
-    assertTraces(1) {
-      trace(4, true) {
-        long testModuleId = testModuleSpan(it, 2, TestEventsHandler.TEST_SKIP)
-        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestSkippedClass", TestEventsHandler.TEST_SKIP)
-        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestSkippedClass", "test_class_skipped", TestEventsHandler.TEST_SKIP, testTags)
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_SKIP)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSkippedClass", TestEventsHandler.TEST_SKIP)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSkippedClass", "test_class_another_skipped", TestEventsHandler.TEST_SKIP, testTags)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSkippedClass", "test_class_skipped", TestEventsHandler.TEST_SKIP, testTags)
+      }
+    })
 
     where:
     testTags = [(Tags.TEST_SKIP_REASON): classSkipReason()] // framework versions used in tests cannot provide skip reason
@@ -221,14 +270,20 @@ abstract class TestNGTest extends TestFrameworkTest {
     testNG.run()
 
     expect:
-    assertTraces(1) {
-      trace(4, true) {
-        long testModuleId = testModuleSpan(it, 2, TestEventsHandler.TEST_PASS)
-        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestSucceedAndSkipped", TestEventsHandler.TEST_PASS)
-        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceedAndSkipped", "test_skipped", TestEventsHandler.TEST_SKIP, testTags)
-        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestSucceedAndSkipped", "test_succeed", TestEventsHandler.TEST_PASS)
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSucceedAndSkipped", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceedAndSkipped", "test_skipped", TestEventsHandler.TEST_SKIP, testTags)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceedAndSkipped", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+    })
 
     where:
     testTags = [(Tags.TEST_SKIP_REASON): "Ignore reason in test"]
@@ -242,15 +297,23 @@ abstract class TestNGTest extends TestFrameworkTest {
     testNG.run()
 
     expect:
-    assertTraces(1) {
-      trace(5, true) {
-        long testModuleId = testModuleSpan(it, 3, TestEventsHandler.TEST_FAIL)
-        long testSuiteId = testSuiteSpan(it, 4, testModuleId, testModuleId, "org.example.TestFailedAndSucceed", TestEventsHandler.TEST_FAIL)
-        testSpan(it, 2, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
-        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_failed", TestEventsHandler.TEST_FAIL, null, exception)
+    ListWriterAssert.assertTraces(TEST_WRITER, 4, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_FAIL)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestFailedAndSucceed", TestEventsHandler.TEST_FAIL)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_another_succeed", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_failed", TestEventsHandler.TEST_FAIL, null, exception)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+    })
 
     where:
     exception = new AssertionError(assertionErrorMessage(), null)
@@ -264,14 +327,20 @@ abstract class TestNGTest extends TestFrameworkTest {
     testNG.run()
 
     expect:
-    assertTraces(1) {
-      trace(4, true) {
-        long testModuleId = testModuleSpan(it, 2, TestEventsHandler.TEST_FAIL)
-        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestFailedSuiteTearDown", TestEventsHandler.TEST_FAIL, null, exception)
-        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestFailedSuiteTearDown", "test_succeed", TestEventsHandler.TEST_PASS)
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_FAIL)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestFailedSuiteTearDown", TestEventsHandler.TEST_FAIL, null, exception)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedSuiteTearDown", "test_another_succeed", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedSuiteTearDown", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+    })
 
     where:
     exception = new RuntimeException("suite tear down failed")
@@ -285,15 +354,21 @@ abstract class TestNGTest extends TestFrameworkTest {
     testNG.run()
 
     expect:
-    assertTraces(1) {
-      trace(4, true) {
-        long testModuleId = testModuleSpan(it, 2, TestEventsHandler.TEST_FAIL)
-        long testSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestFailedSuiteSetup", TestEventsHandler.TEST_FAIL, null, exception)
-        // if suite set up fails, TestNG will report that suite's test cases as skipped
-        testSpan(it, 1, testModuleId, testSuiteId, "org.example.TestFailedSuiteSetup", "test_succeed", TestEventsHandler.TEST_SKIP, testTags)
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_FAIL)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestFailedSuiteSetup", TestEventsHandler.TEST_FAIL, null, exception)
+      }
+      // if suite set up fails, TestNG will report that suite's test cases as skipped
+      trace(1) {
         testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedSuiteSetup", "test_another_succeed", TestEventsHandler.TEST_SKIP, testTags)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedSuiteSetup", "test_succeed", TestEventsHandler.TEST_SKIP, testTags)
+      }
+    })
 
     where:
     exception = new RuntimeException("suite set up failed")
@@ -308,18 +383,25 @@ abstract class TestNGTest extends TestFrameworkTest {
     testNG.run()
 
     expect:
-    assertTraces(1) {
-      trace(6, true) {
-        long testModuleId = testModuleSpan(it, 3, TestEventsHandler.TEST_PASS)
-
-        long firstSuiteId = testSuiteSpan(it, 4, testModuleId, testModuleId, "org.example.TestSucceed", TestEventsHandler.TEST_PASS)
-        testSpan(it, 0, testModuleId, firstSuiteId, "org.example.TestSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
-
-        long secondSuiteId = testSuiteSpan(it, 5, testModuleId, testModuleId, "org.example.TestSucceedAndSkipped", TestEventsHandler.TEST_PASS)
-        testSpan(it, 1, testModuleId, secondSuiteId, "org.example.TestSucceedAndSkipped", "test_skipped", TestEventsHandler.TEST_SKIP, testTags)
-        testSpan(it, 2, testModuleId, secondSuiteId, "org.example.TestSucceedAndSkipped", "test_succeed", TestEventsHandler.TEST_PASS)
+    ListWriterAssert.assertTraces(TEST_WRITER, 4, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long firstSuiteId
+      long secondSuiteId
+      trace(3, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        firstSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSucceed", TestEventsHandler.TEST_PASS)
+        secondSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSucceedAndSkipped", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, firstSuiteId, "org.example.TestSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, secondSuiteId, "org.example.TestSucceedAndSkipped", "test_skipped", TestEventsHandler.TEST_SKIP, testTags)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, secondSuiteId, "org.example.TestSucceedAndSkipped", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+    })
 
     where:
     testTags = [(Tags.TEST_SKIP_REASON): "Ignore reason in test"]
@@ -333,19 +415,28 @@ abstract class TestNGTest extends TestFrameworkTest {
     testNG.run()
 
     expect:
-    assertTraces(1) {
-      trace(7, true) {
-        long testModuleId = testModuleSpan(it, 4, TestEventsHandler.TEST_FAIL)
-
-        long firstSuiteId = testSuiteSpan(it, 6, testModuleId, testModuleId, "org.example.TestSucceed", TestEventsHandler.TEST_PASS)
-        testSpan(it, 3, testModuleId, firstSuiteId, "org.example.TestSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
-
-        long secondSuiteId = testSuiteSpan(it, 5, testModuleId, testModuleId, "org.example.TestFailedAndSucceed", TestEventsHandler.TEST_FAIL)
-        testSpan(it, 2, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
-        testSpan(it, 1, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_failed", TestEventsHandler.TEST_FAIL, null, exception)
+    ListWriterAssert.assertTraces(TEST_WRITER, 5, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long firstSuiteId
+      long secondSuiteId
+      trace(3, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_FAIL)
+        firstSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, "org.example.TestSucceed", TestEventsHandler.TEST_PASS)
+        secondSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestFailedAndSucceed", TestEventsHandler.TEST_FAIL)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_another_succeed", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_failed", TestEventsHandler.TEST_FAIL, null, exception)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, secondSuiteId, "org.example.TestFailedAndSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, firstSuiteId, "org.example.TestSucceed", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+    })
 
     where:
     exception = new AssertionError(assertionErrorMessage(), null)
@@ -359,17 +450,22 @@ abstract class TestNGTest extends TestFrameworkTest {
     testNG.run()
 
     expect:
-    assertTraces(1) {
-      trace(5, true) {
-        long testModuleId = testModuleSpan(it, 2, TestEventsHandler.TEST_PASS)
-
-        long topLevelSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestSucceedNested", TestEventsHandler.TEST_PASS)
-        testSpan(it, 1, testModuleId, topLevelSuiteId, "org.example.TestSucceedNested", "test_succeed", TestEventsHandler.TEST_PASS)
-
-        long nestedSuiteId = testSuiteSpan(it, 4, testModuleId, testModuleId, 'org.example.TestSucceedNested$NestedSuite', TestEventsHandler.TEST_PASS)
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long topLevelSuiteId
+      long nestedSuiteId
+      trace(3, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        topLevelSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSucceedNested", TestEventsHandler.TEST_PASS)
+        nestedSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, 'org.example.TestSucceedNested$NestedSuite', TestEventsHandler.TEST_PASS)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, nestedSuiteId, 'org.example.TestSucceedNested$NestedSuite', "test_succeed_nested", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, topLevelSuiteId, "org.example.TestSucceedNested", "test_succeed", TestEventsHandler.TEST_PASS)
+      }
+    })
   }
 
   def "test nested skipped suites"() {
@@ -380,17 +476,22 @@ abstract class TestNGTest extends TestFrameworkTest {
     testNG.run()
 
     expect:
-    assertTraces(1) {
-      trace(5, true) {
-        long testModuleId = testModuleSpan(it, 2, TestEventsHandler.TEST_PASS)
-
-        long topLevelSuiteId = testSuiteSpan(it, 3, testModuleId, testModuleId, "org.example.TestSkippedNested", TestEventsHandler.TEST_SKIP)
-        testSpan(it, 1, testModuleId, topLevelSuiteId, "org.example.TestSkippedNested", "test_succeed", TestEventsHandler.TEST_SKIP, testTags)
-
-        long nestedSuiteId = testSuiteSpan(it, 4, testModuleId, testModuleId, 'org.example.TestSkippedNested$NestedSuite', TestEventsHandler.TEST_PASS)
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long topLevelSuiteId
+      long nestedSuiteId
+      trace(3, true) {
+        testModuleId = testModuleSpan(it, 0, TestEventsHandler.TEST_PASS)
+        topLevelSuiteId = testSuiteSpan(it, 1, testModuleId, testModuleId, "org.example.TestSkippedNested", TestEventsHandler.TEST_SKIP)
+        nestedSuiteId = testSuiteSpan(it, 2, testModuleId, testModuleId, 'org.example.TestSkippedNested$NestedSuite', TestEventsHandler.TEST_PASS)
+      }
+      trace(1) {
         testSpan(it, 0, testModuleId, nestedSuiteId, 'org.example.TestSkippedNested$NestedSuite', "test_succeed_nested", TestEventsHandler.TEST_PASS)
       }
-    }
+      trace(1) {
+        testSpan(it, 0, testModuleId, topLevelSuiteId, "org.example.TestSkippedNested", "test_succeed", TestEventsHandler.TEST_SKIP, testTags)
+      }
+    })
 
     where:
     testTags = testCaseTagsIfSuiteSetUpFailedOrSkipped("Ignore reason in class")


### PR DESCRIPTION
# What Does This Do
Updates test-case spans to always be root spans.

# Motivation
CI Visibility backend mandates that a span corresponding to an individual test case should always be a root span.
Otherwise (e.g. if test-case span has test-suite span as its parent) multiple test-case spans may share the same trace ID, in which case the UI will render test-case trace incorrectly.