### PR TITLE
add remote peer info for rediscala

### DIFF
--- a/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/RedisClientActorInstrumentation.java
+++ b/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/RedisClientActorInstrumentation.java
@@ -1,0 +1,64 @@
+package datadog.trace.instrumentation.rediscala;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+
+import akka.actor.ActorRef;
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.InstrumentationContext;
+import java.util.Collections;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import redis.RedisClientActorLike;
+
+@AutoService(Instrumenter.class)
+public class RedisClientActorInstrumentation extends Instrumenter.Tracing
+    implements Instrumenter.ForTypeHierarchy {
+  public RedisClientActorInstrumentation() {
+    super("rediscala", "redis", "rediscala-connection");
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "redis.RedisClientActorLike";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return extendsClass(named(hierarchyMarkerType()));
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {packageName + ".RedisConnectionInfo"};
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return Collections.singletonMap("akka.actor.ActorRef", packageName + ".RedisConnectionInfo");
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod().and(named("onConnect")),
+        RedisClientActorInstrumentation.class.getName() + "$ConnectionAdvice");
+  }
+
+  public static class ConnectionAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void beforeOnConnect(@Advice.This final RedisClientActorLike thiz) {
+      if (thiz.redisConnection() != null) {
+        final Object tmpDbIndex = thiz.db().isDefined() ? thiz.db().get() : null;
+        final int dbIndex = (tmpDbIndex instanceof Number) ? ((Number) tmpDbIndex).intValue() : 0;
+        InstrumentationContext.get(ActorRef.class, RedisConnectionInfo.class)
+            .put(
+                thiz.redisConnection(), new RedisConnectionInfo(thiz.host(), thiz.port(), dbIndex));
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/RedisConnectionInfo.java
+++ b/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/RedisConnectionInfo.java
@@ -1,0 +1,13 @@
+package datadog.trace.instrumentation.rediscala;
+
+public class RedisConnectionInfo {
+  public final String host;
+  public final int port;
+  public final int dbIndex;
+
+  public RedisConnectionInfo(String host, int port, int dbIndex) {
+    this.host = host;
+    this.port = port;
+    this.dbIndex = dbIndex;
+  }
+}

--- a/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaClientDecorator.java
+++ b/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaClientDecorator.java
@@ -6,11 +6,9 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
-import redis.RedisCommand;
-import redis.protocol.RedisReply;
 
 public class RediscalaClientDecorator
-    extends DBTypeProcessingDatabaseClientDecorator<RedisCommand<? extends RedisReply, ?>> {
+    extends DBTypeProcessingDatabaseClientDecorator<RedisConnectionInfo> {
 
   private static final CharSequence COMPONENT_NAME = UTF8BytesString.create("redis-command");
 
@@ -47,20 +45,29 @@ public class RediscalaClientDecorator
   }
 
   @Override
-  protected String dbUser(final RedisCommand<? extends RedisReply, ?> session) {
+  protected String dbUser(final RedisConnectionInfo redisConnectionInfo) {
     return null;
   }
 
   @Override
-  protected String dbInstance(final RedisCommand<? extends RedisReply, ?> session) {
+  protected String dbInstance(final RedisConnectionInfo redisConnectionInfo) {
     return null;
   }
 
   @Override
-  protected String dbHostname(RedisCommand<? extends RedisReply, ?> redisCommand) {
-    return null;
+  protected String dbHostname(final RedisConnectionInfo redisConnectionInfo) {
+    return redisConnectionInfo.host;
   }
 
   @Override
   protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {}
+
+  @Override
+  public AgentSpan onConnection(final AgentSpan span, final RedisConnectionInfo connection) {
+    if (connection != null) {
+      setPeerPort(span, connection.port);
+      span.setTag("db.redis.dbIndex", connection.dbIndex);
+    }
+    return super.onConnection(span, connection);
+  }
 }

--- a/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaInstrumentation.java
+++ b/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaInstrumentation.java
@@ -11,14 +11,20 @@ import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
+import akka.actor.ActorRef;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers;
+import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.util.Collections;
+import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
+import redis.ActorRequest;
 import redis.RedisCommand;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.Future;
@@ -51,8 +57,15 @@ public final class RediscalaInstrumentation extends Instrumenter.Tracing
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".OnCompleteHandler", packageName + ".RediscalaClientDecorator",
+      packageName + ".OnCompleteHandler",
+      packageName + ".RediscalaClientDecorator",
+      packageName + ".RedisConnectionInfo"
     };
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return Collections.singletonMap("akka.actor.ActorRef", packageName + ".RedisConnectionInfo");
   }
 
   @Override
@@ -80,14 +93,24 @@ public final class RediscalaInstrumentation extends Instrumenter.Tracing
     public static void stopSpan(
         @Advice.Enter final AgentScope scope,
         @Advice.Thrown final Throwable throwable,
+        @Advice.This final Object thiz,
         @Advice.FieldValue("executionContext") final ExecutionContext ctx,
         @Advice.Return(readOnly = false) final Future<Object> responseFuture) {
 
       final AgentSpan span = scope.span();
-
+      final ContextStore<ActorRef, RedisConnectionInfo> contextStore =
+          InstrumentationContext.get(ActorRef.class, RedisConnectionInfo.class);
+      ActorRef connection = null;
+      if (thiz instanceof ActorRequest) {
+        connection = ((ActorRequest) thiz).redisConnection();
+      }
       if (throwable == null) {
-        responseFuture.onComplete(OnCompleteHandler.INSTANCE, ctx);
+        responseFuture.onComplete(new OnCompleteHandler(contextStore, connection), ctx);
       } else {
+        if (connection != null) {
+          // try to get the info early
+          DECORATE.onConnection(span, contextStore.get(connection));
+        }
         DECORATE.onError(span, throwable);
         DECORATE.beforeFinish(span);
         span.finish();

--- a/dd-java-agent/instrumentation/rediscala-1.8.0/src/test/groovy/RediscalaClientTest.groovy
+++ b/dd-java-agent/instrumentation/rediscala-1.8.0/src/test/groovy/RediscalaClientTest.groovy
@@ -1,3 +1,5 @@
+import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
+
 import akka.actor.ActorSystem
 import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.agent.test.utils.PortUtils
@@ -13,8 +15,6 @@ import scala.Option
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import spock.lang.Shared
-
-import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
 
 abstract class RediscalaClientTest extends VersionedNamingTestBase {
 
@@ -92,6 +92,9 @@ abstract class RediscalaClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" redisClient.host()
+            "$Tags.PEER_PORT" redisClient.port()
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -124,6 +127,9 @@ abstract class RediscalaClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" redisClient.host()
+            "$Tags.PEER_PORT" redisClient.port()
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }
@@ -138,6 +144,9 @@ abstract class RediscalaClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" redisClient.host()
+            "$Tags.PEER_PORT" redisClient.port()
+            "db.redis.dbIndex" 0
             defaultTags()
           }
         }


### PR DESCRIPTION
# What Does This Do

Adds redis connection remote host, port and dbIndex to rediscala spans

# Motivation

# Additional Notes
