### PR TITLE
Provide peer.hostname on jedis spans

### DIFF
--- a/dd-java-agent/instrumentation/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisClientDecorator.java
+++ b/dd-java-agent/instrumentation/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisClientDecorator.java
@@ -6,10 +6,9 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
-import redis.clients.jedis.Protocol;
+import redis.clients.jedis.Connection;
 
-public class JedisClientDecorator
-    extends DBTypeProcessingDatabaseClientDecorator<Protocol.Command> {
+public class JedisClientDecorator extends DBTypeProcessingDatabaseClientDecorator<Connection> {
   private static final String REDIS = "redis";
   public static final CharSequence COMPONENT_NAME = UTF8BytesString.create("redis-command");
   public static final CharSequence OPERATION_NAME =
@@ -44,18 +43,18 @@ public class JedisClientDecorator
   }
 
   @Override
-  protected String dbUser(final Protocol.Command session) {
+  protected String dbUser(final Connection connection) {
     return null;
   }
 
   @Override
-  protected String dbInstance(final Protocol.Command session) {
+  protected String dbInstance(final Connection connection) {
     return null;
   }
 
   @Override
-  protected String dbHostname(Protocol.Command command) {
-    return null;
+  protected String dbHostname(Connection connection) {
+    return connection.getHost();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisInstrumentation.java
+++ b/dd-java-agent/instrumentation/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisInstrumentation.java
@@ -6,16 +6,17 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jedis.JedisClientDecorator.DECORATE;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
-import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.matcher.ElementMatcher;
+import redis.clients.jedis.Connection;
 import redis.clients.jedis.Protocol.Command;
 
 @AutoService(Instrumenter.class)
@@ -34,7 +35,7 @@ public final class JedisInstrumentation extends Instrumenter.Tracing
 
   @Override
   public String instrumentedType() {
-    return "redis.clients.jedis.Protocol";
+    return "redis.clients.jedis.Connection";
   }
 
   @Override
@@ -48,9 +49,8 @@ public final class JedisInstrumentation extends Instrumenter.Tracing
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(
         isMethod()
-            .and(isPublic())
             .and(named("sendCommand"))
-            .and(takesArgument(1, named("redis.clients.jedis.Protocol$Command"))),
+            .and(takesArgument(0, named("redis.clients.jedis.Protocol$Command"))),
         JedisInstrumentation.class.getName() + "$JedisAdvice");
     // FIXME: This instrumentation only incorporates sending the command, not processing the result.
   }
@@ -58,9 +58,14 @@ public final class JedisInstrumentation extends Instrumenter.Tracing
   public static class JedisAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static AgentScope onEnter(@Advice.Argument(1) final Command command) {
+    public static AgentScope onEnter(
+        @Advice.Argument(0) final Command command, @Advice.This final Connection thiz) {
+      if (CallDepthThreadLocalMap.incrementCallDepth(Connection.class) > 0) {
+        return null;
+      }
       final AgentSpan span = startSpan(JedisClientDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
+      DECORATE.onConnection(span, thiz);
       DECORATE.onStatement(span, command.name());
       return activateSpan(span);
     }
@@ -68,6 +73,10 @@ public final class JedisInstrumentation extends Instrumenter.Tracing
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
         @Advice.Enter final AgentScope scope, @Advice.Thrown final Throwable throwable) {
+      if (scope == null) {
+        return;
+      }
+      CallDepthThreadLocalMap.reset(Connection.class);
       DECORATE.onError(scope.span(), throwable);
       DECORATE.beforeFinish(scope.span());
       scope.close();

--- a/dd-java-agent/instrumentation/jedis-1.4/src/test/groovy/JedisClientTest.groovy
+++ b/dd-java-agent/instrumentation/jedis-1.4/src/test/groovy/JedisClientTest.groovy
@@ -71,6 +71,7 @@ abstract class JedisClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -97,6 +98,7 @@ abstract class JedisClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -111,6 +113,7 @@ abstract class JedisClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -137,6 +140,7 @@ abstract class JedisClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -151,6 +155,7 @@ abstract class JedisClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/jedis-3.0/build.gradle
+++ b/dd-java-agent/instrumentation/jedis-3.0/build.gradle
@@ -9,7 +9,7 @@ muzzle {
   pass {
     group = "redis.clients"
     module = "jedis"
-    versions = "[3.0.0,)"
+    versions = "[3.0.0,4.0.0)"
   }
 }
 

--- a/dd-java-agent/instrumentation/jedis-3.0/src/main/java/datadog/trace/instrumentation/jedis30/JedisClientDecorator.java
+++ b/dd-java-agent/instrumentation/jedis-3.0/src/main/java/datadog/trace/instrumentation/jedis30/JedisClientDecorator.java
@@ -6,9 +6,9 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
-import redis.clients.jedis.commands.ProtocolCommand;
+import redis.clients.jedis.Connection;
 
-public class JedisClientDecorator extends DBTypeProcessingDatabaseClientDecorator<ProtocolCommand> {
+public class JedisClientDecorator extends DBTypeProcessingDatabaseClientDecorator<Connection> {
   public static final JedisClientDecorator DECORATE = new JedisClientDecorator();
 
   private static final String REDIS = "redis";
@@ -44,18 +44,18 @@ public class JedisClientDecorator extends DBTypeProcessingDatabaseClientDecorato
   }
 
   @Override
-  protected String dbUser(final ProtocolCommand session) {
+  protected String dbUser(final Connection connection) {
     return null;
   }
 
   @Override
-  protected String dbInstance(final ProtocolCommand session) {
+  protected String dbInstance(final Connection connection) {
     return null;
   }
 
   @Override
-  protected String dbHostname(ProtocolCommand protocolCommand) {
-    return null;
+  protected String dbHostname(final Connection connection) {
+    return connection.getHost();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jedis-3.0/src/main/java/datadog/trace/instrumentation/jedis30/JedisInstrumentation.java
+++ b/dd-java-agent/instrumentation/jedis-3.0/src/main/java/datadog/trace/instrumentation/jedis30/JedisInstrumentation.java
@@ -5,14 +5,15 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.jedis30.JedisClientDecorator.DECORATE;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
-import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import net.bytebuddy.asm.Advice;
+import redis.clients.jedis.Connection;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.commands.ProtocolCommand;
 
@@ -25,11 +26,6 @@ public final class JedisInstrumentation extends Instrumenter.Tracing
   }
 
   @Override
-  public String instrumentedType() {
-    return "redis.clients.jedis.Protocol";
-  }
-
-  @Override
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".JedisClientDecorator",
@@ -37,12 +33,16 @@ public final class JedisInstrumentation extends Instrumenter.Tracing
   }
 
   @Override
+  public String instrumentedType() {
+    return "redis.clients.jedis.Connection";
+  }
+
+  @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(
         isMethod()
-            .and(isPublic())
             .and(named("sendCommand"))
-            .and(takesArgument(1, named("redis.clients.jedis.commands.ProtocolCommand"))),
+            .and(takesArgument(0, named("redis.clients.jedis.commands.ProtocolCommand"))),
         JedisInstrumentation.class.getName() + "$JedisAdvice");
     // FIXME: This instrumentation only incorporates sending the command, not processing the result.
   }
@@ -50,9 +50,15 @@ public final class JedisInstrumentation extends Instrumenter.Tracing
   public static class JedisAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static AgentScope onEnter(@Advice.Argument(1) final ProtocolCommand command) {
+    public static AgentScope onEnter(
+        @Advice.Argument(0) final ProtocolCommand command, @Advice.This final Connection thiz) {
+      if (CallDepthThreadLocalMap.incrementCallDepth(Connection.class) > 0) {
+        return null;
+      }
       final AgentSpan span = startSpan(JedisClientDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
+      DECORATE.onConnection(span, thiz);
+
       if (command instanceof Protocol.Command) {
         DECORATE.onStatement(span, ((Protocol.Command) command).name());
       } else {
@@ -66,6 +72,10 @@ public final class JedisInstrumentation extends Instrumenter.Tracing
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
         @Advice.Enter final AgentScope scope, @Advice.Thrown final Throwable throwable) {
+      if (scope == null) {
+        return;
+      }
+      CallDepthThreadLocalMap.reset(Connection.class);
       DECORATE.onError(scope.span(), throwable);
       DECORATE.beforeFinish(scope.span());
       scope.close();

--- a/dd-java-agent/instrumentation/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
+++ b/dd-java-agent/instrumentation/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
@@ -70,6 +70,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -96,6 +97,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -111,6 +113,8 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
+
             defaultTags()
           }
         }
@@ -138,6 +142,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -153,6 +158,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -185,6 +191,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -199,6 +206,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -234,6 +242,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -248,6 +257,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -262,6 +272,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -276,6 +287,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -290,6 +302,7 @@ abstract class Jedis30ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/jedis-4.0/src/main/java/datadog/trace/instrumentation/jedis40/JedisInstrumentation.java
+++ b/dd-java-agent/instrumentation/jedis-4.0/src/main/java/datadog/trace/instrumentation/jedis40/JedisInstrumentation.java
@@ -3,10 +3,10 @@ package datadog.trace.instrumentation.jedis40;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.instrumentation.jedis40.JedisClientDecorator.DECORATE;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static redis.clients.jedis.JedisClientDecorator.DECORATE;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
@@ -14,6 +14,8 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import net.bytebuddy.asm.Advice;
 import redis.clients.jedis.CommandObject;
+import redis.clients.jedis.Connection;
+import redis.clients.jedis.JedisClientDecorator;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.commands.ProtocolCommand;
 
@@ -33,7 +35,7 @@ public final class JedisInstrumentation extends Instrumenter.Tracing
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".JedisClientDecorator",
+      "redis.clients.jedis.JedisClientDecorator",
     };
   }
 
@@ -50,9 +52,12 @@ public final class JedisInstrumentation extends Instrumenter.Tracing
   public static class JedisAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static AgentScope onEnter(@Advice.Argument(0) final CommandObject<?> commandObject) {
+    public static AgentScope onEnter(
+        @Advice.Argument(0) final CommandObject<?> commandObject,
+        @Advice.This final Connection thiz) {
       final AgentSpan span = startSpan(JedisClientDecorator.OPERATION_NAME);
       DECORATE.afterStart(span);
+      DECORATE.onConnection(span, thiz);
 
       final ProtocolCommand command = commandObject.getArguments().getCommand();
 

--- a/dd-java-agent/instrumentation/jedis-4.0/src/main/java/redis/clients/jedis/JedisClientDecorator.java
+++ b/dd-java-agent/instrumentation/jedis-4.0/src/main/java/redis/clients/jedis/JedisClientDecorator.java
@@ -1,4 +1,4 @@
-package datadog.trace.instrumentation.jedis40;
+package redis.clients.jedis;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
@@ -6,9 +6,8 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
-import redis.clients.jedis.commands.ProtocolCommand;
 
-public class JedisClientDecorator extends DBTypeProcessingDatabaseClientDecorator<ProtocolCommand> {
+public class JedisClientDecorator extends DBTypeProcessingDatabaseClientDecorator<Connection> {
   public static final JedisClientDecorator DECORATE = new JedisClientDecorator();
 
   private static final String REDIS = "redis";
@@ -44,26 +43,19 @@ public class JedisClientDecorator extends DBTypeProcessingDatabaseClientDecorato
   }
 
   @Override
-  protected String dbUser(final ProtocolCommand session) {
+  protected String dbUser(final Connection connection) {
     return null;
   }
 
   @Override
-  protected String dbInstance(final ProtocolCommand session) {
+  protected String dbInstance(final Connection connection) {
     return null;
   }
 
   @Override
-  protected String dbHostname(ProtocolCommand protocolCommand) {
-    // As the instrumentation is on the Connection object to retrieve the current host
-    // should be a matter of calling the getHostAndPort on the instrumented Connection object.
-    // Binding a variable to the `this` of the instrumented method by using `@Advice.This`
-    // annotation to the onEnter method in JedisInstrumentation should allow this
-    // To support this some changes may to how the Decorator is instantiated. Unsure if the host and
-    // port
-    // can change per thread/invocation.
-
-    return null;
+  protected String dbHostname(Connection connection) {
+    // getHostAndPort is protected hence the decorator sits in the same package
+    return connection.getHostAndPort().getHost();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jedis-4.0/src/test/groovy/Jedis40ClientTest.groovy
+++ b/dd-java-agent/instrumentation/jedis-4.0/src/test/groovy/Jedis40ClientTest.groovy
@@ -1,3 +1,7 @@
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
+
 import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.Config
@@ -6,10 +10,6 @@ import datadog.trace.bootstrap.instrumentation.api.Tags
 import redis.clients.jedis.Jedis
 import redis.embedded.RedisServer
 import spock.lang.Shared
-
-import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
 abstract class Jedis40ClientTest extends VersionedNamingTestBase {
 
@@ -70,6 +70,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -96,6 +97,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -111,6 +113,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -138,6 +141,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -153,6 +157,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -185,6 +190,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -199,6 +205,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -234,6 +241,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -248,6 +256,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -262,6 +271,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -276,6 +286,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }
@@ -290,6 +301,7 @@ abstract class Jedis40ClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
             defaultTags()
           }
         }


### PR DESCRIPTION
# What Does This Do

Instrument jedis connection instead of command (on jedis < 4) and set `peer.hostname` on jedis spans

# Motivation

# Additional Notes
