### PR TITLE
Add iast_enabled to StatusLogger (if enabled)

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
@@ -138,6 +138,10 @@ public final class StatusLogger extends JsonAdapter<Config>
     writer.value(config.isDatadogProfilerEnabled());
     writer.name("datadog_profiler_safe");
     writer.value(isDatadogProfilerSafeInCurrentEnvironment());
+    if (config.isIastEnabled()) {
+      writer.name("iast_enabled");
+      writer.value(true);
+    }
     writer.endObject();
   }
 


### PR DESCRIPTION
# What Does This Do
Add iast_enabled=true to StatusLogger.

Omit iast_enabled=false at the moment, to avoid noise before GA.

# Motivation

# Additional Notes
