### PR TITLE
Temporarily pin awssdk to 2.20.33 for aws-java-sqs-2.0:latestDepTest

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/build.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/build.gradle
@@ -5,6 +5,7 @@ muzzle {
     module = "aws-core"
     versions = "[2.2.0,)"
     assertInverse = true
+    skipVersions += '2.20.34' // broken jar on maven central
   }
 }
 

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/build.gradle
@@ -32,6 +32,6 @@ dependencies {
   testImplementation group: 'org.elasticmq', name: 'elasticmq-rest-sqs_2.13', version: '1.2.3'
   testImplementation group: 'com.amazonaws', name: 'amazon-sqs-java-messaging-lib', version: '2.0.0'
 
-  latestDepTestImplementation group: 'software.amazon.awssdk', name: 'sqs', version: '+'
+  latestDepTestImplementation group: 'software.amazon.awssdk', name: 'sqs', version: '2.20.33'
   latestDepTestImplementation group: 'com.amazonaws', name: 'amazon-sqs-java-messaging-lib', version: '2.0.+'
 }

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/build.gradle
@@ -6,6 +6,7 @@ muzzle {
     versions = "[2.0.0,)"
     extraDependency 'com.amazonaws:amazon-sqs-java-messaging-lib:2.0.0'
     assertInverse = true
+    skipVersions += '2.20.34' // broken jar on maven central
   }
 }
 


### PR DESCRIPTION
because 2.20.34 is an incomplete release (the jar is listed on Maven Central but cannot be downloaded)