### PR TITLE
byte-buddy 1.14.3 + asm 9.5

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -31,15 +31,15 @@ dependencies {
   implementation(gradleApi())
   implementation(localGroovy())
 
-  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.12.22")
+  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.14.3")
 
   implementation("org.eclipse.aether", "aether-connector-basic", "1.1.0")
   implementation("org.eclipse.aether", "aether-transport-http", "1.1.0")
   implementation("org.apache.maven", "maven-aether-provider", "3.3.9")
 
   implementation("com.google.guava", "guava", "20.0")
-  implementation("org.ow2.asm", "asm", "9.0")
-  implementation("org.ow2.asm", "asm-tree", "9.0")
+  implementation("org.ow2.asm", "asm", "9.5")
+  implementation("org.ow2.asm", "asm-tree", "9.5")
 
   testImplementation("org.spockframework", "spock-core", "2.0-groovy-3.0")
   testImplementation("org.codehaus.groovy", "groovy-all", "3.0.10")

--- a/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
+++ b/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
@@ -23,7 +23,7 @@ class InstrumentPluginTest extends Specification {
     }
 
     dependencies {
-      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.12.22' // just to build TestPlugin
+      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.3' // just to build TestPlugin
     }
 
     apply plugin: 'instrument'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -14,7 +14,7 @@ final class CachedData {
     groovy        : groovyVer,
     junit5        : "5.9.2",
     logback       : "1.2.3",
-    bytebuddy     : "1.12.22",
+    bytebuddy     : "1.14.3",
     scala         : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)
     scala210      : "2.10.7",
     scala211      : "2.11.12",
@@ -34,7 +34,7 @@ final class CachedData {
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
     jplib         : "0.29.0",
-    asm           : "9.4"
+    asm           : "9.5"
   ]
 
   static deps = [


### PR DESCRIPTION
Byte Buddy 1.14.3
* Make MethodGraph.Compiler failsafe when processing incomplete methods.
* Update ASM.

Byte Buddy 1.14.2
* Fix offset mapping for local variable array remapping in Advice.
* Add possibility to specify an index for skipOn and repeatOn which resolves the checked value from a returned array.

Byte Buddy 1.14.1
* Add extended scope for Maven Byte Buddy plugin to include all non-test-dependencies.

Byte Buddy 1.14.0
* Add Step.Factory.ForDelegation in MemberSubstitution that allows for delegation similar to MethodDelegation but in-code.
* Add handlers for MethodDelegation and Advice that leverage method handles for field access and self-invocation.
* Add Step.Factory for type assignment that allows casting the return value from a previous step to another type.
* Avoid usage of URL class loader as it is deprecated, and use newer method if available.

Byte Buddy 1.13.0
* Complete MemberSubstitution API which now retains the original instruction for invocation.
* Allow excluding methods from a MethodGraph.Compiler using an ElementMatcher.
* Add a filtering ClassFileLocator.
* Add a matcher for a type's ClassFileVersion.
* Unify resolution of constant values by introducing a ConstantValue API.
* Do not exclude ToThrown assignment on void methods.
* Allow constructors as target in MemberSubstitution.

Byte Buddy 1.12.23
* Allow using ClassFileLocator to AgentBuilder to append boot-injected types.
* Add RenamingPlugin that allows for migration of names using the build plugin.
* Add wrapper method to ForAdvice transformation to allow for easier wrapping.
* Fix Gradle plugin raw folder and improve detection of unused configurations.
* Add additional default Steps to MemberSubstitution to reduce need for custom bytecode generation.