### PR TITLE
lettuce: surface remote host and db index information

### DIFF
--- a/dd-java-agent/instrumentation/lettuce-4/src/main/java/datadog/trace/instrumentation/lettuce4/InstrumentationPoints.java
+++ b/dd-java-agent/instrumentation/lettuce-4/src/main/java/datadog/trace/instrumentation/lettuce4/InstrumentationPoints.java
@@ -32,9 +32,11 @@ public final class InstrumentationPoints {
 
   public static final String AGENT_CRASHING_COMMAND_PREFIX = "COMMAND-NAME:";
 
-  public static AgentScope beforeCommand(final RedisCommand<?, ?, ?> command) {
+  public static AgentScope beforeCommand(
+      final RedisCommand<?, ?, ?> command, final RedisURI redisURI) {
     final AgentSpan span = startSpan(LettuceClientDecorator.OPERATION_NAME);
     DECORATE.afterStart(span);
+    DECORATE.onConnection(span, redisURI);
     DECORATE.onCommand(span, command);
     return activateSpan(span);
   }
@@ -74,6 +76,7 @@ public final class InstrumentationPoints {
     final AgentSpan span = startSpan(LettuceClientDecorator.OPERATION_NAME);
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, redisURI);
+    span.setResourceName(DECORATE.resourceNameForConnection(redisURI));
     return activateSpan(span);
   }
 

--- a/dd-java-agent/instrumentation/lettuce-4/src/main/java/datadog/trace/instrumentation/lettuce4/LettuceAsyncCommandsAdvice.java
+++ b/dd-java-agent/instrumentation/lettuce-4/src/main/java/datadog/trace/instrumentation/lettuce4/LettuceAsyncCommandsAdvice.java
@@ -1,15 +1,24 @@
 package datadog.trace.instrumentation.lettuce4;
 
+import com.lambdaworks.redis.AbstractRedisAsyncCommands;
+import com.lambdaworks.redis.RedisURI;
+import com.lambdaworks.redis.api.StatefulConnection;
 import com.lambdaworks.redis.protocol.AsyncCommand;
 import com.lambdaworks.redis.protocol.RedisCommand;
+import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import net.bytebuddy.asm.Advice;
 
 public class LettuceAsyncCommandsAdvice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
-  public static AgentScope onEnter(@Advice.Argument(0) final RedisCommand<?, ?, ?> command) {
-    return InstrumentationPoints.beforeCommand(command);
+  public static AgentScope onEnter(
+      @Advice.Argument(0) final RedisCommand<?, ?, ?> command,
+      @Advice.This AbstractRedisAsyncCommands thiz) {
+    return InstrumentationPoints.beforeCommand(
+        command,
+        InstrumentationContext.get(StatefulConnection.class, RedisURI.class)
+            .get(thiz.getConnection()));
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/lettuce-4/src/main/java/datadog/trace/instrumentation/lettuce4/LettuceAsyncCommandsInstrumentation.java
+++ b/dd-java-agent/instrumentation/lettuce-4/src/main/java/datadog/trace/instrumentation/lettuce4/LettuceAsyncCommandsInstrumentation.java
@@ -6,6 +6,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import java.util.Collections;
+import java.util.Map;
 
 @AutoService(Instrumenter.class)
 public class LettuceAsyncCommandsInstrumentation extends Instrumenter.Tracing
@@ -18,6 +20,12 @@ public class LettuceAsyncCommandsInstrumentation extends Instrumenter.Tracing
   @Override
   public String instrumentedType() {
     return "com.lambdaworks.redis.AbstractRedisAsyncCommands";
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return Collections.singletonMap(
+        "com.lambdaworks.redis.api.StatefulConnection", "com.lambdaworks.redis.RedisURI");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/lettuce-4/src/main/java/datadog/trace/instrumentation/lettuce4/LettuceClientDecorator.java
+++ b/dd-java-agent/instrumentation/lettuce-4/src/main/java/datadog/trace/instrumentation/lettuce4/LettuceClientDecorator.java
@@ -8,7 +8,6 @@ import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
-import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
 
@@ -65,10 +64,8 @@ public class LettuceClientDecorator extends DBTypeProcessingDatabaseClientDecora
   @Override
   public AgentSpan onConnection(final AgentSpan span, final RedisURI connection) {
     if (connection != null) {
-      span.setTag(Tags.PEER_HOSTNAME, connection.getHost());
       setPeerPort(span, connection.getPort());
       span.setTag("db.redis.dbIndex", connection.getDatabase());
-      span.setResourceName(resourceName(connection));
     }
     return super.onConnection(span, connection);
   }
@@ -82,12 +79,12 @@ public class LettuceClientDecorator extends DBTypeProcessingDatabaseClientDecora
     return span;
   }
 
-  private static String resourceName(final RedisURI connection) {
+  public String resourceNameForConnection(final RedisURI redisURI) {
     return "CONNECT:"
-        + connection.getHost()
+        + redisURI.getHost()
         + ":"
-        + connection.getPort()
+        + redisURI.getPort()
         + "/"
-        + connection.getDatabase();
+        + redisURI.getDatabase();
   }
 }

--- a/dd-java-agent/instrumentation/lettuce-4/src/main/java/datadog/trace/instrumentation/lettuce4/LettuceClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/lettuce-4/src/main/java/datadog/trace/instrumentation/lettuce4/LettuceClientInstrumentation.java
@@ -5,6 +5,8 @@ import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import java.util.Collections;
+import java.util.Map;
 
 @AutoService(Instrumenter.class)
 public final class LettuceClientInstrumentation extends Instrumenter.Tracing
@@ -24,6 +26,12 @@ public final class LettuceClientInstrumentation extends Instrumenter.Tracing
     return new String[] {
       packageName + ".LettuceClientDecorator", packageName + ".InstrumentationPoints"
     };
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return Collections.singletonMap(
+        "com.lambdaworks.redis.api.StatefulConnection", "com.lambdaworks.redis.RedisURI");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4AsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4AsyncClientTest.groovy
@@ -1,3 +1,5 @@
+import static datadog.trace.instrumentation.lettuce4.InstrumentationPoints.AGENT_CRASHING_COMMAND_PREFIX
+
 import com.lambdaworks.redis.ClientOptions
 import com.lambdaworks.redis.RedisClient
 import com.lambdaworks.redis.RedisConnectionException
@@ -23,8 +25,6 @@ import java.util.function.BiConsumer
 import java.util.function.BiFunction
 import java.util.function.Consumer
 import java.util.function.Function
-
-import static datadog.trace.instrumentation.lettuce4.InstrumentationPoints.AGENT_CRASHING_COMMAND_PREFIX
 
 abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
   public static final String HOST = "127.0.0.1"
@@ -191,7 +191,10 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -229,7 +232,10 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -281,7 +287,10 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -319,7 +328,10 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -376,7 +388,10 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -392,7 +407,10 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -437,7 +455,10 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             errorTags(IllegalStateException, "TestException")
             defaultTags()
           }
@@ -477,7 +498,10 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             "db.command.cancelled" true
             defaultTags()
           }
@@ -503,7 +527,10 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -529,7 +556,10 @@ abstract class Lettuce4AsyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4SyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-4/src/test/groovy/Lettuce4SyncClientTest.groovy
@@ -1,3 +1,5 @@
+import static datadog.trace.instrumentation.lettuce4.InstrumentationPoints.AGENT_CRASHING_COMMAND_PREFIX
+
 import com.lambdaworks.redis.ClientOptions
 import com.lambdaworks.redis.RedisClient
 import com.lambdaworks.redis.RedisConnectionException
@@ -10,8 +12,6 @@ import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import redis.embedded.RedisServer
 import spock.lang.Shared
-
-import static datadog.trace.instrumentation.lettuce4.InstrumentationPoints.AGENT_CRASHING_COMMAND_PREFIX
 
 abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
   public static final String HOST = "127.0.0.1"
@@ -169,7 +169,10 @@ abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -195,7 +198,10 @@ abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -221,7 +227,10 @@ abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -247,7 +256,10 @@ abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -273,7 +285,10 @@ abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -299,7 +314,10 @@ abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -325,7 +343,10 @@ abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -350,7 +371,10 @@ abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -375,7 +399,10 @@ abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -383,6 +410,7 @@ abstract class Lettuce4SyncClientTest extends VersionedNamingTestBase {
     }
   }
 }
+
 class Lettuce4SyncClientV0ForkedTest extends Lettuce4SyncClientTest {
 
   @Override

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/ConnectionContextBiConsumer.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/ConnectionContextBiConsumer.java
@@ -1,0 +1,25 @@
+package datadog.trace.instrumentation.lettuce5;
+
+import datadog.trace.bootstrap.ContextStore;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulConnection;
+import java.util.function.BiConsumer;
+
+public class ConnectionContextBiConsumer implements BiConsumer<StatefulConnection, Throwable> {
+
+  private final RedisURI redisURI;
+  private final ContextStore<StatefulConnection, RedisURI> contextStore;
+
+  public ConnectionContextBiConsumer(
+      RedisURI redisURI, ContextStore<StatefulConnection, RedisURI> contextStore) {
+    this.redisURI = redisURI;
+    this.contextStore = contextStore;
+  }
+
+  @Override
+  public void accept(StatefulConnection statefulConnection, Throwable throwable) {
+    if (statefulConnection != null) {
+      contextStore.put(statefulConnection, redisURI);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/ConnectionFutureAdvice.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/ConnectionFutureAdvice.java
@@ -4,18 +4,20 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSp
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.lettuce5.LettuceClientDecorator.DECORATE;
 
+import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import io.lettuce.core.ConnectionFuture;
 import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulConnection;
 import net.bytebuddy.asm.Advice;
 
 public class ConnectionFutureAdvice {
-
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static AgentScope onEnter(@Advice.Argument(1) final RedisURI redisUri) {
     final AgentSpan span = startSpan(LettuceClientDecorator.OPERATION_NAME);
     DECORATE.afterStart(span);
+    span.setResourceName(DECORATE.resourceNameForConnection(redisUri));
     DECORATE.onConnection(span, redisUri);
     return activateSpan(span);
   }
@@ -24,7 +26,9 @@ public class ConnectionFutureAdvice {
   public static void stopSpan(
       @Advice.Enter final AgentScope scope,
       @Advice.Thrown final Throwable throwable,
-      @Advice.Return final ConnectionFuture<?> connectionFuture) {
+      @Advice.Argument(1) final RedisURI redisUri,
+      @Advice.Return(readOnly = false)
+          ConnectionFuture<? extends StatefulConnection> connectionFuture) {
     final AgentSpan span = scope.span();
     if (throwable != null) {
       DECORATE.onError(span, throwable);
@@ -33,8 +37,12 @@ public class ConnectionFutureAdvice {
       span.finish();
       return;
     }
-    connectionFuture.handleAsync(new LettuceAsyncBiFunction<>(span));
+    connectionFuture =
+        connectionFuture.whenComplete(
+            new ConnectionContextBiConsumer(
+                    redisUri, InstrumentationContext.get(StatefulConnection.class, RedisURI.class))
+                .andThen(new LettuceAsyncBiConsumer<>(span)));
     scope.close();
-    // span finished by LettuceAsyncBiFunction
+    // span finished by LettuceAsyncBiConsumer
   }
 }

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceAsyncBiConsumer.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceAsyncBiConsumer.java
@@ -4,7 +4,7 @@ import static datadog.trace.instrumentation.lettuce5.LettuceClientDecorator.DECO
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.util.concurrent.CancellationException;
-import java.util.function.BiFunction;
+import java.util.function.BiConsumer;
 
 /**
  * Callback class to close the span on an error or a success in the RedisFuture returned by the
@@ -15,17 +15,17 @@ import java.util.function.BiFunction;
  * @param <R> the return type, should be null since nothing else should happen from tracing
  *     standpoint after the span is closed
  */
-public class LettuceAsyncBiFunction<T extends Object, U extends Throwable, R extends Object>
-    implements BiFunction<T, Throwable, R> {
+public class LettuceAsyncBiConsumer<T extends Object, U extends Throwable>
+    implements BiConsumer<T, Throwable> {
 
   private final AgentSpan span;
 
-  public LettuceAsyncBiFunction(final AgentSpan span) {
+  public LettuceAsyncBiConsumer(final AgentSpan span) {
     this.span = span;
   }
 
   @Override
-  public R apply(final T t, final Throwable throwable) {
+  public void accept(final T t, final Throwable throwable) {
     if (throwable instanceof CancellationException) {
       span.setTag("db.command.cancelled", true);
     } else {
@@ -33,6 +33,5 @@ public class LettuceAsyncBiFunction<T extends Object, U extends Throwable, R ext
     }
     DECORATE.beforeFinish(span);
     span.finish();
-    return null;
   }
 }

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceAsyncCommandsAdvice.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceAsyncCommandsAdvice.java
@@ -5,8 +5,12 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.lettuce5.LettuceClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.lettuce5.LettuceInstrumentationUtil.expectsResponse;
 
+import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import io.lettuce.core.AbstractRedisAsyncCommands;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.protocol.AsyncCommand;
 import io.lettuce.core.protocol.RedisCommand;
 import net.bytebuddy.asm.Advice;
@@ -14,10 +18,16 @@ import net.bytebuddy.asm.Advice;
 public class LettuceAsyncCommandsAdvice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
-  public static AgentScope onEnter(@Advice.Argument(0) final RedisCommand command) {
+  public static AgentScope onEnter(
+      @Advice.Argument(0) final RedisCommand command,
+      @Advice.This final AbstractRedisAsyncCommands thiz) {
 
     final AgentSpan span = startSpan(LettuceClientDecorator.OPERATION_NAME);
     DECORATE.afterStart(span);
+    DECORATE.onConnection(
+        span,
+        InstrumentationContext.get(StatefulConnection.class, RedisURI.class)
+            .get(thiz.getConnection()));
     DECORATE.onCommand(span, command);
 
     return activateSpan(span);
@@ -28,7 +38,7 @@ public class LettuceAsyncCommandsAdvice {
       @Advice.Argument(0) final RedisCommand command,
       @Advice.Enter final AgentScope scope,
       @Advice.Thrown final Throwable throwable,
-      @Advice.Return final AsyncCommand<?, ?, ?> asyncCommand) {
+      @Advice.Return AsyncCommand<?, ?, ?> asyncCommand) {
 
     final AgentSpan span = scope.span();
     if (throwable != null) {
@@ -41,12 +51,12 @@ public class LettuceAsyncCommandsAdvice {
 
     // close spans on error or normal completion
     if (expectsResponse(command)) {
-      asyncCommand.handleAsync(new LettuceAsyncBiFunction<>(span));
+      asyncCommand.whenComplete(new LettuceAsyncBiConsumer<>(span));
     } else {
       DECORATE.beforeFinish(span);
       span.finish();
     }
     scope.close();
-    // span may be finished by LettuceAsyncBiFunction
+    // span may be finished by LettuceAsyncBiConsumer
   }
 }

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceAsyncCommandsInstrumentation.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceAsyncCommandsInstrumentation.java
@@ -6,6 +6,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import java.util.Collections;
+import java.util.Map;
 
 @AutoService(Instrumenter.class)
 public class LettuceAsyncCommandsInstrumentation extends Instrumenter.Tracing
@@ -21,10 +23,16 @@ public class LettuceAsyncCommandsInstrumentation extends Instrumenter.Tracing
   }
 
   @Override
+  public Map<String, String> contextStore() {
+    return Collections.singletonMap(
+        "io.lettuce.core.api.StatefulConnection", "io.lettuce.core.RedisURI");
+  }
+
+  @Override
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".LettuceClientDecorator",
-      packageName + ".LettuceAsyncBiFunction",
+      packageName + ".LettuceAsyncBiConsumer",
       packageName + ".LettuceInstrumentationUtil"
     };
   }

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceClientDecorator.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceClientDecorator.java
@@ -4,7 +4,6 @@ import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
-import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
 import io.lettuce.core.RedisURI;
@@ -64,17 +63,9 @@ public class LettuceClientDecorator extends DBTypeProcessingDatabaseClientDecora
   @Override
   public AgentSpan onConnection(final AgentSpan span, final RedisURI connection) {
     if (connection != null) {
-      span.setTag(Tags.PEER_HOSTNAME, connection.getHost());
       setPeerPort(span, connection.getPort());
 
       span.setTag("db.redis.dbIndex", connection.getDatabase());
-      span.setResourceName(
-          "CONNECT:"
-              + connection.getHost()
-              + ":"
-              + connection.getPort()
-              + "/"
-              + connection.getDatabase());
     }
     return super.onConnection(span, connection);
   }
@@ -83,5 +74,14 @@ public class LettuceClientDecorator extends DBTypeProcessingDatabaseClientDecora
     final String commandName = LettuceInstrumentationUtil.getCommandName(command);
     span.setResourceName(LettuceInstrumentationUtil.getCommandResourceName(commandName));
     return span;
+  }
+
+  public String resourceNameForConnection(final RedisURI redisURI) {
+    return "CONNECT:"
+        + redisURI.getHost()
+        + ":"
+        + redisURI.getPort()
+        + "/"
+        + redisURI.getDatabase();
   }
 }

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceClientInstrumentation.java
@@ -10,6 +10,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import java.util.Collections;
+import java.util.Map;
 
 @AutoService(Instrumenter.class)
 public final class LettuceClientInstrumentation extends Instrumenter.Tracing
@@ -25,11 +27,18 @@ public final class LettuceClientInstrumentation extends Instrumenter.Tracing
   }
 
   @Override
+  public Map<String, String> contextStore() {
+    return Collections.singletonMap(
+        "io.lettuce.core.api.StatefulConnection", "io.lettuce.core.RedisURI");
+  }
+
+  @Override
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".LettuceClientDecorator",
       packageName + ".LettuceInstrumentationUtil",
-      packageName + ".LettuceAsyncBiFunction"
+      packageName + ".LettuceAsyncBiConsumer",
+      packageName + ".ConnectionContextBiConsumer"
     };
   }
 

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceReactiveClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceReactiveClientInstrumentation.java
@@ -4,6 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.nameEnd
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.nameStartsWith;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
@@ -71,7 +72,8 @@ public class LettuceReactiveClientInstrumentation extends Instrumenter.Tracing
       packageName + ".rx.RedisSubscriptionState",
       packageName + ".rx.LettuceFlowTracker",
       packageName + ".LettuceInstrumentationUtil",
-      packageName + ".LettuceClientDecorator"
+      packageName + ".LettuceClientDecorator",
+      packageName + ".ConnectionContextBiConsumer"
     };
   }
 
@@ -80,6 +82,7 @@ public class LettuceReactiveClientInstrumentation extends Instrumenter.Tracing
     Map<String, String> store = new HashMap<>(3);
     store.put("org.reactivestreams.Subscription", packageName + ".rx.RedisSubscriptionState");
     store.put("io.lettuce.core.protocol.RedisCommand", AgentSpan.class.getName());
+    store.put("io.lettuce.core.api.StatefulConnection", "io.lettuce.core.RedisURI");
     return store;
   }
 
@@ -94,6 +97,11 @@ public class LettuceReactiveClientInstrumentation extends Instrumenter.Tracing
             .and(isDeclaredBy(named("io.lettuce.core.RedisPublisher$SubscriptionCommand")))
             .and(namedOneOf("complete", "cancel")),
         packageName + ".rx.RedisSubscriptionCommandCompleteAdvice");
+
+    transformation.applyAdvice(
+        isConstructor()
+            .and(isDeclaredBy(named("io.lettuce.core.RedisPublisher$RedisSubscription"))),
+        packageName + ".rx.RedisSubscriptionConnectionContextAdvice");
 
     // SubscriptionCommand structure has changed due to
     // https://github.com/lettuce-io/lettuce-core/issues/1576 in 5.3.6

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/rx/RedisSubscriptionConnectionContextAdvice.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/rx/RedisSubscriptionConnectionContextAdvice.java
@@ -1,0 +1,23 @@
+package datadog.trace.instrumentation.lettuce5.rx;
+
+import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.InstrumentationContext;
+import io.lettuce.core.api.StatefulConnection;
+import net.bytebuddy.asm.Advice;
+import org.reactivestreams.Subscription;
+
+public class RedisSubscriptionConnectionContextAdvice {
+  @Advice.OnMethodExit(suppress = Throwable.class)
+  public static void afterConstruct(
+      @Advice.This final Subscription subscription,
+      @Advice.Argument(0) final StatefulConnection connection) {
+    final ContextStore<Subscription, RedisSubscriptionState> store =
+        InstrumentationContext.get(Subscription.class, RedisSubscriptionState.class);
+    RedisSubscriptionState value = store.get(subscription);
+    if (value == null) {
+      value = new RedisSubscriptionState();
+      value.connection = connection;
+      store.put(subscription, value);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/rx/RedisSubscriptionState.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/rx/RedisSubscriptionState.java
@@ -1,9 +1,11 @@
 package datadog.trace.instrumentation.lettuce5.rx;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import io.lettuce.core.api.StatefulConnection;
 
 public final class RedisSubscriptionState {
   public boolean cancelled = false;
   public int count = 0;
   public AgentSpan parentSpan;
+  public StatefulConnection<?, ?> connection;
 }

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/rx/RedisSubscriptionSubscribeAdvice.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/rx/RedisSubscriptionSubscribeAdvice.java
@@ -9,6 +9,8 @@ import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.lettuce5.LettuceClientDecorator;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.protocol.RedisCommand;
 import net.bytebuddy.asm.Advice;
 import org.reactivestreams.Subscription;
@@ -41,6 +43,12 @@ public class RedisSubscriptionSubscribeAdvice {
     AgentSpan span = startSpan(LettuceClientDecorator.OPERATION_NAME);
     InstrumentationContext.get(RedisCommand.class, AgentSpan.class).put(subscriptionCommand, span);
     DECORATE.afterStart(span);
+    if (state != null && state.connection != null) {
+      DECORATE.onConnection(
+          span,
+          InstrumentationContext.get(StatefulConnection.class, RedisURI.class)
+              .get(state.connection));
+    }
     DECORATE.onCommand(span, command);
 
     return new State(parentScope, span);

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5AsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5AsyncClientTest.groovy
@@ -196,7 +196,10 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -234,7 +237,10 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -286,7 +292,10 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -324,7 +333,10 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -381,7 +393,10 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -397,7 +412,10 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -442,7 +460,10 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             errorTags(IllegalStateException, "TestException")
             defaultTags()
           }
@@ -482,7 +503,10 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             "db.command.cancelled" true
             defaultTags()
           }
@@ -508,7 +532,10 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -534,7 +561,10 @@ abstract class Lettuce5AsyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
@@ -34,6 +34,9 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
   String embeddedDbUri
 
   @Shared
+  int port
+
+  @Shared
   RedisServer redisServer
 
   RedisClient redisClient
@@ -42,7 +45,7 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
   RedisCommands<String, ?> syncCommands
 
   def setupSpec() {
-    int port = PortUtils.randomOpenPort()
+    port = PortUtils.randomOpenPort()
     String dbAddr = HOST + ":" + port + "/" + DB_INDEX
     embeddedDbUri = "redis://" + dbAddr
 
@@ -109,7 +112,10 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -138,7 +144,10 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -174,7 +183,10 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -208,7 +220,10 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -233,7 +248,10 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             "db.command.results.count" 157
             defaultTags()
           }
@@ -259,7 +277,10 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             "db.command.cancelled" true
             "db.command.results.count" 2
             defaultTags()
@@ -298,7 +319,10 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -323,7 +347,10 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -366,7 +393,10 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -381,7 +411,10 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -420,7 +453,10 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             "db.command.results.count" 157
             defaultTags()
           }
@@ -436,7 +472,10 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -478,7 +517,10 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -493,7 +535,10 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -536,7 +581,10 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -551,7 +599,10 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5SyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5SyncClientTest.groovy
@@ -171,7 +171,10 @@ abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -197,7 +200,10 @@ abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -249,7 +255,10 @@ abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -275,7 +284,10 @@ abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -301,7 +313,10 @@ abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -327,7 +342,10 @@ abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -352,7 +370,10 @@ abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -377,7 +398,10 @@ abstract class Lettuce5SyncClientTest extends VersionedNamingTestBase {
           tags {
             "$Tags.COMPONENT" "redis-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.PEER_HOSTNAME" HOST
+            "$Tags.PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }


### PR DESCRIPTION
# What Does This Do

This PR wants to surface information we have at connection time on all lettuce spans.
Those tags are:
* peer.hostname
* peer.port
* db.redis.dbIndex

This works for all types of lettuce clients: sync, async and reactive

# Motivation

# Additional Notes
