### PR TITLE
Remove all deprecation warnings in preparation for gradle 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,6 +362,19 @@ jobs:
             --max-workers=8
 
       - run:
+          name: Collect reports
+          when: on_fail
+          command: .circleci/collect_reports.sh --destination ./check_reports --move
+
+      - run:
+          name: Delete reports
+          when: on_success
+          command: .circleci/collect_reports.sh --destination ./check_reports --delete
+
+      - store_artifacts:
+          path: ./check_reports
+
+      - run:
           name: Cancel workflow
           when: on_fail
           command: .circleci/cancel_workflow.sh
@@ -406,19 +419,6 @@ jobs:
               command: .circleci/collect_libs.sh
           - store_artifacts:
               path: ./libs
-
-      - run:
-          name: Collect reports
-          when: on_fail
-          command: .circleci/collect_reports.sh --destination ./check_reports --move
-
-      - run:
-          name: Delete reports
-          when: on_success
-          command: .circleci/collect_reports.sh --destination ./check_reports --delete
-
-      - store_artifacts:
-          path: ./check_reports
 
       - save_dependency_cache:
           cacheType: << parameters.cacheType >>

--- a/build.gradle
+++ b/build.gradle
@@ -11,19 +11,17 @@ buildscript {
 }
 
 plugins {
-  id 'com.github.ben-manes.versions' version '0.27.0'
-
   id "com.diffplug.spotless" version "6.11.0"
-  id 'com.github.spotbugs' version '4.6.0'
-  id "de.thetaphi.forbiddenapis" version "3.2"
+  id 'com.github.spotbugs' version '5.0.14'
+  id "de.thetaphi.forbiddenapis" version "3.5.1"
 
-  id 'org.unbroken-dome.test-sets' version '4.0.0'
+  id 'org.unbroken-dome.test-sets' version '4.0.0' // shift this out
   id 'pl.allegro.tech.build.axion-release' version '1.14.4'
-  id 'io.github.gradle-nexus.publish-plugin' version '1.0.0'
+  id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
 
   id "com.github.johnrengelman.shadow" version "7.1.2" apply false
-  id "me.champeau.jmh" version "0.6.5" apply false
-  id 'org.gradle.playframework' version '0.12' apply false
+  id "me.champeau.jmh" version "0.7.0" apply false
+  id 'org.gradle.playframework' version '0.13' apply false
   id 'info.solidsoft.pitest' version '1.9.11'  apply false
 }
 

--- a/dd-java-agent/agent-debugger/build.gradle
+++ b/dd-java-agent/agent-debugger/build.gradle
@@ -65,7 +65,7 @@ shadowJar {
 }
 
 jar {
-  classifier = 'unbundled'
+  archiveClassifier = 'unbundled'
   from sourceSets.main.output
 }
 

--- a/dd-java-agent/agent-profiling/build.gradle
+++ b/dd-java-agent/agent-profiling/build.gradle
@@ -36,5 +36,5 @@ shadowJar {
 }
 
 jar {
-  classifier = 'unbundled'
+  archiveClassifier = 'unbundled'
 }

--- a/dd-java-agent/agent-profiling/profiling-ddprof/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 }
 
 shadowJar {
-  classifier ""
+  archiveClassifier = ''
   include {
     def rslt = false
     rslt |= it.path == "com" || it.path == "com/datadog"

--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
@@ -31,6 +31,7 @@ import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.relocate.api.IOLogger;
 import datadog.trace.util.AgentThreadFactory;
 import datadog.trace.util.PidHelper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.time.Duration;
@@ -340,6 +341,7 @@ public final class ProfileUploader {
     onCompletion.run();
   }
 
+  @SuppressFBWarnings("DCN_NULLPOINTER_EXCEPTION")
   private IOLogger.Response getLoggerResponse(final okhttp3.Response response) {
     if (response != null) {
       try {

--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -221,7 +221,7 @@ tasks.withType(Test).configureEach {
 
   doFirst {
     // Defining here to allow jacoco to be first on the command line.
-    jvmArgs "-javaagent:${shadowJar.archivePath}"
+    jvmArgs "-javaagent:${shadowJar.archiveFile.get()}"
   }
 
   testLogging {

--- a/dd-java-agent/instrumentation/akka-concurrent/build.gradle
+++ b/dd-java-agent/instrumentation/akka-concurrent/build.gradle
@@ -62,14 +62,16 @@ dependencies {
 
   latestDepTestImplementation group: 'com.typesafe.akka', name: "akka-actor_$scalaVersion", version: '+'
   latestDepTestImplementation group: 'com.typesafe.akka', name: "akka-testkit_$scalaVersion", version: '+'
-
-  akka23TestImplementation("com.typesafe.akka:akka-actor_$scalaVersion:2.3.16") {
-    force = true
-  }
-  akka23TestImplementation("com.typesafe.akka:akka-testkit_$scalaVersion:2.3.16") {
-    force = true
-  }
 }
+
+// gradle can't downgrade the akka dependencies with `strictly`
+configurations.matching({ it.name.startsWith('akka23') }).each({
+  it.resolutionStrategy {
+    force group: 'com.typesafe.akka', name: "akka-actor_$scalaVersion", version :'2.3.16'
+    force group: 'com.typesafe.akka', name: "akka-testkit_$scalaVersion", version :'2.3.16'
+  }
+})
+
 
 // Run 2.3 tests along with the rest of unit tests
 tasks.named("test").configure {

--- a/dd-java-agent/instrumentation/build.gradle
+++ b/dd-java-agent/instrumentation/build.gradle
@@ -136,3 +136,7 @@ tasks.register('generateKnownTypesIndex', JavaExec) {
 
 shadowJar.dependsOn 'generateKnownTypesIndex'
 
+// there are implicit dependencies here in the spotless tasks that will fail on gradle 8
+tasks.spotlessGroovyGradle {
+  dependsOn compileJava
+}

--- a/dd-java-agent/instrumentation/grizzly-2/build.gradle
+++ b/dd-java-agent/instrumentation/grizzly-2/build.gradle
@@ -32,7 +32,7 @@ dependencies {
   latestDepTestImplementation group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: '2.+'
 }
 
-configurations.testRuntimeClasspath {
+configurations.testRuntimeOnly {
   // jersey-container-grizzly2-http transitively imports its own set repackaged asm classes
   exclude group: 'org.ow2.asm'
 }

--- a/dd-java-agent/instrumentation/jackson-core/build.gradle
+++ b/dd-java-agent/instrumentation/jackson-core/build.gradle
@@ -21,5 +21,5 @@ testSets {
 dependencies {
   compileOnly(group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.14.1')
   testImplementation(group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.14.1')
-  testRuntimeClasspath project(':dd-java-agent:instrumentation:iast-instrumenter')
+  testRuntimeOnly(project(':dd-java-agent:instrumentation:iast-instrumenter'))
 }

--- a/dd-java-agent/instrumentation/java-io/build.gradle
+++ b/dd-java-agent/instrumentation/java-io/build.gradle
@@ -16,6 +16,6 @@ testSets {
 }
 
 dependencies {
-  testRuntimeClasspath project(':dd-java-agent:instrumentation:iast-instrumenter')
+  testRuntimeOnly project(':dd-java-agent:instrumentation:iast-instrumenter')
 }
 

--- a/dd-java-agent/instrumentation/java-lang/build.gradle
+++ b/dd-java-agent/instrumentation/java-lang/build.gradle
@@ -16,7 +16,7 @@ testSets {
 }
 
 dependencies {
-  testRuntimeClasspath project(':dd-java-agent:instrumentation:iast-instrumenter')
+  testRuntimeOnly project(':dd-java-agent:instrumentation:iast-instrumenter')
 }
 
 tasks.compileTestJava.configure {

--- a/dd-java-agent/instrumentation/java-lang/java-lang-11/build.gradle
+++ b/dd-java-agent/instrumentation/java-lang/java-lang-11/build.gradle
@@ -38,7 +38,7 @@ testSets {
 }
 
 dependencies {
-  testRuntimeClasspath project(':dd-java-agent:instrumentation:iast-instrumenter')
+  testRuntimeOnly project(':dd-java-agent:instrumentation:iast-instrumenter')
 }
 
 project.tasks.withType(AbstractCompile).configureEach {

--- a/dd-java-agent/instrumentation/java-lang/java-lang-9/build.gradle
+++ b/dd-java-agent/instrumentation/java-lang/java-lang-9/build.gradle
@@ -29,7 +29,7 @@ testSets {
 }
 
 dependencies {
-  testRuntimeClasspath project(':dd-java-agent:instrumentation:iast-instrumenter')
+  testRuntimeOnly project(':dd-java-agent:instrumentation:iast-instrumenter')
 }
 
 project.tasks.withType(AbstractCompile).configureEach {

--- a/dd-java-agent/instrumentation/java-net/build.gradle
+++ b/dd-java-agent/instrumentation/java-net/build.gradle
@@ -16,7 +16,7 @@ testSets {
 }
 
 dependencies {
-  testRuntimeClasspath project(':dd-java-agent:instrumentation:iast-instrumenter')
+  testRuntimeOnly project(':dd-java-agent:instrumentation:iast-instrumenter')
 }
 
 tasks.compileTestJava.configure {

--- a/dd-java-agent/instrumentation/javax-naming/build.gradle
+++ b/dd-java-agent/instrumentation/javax-naming/build.gradle
@@ -16,7 +16,7 @@ testSets {
 }
 
 dependencies {
-  testRuntimeClasspath project(':dd-java-agent:instrumentation:iast-instrumenter')
+  testRuntimeOnly project(':dd-java-agent:instrumentation:iast-instrumenter')
 }
 
 

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/build.gradle
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/build.gradle
@@ -35,7 +35,7 @@ dependencies {
   latestDepTestImplementation deps.guava
 }
 
-configurations.testRuntimeClasspath {
+configurations.testRuntimeOnly {
   // spock-core depends on assertj version that is not compatible with kafka-clients
   resolutionStrategy.force 'org.assertj:assertj-core:2.9.1'
 }

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/build.gradle
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/build.gradle
@@ -39,7 +39,7 @@ dependencies {
   latestDepTestImplementation group: 'org.assertj', name: 'assertj-core', version: '3.+'
 }
 
-configurations.testRuntimeClasspath {
+configurations.testRuntimeOnly {
   // spock-core depends on assertj version that is not compatible with kafka-streams
   resolutionStrategy.force 'org.assertj:assertj-core:2.9.1'
 }

--- a/dd-java-agent/instrumentation/liberty-20/build.gradle
+++ b/dd-java-agent/instrumentation/liberty-20/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 
   testImplementation files({ tasks.installOpenLibertyDeps.wsServerJar })
   testRuntimeOnly project(':dd-java-agent:instrumentation:osgi-4.3')
-  testRuntimeClasspath files({ tasks.filterLogbackClassic.filteredLogbackDir })
+  testRuntimeOnly files({ tasks.filterLogbackClassic.filteredLogbackDir })
 
   webappCompileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
   // compileOnly to avoid bringing all the test dependencies to the test app
@@ -49,7 +49,7 @@ dependencies {
 }
 compileWebappJava.dependsOn ':dd-java-agent:instrumentation:servlet:request-3:testFixturesJar'
 
-configurations.testRuntimeClasspath {
+configurations.testRuntimeOnly {
   exclude group: 'ch.qos.logback', module: 'logback-classic'
   exclude group: 'org.codehaus.groovy', module: 'groovy-servlet'
 }

--- a/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/HttpServletExtractAdapter.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/HttpServletExtractAdapter.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.liberty20;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Collections;
 import java.util.Enumeration;
 import javax.servlet.http.HttpServletRequest;
@@ -36,6 +37,7 @@ public abstract class HttpServletExtractAdapter<T> implements AgentPropagation.C
     }
   }
 
+  @SuppressFBWarnings("DCN_NULLPOINTER_EXCEPTION")
   public static final class Response extends HttpServletExtractAdapter<HttpServletResponse> {
     public static final Response GETTER = new Response();
 

--- a/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/LibertyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/LibertyServerInstrumentation.java
@@ -18,6 +18,7 @@ import datadog.trace.api.gateway.Flow;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.servlet.ServletBlockingHelper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.EnumSet;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
@@ -63,6 +64,7 @@ public final class LibertyServerInstrumentation extends Instrumenter.Tracing
         LibertyServerInstrumentation.class.getName() + "$HandleRequestAdvice");
   }
 
+  @SuppressFBWarnings("DCN_NULLPOINTER_EXCEPTION")
   public static class HandleRequestAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class, skipOn = Advice.OnNonDefaultValue.class)

--- a/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/RequestFinishInstrumentation.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/RequestFinishInstrumentation.java
@@ -11,6 +11,7 @@ import com.ibm.ws.webcontainer.srt.SRTServletResponse;
 import com.ibm.wsspi.webcontainer.servlet.IExtendedResponse;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import net.bytebuddy.asm.Advice;
 
 @AutoService(Instrumenter.class)
@@ -46,6 +47,7 @@ public class RequestFinishInstrumentation extends Instrumenter.Tracing
   }
 
   /** The function finish is called when a server receives and sends out a request */
+  @SuppressFBWarnings("DCN_NULLPOINTER_EXCEPTION")
   public static class RequestFinishAdvice {
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(@Advice.This SRTServletRequest req) {

--- a/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/ResponseFinishInstrumentation.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/ResponseFinishInstrumentation.java
@@ -10,6 +10,7 @@ import com.ibm.ws.webcontainer.srt.SRTServletResponse;
 import com.ibm.wsspi.webcontainer.servlet.IExtendedRequest;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import net.bytebuddy.asm.Advice;
 
 @AutoService(Instrumenter.class)
@@ -44,6 +45,7 @@ public class ResponseFinishInstrumentation extends Instrumenter.Tracing
         ResponseFinishInstrumentation.class.getName() + "$ResponseFinishAdvice");
   }
 
+  @SuppressFBWarnings("DCN_NULLPOINTER_EXCEPTION")
   public static class ResponseFinishAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     static AgentSpan onEnter(@Advice.This SRTServletResponse resp) {

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/build.gradle
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/build.gradle
@@ -30,7 +30,7 @@ dependencies {
   latestDepTestImplementation group: 'org.springframework.amqp', name: 'spring-rabbit', version: '2.+'
 }
 
-configurations.testRuntimeClasspath {
+configurations.testRuntimeOnly {
   resolutionStrategy {
     force group: 'com.rabbitmq', name: 'amqp-client', version: '2.7.0'
   }

--- a/dd-java-agent/instrumentation/testng/build.gradle
+++ b/dd-java-agent/instrumentation/testng/build.gradle
@@ -9,9 +9,12 @@ dependencies {
 
   testFixturesImplementation project(':dd-java-agent:testing')
   testFixturesImplementation project(':utils:test-utils')
-  testFixturesImplementation(group: 'org.testng', name: 'testng') {
-    version {
-      strictly '6.4'
-    }
-  }
+  testFixturesImplementation group: 'org.testng', name: 'testng', version: '6.4'
 }
+
+// gradle can't downgrade the testng dependencies with `strictly`
+configurations.matching({ it.name.startsWith('test') }).each({
+  it.resolutionStrategy {
+    force group: 'org.testng', name: 'testng', version: '6.4'
+  }
+})

--- a/dd-java-agent/load-generator/build.gradle
+++ b/dd-java-agent/load-generator/build.gradle
@@ -10,9 +10,9 @@ dependencies {
 
 tasks.register('launch', JavaExec) {
   classpath = sourceSets.main.runtimeClasspath
-  main = 'datadog.loadgenerator.LoadGenerator'
+  mainClass = 'datadog.loadgenerator.LoadGenerator'
   jvmArgs = [
-    "-javaagent:${project(':dd-java-agent').shadowJar.archivePath}",
+    "-javaagent:${project(':dd-java-agent').shadowJar.archiveFile.get()}",
     "-Ddd.service.name=loadtest"
   ]
   systemProperties System.properties

--- a/dd-smoke-tests/appsec/springboot-grpc/build.gradle
+++ b/dd-smoke-tests/appsec/springboot-grpc/build.gradle
@@ -28,5 +28,5 @@ tasks.withType(Test).configureEach {
 
   Task shadowJarTask = project(':dd-smoke-tests:springboot-grpc').tasks['shadowJar']
 
-  jvmArgs "-Ddatadog.smoketest.appsec.springboot-grpc.shadowJar.path=${shadowJarTask.archivePath}"
+  jvmArgs "-Ddatadog.smoketest.appsec.springboot-grpc.shadowJar.path=${shadowJarTask.archiveFile.get()}"
 }

--- a/dd-smoke-tests/appsec/springboot/build.gradle
+++ b/dd-smoke-tests/appsec/springboot/build.gradle
@@ -23,11 +23,11 @@ dependencies {
 tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
 
-  jvmArgs "-Ddatadog.smoketest.appsec.springboot.shadowJar.path=${tasks.shadowJar.archivePath}"
+  jvmArgs "-Ddatadog.smoketest.appsec.springboot.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }
 
 task testRuntimeActivation(type: Test) {
   jvmArgs '-Dsmoke_test.appsec.enabled=inactive',
-    "-Ddatadog.smoketest.appsec.springboot.shadowJar.path=${tasks.shadowJar.archivePath}"
+    "-Ddatadog.smoketest.appsec.springboot.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }
 tasks['check'].dependsOn(testRuntimeActivation)

--- a/dd-smoke-tests/build.gradle
+++ b/dd-smoke-tests/build.gradle
@@ -23,7 +23,7 @@ subprojects { Project subProj ->
 
     // Tests depend on this to know where to run things and what agent jar to use
     jvmArgs "-Ddatadog.smoketest.builddir=${buildDir}"
-    jvmArgs "-Ddatadog.smoketest.agent.shadowJar.path=${project(':dd-java-agent').tasks.shadowJar.archivePath}"
+    jvmArgs "-Ddatadog.smoketest.agent.shadowJar.path=${project(':dd-java-agent').tasks.shadowJar.archiveFile.get()}"
 
     // The jar path for the test agent (taken from https://github.com/DataDog/dd-trace-test-agent )
     jvmArgs "-Ddatadog.smoketest.test.agent.dir=${project.getRootDir()}/dd-smoke-tests/src/main/resources/datadog.smoketest.test.agent.jar"

--- a/dd-smoke-tests/cli/build.gradle
+++ b/dd-smoke-tests/cli/build.gradle
@@ -20,5 +20,5 @@ dependencies {
 tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
 
-  jvmArgs "-Ddatadog.smoketest.cli.shadowJar.path=${tasks.shadowJar.archivePath}"
+  jvmArgs "-Ddatadog.smoketest.cli.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }

--- a/dd-smoke-tests/custom-systemloader/build.gradle
+++ b/dd-smoke-tests/custom-systemloader/build.gradle
@@ -24,5 +24,5 @@ dependencies {
 tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
 
-  jvmArgs "-Ddatadog.smoketest.systemloader.shadowJar.path=${tasks.shadowJar.archivePath}"
+  jvmArgs "-Ddatadog.smoketest.systemloader.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }

--- a/dd-smoke-tests/debugger-integration-tests/build.gradle
+++ b/dd-smoke-tests/debugger-integration-tests/build.gradle
@@ -40,10 +40,10 @@ tasks.withType(Test).configureEach {
   //  }
   //  doFirst {
   //    if (isLatestJdk) {
-  //      jvmArgs "-Ddatadog.smoketest.shadowJar.external.path=${project(':dd-smoke-tests:debugger-integration-tests:latest-jdk-app').tasks.shadowJar.archivePath}"
+  //      jvmArgs "-Ddatadog.smoketest.shadowJar.external.path=${project(':dd-smoke-tests:debugger-integration-tests:latest-jdk-app').tasks.shadowJar.archiveFile.get()}"
   //    }
   //  }
 
-  jvmArgs "-Ddatadog.smoketest.shadowJar.path=${tasks.shadowJar.archivePath}"
+  jvmArgs "-Ddatadog.smoketest.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }
 

--- a/dd-smoke-tests/field-injection/build.gradle
+++ b/dd-smoke-tests/field-injection/build.gradle
@@ -22,5 +22,5 @@ dependencies {
 tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
 
-  jvmArgs "-Ddatadog.smoketest.fieldinjection.shadowJar.path=${tasks.shadowJar.archivePath}"
+  jvmArgs "-Ddatadog.smoketest.fieldinjection.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }

--- a/dd-smoke-tests/jersey-2/build.gradle
+++ b/dd-smoke-tests/jersey-2/build.gradle
@@ -23,5 +23,5 @@ dependencies {
 
 tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
-  jvmArgs "-Ddatadog.smoketest.jersey2.jar.path=${tasks.shadowJar.archivePath}"
+  jvmArgs "-Ddatadog.smoketest.jersey2.jar.path=${tasks.shadowJar.archiveFile.get()}"
 }

--- a/dd-smoke-tests/jersey-3/build.gradle
+++ b/dd-smoke-tests/jersey-3/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 
 tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
-  jvmArgs "-Ddatadog.smoketest.jersey3.jar.path=${tasks.shadowJar.archivePath}"
+  jvmArgs "-Ddatadog.smoketest.jersey3.jar.path=${tasks.shadowJar.archiveFile.get()}"
 }
 
 

--- a/dd-smoke-tests/opentelemetry/build.gradle
+++ b/dd-smoke-tests/opentelemetry/build.gradle
@@ -6,7 +6,7 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 
 application {
-  mainClassName = 'datadog.smoketest.opentelemetry.Application'
+  mainClass = 'datadog.smoketest.opentelemetry.Application'
 }
 
 dependencies {
@@ -16,5 +16,5 @@ dependencies {
 
 tasks.withType(Test).configureEach {
   dependsOn 'shadowJar'
-  jvmArgs "-Ddatadog.smoketest.shadowJar.path=${tasks.shadowJar.getArchiveFile().get()}"
+  jvmArgs "-Ddatadog.smoketest.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }

--- a/dd-smoke-tests/opentracing/build.gradle
+++ b/dd-smoke-tests/opentracing/build.gradle
@@ -21,5 +21,5 @@ dependencies {
 tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
 
-  jvmArgs "-Ddatadog.smoketest.shadowJar.path=${tasks.shadowJar.archivePath}"
+  jvmArgs "-Ddatadog.smoketest.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }

--- a/dd-smoke-tests/osgi/build.gradle
+++ b/dd-smoke-tests/osgi/build.gradle
@@ -41,7 +41,7 @@ jar {
 import aQute.bnd.gradle.Bundle
 
 tasks.register('commonBundle', Bundle) {
-  classifier = 'common'
+  archiveClassifier = 'common'
   from sourceSets.main.output
   include 'datadog/smoketest/osgi/common/**'
   manifest {
@@ -50,7 +50,7 @@ tasks.register('commonBundle', Bundle) {
 }
 
 tasks.register('clientBundle', Bundle) {
-  classifier = 'client'
+  archiveClassifier = 'client'
   from sourceSets.main.output
   include 'datadog/smoketest/osgi/client/**'
   manifest {
@@ -59,7 +59,7 @@ tasks.register('clientBundle', Bundle) {
 }
 
 tasks.register('messagingBundle', Bundle) {
-  classifier = 'messaging'
+  archiveClassifier = 'messaging'
   from sourceSets.main.output
   include 'datadog/smoketest/osgi/messaging/**'
   manifest {
@@ -68,7 +68,7 @@ tasks.register('messagingBundle', Bundle) {
 }
 
 tasks.register('publishingBundle', Bundle) {
-  classifier = 'publishing'
+  archiveClassifier = 'publishing'
   from sourceSets.main.output
   include 'datadog/smoketest/osgi/publishing/**'
   manifest {
@@ -77,7 +77,7 @@ tasks.register('publishingBundle', Bundle) {
 }
 
 tasks.register('subscribingBundle', Bundle) {
-  classifier = 'subscribing'
+  archiveClassifier = 'subscribing'
   from sourceSets.main.output
   include 'datadog/smoketest/osgi/subscribing/**'
   manifest {
@@ -88,15 +88,15 @@ tasks.register('subscribingBundle', Bundle) {
 tasks.withType(Test).configureEach {
   dependsOn "commonBundle", "clientBundle", "messagingBundle", "publishingBundle", "subscribingBundle", "jar"
 
-  jvmArgs "-Ddatadog.smoketest.osgi.appJar.path=${tasks.jar.archivePath}"
+  jvmArgs "-Ddatadog.smoketest.osgi.appJar.path=${tasks.jar.archiveFile.get()}"
   jvmArgs "-Ddatadog.smoketest.osgi.equinoxJar.path=${configurations.equinox.first().path}"
   jvmArgs "-Ddatadog.smoketest.osgi.felixJar.path=${configurations.felix.first().path}"
 
   jvmArgs "-Ddatadog.smoketest.osgi.bundle.paths=" +
-    "${tasks.commonBundle.archivePath}," +
-    "${tasks.clientBundle.archivePath}," +
-    "${tasks.messagingBundle.archivePath}," +
-    "${tasks.publishingBundle.archivePath}," +
-    "${tasks.subscribingBundle.archivePath}," +
+    "${tasks.commonBundle.archiveFile.get()}," +
+    "${tasks.clientBundle.archiveFile.get()}," +
+    "${tasks.messagingBundle.archiveFile.get()}," +
+    "${tasks.publishingBundle.archiveFile.get()}," +
+    "${tasks.subscribingBundle.archiveFile.get()}," +
     "${configurations.bundles*.path.join(',')}"
 }

--- a/dd-smoke-tests/profiling-integration-tests/build.gradle
+++ b/dd-smoke-tests/profiling-integration-tests/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 
 tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
-  jvmArgs "-Ddatadog.smoketest.profiling.shadowJar.path=${tasks.shadowJar.archivePath}"
+  jvmArgs "-Ddatadog.smoketest.profiling.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }
 
 shadowJar {

--- a/dd-smoke-tests/profiling-integration-tests/src/main/java/datadog/smoketest/profiling/ProfilingTestApplication.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/main/java/datadog/smoketest/profiling/ProfilingTestApplication.java
@@ -49,6 +49,7 @@ public class ProfilingTestApplication {
   }
 
   @Trace
+  @SuppressFBWarnings("DMI_RANDOM_USED_ONLY_ONCE")
   private static void tracedBusyMethod() {
     long startTime = THREAD_MX_BEAN.getCurrentThreadCpuTime();
     Random random = new Random();

--- a/dd-smoke-tests/quarkus/build.gradle
+++ b/dd-smoke-tests/quarkus/build.gradle
@@ -14,7 +14,7 @@ def gradlewCommand = isWindows ? 'gradlew.bat' : 'gradlew'
 tasks.register('quarkusBuild', Exec) {
   workingDir "$appDir"
   environment += ["GRADLE_OPTS": "-Dorg.gradle.jvmargs='-Xmx512M'"]
-  commandLine "${rootDir}/${gradlewCommand}", "build", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archivePath}"
+  commandLine "${rootDir}/${gradlewCommand}", "build", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archiveFile.get()}"
 
   outputs.cacheIf { true }
 

--- a/dd-smoke-tests/resteasy/build.gradle
+++ b/dd-smoke-tests/resteasy/build.gradle
@@ -27,5 +27,5 @@ dependencies {
 
 tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
-  jvmArgs "-Ddatadog.smoketest.resteasy.jar.path=${tasks.shadowJar.archivePath}"
+  jvmArgs "-Ddatadog.smoketest.resteasy.jar.path=${tasks.shadowJar.archiveFile.get()}"
 }

--- a/dd-smoke-tests/spring-boot-2.3-webmvc-jetty/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.3-webmvc-jetty/build.gradle
@@ -38,5 +38,5 @@ dependencies {
 tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
 
-  jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archivePath}"
+  jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }

--- a/dd-smoke-tests/spring-boot-2.4-webflux/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.4-webflux/build.gradle
@@ -25,5 +25,5 @@ dependencies {
 tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
 
-  jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archivePath}"
+  jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }

--- a/dd-smoke-tests/spring-boot-2.5-webflux/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.5-webflux/build.gradle
@@ -31,5 +31,5 @@ dependencies {
 tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
 
-  jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archivePath}"
+  jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }

--- a/dd-smoke-tests/spring-boot-2.6-webflux/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.6-webflux/build.gradle
@@ -39,5 +39,5 @@ dependencies {
 tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
 
-  jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archivePath}"
+  jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }

--- a/dd-smoke-tests/spring-boot-2.6-webmvc/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.6-webmvc/build.gradle
@@ -43,5 +43,5 @@ dependencies {
 tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
 
-  jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archivePath}"
+  jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }

--- a/dd-smoke-tests/spring-boot-2.7-webflux/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.7-webflux/build.gradle
@@ -16,7 +16,7 @@ def gradlewCommand = isWindows ? 'gradlew.bat' : 'gradlew'
 tasks.register('webfluxBuild', Exec) {
   workingDir "$appDir"
   environment += ["GRADLE_OPTS": "-Dorg.gradle.jvmargs='-Xmx512M'"]
-  commandLine "$rootDir/${gradlewCommand}", "bootJar", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archivePath}"
+  commandLine "$rootDir/${gradlewCommand}", "bootJar", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archiveFile.get()}"
 
   outputs.cacheIf { true }
 

--- a/dd-smoke-tests/spring-boot-3.0-webflux/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.0-webflux/build.gradle
@@ -20,7 +20,7 @@ tasks.register('webfluxBuild30', Exec) {
   workingDir "$appDir"
   def toolchain17 = getJavaLauncherFor(17).get()
   environment += ["GRADLE_OPTS": "-Dorg.gradle.jvmargs='-Xmx512M'", "JAVA_HOME": "$toolchain17.metadata.installationPath"]
-  commandLine "$rootDir/${gradlewCommand}", "bootJar", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archivePath}"
+  commandLine "$rootDir/${gradlewCommand}", "bootJar", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archiveFile.get()}"
 
   outputs.cacheIf { true }
 

--- a/dd-smoke-tests/spring-boot-3.0-webmvc/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.0-webmvc/build.gradle
@@ -20,7 +20,7 @@ tasks.register('webmvcBuild30', Exec) {
   workingDir "$appDir"
   def toolchain17 = getJavaLauncherFor(17).get()
   environment += ["GRADLE_OPTS": "-Dorg.gradle.jvmargs='-Xmx512M'", "JAVA_HOME": "$toolchain17.metadata.installationPath"]
-  commandLine "$rootDir/${gradlewCommand}", "bootJar", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archivePath}"
+  commandLine "$rootDir/${gradlewCommand}", "bootJar", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archiveFile.get()}"
 
   outputs.cacheIf { true }
 

--- a/dd-smoke-tests/spring-boot-rabbit/build.gradle
+++ b/dd-smoke-tests/spring-boot-rabbit/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
 
-  jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archivePath}"
+  jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 
   usesService(testcontainersLimit)
 }

--- a/dd-smoke-tests/spring-native/build.gradle
+++ b/dd-smoke-tests/spring-native/build.gradle
@@ -31,7 +31,7 @@ if (testJvm != null && testJvm.toLowerCase(Locale.ROOT).startsWith('graalvm')) {
       "GRAALVM_HOME": testJvmHome,
       "DD_TRACE_METHODS" : "datadog.smoketest.springboot.controller.WebController[sayHello]"
     ]
-    commandLine "$rootDir/${gradlewCommand}", "nativeCompile", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PagentPath=${project(':dd-java-agent').tasks.shadowJar.archivePath}"
+    commandLine "$rootDir/${gradlewCommand}", "nativeCompile", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PagentPath=${project(':dd-java-agent').tasks.shadowJar.archiveFile.get()}"
 
     outputs.cacheIf { true }
     outputs.dir(appBuildDir)

--- a/dd-smoke-tests/springboot-grpc/build.gradle
+++ b/dd-smoke-tests/springboot-grpc/build.gradle
@@ -55,5 +55,5 @@ dependencies {
 tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
 
-  jvmArgs "-Ddatadog.smoketest.springboot-grpc.shadowJar.path=${tasks.shadowJar.archivePath}"
+  jvmArgs "-Ddatadog.smoketest.springboot-grpc.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }

--- a/dd-smoke-tests/springboot-mongo/build.gradle
+++ b/dd-smoke-tests/springboot-mongo/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
 
-  jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archivePath}"
+  jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 
   usesService(testcontainersLimit)
 }

--- a/dd-smoke-tests/springboot-tomcat/build.gradle
+++ b/dd-smoke-tests/springboot-tomcat/build.gradle
@@ -67,6 +67,22 @@ dependencies {
   testImplementation project(':dd-smoke-tests')
 }
 
+tasks.bootWar {
+  dependsOn 'unzip'
+}
+
+tasks.bootWarMainClassName {
+  dependsOn 'unzip'
+}
+
+tasks.war {
+  dependsOn 'unzip'
+}
+
+tasks.matching({it.name.startsWith('compileTest')}).configureEach {
+  dependsOn 'war', 'bootWar', 'unzip'
+}
+
 tasks.withType(Test).configureEach {
   dependsOn "war", "bootWar", "unzip"
   jvmArgs "-Ddatadog.smoketest.springboot.war.path=${tasks.bootWar.archiveFile.get().getAsFile()}"

--- a/dd-smoke-tests/springboot/build.gradle
+++ b/dd-smoke-tests/springboot/build.gradle
@@ -27,5 +27,5 @@ dependencies {
 tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
 
-  jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archivePath}"
+  jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }

--- a/dd-smoke-tests/vertx-3.4/build.gradle
+++ b/dd-smoke-tests/vertx-3.4/build.gradle
@@ -18,7 +18,7 @@ def gradlewCommand = isWindows ? 'gradlew.bat' : 'gradlew'
 tasks.register('vertxBuild', Exec) {
   workingDir "$appDir"
   environment += ["GRADLE_OPTS": "-Dorg.gradle.jvmargs='-Xmx512M'"]
-  commandLine "$appDir/${gradlewCommand}", "assemble", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archivePath}"
+  commandLine "$appDir/${gradlewCommand}", "assemble", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archiveFile.get()}"
 
   outputs.cacheIf { true }
 

--- a/dd-smoke-tests/vertx-3.9-resteasy/build.gradle
+++ b/dd-smoke-tests/vertx-3.9-resteasy/build.gradle
@@ -16,7 +16,7 @@ def gradlewCommand = isWindows ? 'gradlew.bat' : 'gradlew'
 tasks.register('vertxBuild', Exec) {
   workingDir "$appDir"
   environment += ["GRADLE_OPTS": "-Dorg.gradle.jvmargs='-Xmx512M'"]
-  commandLine "$appDir/${gradlewCommand}", "assemble", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archivePath}"
+  commandLine "$appDir/${gradlewCommand}", "assemble", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archiveFile.get()}"
 
   outputs.cacheIf { true }
 

--- a/dd-smoke-tests/vertx-3.9/build.gradle
+++ b/dd-smoke-tests/vertx-3.9/build.gradle
@@ -17,7 +17,7 @@ def gradlewCommand = isWindows ? 'gradlew.bat' : 'gradlew'
 tasks.register('vertxBuild', Exec) {
   workingDir "$appDir"
   environment += ["GRADLE_OPTS": "-Dorg.gradle.jvmargs='-Xmx512M'"]
-  commandLine "$appDir/${gradlewCommand}", "assemble", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archivePath}"
+  commandLine "$appDir/${gradlewCommand}", "assemble", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archiveFile.get()}"
 
   outputs.cacheIf { true }
 

--- a/dd-smoke-tests/wildfly/build.gradle
+++ b/dd-smoke-tests/wildfly/build.gradle
@@ -44,7 +44,7 @@ def gradlewCommand = isWindows ? 'gradlew.bat' : 'gradlew'
 tasks.register('earBuild', Exec) {
   workingDir "$appDir"
   environment += ["GRADLE_OPTS": "-Dorg.gradle.jvmargs='-Xmx512M'"]
-  commandLine "$rootDir/${gradlewCommand}", "assemble", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archivePath}"
+  commandLine "$rootDir/${gradlewCommand}", "assemble", "--no-daemon", "--max-workers=4", "-PappBuildDir=$appBuildDir", "-PapiJar=${project(':dd-trace-api').tasks.jar.archiveFile.get()}"
 
   outputs.cacheIf { true }
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteApi.java
@@ -1,6 +1,7 @@
 package datadog.trace.common.writer;
 
 import datadog.trace.relocate.api.IOLogger;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import org.slf4j.Logger;
 
@@ -64,6 +65,7 @@ public abstract class RemoteApi {
         + ".";
   }
 
+  @SuppressFBWarnings("DCN_NULLPOINTER_EXCEPTION")
   protected static String getResponseBody(okhttp3.Response response) {
     if (response != null) {
       try {

--- a/dd-trace-ot/build.gradle
+++ b/dd-trace-ot/build.gradle
@@ -50,26 +50,31 @@ dependencies {
 
   testImplementation project(":dd-java-agent:testing")
 
-  ot31CompatabilityTestImplementation('io.opentracing:opentracing-api:0.31.0') {
-    force = true
+  ot33CompatabilityTestImplementation('io.opentracing:opentracing-api') {
+    version {
+      strictly '0.33.0'
+    }
   }
-  ot31CompatabilityTestImplementation('io.opentracing:opentracing-util:0.31.0')  {
-    force = true
+  ot33CompatabilityTestImplementation('io.opentracing:opentracing-util')  {
+    version {
+      strictly '0.33.0'
+    }
   }
-  ot31CompatabilityTestImplementation('io.opentracing:opentracing-noop:0.31.0')  {
-    force = true
-  }
-
-  ot33CompatabilityTestImplementation('io.opentracing:opentracing-api:0.33.0') {
-    force = true
-  }
-  ot33CompatabilityTestImplementation('io.opentracing:opentracing-util:0.33.0')  {
-    force = true
-  }
-  ot33CompatabilityTestImplementation('io.opentracing:opentracing-noop:0.33.0')  {
-    force = true
+  ot33CompatabilityTestImplementation('io.opentracing:opentracing-noop')  {
+    version {
+      strictly '0.33.0'
+    }
   }
 }
+
+// gradle can't downgrade the opentracing dependencies with `strictly`
+configurations.matching({ it.name.startsWith('ot31') }).each({
+  it.resolutionStrategy {
+    force group: 'io.opentracing', name: 'opentracing-api', version: '0.31.0'
+    force group: 'io.opentracing', name: 'opentracing-util', version: '0.31.0'
+    force group: 'io.opentracing', name: 'opentracing-noop', version: '0.31.0'
+  }
+})
 
 tasks.named("test").configure {
   finalizedBy "ot31CompatabilityTest", "ot33CompatabilityTest"

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -22,8 +22,8 @@ tasks.register('forkedTestJacocoData') {
 tasks.named('jacocoTestReport').configure {
   dependsOn('test', 'forkedTestJacocoData')
   reports {
-    xml.enabled true
-    csv.enabled false
+    xml.required = true
+    csv.required = false
     html.destination file("${buildDir}/reports/jacoco/")
   }
 }

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -60,8 +60,8 @@ if (project.hasProperty('minJavaVersionForTests') && project.getProperty('minJav
   }
 
   dependencies {
-    compileOnly sourceSets."main_$name".compileClasspath
-    implementation sourceSets."main_$name".output
+    compileOnly files(project.sourceSets."main_$name".compileClasspath)
+    implementation files(project.sourceSets."main_$name".output)
   }
 
   jar {
@@ -104,7 +104,7 @@ jar {
 }
 
 tasks.register("packageSources", Jar) {
-  classifier = 'sources'
+  archiveClassifier = 'sources'
   from sourceSets.main.allSource
 }
 artifacts.archives packageSources


### PR DESCRIPTION
# What Does This Do

Removes all deprecated gradle features in preparation for gradle 8.

# Motivation

# Additional Notes

* The `test-sets` plugin is not being maintained and is incompatible with gradle 8. It will be fixed in separate PRs.
* The `MuzzlePlugin` still reaches into the `agent-bootstrap` and `agent-tooling` projects in a deprecated way.I can't for the life of me understand how gradle works and how to solve this 😞 