### PR TITLE
bump jplib to 0.29.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    jplib         : "0.28.0",
+    jplib         : "0.29.0",
     asm           : "9.4"
   ]
 


### PR DESCRIPTION
# What Does This Do

Contains a fix to prevent long strings (symbols, APM attributes) from overflowing JFR buffers

# Motivation

# Additional Notes
