### PR TITLE
Refactoring handling evaluation errors

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ValueReferenceResolver.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ValueReferenceResolver.java
@@ -8,8 +8,6 @@ public interface ValueReferenceResolver {
 
   Object getMember(Object target, String name);
 
-  void addEvaluationError(String expr, String message);
-
   default ValueReferenceResolver withExtensions(Map<String, Object> extensions) {
     return this;
   }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/EvaluationException.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/EvaluationException.java
@@ -1,0 +1,19 @@
+package com.datadog.debugger.el;
+
+public class EvaluationException extends RuntimeException {
+  private final String expr;
+
+  public EvaluationException(String message, String expr) {
+    super(message);
+    this.expr = expr;
+  }
+
+  public EvaluationException(String message, String expr, Throwable cause) {
+    super(message, cause);
+    this.expr = expr;
+  }
+
+  public String getExpr() {
+    return expr;
+  }
+}

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/GetMemberExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/GetMemberExpression.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.expressions;
 
+import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.Generated;
 import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.Visitor;
@@ -21,7 +22,11 @@ public class GetMemberExpression implements ValueExpression<Value<?>> {
     if (targetValue == Value.undefined()) {
       return targetValue;
     }
-    return Value.of(valueRefResolver.getMember(targetValue.getValue(), memberName));
+    try {
+      return Value.of(valueRefResolver.getMember(targetValue.getValue(), memberName));
+    } catch (RuntimeException ex) {
+      throw new EvaluationException(ex.getMessage(), memberName, ex);
+    }
   }
 
   @Generated

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IndexExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IndexExpression.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.expressions;
 
+import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.PrettyPrintVisitor;
 import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.Visitor;
@@ -36,10 +37,8 @@ public class IndexExpression implements ValueExpression<Value<?>> {
         result = ((ListValue) targetValue).get(keyValue.getValue());
       }
     } catch (IllegalArgumentException ex) {
-      valueRefResolver.addEvaluationError(PrettyPrintVisitor.print(this), ex.getMessage());
-      throw ex;
+      throw new EvaluationException(ex.getMessage(), PrettyPrintVisitor.print(this), ex);
     }
-
     return result;
   }
 

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/SubStringExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/SubStringExpression.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.expressions;
 
+import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.PrettyPrintVisitor;
 import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.Visitor;
@@ -24,7 +25,7 @@ public class SubStringExpression implements ValueExpression<Value<String>> {
       try {
         return (Value<String>) Value.of(sourceStr.substring(startIndex, endIndex));
       } catch (StringIndexOutOfBoundsException ex) {
-        valueRefResolver.addEvaluationError(PrettyPrintVisitor.print(this), ex.getMessage());
+        throw new EvaluationException(ex.getMessage(), PrettyPrintVisitor.print(this), ex);
       }
     }
     return Value.undefined();

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ValueRefExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ValueRefExpression.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.expressions;
 
+import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.Generated;
 import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.Visitor;
@@ -16,7 +17,11 @@ public final class ValueRefExpression implements ValueExpression<Value<?>> {
 
   @Override
   public Value<?> evaluate(ValueReferenceResolver valueRefResolver) {
-    return Value.of(valueRefResolver.lookup(symbolName));
+    try {
+      return Value.of(valueRefResolver.lookup(symbolName));
+    } catch (RuntimeException ex) {
+      throw new EvaluationException(ex.getMessage(), symbolName);
+    }
   }
 
   @Generated

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ComparisonExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ComparisonExpressionTest.java
@@ -196,8 +196,5 @@ class ComparisonExpressionTest {
     public Object getMember(Object target, String name) {
       return Value.undefinedValue();
     }
-
-    @Override
-    public void addEvaluationError(String expr, String message) {}
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/SubStringExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/SubStringExpressionTest.java
@@ -2,9 +2,11 @@ package com.datadog.debugger.el.expressions;
 
 import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.datadog.debugger.el.DSL;
+import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.RefResolverHelper;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.Values;
@@ -38,7 +40,8 @@ public class SubStringExpressionTest {
   @Test
   void stringOutOfBoundsExpression() {
     SubStringExpression expression = new SubStringExpression(DSL.value("abc"), 0, 10);
-    assertTrue(expression.evaluate(resolver).isUndefined());
-    assertEquals("substring(\"abc\", 0, 10)", print(expression));
+    EvaluationException evaluationException =
+        assertThrows(EvaluationException.class, () -> expression.evaluate(resolver));
+    assertEquals("substring(\"abc\", 0, 10)", evaluationException.getExpr());
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/LogMessageTemplateBuilder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/LogMessageTemplateBuilder.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.agent;
 
+import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.ValueScript;
 import com.datadog.debugger.probe.LogProbe;
@@ -10,7 +11,6 @@ import datadog.trace.bootstrap.debugger.Snapshot;
 import datadog.trace.bootstrap.debugger.util.TimeoutChecker;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.List;
 
 public class LogMessageTemplateBuilder {
@@ -24,17 +24,12 @@ public class LogMessageTemplateBuilder {
   private static final Duration TIME_OUT = Duration.of(100, ChronoUnit.MILLIS);
 
   private final List<LogProbe.Segment> segments;
-  private final List<Snapshot.EvaluationError> evaluationErrors = new ArrayList<>();
 
   public LogMessageTemplateBuilder(List<LogProbe.Segment> segments) {
     this.segments = segments;
   }
 
-  public List<Snapshot.EvaluationError> getEvaluationErrors() {
-    return evaluationErrors;
-  }
-
-  public String evaluate(Snapshot.CapturedContext context) {
+  public String evaluate(Snapshot.CapturedContext context, Snapshot.CapturedContext.Status status) {
     if (segments == null) {
       return null;
     }
@@ -52,9 +47,11 @@ public class LogMessageTemplateBuilder {
             } else if (result.isNull()) {
               sb.append("null");
             } else {
-              serializeValue(sb, segment.getParsedExpr().getDsl(), result.getValue());
+              serializeValue(sb, segment.getParsedExpr().getDsl(), result.getValue(), status);
             }
-          } catch (RuntimeException ex) {
+          } catch (EvaluationException ex) {
+            status.addError(new Snapshot.EvaluationError(ex.getExpr(), ex.getMessage()));
+            status.setLogTemplateErrors(true);
             sb.append("{").append(ex.getMessage()).append("}");
           }
         }
@@ -63,14 +60,15 @@ public class LogMessageTemplateBuilder {
     return sb.toString();
   }
 
-  private void serializeValue(StringBuilder sb, String expr, Object value) {
+  private void serializeValue(
+      StringBuilder sb, String expr, Object value, Snapshot.CapturedContext.Status status) {
     SerializerWithLimits serializer =
         new SerializerWithLimits(
-            new StringTokenWriter(sb, evaluationErrors), new TimeoutChecker(TIME_OUT));
+            new StringTokenWriter(sb, status.getErrors()), new TimeoutChecker(TIME_OUT));
     try {
       serializer.serialize(value, value != null ? value.getClass().getTypeName() : null, LIMITS);
     } catch (Exception ex) {
-      evaluationErrors.add(new Snapshot.EvaluationError(expr, ex.toString()));
+      status.addError(new Snapshot.EvaluationError(expr, ex.getMessage()));
     }
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
@@ -287,9 +287,6 @@ public class MetricInstrumentor extends Instrumentor {
       return UndefinedValue.INSTANCE;
     }
 
-    @Override
-    public void addEvaluationError(String expr, String message) {}
-
     private Type followReferences(Type currentType, String name, InsnList insnList) {
       Class<?> clazz;
       try {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogMessageTemplateBuilderTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogMessageTemplateBuilderTest.java
@@ -24,7 +24,9 @@ class LogMessageTemplateBuilderTest {
   public void emptyProbe() {
     LogProbe probe = LogProbe.builder().build();
     LogMessageTemplateBuilder summaryBuilder = new LogMessageTemplateBuilder(probe.getSegments());
-    String message = summaryBuilder.evaluate(new Snapshot.CapturedContext());
+    String message =
+        summaryBuilder.evaluate(
+            new Snapshot.CapturedContext(), new Snapshot.CapturedContext.Status(probe));
     assertNull(message);
   }
 
@@ -32,7 +34,9 @@ class LogMessageTemplateBuilderTest {
   public void emptyTemplate() {
     LogProbe probe = createLogProbe("");
     LogMessageTemplateBuilder summaryBuilder = new LogMessageTemplateBuilder(probe.getSegments());
-    String message = summaryBuilder.evaluate(new Snapshot.CapturedContext());
+    String message =
+        summaryBuilder.evaluate(
+            new Snapshot.CapturedContext(), new Snapshot.CapturedContext.Status(probe));
     assertEquals("", message);
   }
 
@@ -40,7 +44,9 @@ class LogMessageTemplateBuilderTest {
   public void onlyStringTemplate() {
     LogProbe probe = createLogProbe("this is a simple string");
     LogMessageTemplateBuilder summaryBuilder = new LogMessageTemplateBuilder(probe.getSegments());
-    String message = summaryBuilder.evaluate(new Snapshot.CapturedContext());
+    String message =
+        summaryBuilder.evaluate(
+            new Snapshot.CapturedContext(), new Snapshot.CapturedContext.Status(probe));
     assertEquals("this is a simple string", message);
   }
 
@@ -48,7 +54,9 @@ class LogMessageTemplateBuilderTest {
   public void undefinedArgTemplate() {
     LogProbe probe = createLogProbe("{arg}");
     LogMessageTemplateBuilder summaryBuilder = new LogMessageTemplateBuilder(probe.getSegments());
-    String message = summaryBuilder.evaluate(new Snapshot.CapturedContext());
+    String message =
+        summaryBuilder.evaluate(
+            new Snapshot.CapturedContext(), new Snapshot.CapturedContext.Status(probe));
     assertEquals("{Cannot find symbol: arg}", message);
   }
 
@@ -61,7 +69,8 @@ class LogMessageTemplateBuilderTest {
         new Snapshot.CapturedValue[] {
           Snapshot.CapturedValue.of("arg", String.class.getTypeName(), "foo")
         });
-    String message = summaryBuilder.evaluate(capturedContext);
+    String message =
+        summaryBuilder.evaluate(capturedContext, new Snapshot.CapturedContext.Status(probe));
     assertEquals("foo", message);
   }
 
@@ -74,14 +83,16 @@ class LogMessageTemplateBuilderTest {
         new Snapshot.CapturedValue[] {
           Snapshot.CapturedValue.of("arg", String.class.getTypeName(), "foo")
         });
-    String message = summaryBuilder.evaluate(capturedContext);
+    String message =
+        summaryBuilder.evaluate(capturedContext, new Snapshot.CapturedContext.Status(probe));
     LogMessageTemplateBuilder summaryBuilder2 = new LogMessageTemplateBuilder(probe.getSegments());
     Snapshot.CapturedContext capturedContext2 = new Snapshot.CapturedContext();
     capturedContext2.addArguments(
         new Snapshot.CapturedValue[] {
           Snapshot.CapturedValue.of("arg", String.class.getTypeName(), "bar")
         });
-    String message2 = summaryBuilder2.evaluate(capturedContext2);
+    String message2 =
+        summaryBuilder2.evaluate(capturedContext2, new Snapshot.CapturedContext.Status(probe));
     assertEquals("foo", message);
     assertEquals("bar", message2);
   }
@@ -95,7 +106,8 @@ class LogMessageTemplateBuilderTest {
         new Snapshot.CapturedValue[] {
           Snapshot.CapturedValue.of("nullObject", Object.class.getTypeName(), null)
         });
-    String message = summaryBuilder.evaluate(capturedContext);
+    String message =
+        summaryBuilder.evaluate(capturedContext, new Snapshot.CapturedContext.Status(probe));
     assertEquals("null", message);
   }
 
@@ -115,7 +127,8 @@ class LogMessageTemplateBuilderTest {
                 "foo0", "foo1", "foo2", "foo3", "foo4", "foo5", "foo6", "foo7", "foo8", "foo9"
               })
         });
-    String message = summaryBuilder.evaluate(capturedContext);
+    String message =
+        summaryBuilder.evaluate(capturedContext, new Snapshot.CapturedContext.Status(probe));
     assertEquals("[0, 1, 2, ...] [foo0, foo1, foo2, ...]", message);
   }
 
@@ -141,7 +154,8 @@ class LogMessageTemplateBuilderTest {
                       "bar0", "bar1", "bar2", "bar3", "bar4", "bar5", "bar6", "bar7", "bar8",
                       "bar9")))
         });
-    String message = summaryBuilder.evaluate(capturedContext);
+    String message =
+        summaryBuilder.evaluate(capturedContext, new Snapshot.CapturedContext.Status(probe));
     assertEquals("[foo0, foo1, foo2, ...] [bar0, bar1, bar2, ...]", message);
   }
 
@@ -158,7 +172,8 @@ class LogMessageTemplateBuilderTest {
         new Snapshot.CapturedValue[] {
           Snapshot.CapturedValue.of("strMap", String.class.getTypeName(), map)
         });
-    String message = summaryBuilder.evaluate(capturedContext);
+    String message =
+        summaryBuilder.evaluate(capturedContext, new Snapshot.CapturedContext.Status(probe));
     assertEquals("{[foo0=bar0], [foo1=bar1], [foo2=bar2], ...}", message);
   }
 
@@ -182,7 +197,8 @@ class LogMessageTemplateBuilderTest {
         new Snapshot.CapturedValue[] {
           Snapshot.CapturedValue.of("obj", Level0.class.getTypeName(), new Level0())
         });
-    String message = summaryBuilder.evaluate(capturedContext);
+    String message =
+        summaryBuilder.evaluate(capturedContext, new Snapshot.CapturedContext.Status(probe));
     assertEquals("{intField0=0, strField0=foo0, level1=...}", message);
   }
 
@@ -196,7 +212,8 @@ class LogMessageTemplateBuilderTest {
           Snapshot.CapturedValue.of(
               "array", Level0[].class.getTypeName(), new Level0[] {new Level0(), new Level0()})
         });
-    String message = summaryBuilder.evaluate(capturedContext);
+    String message =
+        summaryBuilder.evaluate(capturedContext, new Snapshot.CapturedContext.Status(probe));
     assertEquals("[..., ...]", message);
   }
 
@@ -211,11 +228,12 @@ class LogMessageTemplateBuilderTest {
           Snapshot.CapturedValue.of(
               "obj", Object.class.getTypeName(), ManagementFactory.getOperatingSystemMXBean())
         });
-    String message = summaryBuilder.evaluate(capturedContext);
+    Snapshot.CapturedContext.Status status = new Snapshot.CapturedContext.Status(probe);
+    String message = summaryBuilder.evaluate(capturedContext, status);
     assertEquals(
         "{containerMetrics=UNDEFINED, systemLoadTicks=UNDEFINED, processLoadTicks=UNDEFINED, jvm=UNDEFINED, loadavg=UNDEFINED}",
         message);
-    List<Snapshot.EvaluationError> evaluationErrors = summaryBuilder.getEvaluationErrors();
+    List<Snapshot.EvaluationError> evaluationErrors = status.getErrors();
     assertEquals(5, evaluationErrors.size());
     for (int i = 0; i < 5; i++) {
       assertTrue(evaluationErrors.get(i).getMessage().contains("Cannot extract field:"));


### PR DESCRIPTION
# What Does This Do
Introduced EvaluationException that help bubble up errors during evaluation of Expressions and centralized them to add EvaluationError into the CapturedContext's status.
Removed list of evaluation errors from CapturedContext

# Motivation

# Additional Notes
