### PR TITLE
vertx-redis: implement v1 naming and surface remote connection info

### DIFF
--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RedisAPICallAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RedisAPICallAdvice.java
@@ -134,7 +134,6 @@ public class RedisAPICallAdvice {
         break;
       default:
     }
-
     /*
     Store the response handler in the context so that it can be retrieved in RedisAPIImplSendAdvice
     */

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RedisAPIImplSendAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RedisAPIImplSendAdvice.java
@@ -2,19 +2,25 @@ package datadog.trace.instrumentation.vertx_redis_client;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan;
+import static datadog.trace.instrumentation.vertx_redis_client.VertxRedisClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import io.vertx.core.Future;
+import io.vertx.core.net.SocketAddress;
 import io.vertx.redis.RedisClient;
 import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.RedisAPI;
+import io.vertx.redis.client.RedisConnection;
 import io.vertx.redis.client.Response;
 import net.bytebuddy.asm.Advice;
 
 public class RedisAPIImplSendAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
-  public static void afterSend(@Advice.This RedisAPI self, @Advice.Return Future<Response> future) {
+  public static void afterSend(
+      @Advice.This RedisAPI self,
+      @Advice.FieldValue("connection") final RedisConnection connection,
+      @Advice.Return Future<Response> future) {
     /*
     Here we can safely set the handler for a command related Future instance.
     We need to take some precautions due to a non-existent operation which would allow setting the handler
@@ -26,15 +32,25 @@ public class RedisAPIImplSendAdvice {
       // Get the handler from the context, set by RedisAPICallAdvice
       ResponseHandlerWrapper handler =
           InstrumentationContext.get(RedisAPI.class, ResponseHandlerWrapper.class).get(self);
-      if (handler != null && !future.isComplete()) {
-        // Add the handler only when the future is not already completed
-        future.setHandler(handler);
-      }
-      if (handler != null && future.isComplete()) {
-        // Check whether the future has completed some time when adding the handler.
-        // This might lead to executing the handler twice so the handler must be able to deal with
-        // it.
-        handler.handle(future);
+      if (handler != null) {
+        if (handler.clientSpan != null && connection != null) {
+          final SocketAddress socketAddress =
+              InstrumentationContext.get(RedisConnection.class, SocketAddress.class)
+                  .get(connection);
+          if (socketAddress != null) {
+            DECORATE.onConnection(handler.clientSpan, socketAddress);
+            DECORATE.setPeerPort(handler.clientSpan, socketAddress.port());
+          }
+        }
+        if (!future.isComplete()) {
+          // Add the handler only when the future is not already completed
+          future.setHandler(handler);
+        } else {
+          // Check whether the future has completed some time when adding the handler.
+          // This might lead to executing the handler twice so the handler must be able to deal with
+          // it.
+          handler.handle(future);
+        }
       }
     }
   }

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RedisAPIInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RedisAPIInstrumentation.java
@@ -29,6 +29,7 @@ public class RedisAPIInstrumentation extends Instrumenter.Tracing
   public Map<String, String> contextStore() {
     Map<String, String> contextStores = new HashMap<>();
     contextStores.put("io.vertx.redis.client.RedisAPI", packageName + ".ResponseHandlerWrapper");
+    contextStores.put("io.vertx.redis.client.RedisConnection", "io.vertx.core.net.SocketAddress");
     return contextStores;
   }
 

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RedisConnectAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RedisConnectAdvice.java
@@ -1,0 +1,26 @@
+package datadog.trace.instrumentation.vertx_redis_client;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import net.bytebuddy.asm.Advice;
+
+public class RedisConnectAdvice {
+  @Advice.OnMethodEnter
+  public static AgentScope before() {
+    final AgentSpan span = activeSpan();
+    if (span != null && VertxRedisClientDecorator.REDIS_COMMAND.equals(span.getOperationName())) {
+      return activateSpan(span, true);
+    }
+    return null;
+  }
+
+  @Advice.OnMethodExit
+  public static void after(@Advice.Enter final AgentScope scope) {
+    if (scope != null) {
+      scope.close();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RedisConnectionConstructAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/RedisConnectionConstructAdvice.java
@@ -1,0 +1,27 @@
+package datadog.trace.instrumentation.vertx_redis_client;
+
+import datadog.trace.bootstrap.InstrumentationContext;
+import io.vertx.core.net.NetSocket;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.redis.RedisClient;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisConnection;
+import io.vertx.redis.client.impl.RedisConnectionImpl;
+import net.bytebuddy.asm.Advice;
+
+public class RedisConnectionConstructAdvice {
+  @Advice.OnMethodExit(suppress = Throwable.class)
+  public static void afterConstructor(
+      @Advice.Argument(3) final NetSocket netSocket, @Advice.This final RedisConnectionImpl thiz) {
+    if (netSocket != null && netSocket.remoteAddress() != null) {
+      InstrumentationContext.get(RedisConnection.class, SocketAddress.class)
+          .put(thiz, netSocket.remoteAddress());
+    }
+  }
+
+  // Only apply this advice for versions that we instrument 3.9.x
+  private static void muzzleCheck() {
+    RedisClient.create(null); // removed in 4.0.x
+    Redis.createClient(null, "somehost"); // added in 3.9.x
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/ResponseHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/ResponseHandlerWrapper.java
@@ -8,7 +8,7 @@ import io.vertx.redis.client.Response;
 
 public class ResponseHandlerWrapper implements Handler<AsyncResult<Response>> {
   private final Handler<AsyncResult<Response>> handler;
-  private final AgentSpan clientSpan;
+  public final AgentSpan clientSpan;
   private final AgentScope.Continuation parentContinuation;
   private boolean handled = false;
 

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/VertxRedisClientDecorator.java
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/VertxRedisClientDecorator.java
@@ -2,22 +2,28 @@ package datadog.trace.instrumentation.vertx_redis_client;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 
+import datadog.trace.api.Config;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
+import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
+import io.vertx.core.net.SocketAddress;
 import io.vertx.redis.client.Command;
 
-public class VertxRedisClientDecorator extends DBTypeProcessingDatabaseClientDecorator<Object> {
+public class VertxRedisClientDecorator
+    extends DBTypeProcessingDatabaseClientDecorator<SocketAddress> {
 
   public static final VertxRedisClientDecorator DECORATE = new VertxRedisClientDecorator();
 
-  public static final CharSequence REDIS_COMMAND = UTF8BytesString.create("redis.command");
+  private static final String SERVICE_NAME =
+      SpanNaming.instance().namingSchema().cache().service(Config.get().getServiceName(), "redis");
+  public static final CharSequence REDIS_COMMAND =
+      UTF8BytesString.create(SpanNaming.instance().namingSchema().cache().operation("redis"));
 
-  private static final String SERVICE_NAME = "redis";
   private static final CharSequence COMPONENT_NAME = UTF8BytesString.create("redis-command");
 
   // There are 201 possible Redis commands
@@ -50,19 +56,22 @@ public class VertxRedisClientDecorator extends DBTypeProcessingDatabaseClientDec
   }
 
   @Override
-  protected String dbUser(final Object session) {
+  protected String dbUser(final SocketAddress socketAddress) {
     return null;
   }
 
   @Override
-  protected String dbInstance(final Object session) {
+  protected String dbInstance(final SocketAddress socketAddress) {
     return null;
   }
 
   @Override
-  protected String dbHostname(final Object redisCommand) {
-    return null;
+  protected String dbHostname(final SocketAddress socketAddress) {
+    return socketAddress.host();
   }
+
+  @Override
+  protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {}
 
   public AgentSpan startAndDecorateSpan(String command) {
     UTF8BytesString upperCase =

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/test/groovy/VertxRedisTestBase.groovy
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/test/groovy/VertxRedisTestBase.groovy
@@ -1,6 +1,10 @@
-import datadog.trace.agent.test.AgentTestRunner
+import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
+
 import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.agent.test.asserts.TraceAssert
+import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -22,11 +26,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.function.Function
 
-import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
-import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
-
-abstract class VertxRedisTestBase extends AgentTestRunner {
+abstract class VertxRedisTestBase extends VersionedNamingTestBase {
 
   @Shared
   int port = PortUtils.randomOpenPort()
@@ -49,6 +49,21 @@ abstract class VertxRedisTestBase extends AgentTestRunner {
   @AutoCleanup
   @Shared
   Redis redis = null
+
+  @Override
+  int version() {
+    return 0
+  }
+
+  @Override
+  String service() {
+    return "redis"
+  }
+
+  @Override
+  String operation() {
+    return "redis.query"
+  }
 
   def setupSpec() {
     println "Using redis: $redisServer.args"
@@ -98,7 +113,7 @@ abstract class VertxRedisTestBase extends AgentTestRunner {
     result
   }
 
-  static void parentTraceWithCommandAndHandler(ListWriterAssert lw, String command) {
+  void parentTraceWithCommandAndHandler(ListWriterAssert lw, String command) {
     lw.trace(3, true) {
       basicSpan(it, "handler", span(1))
       basicSpan(it,"parent")
@@ -106,13 +121,13 @@ abstract class VertxRedisTestBase extends AgentTestRunner {
     }
   }
 
-  static void redisSpan(TraceAssert trace, String command, DDSpan parentSpan = null) {
+  void redisSpan(TraceAssert trace, String command, DDSpan parentSpan = null) {
     trace.span {
       if (parentSpan) {
         childOf parentSpan
       }
-      serviceName "redis"
-      operationName "redis.query"
+      serviceName service()
+      operationName operation()
       resourceName command
       spanType DDSpanTypes.REDIS
       measured true
@@ -120,6 +135,8 @@ abstract class VertxRedisTestBase extends AgentTestRunner {
         "$Tags.COMPONENT" "redis-command"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
         "$Tags.DB_TYPE" "redis"
+        "$Tags.PEER_PORT" port
+        "$Tags.PEER_HOSTNAME" "127.0.0.1"
         defaultTags()
       }
     }

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/test/groovy/VertxRedisV1ForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/test/groovy/VertxRedisV1ForkedTest.groovy
@@ -1,3 +1,4 @@
+import datadog.trace.api.Config
 import io.vertx.core.AsyncResult
 import io.vertx.core.Handler
 import io.vertx.redis.client.Command
@@ -6,7 +7,22 @@ import io.vertx.redis.client.Response
 
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 
-class VertxRedisForkedTest extends VertxRedisTestBase {
+class VertxRedisV1ForkedTest extends VertxRedisTestBase {
+
+  @Override
+  int version() {
+    return 1
+  }
+
+  @Override
+  String service() {
+    return Config.get().getServiceName()
+  }
+
+  @Override
+  String operation() {
+    return "redis.command"
+  }
 
   def "set and get command"() {
     when:


### PR DESCRIPTION
# What Does This Do

Implements opt-in v1 naming convestions:
* operation: redis.command
* service: DD_SERVICE

Surface remote host connection tags:
* peer.hostname
* peer.port


# Motivation

# Additional Notes
