### PR TITLE
Update resource name expected by recently added GraphQL CompletionStage support test

### DIFF
--- a/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLTest.groovy
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/src/test/groovy/GraphQLTest.groovy
@@ -234,7 +234,7 @@ abstract class GraphQLTest extends VersionedNamingTestBase {
       trace(6) {
         span {
           operationName operation()
-          resourceName operation()
+          resourceName 'findBookHashById'
           spanType DDSpanTypes.GRAPHQL
           errored false
           measured true


### PR DESCRIPTION
…upport to align with updated behavior

# What Does This Do

Because https://github.com/DataDog/dd-trace-java/pull/4896 and https://github.com/DataDog/dd-trace-java/pull/4960 were being worked on independently and merged on around the same time, the changes in behavior introduced in https://github.com/DataDog/dd-trace-java/pull/4960 were not updated in the newly added unit test in https://github.com/DataDog/dd-trace-java/pull/4896.

This MR changes the test to properly expect the right value now.

# Motivation

To help address https://github.com/DataDog/dd-trace-java/pull/5001/files where these tests were marked Flaky, this will reduce the failure rate

# Additional Notes
