### PR TITLE
bump jplib to 0.30.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    jplib         : "0.29.0",
+    jplib         : "0.30.0",
     asm           : "9.5"
   ]
 


### PR DESCRIPTION
# What Does This Do

Consists of a fix to profiler context storage when there are small numbers of hardware threads on the host

# Motivation

# Additional Notes
