### PR TITLE
Remove -PskipBuildSrcTest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,7 +391,6 @@ jobs:
             ./gradlew clean
             << parameters.gradleTarget >>
             -PskipTests
-            -PskipBuildSrcTest
             << pipeline.parameters.gradle_flags >>
             --max-workers=8
             --rerun-tasks

--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -92,5 +92,5 @@ tasks.build {
 
 tasks.test {
   useJUnitPlatform()
-  enabled = !project.hasProperty("skipBuildSrcTest")
+  enabled = project.hasProperty("runBuildSrcTests")
 }


### PR DESCRIPTION
# What Does This Do

# Motivation

We already have -PrunBuildSrcTests

# Additional Notes
