### PR TITLE
Update Muzzle plugin for gradle 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ parameters:
   gradle_flags:
     # Using no-daemon is important for the caches to be in a consistent state
     type: string
-    default: "--stacktrace --no-daemon"
+    default: "--stacktrace --no-daemon --warning-mode=fail"
 
   global_pattern:
     # Pattern for files that should always trigger a test jobs


### PR DESCRIPTION
# What Does This Do

Updates the muzzle plugin to use configurations for cross project dependencies instead of source sets.

# Motivation

Cross project source set access has been removed in gradle 8.

# Additional Notes

Also enabled `--warning-mode=fail` for CI to avoid depending on deprecated gradle features.