### PR TITLE
Add snapshot serialization timeout check

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/TimeoutChecker.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/TimeoutChecker.java
@@ -1,0 +1,30 @@
+package datadog.trace.bootstrap.debugger.util;
+
+import java.time.Duration;
+
+public class TimeoutChecker {
+  private final long start;
+  private final Duration timeOut;
+
+  public TimeoutChecker(Duration timeOut) {
+    this.start = System.currentTimeMillis();
+    this.timeOut = timeOut;
+  }
+
+  public TimeoutChecker(long start, Duration timeOut) {
+    this.start = start;
+    this.timeOut = timeOut;
+  }
+
+  public boolean isTimedOut(long currentTimeMillis) {
+    return (currentTimeMillis - start) > timeOut.toMillis();
+  }
+
+  public long getStart() {
+    return start;
+  }
+
+  public Duration getTimeOut() {
+    return timeOut;
+  }
+}

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/test/java/datadog/trace/bootstrap/debugger/util/TimeoutCheckerTest.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/test/java/datadog/trace/bootstrap/debugger/util/TimeoutCheckerTest.java
@@ -1,0 +1,22 @@
+package datadog.trace.bootstrap.debugger.util;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TimeoutCheckerTest {
+  private static final Duration TIME_OUT = Duration.of(100, ChronoUnit.MILLIS);
+
+  @Test
+  public void timedOut() {
+    long start = System.currentTimeMillis();
+    // assume that start & timestamp captured in instance below are very close
+    TimeoutChecker timeoutChecker = new TimeoutChecker(TIME_OUT);
+    Assertions.assertFalse(timeoutChecker.isTimedOut(start + 1));
+    Assertions.assertTrue(timeoutChecker.isTimedOut(start + TIME_OUT.toMillis() * 2));
+    timeoutChecker = new TimeoutChecker(start, TIME_OUT);
+    Assertions.assertFalse(timeoutChecker.isTimedOut(start + 1));
+    Assertions.assertTrue(timeoutChecker.isTimedOut(start + TIME_OUT.toMillis() * 2));
+  }
+}

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/LogMessageTemplateSummaryBuilder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/LogMessageTemplateSummaryBuilder.java
@@ -9,6 +9,9 @@ import datadog.trace.bootstrap.debugger.CapturedStackFrame;
 import datadog.trace.bootstrap.debugger.Limits;
 import datadog.trace.bootstrap.debugger.Snapshot;
 import datadog.trace.bootstrap.debugger.SummaryBuilder;
+import datadog.trace.bootstrap.debugger.util.TimeoutChecker;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,6 +22,8 @@ public class LogMessageTemplateSummaryBuilder implements SummaryBuilder {
    * obj.field.deepfield or array[1001]
    */
   private static final Limits LIMITS = new Limits(1, 3, 255, 5);
+
+  private static final Duration TIME_OUT = Duration.of(100, ChronoUnit.MILLIS);
 
   private final LogProbe logProbe;
   private final List<Snapshot.EvaluationError> evaluationErrors = new ArrayList<>();
@@ -90,7 +95,8 @@ public class LogMessageTemplateSummaryBuilder implements SummaryBuilder {
 
   private void serializeValue(StringBuilder sb, String expr, Object value) {
     SerializerWithLimits serializer =
-        new SerializerWithLimits(new StringTokenWriter(sb, evaluationErrors));
+        new SerializerWithLimits(
+            new StringTokenWriter(sb, evaluationErrors), new TimeoutChecker(TIME_OUT));
     try {
       serializer.serialize(value, value != null ? value.getClass().getTypeName() : null, LIMITS);
     } catch (Exception ex) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
@@ -7,12 +7,15 @@ import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
 import datadog.trace.bootstrap.debugger.Limits;
 import datadog.trace.bootstrap.debugger.Snapshot;
+import datadog.trace.bootstrap.debugger.util.TimeoutChecker;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -34,6 +37,7 @@ public class MoshiSnapshotHelper {
   public static final String NOT_CAPTURED_REASON = "notCapturedReason";
   public static final String FIELD_COUNT_REASON = "fieldCount";
   public static final String COLLECTION_SIZE_REASON = "collectionSize";
+  public static final String TIMEOUT_REASON = "timeout";
   public static final String DEPTH_REASON = "depth";
   public static final String TYPE = "type";
   public static final String VALUE = "value";
@@ -43,6 +47,7 @@ public class MoshiSnapshotHelper {
   public static final String IS_NULL = "isNull";
   public static final String TRUNCATED = "truncated";
   public static final String SIZE = "size";
+  private static final Duration TIME_OUT = Duration.ofMillis(200);
 
   public static class SnapshotJsonFactory implements JsonAdapter.Factory {
     @Override
@@ -82,6 +87,8 @@ public class MoshiSnapshotHelper {
         jsonWriter.nullValue();
         return;
       }
+      jsonWriter.setTag(
+          TimeoutChecker.class, new TimeoutChecker(System.currentTimeMillis(), TIME_OUT));
       jsonWriter.beginObject();
       jsonWriter.name(ENTRY);
       capturedContextAdapter.toJson(jsonWriter, captures.getEntry());
@@ -117,8 +124,19 @@ public class MoshiSnapshotHelper {
         jsonWriter.nullValue();
         return;
       }
+      TimeoutChecker timeoutChecker = jsonWriter.tag(TimeoutChecker.class);
+      if (timeoutChecker == null) {
+        timeoutChecker = new TimeoutChecker(TIME_OUT);
+      }
       // need to 'freeze' the context before serializing it
-      capturedContext.freeze();
+      capturedContext.freeze(timeoutChecker);
+      if (timeoutChecker.isTimedOut(System.currentTimeMillis())) {
+        jsonWriter.beginObject();
+        jsonWriter.name(NOT_CAPTURED_REASON);
+        jsonWriter.value(TIMEOUT_REASON);
+        jsonWriter.endObject();
+        return;
+      }
       jsonWriter.beginObject();
       jsonWriter.name(ARGUMENTS);
       jsonWriter.beginObject();
@@ -129,30 +147,30 @@ public class MoshiSnapshotHelper {
         jsonWriter.value(capturedContext.getThisClassName());
         jsonWriter.name(FIELDS);
         jsonWriter.beginObject();
-        boolean complete =
+        SerializationResult result =
             toJsonCapturedValues(
-                jsonWriter, capturedContext.getFields(), capturedContext.getLimits());
+                jsonWriter,
+                capturedContext.getFields(),
+                capturedContext.getLimits(),
+                timeoutChecker);
         jsonWriter.endObject(); // FIELDS
-        if (!complete) {
-          jsonWriter.name(NOT_CAPTURED_REASON);
-          jsonWriter.value(FIELD_COUNT_REASON);
-        }
+        handleSerializationResult(jsonWriter, result);
         jsonWriter.endObject(); // THIS
       }
-      boolean completeArgs =
+      SerializationResult resultArgs =
           toJsonCapturedValues(
-              jsonWriter, capturedContext.getArguments(), capturedContext.getLimits());
+              jsonWriter,
+              capturedContext.getArguments(),
+              capturedContext.getLimits(),
+              timeoutChecker);
       jsonWriter.endObject(); // ARGUMENTS
       jsonWriter.name(LOCALS);
       jsonWriter.beginObject();
-      boolean completeLocals =
+      SerializationResult resultLocals =
           toJsonCapturedValues(
-              jsonWriter, capturedContext.getLocals(), capturedContext.getLimits());
+              jsonWriter, capturedContext.getLocals(), capturedContext.getLimits(), timeoutChecker);
       jsonWriter.endObject(); // LOCALS
-      if (!completeArgs || !completeLocals) {
-        jsonWriter.name(NOT_CAPTURED_REASON);
-        jsonWriter.value(FIELD_COUNT_REASON);
-      }
+      handleSerializationResult(jsonWriter, resultLocals, resultArgs);
       jsonWriter.name(THROWABLE);
       throwableAdapter.toJson(jsonWriter, capturedContext.getThrowable());
       // TODO add static fields
@@ -160,17 +178,61 @@ public class MoshiSnapshotHelper {
       jsonWriter.endObject();
     }
 
+    private void handleSerializationResult(JsonWriter jsonWriter, SerializationResult... results)
+        throws IOException {
+      boolean fieldCountReported = false;
+      boolean timeoutReported = false;
+      for (SerializationResult result : results) {
+        switch (result) {
+          case OK:
+            return;
+          case FIELD_COUNT:
+            {
+              if (!fieldCountReported) {
+                jsonWriter.name(NOT_CAPTURED_REASON);
+                jsonWriter.value(FIELD_COUNT_REASON);
+                fieldCountReported = true;
+              }
+              break;
+            }
+          case TIMEOUT:
+            {
+              if (!timeoutReported) {
+                jsonWriter.name(NOT_CAPTURED_REASON);
+                jsonWriter.value(TIMEOUT_REASON);
+                timeoutReported = true;
+              }
+              break;
+            }
+          default:
+            throw new RuntimeException("Unsupported serialization result: " + result);
+        }
+      }
+    }
+
+    enum SerializationResult {
+      OK,
+      FIELD_COUNT,
+      TIMEOUT
+    }
+
     /** @return true if all items where serialized or whether we reach the max field count */
-    private boolean toJsonCapturedValues(
-        JsonWriter jsonWriter, Map<String, Snapshot.CapturedValue> map, Limits limits)
+    private SerializationResult toJsonCapturedValues(
+        JsonWriter jsonWriter,
+        Map<String, Snapshot.CapturedValue> map,
+        Limits limits,
+        TimeoutChecker timeoutChecker)
         throws IOException {
       if (map == null) {
-        return true;
+        return SerializationResult.OK;
       }
       int count = 0;
       for (Map.Entry<String, Snapshot.CapturedValue> entry : map.entrySet()) {
         if (count >= limits.maxFieldCount) {
-          return false;
+          return SerializationResult.FIELD_COUNT;
+        }
+        if (timeoutChecker.isTimedOut(System.currentTimeMillis())) {
+          return SerializationResult.TIMEOUT;
         }
         jsonWriter.name(entry.getKey());
         Snapshot.CapturedValue capturedValue = entry.getValue();
@@ -181,7 +243,7 @@ public class MoshiSnapshotHelper {
                         capturedValue.getStrValue().getBytes(StandardCharsets.UTF_8)))));
         count++;
       }
-      return true;
+      return SerializationResult.OK;
     }
 
     @Override
@@ -192,7 +254,6 @@ public class MoshiSnapshotHelper {
   }
 
   public static class CapturedValueAdapter extends JsonAdapter<Snapshot.CapturedValue> {
-
     @Override
     public void toJson(JsonWriter jsonWriter, Snapshot.CapturedValue capturedValue)
         throws IOException {
@@ -200,13 +261,15 @@ public class MoshiSnapshotHelper {
         jsonWriter.nullValue();
         return;
       }
-      serializeValue(
-          jsonWriter, capturedValue.getValue(), capturedValue.getType(), capturedValue.getLimits());
-    }
-
-    private void serializeValue(JsonWriter jsonWriter, Object value, String type, Limits limits)
-        throws IOException {
-      SerializerWithLimits serializer = new SerializerWithLimits(new JsonTokenWriter(jsonWriter));
+      TimeoutChecker timeoutChecker = capturedValue.getTimeoutChecker();
+      if (timeoutChecker == null) {
+        timeoutChecker = new TimeoutChecker(Duration.of(10, ChronoUnit.MILLIS));
+      }
+      Object value = capturedValue.getValue();
+      String type = capturedValue.getType();
+      Limits limits = capturedValue.getLimits();
+      SerializerWithLimits serializer =
+          new SerializerWithLimits(new JsonTokenWriter(jsonWriter), timeoutChecker);
       try {
         serializer.serialize(value, type, limits);
       } catch (Exception ex) {
@@ -368,24 +431,34 @@ public class MoshiSnapshotHelper {
       }
 
       @Override
-      public void objectMaxFieldCount() {
-        try {
-          jsonWriter.name(NOT_CAPTURED_REASON);
-          jsonWriter.value(FIELD_COUNT_REASON);
-        } catch (IOException e) {
-          LOG.debug("Error during serializing reason for reaching max field count", e);
-        }
-      }
-
-      @Override
       public void objectEpilogue(Object value) throws Exception {
         jsonWriter.endObject();
       }
 
       @Override
-      public void reachedMaxDepth() throws Exception {
-        jsonWriter.name(NOT_CAPTURED_REASON);
-        jsonWriter.value(DEPTH_REASON);
+      public void notCaptured(SerializerWithLimits.NotCapturedReason reason) throws Exception {
+        switch (reason) {
+          case MAX_DEPTH:
+            {
+              jsonWriter.name(NOT_CAPTURED_REASON);
+              jsonWriter.value(DEPTH_REASON);
+              break;
+            }
+          case FIELD_COUNT:
+            {
+              jsonWriter.name(NOT_CAPTURED_REASON);
+              jsonWriter.value(FIELD_COUNT_REASON);
+              break;
+            }
+          case TIMEOUT:
+            {
+              jsonWriter.name(NOT_CAPTURED_REASON);
+              jsonWriter.value(FIELD_COUNT_REASON);
+              break;
+            }
+          default:
+            throw new RuntimeException("Unsupported NotCapturedReason: " + reason);
+        }
       }
     }
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/SerializerWithLimits.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/SerializerWithLimits.java
@@ -2,6 +2,7 @@ package com.datadog.debugger.util;
 
 import datadog.trace.bootstrap.debugger.Limits;
 import datadog.trace.bootstrap.debugger.Snapshot;
+import datadog.trace.bootstrap.debugger.util.TimeoutChecker;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -39,6 +40,12 @@ public class SerializerWithLimits {
         return true;
     }
     return false;
+  }
+
+  enum NotCapturedReason {
+    MAX_DEPTH,
+    FIELD_COUNT,
+    TIMEOUT
   }
 
   public interface TokenWriter {
@@ -86,23 +93,28 @@ public class SerializerWithLimits {
 
     void objectFieldPrologue(Field field, Object value, int maxDepth) throws Exception;
 
-    void objectMaxFieldCount() throws Exception;
-
     void handleFieldException(Exception ex, Field field);
 
     void objectEpilogue(Object value) throws Exception;
 
-    void reachedMaxDepth() throws Exception;
+    void notCaptured(NotCapturedReason reason) throws Exception;
   }
 
   private final TokenWriter tokenWriter;
+  private final TimeoutChecker timeoutChecker;
 
-  public SerializerWithLimits(TokenWriter tokenWriter) {
+  public SerializerWithLimits(TokenWriter tokenWriter, TimeoutChecker timeoutChecker) {
     this.tokenWriter = tokenWriter;
+    this.timeoutChecker = timeoutChecker;
   }
 
   public void serialize(Object value, String type, Limits limits) throws Exception {
     tokenWriter.prologue(value, type);
+    if (timeoutChecker.isTimedOut(System.currentTimeMillis())) {
+      tokenWriter.notCaptured(NotCapturedReason.TIMEOUT);
+      tokenWriter.epilogue(value);
+      return;
+    }
     if (value == null) {
       tokenWriter.nullValue();
     } else if (isPrimitive(type) || WellKnownClasses.isToStringSafe(type)) {
@@ -166,7 +178,7 @@ public class SerializerWithLimits {
     } else if (limits.maxReferenceDepth > 0) {
       serializeObjectValue(value, limits);
     } else {
-      tokenWriter.reachedMaxDepth();
+      tokenWriter.notCaptured(NotCapturedReason.MAX_DEPTH);
     }
     tokenWriter.epilogue(value);
   }
@@ -188,7 +200,7 @@ public class SerializerWithLimits {
           onField(field, fieldValue, limits);
           processedFieldCount++;
           if (processedFieldCount >= limits.maxFieldCount) {
-            tokenWriter.objectMaxFieldCount();
+            tokenWriter.notCaptured(NotCapturedReason.FIELD_COUNT);
             break classLoop;
           }
         } catch (Exception e) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/StringTokenWriter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/StringTokenWriter.java
@@ -147,12 +147,17 @@ public class StringTokenWriter implements SerializerWithLimits.TokenWriter {
   }
 
   @Override
-  public void objectMaxFieldCount() {
-    sb.append(", ...");
-  }
-
-  @Override
-  public void reachedMaxDepth() {
-    sb.append("...");
+  public void notCaptured(SerializerWithLimits.NotCapturedReason reason) {
+    switch (reason) {
+      case MAX_DEPTH:
+      case TIMEOUT:
+        sb.append("...");
+        break;
+      case FIELD_COUNT:
+        sb.append(", ...");
+        break;
+      default:
+        throw new RuntimeException("Unsupported NotCapturedReason: " + reason);
+    }
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/el/ELIntegrationSanityTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/el/ELIntegrationSanityTest.java
@@ -7,7 +7,10 @@ import com.datadog.debugger.agent.JsonSnapshotSerializer;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.debugger.Limits;
 import datadog.trace.bootstrap.debugger.Snapshot;
+import datadog.trace.bootstrap.debugger.util.TimeoutChecker;
 import java.lang.reflect.Field;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -68,7 +71,7 @@ public class ELIntegrationSanityTest {
     assertEquals(p.name.value, val.getValue());
 
     // freeze the captured context
-    capturedContext.freeze();
+    capturedContext.freeze(new TimeoutChecker(Duration.of(1, ChronoUnit.SECONDS)));
 
     // after freezing the original value is removed and only the serialized json representation
     // remains

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/StringTokenWriterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/StringTokenWriterTest.java
@@ -7,6 +7,9 @@ import static datadog.trace.bootstrap.debugger.Limits.DEFAULT_REFERENCE_DEPTH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import datadog.trace.bootstrap.debugger.Limits;
+import datadog.trace.bootstrap.debugger.util.TimeoutChecker;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -118,7 +121,9 @@ class StringTokenWriterTest {
   private String serializeValue(Object value, Limits limits) throws Exception {
     StringBuilder sb = new StringBuilder();
     SerializerWithLimits serializer =
-        new SerializerWithLimits(new StringTokenWriter(sb, new ArrayList<>()));
+        new SerializerWithLimits(
+            new StringTokenWriter(sb, new ArrayList<>()),
+            new TimeoutChecker(Duration.of(1, ChronoUnit.SECONDS)));
     serializer.serialize(value, value != null ? value.getClass().getTypeName() : null, limits);
     return sb.toString();
   }


### PR DESCRIPTION
# What Does This Do
Ensure the serialization of a snapshot does not take more then 200ms to be done otherwise stop it and send it as is.
Add `notCapturedReason` for timeout in that case

# Motivation

# Additional Notes
