### PR TITLE
add kafka bootstrap server to producer span

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -28,6 +28,7 @@ import java.util.LinkedHashMap;
 import net.bytebuddy.asm.Advice;
 import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.record.RecordBatch;
 
@@ -69,12 +70,13 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Tracing
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope onEnter(
         @Advice.FieldValue("apiVersions") final ApiVersions apiVersions,
+        @Advice.FieldValue("producerConfig") ProducerConfig producerConfig,
         @Advice.Argument(value = 0, readOnly = false) ProducerRecord record,
         @Advice.Argument(value = 1, readOnly = false) Callback callback) {
       final AgentSpan parent = activeSpan();
       final AgentSpan span = startSpan(KAFKA_PRODUCE);
       PRODUCER_DECORATE.afterStart(span);
-      PRODUCER_DECORATE.onProduce(span, record);
+      PRODUCER_DECORATE.onProduce(span, record, producerConfig);
 
       callback = new KafkaProducerCallback(callback, parent, span);
 

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
@@ -156,7 +156,7 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
       trace(3) {
         basicSpan(it, "parent")
         basicSpan(it, "producer callback", span(0))
-        producerSpan(it, span(0), false)
+        producerSpan(it, senderProps, span(0), false)
       }
       if (hasQueueSpan()) {
         trace(2) {
@@ -291,7 +291,7 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
       trace(3) {
         basicSpan(it, "parent")
         basicSpan(it, "producer callback", span(0))
-        producerSpan(it, span(0), false)
+        producerSpan(it, senderProps, span(0), false)
       }
       if (hasQueueSpan()) {
         trace(2) {
@@ -393,7 +393,7 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
 
     assertTraces(2, SORT_TRACES_BY_ID) {
       trace(1) {
-        producerSpan(it, null, false, true)
+        producerSpan(it, senderProps, null, false, true)
       }
       if (hasQueueSpan()) {
         trace(2) {
@@ -447,7 +447,7 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
 
     assertTraces(2, SORT_TRACES_BY_ID) {
       trace(1) {
-        producerSpan(it)
+        producerSpan(it, senderProps)
       }
       if (hasQueueSpan()) {
         trace(2) {
@@ -503,7 +503,7 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
 
     assertTraces(2, SORT_TRACES_BY_ID) {
       trace(1) {
-        producerSpan(it)
+        producerSpan(it, senderProps)
       }
       if (hasQueueSpan()) {
         trace(2) {
@@ -559,7 +559,7 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
 
     assertTraces(2, SORT_TRACES_BY_ID) {
       trace(1) {
-        producerSpan(it)
+        producerSpan(it, senderProps)
       }
       if (hasQueueSpan()) {
         trace(2) {
@@ -620,13 +620,13 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
 
       // producing traces
       trace(1) {
-        producerSpan(it)
+        producerSpan(it, senderProps)
       }
       trace(1) {
-        producerSpan(it)
+        producerSpan(it, senderProps)
       }
       trace(1) {
-        producerSpan(it)
+        producerSpan(it, senderProps)
       }
 
       // iterating to the end of ListIterator:
@@ -750,11 +750,11 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
       trace(7) {
         basicSpan(it, "parent")
         basicSpan(it, "producer callback", span(0))
-        producerSpan(it, span(0), false)
+        producerSpan(it, senderProps, span(0), false)
         basicSpan(it, "producer callback", span(0))
-        producerSpan(it, span(0), false)
+        producerSpan(it, senderProps, span(0), false)
         basicSpan(it, "producer callback", span(0))
-        producerSpan(it, span(0), false)
+        producerSpan(it, senderProps, span(0), false)
       }
 
       if (hasQueueSpan()) {
@@ -871,6 +871,7 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
 
   def producerSpan(
     TraceAssert trace,
+    Map<String,?> config,
     DDSpan parentSpan = null,
     boolean partitioned = true,
     boolean tombstone = false
@@ -890,6 +891,7 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
       tags {
         "$Tags.COMPONENT" "java-kafka"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
+        "$InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS" config.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
         if (partitioned) {
           "$InstrumentationTags.PARTITION" { it >= 0 }
         }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InstrumentationTags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InstrumentationTags.java
@@ -71,6 +71,7 @@ public class InstrumentationTags {
   public static final String EVENT = "event";
   public static final String MESSAGE = "message";
   public static final String HANDLER_TYPE = "handler.type";
+  public static final String KAFKA_BOOTSTRAP_SERVERS = "messaging.kafka.bootstrap.servers";
   public static final String QUARTZ_JOB_NAME = "quartz.job.name";
   public static final String QUARTZ_JOB_GROUP = "quartz.job.group";
   public static final String QUARTZ_TRIGGER_NAME = "quartz.trigger.name";


### PR DESCRIPTION
# What Does This Do

Adds kafka bootstrap servers list (tag `messaging.kafka.bootstrap.servers` to the kafka producer span (used to compute later `peer.service`).

# Motivation

# Additional Notes
