### PR TITLE
Memoized type matching

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -7,6 +7,7 @@ import datadog.trace.agent.tooling.bytebuddy.DDCachingPoolStrategy;
 import datadog.trace.agent.tooling.bytebuddy.DDOutlinePoolStrategy;
 import datadog.trace.agent.tooling.bytebuddy.SharedTypePools;
 import datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers;
+import datadog.trace.agent.tooling.bytebuddy.memoize.MemoizedMatchers;
 import datadog.trace.agent.tooling.usm.UsmExtractorImpl;
 import datadog.trace.agent.tooling.usm.UsmMessageFactoryImpl;
 import datadog.trace.api.InstrumenterConfig;
@@ -101,7 +102,11 @@ public class AgentInstaller {
       DDCachingPoolStrategy.registerAsSupplier();
     }
 
-    DDElementMatchers.registerAsSupplier();
+    if (InstrumenterConfig.get().isResolverMemoizingEnabled()) {
+      MemoizedMatchers.registerAsSupplier();
+    } else {
+      DDElementMatchers.registerAsSupplier();
+    }
 
     if (enabledSystems.contains(Instrumenter.TargetSystem.USM)) {
       UsmMessageFactoryImpl.registerAsSupplier();

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ClassLoaderMatchers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ClassLoaderMatchers.java
@@ -89,7 +89,7 @@ public final class ClassLoaderMatchers {
     return new ElementMatcher.Junction.Disjunction<>(matchers);
   }
 
-  public static void reset() {
+  public static void resetState() {
     hasClassCache.clear();
   }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/HasContextField.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/HasContextField.java
@@ -1,0 +1,63 @@
+package datadog.trace.agent.tooling.bytebuddy.memoize;
+
+import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
+import java.util.BitSet;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+/** Matches types that should have context-store fields injected. */
+final class HasContextField extends ElementMatcher.Junction.ForNonNullValues<TypeDescription> {
+  private final ElementMatcher<TypeDescription> storeMatcher;
+  private final ElementMatcher<TypeDescription> skipMatcher;
+  private final BitSet skippableStoreIds = new BitSet();
+
+  HasContextField(ElementMatcher<TypeDescription> storeMatcher) {
+    this(storeMatcher, null);
+  }
+
+  HasContextField(
+      ElementMatcher<TypeDescription> storeMatcher, ElementMatcher<TypeDescription> skipMatcher) {
+    this.storeMatcher = storeMatcher;
+    this.skipMatcher = skipMatcher;
+  }
+
+  @Override
+  protected boolean doMatch(TypeDescription target) {
+    // match first type in the hierarchy which injects this store, that isn't skipped
+    return storeMatcher.matches(target)
+        && (null == skipMatcher || !skipMatcher.matches(target))
+        && (!storeMatcher.matches(target.getSuperClass().asErasure()));
+  }
+
+  void maybeSkip(int contextStoreId) {
+    skippableStoreIds.set(contextStoreId);
+  }
+
+  boolean hasSuperStore(TypeDescription target, BitSet weakStoreIds) {
+    TypeDescription superTarget = target.getSuperClass().asErasure();
+    boolean hasSuperStore = storeMatcher.matches(superTarget);
+    if (hasSuperStore) {
+      // report if super-class was skipped from field-injection
+      if (null != skipMatcher && skipMatcher.matches(superTarget)) {
+        synchronized (weakStoreIds) {
+          weakStoreIds.or(skippableStoreIds);
+        }
+      }
+    }
+    return hasSuperStore;
+  }
+
+  /** Matches types that would have had fields injected, but were explicitly excluded. */
+  static final class Skip extends ElementMatcher.Junction.ForNonNullValues<TypeDescription> {
+    private final ExcludeFilter.ExcludeType excludeType;
+
+    Skip(ExcludeFilter.ExcludeType excludeType) {
+      this.excludeType = excludeType;
+    }
+
+    @Override
+    protected boolean doMatch(TypeDescription target) {
+      return ExcludeFilter.exclude(excludeType, target.getName());
+    }
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/HasContextField.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/HasContextField.java
@@ -39,9 +39,7 @@ final class HasContextField extends ElementMatcher.Junction.ForNonNullValues<Typ
     if (hasSuperStore) {
       // report if super-class was skipped from field-injection
       if (null != skipMatcher && skipMatcher.matches(superTarget)) {
-        synchronized (weakStoreIds) {
-          weakStoreIds.or(skippableStoreIds);
-        }
+        weakStoreIds.or(skippableStoreIds);
       }
     }
     return hasSuperStore;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/HasSuperMethod.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/HasSuperMethod.java
@@ -1,0 +1,83 @@
+package datadog.trace.agent.tooling.bytebuddy.memoize;
+
+import static net.bytebuddy.matcher.ElementMatchers.hasSignature;
+
+import java.util.HashSet;
+import java.util.Set;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDefinition;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.description.type.TypeList;
+import net.bytebuddy.matcher.ElementMatcher;
+
+/**
+ * Matches methods that are either a direct match or have a super-class method with the same
+ * signature that matches. Uses a memoized type matcher to reduce the potential search space.
+ */
+final class HasSuperMethod extends ElementMatcher.Junction.ForNonNullValues<MethodDescription> {
+  private final ElementMatcher<TypeDescription> typeMatcher;
+  private final ElementMatcher<? super MethodDescription> methodMatcher;
+
+  HasSuperMethod(
+      ElementMatcher<TypeDescription> typeMatcher,
+      ElementMatcher<? super MethodDescription> methodMatcher) {
+    this.typeMatcher = typeMatcher;
+    this.methodMatcher = methodMatcher;
+  }
+
+  @Override
+  protected boolean doMatch(MethodDescription target) {
+    if (target.isConstructor()) {
+      return false;
+    }
+
+    TypeDefinition type = target.getDeclaringType();
+    if (!typeMatcher.matches(type.asErasure())) {
+      return false; // no further matches recorded in hierarchy
+    } else if (methodMatcher.matches(target)) {
+      return true; // direct match, no need to check hierarchy
+    }
+
+    // need to search hierarchy; use expected signature to filter candidate methods
+    ElementMatcher<MethodDescription> signatureMatcher = hasSignature(target.asSignatureToken());
+    Set<String> visited = new HashSet<>();
+
+    if (interfaceMatches(type.getInterfaces(), signatureMatcher, visited)) {
+      return true;
+    }
+
+    type = type.getSuperClass();
+    while (null != type && typeMatcher.matches(type.asErasure())) {
+      for (MethodDescription method : type.getDeclaredMethods()) {
+        if (signatureMatcher.matches(method) && methodMatcher.matches(method)) {
+          return true;
+        }
+      }
+      if (interfaceMatches(type.getInterfaces(), signatureMatcher, visited)) {
+        return true;
+      }
+      type = type.getSuperClass();
+    }
+    return false;
+  }
+
+  private boolean interfaceMatches(
+      TypeList.Generic interfaces,
+      ElementMatcher<MethodDescription> signatureMatcher,
+      Set<String> visited) {
+    for (TypeDefinition type : interfaces) {
+      if (!visited.add(type.getTypeName()) || !typeMatcher.matches(type.asErasure())) {
+        continue; // skip if already visited or that part of the hierarchy doesn't match
+      }
+      for (MethodDescription method : type.getDeclaredMethods()) {
+        if (signatureMatcher.matches(method) && methodMatcher.matches(method)) {
+          return true;
+        }
+      }
+      if (interfaceMatches(type.getInterfaces(), signatureMatcher, visited)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/MemoizedMatchers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/MemoizedMatchers.java
@@ -1,0 +1,130 @@
+package datadog.trace.agent.tooling.bytebuddy.memoize;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.memoize.Memoizer.MatcherKind.ANNOTATION;
+import static datadog.trace.agent.tooling.bytebuddy.memoize.Memoizer.MatcherKind.CLASS;
+import static datadog.trace.agent.tooling.bytebuddy.memoize.Memoizer.MatcherKind.FIELD;
+import static datadog.trace.agent.tooling.bytebuddy.memoize.Memoizer.MatcherKind.INTERFACE;
+import static datadog.trace.agent.tooling.bytebuddy.memoize.Memoizer.MatcherKind.METHOD;
+import static datadog.trace.agent.tooling.bytebuddy.memoize.Memoizer.MatcherKind.TYPE;
+import static datadog.trace.bootstrap.FieldBackedContextStores.getContextStoreId;
+
+import datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.Map;
+import net.bytebuddy.description.NamedElement;
+import net.bytebuddy.description.field.FieldDescription;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+/** Supplies memoized matchers. */
+public final class MemoizedMatchers implements HierarchyMatchers.Supplier {
+  public static void registerAsSupplier() {
+    HierarchyMatchers.registerIfAbsent(new MemoizedMatchers());
+    Memoizer.resetState();
+  }
+
+  @Override
+  public ElementMatcher.Junction<TypeDescription> declaresAnnotation(
+      ElementMatcher.Junction<? super NamedElement> matcher) {
+    return Memoizer.prepare(ANNOTATION, matcher, false);
+  }
+
+  @Override
+  public ElementMatcher.Junction<TypeDescription> declaresField(
+      ElementMatcher.Junction<? super FieldDescription> matcher) {
+    return Memoizer.prepare(FIELD, matcher, false);
+  }
+
+  @Override
+  public ElementMatcher.Junction<TypeDescription> declaresMethod(
+      ElementMatcher.Junction<? super MethodDescription> matcher) {
+    return Memoizer.prepare(METHOD, matcher, false);
+  }
+
+  @Override
+  public ElementMatcher.Junction<TypeDescription> concreteClass() {
+    return Memoizer.isConcrete;
+  }
+
+  @Override
+  public ElementMatcher.Junction<TypeDescription> extendsClass(
+      ElementMatcher.Junction<? super TypeDescription> matcher) {
+    return Memoizer.prepare(CLASS, matcher, true);
+  }
+
+  @Override
+  public ElementMatcher.Junction<TypeDescription> implementsInterface(
+      ElementMatcher.Junction<? super TypeDescription> matcher) {
+    return Memoizer.isClass.and(Memoizer.prepare(INTERFACE, matcher, true));
+  }
+
+  @Override
+  public ElementMatcher.Junction<TypeDescription> hasInterface(
+      ElementMatcher.Junction<? super TypeDescription> matcher) {
+    return Memoizer.prepare(INTERFACE, matcher, true);
+  }
+
+  @Override
+  public ElementMatcher.Junction<TypeDescription> hasSuperType(
+      ElementMatcher.Junction<? super TypeDescription> matcher) {
+    return Memoizer.isClass.and(Memoizer.prepare(TYPE, matcher, true));
+  }
+
+  @Override
+  public ElementMatcher.Junction<MethodDescription> hasSuperMethod(
+      ElementMatcher.Junction<? super MethodDescription> matcher) {
+    return new HasSuperMethod(Memoizer.prepare(METHOD, matcher, true), matcher);
+  }
+
+  /** Keeps track of which context-field matchers we've supplied so far. */
+  private static final Map<String, HasContextField> contextFields = new HashMap<>();
+
+  @Override
+  public ElementMatcher.Junction<TypeDescription> declaresContextField(
+      String keyType, String contextType) {
+
+    // is there a chance a type might match, but be excluded (skipped) from field-injection?
+    ExcludeFilter.ExcludeType excludeType = ExcludeFilter.ExcludeType.fromFieldType(keyType);
+
+    HasContextField contextField = contextFields.get(keyType);
+    if (null == contextField) {
+      ElementMatcher<TypeDescription> storeMatcher = hasSuperType(named(keyType));
+      if (null != excludeType) {
+        ElementMatcher<TypeDescription> skipMatcher =
+            Memoizer.prepare(CLASS, new HasContextField.Skip(excludeType), true);
+        contextField = new HasContextField(storeMatcher, skipMatcher);
+      } else {
+        contextField = new HasContextField(storeMatcher);
+      }
+      contextFields.put(keyType, contextField);
+    }
+
+    if (null != excludeType) {
+      // record that this store may be skipped from field-injection
+      contextField.maybeSkip(getContextStoreId(keyType, contextType));
+    }
+
+    return contextField;
+  }
+
+  /**
+   * Returns {@code true} if ancestors of the given type have any context-stores.
+   *
+   * <p>Stores which were skipped from field-injection in the super-class hierarchy are recorded in
+   * {@code weakStoreIds} so the appropriate weak-map delegation can be applied when injecting code
+   * to handle context-store requests.
+   */
+  public static boolean hasSuperStores(TypeDescription target, BitSet weakStoreIds) {
+    boolean hasSuperStores = false;
+    for (HasContextField contextField : contextFields.values()) {
+      if (contextField.hasSuperStore(target, weakStoreIds)) {
+        hasSuperStores = true;
+      }
+    }
+    return hasSuperStores;
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/Memoizer.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/Memoizer.java
@@ -1,0 +1,234 @@
+package datadog.trace.agent.tooling.bytebuddy.memoize;
+
+import static net.bytebuddy.matcher.ElementMatchers.not;
+
+import datadog.trace.agent.tooling.bytebuddy.TypeInfoCache;
+import datadog.trace.agent.tooling.bytebuddy.TypeInfoCache.SharedTypeInfo;
+import datadog.trace.agent.tooling.bytebuddy.outline.TypePoolFacade;
+import datadog.trace.api.InstrumenterConfig;
+import datadog.trace.api.cache.DDCache;
+import datadog.trace.api.cache.DDCaches;
+import de.thetaphi.forbiddenapis.SuppressForbidden;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import net.bytebuddy.description.annotation.AnnotationDescription;
+import net.bytebuddy.description.field.FieldDescription;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatchers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressForbidden
+@SuppressWarnings("rawtypes")
+public final class Memoizer {
+  private static final Logger log = LoggerFactory.getLogger(Memoizer.class);
+
+  enum MatcherKind {
+    ANNOTATION,
+    FIELD,
+    METHOD,
+    CLASS,
+    INTERFACE,
+    TYPE // i.e. class or interface
+  }
+
+  private static final BitSet NO_MATCH = new BitSet(0);
+
+  private static final int SIZE_HINT = 320; // estimated number of matchers
+
+  // records the kind of matcher and whether matches should be inherited
+  private static final BitSet annotationMatcherIds = new BitSet(SIZE_HINT);
+  private static final BitSet fieldMatcherIds = new BitSet(SIZE_HINT);
+  private static final BitSet methodMatcherIds = new BitSet(SIZE_HINT);
+  private static final BitSet classMatcherIds = new BitSet(SIZE_HINT);
+  private static final BitSet interfaceMatcherIds = new BitSet(SIZE_HINT);
+  private static final BitSet inheritedMatcherIds = new BitSet(SIZE_HINT);
+
+  // matchers that are ready for memoization
+  static final List<ElementMatcher> matchers = new ArrayList<>();
+
+  // small cache to de-duplicate memoization requests
+  private static final DDCache<ElementMatcher, MemoizingMatcher> memoizingMatcherCache =
+      DDCaches.newFixedSizeIdentityCache(8);
+
+  // caches positive memoized matches
+  private static final TypeInfoCache<BitSet> memos =
+      new TypeInfoCache<>(InstrumenterConfig.get().getResolverMemoPoolSize(), true);
+
+  // local memoized results, used to detect circular references
+  static final ThreadLocal<Map<String, BitSet>> localMemosHolder =
+      ThreadLocal.withInitial(HashMap::new);
+
+  private static final int INTERNAL_MATCHERS = 2; // isClass and isConcrete
+
+  // memoize whether the type is a class
+  static final ElementMatcher.Junction<TypeDescription> isClass =
+      prepare(MatcherKind.CLASS, ElementMatchers.any(), true);
+
+  // memoize whether the type is a concrete class, i.e. no abstract methods
+  static final ElementMatcher.Junction<TypeDescription> isConcrete =
+      prepare(MatcherKind.CLASS, not(ElementMatchers.isAbstract()), false);
+
+  public static void resetState() {
+    // no need to reset the state if we haven't added any external matchers
+    if (matchers.size() > INTERNAL_MATCHERS) {
+      Memoizer.clear();
+    }
+  }
+
+  public static void clear() {
+    memos.clear();
+  }
+
+  static MemoizingMatcher withMatcherId(ElementMatcher matcher) {
+    return new MemoizingMatcher(matchers.size());
+  }
+
+  /** Prepares a matcher for memoization. */
+  static <T> ElementMatcher.Junction<TypeDescription> prepare(
+      MatcherKind kind, ElementMatcher.Junction<T> matcher, boolean inherited) {
+
+    MemoizingMatcher memoizingMatcher =
+        memoizingMatcherCache.computeIfAbsent(matcher, Memoizer::withMatcherId);
+
+    int matcherId = memoizingMatcher.matcherId;
+    if (matcherId < matchers.size()) {
+      return memoizingMatcher; // de-duplicated matcher
+    } else {
+      matchers.add(matcher);
+    }
+
+    switch (kind) {
+      case ANNOTATION:
+        annotationMatcherIds.set(matcherId);
+        break;
+      case FIELD:
+        fieldMatcherIds.set(matcherId);
+        break;
+      case METHOD:
+        methodMatcherIds.set(matcherId);
+        break;
+      case CLASS:
+        classMatcherIds.set(matcherId);
+        break;
+      case INTERFACE:
+        interfaceMatcherIds.set(matcherId);
+        break;
+      case TYPE:
+        classMatcherIds.set(matcherId);
+        interfaceMatcherIds.set(matcherId);
+        break;
+    }
+
+    if (inherited) {
+      inheritedMatcherIds.set(matcherId);
+    }
+
+    return memoizingMatcher;
+  }
+
+  /** Matcher wrapper that triggers memoization on request. */
+  static final class MemoizingMatcher
+      extends ElementMatcher.Junction.ForNonNullValues<TypeDescription> {
+    final int matcherId;
+
+    MemoizingMatcher(int matcherId) {
+      this.matcherId = matcherId;
+    }
+
+    @Override
+    protected boolean doMatch(TypeDescription target) {
+      if ("java.lang.Object".equals(target.getName()) || target.isPrimitive()) {
+        return false;
+      } else {
+        return doMemoize(target, localMemosHolder.get()).get(matcherId);
+      }
+    }
+  }
+
+  static BitSet doMemoize(TypeDescription type, Map<String, BitSet> localMemos) {
+
+    String name = type.getName();
+    BitSet memo = localMemos.get(name);
+    if (null != memo) {
+      return memo; // short-circuit circular references
+    }
+
+    SharedTypeInfo<BitSet> sharedMemo = memos.find(name);
+    if (null != sharedMemo) {
+      return sharedMemo.get();
+    }
+
+    localMemos.put(name, memo = new BitSet(matchers.size()));
+    boolean wasFullParsing = TypePoolFacade.disableFullDescriptions(); // only need outlines here
+    try {
+      TypeDescription.Generic superType = type.getSuperClass();
+      if (null != superType && !"java.lang.Object".equals(superType.getTypeName())) {
+        inherit(doMemoize(superType.asErasure(), localMemos), memo);
+      }
+      for (TypeDescription.Generic intf : type.getInterfaces()) {
+        inherit(doMemoize(intf.asErasure(), localMemos), memo);
+      }
+      for (AnnotationDescription ann : type.getDeclaredAnnotations()) {
+        record(annotationMatcherIds, ann.getAnnotationType(), memo);
+      }
+      for (FieldDescription field : type.getDeclaredFields()) {
+        record(fieldMatcherIds, field, memo);
+      }
+      for (MethodDescription method : type.getDeclaredMethods()) {
+        record(methodMatcherIds, method, memo);
+      }
+      record(type.isInterface() ? interfaceMatcherIds : classMatcherIds, type, memo);
+    } catch (Throwable e) {
+      if (log.isDebugEnabled()) {
+        log.debug(
+            "{} recording matches for type {}: {}",
+            e.getClass().getSimpleName(),
+            name,
+            e.getMessage());
+      }
+    } finally {
+      localMemos.remove(name);
+      if (wasFullParsing) {
+        TypePoolFacade.enableFullDescriptions();
+      }
+    }
+
+    if (memo.nextSetBit(INTERNAL_MATCHERS) < 0) {
+      memo = NO_MATCH; // we're only interested if there's at least one external match
+    }
+
+    memos.share(name, null, null, memo);
+
+    return memo;
+  }
+
+  /** Inherit positive matches from a super-class or interface. */
+  private static void inherit(BitSet superMemo, BitSet memo) {
+    int matcherId = superMemo.nextSetBit(0);
+    while (matcherId >= 0) {
+      if (inheritedMatcherIds.get(matcherId)) {
+        memo.set(matcherId);
+      }
+      matcherId = superMemo.nextSetBit(matcherId + 1);
+    }
+  }
+
+  /** Run a series of memoized matchers and record positive matches. */
+  @SuppressWarnings("unchecked")
+  private static void record(BitSet matcherIds, Object type, BitSet memo) {
+    int matcherId = matcherIds.nextSetBit(0);
+    while (matcherId >= 0) {
+      // can skip match if we've already inherited a positive result
+      if (!memo.get(matcherId) && matchers.get(matcherId).matches(type)) {
+        memo.set(matcherId);
+      }
+      matcherId = matcherIds.nextSetBit(matcherId + 1);
+    }
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/Memoizer.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/Memoizer.java
@@ -220,17 +220,13 @@ public final class Memoizer {
       }
     }
 
-    // don't cache the result if it's based on partial/incomplete type information
-    if (memo.get(isPartial.matcherId)) {
-      return memo;
-    }
-
-    // we're only interested in the type if there's at least one external match
-    if (memo.nextSetBit(INTERNAL_MATCHERS) < 0) {
+    // update no-match filter if there's no interesting matches and result is complete
+    if (memo.nextSetBit(INTERNAL_MATCHERS) < 0 && !memo.get(isPartial.matcherId)) {
       NoMatchFilter.add(name);
       return NO_MATCH;
     }
 
+    // otherwise share result for this location (other locations may have different results)
     if (namesAreUnique || name.startsWith("java.") || !(type instanceof WithLocation)) {
       memos.share(name, null, null, memo);
     } else {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/NoMatchFilter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/NoMatchFilter.java
@@ -1,7 +1,23 @@
 package datadog.trace.agent.tooling.bytebuddy.memoize;
 
+import static datadog.trace.util.AgentThreadFactory.AGENT_THREAD_GROUP;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.DDTraceApiInfo;
 import datadog.trace.api.InstrumenterConfig;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Compact filter that records the hash and short 'class-code' for uninteresting types.
@@ -12,6 +28,8 @@ import java.util.Arrays;
  * which would otherwise make the no-match filter overly large.
  */
 final class NoMatchFilter {
+  private static final Logger log = LoggerFactory.getLogger(NoMatchFilter.class);
+
   private static final int MAX_CAPACITY = 1 << 16;
   private static final int MIN_CAPACITY = 1 << 8;
   private static final int MAX_HASH_ATTEMPTS = 3;
@@ -30,6 +48,12 @@ final class NoMatchFilter {
     // choose enough slot bits to cover the chosen capacity
     slotMask = 0xFFFFFFFF >>> Integer.numberOfLeadingZeros(capacity - 1);
     slots = new long[slotMask + 1];
+
+    // seed filter from previously collected results?
+    Path noMatchFile = discoverNoMatchFile();
+    if (null != noMatchFile) {
+      seedNoMatchFilter(noMatchFile);
+    }
   }
 
   public static boolean contains(String name) {
@@ -82,5 +106,99 @@ final class NoMatchFilter {
 
   private static int rehash(int oldHash) {
     return Integer.reverseBytes(oldHash * 0x9e3775cd) * 0x9e3775cd;
+  }
+
+  static Path discoverNoMatchFile() {
+    String cacheDir = InstrumenterConfig.get().getResolverCacheDir();
+    if (null == cacheDir) {
+      return null;
+    }
+
+    // use different file for each tracer + service combination
+    String filterKey =
+        DDTraceApiInfo.VERSION
+            + "/"
+            + Config.get().getServiceName()
+            + "/"
+            + Config.get().getVersion();
+
+    String noMatchFilterName =
+        UUID.nameUUIDFromBytes(filterKey.getBytes(StandardCharsets.UTF_8)) + "-nomatch.filter";
+
+    return Paths.get(cacheDir, noMatchFilterName);
+  }
+
+  static void seedNoMatchFilter(Path noMatchFile) {
+    if (!Files.exists(noMatchFile)) {
+      Runtime.getRuntime().addShutdownHook(new ShutdownHook(noMatchFile));
+    } else {
+      log.debug("Seeding NoMatchFilter from {}", noMatchFile);
+      try (DataInputStream in =
+          new DataInputStream(new BufferedInputStream(Files.newInputStream(noMatchFile)))) {
+        while (true) {
+          switch (in.readUTF()) {
+            case "dd-java-agent":
+              expectVersion(in, DDTraceApiInfo.VERSION);
+              break;
+            case "NoMatchFilter":
+              if (in.readInt() != slots.length) {
+                throw new IOException("filter size mismatch");
+              }
+              for (int i = 0; i < slots.length; i++) {
+                slots[i] = in.readLong();
+              }
+              return;
+            default:
+              throw new IOException("unexpected content");
+          }
+        }
+      } catch (IOException e) {
+        if (log.isDebugEnabled()) {
+          log.info("Unable to seed NoMatchFilter from {}", noMatchFile, e);
+        } else {
+          log.info("Unable to seed NoMatchFilter from {}: {}", noMatchFile, e.getMessage());
+        }
+      }
+    }
+  }
+
+  static void persistNoMatchFilter(Path noMatchFile) {
+    log.debug("Persisting NoMatchFilter to {}", noMatchFile);
+    try (DataOutputStream out =
+        new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(noMatchFile)))) {
+      out.writeUTF("dd-java-agent");
+      out.writeUTF(DDTraceApiInfo.VERSION);
+      out.writeUTF("NoMatchFilter");
+      out.writeInt(slots.length);
+      for (long slot : slots) {
+        out.writeLong(slot);
+      }
+    } catch (IOException e) {
+      if (log.isDebugEnabled()) {
+        log.info("Unable to persist NoMatchFilter to {}", noMatchFile, e);
+      } else {
+        log.info("Unable to persist NoMatchFilter to {}: {}", noMatchFile, e.getMessage());
+      }
+    }
+  }
+
+  static void expectVersion(DataInputStream in, String version) throws IOException {
+    if (!version.equals(in.readUTF())) {
+      throw new IOException("version mismatch");
+    }
+  }
+
+  static class ShutdownHook extends Thread {
+    private final Path noMatchFile;
+
+    ShutdownHook(Path noMatchFile) {
+      super(AGENT_THREAD_GROUP, "dd-NoMatchFilter-persist-hook");
+      this.noMatchFile = noMatchFile;
+    }
+
+    @Override
+    public void run() {
+      persistNoMatchFilter(noMatchFile);
+    }
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/NoMatchFilter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/NoMatchFilter.java
@@ -1,0 +1,86 @@
+package datadog.trace.agent.tooling.bytebuddy.memoize;
+
+import datadog.trace.api.InstrumenterConfig;
+import java.util.Arrays;
+
+/**
+ * Compact filter that records the hash and short 'class-code' for uninteresting types.
+ *
+ * <p>The 'class-code' includes the length of the package prefix and simple name, as well as the
+ * first and last characters of the simple name. These elements coupled with the hash of the full
+ * class name should minimize the probability of collisions without needing to store full names,
+ * which would otherwise make the no-match filter overly large.
+ */
+final class NoMatchFilter {
+  private static final int MAX_CAPACITY = 1 << 16;
+  private static final int MIN_CAPACITY = 1 << 8;
+  private static final int MAX_HASH_ATTEMPTS = 3;
+
+  private static final long[] slots;
+  private static final int slotMask;
+
+  static {
+    int capacity = InstrumenterConfig.get().getResolverNoMatchesSize();
+    if (capacity < MIN_CAPACITY) {
+      capacity = MIN_CAPACITY;
+    } else if (capacity > MAX_CAPACITY) {
+      capacity = MAX_CAPACITY;
+    }
+
+    // choose enough slot bits to cover the chosen capacity
+    slotMask = 0xFFFFFFFF >>> Integer.numberOfLeadingZeros(capacity - 1);
+    slots = new long[slotMask + 1];
+  }
+
+  public static boolean contains(String name) {
+    int hash = name.hashCode();
+    for (int i = 1, h = hash; true; i++) {
+      long value = slots[slotMask & h];
+      if (value == 0) {
+        return false;
+      } else if ((int) value == hash) {
+        return (int) (value >>> 32) == classCode(name);
+      } else if (i == MAX_HASH_ATTEMPTS) {
+        return false;
+      }
+      h = rehash(h);
+    }
+  }
+
+  public static void add(String name) {
+    int index;
+    int hash = name.hashCode();
+    for (int i = 1, h = hash; true; i++) {
+      index = slotMask & h;
+      if (slots[index] == 0) {
+        break;
+      } else if (i == MAX_HASH_ATTEMPTS) {
+        index = slotMask & hash; // overwrite original slot
+        break;
+      }
+      h = rehash(h);
+    }
+    slots[index] = (long) classCode(name) << 32 | 0xFFFFFFFFL & hash;
+  }
+
+  public static void clear() {
+    Arrays.fill(slots, 0);
+  }
+
+  /**
+   * Computes a 32-bit 'class-code' that includes the length of the package prefix and simple name,
+   * plus the first and last characters of the simple name (each truncated to fit into 8-bits.)
+   */
+  private static int classCode(String name) {
+    int start = name.lastIndexOf('.') + 1;
+    int end = name.length() - 1;
+    int code = 0xFF & start;
+    code = (code << 8) | (0xFF & name.charAt(start));
+    code = (code << 8) | (0xFF & name.charAt(end));
+    return (code << 8) | (0xFF & (end - start));
+  }
+
+  private static int rehash(int oldHash) {
+    return Integer.reverseBytes(oldHash * 0x9e3775cd) * 0x9e3775cd;
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypePoolFacade.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypePoolFacade.java
@@ -5,6 +5,8 @@ import static datadog.trace.agent.tooling.bytebuddy.outline.TypeFactory.findType
 import static datadog.trace.agent.tooling.bytebuddy.outline.TypeFactory.typeFactory;
 
 import datadog.trace.agent.tooling.bytebuddy.SharedTypePools;
+import datadog.trace.agent.tooling.bytebuddy.memoize.Memoizer;
+import datadog.trace.api.InstrumenterConfig;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.pool.TypePool;
 
@@ -63,6 +65,9 @@ public final class TypePoolFacade implements TypePool, SharedTypePools.Supplier 
 
   @Override
   public void clear() {
+    if (InstrumenterConfig.get().isResolverMemoizingEnabled()) {
+      Memoizer.clear();
+    }
     TypeFactory.clear();
   }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
@@ -44,7 +44,7 @@ public class MuzzleVersionScanPlugin {
       final List<Reference.Mismatch> mismatches =
           muzzle.getMismatchedReferenceSources(testApplicationLoader);
 
-      ClassLoaderMatchers.reset();
+      ClassLoaderMatchers.resetState();
 
       final boolean classLoaderMatch =
           instrumenter.classLoaderMatcher().matches(testApplicationLoader);

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -105,6 +105,7 @@ public final class TraceInstrumentationConfig {
       "spring-data.repository.interface.resource-name";
 
   public static final String RESOLVER_CACHE_CONFIG = "resolver.cache.config";
+  public static final String RESOLVER_CACHE_DIR = "resolver.cache.dir";
   public static final String RESOLVER_USE_LOADCLASS = "resolver.use.loadclass";
   public static final String RESOLVER_RESET_INTERVAL = "resolver.reset.interval";
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -108,6 +108,7 @@ public final class TraceInstrumentationConfig {
   public static final String RESOLVER_CACHE_DIR = "resolver.cache.dir";
   public static final String RESOLVER_USE_LOADCLASS = "resolver.use.loadclass";
   public static final String RESOLVER_RESET_INTERVAL = "resolver.reset.interval";
+  public static final String RESOLVER_NAMES_ARE_UNIQUE = "resolver.names.are.unique";
 
   private TraceInstrumentationConfig() {}
 }

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -102,6 +102,7 @@ excludedClassesCoverage += [
   "datadog.trace.api.DynamicConfig.Builder",
   "datadog.trace.api.DynamicConfig.State",
   "datadog.trace.api.InstrumenterConfig",
+  "datadog.trace.api.ResolverCacheConfig.*",
   // can't reliably force same identity hash for different instance to cover branch
   "datadog.trace.api.cache.FixedSizeCache.IdentityHash",
   "datadog.trace.api.cache.FixedSizeWeakKeyCache",

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -288,6 +288,10 @@ public class InstrumenterConfig {
     return excludedCodeSources;
   }
 
+  public int getResolverNoMatchesSize() {
+    return resolverCacheConfig.noMatchesSize();
+  }
+
   public boolean isResolverMemoizingEnabled() {
     return resolverCacheConfig.memoPoolSize() > 0;
   }

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -35,6 +35,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_MDC_TAGS_
 import static datadog.trace.api.config.TraceInstrumentationConfig.MEASURE_METHODS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_CACHE_CONFIG;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_CACHE_DIR;
+import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_NAMES_ARE_UNIQUE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_RESET_INTERVAL;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_USE_LOADCLASS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
@@ -94,6 +95,7 @@ public class InstrumenterConfig {
 
   private final ResolverCacheConfig resolverCacheConfig;
   private final String resolverCacheDir;
+  private final boolean resolverNamesAreUnique;
   private final boolean resolverUseLoadClass;
   private final int resolverResetInterval;
 
@@ -171,6 +173,7 @@ public class InstrumenterConfig {
         configProvider.getEnum(
             RESOLVER_CACHE_CONFIG, ResolverCacheConfig.class, ResolverCacheConfig.MEMOS);
     resolverCacheDir = configProvider.getString(RESOLVER_CACHE_DIR);
+    resolverNamesAreUnique = configProvider.getBoolean(RESOLVER_NAMES_ARE_UNIQUE, false);
     resolverUseLoadClass = configProvider.getBoolean(RESOLVER_USE_LOADCLASS, true);
     resolverResetInterval =
         Platform.isNativeImageBuilder()
@@ -319,6 +322,10 @@ public class InstrumenterConfig {
     return resolverCacheDir;
   }
 
+  public boolean isResolverNamesAreUnique() {
+    return resolverNamesAreUnique;
+  }
+
   public boolean isResolverUseLoadClass() {
     return resolverUseLoadClass;
   }
@@ -422,6 +429,8 @@ public class InstrumenterConfig {
         + resolverCacheConfig
         + ", resolverCacheDir="
         + resolverCacheDir
+        + ", resolverNamesAreUnique="
+        + resolverNamesAreUnique
         + ", resolverUseLoadClass="
         + resolverUseLoadClass
         + ", resolverResetInterval="

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -167,7 +167,7 @@ public class InstrumenterConfig {
 
     resolverCacheConfig =
         configProvider.getEnum(
-            RESOLVER_CACHE_CONFIG, ResolverCacheConfig.class, ResolverCacheConfig.DEFAULT);
+            RESOLVER_CACHE_CONFIG, ResolverCacheConfig.class, ResolverCacheConfig.MEMOS);
     resolverUseLoadClass = configProvider.getBoolean(RESOLVER_USE_LOADCLASS, true);
     resolverResetInterval =
         Platform.isNativeImageBuilder()
@@ -286,6 +286,14 @@ public class InstrumenterConfig {
 
   public List<String> getExcludedCodeSources() {
     return excludedCodeSources;
+  }
+
+  public boolean isResolverMemoizingEnabled() {
+    return resolverCacheConfig.memoPoolSize() > 0;
+  }
+
+  public int getResolverMemoPoolSize() {
+    return resolverCacheConfig.memoPoolSize();
   }
 
   public boolean isResolverOutliningEnabled() {

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -34,6 +34,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_INJECTION
 import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_MDC_TAGS_INJECTION_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.MEASURE_METHODS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_CACHE_CONFIG;
+import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_CACHE_DIR;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_RESET_INTERVAL;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_USE_LOADCLASS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
@@ -92,6 +93,7 @@ public class InstrumenterConfig {
   private final List<String> excludedCodeSources;
 
   private final ResolverCacheConfig resolverCacheConfig;
+  private final String resolverCacheDir;
   private final boolean resolverUseLoadClass;
   private final int resolverResetInterval;
 
@@ -168,6 +170,7 @@ public class InstrumenterConfig {
     resolverCacheConfig =
         configProvider.getEnum(
             RESOLVER_CACHE_CONFIG, ResolverCacheConfig.class, ResolverCacheConfig.MEMOS);
+    resolverCacheDir = configProvider.getString(RESOLVER_CACHE_DIR);
     resolverUseLoadClass = configProvider.getBoolean(RESOLVER_USE_LOADCLASS, true);
     resolverResetInterval =
         Platform.isNativeImageBuilder()
@@ -312,6 +315,10 @@ public class InstrumenterConfig {
     return resolverCacheConfig.typePoolSize();
   }
 
+  public String getResolverCacheDir() {
+    return resolverCacheDir;
+  }
+
   public boolean isResolverUseLoadClass() {
     return resolverUseLoadClass;
   }
@@ -413,6 +420,8 @@ public class InstrumenterConfig {
         + excludedCodeSources
         + ", resolverCacheConfig="
         + resolverCacheConfig
+        + ", resolverCacheDir="
+        + resolverCacheDir
         + ", resolverUseLoadClass="
         + resolverUseLoadClass
         + ", resolverResetInterval="

--- a/internal-api/src/main/java/datadog/trace/api/ResolverCacheConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/ResolverCacheConfig.java
@@ -3,21 +3,49 @@ package datadog.trace.api;
 /** Named presets to help configure various caches inside the type resolver/matcher. */
 public enum ResolverCacheConfig {
 
-  /** Pool sizes to fit large enterprise apps. */
+  /** Memoizing and outlining for large enterprise apps. */
   LARGE {
     @Override
+    public int memoPoolSize() {
+      return 32768;
+    }
+
+    @Override
     public int outlinePoolSize() {
-      return 4096;
+      return 512;
     }
 
     @Override
     public int typePoolSize() {
-      return 256;
+      return 128;
     }
   },
 
-  /** Pool sizes to fit the average sized app. */
-  DEFAULT {
+  /** Memoizing and outlining for the average sized app. */
+  MEMOS {
+    @Override
+    public int memoPoolSize() {
+      return 8192;
+    }
+
+    @Override
+    public int outlinePoolSize() {
+      return 128;
+    }
+
+    @Override
+    public int typePoolSize() {
+      return 32;
+    }
+  },
+
+  /** Outlining only for the average sized app, no memoizing. */
+  NO_MEMOS {
+    @Override
+    public int memoPoolSize() {
+      return 0;
+    }
+
     @Override
     public int outlinePoolSize() {
       return 256;
@@ -29,8 +57,13 @@ public enum ResolverCacheConfig {
     }
   },
 
-  /** Pool sizes to fit small microservice apps. */
+  /** Outlining only for small microservice apps. */
   SMALL {
+    @Override
+    public int memoPoolSize() {
+      return 0;
+    }
+
     @Override
     public int outlinePoolSize() {
       return 32;
@@ -45,6 +78,11 @@ public enum ResolverCacheConfig {
   /** The old {@code DDCachingPoolStrategy} behaviour. */
   LEGACY {
     @Override
+    public int memoPoolSize() {
+      return 0;
+    }
+
+    @Override
     public int outlinePoolSize() {
       return 0;
     }
@@ -54,6 +92,8 @@ public enum ResolverCacheConfig {
       return 64;
     }
   };
+
+  public abstract int memoPoolSize();
 
   public abstract int outlinePoolSize();
 

--- a/internal-api/src/main/java/datadog/trace/api/ResolverCacheConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/ResolverCacheConfig.java
@@ -6,26 +6,36 @@ public enum ResolverCacheConfig {
   /** Memoizing and outlining for large enterprise apps. */
   LARGE {
     @Override
+    public int noMatchesSize() {
+      return 65536;
+    }
+
+    @Override
     public int memoPoolSize() {
-      return 32768;
+      return 4096;
     }
 
     @Override
     public int outlinePoolSize() {
-      return 512;
+      return 256;
     }
 
     @Override
     public int typePoolSize() {
-      return 128;
+      return 64;
     }
   },
 
   /** Memoizing and outlining for the average sized app. */
   MEMOS {
     @Override
+    public int noMatchesSize() {
+      return 16384;
+    }
+
+    @Override
     public int memoPoolSize() {
-      return 8192;
+      return 2048;
     }
 
     @Override
@@ -41,6 +51,11 @@ public enum ResolverCacheConfig {
 
   /** Outlining only for the average sized app, no memoizing. */
   NO_MEMOS {
+    @Override
+    public int noMatchesSize() {
+      return 0;
+    }
+
     @Override
     public int memoPoolSize() {
       return 0;
@@ -60,6 +75,11 @@ public enum ResolverCacheConfig {
   /** Outlining only for small microservice apps. */
   SMALL {
     @Override
+    public int noMatchesSize() {
+      return 0;
+    }
+
+    @Override
     public int memoPoolSize() {
       return 0;
     }
@@ -78,6 +98,11 @@ public enum ResolverCacheConfig {
   /** The old {@code DDCachingPoolStrategy} behaviour. */
   LEGACY {
     @Override
+    public int noMatchesSize() {
+      return 0;
+    }
+
+    @Override
     public int memoPoolSize() {
       return 0;
     }
@@ -92,6 +117,8 @@ public enum ResolverCacheConfig {
       return 64;
     }
   };
+
+  public abstract int noMatchesSize();
 
   public abstract int memoPoolSize();
 


### PR DESCRIPTION
# What Does This Do

Enables memoization of hierarchical type matchers to reduce the number of times we need to sweep a given type hierarchy.

To turn off memoization add this JVM option:
```
-Ddd.resolver.cache.config=NO_MEMOS
```
or set this environment variable:
```
DD_RESOLVER_CACHE_CONFIG=NO_MEMOS
```

# Motivation

For applications with deep type inheritance each sweep of a hierarchy might result in a complete churn of the type cache. When this happens types cached at the start of each sweep get replaced by others by the end, leading to repeated parsing of the same types for each sweep. This can lead to long startup times when resource lookup is relatively expensive, such as certain OSGi configurations.

# Memoization Approach

Each hierarchy matcher is assigned a unique id as it is requested from `HierarchyMatchers` and a replacement matcher that triggers memoization is returned in its place. We do some limited de-duplication of requests for the same matcher using identity equivalence and a tiny lookup cache. (We cannot rely on `equals` being implemented properly for every matcher.)

When memoization is triggered for a type we first check for previously shared results. If none exist then memoization is triggered recursively for the super-class and any interfaces. Inherited matches are copied into the current result.  Next we record matches for members declared in the type: annotations, fields, and methods. Finally we record matches for the type itself, before sharing the result.

Since all hierarchy matchers are requested before any are used we can store match results in a simple `BitSet`.  The type of each match and whether the match can be inherited are spread over other `BitSets`, shared across all results like a schema.

# "No Match" Filter

Memoization has an additional benefit: we can now easily tell when a type is not interesting to any hierarchical matcher. In most applications these "no match" results heavily outweigh any matches. Unfortunately recording "no matches" has the potential to use a lot of memory, especially if we need to take the class location/class-loader into account.

However if we assume that when a type is not interesting, all types with the same name are also not interesting then we can simplify the "no match" cache down to a simple `long` array. The first 32 bits of each entry are the hash of the class-name while the remaining 32-bits record extra characteristics of the name, such as the length of the package and simple names. These are used to further reduce the probability of collisions, compared to just using the name hash.

# Persisting "No Match" Results

Basing the "No Match" filter on just the class-name also means we can persist it between runs of the same application, because the `String.hashCode()` algorithm is well-defined and stable. This can provide a further performance boost because it can prune the matching space without needing to load/parse any types.

To enable the "No Match" filter add this JVM option:
```
-Ddd.resolver.cache.dir=<writable-directory>
```
or set this environment variable:
```
DD_RESOLVER_CACHE_DIR=<writable-directory>
```
The Java tracer will then write a file at shutdown based on the following name pattern:
```
<writable-directory>/<uuid>-nomatch.filter
```
where the UUID is based on the configured service name and version, so each unique service+version has its own file.

If a `nomatch.filter` file already exists for a particular service+version it will be used to re-seed the "No Match" filter at startup. It won't then be updated at shutdown; to regenerate a `nomatch.filter` file, delete it and restart the application.

# Additional Notes

Here's a short history of the total transformation time for a sizeable, modular web application. Transformation time covers the accumulated time spent inside our `ClassFileTransformer` for both initial transformations and any retransformations during warmup of the application. I've included some of the more notable changes related to matching and transforming.

| Version | Transformation time | Notable changes                                                |
|---------|---------------------|----------------------------------------------------------------|
| 0.81.0  | 32.7s               |                                                                |
| 0.100.0 | 29.8s               | global ignores trie                                            |
| 0.104.0 | 22.4s               | outline type parsing                                           |
| 0.109.1 | 17.2s               | class-loader masks + rework context-store matchers             |
| 0.115.1 | 16.7s               | reduce allocations when matching                               |
| 1.2.0   | 16.3s               | reduce need for full-type parsing                              |
| 1.3.0   | 16.0s               | use outline types in more situations                           |
| 1.4.0   | 15.5s               | re-use bytecode during type resolution                         |
| 1.6.0   | 13.3s               | single combining matcher + splitting transformer               |
| 1.11.0  | 12.7s               | replace map-based WeakCache with fixed-sized array approach    |
|---------|---------------------|----------------------------------------------------------------|
|         |  9.6s               | memoization                                                    |
|         |  8.9s               | memoization (LARGE)                                            |
|         |  8.5s               | memoization, previously persisted no-match filter              |
|         |  6.3s               | memoization, previously persisted no-match filter (LARGE)      |

`LARGE` here refers to the [`dd.resolver.cache.config`](https://github.com/DataDog/dd-trace-java/pull/4408) preset, for example: `-Ddd.resolver.cache.config=LARGE`

The smallest overall transformation time is 6.3 seconds, by using the `LARGE` preset with a pre-seeded "No Match" filter. Less than half of that time is matching - the rest is actually transforming the bytecode. Of the 2.5s matching time, muzzle and class-loader checks take roughly a second as does hierarchy matching. The remaining 0.5s is composed of context-store matching and structural checks.