### PR TITLE
Add support for SSRF vulnerabilities

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
@@ -14,6 +14,7 @@ public interface VulnerabilityType {
   InjectionType PATH_TRAVERSAL =
       new InjectionTypeImpl(VulnerabilityTypes.PATH_TRAVERSAL, File.separatorChar);
   InjectionType LDAP_INJECTION = new InjectionTypeImpl(VulnerabilityTypes.LDAP_INJECTION, ' ');
+  InjectionType SSRF = new InjectionTypeImpl(VulnerabilityTypes.SSRF, ' ');
 
   String name();
 

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/SsrfModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/SsrfModuleImpl.java
@@ -1,0 +1,24 @@
+package com.datadog.iast.sink;
+
+import com.datadog.iast.IastRequestContext;
+import com.datadog.iast.model.VulnerabilityType;
+import datadog.trace.api.iast.sink.SsrfModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import javax.annotation.Nullable;
+
+public class SsrfModuleImpl extends SinkModuleBase implements SsrfModule {
+
+  @Override
+  public void onURLConnection(@Nullable final Object url) {
+    if (url == null) {
+      return;
+    }
+    final AgentSpan span = AgentTracer.activeSpan();
+    final IastRequestContext ctx = IastRequestContext.get(span);
+    if (ctx == null) {
+      return;
+    }
+    checkInjection(span, ctx, VulnerabilityType.SSRF, url);
+  }
+}

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/SsrfModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/SsrfModuleTest.groovy
@@ -1,0 +1,72 @@
+package com.datadog.iast.sink
+
+import com.datadog.iast.IastModuleImplTestBase
+import com.datadog.iast.IastRequestContext
+import com.datadog.iast.model.Source
+import com.datadog.iast.model.Vulnerability
+import com.datadog.iast.model.VulnerabilityType
+import datadog.trace.api.gateway.RequestContext
+import datadog.trace.api.gateway.RequestContextSlot
+import datadog.trace.api.iast.SourceTypes
+import datadog.trace.api.iast.sink.SsrfModule
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+
+class SsrfModuleTest extends IastModuleImplTestBase {
+
+  private List<Object> objectHolder
+
+  private IastRequestContext ctx
+
+  private SsrfModule module
+
+  private AgentSpan span
+
+  def setup() {
+    module = registerDependencies(new SsrfModuleImpl())
+    objectHolder = []
+    ctx = new IastRequestContext()
+    final reqCtx = Mock(RequestContext) {
+      getData(RequestContextSlot.IAST) >> ctx
+    }
+    span = Mock(AgentSpan) {
+      getSpanId() >> 123456
+      getRequestContext() >> reqCtx
+    }
+  }
+
+  void 'test SSRF detection'() {
+    when:
+    def reported = module.onURLConnection(url)
+
+    then: 'report is not called if no active span'
+    tracer.activeSpan() >> null
+    !reported
+    0 * reporter.report(_, _)
+
+    when:
+    reported = module.onURLConnection(url)
+
+    then: 'report is not called if url is not tainted'
+    tracer.activeSpan() >> span
+    !reported
+    0 * reporter.report(_, _)
+
+    when:
+    taint(url)
+    reported = module.onURLConnection(url)
+
+    then: 'report is called when the url is tainted'
+    tracer.activeSpan() >> span
+    reported
+    1 * reporter.report(span, { Vulnerability vul -> vul.type == VulnerabilityType.SSRF })
+
+    where:
+    url                        | _
+    new URL('http://test.com') | _
+    'http://test.com'          | _
+  }
+
+  private void taint(final Object value) {
+    ctx.getTaintedObjects().taintInputObject(value, new Source(SourceTypes.REQUEST_PARAMETER_VALUE, 'name', value.toString()))
+  }
+}

--- a/dd-java-agent/instrumentation/commons-httpclient-2/build.gradle
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/build.gradle
@@ -7,6 +7,15 @@ muzzle {
     skipVersions += '2.0-final' // broken metadata on maven central
     assertInverse = true
   }
+  pass {
+    name = 'commons-http-client-x' // for IAST instrumenters valid for 1.x
+    group = "commons-httpclient"
+    module = "commons-httpclient"
+    versions = "[2.0,]"
+    skipVersions += "20020423" // ancient pre-release version
+    skipVersions += '2.0-final' // broken metadata on maven central
+    assertInverse = false
+  }
 }
 
 apply from: "$rootDir/gradle/java.gradle"

--- a/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/IastCommonsHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/IastCommonsHttpClientInstrumentation.java
@@ -1,0 +1,52 @@
+package datadog.trace.instrumentation.commonshttpclient;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.sink.SsrfModule;
+import net.bytebuddy.asm.Advice;
+import org.apache.commons.httpclient.HttpMethod;
+
+@AutoService(Instrumenter.class)
+public class IastCommonsHttpClientInstrumentation extends Instrumenter.Iast
+    implements Instrumenter.ForSingleType {
+
+  public IastCommonsHttpClientInstrumentation() {
+    super("commons-http-client");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.apache.commons.httpclient.HttpClient";
+  }
+
+  @Override
+  public String muzzleDirective() {
+    return "commons-http-client-x";
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod()
+            .and(named("executeMethod"))
+            .and(takesArguments(3))
+            .and(takesArgument(1, named("org.apache.commons.httpclient.HttpMethod"))),
+        IastCommonsHttpClientInstrumentation.class.getName() + "$ExecAdvice");
+  }
+
+  public static class ExecAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void methodEnter(@Advice.Argument(1) final HttpMethod httpMethod) {
+      final SsrfModule module = InstrumentationBridge.SSRF;
+      if (module != null) {
+        module.onURLConnection(httpMethod);
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/IastHttpMethodBaseInstrumentation.java
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/IastHttpMethodBaseInstrumentation.java
@@ -1,0 +1,56 @@
+package datadog.trace.instrumentation.commonshttpclient;
+
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor;
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.propagation.PropagationModule;
+import net.bytebuddy.asm.Advice;
+
+@AutoService(Instrumenter.class)
+public class IastHttpMethodBaseInstrumentation extends Instrumenter.Iast
+    implements Instrumenter.ForSingleType {
+
+  private final String className = IastHttpMethodBaseInstrumentation.class.getName();
+
+  public IastHttpMethodBaseInstrumentation() {
+    super("commons-http-client");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.apache.commons.httpclient.HttpMethodBase";
+  }
+
+  @Override
+  public String muzzleDirective() {
+    return "commons-http-client-x";
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isConstructor().and(takesArguments(1)).and(takesArgument(0, String.class)),
+        className + "$CtorAdvice");
+  }
+
+  @Override
+  public AdviceTransformer transformer() {
+    return new VisitingTransformer(new TaintableVisitor(instrumentedType()));
+  }
+
+  public static class CtorAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void afterCtor(
+        @Advice.This final Object self, @Advice.Argument(0) final Object argument) {
+      final PropagationModule module = InstrumentationBridge.PROPAGATION;
+      if (module != null) {
+        module.taintIfInputIsTainted(self, argument);
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/commons-httpclient-2/src/test/groovy/IastCommonsHttpClientInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/src/test/groovy/IastCommonsHttpClientInstrumentationTest.groovy
@@ -1,0 +1,62 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.propagation.PropagationModule
+import datadog.trace.api.iast.sink.SsrfModule
+import org.apache.commons.httpclient.HttpClient
+import org.apache.commons.httpclient.methods.GetMethod
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
+
+class IastCommonsHttpClientInstrumentationTest extends AgentTestRunner {
+
+  @Override
+  protected void configurePreAgent() {
+    injectSysConfig('dd.iast.enabled', 'true')
+  }
+
+  @AutoCleanup
+  @Shared
+  def server = httpServer {
+    handlers {
+      prefix('/') {
+        String msg = "Hello."
+        response.status(200).send(msg)
+      }
+    }
+  }
+
+  @Shared
+  Map<?, ?> tainteds = new IdentityHashMap<>()
+
+  void setup() {
+    tainteds.clear()
+    mockPropagation()
+  }
+
+  void 'test ssrf'() {
+    given:
+    final url = server.address.toString()
+    tainteds.put(url, null)
+    final ssrf = Mock(SsrfModule)
+    InstrumentationBridge.registerIastModule(ssrf)
+
+    when:
+    new HttpClient().executeMethod(new GetMethod(url))
+
+    then:
+    1 * ssrf.onURLConnection({ value -> tainteds.containsKey(value) })
+  }
+
+  private void mockPropagation() {
+    final propagation = Mock(PropagationModule) {
+      taintIfInputIsTainted(_, _) >> {
+        if (tainteds.containsKey(it[1])) {
+          tainteds.put(it[0], null)
+        }
+      }
+    }
+    InstrumentationBridge.registerIastModule(propagation)
+  }
+}

--- a/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
@@ -9,6 +9,7 @@
 # 2 = Iast Instrumenter allows and filter stacktrace
 
 # -------- JDK --------
+1 com.azul.*
 1 com.sun.*
 1 java.*
 1 javax.*
@@ -122,6 +123,11 @@
 1 net.sourceforge.barbecue.*
 1 netscape.*
 1 okhttp3.*
+# Required for propagation purposes
+2 com.squareup.okhttp.Request
+2 com.squareup.okhttp.Request$*
+2 okhttp3.Request
+2 okhttp3.Request$*
 1 oracle.jdbc.*
 1 oracle.sql.*
 1 org.aopalliance.*

--- a/dd-java-agent/instrumentation/java-net/src/main/java/datadog/trace/instrumentation/java/net/URICallSite.java
+++ b/dd-java-agent/instrumentation/java-net/src/main/java/datadog/trace/instrumentation/java/net/URICallSite.java
@@ -51,4 +51,33 @@ public class URICallSite {
     }
     return result;
   }
+
+  @CallSite.After("java.lang.String java.net.URI.toString()")
+  @CallSite.After("java.lang.String java.net.URI.toASCIIString()")
+  public static String afterToString(
+      @CallSite.This final URI url, @CallSite.Return final String result) {
+    final PropagationModule module = InstrumentationBridge.PROPAGATION;
+    if (module != null) {
+      try {
+        module.taintIfInputIsTainted(result, url);
+      } catch (final Throwable e) {
+        module.onUnexpectedException("After toString threw", e);
+      }
+    }
+    return result;
+  }
+
+  @CallSite.After("java.net.URI java.net.URI.normalize()")
+  public static URI afterNormalize(
+      @CallSite.This final URI url, @CallSite.Return final URI result) {
+    final PropagationModule module = InstrumentationBridge.PROPAGATION;
+    if (module != null) {
+      try {
+        module.taintIfInputIsTainted(result, url);
+      } catch (final Throwable e) {
+        module.onUnexpectedException("After toString threw", e);
+      }
+    }
+    return result;
+  }
 }

--- a/dd-java-agent/instrumentation/java-net/src/main/java/datadog/trace/instrumentation/java/net/URLCallSite.java
+++ b/dd-java-agent/instrumentation/java-net/src/main/java/datadog/trace/instrumentation/java/net/URLCallSite.java
@@ -1,0 +1,114 @@
+package datadog.trace.instrumentation.java.net;
+
+import datadog.trace.agent.tooling.csi.CallSite;
+import datadog.trace.api.iast.IastAdvice;
+import datadog.trace.api.iast.IastAdvice.Propagation;
+import datadog.trace.api.iast.IastAdvice.Sink;
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.PropagationTypes;
+import datadog.trace.api.iast.VulnerabilityTypes;
+import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.api.iast.sink.SsrfModule;
+import java.net.Proxy;
+import java.net.URI;
+import java.net.URL;
+import javax.annotation.Nonnull;
+
+@CallSite(spi = IastAdvice.class)
+public class URLCallSite {
+
+  @Propagation(PropagationTypes.URL)
+  @CallSite.After("void java.net.URL.<init>(java.lang.String)")
+  @CallSite.After(
+      "void java.net.URL.<init>(java.lang.String, java.lang.String, int, java.lang.String)")
+  @CallSite.After(
+      "void java.net.URL.<init>(java.lang.String, java.lang.String, int, java.lang.String, java.net.URLStreamHandler)")
+  @CallSite.After("void java.net.URL.<init>(java.lang.String, java.lang.String, java.lang.String)")
+  @CallSite.After("void java.net.URL.<init>(java.net.URL, java.lang.String)")
+  @CallSite.After(
+      "void java.net.URL.<init>(java.net.URL, java.lang.String, java.net.URLStreamHandler)")
+  public static URL afterCtor(
+      @CallSite.AllArguments final Object[] args, @CallSite.Return @Nonnull final URL result) {
+    if (args != null && args.length > 0) {
+      final PropagationModule module = InstrumentationBridge.PROPAGATION;
+      if (module != null) {
+        try {
+          module.taintIfAnyInputIsTainted(result, args);
+        } catch (final Throwable e) {
+          module.onUnexpectedException("ctor threw", e);
+        }
+      }
+    }
+    return result;
+  }
+
+  @Propagation(PropagationTypes.URL)
+  @CallSite.After("java.lang.String java.net.URL.toString()")
+  @CallSite.After("java.lang.String java.net.URL.toExternalForm()")
+  public static String afterToString(
+      @CallSite.This final URL url, @CallSite.Return final String result) {
+    final PropagationModule module = InstrumentationBridge.PROPAGATION;
+    if (module != null) {
+      try {
+        module.taintIfInputIsTainted(result, url);
+      } catch (final Throwable e) {
+        module.onUnexpectedException("After toString threw", e);
+      }
+    }
+    return result;
+  }
+
+  @Propagation(PropagationTypes.URL)
+  @CallSite.After("java.net.URI java.net.URL.toURI()")
+  public static URI afterToURI(@CallSite.This final URL url, @CallSite.Return final URI result) {
+    final PropagationModule module = InstrumentationBridge.PROPAGATION;
+    if (module != null) {
+      try {
+        module.taintIfInputIsTainted(result, url);
+      } catch (final Throwable e) {
+        module.onUnexpectedException("After toURI threw", e);
+      }
+    }
+    return result;
+  }
+
+  @Sink(VulnerabilityTypes.SSRF)
+  @CallSite.Before("java.net.URLConnection java.net.URL.openConnection()")
+  public static void beforeOpenConnection(@CallSite.This final URL url) {
+    final SsrfModule module = InstrumentationBridge.SSRF;
+    if (module != null) {
+      try {
+        module.onURLConnection(url);
+      } catch (final Throwable e) {
+        module.onUnexpectedException("After open connection threw", e);
+      }
+    }
+  }
+
+  @Sink(VulnerabilityTypes.SSRF)
+  @CallSite.Before("java.net.URLConnection java.net.URL.openConnection(java.net.Proxy)")
+  public static void beforeOpenConnection(
+      @CallSite.This final URL url, @CallSite.Argument final Proxy proxy) {
+    final SsrfModule module = InstrumentationBridge.SSRF;
+    if (module != null) {
+      try {
+        module.onURLConnection(url);
+      } catch (final Throwable e) {
+        module.onUnexpectedException("After open connection threw", e);
+      }
+    }
+  }
+
+  @Sink(VulnerabilityTypes.SSRF)
+  @CallSite.Before("java.io.InputStream java.net.URL.openStream()")
+  public static void beforeOpenStream(@CallSite.This final URL url) {
+    final SsrfModule module = InstrumentationBridge.SSRF;
+    if (module != null) {
+      try {
+        module.onURLConnection(url);
+      } catch (final Throwable e) {
+        module.onUnexpectedException("After open connection threw", e);
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/java-net/src/test/groovy/datadog/trace/instrumentation/java/net/URICallSIteTest.groovy
+++ b/dd-java-agent/instrumentation/java-net/src/test/groovy/datadog/trace/instrumentation/java/net/URICallSIteTest.groovy
@@ -14,7 +14,7 @@ class URICallSIteTest extends AgentTestRunner {
     injectSysConfig('dd.iast.enabled', 'true')
   }
 
-  void 'test uri propagation'() {
+  void 'test uri ctor propagation'() {
     given:
     final module = Mock(PropagationModule)
     InstrumentationBridge.registerIastModule(module)
@@ -34,5 +34,23 @@ class URICallSIteTest extends AgentTestRunner {
     'uri'    | ['http', 'test.com', '/index', 'fragment']                                    | 'http://test.com/index#fragment'
     'uri'    | ['http', '//test.com/index?name=value', 'fragment']                           | 'http://test.com/index?name=value#fragment'
     'create' | ['http://test.com/index?name=value#fragment']                                 | 'http://test.com/index?name=value#fragment'
+  }
+
+  void 'test uri propagation'() {
+    given:
+    final module = Mock(PropagationModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    TestURICallSiteSuite.&"$method".call(args as Object[])
+
+    then:
+    1 * module.taintIfInputIsTainted(_, _ as URI)
+
+    where:
+    method          | args
+    'normalize'     | [new URI('http://test.com/index?name=value#fragment')]
+    'toString'      | [new URI('http://test.com/index?name=value#fragment')]
+    'toASCIIString' | [new URI('http://test.com/index?name=value#fragment')]
   }
 }

--- a/dd-java-agent/instrumentation/java-net/src/test/groovy/datadog/trace/instrumentation/java/net/URLCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-net/src/test/groovy/datadog/trace/instrumentation/java/net/URLCallSiteTest.groovy
@@ -1,0 +1,82 @@
+package datadog.trace.instrumentation.java.net
+
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.propagation.PropagationModule
+import datadog.trace.api.iast.sink.SsrfModule
+import foo.bar.TestURLCallSiteSuite
+
+class URLCallSiteTest extends AgentTestRunner {
+
+  @Override
+  protected void configurePreAgent() {
+    injectSysConfig('dd.iast.enabled', 'true')
+  }
+
+  void 'test url ctor propagation'() {
+    given:
+    final module = Mock(PropagationModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    final uri = TestURLCallSiteSuite.&"$method".call(args as Object[])
+
+    then:
+    uri.toString() == expected
+    1 * module.taintIfAnyInputIsTainted(_ as URL, args as Object[])
+
+    where:
+    method | args                                                                             | expected
+    'url'  | ['http://test.com/index?name=value#fragment']                                    | 'http://test.com/index?name=value#fragment'
+    'url'  | ['http', 'test.com', 80, '/index?name=value#fragment']                           | 'http://test.com:80/index?name=value#fragment'
+    'url'  | ['http', 'test.com', 80, '/index?name=value#fragment', dummyStreamHandler()]     | 'http://test.com:80/index?name=value#fragment'
+    'url'  | ['http', 'test.com', '/index?name=value#fragment']                               | 'http://test.com/index?name=value#fragment'
+    'url'  | [new URL('http://test.com'), '/index?name=value#fragment']                       | 'http://test.com/index?name=value#fragment'
+    'url'  | [new URL('http://test.com'), '/index?name=value#fragment', dummyStreamHandler()] | 'http://test.com/index?name=value#fragment'
+  }
+
+  void 'test url propagation'() {
+    given:
+    final module = Mock(PropagationModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    TestURLCallSiteSuite.&"$method".call(args as Object[])
+
+    then:
+    1 * module.taintIfInputIsTainted(_, _ as URL)
+
+    where:
+    method           | args
+    'toURI'          | [new URL('http://test.com/index?name=value#fragment')]
+    'toString'       | [new URL('http://test.com/index?name=value#fragment')]
+    'toExternalForm' | [new URL('http://test.com/index?name=value#fragment')]
+  }
+
+  void 'test ssrf endpoints'() {
+    given:
+    final module = Mock(SsrfModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    TestURLCallSiteSuite.&"$method".call(args as Object[])
+
+    then:
+    1 * module.onURLConnection(_ as URL)
+
+    where:
+    method           | args
+    'openConnection' | [URLCallSiteTest.getResource('.')]
+    'openConnection' | [URLCallSiteTest.getResource('.'), Proxy.NO_PROXY]
+    'openStream'     | [URLCallSiteTest.getResource('.')]
+  }
+
+  protected URLStreamHandler dummyStreamHandler() {
+    return new URLStreamHandler() {
+        @Override
+        protected URLConnection openConnection(URL u) throws IOException {
+          throw new UnsupportedOperationException()
+        }
+      }
+  }
+}

--- a/dd-java-agent/instrumentation/java-net/src/test/java/foo/bar/TestURICallSiteSuite.java
+++ b/dd-java-agent/instrumentation/java-net/src/test/java/foo/bar/TestURICallSiteSuite.java
@@ -84,4 +84,25 @@ public class TestURICallSiteSuite {
     LOGGER.debug("After create {}", uri);
     return uri;
   }
+
+  public static URI normalize(final URI uri) {
+    LOGGER.debug("Before normalize {}", uri);
+    final URI result = uri.normalize();
+    LOGGER.debug("After normalize {}", result);
+    return result;
+  }
+
+  public static String toString(final URI uri) {
+    LOGGER.debug("Before toString {}", uri);
+    final String result = uri.toString();
+    LOGGER.debug("After toString {}", result);
+    return result;
+  }
+
+  public static String toASCIIString(final URI uri) {
+    LOGGER.debug("Before toAsciiString {}", uri);
+    final String result = uri.toASCIIString();
+    LOGGER.debug("After toAsciiString {}", result);
+    return result;
+  }
 }

--- a/dd-java-agent/instrumentation/java-net/src/test/java/foo/bar/TestURLCallSiteSuite.java
+++ b/dd-java-agent/instrumentation/java-net/src/test/java/foo/bar/TestURLCallSiteSuite.java
@@ -1,0 +1,148 @@
+package foo.bar;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.Proxy;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestURLCallSiteSuite {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TestURLCallSiteSuite.class);
+
+  public static URL url(final String value) {
+    try {
+      LOGGER.debug("Before ctor {}", value);
+      final URL url = new URL(value);
+      LOGGER.debug("After ctor {}", url);
+      return url;
+    } catch (MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static URL url(
+      final String protocol, final String host, final int port, final String file) {
+    try {
+      LOGGER.debug("Before ctor {} {} {} {}", protocol, host, port, file);
+      final URL url = new URL(protocol, host, port, file);
+      LOGGER.debug("After ctor {}", url);
+      return url;
+    } catch (MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static URL url(
+      final String protocol,
+      final String host,
+      final int port,
+      final String file,
+      final URLStreamHandler handler) {
+    try {
+      LOGGER.debug("Before ctor {} {} {} {} {}", protocol, host, port, file, handler);
+      final URL url = new URL(protocol, host, port, file, handler);
+      LOGGER.debug("After ctor {}", url);
+      return url;
+    } catch (MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static URL url(final String protocol, final String host, final String file) {
+    try {
+      LOGGER.debug("Before ctor {} {} {}", protocol, host, file);
+      final URL url = new URL(protocol, host, file);
+      LOGGER.debug("After ctor {}", url);
+      return url;
+    } catch (MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static URL url(final URL context, final String spec) {
+    try {
+      LOGGER.debug("Before ctor {} {}", context, spec);
+      final URL url = new URL(context, spec);
+      LOGGER.debug("After ctor {}", url);
+      return url;
+    } catch (MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static URL url(final URL context, final String spec, final URLStreamHandler handler) {
+    try {
+      LOGGER.debug("Before ctor {} {} {}", context, spec, handler);
+      final URL url = new URL(context, spec, handler);
+      LOGGER.debug("After ctor {}", url);
+      return url;
+    } catch (MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static URI toURI(final URL url) {
+    try {
+      LOGGER.debug("Before toURI {}", url);
+      final URI result = url.toURI();
+      LOGGER.debug("After toURI {}", result);
+      return result;
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static String toString(final URL url) {
+    LOGGER.debug("Before toString {}", url);
+    final String result = url.toString();
+    LOGGER.debug("After toString {}", result);
+    return result;
+  }
+
+  public static String toExternalForm(final URL url) {
+    LOGGER.debug("Before toExternalForm {}", url);
+    final String result = url.toExternalForm();
+    LOGGER.debug("After toExternalForm {}", result);
+    return result;
+  }
+
+  public static URLConnection openConnection(final URL url) {
+    try {
+      LOGGER.debug("Before openConnection {}", url);
+      final URLConnection result = url.openConnection();
+      LOGGER.debug("After openConnection {}", result);
+      return result;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static URLConnection openConnection(final URL url, final Proxy proxy) {
+    try {
+      LOGGER.debug("Before openConnection {}", url);
+      final URLConnection result = url.openConnection(proxy);
+      LOGGER.debug("After openConnection {}", result);
+      return result;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static InputStream openStream(final URL url) {
+    try {
+      LOGGER.debug("Before openStream {}", url);
+      final InputStream result = url.openStream();
+      LOGGER.debug("After openStream {}", result);
+      return result;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/okhttp-2/build.gradle
+++ b/dd-java-agent/instrumentation/okhttp-2/build.gradle
@@ -9,6 +9,12 @@ muzzle {
     versions = "[2.2,3)"
     assertInverse = true
   }
+  pass {
+    name = 'okhttp-2.4' // for IastHttpUrlInstrumentation
+    group = "com.squareup.okhttp"
+    module = "okhttp"
+    versions = "[2.4,3)"
+  }
 }
 
 apply from: "$rootDir/gradle/java.gradle"
@@ -32,6 +38,9 @@ dependencies {
     exclude module: 'okhttp'
   }
   testImplementation group: 'com.squareup.okhttp', name: 'okhttp', version: '2.2.0'
+
+  testRuntimeOnly(project(':dd-java-agent:instrumentation:iast-instrumenter'))
+  testRuntimeOnly(project(':dd-java-agent:instrumentation:java-net'))
 
   latestDepTestImplementation group: 'com.squareup.okhttp', name: 'okhttp', version: '[2.6,3)'
 }

--- a/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/IastHttpUrlInstrumentation.java
+++ b/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/IastHttpUrlInstrumentation.java
@@ -1,0 +1,93 @@
+package datadog.trace.instrumentation.okhttp2;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isStatic;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor;
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.propagation.PropagationModule;
+import java.net.URL;
+import net.bytebuddy.asm.Advice;
+
+@AutoService(Instrumenter.class)
+public class IastHttpUrlInstrumentation extends Instrumenter.Iast
+    implements Instrumenter.ForSingleType {
+
+  /**
+   * Adding fields to an already loaded class is not possible, during testing
+   * com.squareup.okhttp.HttpUrl gets loaded before the instrumenter kicks in, so we must disable
+   * the advice transformer or none of the transformations will be applied
+   */
+  protected static boolean DISABLE_ADVICE_TRANSFORMER = false;
+
+  private final String className = IastHttpUrlInstrumentation.class.getName();
+
+  public IastHttpUrlInstrumentation() {
+    super("okhttp", "okhttp-2");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "com.squareup.okhttp.HttpUrl";
+  }
+
+  @Override
+  public String muzzleDirective() {
+    return "okhttp-2.4";
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod()
+            .and(isStatic())
+            .and(named("parse"))
+            .and(takesArguments(1))
+            .and(takesArgument(0, String.class)),
+        className + "$ParseAdvice");
+    transformation.applyAdvice(
+        isMethod()
+            .and(isStatic())
+            .and(named("get"))
+            .and(takesArguments(1))
+            .and(takesArgument(0, URL.class)),
+        className + "$ParseAdvice");
+    transformation.applyAdvice(
+        isMethod().and(named("url")).and(takesArguments(0)), className + "$PropagationAdvice");
+  }
+
+  @Override
+  public AdviceTransformer transformer() {
+    return DISABLE_ADVICE_TRANSFORMER
+        ? null
+        : new VisitingTransformer(new TaintableVisitor(instrumentedType()));
+  }
+
+  public static class ParseAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onParse(
+        @Advice.Argument(0) final Object argument, @Advice.Return final Object result) {
+      final PropagationModule module = InstrumentationBridge.PROPAGATION;
+      if (module != null) {
+        module.taintIfInputIsTainted(result, argument);
+      }
+    }
+  }
+
+  public static class PropagationAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onPropagation(
+        @Advice.This final Object self, @Advice.Return final Object result) {
+      final PropagationModule module = InstrumentationBridge.PROPAGATION;
+      if (module != null) {
+        module.taintIfInputIsTainted(result, self);
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/IastInterceptor.java
+++ b/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/IastInterceptor.java
@@ -1,0 +1,25 @@
+package datadog.trace.instrumentation.okhttp2;
+
+import com.squareup.okhttp.Interceptor;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.sink.SsrfModule;
+import java.io.IOException;
+
+public class IastInterceptor implements Interceptor {
+
+  @Override
+  public Response intercept(final Chain chain) throws IOException {
+    final Request request = chain.request();
+    final SsrfModule module = InstrumentationBridge.SSRF;
+    if (module != null) {
+      try {
+        module.onURLConnection(request.url());
+      } catch (final Throwable e) {
+        module.onUnexpectedException("Error handling SSRF connection", e);
+      }
+    }
+    return chain.proceed(request);
+  }
+}

--- a/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/IastOkHttp2Instrumentation.java
+++ b/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/IastOkHttp2Instrumentation.java
@@ -1,0 +1,48 @@
+package datadog.trace.instrumentation.okhttp2;
+
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+
+import com.google.auto.service.AutoService;
+import com.squareup.okhttp.Interceptor;
+import com.squareup.okhttp.OkHttpClient;
+import datadog.trace.agent.tooling.Instrumenter;
+import net.bytebuddy.asm.Advice;
+
+@AutoService(Instrumenter.class)
+public class IastOkHttp2Instrumentation extends Instrumenter.Iast
+    implements Instrumenter.ForSingleType {
+
+  public IastOkHttp2Instrumentation() {
+    super("okhttp", "okhttp-2");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "com.squareup.okhttp.OkHttpClient";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".IastInterceptor",
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isConstructor(), IastOkHttp2Instrumentation.class.getName() + "$OkHttp2ClientAdvice");
+  }
+
+  public static class OkHttp2ClientAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void addIastInterceptor(@Advice.This final OkHttpClient client) {
+      for (final Interceptor interceptor : client.interceptors()) {
+        if (interceptor instanceof IastInterceptor) {
+          return;
+        }
+      }
+      client.interceptors().add(new IastInterceptor());
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/IastOkHttp2InstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/IastOkHttp2InstrumentationTest.groovy
@@ -1,0 +1,78 @@
+import com.squareup.okhttp.OkHttpClient
+import com.squareup.okhttp.Request
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.propagation.PropagationModule
+import datadog.trace.api.iast.sink.SsrfModule
+import datadog.trace.instrumentation.okhttp2.IastHttpUrlInstrumentation
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
+
+class IastOkHttp2InstrumentationTest extends AgentTestRunner {
+
+  @Override
+  protected void configurePreAgent() {
+    // HttpUrl gets loaded early so we have to disable the advice transformer
+    IastHttpUrlInstrumentation.DISABLE_ADVICE_TRANSFORMER = true
+    injectSysConfig('dd.iast.enabled', 'true')
+  }
+
+  @AutoCleanup
+  @Shared
+  def server = httpServer {
+    handlers {
+      prefix('/') {
+        String msg = "Hello."
+        response.status(200).send(msg)
+      }
+    }
+  }
+
+  @Shared
+  Map<?, ?> tainteds = new IdentityHashMap<>()
+
+  void setup() {
+    tainteds.clear()
+    mockPropagation()
+  }
+
+  void 'test ssrf'() {
+    given:
+    tainteds.put(url, null)
+    final module = Mock(SsrfModule)
+    InstrumentationBridge.registerIastModule(module)
+    final request = new Request.Builder()
+      .url(url)
+      .get()
+      .build()
+
+    when:
+    new OkHttpClient().newCall(request).execute()
+
+    then:
+    1 * module.onURLConnection({ value -> tainteds.containsKey(value) })
+
+    where:
+    url                       | _
+    server.address.toString() | _
+    server.address.toURL()    | _
+  }
+
+  private void mockPropagation() {
+    final propagation = Mock(PropagationModule) {
+      taintIfAnyInputIsTainted(_, _) >> {
+        if ((it[1] as List).any { input -> tainteds.containsKey(input) }) {
+          tainteds.put(it[0], null)
+        }
+      }
+      taintIfInputIsTainted(_, _) >> {
+        if (tainteds.containsKey(it[1])) {
+          tainteds.put(it[0], null)
+        }
+      }
+    }
+    InstrumentationBridge.registerIastModule(propagation)
+  }
+}

--- a/dd-java-agent/instrumentation/okhttp-3/build.gradle
+++ b/dd-java-agent/instrumentation/okhttp-3/build.gradle
@@ -28,4 +28,7 @@ dependencies {
   }
   latestDepTestImplementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '[3.11.0, 4)'
   latestDepTestImplementation group: 'com.squareup.okio', name: 'okio', version: '1.+'
+
+  testRuntimeOnly(project(':dd-java-agent:instrumentation:iast-instrumenter'))
+  testRuntimeOnly(project(':dd-java-agent:instrumentation:java-net'))
 }

--- a/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/IastHttpUrlInstrumentation.java
+++ b/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/IastHttpUrlInstrumentation.java
@@ -1,0 +1,81 @@
+package datadog.trace.instrumentation.okhttp3;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isStatic;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor;
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.propagation.PropagationModule;
+import java.net.URL;
+import net.bytebuddy.asm.Advice;
+
+@AutoService(Instrumenter.class)
+public class IastHttpUrlInstrumentation extends Instrumenter.Iast
+    implements Instrumenter.ForSingleType {
+
+  /**
+   * Adding fields to a loaded class is not possible, during testing okhttp3.HttpUrl gets loaded
+   * before the instrumenter kicks in, so we must disable the advice transformer or none of the
+   * transformations will be applied happen
+   */
+  protected static boolean DISABLE_ADVICE_TRANSFORMER = false;
+
+  private final String className = IastHttpUrlInstrumentation.class.getName();
+
+  public IastHttpUrlInstrumentation() {
+    super("okhttp", "okhttp-3");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "okhttp3.HttpUrl";
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod()
+            .and(isStatic())
+            .and(named("parse"))
+            .and(takesArguments(1))
+            .and(takesArgument(0, String.class)),
+        className + "$ParseAdvice");
+    transformation.applyAdvice(
+        isMethod()
+            .and(isStatic())
+            .and(named("get"))
+            .and(takesArguments(1))
+            .and(takesArgument(0, URL.class)),
+        className + "$ParseAdvice");
+    transformation.applyAdvice(
+        isMethod()
+            .and(isStatic())
+            .and(named("get"))
+            .and(takesArguments(1))
+            .and(takesArgument(0, String.class)),
+        className + "$ParseAdvice");
+  }
+
+  @Override
+  public AdviceTransformer transformer() {
+    return DISABLE_ADVICE_TRANSFORMER
+        ? null
+        : new VisitingTransformer(new TaintableVisitor(instrumentedType()));
+  }
+
+  public static class ParseAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onParse(
+        @Advice.Argument(0) final Object arg, @Advice.Return final Object result) {
+      final PropagationModule module = InstrumentationBridge.PROPAGATION;
+      if (module != null) {
+        module.taintIfInputIsTainted(result, arg);
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/IastInterceptor.java
+++ b/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/IastInterceptor.java
@@ -1,0 +1,25 @@
+package datadog.trace.instrumentation.okhttp3;
+
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.sink.SsrfModule;
+import java.io.IOException;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class IastInterceptor implements Interceptor {
+
+  @Override
+  public Response intercept(final Chain chain) throws IOException {
+    final Request request = chain.request();
+    final SsrfModule module = InstrumentationBridge.SSRF;
+    if (module != null) {
+      try {
+        module.onURLConnection(request.url());
+      } catch (final Throwable e) {
+        module.onUnexpectedException("Error handling SSRF connection", e);
+      }
+    }
+    return chain.proceed(request);
+  }
+}

--- a/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/IastOkHttp3Instrumentation.java
+++ b/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/IastOkHttp3Instrumentation.java
@@ -1,0 +1,51 @@
+package datadog.trace.instrumentation.okhttp3;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import net.bytebuddy.asm.Advice;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+
+@AutoService(Instrumenter.class)
+public class IastOkHttp3Instrumentation extends Instrumenter.Iast
+    implements Instrumenter.ForSingleType {
+
+  public IastOkHttp3Instrumentation() {
+    super("okhttp", "okhttp-3");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "okhttp3.OkHttpClient";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".IastInterceptor",
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isConstructor().and(takesArgument(0, named("okhttp3.OkHttpClient$Builder"))),
+        IastOkHttp3Instrumentation.class.getName() + "$OkHttp3ClientAdvice");
+  }
+
+  public static class OkHttp3ClientAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void addIastInterceptor(@Advice.Argument(0) final OkHttpClient.Builder builder) {
+      for (final Interceptor interceptor : builder.interceptors()) {
+        if (interceptor instanceof IastInterceptor) {
+          return;
+        }
+      }
+      builder.addInterceptor(new IastInterceptor());
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/IastOkHttp3InstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/IastOkHttp3InstrumentationTest.groovy
@@ -1,0 +1,73 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.propagation.PropagationModule
+import datadog.trace.api.iast.sink.SsrfModule
+import datadog.trace.instrumentation.okhttp3.IastHttpUrlInstrumentation
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
+
+class IastOkHttp3InstrumentationTest extends AgentTestRunner {
+
+  @Override
+  protected void configurePreAgent() {
+    // HttpUrl gets loaded early so we have to disable the advice transformer
+    IastHttpUrlInstrumentation.DISABLE_ADVICE_TRANSFORMER = true
+    injectSysConfig('dd.iast.enabled', 'true')
+  }
+
+  @AutoCleanup
+  @Shared
+  def server = httpServer {
+    handlers {
+      prefix('/') {
+        String msg = "Hello."
+        response.status(200).send(msg)
+      }
+    }
+  }
+
+  @Shared
+  Map<?, ?> tainteds = new IdentityHashMap<>()
+
+  void setup() {
+    tainteds.clear()
+    mockPropagation()
+  }
+
+  void 'test ssrf'() {
+    given:
+    tainteds.put(url, null)
+    final ssrf = Mock(SsrfModule)
+    InstrumentationBridge.registerIastModule(ssrf)
+    final request = new Request.Builder()
+      .url(url)
+      .get()
+      .build()
+
+    when:
+    new OkHttpClient().newCall(request).execute()
+
+    then:
+    1 * ssrf.onURLConnection({ value -> tainteds.containsKey(value) })
+
+    where:
+    url                         | _
+    server.address.toString()   | _
+    server.address.toURL()      | _
+  }
+
+  private void mockPropagation() {
+    final propagation = Mock(PropagationModule) {
+      taintIfInputIsTainted(_, _) >> {
+        if (tainteds.containsKey(it[1])) {
+          tainteds.put(it[0], null)
+        }
+      }
+    }
+    InstrumentationBridge.registerIastModule(propagation)
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/iast/InstrumentationBridge.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/InstrumentationBridge.java
@@ -7,6 +7,7 @@ import datadog.trace.api.iast.sink.CommandInjectionModule;
 import datadog.trace.api.iast.sink.LdapInjectionModule;
 import datadog.trace.api.iast.sink.PathTraversalModule;
 import datadog.trace.api.iast.sink.SqlInjectionModule;
+import datadog.trace.api.iast.sink.SsrfModule;
 import datadog.trace.api.iast.sink.WeakCipherModule;
 import datadog.trace.api.iast.sink.WeakHashModule;
 import datadog.trace.api.iast.source.WebModule;
@@ -24,6 +25,7 @@ public abstract class InstrumentationBridge {
   public static volatile WeakHashModule WEAK_HASH;
   public static volatile LdapInjectionModule LDAP_INJECTION;
   public static volatile PropagationModule PROPAGATION;
+  public static volatile SsrfModule SSRF;
 
   private InstrumentationBridge() {}
 
@@ -48,6 +50,8 @@ public abstract class InstrumentationBridge {
       LDAP_INJECTION = (LdapInjectionModule) module;
     } else if (module instanceof PropagationModule) {
       PROPAGATION = (PropagationModule) module;
+    } else if (module instanceof SsrfModule) {
+      SSRF = (SsrfModule) module;
     } else {
       throw new UnsupportedOperationException("Module not yet supported: " + module);
     }
@@ -84,6 +88,9 @@ public abstract class InstrumentationBridge {
     }
     if (type == PropagationModule.class) {
       return (E) PROPAGATION;
+    }
+    if (type == SsrfModule.class) {
+      return (E) SSRF;
     }
     throw new UnsupportedOperationException("Module not yet supported: " + type);
   }

--- a/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityTypes.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityTypes.java
@@ -10,4 +10,5 @@ public abstract class VulnerabilityTypes {
   public static final String COMMAND_INJECTION = "COMMAND_INJECTION";
   public static final String PATH_TRAVERSAL = "PATH_TRAVERSAL";
   public static final String LDAP_INJECTION = "LDAP_INJECTION";
+  public static final String SSRF = "SSRF";
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/sink/SsrfModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/sink/SsrfModule.java
@@ -1,0 +1,9 @@
+package datadog.trace.api.iast.sink;
+
+import datadog.trace.api.iast.IastModule;
+import javax.annotation.Nullable;
+
+public interface SsrfModule extends IastModule {
+
+  void onURLConnection(@Nullable Object url);
+}


### PR DESCRIPTION
# What Does This Do
Adds support for SSRF detection via jdk (URL/URI), okhttp (versions 2 and 3) and commons httpclient (versions 1 and 2)

# Motivation

# Additional Notes
Support for other frameworks like apache commons (4 and 5), spring rest-template will come later
