### PR TITLE
Catch IllegalArgumentException for URLDecoder

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -196,7 +196,7 @@ public class HttpCodec {
     String decoded = value;
     try {
       decoded = URLDecoder.decode(value, "UTF-8");
-    } catch (final UnsupportedEncodingException e) {
+    } catch (final UnsupportedEncodingException | IllegalArgumentException e) {
       log.debug("Failed to decode value - {}", value);
     }
     return decoded;


### PR DESCRIPTION
# What Does This Do

Handles `IllegalArgumentException` thrown by `java.net.URLDecoder` when illegal escape patterns are decoded.
