### PR TITLE
Report eval error in case of uncaught exception

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
@@ -292,10 +292,18 @@ public class DebuggerContext {
         shouldCommit = true;
       }
       if (entryStatus.shouldReportError()) {
+        if (entryContext.getThrowable() != null) {
+          // report also uncaught exception
+          snapshot.setEntry(entryContext);
+        }
         snapshot.addEvaluationErrors(entryStatus.errors);
         shouldCommit = true;
       }
       if (exitStatus.shouldReportError()) {
+        if (exitContext.getThrowable() != null) {
+          // report also uncaught exception
+          snapshot.setExit(exitContext);
+        }
         snapshot.addEvaluationErrors(exitStatus.errors);
         shouldCommit = true;
       }

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/Snapshot.java
@@ -794,6 +794,10 @@ public class Snapshot {
       if (shouldEvaluate) {
         status.condition = executeScript(probeDetails.getScript(), this, probeId);
         status.hasConditionErrors = handleEvalErrors(status.errors);
+        if (status.hasConditionErrors && throwable != null) {
+          status.errors.add(
+              new EvaluationError("uncaught exception", throwable.type + ": " + throwable.message));
+        }
         if (status.condition) {
           switch (methodLocation) {
             case ENTRY:

--- a/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot05.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot05.java
@@ -17,11 +17,14 @@ public class CapturedSnapshot05 {
 
   public static int main(String arg) {
     CapturedSnapshot05 cs5 = new CapturedSnapshot05();
+    long before = System.currentTimeMillis();
     if ("triggerUncaughtException".equals(arg)) {
       cs5.triggerUncaughtException();
     } else if ("triggerCaughtException".equals(arg)) {
       return cs5.triggerCaughtException();
     }
+    long after = System.currentTimeMillis();
+    System.out.println(after-before);
     return 0;
   }
 


### PR DESCRIPTION
# What Does This Do
include context with uncaught exception to the snapshot and add an evaluation error with the type + message of it.

# Motivation
Help to contextualize why evaluation of a condition may fail (locals not available)

# Additional Notes
