### PR TITLE
Temporarily pin awssdk to 2.20.33 for aws-java-sdk-2.2:latestDepTest

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/build.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/build.gradle
@@ -17,6 +17,8 @@ testSets {
   latestDepTest
 }
 
+def fixedSdkVersion = '2.20.33' // 2.20.34 is missing and breaks IDEA import
+
 dependencies {
   compileOnly group: 'software.amazon.awssdk', name: 'aws-core', version: '2.2.0'
 
@@ -36,12 +38,12 @@ dependencies {
   latestDepTestImplementation project(':dd-java-agent:instrumentation:apache-httpclient-4')
   latestDepTestImplementation project(':dd-java-agent:instrumentation:netty-4.1')
 
-  latestDepTestImplementation group: 'software.amazon.awssdk', name: 'apache-client', version: '+'
-  latestDepTestImplementation group: 'software.amazon.awssdk', name: 's3', version: '+'
-  latestDepTestImplementation group: 'software.amazon.awssdk', name: 'rds', version: '+'
-  latestDepTestImplementation group: 'software.amazon.awssdk', name: 'ec2', version: '+'
-  latestDepTestImplementation group: 'software.amazon.awssdk', name: 'sqs', version: '+'
-  latestDepTestImplementation group: 'software.amazon.awssdk', name: 'sns', version: '+'
-  latestDepTestImplementation group: 'software.amazon.awssdk', name: 'dynamodb', version: '+'
-  latestDepTestImplementation group: 'software.amazon.awssdk', name: 'kinesis', version: '+'
+  latestDepTestImplementation group: 'software.amazon.awssdk', name: 'apache-client', version: fixedSdkVersion
+  latestDepTestImplementation group: 'software.amazon.awssdk', name: 's3', version: fixedSdkVersion
+  latestDepTestImplementation group: 'software.amazon.awssdk', name: 'rds', version: fixedSdkVersion
+  latestDepTestImplementation group: 'software.amazon.awssdk', name: 'ec2', version: fixedSdkVersion
+  latestDepTestImplementation group: 'software.amazon.awssdk', name: 'sqs', version: fixedSdkVersion
+  latestDepTestImplementation group: 'software.amazon.awssdk', name: 'sns', version: fixedSdkVersion
+  latestDepTestImplementation group: 'software.amazon.awssdk', name: 'dynamodb', version: fixedSdkVersion
+  latestDepTestImplementation group: 'software.amazon.awssdk', name: 'kinesis', version: fixedSdkVersion
 }


### PR DESCRIPTION
# What Does This Do
Since `2.20.34` is an incomplete release.

# Motivation
Unable to do an import into IntelliJ IDEA, since `software.amazon.awssdk:sdk-core:2.20.34` is missing.

# Additional Notes
