### PR TITLE
Fix Couchbase client race condition

### DIFF
--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/main/java/datadog/trace/instrumentation/couchbase_31/client/DatadogRequestSpan.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/main/java/datadog/trace/instrumentation/couchbase_31/client/DatadogRequestSpan.java
@@ -132,9 +132,9 @@ public class DatadogRequestSpan implements RequestSpan, StatusSettable<Integer> 
 
   @Override
   public void setSuccess(Integer context) {
-    if (context == 0 && shouldSetStatus()) {
-      span.setError(false);
-    }
+    // We can get a call to setSuccess from StatusSettingCompletableFuture before we intercept an
+    // exception.
+    // So do nothing here.
   }
 
   @Override

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/DatadogRequestSpan.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/DatadogRequestSpan.java
@@ -145,9 +145,9 @@ public class DatadogRequestSpan implements RequestSpan, StatusSettable<Integer> 
 
   @Override
   public void setSuccess(Integer context) {
-    if (context == 0 && shouldSetStatus()) {
-      span.setError(false);
-    }
+    // We can get a call to setSuccess from StatusSettingCompletableFuture before we intercept an
+    // exception.
+    // So do nothing here.
   }
 
   @Override


### PR DESCRIPTION


# What Does This Do

# Motivation
Under high load, we can observe Couchbase integration getting set to success early, and not getting set to error after an exception is raised.

This can fail on `CouchbaseClient32V0ForkedTest` and `CouchbaseClient32V1ForkedTest` suites, in the `check basic error spans` case. Example:

```
Condition failed with Exception:

assertTraces(1) { sortSpansByStart() trace(2) { // Span might have already been created, but still not marked as error. blockUntil { trace.any { it.isError() } } assertCouchbaseCall(it, "get", [ 'db.couchbase.collection' : '_default', 'db.couchbase.document_id': { String }, 'db.couchbase.retries'    : { Long }, 'db.couchbase.scope'      : '_default', 'db.couchbase.service'    : 'kv', 'db.name'                 : BUCKET, 'db.operation'            : 'get' ], false, ex) assertCouchbaseDispatchCall(it, span(0), [ 'db.couchbase.collection'     : '_default', 'db.couchbase.document_id'    : { String }, 'db.couchbase.scope'          : '_default', 'db.name'                     : BUCKET ]) } }

	at CouchbaseClient32Test.check basic error spans(CouchbaseClient32Test.groovy:121)
Caused by: java.util.concurrent.TimeoutException: Timed out waiting to satisfy condition
	at datadog.trace.agent.test.AgentTestRunner.blockUntil(AgentTestRunner.groovy:353)
	at groovy.lang.GroovyObject.invokeMethod(GroovyObject.java:39)
	at CouchbaseClient32Test.$spock_feature_3_1_closure12$_closure30(CouchbaseClient32Test.groovy:125)
```

[Example CI job](https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/22745/workflows/a6e901aa-3195-4357-8d7a-544c48cd1bb5/jobs/641580)

# Additional Notes
