### PR TITLE
Decouple time in queue from legacy tracing

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/SessionState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/SessionState.java
@@ -62,17 +62,17 @@ public final class SessionState {
   @SuppressFBWarnings("IS2_INCONSISTENT_SYNC")
   private boolean capturingFlipped = false;
 
-  public SessionState(int ackMode, boolean legacyTracing) {
+  public SessionState(int ackMode, boolean timeInQueueEnabled) {
     this.ackMode = ackMode;
     if (isAutoAcknowledge()) {
       this.capturedSpans = null; // unused in auto-ack
     } else {
       this.capturedSpans = new ArrayDeque<>();
     }
-    if (legacyTracing) {
-      this.timeInQueueSpans = Collections.emptyMap();
-    } else {
+    if (timeInQueueEnabled) {
       this.timeInQueueSpans = new ConcurrentHashMap<>();
+    } else {
+      this.timeInQueueSpans = Collections.emptyMap();
     }
   }
 

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsDecorator.java
@@ -22,7 +22,9 @@ public class SqsDecorator extends MessagingClientDecorator {
       SpanNaming.instance().namingSchema().messaging().timeInQueueOperation("sqs");
   public static final boolean SQS_LEGACY_TRACING =
       Config.get().isLegacyTracingEnabled(SpanNaming.instance().version() == 0, "sqs");
-
+  public static final boolean TIME_IN_QUEUE_ENABLED =
+      Config.get()
+          .isTimeInQueueEnabled(!SQS_LEGACY_TRACING && SpanNaming.instance().version() == 0, "sqs");
   private final String spanKind;
   private final CharSequence spanType;
   private final String serviceName;

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingIterator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/TracingIterator.java
@@ -8,8 +8,8 @@ import static datadog.trace.instrumentation.aws.v1.sqs.MessageExtractAdapter.GET
 import static datadog.trace.instrumentation.aws.v1.sqs.SqsDecorator.BROKER_DECORATE;
 import static datadog.trace.instrumentation.aws.v1.sqs.SqsDecorator.CONSUMER_DECORATE;
 import static datadog.trace.instrumentation.aws.v1.sqs.SqsDecorator.SQS_INBOUND_OPERATION;
-import static datadog.trace.instrumentation.aws.v1.sqs.SqsDecorator.SQS_LEGACY_TRACING;
 import static datadog.trace.instrumentation.aws.v1.sqs.SqsDecorator.SQS_TIME_IN_QUEUE_OPERATION;
+import static datadog.trace.instrumentation.aws.v1.sqs.SqsDecorator.TIME_IN_QUEUE_ENABLED;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import com.amazonaws.services.sqs.model.Message;
@@ -58,7 +58,7 @@ public class TracingIterator<L extends Iterator<Message>> implements Iterator<Me
           AgentSpan.Context spanContext =
               Config.get().isSqsPropagationEnabled() ? propagate().extract(message, GETTER) : null;
           // next add a time-in-queue span for non-legacy SQS traces
-          if (!SQS_LEGACY_TRACING) {
+          if (TIME_IN_QUEUE_ENABLED) {
             long timeInQueueStart = GETTER.extractTimeInQueueStart(message);
             if (timeInQueueStart > 0) {
               queueSpan =

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/SqsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/SqsClientTest.groovy
@@ -342,9 +342,4 @@ class SqsClientV1ForkedTest extends SqsClientTest {
   int version() {
     1
   }
-
-  @Override
-  boolean hasTimeInQueueSpan() {
-    true
-  }
 }

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsDecorator.java
@@ -22,6 +22,10 @@ public class SqsDecorator extends MessagingClientDecorator {
       SpanNaming.instance().namingSchema().messaging().timeInQueueOperation("sqs");
   public static final boolean SQS_LEGACY_TRACING =
       Config.get().isLegacyTracingEnabled(SpanNaming.instance().version() == 0, "sqs");
+
+  public static final boolean TIME_IN_QUEUE_ENABLED =
+      Config.get()
+          .isTimeInQueueEnabled(!SQS_LEGACY_TRACING && SpanNaming.instance().version() == 0, "sqs");
   private final String spanKind;
   private final CharSequence spanType;
   private final String serviceName;

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingIterator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingIterator.java
@@ -8,8 +8,8 @@ import static datadog.trace.instrumentation.aws.v2.sqs.MessageExtractAdapter.GET
 import static datadog.trace.instrumentation.aws.v2.sqs.SqsDecorator.BROKER_DECORATE;
 import static datadog.trace.instrumentation.aws.v2.sqs.SqsDecorator.CONSUMER_DECORATE;
 import static datadog.trace.instrumentation.aws.v2.sqs.SqsDecorator.SQS_INBOUND_OPERATION;
-import static datadog.trace.instrumentation.aws.v2.sqs.SqsDecorator.SQS_LEGACY_TRACING;
 import static datadog.trace.instrumentation.aws.v2.sqs.SqsDecorator.SQS_TIME_IN_QUEUE_OPERATION;
+import static datadog.trace.instrumentation.aws.v2.sqs.SqsDecorator.TIME_IN_QUEUE_ENABLED;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import datadog.trace.api.Config;
@@ -60,7 +60,7 @@ public class TracingIterator<L extends Iterator<Message>> implements Iterator<Me
           AgentSpan.Context spanContext =
               Config.get().isSqsPropagationEnabled() ? propagate().extract(message, GETTER) : null;
           // next add a time-in-queue span for non-legacy SQS traces
-          if (!SQS_LEGACY_TRACING) {
+          if (TIME_IN_QUEUE_ENABLED) {
             long timeInQueueStart = GETTER.extractTimeInQueueStart(message);
             if (timeInQueueStart > 0) {
               queueSpan =

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/SqsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/SqsClientTest.groovy
@@ -346,9 +346,4 @@ class SqsClientV1ForkedTest extends SqsClientTest {
   int version() {
     1
   }
-
-  @Override
-  boolean hasTimeInQueueSpan() {
-    true
-  }
 }

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/DatadogMessageListener.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/DatadogMessageListener.java
@@ -7,7 +7,7 @@ import static datadog.trace.instrumentation.jms.JMSDecorator.BROKER_DECORATE;
 import static datadog.trace.instrumentation.jms.JMSDecorator.CONSUMER_DECORATE;
 import static datadog.trace.instrumentation.jms.JMSDecorator.JMS_CONSUME;
 import static datadog.trace.instrumentation.jms.JMSDecorator.JMS_DELIVER;
-import static datadog.trace.instrumentation.jms.JMSDecorator.JMS_LEGACY_TRACING;
+import static datadog.trace.instrumentation.jms.JMSDecorator.TIME_IN_QUEUE_ENABLED;
 import static datadog.trace.instrumentation.jms.MessageExtractAdapter.GETTER;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -42,7 +42,7 @@ public class DatadogMessageListener implements MessageListener {
       propagatedContext = propagate().extract(message, GETTER);
     }
     long startMillis = GETTER.extractTimeInQueueStart(message);
-    if (startMillis == 0 || JMS_LEGACY_TRACING) {
+    if (startMillis == 0 || !TIME_IN_QUEUE_ENABLED) {
       span = startSpan(JMS_CONSUME, propagatedContext);
     } else {
       long batchId = GETTER.extractMessageBatchId(message);

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
@@ -39,6 +39,9 @@ public final class JMSDecorator extends MessagingClientDecorator {
   public static final boolean JMS_LEGACY_TRACING =
       Config.get().isLegacyTracingEnabled(SpanNaming.instance().version() == 0, "jms");
 
+  public static final boolean TIME_IN_QUEUE_ENABLED =
+      Config.get()
+          .isTimeInQueueEnabled(!JMS_LEGACY_TRACING && SpanNaming.instance().version() == 0, "jms");
   public static final String JMS_PRODUCED_KEY = "x_datadog_jms_produced";
   public static final String JMS_BATCH_ID_KEY = "x_datadog_jms_batch_id";
 

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageConsumerInstrumentation.java
@@ -11,7 +11,7 @@ import static datadog.trace.instrumentation.jms.JMSDecorator.BROKER_DECORATE;
 import static datadog.trace.instrumentation.jms.JMSDecorator.CONSUMER_DECORATE;
 import static datadog.trace.instrumentation.jms.JMSDecorator.JMS_CONSUME;
 import static datadog.trace.instrumentation.jms.JMSDecorator.JMS_DELIVER;
-import static datadog.trace.instrumentation.jms.JMSDecorator.JMS_LEGACY_TRACING;
+import static datadog.trace.instrumentation.jms.JMSDecorator.TIME_IN_QUEUE_ENABLED;
 import static datadog.trace.instrumentation.jms.MessageExtractAdapter.GETTER;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -126,7 +126,7 @@ public final class JMSMessageConsumerInstrumentation extends Instrumenter.Tracin
         propagatedContext = propagate().extract(message, GETTER);
       }
       long startMillis = GETTER.extractTimeInQueueStart(message);
-      if (startMillis == 0 || JMS_LEGACY_TRACING) {
+      if (startMillis == 0 || !TIME_IN_QUEUE_ENABLED) {
         span = startSpan(JMS_CONSUME, propagatedContext);
       } else {
         long batchId = GETTER.extractMessageBatchId(message);

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
@@ -5,9 +5,9 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-import static datadog.trace.instrumentation.jms.JMSDecorator.JMS_LEGACY_TRACING;
 import static datadog.trace.instrumentation.jms.JMSDecorator.JMS_PRODUCE;
 import static datadog.trace.instrumentation.jms.JMSDecorator.PRODUCER_DECORATE;
+import static datadog.trace.instrumentation.jms.JMSDecorator.TIME_IN_QUEUE_ENABLED;
 import static datadog.trace.instrumentation.jms.MessageInjectAdapter.SETTER;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -107,7 +107,7 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Tracin
           && (null == producerState || !producerState.isPropagationDisabled())) {
         propagate().inject(span, message, SETTER);
       }
-      if (!JMS_LEGACY_TRACING) {
+      if (TIME_IN_QUEUE_ENABLED) {
         if (null != producerState) {
           SETTER.injectTimeInQueue(message, producerState);
         }
@@ -152,7 +152,7 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Tracin
           && !Config.get().isJmsPropagationDisabledForDestination(destinationName)) {
         propagate().inject(span, message, SETTER);
       }
-      if (!JMS_LEGACY_TRACING) {
+      if (TIME_IN_QUEUE_ENABLED) {
         MessageProducerState producerState =
             InstrumentationContext.get(MessageProducer.class, MessageProducerState.class)
                 .get(producer);

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/SessionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/SessionInstrumentation.java
@@ -7,6 +7,7 @@ import static datadog.trace.instrumentation.jms.JMSDecorator.BROKER_DECORATE;
 import static datadog.trace.instrumentation.jms.JMSDecorator.CONSUMER_DECORATE;
 import static datadog.trace.instrumentation.jms.JMSDecorator.JMS_LEGACY_TRACING;
 import static datadog.trace.instrumentation.jms.JMSDecorator.PRODUCER_DECORATE;
+import static datadog.trace.instrumentation.jms.JMSDecorator.TIME_IN_QUEUE_ENABLED;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -133,7 +134,8 @@ public class SessionInstrumentation extends Instrumenter.Tracing
             ackMode = Session.AUTO_ACKNOWLEDGE;
           }
           sessionState =
-              sessionStateStore.putIfAbsent(session, new SessionState(ackMode, JMS_LEGACY_TRACING));
+              sessionStateStore.putIfAbsent(
+                  session, new SessionState(ackMode, TIME_IN_QUEUE_ENABLED));
         }
 
         boolean isQueue = PRODUCER_DECORATE.isQueue(destination);
@@ -173,7 +175,8 @@ public class SessionInstrumentation extends Instrumenter.Tracing
             ackMode = Session.AUTO_ACKNOWLEDGE;
           }
           sessionState =
-              sessionStateStore.putIfAbsent(session, new SessionState(ackMode, JMS_LEGACY_TRACING));
+              sessionStateStore.putIfAbsent(
+                  session, new SessionState(ackMode, TIME_IN_QUEUE_ENABLED));
         }
 
         boolean isQueue = CONSUMER_DECORATE.isQueue(destination);

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/TimeInQueueForkedTest.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/TimeInQueueForkedTest.groovy
@@ -649,6 +649,13 @@ class TimeInQueueV0ForkedTest extends TimeInQueueForkedTest {
 }
 
 class TimeInQueueV1ForkedTest extends TimeInQueueForkedTest {
+
+  @Override
+  void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("dd.jms.time-in-queue.enabled", "true")
+  }
+
   @Override
   String operationForProducer() {
     "jms.send"
@@ -668,7 +675,6 @@ class TimeInQueueV1ForkedTest extends TimeInQueueForkedTest {
   int version() {
     1
   }
-
 }
 
 

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
@@ -32,7 +32,10 @@ public class KafkaDecorator extends MessagingClientDecorator {
   public static final CharSequence KAFKA_DELIVER = UTF8BytesString.create("kafka.deliver");
   public static final boolean KAFKA_LEGACY_TRACING =
       Config.get().isLegacyTracingEnabled(SpanNaming.instance().version() == 0, KAFKA);
-
+  public static final boolean TIME_IN_QUEUE_ENABLED =
+      Config.get()
+          .isTimeInQueueEnabled(
+              !KAFKA_LEGACY_TRACING && SpanNaming.instance().version() == 0, KAFKA);
   public static final String KAFKA_PRODUCED_KEY = "x_datadog_kafka_produced";
   private final String spanKind;
   private final CharSequence spanType;

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -9,9 +9,9 @@ import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_OUT;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TOPIC_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TYPE_TAG;
-import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.KAFKA_LEGACY_TRACING;
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.KAFKA_PRODUCE;
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.PRODUCER_DECORATE;
+import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.TIME_IN_QUEUE_ENABLED;
 import static datadog.trace.instrumentation.kafka_clients.TextMapInjectAdapter.SETTER;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -112,7 +112,7 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Tracing
           propagate().inject(span, record.headers(), SETTER);
           propagate().injectBinaryPathwayContext(span, record.headers(), SETTER, sortedTags);
         }
-        if (!KAFKA_LEGACY_TRACING) {
+        if (TIME_IN_QUEUE_ENABLED) {
           SETTER.injectTimeInQueue(record.headers());
         }
       }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
@@ -11,7 +11,7 @@ import static datadog.trace.core.datastreams.TagsProcessor.TOPIC_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TYPE_TAG;
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.BROKER_DECORATE;
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.KAFKA_DELIVER;
-import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.KAFKA_LEGACY_TRACING;
+import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.TIME_IN_QUEUE_ENABLED;
 import static datadog.trace.instrumentation.kafka_clients.TextMapExtractAdapter.GETTER;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -72,7 +72,7 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
         if (!Config.get().isKafkaClientPropagationDisabledForTopic(val.topic())) {
           final Context spanContext = propagate().extract(val.headers(), GETTER);
           long timeInQueueStart = GETTER.extractTimeInQueueStart(val.headers());
-          if (timeInQueueStart == 0 || KAFKA_LEGACY_TRACING) {
+          if (timeInQueueStart == 0 || !TIME_IN_QUEUE_ENABLED) {
             span = startSpan(operationName, spanContext);
           } else {
             queueSpan =

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
@@ -1015,6 +1015,11 @@ class KafkaClientV1ForkedTest extends KafkaClientForkedTest {
   String serviceForTimeInQueue() {
     "kafka-queue"
   }
+
+  @Override
+  boolean hasQueueSpan() {
+    false
+  }
 }
 
 class KafkaClientSplitByDestinationForkedTest extends KafkaClientTestBase {

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
@@ -13,7 +13,7 @@ import static datadog.trace.instrumentation.kafka_streams.KafkaStreamsDecorator.
 import static datadog.trace.instrumentation.kafka_streams.KafkaStreamsDecorator.CONSUMER_DECORATE;
 import static datadog.trace.instrumentation.kafka_streams.KafkaStreamsDecorator.KAFKA_CONSUME;
 import static datadog.trace.instrumentation.kafka_streams.KafkaStreamsDecorator.KAFKA_DELIVER;
-import static datadog.trace.instrumentation.kafka_streams.KafkaStreamsDecorator.KAFKA_LEGACY_TRACING;
+import static datadog.trace.instrumentation.kafka_streams.KafkaStreamsDecorator.TIME_IN_QUEUE_ENABLED;
 import static datadog.trace.instrumentation.kafka_streams.ProcessorRecordContextVisitor.PR_GETTER;
 import static datadog.trace.instrumentation.kafka_streams.StampedRecordContextVisitor.SR_GETTER;
 import static java.util.Collections.singletonMap;
@@ -219,7 +219,7 @@ public class KafkaStreamTaskInstrumentation extends Instrumenter.Tracing
       if (!Config.get().isKafkaClientPropagationDisabledForTopic(record.topic())) {
         final AgentSpan.Context extractedContext = propagate().extract(record, SR_GETTER);
         long timeInQueueStart = SR_GETTER.extractTimeInQueueStart(record);
-        if (timeInQueueStart == 0 || KAFKA_LEGACY_TRACING) {
+        if (timeInQueueStart == 0 || !TIME_IN_QUEUE_ENABLED) {
           span = startSpan(KAFKA_CONSUME, extractedContext);
         } else {
           queueSpan =
@@ -284,7 +284,7 @@ public class KafkaStreamTaskInstrumentation extends Instrumenter.Tracing
       if (!Config.get().isKafkaClientPropagationDisabledForTopic(record.topic())) {
         final AgentSpan.Context extractedContext = propagate().extract(record, PR_GETTER);
         long timeInQueueStart = PR_GETTER.extractTimeInQueueStart(record);
-        if (timeInQueueStart == 0 || KAFKA_LEGACY_TRACING) {
+        if (timeInQueueStart == 0 || !TIME_IN_QUEUE_ENABLED) {
           span = startSpan(KAFKA_CONSUME, extractedContext);
         } else {
           queueSpan =

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsDecorator.java
@@ -28,7 +28,10 @@ public class KafkaStreamsDecorator extends MessagingClientDecorator {
 
   public static final boolean KAFKA_LEGACY_TRACING =
       Config.get().isLegacyTracingEnabled(SpanNaming.instance().version() == 0, KAFKA);
-
+  public static final boolean TIME_IN_QUEUE_ENABLED =
+      Config.get()
+          .isTimeInQueueEnabled(
+              !KAFKA_LEGACY_TRACING && SpanNaming.instance().version() == 0, KAFKA);
   public static final String KAFKA_PRODUCED_KEY = "x_datadog_kafka_produced";
 
   private final String spanKind;

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTestBase.groovy
@@ -367,6 +367,11 @@ class KafkaStreamsV1ForkedTest extends KafkaStreamsForkedTest {
   String serviceForTimeInQueue() {
     "kafka-queue"
   }
+
+  @Override
+  boolean hasQueueSpan() {
+    return false
+  }
 }
 
 class KafkaStreamsSplitByDestinationForkedTest extends KafkaStreamsTestBase {

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -18,7 +18,7 @@ import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.CONSUM
 import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.OPERATION_AMQP_COMMAND;
 import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.OPERATION_AMQP_OUTBOUND;
 import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.PRODUCER_DECORATE;
-import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.RABBITMQ_LEGACY_TRACING;
+import static datadog.trace.instrumentation.rabbitmq.amqp.RabbitDecorator.TIME_IN_QUEUE_ENABLED;
 import static datadog.trace.instrumentation.rabbitmq.amqp.TextMapInjectAdapter.SETTER;
 import static net.bytebuddy.matcher.ElementMatchers.canThrow;
 import static net.bytebuddy.matcher.ElementMatchers.isGetter;
@@ -182,7 +182,7 @@ public class RabbitChannelInstrumentation extends Instrumenter.Tracing
         // We need to copy the BasicProperties and provide a header map we can modify
         Map<String, Object> headers = props.getHeaders();
         headers = (headers == null) ? new HashMap<String, Object>() : new HashMap<>(headers);
-        if (!RABBITMQ_LEGACY_TRACING) {
+        if (TIME_IN_QUEUE_ENABLED) {
           RabbitDecorator.injectTimeInQueueStart(headers);
         }
         propagate().inject(span, headers, SETTER);

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
@@ -49,6 +49,14 @@ public class RabbitDecorator extends MessagingClientDecorator {
   public static final boolean RABBITMQ_LEGACY_TRACING =
       Config.get()
           .isLegacyTracingEnabled(SpanNaming.instance().version() == 0, "rabbit", "rabbitmq");
+
+  public static final boolean TIME_IN_QUEUE_ENABLED =
+      Config.get()
+          .isTimeInQueueEnabled(
+              !RABBITMQ_LEGACY_TRACING && SpanNaming.instance().version() == 0,
+              "rabbit",
+              "rabbitmq");
+
   private static final String LOCAL_SERVICE_NAME =
       RABBITMQ_LEGACY_TRACING ? "rabbitmq" : Config.get().getServiceName();
   public static final RabbitDecorator CLIENT_DECORATE =
@@ -194,7 +202,7 @@ public class RabbitDecorator extends MessagingClientDecorator {
       spanStartMillis = System.currentTimeMillis();
     }
     long queueStartMillis = 0;
-    if (null != headers && !RABBITMQ_LEGACY_TRACING) {
+    if (null != headers && TIME_IN_QUEUE_ENABLED) {
       queueStartMillis = extractTimeInQueueStart(headers);
     }
     long spanStartMicros = TimeUnit.MILLISECONDS.toMicros(spanStartMillis);

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -911,6 +911,10 @@ class RabbitMQNamingV1ForkedTest extends RabbitMQForkedTest {
     1
   }
 
+  @Override
+  boolean hasQueueSpan() {
+    false
+  }
 }
 
 class RabbitMQDatastreamsDisabledForkedTest extends RabbitMQTestBase {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -2661,6 +2661,12 @@ public class Config {
         Arrays.asList(integrationNames), "", ".legacy.tracing.enabled", defaultEnabled);
   }
 
+  public boolean isTimeInQueueEnabled(
+      final boolean defaultEnabled, final String... integrationNames) {
+    return configProvider.isEnabled(
+        Arrays.asList(integrationNames), "", ".time-in-queue.enabled", defaultEnabled);
+  }
+
   public boolean isEnabled(
       final boolean defaultEnabled, final String settingName, String settingSuffix) {
     return configProvider.isEnabled(


### PR DESCRIPTION
# What Does This Do

Decouple time in queue tracking from legacy tracing.
The time in queue can be driven independently with the parameter `dd.<instrumentation>.time-in-queue.enabled`
By default it will be enabled if legacy tracing is disabled (as today)

Quick note: for the v1 naming schema, time in queue is disabled by default because synthetic spans should not be present in the service map

# Motivation

# Additional Notes
