### PR TITLE
Restore support for matching custom 'dd.trace.executors'

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/CombiningTransformerBuilder.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/CombiningTransformerBuilder.java
@@ -3,6 +3,7 @@ package datadog.trace.agent.tooling;
 import static datadog.trace.agent.tooling.bytebuddy.DDTransformers.defaultTransformers;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.ANY_CLASS_LOADER;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.isSynthetic;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
@@ -17,6 +18,7 @@ import java.lang.instrument.Instrumentation;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import net.bytebuddy.agent.builder.AgentBuilder;
@@ -76,10 +78,11 @@ public final class CombiningTransformerBuilder extends AbstractTransformerBuilde
           new MatchRecorder.ForType(id, ((Instrumenter.ForCallSite) instrumenter).callerType()));
     }
 
-    if (instrumenter instanceof Instrumenter.ForConfiguredType) {
-      String name = ((Instrumenter.ForConfiguredType) instrumenter).configuredMatchingType();
-      if (null != name && !name.isEmpty()) {
-        matchers.add(new MatchRecorder.ForType(id, named(name)));
+    if (instrumenter instanceof Instrumenter.ForConfiguredTypes) {
+      Collection<String> names =
+          ((Instrumenter.ForConfiguredTypes) instrumenter).configuredMatchingTypes();
+      if (null != names && !names.isEmpty()) {
+        matchers.add(new MatchRecorder.ForType(id, namedOneOf(names)));
       }
     }
 

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/KnownTypesMatcher.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/KnownTypesMatcher.java
@@ -1,7 +1,8 @@
 package datadog.trace.agent.tooling.bytebuddy.matcher;
 
 import java.security.ProtectionDomain;
-import java.util.Collections;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import net.bytebuddy.agent.builder.AgentBuilder;
@@ -15,8 +16,11 @@ public class KnownTypesMatcher extends ElementMatcher.Junction.ForNonNullValues<
   private final Set<String> names;
 
   public KnownTypesMatcher(final String[] names) {
-    this.names = new HashSet<>(names.length);
-    Collections.addAll(this.names, names);
+    this(Arrays.asList(names));
+  }
+
+  public KnownTypesMatcher(final Collection<String> names) {
+    this.names = new HashSet<>(names);
   }
 
   @Override

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -2,6 +2,7 @@ package datadog.trace.agent.tooling;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.ANY_CLASS_LOADER;
 import static java.util.Collections.addAll;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static net.bytebuddy.matcher.ElementMatchers.isSynthetic;
@@ -17,6 +18,7 @@ import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
 import java.security.ProtectionDomain;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -65,11 +67,6 @@ public interface Instrumenter {
     String instrumentedType();
   }
 
-  /** Instrumentation that matches a type configured at runtime. */
-  interface ForConfiguredType {
-    String configuredMatchingType();
-  }
-
   /** Instrumentation that can match a series of named types. */
   interface ForKnownTypes {
     String[] knownMatchingTypes();
@@ -81,6 +78,26 @@ public interface Instrumenter {
     String hierarchyMarkerType();
 
     ElementMatcher<TypeDescription> hierarchyMatcher();
+  }
+
+  /** Instrumentation that matches a series of types configured at runtime. */
+  interface ForConfiguredTypes {
+    Collection<String> configuredMatchingTypes();
+  }
+
+  /** Instrumentation that matches an optional type configured at runtime. */
+  interface ForConfiguredType extends ForConfiguredTypes {
+    @Override
+    default Collection<String> configuredMatchingTypes() {
+      String type = configuredMatchingType();
+      if (null != type && !type.isEmpty()) {
+        return singletonList(type);
+      } else {
+        return emptyList();
+      }
+    }
+
+    String configuredMatchingType();
   }
 
   /** Instrumentation that matches based on the caller of an instruction. */


### PR DESCRIPTION
PR #4578 introduced a build-time index of instrumentations that matched based on known types (`ForKnownTypes`)

This accidentally removed support for custom `dd.trace.executors` because that config option was being added at runtime to the list of known-types, and is not available at build-time. Since known-types are supposed to only include types that we know at build-time the solution is to instead report any custom `dd.trace.executors` via `ForConfiguredTypes`, which is mixed correctly at runtime with the build-time index.