### PR TITLE
Add span decoration config

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/Configuration.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/Configuration.java
@@ -3,6 +3,7 @@ package com.datadog.debugger.agent;
 import com.datadog.debugger.probe.LogProbe;
 import com.datadog.debugger.probe.MetricProbe;
 import com.datadog.debugger.probe.ProbeDefinition;
+import com.datadog.debugger.probe.SpanDecorationProbe;
 import com.datadog.debugger.probe.SpanProbe;
 import com.squareup.moshi.Json;
 import java.util.ArrayList;
@@ -63,6 +64,7 @@ public class Configuration {
   private final Collection<MetricProbe> metricProbes;
   private final Collection<LogProbe> logProbes;
   private final Collection<SpanProbe> spanProbes;
+  private final Collection<SpanDecorationProbe> spanDecorationProbes;
   private final FilterList allowList;
   private final FilterList denyList;
   private final LogProbe.Sampling sampling;
@@ -76,7 +78,7 @@ public class Configuration {
       Collection<MetricProbe> metricProbes,
       Collection<LogProbe> logProbes,
       Collection<SpanProbe> spanProbes) {
-    this(serviceName, metricProbes, logProbes, spanProbes, null, null, null);
+    this(serviceName, metricProbes, logProbes, spanProbes, null, null, null, null);
   }
 
   public Configuration(
@@ -84,6 +86,7 @@ public class Configuration {
       Collection<MetricProbe> metricProbes,
       Collection<LogProbe> logProbes,
       Collection<SpanProbe> spanProbes,
+      Collection<SpanDecorationProbe> spanDecorationProbes,
       FilterList allowList,
       FilterList denyList,
       LogProbe.Sampling sampling) {
@@ -91,6 +94,7 @@ public class Configuration {
     this.metricProbes = metricProbes;
     this.logProbes = logProbes;
     this.spanProbes = spanProbes;
+    this.spanDecorationProbes = spanDecorationProbes;
     this.allowList = allowList;
     this.denyList = denyList;
     this.sampling = sampling;
@@ -110,6 +114,10 @@ public class Configuration {
 
   public Collection<SpanProbe> getSpanProbes() {
     return spanProbes;
+  }
+
+  public Collection<SpanDecorationProbe> getSpanDecorationProbes() {
+    return spanDecorationProbes;
   }
 
   public FilterList getAllowList() {
@@ -134,6 +142,9 @@ public class Configuration {
     }
     if (spanProbes != null) {
       result.addAll(spanProbes);
+    }
+    if (spanDecorationProbes != null) {
+      result.addAll(spanDecorationProbes);
     }
     return result;
   }
@@ -186,6 +197,7 @@ public class Configuration {
     private List<MetricProbe> metricProbes = null;
     private List<LogProbe> logProbes = null;
     private List<SpanProbe> spanProbes = null;
+    private List<SpanDecorationProbe> spanDecorationProbes = null;
     private FilterList allowList = null;
     private FilterList denyList = null;
     private LogProbe.Sampling sampling = null;
@@ -216,6 +228,14 @@ public class Configuration {
         spanProbes = new ArrayList<>();
       }
       spanProbes.add(probe);
+      return this;
+    }
+
+    public Configuration.Builder add(SpanDecorationProbe probe) {
+      if (spanProbes == null) {
+        spanProbes = new ArrayList<>();
+      }
+      spanDecorationProbes.add(probe);
       return this;
     }
 
@@ -256,6 +276,16 @@ public class Configuration {
       return this;
     }
 
+    public Configuration.Builder addSpanDecorationProbes(Collection<SpanDecorationProbe> probes) {
+      if (probes == null) {
+        return this;
+      }
+      for (SpanDecorationProbe probe : probes) {
+        add(probe);
+      }
+      return this;
+    }
+
     public Configuration.Builder addAllowList(FilterList newAllowList) {
       if (newAllowList == null) {
         return this;
@@ -291,6 +321,8 @@ public class Configuration {
       }
       addMetricProbes(other.getMetricProbes());
       addLogProbes(other.getLogProbes());
+      addSpanProbes(other.getSpanProbes());
+      addSpanDecorationProbes(other.getSpanDecorationProbes());
       addAllowList(other.getAllowList());
       addDenyList(other.getDenyList());
       add(other.getSampling());
@@ -299,7 +331,14 @@ public class Configuration {
 
     public Configuration build() {
       return new Configuration(
-          service, metricProbes, logProbes, spanProbes, allowList, denyList, sampling);
+          service,
+          metricProbes,
+          logProbes,
+          spanProbes,
+          spanDecorationProbes,
+          allowList,
+          denyList,
+          sampling);
     }
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -4,6 +4,7 @@ import com.datadog.debugger.instrumentation.InstrumentationResult;
 import com.datadog.debugger.probe.LogProbe;
 import com.datadog.debugger.probe.MetricProbe;
 import com.datadog.debugger.probe.ProbeDefinition;
+import com.datadog.debugger.probe.SpanDecorationProbe;
 import com.datadog.debugger.probe.SpanProbe;
 import com.datadog.debugger.sink.DebuggerSink;
 import com.datadog.debugger.util.ExceptionHelper;
@@ -34,6 +35,7 @@ public class ConfigurationUpdater
   public static final int MAX_ALLOWED_METRIC_PROBES = 100;
   public static final int MAX_ALLOWED_LOG_PROBES = 100;
   private static final int MAX_ALLOWED_SPAN_PROBES = 100;
+  private static final int MAX_ALLOWED_SPAN_DECORATION_PROBES = 100;
   private static final double RATE_LIMIT_PER_SNAPSHOT_PROBE = 1.0;
   private static final double RATE_LIMIT_PER_LOG_PROBE = 5000.0;
 
@@ -122,11 +124,14 @@ public class ConfigurationUpdater
         filterProbes(configuration::getLogProbes, MAX_ALLOWED_LOG_PROBES);
     Collection<SpanProbe> spanProbes =
         filterProbes(configuration::getSpanProbes, MAX_ALLOWED_SPAN_PROBES);
+    Collection<SpanDecorationProbe> spanDecorationProbes =
+        filterProbes(configuration::getSpanDecorationProbes, MAX_ALLOWED_SPAN_DECORATION_PROBES);
     return new Configuration(
         serviceName,
         metricProbes,
         logProbes,
         spanProbes,
+        spanDecorationProbes,
         configuration.getAllowList(),
         configuration.getDenyList(),
         configuration.getSampling());

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerProductChangesListener.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerProductChangesListener.java
@@ -2,6 +2,7 @@ package com.datadog.debugger.agent;
 
 import com.datadog.debugger.probe.LogProbe;
 import com.datadog.debugger.probe.MetricProbe;
+import com.datadog.debugger.probe.SpanDecorationProbe;
 import com.datadog.debugger.probe.SpanProbe;
 import com.datadog.debugger.util.MoshiHelper;
 import com.squareup.moshi.JsonAdapter;
@@ -39,6 +40,9 @@ public class DebuggerProductChangesListener implements ProductListener {
     static final JsonAdapter<SpanProbe> SPAN_PROBE_JSON_ADAPTER =
         MoshiHelper.createMoshiConfig().adapter(SpanProbe.class);
 
+    static final JsonAdapter<SpanDecorationProbe> SPAN_DECORATION_PROBE_JSON_ADAPTER =
+        MoshiHelper.createMoshiConfig().adapter(SpanDecorationProbe.class);
+
     static Configuration deserializeConfiguration(byte[] content) throws IOException {
       return CONFIGURATION_JSON_ADAPTER.fromJson(
           Okio.buffer(Okio.source(new ByteArrayInputStream(content))));
@@ -56,6 +60,11 @@ public class DebuggerProductChangesListener implements ProductListener {
 
     static SpanProbe deserializeSpanProbe(byte[] content) throws IOException {
       return SPAN_PROBE_JSON_ADAPTER.fromJson(
+          Okio.buffer(Okio.source(new ByteArrayInputStream(content))));
+    }
+
+    static SpanDecorationProbe deserializeSpanDecorationProbe(byte[] content) throws IOException {
+      return SPAN_DECORATION_PROBE_JSON_ADAPTER.fromJson(
           Okio.buffer(Okio.source(new ByteArrayInputStream(content))));
     }
   }
@@ -92,6 +101,9 @@ public class DebuggerProductChangesListener implements ProductListener {
     } else if (configId.startsWith("spanProbe_")) {
       SpanProbe spanProbe = Adapter.deserializeSpanProbe(content);
       configChunks.put(configId, (builder) -> builder.add(spanProbe));
+    } else if (configId.startsWith("spanDecorationProbe_")) {
+      SpanDecorationProbe spanDecorationProbe = Adapter.deserializeSpanDecorationProbe(content);
+      configChunks.put(configId, (builder) -> builder.add(spanDecorationProbe));
     } else if (IS_UUID.test(configId)) {
       Configuration newConfig = Adapter.deserializeConfiguration(content);
       if (newConfig.getService().equals(serviceName)) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
@@ -1,0 +1,169 @@
+package com.datadog.debugger.probe;
+
+import com.datadog.debugger.agent.Generated;
+import com.datadog.debugger.el.ProbeCondition;
+import com.datadog.debugger.el.ValueScript;
+import datadog.trace.bootstrap.debugger.DiagnosticMessage;
+import datadog.trace.bootstrap.debugger.ProbeId;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
+
+public class SpanDecorationProbe extends ProbeDefinition {
+  public enum TargetSpan {
+    ACTIVE,
+    ROOT
+  }
+
+  public static class Tag {
+    private final String tagName;
+    private final ValueScript tagValue;
+
+    public Tag(String tagName, ValueScript tagValue) {
+      this.tagName = tagName;
+      this.tagValue = tagValue;
+    }
+
+    public String getTagName() {
+      return tagName;
+    }
+
+    public ValueScript getTagValue() {
+      return tagValue;
+    }
+  }
+
+  public static class Decoration {
+    private final ProbeCondition when;
+    private final List<Tag> tags;
+
+    public Decoration(ProbeCondition when, List<Tag> tags) {
+      this.when = when;
+      this.tags = tags;
+    }
+
+    public ProbeCondition getWhen() {
+      return when;
+    }
+
+    public List<Tag> getTags() {
+      return tags;
+    }
+  }
+
+  private final TargetSpan targetSpan;
+  private final List<Decoration> decorate;
+
+  // no-arg constructor is required by Moshi to avoid creating instance with unsafe and by-passing
+  // constructors, including field initializers.
+  public SpanDecorationProbe() {
+    this(LANGUAGE, null, null, null, MethodLocation.DEFAULT, TargetSpan.ACTIVE, null);
+  }
+
+  public SpanDecorationProbe(
+      String language,
+      ProbeId probeId,
+      String[] tagStrs,
+      Where where,
+      MethodLocation methodLocation,
+      TargetSpan targetSpan,
+      List<Decoration> decorate) {
+    super(language, probeId, tagStrs, where, methodLocation);
+    this.targetSpan = targetSpan;
+    this.decorate = decorate;
+  }
+
+  @Override
+  public void instrument(
+      ClassLoader classLoader,
+      ClassNode classNode,
+      MethodNode methodNode,
+      List<DiagnosticMessage> diagnostics,
+      List<String> probeIds) {}
+
+  public TargetSpan getTargetSpan() {
+    return targetSpan;
+  }
+
+  public List<Decoration> getDecorate() {
+    return decorate;
+  }
+
+  @Generated
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(language, id, version, tagMap, where, evaluateAt);
+    result = 31 * result + Arrays.hashCode(tags);
+    return result;
+  }
+
+  @Generated
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    SpanDecorationProbe that = (SpanDecorationProbe) o;
+    return Objects.equals(language, that.language)
+        && Objects.equals(id, that.id)
+        && version == that.version
+        && Arrays.equals(tags, that.tags)
+        && Objects.equals(tagMap, that.tagMap)
+        && Objects.equals(where, that.where)
+        && Objects.equals(evaluateAt, that.evaluateAt);
+  }
+
+  @Generated
+  @Override
+  public String toString() {
+    return "SpanDecorationProbe{"
+        + "language='"
+        + language
+        + '\''
+        + ", id='"
+        + id
+        + '\''
+        + ", version="
+        + version
+        + ", tags="
+        + Arrays.toString(tags)
+        + ", tagMap="
+        + tagMap
+        + ", where="
+        + where
+        + ", evaluateAt="
+        + evaluateAt
+        + "} ";
+  }
+
+  public static SpanDecorationProbe.Builder builder() {
+    return new SpanDecorationProbe.Builder();
+  }
+
+  public static class Builder extends ProbeDefinition.Builder<SpanDecorationProbe.Builder> {
+    private TargetSpan targetSpan;
+    private List<Decoration> decorate;
+
+    public Builder targetSpan(TargetSpan targetSpan) {
+      this.targetSpan = targetSpan;
+      return this;
+    }
+
+    public Builder decorate(List<Decoration> decorate) {
+      this.decorate = decorate;
+      return this;
+    }
+
+    public Builder decorate(Decoration decoration) {
+      this.decorate = Collections.singletonList(decoration);
+      return this;
+    }
+
+    public SpanDecorationProbe build() {
+      return new SpanDecorationProbe(
+          LANGUAGE, probeId, tagStrs, where, evaluateAt, targetSpan, decorate);
+    }
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
@@ -5,11 +5,16 @@ import static com.datadog.debugger.probe.MetricProbe.MetricKind.GAUGE;
 import static com.datadog.debugger.util.LogProbeTestHelper.parseTemplate;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.datadog.debugger.el.DSL;
+import com.datadog.debugger.el.ProbeCondition;
+import com.datadog.debugger.el.ValueScript;
 import com.datadog.debugger.probe.LogProbe;
 import com.datadog.debugger.probe.MetricProbe;
 import com.datadog.debugger.probe.ProbeDefinition;
+import com.datadog.debugger.probe.SpanDecorationProbe;
 import com.datadog.debugger.probe.SpanProbe;
 import com.datadog.debugger.util.MoshiHelper;
 import com.squareup.moshi.JsonAdapter;
@@ -29,12 +34,13 @@ public class ConfigurationTest {
   @Test
   public void getDefinitions() {
     Configuration config1 = createConfig1();
-    assertEquals(4, config1.getDefinitions().size());
+    assertEquals(5, config1.getDefinitions().size());
     Iterator<ProbeDefinition> iterator = config1.getDefinitions().iterator();
     assertEquals("metric1", iterator.next().getId());
     assertEquals("probe1", iterator.next().getId());
     assertEquals("log1", iterator.next().getId());
     assertEquals("span1", iterator.next().getId());
+    assertEquals("decorateSpan1", iterator.next().getId());
   }
 
   @Test
@@ -52,6 +58,50 @@ public class ConfigurationTest {
     assertEquals("datadog.debugger.refpathvalue", metricProbes.get(2).getMetricName());
     assertEquals("ValueScript{dsl='obj.field'}", metricProbes.get(2).getValue().toString());
     assertEquals("datadog.debugger.novalue", metricProbes.get(3).getMetricName());
+  }
+
+  @Test
+  public void deserializeSpanProbes() throws Exception {
+    String content = TestHelper.getFixtureContent("/test_span_probe.json");
+    JsonAdapter<Configuration> adapter =
+        MoshiHelper.createMoshiConfig().adapter(Configuration.class);
+    Configuration config = adapter.fromJson(content);
+    List<SpanProbe> spanProbes = new ArrayList<>(config.getSpanProbes());
+    assertEquals(4, spanProbes.size());
+    assertEquals("123356536", spanProbes.get(0).getId());
+    assertEquals("123356537", spanProbes.get(1).getId());
+    assertEquals("123356538", spanProbes.get(2).getId());
+    assertEquals("123356539", spanProbes.get(3).getId());
+  }
+
+  @Test
+  public void deserializeSpanDecorationProbes() throws Exception {
+    String content = TestHelper.getFixtureContent("/test_span_decoration_probe.json");
+    JsonAdapter<Configuration> adapter =
+        MoshiHelper.createMoshiConfig().adapter(Configuration.class);
+    Configuration config = adapter.fromJson(content);
+    List<SpanDecorationProbe> spanDecorationProbes =
+        new ArrayList<>(config.getSpanDecorationProbes());
+    assertEquals(4, spanDecorationProbes.size());
+    assertEquals(
+        SpanDecorationProbe.TargetSpan.ACTIVE, spanDecorationProbes.get(0).getTargetSpan());
+    assertEquals(
+        "uuid == 'showMe'",
+        spanDecorationProbes.get(0).getDecorate().get(0).getWhen().getDslExpression());
+    assertEquals(
+        "uuid", spanDecorationProbes.get(0).getDecorate().get(0).getTags().get(0).getTagName());
+    assertEquals(
+        "uuid",
+        spanDecorationProbes.get(0).getDecorate().get(0).getTags().get(0).getTagValue().getDsl());
+    assertEquals(
+        SpanDecorationProbe.TargetSpan.ACTIVE, spanDecorationProbes.get(1).getTargetSpan());
+    assertNull(spanDecorationProbes.get(1).getDecorate().get(0).getWhen());
+    assertEquals(
+        "uuid", spanDecorationProbes.get(1).getDecorate().get(0).getTags().get(0).getTagName());
+    assertEquals(
+        "tag2", spanDecorationProbes.get(1).getDecorate().get(0).getTags().get(1).getTagName());
+    assertEquals(SpanDecorationProbe.TargetSpan.ROOT, spanDecorationProbes.get(2).getTargetSpan());
+    assertEquals(SpanDecorationProbe.TargetSpan.ROOT, spanDecorationProbes.get(3).getTargetSpan());
   }
 
   @Test
@@ -187,6 +237,15 @@ public class ConfigurationTest {
     SpanProbe spanProbe1 = config0.getSpanProbes().iterator().next();
     SpanProbe spanProbe2 = config1.getSpanProbes().iterator().next();
     assertEquals("12-23", spanProbe2.getWhere().getLines()[0]);
+    // span decoration probe
+    assertEquals(1, config0.getSpanDecorationProbes().size());
+    SpanDecorationProbe spanDecoration1 = config0.getSpanDecorationProbes().iterator().next();
+    assertEquals(SpanDecorationProbe.TargetSpan.ACTIVE, spanDecoration1.getTargetSpan());
+    assertEquals(
+        "arg1 == 'foo'", spanDecoration1.getDecorate().get(0).getWhen().getDslExpression());
+    assertEquals("id", spanDecoration1.getDecorate().get(0).getTags().get(0).getTagName());
+    assertEquals(
+        "id", spanDecoration1.getDecorate().get(0).getTags().get(0).getTagValue().getDsl());
   }
 
   private Configuration createConfig1() {
@@ -197,6 +256,19 @@ public class ConfigurationTest {
         createLog(
             "log1", "this is a log line with arg={arg}", "java.lang.String", "indexOf", "(String)");
     SpanProbe span1 = createSpan("span1", "java.lang.String", "indexOf", "(String)");
+    SpanDecorationProbe.Decoration decoration =
+        new SpanDecorationProbe.Decoration(
+            new ProbeCondition(
+                DSL.when(DSL.eq(DSL.ref("arg1"), DSL.value("foo"))), "arg1 == 'foo'"),
+            Arrays.asList(new SpanDecorationProbe.Tag("id", new ValueScript(DSL.ref("id"), "id"))));
+    SpanDecorationProbe spanDecoration1 =
+        createDecorationSpan(
+            "decorateSpan1",
+            SpanDecorationProbe.TargetSpan.ACTIVE,
+            decoration,
+            "java.lang.String",
+            "indexOf",
+            "(String)");
     Configuration.FilterList allowList =
         new Configuration.FilterList(
             Arrays.asList("java.lang.util"), Arrays.asList("java.lang.String"));
@@ -209,6 +281,7 @@ public class ConfigurationTest {
         Arrays.asList(metric1),
         Arrays.asList(probe1, log1),
         Arrays.asList(span1),
+        Arrays.asList(spanDecoration1),
         allowList,
         denyList,
         globalSampling);
@@ -226,6 +299,20 @@ public class ConfigurationTest {
             "indexOf",
             "(String)");
     SpanProbe span2 = createSpan("span2", "String.java", 12, 23);
+    SpanDecorationProbe.Decoration decoration =
+        new SpanDecorationProbe.Decoration(
+            new ProbeCondition(DSL.when(DSL.eq(DSL.ref("arg"), DSL.value("foo"))), "arg == 'foo'"),
+            Arrays.asList(
+                new SpanDecorationProbe.Tag("tag1", new ValueScript(DSL.ref("arg1"), "arg1")),
+                new SpanDecorationProbe.Tag("tag2", new ValueScript(DSL.ref("arg2"), "arg2"))));
+    SpanDecorationProbe spanDecoration2 =
+        createDecorationSpan(
+            "span2",
+            SpanDecorationProbe.TargetSpan.ACTIVE,
+            decoration,
+            "String.java",
+            "indexOf",
+            "(String)");
     Configuration.FilterList allowList =
         new Configuration.FilterList(
             Arrays.asList("java.lang.util"), Arrays.asList("java.lang.String"));
@@ -238,6 +325,7 @@ public class ConfigurationTest {
         Arrays.asList(metric2),
         Arrays.asList(probe2, log2),
         Arrays.asList(span2),
+        Arrays.asList(spanDecoration2),
         allowList,
         denyList,
         globalSampling);
@@ -300,6 +388,24 @@ public class ConfigurationTest {
         .where(typeName, methodName, signature)
         .evaluateAt(ProbeDefinition.MethodLocation.ENTRY)
         .tags("tag1:value1", "tag2:value2")
+        .build();
+  }
+
+  private static SpanDecorationProbe createDecorationSpan(
+      String id,
+      SpanDecorationProbe.TargetSpan targetSpan,
+      SpanDecorationProbe.Decoration decoration,
+      String typeName,
+      String methodName,
+      String signature) {
+    return SpanDecorationProbe.builder()
+        .language("java")
+        .probeId(id, 0)
+        .where(typeName, methodName, signature)
+        .evaluateAt(ProbeDefinition.MethodLocation.ENTRY)
+        .tags("tag1:value1", "tag2:value2")
+        .targetSpan(targetSpan)
+        .decorate(decoration)
         .build();
   }
 

--- a/dd-java-agent/agent-debugger/src/test/resources/test_span_decoration_probe.json
+++ b/dd-java-agent/agent-debugger/src/test/resources/test_span_decoration_probe.json
@@ -1,0 +1,148 @@
+{
+  "id": "petclinic",
+  "orgId": 2,
+  "allowList": {
+    "packagePrefixes": ["com.datadog", "org.apache"],
+    "classes": []
+  },
+  "denyList": {
+    "packagePrefixes": ["java.security", "sun.security"],
+    "classes": []
+  },
+  "spanDecorationProbes": [{
+    "id": "123356536",
+    "language": "java",
+    "created": 1606407800.445507000,
+    "where": {
+      "typeName": "java.lang.Object",
+      "methodName": "toString",
+      "signature": "java.lang.String ()"
+    },
+    "targetSpan": "ACTIVE",
+    "decorate": [
+      {
+        "when":
+        {
+          "dsl": "uuid == 'showMe'",
+          "json":
+          {
+            "eq":
+            [
+              {
+                "ref": "uuid"
+              },
+              "showMe"
+            ]
+          }
+        },
+        "tags":
+        [
+          {
+            "tagName": "uuid",
+            "tagValue":
+            {
+              "dsl": "uuid",
+              "json": {
+                "ref": "uuid"
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }, {
+    "id": "123356537",
+    "language": "java",
+    "created": 1606407801.445507000,
+    "where": {
+      "typeName": "java.lang.Object",
+      "methodName": "toString",
+      "signature": "java.lang.String ()"
+    },
+    "tags": ["version:v123", "env:staging"],
+    "targetSpan": "ACTIVE",
+    "decorate": [
+      {
+        "tags":
+        [
+          {
+            "tagName": "uuid",
+            "tagValue":
+            {
+              "dsl": "uuid",
+              "json": {
+                "ref": "uuid"
+              }
+            }
+          },
+          {
+            "tagName": "tag2",
+            "tagValue":
+            {
+              "dsl": "arg2",
+              "json": {
+                "ref": "arg2"
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }, {
+    "id": "123356538",
+    "language": "java",
+    "created": 1606407801.445507000,
+    "where": {
+      "typeName": "java.lang.Object",
+      "methodName": "toString",
+      "signature": "java.lang.String ()"
+    },
+    "tags": ["version:v123", "env:staging"],
+    "targetSpan": "ROOT",
+    "decorate": [
+    ]
+  },{
+    "id": "123356539",
+    "language": "java",
+    "created": 1606407801.445507000,
+    "where": {
+      "typeName": "java.lang.Object",
+      "methodName": "toString",
+      "signature": "java.lang.String ()"
+    },
+    "tags": ["version:v123", "env:staging"],
+    "evaluateAt": "EXIT",
+    "targetSpan": "ROOT",
+    "decorate": [
+      {
+        "when":
+        {
+          "dsl": "@duration > 0",
+          "json":
+          {
+            "gt":
+            [
+              {
+                "ref": "@duration"
+              },
+              0
+            ]
+          }
+        },
+        "tags":
+        [
+          {
+            "tagName": "uuid",
+            "tagValue":
+            {
+              "dsl": "uuid",
+              "json": {
+                "ref": "uuid"
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }]
+}

--- a/dd-java-agent/agent-debugger/src/test/resources/test_span_probe.json
+++ b/dd-java-agent/agent-debugger/src/test/resources/test_span_probe.json
@@ -1,0 +1,52 @@
+{
+  "id": "petclinic",
+  "orgId": 2,
+  "allowList": {
+    "packagePrefixes": ["com.datadog", "org.apache"],
+    "classes": []
+  },
+  "denyList": {
+    "packagePrefixes": ["java.security", "sun.security"],
+    "classes": []
+  },
+  "spanProbes": [{
+    "id": "123356536",
+    "language": "java",
+    "created": 1606407800.445507000,
+    "where": {
+      "typeName": "java.lang.Object",
+      "methodName": "toString",
+      "signature": "java.lang.String ()"
+    }
+  }, {
+    "id": "123356537",
+    "language": "java",
+    "created": 1606407801.445507000,
+    "where": {
+      "typeName": "java.lang.Object",
+      "methodName": "toString",
+      "signature": "java.lang.String ()"
+    },
+    "tags": ["version:v123", "env:staging"]
+  }, {
+    "id": "123356538",
+    "language": "java",
+    "created": 1606407801.445507000,
+    "where": {
+      "typeName": "java.lang.Object",
+      "methodName": "toString",
+      "signature": "java.lang.String ()"
+    },
+    "tags": ["version:v123", "env:staging"]
+  },{
+    "id": "123356539",
+    "language": "java",
+    "created": 1606407801.445507000,
+    "where": {
+      "typeName": "java.lang.Object",
+      "methodName": "toString",
+      "signature": "java.lang.String ()"
+    },
+    "tags": ["version:v123", "env:staging"]
+  }]
+}


### PR DESCRIPTION
# What Does This Do
Add support for decorating current active or root span with dynamic tag values taken from the context where the probe is set. Adding the tag can also depend on condition

# Motivation
Introduced new kind of probe to decorate existing span with dynamic tags

# Additional Notes
Instrumentation will be implemented in next PR