### PR TITLE
Create deb and rpm packages in gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,14 +80,11 @@ package:
     - cp ../workspace/dd-java-agent/build/libs/*.jar dd-java-agent.jar
     - source common_build_functions.sh
     - fpm_wrapper "datadog-apm-library-java" "$VERSION" --input-type dir dd-java-agent.jar="$LIBRARIES_INSTALL_BASE/java/dd-java-agent.jar" auto_inject-java.version="$LIBRARIES_INSTALL_BASE/java/version"
-    - $S3_CP_CMD . $S3_RELEASE_ARTIFACTS_URI/deb/amd64/ --exclude "*" --include "*amd64.deb" --recursive
-    - $S3_CP_CMD . $S3_RELEASE_ARTIFACTS_URI/rpm/x86_64/ --exclude "*" --include "*x86_64.rpm" --recursive
 
 .release-package:
   stage: deploy
-  before_script:
-    - export VERSION=$(<packaging/auto_inject-java.version)
-    - export PRODUCT_NAME=auto_inject-java
+  variables:
+    PRODUCT_NAME=auto_inject-java
 
 deploy_to_reliability_env:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 stages:
   - build
+  - package
   - deploy
   - benchmarks
   - generate-signing-key
@@ -16,6 +17,7 @@ variables:
 
 include:
   - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/ci_authenticated_job.yml
+  - remote: s3://gitlab-templates.ddbuild.io/apm/packaging.yml
   - local: ".gitlab/benchmarks.yml"
 
 .common: &common
@@ -66,6 +68,25 @@ build_with_cache:
   cache:
     <<: *default_cache
     policy: push
+
+package:
+  <<: *.package
+  needs: [ build ]
+  script:
+    - source ../upstream.env
+    - echo -n $UPSTREAM_TRACER_VERSION$CI_VERSION_SUFFIX > auto_inject-java.version
+    - cp ../workspace/dd-java-agent/build/libs/*.jar dd-java-agent.jar
+    - >
+      fpm_wrapper "datadog-apm-library-java" "$JAVA_PACKAGE_VERSION" 
+        --input-type dir 
+        dd-java-agent.jar="$LIBRARIES_INSTALL_BASE/java/dd-java-agent.jar"
+        auto_inject-java.version="$LIBRARIES_INSTALL_BASE/java/version"
+
+.release-package:
+  stage: deploy
+  before_script:
+    - export VERSION=$(<packaging/auto_inject-java.version)
+    - export PRODUCT_NAME=auto_inject-java
 
 deploy_to_reliability_env:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,7 +76,7 @@ package:
     - source ../upstream.env
     - echo -n $UPSTREAM_TRACER_VERSION$CI_VERSION_SUFFIX > auto_inject-java.version
     - cp ../workspace/dd-java-agent/build/libs/*.jar dd-java-agent.jar
-    - source /packaging/common_build_functions.sh
+    - source common_build_functions.sh
     - >
       fpm_wrapper "datadog-apm-library-java" "$JAVA_PACKAGE_VERSION" 
         --input-type dir 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,8 @@
+include:
+  - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/ci_authenticated_job.yml
+  - remote: https://gitlab-templates.ddbuild.io/apm/packaging.yml
+  - local: ".gitlab/benchmarks.yml"
+
 stages:
   - build
   - package
@@ -8,17 +13,13 @@ stages:
 variables:
   REGISTRY: 486234852809.dkr.ecr.us-east-1.amazonaws.com
   SONATYPE_USERNAME: robot-sonatype-apm-java
+  S3_RELEASE_ARTIFACTS_URI: ${S3_RELEASE_ARTIFACTS_BASE}-java/$CI_PIPELINE_ID
   DOWNSTREAM_BRANCH:
     value: "master"
     description: "Run a specific datadog-reliability-env branch downstream"
   FORCE_TRIGGER:
     value: "false"
     description: "Set to true to override rules in the reliability-env pipeline (e.g. override 'only deploy master')"
-
-include:
-  - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/ci_authenticated_job.yml
-  - remote: https://gitlab-templates.ddbuild.io/apm/packaging.yml
-  - local: ".gitlab/benchmarks.yml"
 
 .common: &common
   tags: [ "runner:main", "size:large" ]
@@ -79,6 +80,8 @@ package:
     - cp ../workspace/dd-java-agent/build/libs/*.jar dd-java-agent.jar
     - source common_build_functions.sh
     - fpm_wrapper "datadog-apm-library-java" "$VERSION" --input-type dir dd-java-agent.jar="$LIBRARIES_INSTALL_BASE/java/dd-java-agent.jar" auto_inject-java.version="$LIBRARIES_INSTALL_BASE/java/version"
+    - $S3_CP_CMD . $S3_RELEASE_ARTIFACTS_URI/deb/amd64/ --exclude "*" --include "*amd64.deb" --recursive
+    - $S3_CP_CMD . $S3_RELEASE_ARTIFACTS_URI/rpm/x86_64/ --exclude "*" --include "*x86_64.rpm" --recursive
 
 .release-package:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,6 @@ stages:
 variables:
   REGISTRY: 486234852809.dkr.ecr.us-east-1.amazonaws.com
   SONATYPE_USERNAME: robot-sonatype-apm-java
-  S3_RELEASE_ARTIFACTS_URI: ${S3_RELEASE_ARTIFACTS_BASE}-java/$CI_PIPELINE_ID
   DOWNSTREAM_BRANCH:
     value: "master"
     description: "Run a specific datadog-reliability-env branch downstream"
@@ -84,7 +83,7 @@ package:
 .release-package:
   stage: deploy
   variables:
-    PRODUCT_NAME=auto_inject-java
+    PRODUCT_NAME: auto_inject-java
 
 deploy_to_reliability_env:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ variables:
 
 include:
   - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/ci_authenticated_job.yml
-  - remote: s3://gitlab-templates.ddbuild.io/apm/packaging.yml
+  - remote: https://gitlab-templates.ddbuild.io/apm/packaging.yml
   - local: ".gitlab/benchmarks.yml"
 
 .common: &common
@@ -70,12 +70,13 @@ build_with_cache:
     policy: push
 
 package:
-  <<: *.package
+  extends: .package
   needs: [ build ]
   script:
     - source ../upstream.env
     - echo -n $UPSTREAM_TRACER_VERSION$CI_VERSION_SUFFIX > auto_inject-java.version
     - cp ../workspace/dd-java-agent/build/libs/*.jar dd-java-agent.jar
+    - source /packaging/common_build_functions.sh
     - >
       fpm_wrapper "datadog-apm-library-java" "$JAVA_PACKAGE_VERSION" 
         --input-type dir 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,14 +74,11 @@ package:
   needs: [ build ]
   script:
     - source ../upstream.env
-    - echo -n $UPSTREAM_TRACER_VERSION$CI_VERSION_SUFFIX > auto_inject-java.version
+    - export VERSION=$UPSTREAM_TRACER_VERSION$CI_VERSION_SUFFIX
+    - echo -n $VERSION > auto_inject-java.version
     - cp ../workspace/dd-java-agent/build/libs/*.jar dd-java-agent.jar
     - source common_build_functions.sh
-    - >
-      fpm_wrapper "datadog-apm-library-java" "$JAVA_PACKAGE_VERSION" 
-        --input-type dir 
-        dd-java-agent.jar="$LIBRARIES_INSTALL_BASE/java/dd-java-agent.jar"
-        auto_inject-java.version="$LIBRARIES_INSTALL_BASE/java/version"
+    - fpm_wrapper "datadog-apm-library-java" "$VERSION" --input-type dir dd-java-agent.jar="$LIBRARIES_INSTALL_BASE/java/dd-java-agent.jar" auto_inject-java.version="$LIBRARIES_INSTALL_BASE/java/version"
 
 .release-package:
   stage: deploy


### PR DESCRIPTION
# What Does This Do
Adds steps to build and deploy `.deb` and `.rpm` packages in Gitlab.

# Motivation
Previously, this was done in the `auto_inject` repo. The goal is to have these steps done in individual language repos.

# Additional Notes
I put the ~6 lines to build the package directly in the gitlab.yml file. Another choice might be to have that in a separate `.sh` file