### PR TITLE
lazy calculate peer service for client and precursors

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/rmi/RmiClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/rmi/RmiClientDecorator.java
@@ -1,9 +1,14 @@
 package datadog.trace.bootstrap.instrumentation.rmi;
 
+import datadog.trace.api.cache.DDCache;
+import datadog.trace.api.cache.DDCaches;
 import datadog.trace.api.naming.SpanNaming;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.ClientDecorator;
+import java.lang.reflect.Method;
 
 public class RmiClientDecorator extends ClientDecorator {
   public static final CharSequence RMI_INVOKE =
@@ -11,6 +16,9 @@ public class RmiClientDecorator extends ClientDecorator {
           SpanNaming.instance().namingSchema().client().operationForProtocol("rmi"));
   public static final CharSequence RMI_CLIENT = UTF8BytesString.create("rmi-client");
   public static final RmiClientDecorator DECORATE = new RmiClientDecorator();
+
+  private static final DDCache<Method, CharSequence> METHOD_CACHE =
+      DDCaches.newFixedSizeIdentityCache(32);
 
   @Override
   protected String[] instrumentationNames() {
@@ -30,5 +38,13 @@ public class RmiClientDecorator extends ClientDecorator {
   @Override
   protected String service() {
     return null;
+  }
+
+  public AgentSpan onMethodInvocation(final AgentSpan span, final Method method) {
+    span.setResourceName(spanNameForMethod(method));
+    span.setTag(
+        Tags.RPC_SERVICE,
+        METHOD_CACHE.computeIfAbsent(method, m -> m.getDeclaringClass().getName()));
+    return span;
   }
 }

--- a/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeBaseTest.groovy
+++ b/dd-java-agent/instrumentation/aerospike-4/src/test/groovy/datadog/trace/instrumentation/aerospike4/AerospikeBaseTest.groovy
@@ -62,6 +62,7 @@ abstract class AerospikeBaseTest extends VersionedNamingTestBase {
         "$Tags.PEER_PORT" aerospikePort
         "$Tags.DB_TYPE" "aerospike"
         "$Tags.DB_INSTANCE" "test"
+        peerServiceFrom(Tags.DB_INSTANCE)
         defaultTags()
       }
     }

--- a/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
@@ -154,7 +154,8 @@ abstract class AbstractCouchbaseTest extends VersionedNamingTestBase {
         if (bucketName != null) {
           "bucket" bucketName
         }
-        defaultTags()
+        //FIXME: check for peer.service when available
+        defaultTagsNoPeerService()
       }
     }
   }

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/test/groovy/CouchbaseClient31Test.groovy
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/test/groovy/CouchbaseClient31Test.groovy
@@ -392,8 +392,10 @@ abstract class CouchbaseClient31Test extends VersionedNamingTestBase {
         if (isLatestDepTest && extraTags != null) {
           tag('db.system','couchbase')
           addTags(extraTags)
+          peerServiceFrom(Tags.PEER_HOSTNAME)
         }
-        defaultTags()
+        //fixme: check peer service from seed nodes when the info will be available
+        defaultTags(false, isLatestDepTest && extraTags != null)
       }
     }
   }

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/test/groovy/CouchbaseClient32Test.groovy
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/test/groovy/CouchbaseClient32Test.groovy
@@ -372,7 +372,7 @@ abstract class CouchbaseClient32Test extends VersionedNamingTestBase {
     assertCouchbaseCall(trace, name, extraTags, null, internal, ex)
   }
 
-  void assertCouchbaseCall(TraceAssert trace, String name, Map<String, Serializable> extraTags, Object parentSpan, boolean internal = false, Throwable ex = null) {
+  void assertCouchbaseCall(TraceAssert trace, String name, Map<String, Serializable> extraTags, Object parentSpan, boolean internal = false, Throwable ex = null, boolean checkPeerService = false) {
     def opName = internal ? 'couchbase.internal' : operation()
     def isMeasured = !internal
     def isErrored = ex != null
@@ -404,7 +404,11 @@ abstract class CouchbaseClient32Test extends VersionedNamingTestBase {
         if (extraTags != null) {
           addTags(extraTags)
         }
-        defaultTags()
+        //fixme: check peer service from seed nodes when the info will be available
+        if (checkPeerService) {
+          peerServiceFrom('net.peer.name')
+        }
+        defaultTags(false, checkPeerService)
       }
     }
   }
@@ -423,7 +427,7 @@ abstract class CouchbaseClient32Test extends VersionedNamingTestBase {
     if (extraTags != null) {
       allExtraTags.putAll(extraTags)
     }
-    assertCouchbaseCall(trace, 'dispatch_to_server', allExtraTags, parentSpan, true)
+    assertCouchbaseCall(trace, 'dispatch_to_server', allExtraTags, parentSpan, true, null, true)
   }
 }
 

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/src/test/groovy/CassandraClientTest.groovy
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/src/test/groovy/CassandraClientTest.groovy
@@ -152,6 +152,7 @@ abstract class CassandraClientTest extends VersionedNamingTestBase {
         "$Tags.PEER_PORT" port
         "$Tags.DB_TYPE" "cassandra"
         "$Tags.DB_INSTANCE" keyspace
+        peerServiceFrom(Tags.PEER_HOSTNAME)
         defaultTags()
       }
     }

--- a/dd-java-agent/instrumentation/datastax-cassandra-4/src/test/groovy/CassandraClientTest.groovy
+++ b/dd-java-agent/instrumentation/datastax-cassandra-4/src/test/groovy/CassandraClientTest.groovy
@@ -233,6 +233,7 @@ abstract class CassandraClientTest extends VersionedNamingTestBase {
         if (throwable != null) {
           errorTags(throwable)
         }
+        peerServiceFrom(Tags.PEER_HOSTNAME)
         defaultTags()
       }
     }

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/src/test/groovy/Elasticsearch5RestClientTest.groovy
@@ -98,6 +98,7 @@ abstract class Elasticsearch5RestClientTest extends VersionedNamingTestBase {
             "$Tags.HTTP_URL" "_cluster/health"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.DB_TYPE" "elasticsearch"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -113,7 +114,7 @@ abstract class Elasticsearch5RestClientTest extends VersionedNamingTestBase {
             "$Tags.HTTP_URL" "_cluster/health"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 200
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -121,7 +122,7 @@ abstract class Elasticsearch5RestClientTest extends VersionedNamingTestBase {
   }
 }
 
-class Elasticsearch5RestClientV0ForkedTest extends Elasticsearch5RestClientTest {
+class Elasticsearch5RestClientV0Test extends Elasticsearch5RestClientTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/build.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/build.gradle
@@ -15,7 +15,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteForDir('latestDepTest', 'latestDepTest')
 
 dependencies {
   compileOnly group: 'org.elasticsearch', name: 'elasticsearch', version: '2.0.0'

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
@@ -82,7 +82,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -113,7 +113,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
             errorTags IndexNotFoundException, "no such index"
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -178,7 +178,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -194,7 +194,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -214,7 +214,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
             "elasticsearch.version"(-1)
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -232,7 +232,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" indexType
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -249,7 +249,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -269,7 +269,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
             "elasticsearch.version" 1
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
@@ -94,6 +94,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -125,7 +126,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
             errorTags RemoteTransportException, String
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -192,6 +193,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -211,6 +213,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -234,6 +237,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
             "elasticsearch.version"(-1)
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -255,6 +259,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" indexType
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -272,7 +277,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -295,6 +300,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
             "elasticsearch.version" 1
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -55,7 +55,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.search.types" "doc"
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -75,7 +75,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
     repo.index(doc) == doc
 
     and:
-    assertTraces(2) {
+    assertTraces(3) {
       trace(1) {
         span {
           resourceName "IndexAction"
@@ -89,7 +89,23 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" "doc"
-            defaultTags()
+            defaultTagsNoPeerService()
+          }
+        }
+      }
+      trace(1) {
+        span {
+          resourceName "PutMappingAction"
+          operationName "elasticsearch.query"
+          spanType DDSpanTypes.ELASTICSEARCH
+          tags {
+            "$Tags.COMPONENT" "elasticsearch-java"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "PutMappingAction"
+            "elasticsearch.request" "PutMappingRequest"
+            "elasticsearch.request.indices" indexName
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -108,7 +124,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.shard.broadcast.failed" 0
             "elasticsearch.shard.broadcast.successful" 5
             "elasticsearch.shard.broadcast.total" 10
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -136,7 +152,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.type" "doc"
             "elasticsearch.id" "1"
             "elasticsearch.version" Number
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -165,7 +181,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" "doc"
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -184,7 +200,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.shard.broadcast.failed" 0
             "elasticsearch.shard.broadcast.successful" 5
             "elasticsearch.shard.broadcast.total" 10
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -204,7 +220,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.type" "doc"
             "elasticsearch.id" "1"
             "elasticsearch.version" Number
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -232,7 +248,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.request" "DeleteRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" "doc"
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -251,7 +267,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.shard.broadcast.failed" 0
             "elasticsearch.shard.broadcast.successful" 5
             "elasticsearch.shard.broadcast.total" 10
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -269,7 +285,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.search.types" "doc"
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -87,7 +87,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
             errorTags IndexNotFoundException, "no such index"
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -144,7 +144,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -160,7 +160,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -178,7 +178,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.search.types" indexType
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -196,7 +196,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" indexType
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -213,7 +213,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -233,7 +233,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "elasticsearch.shard.broadcast.failed" 0
             "elasticsearch.shard.broadcast.successful" 5
             "elasticsearch.shard.broadcast.total" 10
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -251,7 +251,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.search.types" indexType
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -335,7 +335,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -78,7 +78,7 @@ abstract class Elasticsearch2NodeClientTest extends VersionedNamingTestBase {
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -109,7 +109,7 @@ abstract class Elasticsearch2NodeClientTest extends VersionedNamingTestBase {
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
             errorTags IndexNotFoundException, "no such index"
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -174,7 +174,7 @@ abstract class Elasticsearch2NodeClientTest extends VersionedNamingTestBase {
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -190,7 +190,7 @@ abstract class Elasticsearch2NodeClientTest extends VersionedNamingTestBase {
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -212,6 +212,7 @@ abstract class Elasticsearch2NodeClientTest extends VersionedNamingTestBase {
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
             "elasticsearch.version"(-1)
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -232,6 +233,7 @@ abstract class Elasticsearch2NodeClientTest extends VersionedNamingTestBase {
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" indexType
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -249,7 +251,7 @@ abstract class Elasticsearch2NodeClientTest extends VersionedNamingTestBase {
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -271,6 +273,7 @@ abstract class Elasticsearch2NodeClientTest extends VersionedNamingTestBase {
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
             "elasticsearch.version" 1
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -287,7 +290,7 @@ abstract class Elasticsearch2NodeClientTest extends VersionedNamingTestBase {
   }
 }
 
-class Elasticsearch2NodeClientV0ForkedTest extends Elasticsearch2NodeClientTest {
+class Elasticsearch2NodeClientV0Test extends Elasticsearch2NodeClientTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -97,6 +97,7 @@ abstract class Elasticsearch2TransportClientTest extends VersionedNamingTestBase
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -132,6 +133,7 @@ abstract class Elasticsearch2TransportClientTest extends VersionedNamingTestBase
             "elasticsearch.action" "ClusterStatsAction"
             "elasticsearch.request" "ClusterStatsRequest"
             "elasticsearch.node.cluster.name" clusterName
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -163,7 +165,7 @@ abstract class Elasticsearch2TransportClientTest extends VersionedNamingTestBase
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
             errorTags RemoteTransportException, String
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -230,6 +232,7 @@ abstract class Elasticsearch2TransportClientTest extends VersionedNamingTestBase
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -249,6 +252,7 @@ abstract class Elasticsearch2TransportClientTest extends VersionedNamingTestBase
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -272,6 +276,7 @@ abstract class Elasticsearch2TransportClientTest extends VersionedNamingTestBase
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
             "elasticsearch.version"(-1)
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -293,6 +298,7 @@ abstract class Elasticsearch2TransportClientTest extends VersionedNamingTestBase
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" indexType
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -310,7 +316,7 @@ abstract class Elasticsearch2TransportClientTest extends VersionedNamingTestBase
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -333,6 +339,7 @@ abstract class Elasticsearch2TransportClientTest extends VersionedNamingTestBase
             "elasticsearch.type" indexType
             "elasticsearch.id" "1"
             "elasticsearch.version" 1
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -349,7 +356,7 @@ abstract class Elasticsearch2TransportClientTest extends VersionedNamingTestBase
   }
 }
 
-class Elasticsearch2TransportClientV0ForkedTest extends Elasticsearch2TransportClientTest {
+class Elasticsearch2TransportClientV0Test extends Elasticsearch2TransportClientTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -65,7 +65,7 @@ abstract class Elasticsearch2SpringRepositoryTest extends VersionedNamingTestBas
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.search.types" "doc"
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -101,6 +101,7 @@ abstract class Elasticsearch2SpringRepositoryTest extends VersionedNamingTestBas
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" "doc"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -120,7 +121,7 @@ abstract class Elasticsearch2SpringRepositoryTest extends VersionedNamingTestBas
             "elasticsearch.shard.broadcast.failed" 0
             "elasticsearch.shard.broadcast.successful" 5
             "elasticsearch.shard.broadcast.total" 10
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -150,6 +151,7 @@ abstract class Elasticsearch2SpringRepositoryTest extends VersionedNamingTestBas
             "elasticsearch.type" "doc"
             "elasticsearch.id" "1"
             "elasticsearch.version" Number
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -181,6 +183,7 @@ abstract class Elasticsearch2SpringRepositoryTest extends VersionedNamingTestBas
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" "doc"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -200,7 +203,7 @@ abstract class Elasticsearch2SpringRepositoryTest extends VersionedNamingTestBas
             "elasticsearch.shard.broadcast.failed" 0
             "elasticsearch.shard.broadcast.successful" 5
             "elasticsearch.shard.broadcast.total" 10
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -222,6 +225,7 @@ abstract class Elasticsearch2SpringRepositoryTest extends VersionedNamingTestBas
             "elasticsearch.type" "doc"
             "elasticsearch.id" "1"
             "elasticsearch.version" Number
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -252,6 +256,7 @@ abstract class Elasticsearch2SpringRepositoryTest extends VersionedNamingTestBas
             "elasticsearch.request" "DeleteRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" "doc"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -271,7 +276,7 @@ abstract class Elasticsearch2SpringRepositoryTest extends VersionedNamingTestBas
             "elasticsearch.shard.broadcast.failed" 0
             "elasticsearch.shard.broadcast.successful" 5
             "elasticsearch.shard.broadcast.total" 10
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -289,7 +294,7 @@ abstract class Elasticsearch2SpringRepositoryTest extends VersionedNamingTestBas
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.search.types" "doc"
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -300,7 +305,7 @@ abstract class Elasticsearch2SpringRepositoryTest extends VersionedNamingTestBas
   }
 }
 
-class Elasticsearch2SpringRepositoryV0ForkedTest extends Elasticsearch2SpringRepositoryTest {
+class Elasticsearch2SpringRepositoryV0Test extends Elasticsearch2SpringRepositoryTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -86,7 +86,7 @@ abstract class Elasticsearch2SpringTemplateTest extends VersionedNamingTestBase 
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
             errorTags IndexNotFoundException, "no such index"
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -143,7 +143,7 @@ abstract class Elasticsearch2SpringTemplateTest extends VersionedNamingTestBase 
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -159,7 +159,7 @@ abstract class Elasticsearch2SpringTemplateTest extends VersionedNamingTestBase 
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -177,7 +177,7 @@ abstract class Elasticsearch2SpringTemplateTest extends VersionedNamingTestBase 
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.search.types" indexType
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -197,6 +197,7 @@ abstract class Elasticsearch2SpringTemplateTest extends VersionedNamingTestBase 
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.write.type" indexType
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -214,7 +215,7 @@ abstract class Elasticsearch2SpringTemplateTest extends VersionedNamingTestBase 
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -234,7 +235,7 @@ abstract class Elasticsearch2SpringTemplateTest extends VersionedNamingTestBase 
             "elasticsearch.shard.broadcast.failed" 0
             "elasticsearch.shard.broadcast.successful" 5
             "elasticsearch.shard.broadcast.total" 10
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -252,7 +253,7 @@ abstract class Elasticsearch2SpringTemplateTest extends VersionedNamingTestBase 
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
             "elasticsearch.request.search.types" indexType
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -336,7 +337,7 @@ abstract class Elasticsearch2SpringTemplateTest extends VersionedNamingTestBase 
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -350,7 +351,7 @@ abstract class Elasticsearch2SpringTemplateTest extends VersionedNamingTestBase 
   }
 }
 
-class Elasticsearch2SpringTemplateV0ForkedTest extends Elasticsearch2SpringTemplateTest {
+class Elasticsearch2SpringTemplateV0Test extends Elasticsearch2SpringTemplateTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
@@ -152,9 +152,11 @@ abstract class GrpcStreamingTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "grpc-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.RPC_SERVICE" "example.Greeter"
             "status.code" "OK"
             "request.type" "example.Helloworld\$Response"
             "response.type" "example.Helloworld\$Response"
+            peerServiceFrom(Tags.RPC_SERVICE)
             defaultTags()
           }
         }
@@ -169,7 +171,7 @@ abstract class GrpcStreamingTest extends VersionedNamingTestBase {
               "$Tags.COMPONENT" "grpc-client"
               "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
               "message.type" "example.Helloworld\$Response"
-              defaultTags()
+              defaultTagsNoPeerService()
             }
           }
         }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -145,12 +145,14 @@ abstract class GrpcTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "grpc-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.RPC_SERVICE" "example.Greeter"
             "status.code" "OK"
             "request.type" "example.Helloworld\$Request"
             "response.type" "example.Helloworld\$Response"
             if ({ isDataStreamsEnabled() }) {
               "$DDTags.PATHWAY_HASH" { String }
             }
+            peerServiceFrom(Tags.RPC_SERVICE)
             defaultTags()
           }
         }
@@ -165,7 +167,7 @@ abstract class GrpcTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "grpc-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "message.type" "example.Helloworld\$Response"
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -283,6 +285,7 @@ abstract class GrpcTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "grpc-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.RPC_SERVICE" "example.Greeter"
             "status.code" "${status.code.name()}"
             "status.description" description
             "request.type" "example.Helloworld\$Request"
@@ -290,6 +293,7 @@ abstract class GrpcTest extends VersionedNamingTestBase {
             if ({ isDataStreamsEnabled() }) {
               "$DDTags.PATHWAY_HASH" { String }
             }
+            peerServiceFrom(Tags.RPC_SERVICE)
             defaultTags()
           }
         }
@@ -383,12 +387,14 @@ abstract class GrpcTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "grpc-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.RPC_SERVICE" "example.Greeter"
             "status.code" "UNKNOWN"
             "request.type" "example.Helloworld\$Request"
             "response.type" "example.Helloworld\$Response"
             if ({ isDataStreamsEnabled() }) {
               "$DDTags.PATHWAY_HASH" { String }
             }
+            peerServiceFrom(Tags.RPC_SERVICE)
             defaultTags()
           }
         }
@@ -570,12 +576,14 @@ abstract class GrpcTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "grpc-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.RPC_SERVICE" "example.Greeter"
             "status.code" "OK"
             "request.type" "example.Helloworld\$Request"
             "response.type" "example.Helloworld\$Response"
             if ({ isDataStreamsEnabled() }) {
               "$DDTags.PATHWAY_HASH" { String }
             }
+            peerServiceFrom(Tags.RPC_SERVICE)
             defaultTags()
           }
         }
@@ -590,7 +598,7 @@ abstract class GrpcTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "grpc-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "message.type" "example.Helloworld\$Response"
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }

--- a/dd-java-agent/instrumentation/hazelcast-3.6/src/test/groovy/test/hazelcast/v3/HazelcastTest.groovy
+++ b/dd-java-agent/instrumentation/hazelcast-3.6/src/test/groovy/test/hazelcast/v3/HazelcastTest.groovy
@@ -341,6 +341,7 @@ abstract class HazelcastTest extends VersionedNamingTestBase {
         "hazelcast.operation" matcher.group("operation")
         "hazelcast.service" "hz:impl:${matcher.group("service")}Service"
         "hazelcast.instance" client.name
+        peerServiceFrom("hazelcast.instance")
         defaultTags()
       }
     }

--- a/dd-java-agent/instrumentation/hazelcast-3.9/src/test/groovy/test/hazelcast/v39/HazelcastTest.groovy
+++ b/dd-java-agent/instrumentation/hazelcast-3.9/src/test/groovy/test/hazelcast/v39/HazelcastTest.groovy
@@ -397,6 +397,7 @@ abstract class HazelcastTest extends VersionedNamingTestBase {
         "hazelcast.service" matcher.group("service")
         "hazelcast.instance" client.name
         "hazelcast.correlationId" Long
+        peerServiceFrom("hazelcast.instance")
         defaultTags()
       }
     }

--- a/dd-java-agent/instrumentation/hazelcast-4.0/src/test/groovy/test/hazelcast/v4/HazelcastTest.groovy
+++ b/dd-java-agent/instrumentation/hazelcast-4.0/src/test/groovy/test/hazelcast/v4/HazelcastTest.groovy
@@ -105,7 +105,7 @@ abstract class HazelcastTest extends VersionedNamingTestBase {
           "hazelcast.operation" "Event.Handle"
           "hazelcast.service" "Event"
           "hazelcast.correlationId" Long
-          defaultTags()
+          defaultTagsNoPeerService()
         }
       }
     }
@@ -141,6 +141,7 @@ abstract class HazelcastTest extends VersionedNamingTestBase {
         "hazelcast.service" matcher.group("service")
         "hazelcast.instance" client.name
         "hazelcast.correlationId" Long
+        peerServiceFrom("hazelcast.instance")
         defaultTags()
       }
     }

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
@@ -105,7 +105,7 @@ abstract class UrlConnectionTest extends VersionedNamingTestBase {
             // FIXME: These tags really make no sense for non-http connections, why do we set them?
             "$Tags.HTTP_URL" "$url"
             errorTags IllegalArgumentException, String
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }

--- a/dd-java-agent/instrumentation/ignite-2.0/src/test/groovy/test/AbstractIgniteTest.groovy
+++ b/dd-java-agent/instrumentation/ignite-2.0/src/test/groovy/test/AbstractIgniteTest.groovy
@@ -79,7 +79,7 @@ abstract class AbstractIgniteTest extends VersionedNamingTestBase {
           "ignite.instance" igniteClient.name()
         }
         "ignite.version" igniteClient.version().toString()
-        defaultTags()
+        defaultTagsNoPeerService()
       }
     }
   }

--- a/dd-java-agent/instrumentation/ignite-2.0/src/test/groovy/test/IgniteCacheFailureTest.groovy
+++ b/dd-java-agent/instrumentation/ignite-2.0/src/test/groovy/test/IgniteCacheFailureTest.groovy
@@ -100,7 +100,7 @@ abstract class IgniteCacheFailureTest extends VersionedNamingTestBase {
             }
             "ignite.version" igniteClient.version().toString()
             errorTags(ex.class, ex.message)
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -142,7 +142,7 @@ abstract class IgniteCacheFailureTest extends VersionedNamingTestBase {
             }
             "ignite.version" igniteClient.version().toString()
             errorTags(ex.class, ex.message)
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }

--- a/dd-java-agent/instrumentation/ignite-2.0/src/test/groovy/test/IgniteCacheSyncTest.groovy
+++ b/dd-java-agent/instrumentation/ignite-2.0/src/test/groovy/test/IgniteCacheSyncTest.groovy
@@ -130,7 +130,7 @@ abstract class IgniteCacheSyncTest extends AbstractIgniteTest {
               "ignite.instance" igniteClient.name()
             }
             "ignite.version" igniteClient.version().toString()
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -189,7 +189,7 @@ abstract class IgniteCacheSyncTest extends AbstractIgniteTest {
               "ignite.instance" igniteClient.name()
             }
             "ignite.version" igniteClient.version().toString()
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -241,7 +241,7 @@ abstract class IgniteCacheSyncTest extends AbstractIgniteTest {
               "ignite.instance" igniteClient.name()
             }
             "ignite.version" igniteClient.version().toString()
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }

--- a/dd-java-agent/instrumentation/jdbc/scalikejdbc/src/test/groovy/ScalikeJDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/scalikejdbc/src/test/groovy/ScalikeJDBCInstrumentationTest.groovy
@@ -159,6 +159,7 @@ class ScalikeJDBCInstrumentationTest extends AgentTestRunner {
               "$Tags.DB_USER" username
             }
             "$Tags.DB_OPERATION" "SELECT"
+            peerServiceFrom(Tags.DB_INSTANCE)
             defaultTags()
           }
         }
@@ -171,7 +172,7 @@ class ScalikeJDBCInstrumentationTest extends AgentTestRunner {
           errored false
           tags {
             "$Tags.COMPONENT" "java-jdbc-connection"
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTestBase.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTestBase.groovy
@@ -201,6 +201,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
             if (addDbmTag) {
               "$InstrumentationTags.DBM_TRACE_INJECTED" true
             }
+            peerServiceFrom(Tags.DB_INSTANCE)
             defaultTags()
           }
         }
@@ -272,6 +273,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
             // since Connection.getClientInfo will not provide the username
             "$Tags.DB_USER" jdbcUserNames.get(driver)
             "$Tags.DB_OPERATION" operation
+            peerServiceFrom(Tags.DB_INSTANCE)
             defaultTags()
           }
         }
@@ -326,6 +328,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
             // since Connection.getClientInfo will not provide the username
             "$Tags.DB_USER" jdbcUserNames.get(driver)
             "$Tags.DB_OPERATION" operation
+            peerServiceFrom(Tags.DB_INSTANCE)
             defaultTags()
           }
         }
@@ -380,6 +383,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
             // since Connection.getClientInfo will not provide the username
             "$Tags.DB_USER" jdbcUserNames.get(driver)
             "${Tags.DB_OPERATION}" operation
+            peerServiceFrom(Tags.DB_INSTANCE)
             defaultTags()
           }
         }
@@ -437,6 +441,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
             if (addDbmTag) {
               "$InstrumentationTags.DBM_TRACE_INJECTED" true
             }
+            peerServiceFrom(Tags.DB_INSTANCE)
             defaultTags()
           }
         }
@@ -493,6 +498,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
               "$Tags.DB_USER" username
             }
             "$Tags.DB_OPERATION" operation
+            peerServiceFrom(Tags.DB_INSTANCE)
             defaultTags()
           }
         }
@@ -569,6 +575,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
             if (addDbmTag && !prepareStatement) {
               "$InstrumentationTags.DBM_TRACE_INJECTED" true
             }
+            peerServiceFrom(Tags.DB_INSTANCE)
             defaultTags()
           }
         }
@@ -619,7 +626,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
           childOf span(0)
           tags {
             "$Tags.COMPONENT" "java-jdbc-connection"
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
         if (recursive) {
@@ -629,7 +636,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
             childOf span(1)
             tags {
               "$Tags.COMPONENT" "java-jdbc-connection"
-              defaultTags()
+              defaultTagsNoPeerService()
             }
           }
         }
@@ -683,7 +690,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
             if (addDbmTag) {
               "$InstrumentationTags.DBM_TRACE_INJECTED" true
             }
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -752,6 +759,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
             "$Tags.DB_INSTANCE" dbName.toLowerCase()
             "$Tags.DB_USER" "SA"
             "$Tags.DB_OPERATION" "SELECT"
+            peerServiceFrom(Tags.DB_INSTANCE)
             defaultTags()
           }
         }
@@ -771,6 +779,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
               "$Tags.DB_INSTANCE" dbName.toLowerCase()
               "$Tags.DB_USER" "SA"
               "$Tags.DB_OPERATION" "SELECT"
+              peerServiceFrom(Tags.DB_INSTANCE)
               defaultTags()
             }
           }

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCWrappedInterfacesTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCWrappedInterfacesTest.groovy
@@ -259,7 +259,7 @@ class JDBCWrappedInterfacesTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "${database}"
             "$Tags.DB_OPERATION" "${operation}"
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
@@ -220,6 +220,7 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
             if (addDbmTag) {
               "$InstrumentationTags.DBM_TRACE_INJECTED" true
             }
+            peerServiceFrom(Tags.DB_INSTANCE)
             defaultTags()
           }
         }
@@ -280,6 +281,7 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
             // since Connection.getClientInfo will not provide the username
             "$Tags.DB_USER" { it == null || it == jdbcUserNames.get(driver) }
             "$Tags.DB_OPERATION" operation
+            peerServiceFrom(Tags.DB_INSTANCE)
             defaultTags()
           }
         }
@@ -338,6 +340,7 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
             // since Connection.getClientInfo will not provide the username
             "$Tags.DB_USER" { it == null || it == jdbcUserNames.get(driver) }
             "$Tags.DB_OPERATION" operation
+            peerServiceFrom(Tags.DB_INSTANCE)
             defaultTags()
           }
         }
@@ -458,6 +461,7 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
             if (addDbmTag) {
               "$InstrumentationTags.DBM_TRACE_INJECTED" true
             }
+            peerServiceFrom(Tags.DB_INSTANCE)
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/jedis-1.4/src/test/groovy/JedisClientTest.groovy
+++ b/dd-java-agent/instrumentation/jedis-1.4/src/test/groovy/JedisClientTest.groovy
@@ -99,6 +99,7 @@ abstract class JedisClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -114,6 +115,7 @@ abstract class JedisClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -141,6 +143,7 @@ abstract class JedisClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -156,6 +159,7 @@ abstract class JedisClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -164,7 +168,7 @@ abstract class JedisClientTest extends VersionedNamingTestBase {
   }
 }
 
-class JedisClientV0ForkedTest extends JedisClientTest {
+class JedisClientV0Test extends JedisClientTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
+++ b/dd-java-agent/instrumentation/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
@@ -71,6 +71,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -98,6 +99,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -114,7 +116,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
-
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -143,6 +145,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -159,6 +162,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -192,6 +196,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -207,6 +212,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -243,6 +249,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -258,6 +265,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -273,6 +281,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -288,6 +297,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -303,6 +313,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -311,7 +322,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
   }
 }
 
-class Jedis30ClientV0ForkedTest extends Jedis30ClientTest {
+class Jedis30ClientV0Test extends Jedis30ClientTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/jedis-4.0/src/test/groovy/Jedis40ClientTest.groovy
+++ b/dd-java-agent/instrumentation/jedis-4.0/src/test/groovy/Jedis40ClientTest.groovy
@@ -71,6 +71,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -98,7 +99,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
-            defaultTags()
+            peerServiceFrom(Tags.PEER_HOSTNAME)
           }
         }
       }
@@ -114,6 +115,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -142,6 +144,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -158,6 +161,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -191,6 +195,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -206,6 +211,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -242,6 +248,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -257,6 +264,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -272,6 +280,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -287,6 +296,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -302,6 +312,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
             "$Tags.PEER_HOSTNAME" "localhost"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/JMS2Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/JMS2Test.groovy
@@ -228,7 +228,7 @@ class JMS2Test extends AgentTestRunner {
         tags {
           "$Tags.COMPONENT" "jms"
           "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
-          defaultTags()
+          defaultTagsNoPeerService()
         }
       }
     }
@@ -250,7 +250,7 @@ class JMS2Test extends AgentTestRunner {
           if (!isTimestampDisabled) {
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" {it >= 0 }
           }
-          defaultTags(true)
+          defaultTagsNoPeerService(true)
         }
       }
     }

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
@@ -477,7 +477,7 @@ class JMS1Test extends AgentTestRunner {
             "$Tags.COMPONENT" "jms"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -591,7 +591,7 @@ class JMS1Test extends AgentTestRunner {
               "$Tags.COMPONENT" "jms"
               "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
               "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
-              defaultTags()
+              defaultTagsNoPeerService()
             }
           }
         }
@@ -644,7 +644,7 @@ class JMS1Test extends AgentTestRunner {
               "$Tags.COMPONENT" "jms"
               "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
               "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
-              defaultTags()
+              defaultTagsNoPeerService()
             }
           }
         }
@@ -704,7 +704,7 @@ class JMS1Test extends AgentTestRunner {
               "$Tags.COMPONENT" "jms"
               "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
               "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
-              defaultTags()
+              defaultTagsNoPeerService()
             }
           }
         }
@@ -896,7 +896,7 @@ class JMS1Test extends AgentTestRunner {
       tags {
         "$Tags.COMPONENT" "jms"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
-        defaultTags()
+        defaultTagsNoPeerService()
       }
     }
   }
@@ -923,7 +923,7 @@ class JMS1Test extends AgentTestRunner {
         if (!isTimestampDisabled) {
           "$InstrumentationTags.RECORD_QUEUE_TIME_MS" { it >= 0 }
         }
-        defaultTags(true)
+        defaultTagsNoPeerService(true)
       }
     }
   }

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/TimeInQueueForkedTest.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/TimeInQueueForkedTest.groovy
@@ -587,7 +587,7 @@ abstract class TimeInQueueForkedTestBase extends VersionedNamingTestBase {
       tags {
         "$Tags.COMPONENT" "jms"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
-        defaultTags()
+        defaultTagsNoPeerService()
       }
     }
   }
@@ -631,7 +631,7 @@ abstract class TimeInQueueForkedTestBase extends VersionedNamingTestBase {
       tags {
         "$Tags.COMPONENT" "jms"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_BROKER
-        defaultTags(true)
+        defaultTagsNoPeerService(true)
       }
     }
   }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTest.groovy
@@ -9,6 +9,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.Producer
+import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.serialization.StringSerializer
@@ -133,6 +134,8 @@ class KafkaClientTest extends AgentTestRunner {
             if ({ isDataStreamsEnabled() }) {
               "$DDTags.PATHWAY_HASH" { String }
             }
+            "$InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS" producerProps.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
+            peerServiceFrom(InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS)
             defaultTags()
           }
         }
@@ -262,6 +265,8 @@ class KafkaClientTest extends AgentTestRunner {
             if ({ isDataStreamsEnabled()}) {
               "$DDTags.PATHWAY_HASH" { String }
             }
+            "$InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS" producerProps.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
+            peerServiceFrom(InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS)
             defaultTags()
           }
         }
@@ -384,6 +389,8 @@ class KafkaClientTest extends AgentTestRunner {
             if ({ isDataStreamsEnabled()}) {
               "$DDTags.PATHWAY_HASH" { String }
             }
+            "$InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS" producerProps.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
+            peerServiceFrom(InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS)
             defaultTags()
           }
         }
@@ -473,6 +480,8 @@ class KafkaClientTest extends AgentTestRunner {
             if ({ isDataStreamsEnabled()}) {
               "$DDTags.PATHWAY_HASH" { String }
             }
+            "$InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS" producerProps.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
+            peerServiceFrom(InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS)
             defaultTags(true)
           }
         }
@@ -564,6 +573,8 @@ class KafkaClientTest extends AgentTestRunner {
             if ({ isDataStreamsEnabled()}) {
               "$DDTags.PATHWAY_HASH" { String }
             }
+            "$InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS" producerProps.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
+            peerServiceFrom(InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS)
             defaultTags(true)
           }
         }
@@ -583,6 +594,8 @@ class KafkaClientTest extends AgentTestRunner {
             if ({ isDataStreamsEnabled()}) {
               "$DDTags.PATHWAY_HASH" { String }
             }
+            "$InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS" producerProps.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
+            peerServiceFrom(InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS)
             defaultTags(true)
           }
         }
@@ -602,6 +615,8 @@ class KafkaClientTest extends AgentTestRunner {
             if ({ isDataStreamsEnabled()}) {
               "$DDTags.PATHWAY_HASH" { String }
             }
+            "$InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS" producerProps.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
+            peerServiceFrom(InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS)
             defaultTags(true)
           }
         }
@@ -829,6 +844,8 @@ class KafkaClientTest extends AgentTestRunner {
             if ({ isDataStreamsEnabled()}) {
               "$DDTags.PATHWAY_HASH" { String }
             }
+            "$InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS" producerProps.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
+            peerServiceFrom(InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS)
             defaultTags()
           }
         }
@@ -846,6 +863,8 @@ class KafkaClientTest extends AgentTestRunner {
             if ({ isDataStreamsEnabled()}) {
               "$DDTags.PATHWAY_HASH" { String }
             }
+            "$InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS" producerProps.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
+            peerServiceFrom(InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS)
             defaultTags()
           }
         }
@@ -863,6 +882,8 @@ class KafkaClientTest extends AgentTestRunner {
             if ({ isDataStreamsEnabled()}) {
               "$DDTags.PATHWAY_HASH" { String }
             }
+            "$InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS" producerProps.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
+            peerServiceFrom(InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS)
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
@@ -898,6 +898,7 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
         if ({isDataStreamsEnabled()}) {
           "$DDTags.PATHWAY_HASH" { String }
         }
+        peerServiceFrom(InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS)
         defaultTags()
       }
     }

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/latestDepTest/groovy/KafkaStreamsTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/latestDepTest/groovy/KafkaStreamsTest.groovy
@@ -134,7 +134,7 @@ class KafkaStreamsTest extends AgentTestRunner {
             if ({ isDataStreamsEnabled()}) {
               "$DDTags.PATHWAY_HASH" { String }
             }
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -183,7 +183,7 @@ class KafkaStreamsTest extends AgentTestRunner {
             if ({ isDataStreamsEnabled()}) {
               "$DDTags.PATHWAY_HASH" { String }
             }
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTestBase.groovy
@@ -160,7 +160,7 @@ abstract class KafkaStreamsTestBase extends VersionedNamingTestBase {
             if ({ isDataStreamsEnabled() }){
               "$DDTags.PATHWAY_HASH" { String }
             }
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }
@@ -226,7 +226,7 @@ abstract class KafkaStreamsTestBase extends VersionedNamingTestBase {
             if ({isDataStreamsEnabled()}) {
               "$DDTags.PATHWAY_HASH" { String }
             }
-            defaultTags()
+            defaultTagsNoPeerService()
           }
         }
       }

--- a/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4AsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4AsyncClientTest.groovy
@@ -126,6 +126,7 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -165,6 +166,7 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
             errorTags RedisConnectionException, String
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -195,6 +197,7 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -236,6 +239,7 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -291,6 +295,7 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -332,6 +337,7 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -392,6 +398,7 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -411,6 +418,7 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -460,6 +468,7 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
             errorTags(IllegalStateException, "TestException")
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -503,6 +512,7 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
             "db.command.cancelled" true
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -531,6 +541,7 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -560,6 +571,7 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -568,7 +580,7 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
   }
 }
 
-class Lettuce4AsyncClientV0ForkedTest extends Lettuce4AsyncClientTest {
+class Lettuce4AsyncClientV0Test extends Lettuce4AsyncClientTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4SyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4SyncClientTest.groovy
@@ -107,6 +107,7 @@ abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -144,6 +145,7 @@ abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
             errorTags RedisConnectionException, String
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -173,6 +175,7 @@ abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -202,6 +205,7 @@ abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -231,6 +235,7 @@ abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -260,6 +265,7 @@ abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -289,6 +295,7 @@ abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -318,6 +325,7 @@ abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -347,6 +355,7 @@ abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -375,6 +384,7 @@ abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -403,6 +413,7 @@ abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -411,7 +422,7 @@ abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
   }
 }
 
-class Lettuce4SyncClientV0ForkedTest extends Lettuce4SyncClientTest {
+class Lettuce4SyncClientV0Test extends Lettuce4SyncClientTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5AsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5AsyncClientTest.groovy
@@ -130,6 +130,7 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -170,6 +171,7 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
             errorTags CompletionException, String
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -200,6 +202,7 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -241,6 +244,7 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -296,6 +300,7 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -337,6 +342,7 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -397,6 +403,7 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -416,6 +423,7 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -465,6 +473,7 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
             errorTags(IllegalStateException, "TestException")
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -508,6 +517,7 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
             "db.command.cancelled" true
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -536,6 +546,7 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -565,6 +576,7 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -573,7 +585,7 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
   }
 }
 
-class Lettuce5SyncClientV0ForkedTest extends Lettuce5AsyncClientTest {
+class Lettuce5SyncClientV0Test extends Lettuce5AsyncClientTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
@@ -116,6 +116,7 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -148,6 +149,7 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -187,6 +189,7 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -224,6 +227,7 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -253,6 +257,7 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
             "db.command.results.count" 157
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -283,6 +288,7 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
             "db.redis.dbIndex" 0
             "db.command.cancelled" true
             "db.command.results.count" 2
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -323,6 +329,7 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -351,6 +358,7 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -397,6 +405,7 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -415,6 +424,7 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -458,6 +468,7 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
             "db.command.results.count" 157
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -476,6 +487,7 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -521,6 +533,7 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -539,6 +552,7 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -585,6 +599,7 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -603,6 +618,7 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -611,7 +627,7 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
   }
 }
 
-class Lettuce5ReactiveClientV0ForkedTest extends Lettuce5ReactiveClientTest {
+class Lettuce5ReactiveClientV0Test extends Lettuce5ReactiveClientTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5SyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5SyncClientTest.groovy
@@ -109,6 +109,7 @@ abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -146,6 +147,7 @@ abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
             errorTags CompletionException, String
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -175,6 +177,7 @@ abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -204,6 +207,7 @@ abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -230,6 +234,7 @@ abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -259,6 +264,7 @@ abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -288,6 +294,7 @@ abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -317,6 +324,7 @@ abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -346,6 +354,7 @@ abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -374,6 +383,7 @@ abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -402,6 +412,7 @@ abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -409,7 +420,7 @@ abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
     }
   }
 }
-class Lettuce5AsyncClientV0ForkedTest extends Lettuce5AsyncClientTest {
+class Lettuce5AsyncClientV0Test extends Lettuce5AsyncClientTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/mongo/driver-3.1-core-test/src/test/groovy/MongoCore31ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1-core-test/src/test/groovy/MongoCore31ClientTest.groovy
@@ -245,7 +245,7 @@ abstract class MongoCore31ClientTest extends MongoBaseTest {
   }
 }
 
-class MongoCore31ClientV0ForkedTest extends MongoCore31ClientTest {
+class MongoCore31ClientV0Test extends MongoCore31ClientTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoJava31ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoJava31ClientTest.groovy
@@ -247,7 +247,7 @@ abstract class MongoJava31ClientTest extends MongoBaseTest {
   }
 }
 
-class MongoJava31ClientV0ForkedTest extends MongoJava31ClientTest {
+class MongoJava31ClientV0Test extends MongoJava31ClientTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/mongo/driver-3.10-sync-test/src/test/groovy/MongoSyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.10-sync-test/src/test/groovy/MongoSyncClientTest.groovy
@@ -232,7 +232,7 @@ abstract class MongoSyncClientTest extends MongoBaseTest {
   }
 }
 
-class MongoSyncClientV0ForkedTest extends MongoSyncClientTest {
+class MongoSyncClientV0Test extends MongoSyncClientTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/mongo/driver-3.3-async-test/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.3-async-test/src/test/groovy/MongoAsyncClientTest.groovy
@@ -229,7 +229,7 @@ abstract class MongoAsyncClientTest extends MongoBaseTest {
   }
 }
 
-class MongoAsyncClientV0ForkedTest extends MongoAsyncClientTest {
+class MongoAsyncClientV0Test extends MongoAsyncClientTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/mongo/driver-3.4/src/test/groovy/MongoJava34ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.4/src/test/groovy/MongoJava34ClientTest.groovy
@@ -245,7 +245,7 @@ abstract class MongoJava34ClientTest extends MongoBaseTest {
   }
 }
 
-class MongoJava34ClientV0ForkedTest extends MongoJava34ClientTest {
+class MongoJava34ClientV0Test extends MongoJava34ClientTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/mongo/driver-3.7-core-test/src/test/groovy/MongoCore37ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.7-core-test/src/test/groovy/MongoCore37ClientTest.groovy
@@ -232,7 +232,7 @@ abstract class MongoCore37ClientTest extends MongoBaseTest {
   }
 }
 
-class MongoCore37ClientV0ForkedTest extends MongoCore37ClientTest {
+class MongoCore37ClientV0Test extends MongoCore37ClientTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/Mongo4ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/Mongo4ClientTest.groovy
@@ -232,7 +232,7 @@ abstract class Mongo4ClientTest extends MongoBaseTest {
   }
 }
 
-class Mongo4ClientV0ForkedTest extends Mongo4ClientTest {
+class Mongo4ClientV0Test extends Mongo4ClientTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/MongoReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/MongoReactiveClientTest.groovy
@@ -396,7 +396,7 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
   }
 }
 
-class MongoReactiveClientV0ForkedTest extends MongoReactiveClientTest {
+class MongoReactiveClientV0Test extends MongoReactiveClientTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/mongo/src/test/groovy/MongoBaseTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/src/test/groovy/MongoBaseTest.groovy
@@ -125,6 +125,7 @@ abstract class MongoBaseTest extends VersionedNamingTestBase {
         "$Tags.DB_TYPE" dbType
         "$Tags.DB_INSTANCE" instance
         "$Tags.DB_OPERATION" mongoOp
+        peerServiceFrom(Tags.DB_INSTANCE)
         defaultTags()
       }
     }

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -293,7 +293,7 @@ abstract class RabbitMQTestBase extends VersionedNamingTestBase {
         def deliverParentSpan = null
         trace(1) {
           deliverParentSpan = span(0)
-          rabbitSpan(it, "basic.publish $exchangeName -> <all>",false, null, operationForProducer())
+          rabbitSpan(it, "basic.publish $exchangeName -> <all>", false, null, operationForProducer())
         }
         if (hasQueueSpan()) {
           trace(2) {
@@ -305,7 +305,7 @@ abstract class RabbitMQTestBase extends VersionedNamingTestBase {
           trace(1) {
             // TODO - test with and without feature enabled once Config is easier to control
             rabbitSpan(it, "basic.deliver $resourceQueueName", true, deliverParentSpan,
-              operationForConsumer(),null, null, setTimestamp)
+              operationForConsumer(), null, null, setTimestamp)
           }
         }
       }
@@ -391,7 +391,7 @@ abstract class RabbitMQTestBase extends VersionedNamingTestBase {
       def deliverParentSpan = null
       trace(1) {
         deliverParentSpan = span(0)
-        rabbitSpan(it, "basic.publish $exchangeName -> <all>",false, null, operationForProducer())
+        rabbitSpan(it, "basic.publish $exchangeName -> <all>", false, null, operationForProducer())
       }
       if (hasQueueSpan()) {
         trace(2) {
@@ -443,14 +443,14 @@ abstract class RabbitMQTestBase extends VersionedNamingTestBase {
     }
 
     where:
-    command                 | exception             | exptectedOperation      | errorMsg                     | closure
-    "exchange.declare"      | IOException           | operation()             | null                         | {
+    command                 | exception             | exptectedOperation     | errorMsg                                           | closure
+    "exchange.declare"      | IOException           | operation()            | null                                               | {
       it.exchangeDeclare("some-exchange", "invalid-type", true)
     }
-    "Channel.basicConsume"  | IllegalStateException | operation()  | "Invalid configuration: 'queue' must be non-null." | {
+    "Channel.basicConsume"  | IllegalStateException | operation()            | "Invalid configuration: 'queue' must be non-null." | {
       it.basicConsume(null, null)
     }
-    "basic.get <generated>" | IOException           | operationForConsumer()  | null                                               | {
+    "basic.get <generated>" | IOException           | operationForConsumer() | null                                               | {
       it.basicGet("amq.gen-invalid-channel", true)
     }
   }
@@ -479,7 +479,7 @@ abstract class RabbitMQTestBase extends VersionedNamingTestBase {
       def publishSpan = null
       trace(1) {
         publishSpan = span(0)
-        rabbitSpan(it, "basic.publish <default> -> some-routing-queue",false, null, operationForProducer())
+        rabbitSpan(it, "basic.publish <default> -> some-routing-queue", false, null, operationForProducer())
       }
       if (hasQueueSpan()) {
         trace(2) {
@@ -662,7 +662,7 @@ abstract class RabbitMQTestBase extends VersionedNamingTestBase {
       } else {
         trace(1) {
           if (noParent) {
-            rabbitSpan(it, "basic.$type $queueName",false, null, operationForConsumer())
+            rabbitSpan(it, "basic.$type $queueName", false, null, operationForConsumer())
           } else {
             rabbitSpan(it, "basic.$type $queueName", true, publishSpan, operationForConsumer())
           }
@@ -832,10 +832,15 @@ abstract class RabbitMQTestBase extends VersionedNamingTestBase {
         if (exception) {
           errorTags(exception.class, errorMsg)
         }
-        if ({ isDataStreamsEnabled() }){
+        if ({ isDataStreamsEnabled() }) {
           "$DDTags.PATHWAY_HASH" { String }
         }
-        defaultTags(distributedRootSpan)
+        if ([Tags.SPAN_KIND_PRODUCER, Tags.SPAN_KIND_CLIENT].any({ it == tag(Tags.SPAN_KIND) })) {
+          peerServiceFrom(Tags.PEER_HOSTNAME)
+          defaultTags(distributedRootSpan)
+        } else {
+          defaultTagsNoPeerService(distributedRootSpan)
+        }
       }
     }
   }
@@ -871,7 +876,7 @@ abstract class RabbitMQForkedTest extends RabbitMQTestBase {
   }
 
   @Override
-  String service()  {
+  String service() {
     return "RabbitMQTest"
   }
 
@@ -886,7 +891,7 @@ abstract class RabbitMQForkedTest extends RabbitMQTestBase {
   }
 }
 
-class RabbitMQNamingV0ForkedTest extends RabbitMQForkedTest {
+class RabbitMQNamingV0Test extends RabbitMQForkedTest {
 
 }
 
@@ -926,7 +931,7 @@ class RabbitMQDatastreamsDisabledForkedTest extends RabbitMQTestBase {
   }
 
   @Override
-  String service()  {
+  String service() {
     return "RabbitMQDatastreamsDisabledForkedTest"
   }
 
@@ -956,7 +961,7 @@ class RabbitMQSplitByDestinationForkedTest extends RabbitMQTestBase {
   }
 
   @Override
-  String service()  {
+  String service() {
     return "RabbitMQTest"
   }
 

--- a/dd-java-agent/instrumentation/rediscala-1.8.0/src/test/groovy/RediscalaClientTest.groovy
+++ b/dd-java-agent/instrumentation/rediscala-1.8.0/src/test/groovy/RediscalaClientTest.groovy
@@ -95,6 +95,7 @@ abstract class RediscalaClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_HOSTNAME" redisClient.host()
             "$Tags.PEER_PORT" redisClient.port()
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -130,6 +131,7 @@ abstract class RediscalaClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_HOSTNAME" redisClient.host()
             "$Tags.PEER_PORT" redisClient.port()
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -147,6 +149,7 @@ abstract class RediscalaClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_HOSTNAME" redisClient.host()
             "$Tags.PEER_PORT" redisClient.port()
             "db.redis.dbIndex" 0
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -155,7 +158,7 @@ abstract class RediscalaClientTest extends VersionedNamingTestBase {
   }
 }
 
-class RediscalaClientV0ForkedTest extends RediscalaClientTest {
+class RediscalaClientV0Test extends RediscalaClientTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redisson20/groovy/RedissonClientTest.groovy
+++ b/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redisson20/groovy/RedissonClientTest.groovy
@@ -146,6 +146,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" port
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -341,13 +342,14 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
         "$Tags.PEER_HOSTNAME" "localhost"
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" port
+        peerServiceFrom(Tags.PEER_HOSTNAME)
         defaultTags()
       }
     }
   }
 }
 
-class RedissonClientV0ForkedTest extends RedissonClientTest {
+class RedissonClientV0Test extends RedissonClientTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redisson23/groovy/RedissonClientTest.groovy
+++ b/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redisson23/groovy/RedissonClientTest.groovy
@@ -149,6 +149,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" port
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -344,13 +345,14 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
         "$Tags.PEER_HOSTNAME" "localhost"
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" port
+        peerServiceFrom(Tags.PEER_HOSTNAME)
         defaultTags()
       }
     }
   }
 }
 
-class RedissonClientV0ForkedTest extends RedissonClientTest {
+class RedissonClientV0Test extends RedissonClientTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redissonLatest/groovy/RedissonClientTest.groovy
+++ b/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redissonLatest/groovy/RedissonClientTest.groovy
@@ -140,6 +140,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
             "$Tags.PEER_HOSTNAME" "localhost"
             "$Tags.PEER_HOST_IPV4" "127.0.0.1"
             "$Tags.PEER_PORT" port
+            peerServiceFrom(Tags.PEER_HOSTNAME)
             defaultTags()
           }
         }
@@ -335,13 +336,14 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
         "$Tags.PEER_HOSTNAME" "localhost"
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"
         "$Tags.PEER_PORT" port
+        peerServiceFrom(Tags.PEER_HOSTNAME)
         defaultTags()
       }
     }
   }
 }
 
-class RedissonClientV0ForkedTest extends RedissonClientTest {
+class RedissonClientV0Test extends RedissonClientTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/client/RmiClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/client/RmiClientInstrumentation.java
@@ -54,9 +54,8 @@ public final class RmiClientInstrumentation extends Instrumenter.Tracing
         return null;
       }
       final AgentSpan span = startSpan(RMI_INVOKE);
-      span.setResourceName(DECORATE.spanNameForMethod(method));
-
       DECORATE.afterStart(span);
+      DECORATE.onMethodInvocation(span, method);
       return activateSpan(span);
     }
 

--- a/dd-java-agent/instrumentation/rmi/src/test/groovy/RmiTest.groovy
+++ b/dd-java-agent/instrumentation/rmi/src/test/groovy/RmiTest.groovy
@@ -63,7 +63,9 @@ abstract class RmiTest extends VersionedNamingTestBase {
 
           tags {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.RPC_SERVICE" "rmi.app.Greeter"
             "$Tags.COMPONENT" "rmi-client"
+            peerServiceFrom(Tags.RPC_SERVICE)
             defaultTags()
           }
         }
@@ -144,8 +146,10 @@ abstract class RmiTest extends VersionedNamingTestBase {
 
           tags {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.RPC_SERVICE" "rmi.app.Greeter"
             "$Tags.COMPONENT" "rmi-client"
             errorTags(RuntimeException, String)
+            peerServiceFrom(Tags.RPC_SERVICE)
             defaultTags()
           }
         }
@@ -198,6 +202,8 @@ abstract class RmiTest extends VersionedNamingTestBase {
           tags {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.COMPONENT" "rmi-client"
+            "$Tags.RPC_SERVICE" "rmi.app.Greeter"
+            peerServiceFrom(Tags.RPC_SERVICE)
             defaultTags()
           }
         }
@@ -223,7 +229,7 @@ abstract class RmiTest extends VersionedNamingTestBase {
   }
 }
 
-class RmiV0ForkedTest extends RmiTest {
+class RmiV0Test extends RmiTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/spring-jms-3.1/src/test/groovy/SpringSAListenerTest.groovy
+++ b/dd-java-agent/instrumentation/spring-jms-3.1/src/test/groovy/SpringSAListenerTest.groovy
@@ -68,7 +68,7 @@ class SpringSAListenerTest extends AgentTestRunner {
         tags {
           "$Tags.COMPONENT" "jms"
           "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
-          defaultTags()
+          defaultTagsNoPeerService()
         }
       }
     }
@@ -90,7 +90,7 @@ class SpringSAListenerTest extends AgentTestRunner {
           if ("$InstrumentationTags.RECORD_QUEUE_TIME_MS") {
             "$InstrumentationTags.RECORD_QUEUE_TIME_MS" {it >= 0 }
           }
-          defaultTags(true)
+          defaultTagsNoPeerService(true)
         }
       }
     }

--- a/dd-java-agent/instrumentation/spymemcached-2.10/src/test/groovy/datadog/trace/instrumentation/spymemcached/SpymemcachedTest.groovy
+++ b/dd-java-agent/instrumentation/spymemcached-2.10/src/test/groovy/datadog/trace/instrumentation/spymemcached/SpymemcachedTest.groovy
@@ -709,14 +709,18 @@ abstract class SpymemcachedTest extends VersionedNamingTestBase {
           "$Tags.PEER_HOSTNAME" memcachedAddress.getHostName()
           "$Tags.PEER_HOST_IPV4" InetAddress.getByName(memcachedAddress.getHostName()).getHostAddress()
           "$Tags.PEER_PORT" memcachedAddress.getPort()
+          peerServiceFrom(Tags.PEER_HOSTNAME)
+          defaultTags()
+        } else {
+          defaultTagsNoPeerService()
         }
-        defaultTags()
+
       }
     }
   }
 }
 
-class SpymemcachedV0ForkedTest extends SpymemcachedTest {
+class SpymemcachedV0Test extends SpymemcachedTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/test/groovy/VertxRedisTestBase.groovy
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/test/groovy/VertxRedisTestBase.groovy
@@ -137,6 +137,7 @@ abstract class VertxRedisTestBase extends VersionedNamingTestBase {
         "$Tags.DB_TYPE" "redis"
         "$Tags.PEER_PORT" port
         "$Tags.PEER_HOSTNAME" "127.0.0.1"
+        peerServiceFrom(Tags.PEER_HOSTNAME)
         defaultTags()
       }
     }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
@@ -36,9 +36,21 @@ class TagsAssert {
   }
 
   /**
+   * Check that, if the peer.service tag source has been set, it matches the provided one.
+   * @param sourceTag the source to match
+   */
+  def peerServiceFrom(String sourceTag) {
+    tag(DDTags.PEER_SERVICE_SOURCE, { SpanNaming.instance().namingSchema().peerService().supports() ? it == sourceTag : it == null})
+  }
+
+  def defaultTagsNoPeerService(boolean distributedRootSpan = false) {
+    defaultTags(distributedRootSpan, false)
+  }
+
+  /**
    * @param distributedRootSpan set to true if current span has a parent span but still considered 'root' for current service
    */
-  def defaultTags(boolean distributedRootSpan = false) {
+  def defaultTags(boolean distributedRootSpan = false, boolean checkPeerService = true) {
     assertedTags.add("thread.name")
     assertedTags.add("thread.id")
     assertedTags.add(DDTags.RUNTIME_ID_TAG)
@@ -48,6 +60,7 @@ class TagsAssert {
     assertedTags.add("_sample_rate")
     assertedTags.add(DDTags.PID_TAG)
     assertedTags.add(DDTags.SCHEMA_VERSION_TAG_KEY)
+
 
     assert tags["thread.name"] != null
     assert tags["thread.id"] != null
@@ -65,12 +78,22 @@ class TagsAssert {
     } else {
       assert tags[DDTags.RUNTIME_ID_TAG] == null
     }
-
-    boolean isServer = (tags[Tags.SPAN_KIND] == Tags.SPAN_KIND_SERVER)
+    String spanKind = tags[Tags.SPAN_KIND]
+    boolean isServer = (spanKind == Tags.SPAN_KIND_SERVER)
     if (isRoot || distributedRootSpan || isServer) {
       assert tags[DDTags.LANGUAGE_TAG_KEY] == DDTags.LANGUAGE_TAG_VALUE
     } else {
       assert tags[DDTags.LANGUAGE_TAG_KEY] == null
+    }
+    boolean shouldSetPeerService = checkPeerService && (spanKind == Tags.SPAN_KIND_CLIENT || spanKind == Tags.SPAN_KIND_PRODUCER)
+    if (shouldSetPeerService && SpanNaming.instance().namingSchema().peerService().supports()) {
+      assertedTags.add(Tags.PEER_SERVICE)
+      assertedTags.add(DDTags.PEER_SERVICE_SOURCE)
+      assert tags[Tags.PEER_SERVICE] != null
+      assert tags[Tags.PEER_SERVICE] == tags[tags[DDTags.PEER_SERVICE_SOURCE]]
+    } else {
+      assert tags[Tags.PEER_SERVICE] == null
+      assert tags[DDTags.PEER_SERVICE_SOURCE] == null
     }
   }
 
@@ -98,15 +121,15 @@ class TagsAssert {
     assertedTags.add(name)
     def value = tag(name)
     if (expected instanceof Pattern) {
-      assert value =~ expected : "Tag \"$name\": \"${value.toString()}\" does not match pattern \"$expected\""
+      assert value =~ expected: "Tag \"$name\": \"${value.toString()}\" does not match pattern \"$expected\""
     } else if (expected instanceof Class) {
-      assert ((Class) expected).isInstance(value) : "Tag \"$name\": instance check $expected failed for \"${value.toString()}\" of class \"${value.class}\""
+      assert ((Class) expected).isInstance(value): "Tag \"$name\": instance check $expected failed for \"${value.toString()}\" of class \"${value.class}\""
     } else if (expected instanceof Closure) {
-      assert ((Closure) expected).call(value) : "Tag \"$name\": closure call ${expected.toString()} failed with \"$value\""
+      assert ((Closure) expected).call(value): "Tag \"$name\": closure call ${expected.toString()} failed with \"$value\""
     } else if (expected instanceof UTF8BytesString) {
-      assert value == expected.toString() : "Tag \"$name\": \"$value\" != \"${expected.toString()}\""
+      assert value == expected.toString(): "Tag \"$name\": \"$value\" != \"${expected.toString()}\""
     } else {
-      assert value == expected : "Tag \"$name\": \"$value\" != \"$expected\""
+      assert value == expected: "Tag \"$name\": \"$value\" != \"$expected\""
     }
   }
 
@@ -123,7 +146,7 @@ class TagsAssert {
   }
 
   def addTags(Map<String, Serializable> tags) {
-    tags.each {tag(it.key, it.value)}
+    tags.each { tag(it.key, it.value) }
     true
   }
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -774,6 +774,7 @@ abstract class HttpClientTest extends VersionedNamingTestBase {
         if (exception) {
           errorTags(exception.class, exception.message)
         }
+        peerServiceFrom(Tags.PEER_HOSTNAME)
         defaultTags()
       }
     }

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -44,7 +44,8 @@ public class DDTags {
   public static final String MEASURED = "_dd.measured";
   public static final String PID_TAG = "process_id";
   public static final String SCHEMA_VERSION_TAG_KEY = "_dd.trace_span_attribute_schema";
-
+  public static final String PEER_SERVICE_SOURCE = "_dd.peer.service.source";
+  public static final String PEER_SERVICE_REMAPPED_FROM = "_dd.peer.service.remapped_from";
   public static final String INTERNAL_GIT_REPOSITORY_URL = "_dd.git.repository_url";
   public static final String INTERNAL_GIT_COMMIT_SHA = "_dd.git.commit.sha";
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -106,5 +106,10 @@ public final class TracerConfig {
 
   public static final String TRACE_SPAN_ATTRIBUTE_SCHEMA = "trace.span.attribute.schema";
 
+  public static final String TRACE_PEER_SERVICE_DEFAULTS_ENABLED =
+      "trace.peer.service.defaults.enabled";
+
+  public static final String TRACE_PEER_SERVICE_MAPPING = "trace.peer.service.mapping";
+
   private TracerConfig() {}
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ListWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ListWriter.java
@@ -1,8 +1,13 @@
 package datadog.trace.common.writer;
 
+import datadog.trace.api.DDTags;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.core.DDSpan;
+import datadog.trace.core.tagprocessor.PeerServiceCalculator;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -27,6 +32,8 @@ public class ListWriter extends CopyOnWriteArrayList<List<DDSpan>> implements Wr
   private final List<CountDownLatch> latches = new ArrayList<>();
   private final AtomicInteger traceCount = new AtomicInteger();
   private final TraceStructureWriter structureWriter = new TraceStructureWriter(true);
+
+  private final PeerServiceCalculator peerServiceCalculator = new PeerServiceCalculator();
   private Filter filter = ACCEPT_ALL;
 
   public List<DDSpan> firstTrace() {
@@ -38,7 +45,20 @@ public class ListWriter extends CopyOnWriteArrayList<List<DDSpan>> implements Wr
     if (!filter.accept(trace)) {
       return;
     }
-
+    for (DDSpan span : trace) {
+      // todo: this can be better with span.processTagsAndBaggage(NoopMetadataConsumer.INSTANCE);
+      // we cannot use the full postProcessor chain since it trigger also query obsfuscator and will
+      // make fail a lot of tests
+      // only kicks in peer.service computation (avoid scrambling queries and url)
+      final Map<String, ?> enriched =
+          peerServiceCalculator.processTags(new HashMap<>(span.getTags()));
+      final Object peerServiceSource = enriched.get(DDTags.PEER_SERVICE_SOURCE);
+      // we needed to copy the original tag map since it's unmodifiable
+      if (peerServiceSource != null) {
+        span.setTag(Tags.PEER_SERVICE, enriched.get(Tags.PEER_SERVICE));
+        span.setTag(DDTags.PEER_SERVICE_SOURCE, peerServiceSource);
+      }
+    }
     traceCount.incrementAndGet();
     synchronized (latches) {
       add(trace);

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -24,6 +24,8 @@ import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.core.propagation.PropagationTags;
 import datadog.trace.core.taginterceptor.TagInterceptor;
+import datadog.trace.core.tagprocessor.PeerServiceCalculator;
+import datadog.trace.core.tagprocessor.PostProcessorChain;
 import datadog.trace.core.tagprocessor.QueryObfuscator;
 import datadog.trace.core.tagprocessor.TagsPostProcessor;
 import datadog.trace.util.TagsHelper;
@@ -82,7 +84,9 @@ public class DDSpanContext
   private volatile short httpStatusCode;
 
   private static final TagsPostProcessor postProcessor =
-      new QueryObfuscator(Config.get().getObfuscationQueryRegexp());
+      new PostProcessorChain(
+          new PeerServiceCalculator(),
+          new QueryObfuscator(Config.get().getObfuscationQueryRegexp()));
 
   /**
    * Tags are associated to the current span, they will not propagate to the children span.

--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/TagInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/TagInterceptor.java
@@ -8,7 +8,13 @@ import static datadog.trace.api.sampling.PrioritySampling.USER_DROP;
 import static datadog.trace.bootstrap.instrumentation.api.Tags.HTTP_METHOD;
 import static datadog.trace.bootstrap.instrumentation.api.Tags.HTTP_STATUS;
 import static datadog.trace.bootstrap.instrumentation.api.Tags.HTTP_URL;
-import static datadog.trace.core.taginterceptor.RuleFlags.Feature.*;
+import static datadog.trace.core.taginterceptor.RuleFlags.Feature.FORCE_MANUAL_DROP;
+import static datadog.trace.core.taginterceptor.RuleFlags.Feature.PEER_SERVICE;
+import static datadog.trace.core.taginterceptor.RuleFlags.Feature.RESOURCE_NAME;
+import static datadog.trace.core.taginterceptor.RuleFlags.Feature.SERVICE_NAME;
+import static datadog.trace.core.taginterceptor.RuleFlags.Feature.STATUS_404;
+import static datadog.trace.core.taginterceptor.RuleFlags.Feature.STATUS_404_DECORATOR;
+import static datadog.trace.core.taginterceptor.RuleFlags.Feature.URL_AS_RESOURCE_NAME;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.ConfigDefaults;
@@ -74,6 +80,8 @@ public class TagInterceptor {
       case "service":
         return interceptServiceName(SERVICE_NAME, span, value);
       case Tags.PEER_SERVICE:
+        // we still need to intercept and add this tag when the user manually set
+        span.setTag(DDTags.PEER_SERVICE_SOURCE, Tags.PEER_SERVICE);
         return interceptServiceName(PEER_SERVICE, span, value);
       case DDTags.MANUAL_KEEP:
         if (asBoolean(value)) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/PeerServiceCalculator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/PeerServiceCalculator.java
@@ -1,0 +1,59 @@
+package datadog.trace.core.tagprocessor;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.DDTags;
+import datadog.trace.api.naming.NamingSchema;
+import datadog.trace.api.naming.SpanNaming;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import java.util.Map;
+import javax.annotation.Nonnull;
+
+public class PeerServiceCalculator implements TagsPostProcessor {
+  private final NamingSchema.ForPeerService peerServiceNaming;
+
+  private final Map<String, String> peerServiceMapping;
+
+  private final boolean canRemap;
+
+  public PeerServiceCalculator() {
+    this(SpanNaming.instance().namingSchema().peerService(), Config.get().getPeerServiceMapping());
+  }
+
+  // Visible for testing
+  PeerServiceCalculator(
+      @Nonnull final NamingSchema.ForPeerService peerServiceNaming,
+      @Nonnull final Map<String, String> peerServiceMapping) {
+    this.peerServiceNaming = peerServiceNaming;
+    this.peerServiceMapping = peerServiceMapping;
+    this.canRemap = !peerServiceMapping.isEmpty();
+  }
+
+  @Override
+  public Map<String, Object> processTags(Map<String, Object> unsafeTags) {
+    Object peerService = unsafeTags.get(Tags.PEER_SERVICE);
+    // the user set it
+    if (peerService != null) {
+      if (canRemap) {
+        return remapPeerService(unsafeTags, peerService);
+      }
+    } else if (peerServiceNaming.supports()) {
+      // calculate the defaults (if any)
+      peerServiceNaming.tags(unsafeTags);
+      // only remap if the mapping is not empty (saves one get)
+      return remapPeerService(unsafeTags, canRemap ? unsafeTags.get(Tags.PEER_SERVICE) : null);
+    }
+    // we have no peer.service and we do not compute defaults. Leave the map untouched
+    return unsafeTags;
+  }
+
+  private Map<String, Object> remapPeerService(Map<String, Object> unsafeTags, Object value) {
+    if (value != null) {
+      String mapped = peerServiceMapping.get(value);
+      if (mapped != null) {
+        unsafeTags.put(Tags.PEER_SERVICE, mapped);
+        unsafeTags.put(DDTags.PEER_SERVICE_REMAPPED_FROM, value);
+      }
+    }
+    return unsafeTags;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/PostProcessorChain.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/PostProcessorChain.java
@@ -1,0 +1,22 @@
+package datadog.trace.core.tagprocessor;
+
+import java.util.Map;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+
+public class PostProcessorChain implements TagsPostProcessor {
+  private final TagsPostProcessor[] chain;
+
+  public PostProcessorChain(@Nonnull final TagsPostProcessor... processors) {
+    chain = Objects.requireNonNull(processors);
+  }
+
+  @Override
+  public Map<String, Object> processTags(Map<String, Object> unsafeTags) {
+    Map<String, Object> currentTags = unsafeTags;
+    for (final TagsPostProcessor tagsPostProcessor : chain) {
+      currentTags = tagsPostProcessor.processTags(currentTags);
+    }
+    return currentTags;
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/taginterceptor/TagInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/taginterceptor/TagInterceptorTest.groovy
@@ -1,5 +1,10 @@
 package datadog.trace.core.taginterceptor
 
+import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME
+import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVLET_ROOT_CONTEXT_SERVICE_NAME
+import static datadog.trace.api.DDTags.ANALYTICS_SAMPLE_RATE
+import static datadog.trace.api.config.TracerConfig.SPLIT_BY_TAGS
+
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.api.config.GeneralConfig
@@ -13,11 +18,6 @@ import datadog.trace.common.writer.ListWriter
 import datadog.trace.common.writer.LoggingWriter
 import datadog.trace.core.CoreSpan
 import datadog.trace.core.test.DDCoreSpecification
-
-import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME
-import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVLET_ROOT_CONTEXT_SERVICE_NAME
-import static datadog.trace.api.DDTags.ANALYTICS_SAMPLE_RATE
-import static datadog.trace.api.config.TracerConfig.SPLIT_BY_TAGS
 
 class TagInterceptorTest extends DDCoreSpecification {
   def setup() {
@@ -655,5 +655,23 @@ class TagInterceptorTest extends DDCoreSpecification {
     "/with-method"              | "POST /with-method" | [(Tags.HTTP_METHOD): "Post"]
 
     ignore = meta.put(Tags.HTTP_URL, value)
+  }
+
+  def "when user sets peer.service the source should be peer.service"() {
+    setup:
+    def tracer = tracerBuilder().writer(new ListWriter()).build()
+
+    def span = tracer.buildSpan("fakeOperation").start()
+
+
+    when:
+    span.setTag(Tags.PEER_SERVICE, "test")
+
+    then:
+    span.getTag(DDTags.PEER_SERVICE_SOURCE) == "peer.service"
+
+    cleanup:
+    span.finish()
+    tracer.close()
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/tagprocessor/PeerServiceCalculatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/tagprocessor/PeerServiceCalculatorTest.groovy
@@ -1,0 +1,101 @@
+package datadog.trace.core.tagprocessor
+
+import datadog.trace.api.DDTags
+import datadog.trace.api.config.TracerConfig
+import datadog.trace.api.naming.v0.NamingSchemaV0
+import datadog.trace.api.naming.v1.NamingSchemaV1
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.test.util.DDSpecification
+
+class PeerServiceCalculatorTest extends DDSpecification {
+  def "schema v0 : peer service is not calculated by default"() {
+    setup:
+    def calculator = new PeerServiceCalculator(new NamingSchemaV0().peerService(), Collections.emptyMap())
+    when:
+    def enrichedTags = calculator.processTags(tags)
+    then:
+    // tags are not modified
+    assert enrichedTags == tags
+
+    where:
+    tags                                                 | _
+    [:]                                                  | _
+    ["peer.hostname": "test"]                            | _
+    ["peer.hostname": "test", "db.instance": "instance"] | _
+    ["db.instance": "instance", "peer.hostname": "test"] | _
+    ["peer.hostname": "test", "rpc.service": "svc"]      | _
+    ["rpc.service": "svc", "peer.hostname": "test"]      | _
+  }
+
+  def "schema v1: test peer service default logic and precursors"() {
+    setup:
+    def calculator = new PeerServiceCalculator(new NamingSchemaV1().peerService(), Collections.emptyMap())
+    when:
+    tags.put(Tags.SPAN_KIND, Tags.SPAN_KIND_CLIENT)
+    def calculated = calculator.processTags(tags)
+
+    then:
+    calculated.get(DDTags.PEER_SERVICE_SOURCE) == provenance
+    calculated.get(Tags.PEER_SERVICE) == peerService
+
+    where:
+    tags                                                                          | provenance         | peerService
+    [:]                                                                           | null               | null
+    ["peer.hostname": "test"]                                                     | Tags.PEER_HOSTNAME | "test"
+    ["peer.hostname": "test"]                                                     | Tags.PEER_HOSTNAME | "test"
+    ["peer.hostname": "test", "db.instance": "instance"]                          | Tags.DB_INSTANCE   | "instance"
+    ["db.instance": "instance", "peer.hostname": "test"]                          | Tags.DB_INSTANCE   | "instance"
+    ["peer.hostname": "test", "rpc.service": "svc", "component": "grpc-client"]   | Tags.RPC_SERVICE   | "svc"
+    ["rpc.service": "svc", "peer.hostname": "test", "component": "grpc-client"]   | Tags.RPC_SERVICE   | "svc"
+    ["peer.hostname": "test", "peer.service": "userService"]                      | null               | "userService"
+  }
+
+  def "schema v0: should calculate defaults if enabled"() {
+    setup:
+    injectSysConfig(TracerConfig.TRACE_PEER_SERVICE_DEFAULTS_ENABLED, "true")
+    def calculator = new PeerServiceCalculator(new NamingSchemaV1().peerService(), Collections.emptyMap())
+    when:
+    def calculated = calculator.processTags(["span.kind": "client", "peer.hostname": "test"])
+    then:
+    assert calculated.get(Tags.PEER_SERVICE) == "test"
+  }
+
+
+  def "calculate only for span kind client or producer"() {
+    setup:
+    def calculator = new PeerServiceCalculator(new NamingSchemaV1().peerService(), Collections.emptyMap())
+
+    when:
+    def tags = ["span.kind": kind, "peer.hostname": "test"]
+
+    then:
+    assert calculator.processTags(tags).containsKey(Tags.PEER_SERVICE) == calculate
+
+    where:
+    kind       | calculate
+    "client"   | true
+    "producer" | true
+    "server"   | false
+  }
+
+  def "should apply peer service mappings if configured"() {
+    setup:
+    injectSysConfig(TracerConfig.TRACE_PEER_SERVICE_MAPPING, "service1:best_service,userService:my_service")
+    injectSysConfig(TracerConfig.TRACE_PEER_SERVICE_DEFAULTS_ENABLED, "true")
+
+    def calculator = new PeerServiceCalculator()
+
+    when:
+    def calculated = calculator.processTags(tags)
+
+    then:
+    assert calculated.get(Tags.PEER_SERVICE) == expected
+    assert calculated.get(DDTags.PEER_SERVICE_REMAPPED_FROM) == original
+
+    where:
+    tags                                                                    | expected            | original
+    ["peer.service": "userService"]                                         | "my_service"        | "userService"
+    ["peer.hostname": "test", "span.kind": "client"]                        | "test"              | null
+    ["peer.hostname": "service1", "span.kind": "producer"]                  | "best_service"      | "service1"
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/tagprocessor/PostProcessorChainTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/tagprocessor/PostProcessorChainTest.groovy
@@ -1,0 +1,62 @@
+package datadog.trace.core.tagprocessor
+
+
+import datadog.trace.test.util.DDSpecification
+
+class PostProcessorChainTest extends DDSpecification {
+  def "chain works"() {
+    setup:
+    def processor1 = new TagsPostProcessor() {
+        @Override
+        Map<String, Object> processTags(Map<String, Object> unsafeTags) {
+          unsafeTags.put("key1", "processor1")
+          unsafeTags.put("key2", "processor1")
+          return unsafeTags
+        }
+      }
+    def processor2 = new TagsPostProcessor() {
+        @Override
+        Map<String, Object> processTags(Map<String, Object> unsafeTags) {
+          unsafeTags.put("key1", "processor2")
+          return unsafeTags
+        }
+      }
+
+    def chain = new PostProcessorChain(processor1, processor2)
+    def tags = ["key1": "root", "key3": "root"]
+
+    when:
+    def out = chain.processTags(tags)
+
+    then:
+    assert out == ["key1": "processor2", "key2": "processor1", "key3": "root"]
+  }
+
+  def "processor can hide tags to next one()"() {
+    setup:
+    def processor1 = new TagsPostProcessor() {
+        @Override
+        Map<String, Object> processTags(Map<String, Object> unsafeTags) {
+          return ["my": "tag"]
+        }
+      }
+    def processor2 = new TagsPostProcessor() {
+        @Override
+        Map<String, Object> processTags(Map<String, Object> unsafeTags) {
+          if (unsafeTags.containsKey("test")) {
+            unsafeTags.put("found", "true")
+          }
+          return unsafeTags
+        }
+      }
+
+    def chain = new PostProcessorChain(processor1, processor2)
+    def tags = ["test": "test"]
+
+    when:
+    def out = chain.processTags(tags)
+
+    then:
+    assert out == ["my": "tag"]
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -303,6 +303,8 @@ import static datadog.trace.api.config.TracerConfig.TRACE_GIT_METADATA_ENABLED;
 import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_CLIENT_PATH_RESOURCE_NAME_MAPPING;
 import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_RESOURCE_REMOVE_TRAILING_SLASH;
 import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING;
+import static datadog.trace.api.config.TracerConfig.TRACE_PEER_SERVICE_DEFAULTS_ENABLED;
+import static datadog.trace.api.config.TracerConfig.TRACE_PEER_SERVICE_MAPPING;
 import static datadog.trace.api.config.TracerConfig.TRACE_PROPAGATION_STYLE;
 import static datadog.trace.api.config.TracerConfig.TRACE_PROPAGATION_STYLE_EXTRACT;
 import static datadog.trace.api.config.TracerConfig.TRACE_PROPAGATION_STYLE_INJECT;
@@ -433,8 +435,9 @@ public class Config {
   private final boolean prioritySamplingEnabled;
   private final String prioritySamplingForce;
   private final boolean traceResolverEnabled;
-
   private final int spanAttributeSchemaVersion;
+  private final boolean peerServiceDefaultsEnabled;
+  private final Map<String, String> peerServiceMapping;
   private final Map<String, String> serviceMapping;
   private final Map<String, String> tags;
   private final Map<String, String> spanTags;
@@ -876,6 +879,12 @@ public class Config {
     baggageMapping = configProvider.getMergedMap(BAGGAGE_MAPPING);
 
     spanAttributeSchemaVersion = schemaVersionFromConfig();
+
+    // only used in v0. in v1+ defaults are always calculated regardless this feature flag
+    peerServiceDefaultsEnabled =
+        configProvider.getBoolean(TRACE_PEER_SERVICE_DEFAULTS_ENABLED, false);
+
+    peerServiceMapping = configProvider.getMergedMap(TRACE_PEER_SERVICE_MAPPING);
 
     httpServerPathResourceNameMapping =
         configProvider.getOrderedMap(TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING);
@@ -1609,6 +1618,14 @@ public class Config {
 
   public int getSpanAttributeSchemaVersion() {
     return spanAttributeSchemaVersion;
+  }
+
+  public boolean isPeerServiceDefaultsEnabled() {
+    return peerServiceDefaultsEnabled;
+  }
+
+  public Map<String, String> getPeerServiceMapping() {
+    return peerServiceMapping;
   }
 
   public Map<String, String> getServiceMapping() {

--- a/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
@@ -1,5 +1,6 @@
 package datadog.trace.api.naming;
 
+import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -45,6 +46,13 @@ public interface NamingSchema {
    * @return a {@link NamingSchema.ForServer} instance.
    */
   ForServer server();
+
+  /**
+   * Policy for peer service tags calculation
+   *
+   * @return
+   */
+  ForPeerService peerService();
 
   interface ForCache {
     /**
@@ -207,6 +215,24 @@ public interface NamingSchema {
      */
     @Nonnull
     String timeInQueueOperation(@Nonnull String messagingSystem);
+  }
+
+  interface ForPeerService {
+    /**
+     * Whenever the schema supports peer service calculation
+     *
+     * @return
+     */
+    boolean supports();
+
+    /**
+     * Calculate the tags to be added to a span to represent the peer service
+     *
+     * @param unsafeTags the span tags. Map che be mutated
+     * @return the input tags
+     */
+    @Nonnull
+    Map<String, Object> tags(@Nonnull Map<String, Object> unsafeTags);
   }
 
   interface ForServer {

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/NamingSchemaV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/NamingSchemaV0.java
@@ -1,6 +1,8 @@
 package datadog.trace.api.naming.v0;
 
+import datadog.trace.api.Config;
 import datadog.trace.api.naming.NamingSchema;
+import datadog.trace.api.naming.v1.PeerServiceNamingV1;
 
 public class NamingSchemaV0 implements NamingSchema {
   private final NamingSchema.ForCache cacheNaming = new CacheNamingV0();
@@ -8,6 +10,10 @@ public class NamingSchemaV0 implements NamingSchema {
   private final NamingSchema.ForCloud cloudNaming = new CloudNamingV0();
   private final NamingSchema.ForDatabase databaseNaming = new DatabaseNamingV0();
   private final NamingSchema.ForMessaging messagingNaming = new MessagingNamingV0();
+  private final NamingSchema.ForPeerService peerServiceNaming =
+      Config.get().isPeerServiceDefaultsEnabled()
+          ? new PeerServiceNamingV1()
+          : new PeerServiceNamingV0();
   private final NamingSchema.ForServer serverNaming = new ServerNamingV0();
 
   @Override
@@ -38,5 +44,10 @@ public class NamingSchemaV0 implements NamingSchema {
   @Override
   public ForServer server() {
     return serverNaming;
+  }
+
+  @Override
+  public ForPeerService peerService() {
+    return peerServiceNaming;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/PeerServiceNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/PeerServiceNamingV0.java
@@ -1,0 +1,19 @@
+package datadog.trace.api.naming.v0;
+
+import datadog.trace.api.naming.NamingSchema;
+import java.util.Collections;
+import java.util.Map;
+import javax.annotation.Nonnull;
+
+public class PeerServiceNamingV0 implements NamingSchema.ForPeerService {
+  @Override
+  public boolean supports() {
+    return false;
+  }
+
+  @Nonnull
+  @Override
+  public Map<String, Object> tags(@Nonnull final Map<String, Object> unsafeTags) {
+    return Collections.emptyMap();
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/NamingSchemaV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/NamingSchemaV1.java
@@ -8,6 +8,7 @@ public class NamingSchemaV1 implements NamingSchema {
   private final NamingSchema.ForCloud cloudNaming = new CloudNamingV1();
   private final NamingSchema.ForDatabase databaseNaming = new DatabaseNamingV1();
   private final NamingSchema.ForMessaging messagingNaming = new MessagingNamingV1();
+  private final NamingSchema.ForPeerService peerServiceNaming = new PeerServiceNamingV1();
   private final NamingSchema.ForServer serverNaming = new ServerNamingV1();
 
   @Override
@@ -33,6 +34,11 @@ public class NamingSchemaV1 implements NamingSchema {
   @Override
   public ForMessaging messaging() {
     return messagingNaming;
+  }
+
+  @Override
+  public ForPeerService peerService() {
+    return peerServiceNaming;
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/PeerServiceNamingV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/PeerServiceNamingV1.java
@@ -1,0 +1,87 @@
+package datadog.trace.api.naming.v1;
+
+import datadog.trace.api.DDTags;
+import datadog.trace.api.naming.NamingSchema;
+import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class PeerServiceNamingV1 implements NamingSchema.ForPeerService {
+  private static final Map<Object, String[]> SPECIFIC_PRECURSORS_BY_COMPONENT = new HashMap<>(6);
+  private static final String[] DEFAULT_PRECURSORS = {Tags.DB_INSTANCE, Tags.PEER_HOSTNAME};
+
+  static {
+    // messaging
+    SPECIFIC_PRECURSORS_BY_COMPONENT.put(
+        "java-kafka", new String[] {InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS});
+    // database
+    SPECIFIC_PRECURSORS_BY_COMPONENT.put(
+        "hazelcast-sdk", new String[] {"hazelcast.instance", Tags.PEER_HOSTNAME});
+    // todo: add couchbase seed nodes when the precursor will be available
+    SPECIFIC_PRECURSORS_BY_COMPONENT.put(
+        "couchbase-client", new String[] {"net.peer.name", Tags.PEER_HOSTNAME});
+
+    // fixme: cassandra instance is the keyspace and it's not adapted for the peer.service. Replace
+    // with seed nodes when available
+    SPECIFIC_PRECURSORS_BY_COMPONENT.put("java-cassandra", new String[] {Tags.PEER_HOSTNAME});
+    // rpc
+    final String[] rpcPrecursors = {Tags.RPC_SERVICE, Tags.PEER_HOSTNAME};
+    SPECIFIC_PRECURSORS_BY_COMPONENT.put("grpc-client", rpcPrecursors);
+    SPECIFIC_PRECURSORS_BY_COMPONENT.put("rmi-client", rpcPrecursors);
+  }
+
+  @Override
+  public boolean supports() {
+    return true;
+  }
+
+  private void resolve(@Nonnull final Map<String, Object> unsafeTags) {
+    final Object component = unsafeTags.get(Tags.COMPONENT);
+    // avoid issues with UTF8ByteString or others
+    if (resolveBy(
+        unsafeTags,
+        SPECIFIC_PRECURSORS_BY_COMPONENT.get(component == null ? null : component.toString()))) {
+      return;
+    }
+    // fallback to default lookup
+    resolveBy(unsafeTags, DEFAULT_PRECURSORS);
+  }
+
+  private boolean resolveBy(
+      @Nonnull final Map<String, Object> unsafeTags, @Nullable final String[] precursors) {
+    if (precursors == null) {
+      return false;
+    }
+    Object value = null;
+    String source = null;
+    for (String precursor : precursors) {
+      value = unsafeTags.get(precursor);
+      if (value != null) {
+        // we have a match. Use the tag name for the source
+        source = precursor;
+        break;
+      }
+    }
+    // if something matched now set the value and the source
+    if (value != null) {
+      unsafeTags.put(Tags.PEER_SERVICE, value);
+      unsafeTags.put(DDTags.PEER_SERVICE_SOURCE, source);
+    }
+    return true;
+  }
+
+  @Nonnull
+  @Override
+  public Map<String, Object> tags(@Nonnull final Map<String, Object> unsafeTags) {
+    // check span.kind eligibility
+    final Object kind = unsafeTags.get(Tags.SPAN_KIND);
+    if (Tags.SPAN_KIND_CLIENT.equals(kind) || Tags.SPAN_KIND_PRODUCER.equals(kind)) {
+      // we can calculate the peer service now
+      resolve(unsafeTags);
+    }
+    return unsafeTags;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
@@ -30,6 +30,7 @@ public class Tags {
   public static final String PEER_SERVICE = "peer.service";
   public static final String PEER_HOSTNAME = "peer.hostname";
   public static final String PEER_PORT = "peer.port";
+  public static final String RPC_SERVICE = "rpc.service";
   public static final String SAMPLING_PRIORITY = "sampling.priority";
   public static final String SPAN_KIND = "span.kind";
   public static final String COMPONENT = "component";


### PR DESCRIPTION
# What Does This Do

Implement `peer.service` tag logic for *span kind producer or client*. Other span kinds are out of scope.

Peer service, its precursors and the source are calculated lazily leveraging the TagPostProcessor mechanism. 

Peer service can be:
* Set by the user: in this case it takes precedence to automatic calculation
* Automatically calculated (value derived from other tags that are called _precursors_)

Calculation logic generally depends to the instrumentation. As a generic fallback we use (in order of priority) 
* `db.instance` 
* `peer.hostname`

Some other specialized precursors are used:
* kafka producers: `messaging.kafka.bootstrap.servers`
* grpc or rmi clients: `rpc.service`

Once the `peer.service` value is set we also have to know it's provenance. For this we set the tag `_dd.peer.service.source` having as value the tag name which has served as source to calculate peer service.

If the user (or a third party instrumentation) sets the tag `peer.service` so that the source will be set to `peer.service`

The computation is done lazily on a tag postprocessor that kicks in if:
* The schema version is v1 -> always enabled
* The schema version is v0 -> enabled only if `DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED` is set to true

There is also the possibility to remap the value automatically calculated. For this the parameter `DD_TRACE_PEER_SERVICE_MAPPING` has to be supplied by the user. The same format as `DD_SERVICE_MAPPING` is accepted

In terms of testing, the `tagsAssert` grants that, generally speaking, all the span of kind client and producer should define the tag `peer.service` whose value has to be the same as the used precursor. 
In order to test that the value has been calculated using the right precursor, the macro `TagsAssert.peerServiceFrom(String)` should be used.

Since not all the instrumentation set the precursors today, there can be some exceptions and for some of them the value cannot be calculated. On this case, on the related tests the macro `defaultTagsNoPeerService()` should be used explicitely


# Motivation

# Additional Notes
