### PR TITLE
redisson: surface peer connection tags

### DIFF
--- a/dd-java-agent/instrumentation/redisson-2.0.0/build.gradle
+++ b/dd-java-agent/instrumentation/redisson-2.0.0/build.gradle
@@ -18,13 +18,39 @@ testSets {
     dirName = 'test/redisson20'
   }
 
+  latestRedisson20ForkedTest {
+    dirName = 'test/redisson20'
+    extendsFrom latestRedisson20Test
+  }
+
   latestRedisson23Test {
     dirName = 'test/redisson23'
+  }
+
+  latestRedisson23ForkedTest {
+    dirName = 'test/redisson23'
+    extendsFrom latestRedisson23Test
   }
 
   latestDepTest {
     dirName = 'test/redissonLatest'
   }
+
+  latestDepForkedTest {
+    dirName = 'test/redissonLatest'
+    extendsFrom latestDepTest
+  }
+}
+latestRedisson20Test {
+  finalizedBy latestRedisson20ForkedTest
+}
+
+latestRedisson23Test {
+  finalizedBy latestRedisson20ForkedTest
+}
+
+latestDepTest {
+  finalizedBy latestDepForkedTest
 }
 
 tasks.named('test').configure {

--- a/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redisson20/groovy/RedissonClientTest.groovy
+++ b/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redisson20/groovy/RedissonClientTest.groovy
@@ -1,3 +1,8 @@
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
+
+import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
@@ -11,10 +16,6 @@ import org.redisson.client.RedisConnection
 import org.redisson.client.protocol.RedisCommands
 import redis.embedded.RedisServer
 import spock.lang.Shared
-
-import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
 abstract class RedissonClientTest extends VersionedNamingTestBase {
 
@@ -83,19 +84,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET")
       }
     }
   }
@@ -110,33 +99,10 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 
     assertTraces(2) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET"
-          spanType DDSpanTypes.REDIS
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET")
       }
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "GET"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "GET")
       }
     }
   }
@@ -148,19 +114,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET")
       }
     }
   }
@@ -175,18 +129,8 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 
     assertTraces(2) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET"
-          spanType DDSpanTypes.REDIS
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET")
+
       }
       trace(1) {
         span {
@@ -199,6 +143,9 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+            "$Tags.PEER_PORT" port
             defaultTags()
           }
         }
@@ -216,33 +163,10 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 
     assertTraces(2) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET"
-          spanType DDSpanTypes.REDIS
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET")
       }
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "INCR"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "INCR")
       }
     }
   }
@@ -254,19 +178,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "PUBLISH"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "PUBLISH")
       }
     }
   }
@@ -278,19 +190,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "PFADD"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "PFADD")
       }
     }
   }
@@ -305,34 +205,10 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 
     assertTraces(2) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "PFADD"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "PFADD")
       }
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "PFCOUNT"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "PFCOUNT")
       }
     }
   }
@@ -344,19 +220,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "EVAL"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "EVAL")
       }
     }
   }
@@ -368,19 +232,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SADD"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SADD")
       }
     }
   }
@@ -395,34 +247,10 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 
     assertTraces(2) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SADD"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SADD")
       }
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SREM"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SREM")
       }
     }
   }
@@ -434,19 +262,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "RPUSH"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "RPUSH")
       }
     }
   }
@@ -460,19 +276,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET")
       }
     }
   }
@@ -490,19 +294,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET;GET"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET;GET")
       }
     }
   }
@@ -530,19 +322,26 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET;SET;GET;RPUSH;RPUSH;LRANGE"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET;SET;GET;RPUSH;RPUSH;LRANGE")
+      }
+    }
+  }
+
+  def redisSpan(TraceAssert traceAssert, String resource) {
+    traceAssert.span {
+      serviceName service()
+      operationName operation()
+      resourceName resource
+      spanType DDSpanTypes.REDIS
+      measured true
+      tags {
+        "$Tags.COMPONENT" "redis-command"
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+        "$Tags.DB_TYPE" "redis"
+        "$Tags.PEER_HOSTNAME" "localhost"
+        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+        "$Tags.PEER_PORT" port
+        defaultTags()
       }
     }
   }
@@ -583,3 +382,4 @@ class RedissonClientV1ForkedTest extends RedissonClientTest {
     return "redis.command"
   }
 }
+

--- a/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redisson23/groovy/RedissonClientTest.groovy
+++ b/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redisson23/groovy/RedissonClientTest.groovy
@@ -1,3 +1,8 @@
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
+
+import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
@@ -11,10 +16,6 @@ import org.redisson.config.Config
 import org.redisson.config.SingleServerConfig
 import redis.embedded.RedisServer
 import spock.lang.Shared
-
-import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
 abstract class RedissonClientTest extends VersionedNamingTestBase {
 
@@ -86,19 +87,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET")
       }
     }
   }
@@ -113,33 +102,10 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 
     assertTraces(2) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET"
-          spanType DDSpanTypes.REDIS
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET")
       }
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "GET"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "GET")
       }
     }
   }
@@ -151,19 +117,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET")
       }
     }
   }
@@ -178,30 +132,23 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 
     assertTraces(2) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET"
-          spanType DDSpanTypes.REDIS
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET")
+
       }
       trace(1) {
         span {
           serviceName service()
           operationName operation()
-          resourceName "INCRBY"
+          resourceName "GET"
           spanType DDSpanTypes.REDIS
           measured true
           tags {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+            "$Tags.PEER_PORT" port
             defaultTags()
           }
         }
@@ -219,33 +166,10 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 
     assertTraces(2) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET"
-          spanType DDSpanTypes.REDIS
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET")
       }
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "INCR"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "INCR")
       }
     }
   }
@@ -257,19 +181,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "PUBLISH"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "PUBLISH")
       }
     }
   }
@@ -281,19 +193,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "PFADD"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "PFADD")
       }
     }
   }
@@ -308,34 +208,10 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 
     assertTraces(2) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "PFADD"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "PFADD")
       }
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "PFCOUNT"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "PFCOUNT")
       }
     }
   }
@@ -347,19 +223,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "EVAL"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "EVAL")
       }
     }
   }
@@ -371,19 +235,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SADD"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SADD")
       }
     }
   }
@@ -398,34 +250,10 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 
     assertTraces(2) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SADD"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SADD")
       }
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SREM"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SREM")
       }
     }
   }
@@ -437,19 +265,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "RPUSH"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SREM")
       }
     }
   }
@@ -463,19 +279,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET")
       }
     }
   }
@@ -493,19 +297,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET;GET"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET;GET")
       }
     }
   }
@@ -533,19 +325,26 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET;SET;GET;RPUSH;RPUSH;LRANGE"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET;SET;GET;RPUSH;RPUSH;LRANGE")
+      }
+    }
+  }
+
+  def redisSpan(TraceAssert traceAssert, String resource) {
+    traceAssert.span {
+      serviceName service()
+      operationName operation()
+      resourceName resource
+      spanType DDSpanTypes.REDIS
+      measured true
+      tags {
+        "$Tags.COMPONENT" "redis-command"
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+        "$Tags.DB_TYPE" "redis"
+        "$Tags.PEER_HOSTNAME" "localhost"
+        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+        "$Tags.PEER_PORT" port
+        defaultTags()
       }
     }
   }

--- a/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redissonLatest/groovy/RedissonClientTest.groovy
+++ b/dd-java-agent/instrumentation/redisson-2.0.0/src/test/redissonLatest/groovy/RedissonClientTest.groovy
@@ -1,3 +1,8 @@
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
+
+import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
@@ -9,10 +14,6 @@ import org.redisson.config.Config
 import org.redisson.config.SingleServerConfig
 import redis.embedded.RedisServer
 import spock.lang.Shared
-
-import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
 abstract class RedissonClientTest extends VersionedNamingTestBase {
 
@@ -77,19 +78,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET")
       }
     }
   }
@@ -104,33 +93,10 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 
     assertTraces(2) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET"
-          spanType DDSpanTypes.REDIS
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET")
       }
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "GET"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "GET")
       }
     }
   }
@@ -142,19 +108,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET")
       }
     }
   }
@@ -169,18 +123,8 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 
     assertTraces(2) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET"
-          spanType DDSpanTypes.REDIS
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET")
+
       }
       trace(1) {
         span {
@@ -193,6 +137,9 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
             "$Tags.COMPONENT" "redis-command"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             "$Tags.DB_TYPE" "redis"
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+            "$Tags.PEER_PORT" port
             defaultTags()
           }
         }
@@ -210,33 +157,10 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 
     assertTraces(2) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET"
-          spanType DDSpanTypes.REDIS
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET")
       }
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "INCR"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "INCR")
       }
     }
   }
@@ -248,19 +172,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "PUBLISH"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "PUBLISH")
       }
     }
   }
@@ -272,19 +184,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "PFADD"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "PFADD")
       }
     }
   }
@@ -299,34 +199,10 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 
     assertTraces(2) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "PFADD"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "PFADD")
       }
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "PFCOUNT"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "PFCOUNT")
       }
     }
   }
@@ -338,19 +214,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "EVAL"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "EVAL")
       }
     }
   }
@@ -362,19 +226,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SADD"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SADD")
       }
     }
   }
@@ -389,34 +241,10 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 
     assertTraces(2) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SADD"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SADD")
       }
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SREM"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SREM")
       }
     }
   }
@@ -428,19 +256,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "RPUSH"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "RPUSH")
       }
     }
   }
@@ -454,19 +270,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
     then:
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET")
       }
     }
   }
@@ -484,19 +288,7 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET;GET"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET;GET")
       }
     }
   }
@@ -524,23 +316,31 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
 
     assertTraces(1) {
       trace(1) {
-        span {
-          serviceName service()
-          operationName operation()
-          resourceName "SET;SET;GET;RPUSH;RPUSH;LRANGE"
-          spanType DDSpanTypes.REDIS
-          measured true
-          tags {
-            "$Tags.COMPONENT" "redis-command"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "redis"
-            defaultTags()
-          }
-        }
+        redisSpan(it, "SET;SET;GET;RPUSH;RPUSH;LRANGE")
+      }
+    }
+  }
+
+  def redisSpan(TraceAssert traceAssert, String resource) {
+    traceAssert.span {
+      serviceName service()
+      operationName operation()
+      resourceName resource
+      spanType DDSpanTypes.REDIS
+      measured true
+      tags {
+        "$Tags.COMPONENT" "redis-command"
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+        "$Tags.DB_TYPE" "redis"
+        "$Tags.PEER_HOSTNAME" "localhost"
+        "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+        "$Tags.PEER_PORT" port
+        defaultTags()
       }
     }
   }
 }
+
 class RedissonClientV0ForkedTest extends RedissonClientTest {
 
   @Override


### PR DESCRIPTION
# What Does This Do

Surface remote peer connection tags on redisson spans. Refactored also the test and fixed the fact that latestdep with forked tests were not explicitely executed

# Motivation

# Additional Notes
