### PR TITLE
Add inactive state for IAST

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -226,7 +226,7 @@ public class AgentInstaller {
     if (cfg.getAppSecActivation() != ProductActivation.FULLY_DISABLED) {
       enabledSystems.add(Instrumenter.TargetSystem.APPSEC);
     }
-    if (cfg.isIastEnabled()) {
+    if (cfg.getIastActivation() != ProductActivation.FULLY_DISABLED) {
       enabledSystems.add(Instrumenter.TargetSystem.IAST);
     }
     if (cfg.isCiVisibilityEnabled()) {

--- a/dd-java-agent/agent-iast/src/jmh/java/com/datadog/iast/propagation/AbstractBenchmark.java
+++ b/dd-java-agent/agent-iast/src/jmh/java/com/datadog/iast/propagation/AbstractBenchmark.java
@@ -7,6 +7,7 @@ import com.datadog.iast.IastSystem;
 import com.datadog.iast.model.Range;
 import com.datadog.iast.model.Source;
 import datadog.trace.api.Config;
+import datadog.trace.api.ProductActivation;
 import datadog.trace.api.gateway.InstrumentationGateway;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -58,7 +59,7 @@ public abstract class AbstractBenchmark<C extends AbstractBenchmark.BenchmarkCon
   public void start() {
     context = initializeContext();
     final TagContext tagContext = new TagContext();
-    if (Config.get().isIastEnabled()) {
+    if (Config.get().getIastActivation() == ProductActivation.FULLY_ENABLED) {
       tagContext.withRequestContextDataIast(context.getIastContext());
     }
     span = AgentTracer.startSpan("benchmark", tagContext);

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastSystem.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastSystem.java
@@ -14,6 +14,7 @@ import com.datadog.iast.sink.WeakHashModuleImpl;
 import com.datadog.iast.source.WebModuleImpl;
 import com.datadog.iast.telemetry.IastTelemetry;
 import datadog.trace.api.Config;
+import datadog.trace.api.ProductActivation;
 import datadog.trace.api.gateway.EventType;
 import datadog.trace.api.gateway.Events;
 import datadog.trace.api.gateway.Flow;
@@ -45,7 +46,7 @@ public class IastSystem {
       OverheadController overheadController,
       IastTelemetry telemetry) {
     final Config config = Config.get();
-    if (!config.isIastEnabled()) {
+    if (config.getIastActivation() != ProductActivation.FULLY_ENABLED) {
       LOGGER.debug("IAST is disabled");
       return;
     }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -9,6 +9,7 @@ import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
+import datadog.trace.api.ProductActivation
 import datadog.trace.api.config.GeneralConfig
 import datadog.trace.api.env.CapturedEnvironment
 import datadog.trace.api.function.TriConsumer
@@ -114,7 +115,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     ss.registerCallback(events.responseHeaderDone(), callbacks.responseHeaderDoneCb)
     ss.registerCallback(events.requestPathParams(), callbacks.requestParamsCb)
 
-    if (Config.get().iastEnabled) {
+    if (Config.get().getIastActivation() == ProductActivation.FULLY_ENABLED) {
       def iastSubService = get().getSubscriptionService(RequestContextSlot.IAST)
       def iastCallbacks = new IastIGCallbacks()
       Events<IastIGCallbacks.Context> iastEvents = Events.get()

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -85,7 +85,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_APPSEC_WAF_METRICS = true;
   static final int DEFAULT_APPSEC_WAF_TIMEOUT = 100000; // 0.1 s
 
-  static final boolean DEFAULT_IAST_ENABLED = false;
+  static final String DEFAULT_IAST_ENABLED = "false";
   static final boolean DEFAULT_IAST_DEBUG_ENABLED = false;
   public static final int DEFAULT_IAST_MAX_CONCURRENT_REQUESTS = 4;
   public static final int DEFAULT_IAST_VULNERABILITIES_PER_REQUEST = 2;

--- a/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
@@ -8,6 +8,7 @@ import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.JsonWriter;
 import com.squareup.moshi.Moshi;
 import datadog.trace.api.Config;
+import datadog.trace.api.ProductActivation;
 import datadog.trace.logging.LoggingSettingsDescription;
 import datadog.trace.util.AgentTaskScheduler;
 import java.io.IOException;
@@ -138,9 +139,9 @@ public final class StatusLogger extends JsonAdapter<Config>
     writer.value(config.isDatadogProfilerEnabled());
     writer.name("datadog_profiler_safe");
     writer.value(isDatadogProfilerSafeInCurrentEnvironment());
-    if (config.isIastEnabled()) {
+    if (config.getIastActivation() != ProductActivation.FULLY_DISABLED) {
       writer.name("iast_enabled");
-      writer.value(true);
+      writer.value(config.getIastActivation().toString());
     }
     writer.endObject();
   }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1992,8 +1992,8 @@ public class Config {
     return appSecHttpBlockedTemplateJson;
   }
 
-  public boolean isIastEnabled() {
-    return instrumenterConfig.isIastEnabled();
+  public ProductActivation getIastActivation() {
+    return instrumenterConfig.getIastActivation();
   }
 
   public boolean isIastDebugEnabled() {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
@@ -77,6 +77,20 @@ public final class ConfigProvider {
     return defaultValue;
   }
 
+  /**
+   * Like {@link #getString(String, String, String...)} but falls back to next source if a value is
+   * an empty or blank string.
+   */
+  public String getStringNotEmpty(String key, String defaultValue, String... aliases) {
+    for (ConfigProvider.Source source : sources) {
+      String value = source.get(key, aliases);
+      if (value != null && !value.trim().isEmpty()) {
+        return value;
+      }
+    }
+    return defaultValue;
+  }
+
   public String getStringExcludingSource(
       String key,
       String defaultValue,

--- a/internal-api/src/test/groovy/datadog/trace/api/InstrumenterConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/InstrumenterConfigTest.groovy
@@ -76,4 +76,46 @@ class InstrumenterConfigTest extends DDSpecification {
     where:
     preset << ['INVALID', '']
   }
+
+  def "appsec enabled = #input"() {
+    setup:
+    if (input != null) {
+      injectSysConfig("appsec.enabled", input)
+    }
+
+    expect:
+    InstrumenterConfig.get().getAppSecActivation() == expected
+
+    where:
+    input      | expected
+    null       | ProductActivation.ENABLED_INACTIVE
+    ""         | ProductActivation.ENABLED_INACTIVE
+    "bad"      | ProductActivation.FULLY_DISABLED
+    "false"    | ProductActivation.FULLY_DISABLED
+    "0"        | ProductActivation.FULLY_DISABLED
+    "true"     | ProductActivation.FULLY_ENABLED
+    "1"        | ProductActivation.FULLY_ENABLED
+    "inactive" | ProductActivation.ENABLED_INACTIVE
+  }
+
+  def "iast enabled = #input"() {
+    setup:
+    if (input != null) {
+      injectSysConfig("iast.enabled", input)
+    }
+
+    expect:
+    InstrumenterConfig.get().getIastActivation() == expected
+
+    where:
+    input      | expected
+    null       | ProductActivation.FULLY_DISABLED
+    ""         | ProductActivation.FULLY_DISABLED
+    "bad"      | ProductActivation.FULLY_DISABLED
+    "false"    | ProductActivation.FULLY_DISABLED
+    "0"        | ProductActivation.FULLY_DISABLED
+    "true"     | ProductActivation.FULLY_ENABLED
+    "1"        | ProductActivation.FULLY_ENABLED
+    "inactive" | ProductActivation.ENABLED_INACTIVE
+  }
 }


### PR DESCRIPTION
# What Does This Do
This state enables IAST instrumentation, but does not enable the IAST subsystem itself.

# Motivation
At the moment, this is meant for dogfooding IAST instrumentation, as well as measuring the impact of IAST with instrumentation only.

# Additional Notes
