### PR TITLE
Remove abandoned test sets plugin for gradle 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@ plugins {
   id 'com.github.spotbugs' version '5.0.14'
   id "de.thetaphi.forbiddenapis" version "3.5.1"
 
-  id 'org.unbroken-dome.test-sets' version '4.0.0' // shift this out
   id 'pl.allegro.tech.build.axion-release' version '1.14.4'
   id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
 

--- a/dd-java-agent/instrumentation/aerospike-4/build.gradle
+++ b/dd-java-agent/instrumentation/aerospike-4/build.gradle
@@ -1,12 +1,6 @@
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 muzzle {
   pass {

--- a/dd-java-agent/instrumentation/akka-concurrent/build.gradle
+++ b/dd-java-agent/instrumentation/akka-concurrent/build.gradle
@@ -15,14 +15,8 @@ muzzle {
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/test-with-scala.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  akka23Test
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuite('akka23Test')
+addTestSuiteForDir('latestDepTest', 'test')
 
 tasks.named("compileAkka23TestGroovy").configure {
   classpath += files(sourceSets.akka23Test.scala.classesDirectory)

--- a/dd-java-agent/instrumentation/akka-http-10.0/build.gradle
+++ b/dd-java-agent/instrumentation/akka-http-10.0/build.gradle
@@ -6,21 +6,13 @@ ext {
 apply from: "$rootDir/gradle/java.gradle"
 apply plugin: 'scala'
 
-apply plugin: 'org.unbroken-dome.test-sets'
-testSets {
-  // Since we are using different scala versions for different test sets,
-  // we put the test classes in the baseTest test set so that the scala
-  // version is not inherited
-  baseTest
-
-  version101Test {
-    dirName = 'baseTest'
-  }
-
-  latestDepTest
-
-  lagomTest
-}
+// Since we are using different scala versions for different test sets,
+// we put the test classes in the baseTest test set so that the scala
+// version is not inherited
+addTestSuite('baseTest')
+addTestSuiteForDir('version101Test', 'baseTest')
+addTestSuite('latestDepTest')
+addTestSuite('lagomTest')
 
 compileLagomTestJava {
   sourceCompatibility = JavaVersion.VERSION_1_8

--- a/dd-java-agent/instrumentation/akka-init/build.gradle
+++ b/dd-java-agent/instrumentation/akka-init/build.gradle
@@ -14,13 +14,7 @@ muzzle {
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/test-with-scala.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'com.typesafe.akka', name: "akka-actor_$scalaVersion", version: akkaVersion

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/build.gradle
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/build.gradle
@@ -9,13 +9,8 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.apache.httpcomponents', name: 'httpasyncclient', version: '4.0'

--- a/dd-java-agent/instrumentation/apache-httpclient-4/build.gradle
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/build.gradle
@@ -21,13 +21,8 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.0'

--- a/dd-java-agent/instrumentation/apache-httpclient-5/build.gradle
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/build.gradle
@@ -8,13 +8,8 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.0'

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/build.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/build.gradle
@@ -16,23 +16,14 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  // Features used in test_1_11_106 (builder) is available since 1.11.84, but
-  // using 1.11.106 because of previous concerns with byte code differences
-  // in 1.11.106, also, the DeleteOptionGroup request generates more spans
-  // in 1.11.106 than 1.11.84.
-  // We test older version in separate test set to test newer version and latest deps in the 'default'
-  // test dir. Otherwise we get strange warnings in Idea.
-  test_before_1_11_106 {
-    dirName = 'test_before_1_11_106'
-  }
-
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+// Features used in test_1_11_106 (builder) is available since 1.11.84, but
+// using 1.11.106 because of previous concerns with byte code differences
+// in 1.11.106, also, the DeleteOptionGroup request generates more spans
+// in 1.11.106 than 1.11.84.
+// We test older version in separate test set to test newer version and latest deps in the 'default'
+// test dir. Otherwise we get strange warnings in Idea.
+addTestSuite('test_before_1_11_106')
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.11.0'

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/build.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/build.gradle
@@ -11,11 +11,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest
-}
+addTestSuite('latestDepTest')
 
 def fixedSdkVersion = '2.20.33' // 2.20.34 is missing and breaks IDEA import
 

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/build.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/build.gradle
@@ -11,13 +11,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-sqs', version: '1.11.0'

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/build.gradle
@@ -12,13 +12,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'software.amazon.awssdk', name: 'sqs', version: '2.2.0'

--- a/dd-java-agent/instrumentation/aws-lambda-handler/build.gradle
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/build.gradle
@@ -1,20 +1,17 @@
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-    environment "_HANDLER", "Handler"
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 test {
   environment "_HANDLER", "Handler"
 }
 
 forkedTest {
+  environment "_HANDLER", "Handler"
+}
+
+latestDepTest {
   environment "_HANDLER", "Handler"
 }
 

--- a/dd-java-agent/instrumentation/axis-2/build.gradle
+++ b/dd-java-agent/instrumentation/axis-2/build.gradle
@@ -8,14 +8,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
-
+addTestSuiteForDir('latestDepTest', 'test')
 configurations.all {
   // the version used by axis2 isn't available in a public repository - we don't need it, so exclude it
   exclude group: 'org.apache.woden', module: 'woden'

--- a/dd-java-agent/instrumentation/caffeine/build.gradle
+++ b/dd-java-agent/instrumentation/caffeine/build.gradle
@@ -1,5 +1,4 @@
 apply from: "$rootDir/gradle/java.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
 
 dependencies {
   compileOnly group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '1.0.0'

--- a/dd-java-agent/instrumentation/cdi-1.2/build.gradle
+++ b/dd-java-agent/instrumentation/cdi-1.2/build.gradle
@@ -1,12 +1,6 @@
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   testImplementation group: 'org.jboss.weld', name: 'weld-core', version: '2.3.0.Final'

--- a/dd-java-agent/instrumentation/classloading/tomcat-testing/build.gradle
+++ b/dd-java-agent/instrumentation/classloading/tomcat-testing/build.gradle
@@ -9,13 +9,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   testImplementation project(':dd-java-agent:instrumentation:classloading')

--- a/dd-java-agent/instrumentation/commons-codec-1/build.gradle
+++ b/dd-java-agent/instrumentation/commons-codec-1/build.gradle
@@ -8,14 +8,9 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
 apply plugin: 'call-site-instrumentation'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'commons-codec', name: 'commons-codec', version: '1.1'

--- a/dd-java-agent/instrumentation/commons-httpclient-2/build.gradle
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/build.gradle
@@ -10,13 +10,8 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'commons-httpclient', name: 'commons-httpclient', version: '2.0'

--- a/dd-java-agent/instrumentation/couchbase/couchbase-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-2.0/build.gradle
@@ -1,13 +1,7 @@
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 muzzle {
   // Version 2.7.5 and 2.7.8 were not released properly and muzzle cannot test against it causing failure.

--- a/dd-java-agent/instrumentation/couchbase/couchbase-2.6/build.gradle
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-2.6/build.gradle
@@ -1,13 +1,7 @@
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 muzzle {
   // Version 2.7.5 and 2.7.8 were not released properly and muzzle cannot test against it causing failure.

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.1/build.gradle
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.1/build.gradle
@@ -12,13 +12,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'com.couchbase.client', name: 'java-client', version: '3.1.0'

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.2/build.gradle
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.2/build.gradle
@@ -12,13 +12,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'com.couchbase.client', name: 'java-client', version: '3.2.0'

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/build.gradle
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/build.gradle
@@ -36,13 +36,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'com.datastax.cassandra', name: 'cassandra-driver-core', version: '3.0.0'

--- a/dd-java-agent/instrumentation/datastax-cassandra-4/build.gradle
+++ b/dd-java-agent/instrumentation/datastax-cassandra-4/build.gradle
@@ -15,13 +15,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'com.datastax.oss', name: 'java-driver-core', version: '4.0.0'

--- a/dd-java-agent/instrumentation/dropwizard/build.gradle
+++ b/dd-java-agent/instrumentation/dropwizard/build.gradle
@@ -1,12 +1,6 @@
 apply from: "$rootDir/gradle/java.gradle"
 
-//apply plugin: 'org.unbroken-dome.test-sets'
-//
-//testSets {
-//  latestDepTest {
-//    dirName = 'test'
-//  }
-//}
+//addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   testImplementation project(':dd-java-agent:instrumentation:jax-rs-annotations-2')

--- a/dd-java-agent/instrumentation/elasticsearch/rest-5/build.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-5/build.gradle
@@ -24,11 +24,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest
-}
+addTestSuite('latestDepTest')
 
 dependencies {
   compileOnly group: 'org.elasticsearch.client', name: 'rest', version: '5.0.0'

--- a/dd-java-agent/instrumentation/elasticsearch/rest-6.4/build.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-6.4/build.gradle
@@ -17,11 +17,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest
-}
+addTestSuite('latestDepTest')
 
 dependencies {
   compileOnly group: 'org.elasticsearch.client', name: 'elasticsearch-rest-client', version: '6.4.0'

--- a/dd-java-agent/instrumentation/elasticsearch/rest-7/build.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-7/build.gradle
@@ -17,13 +17,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.elasticsearch.client', name: 'elasticsearch-rest-client', version: '7.0.0'

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/build.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/build.gradle
@@ -15,11 +15,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.elasticsearch', name: 'elasticsearch', version: '2.0.0'

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/build.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/build.gradle
@@ -18,13 +18,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.elasticsearch.client', name: 'transport', version: '5.3.0'

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/build.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/build.gradle
@@ -18,13 +18,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.elasticsearch.client', name: 'transport', version: '6.0.0'

--- a/dd-java-agent/instrumentation/elasticsearch/transport-7.3/build.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-7.3/build.gradle
@@ -18,13 +18,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.elasticsearch.client', name: 'transport', version: '7.3.0'

--- a/dd-java-agent/instrumentation/elasticsearch/transport/build.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/transport/build.gradle
@@ -18,8 +18,6 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
 dependencies {
   compileOnly group: 'org.elasticsearch.client', name: 'transport', version: '7.3.0'
 }

--- a/dd-java-agent/instrumentation/finatra-2.9/build.gradle
+++ b/dd-java-agent/instrumentation/finatra-2.9/build.gradle
@@ -2,16 +2,9 @@
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/test-with-scala.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  // Up to 20.7 where the server structure changes
-  latestPre207Test {
-    dirName = 'test'
-  }
-
-  latestDepTest
-}
+// Up to 20.7 where the server structure changes
+addTestSuiteForDir('latestPre207Test', 'test')
+addTestSuite('latestDepTest')
 
 muzzle {
   // There are some weird library issues below 2.9 so can't assert inverse

--- a/dd-java-agent/instrumentation/glassfish/build.gradle
+++ b/dd-java-agent/instrumentation/glassfish/build.gradle
@@ -14,13 +14,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   testImplementation project(':dd-java-agent:instrumentation:servlet:request-3')

--- a/dd-java-agent/instrumentation/google-http-client/build.gradle
+++ b/dd-java-agent/instrumentation/google-http-client/build.gradle
@@ -9,13 +9,8 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'com.google.http-client', name: 'google-http-client', version: '1.19.0'

--- a/dd-java-agent/instrumentation/graphql-java-14.0/build.gradle
+++ b/dd-java-agent/instrumentation/graphql-java-14.0/build.gradle
@@ -14,13 +14,8 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'com.graphql-java', name: 'graphql-java', version: '14.0'

--- a/dd-java-agent/instrumentation/grizzly-2/build.gradle
+++ b/dd-java-agent/instrumentation/grizzly-2/build.gradle
@@ -12,13 +12,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.glassfish.grizzly', name: 'grizzly-http-server', version: '2.0'

--- a/dd-java-agent/instrumentation/grizzly-client-1.9/build.gradle
+++ b/dd-java-agent/instrumentation/grizzly-client-1.9/build.gradle
@@ -16,13 +16,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.glassfish.grizzly', name: 'grizzly-http-client', version: '1.9'

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/build.gradle
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/build.gradle
@@ -13,13 +13,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
 

--- a/dd-java-agent/instrumentation/grpc-1.5/build.gradle
+++ b/dd-java-agent/instrumentation/grpc-1.5/build.gradle
@@ -30,13 +30,7 @@ protobuf {
   }
 }
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'io.grpc', name: 'grpc-core', version: grpcVersion

--- a/dd-java-agent/instrumentation/guava-10/build.gradle
+++ b/dd-java-agent/instrumentation/guava-10/build.gradle
@@ -9,13 +9,8 @@ muzzle {
 }
 
 apply from: "${rootDir}/gradle/java.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'com.google.guava', name: 'guava', version: '10.0'

--- a/dd-java-agent/instrumentation/hazelcast-3.6/build.gradle
+++ b/dd-java-agent/instrumentation/hazelcast-3.6/build.gradle
@@ -9,13 +9,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'com.hazelcast', name: 'hazelcast-all', version: '3.6'

--- a/dd-java-agent/instrumentation/hazelcast-3.9/build.gradle
+++ b/dd-java-agent/instrumentation/hazelcast-3.9/build.gradle
@@ -9,13 +9,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'com.hazelcast', name: 'hazelcast-all', version: '3.9'

--- a/dd-java-agent/instrumentation/hazelcast-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/hazelcast-4.0/build.gradle
@@ -10,14 +10,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'com.hazelcast', name: 'hazelcast-all', version: '4.0'

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/build.gradle
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/build.gradle
@@ -16,13 +16,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.hibernate', name: 'hibernate-core', version: '3.3.0.GA'

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/build.gradle
@@ -9,13 +9,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.hibernate', name: 'hibernate-core', version: '4.0.0.Final'

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/build.gradle
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/build.gradle
@@ -9,13 +9,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.hibernate', name: 'hibernate-core', version: '4.3.0.Final'

--- a/dd-java-agent/instrumentation/hystrix-1.4/build.gradle
+++ b/dd-java-agent/instrumentation/hystrix-1.4/build.gradle
@@ -8,13 +8,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   implementation project(':dd-java-agent:instrumentation:rxjava-1')

--- a/dd-java-agent/instrumentation/iast-instrumenter/build.gradle
+++ b/dd-java-agent/instrumentation/iast-instrumenter/build.gradle
@@ -7,13 +7,7 @@ muzzle {
 apply from: "${rootDir}/gradle/java.gradle"
 apply from: "${rootDir}/gradle/tries.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 compileJava.dependsOn 'generateClassNameTries'
 packageSources.dependsOn 'generateClassNameTries'

--- a/dd-java-agent/instrumentation/ignite-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/ignite-2.0/build.gradle
@@ -13,13 +13,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.apache.ignite', name: 'ignite-core', version: '2.0.0'

--- a/dd-java-agent/instrumentation/jackson-core/build.gradle
+++ b/dd-java-agent/instrumentation/jackson-core/build.gradle
@@ -16,18 +16,13 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
 apply plugin: 'call-site-instrumentation'
 
 csi {
   javaVersion = JavaLanguageVersion.of(8)
 }
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly(group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.14.0')

--- a/dd-java-agent/instrumentation/jakarta-rs-annotations-3/build.gradle
+++ b/dd-java-agent/instrumentation/jakarta-rs-annotations-3/build.gradle
@@ -9,17 +9,8 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-  latestDepJava11Test {
-    extendsFrom latestDepTest
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteExtendingForDir('latestDepJava11Test', 'latestDepTest', 'test')
 
 tasks.named("compileLatestDepJava11TestJava").configure {
   setJavaVersion(it, 11)

--- a/dd-java-agent/instrumentation/java-concurrent/lambda-testing/build.gradle
+++ b/dd-java-agent/instrumentation/java-concurrent/lambda-testing/build.gradle
@@ -2,13 +2,7 @@
 
 apply from: "${rootDir}/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   testImplementation project(':dd-java-agent:instrumentation:trace-annotation')

--- a/dd-java-agent/instrumentation/java-io/build.gradle
+++ b/dd-java-agent/instrumentation/java-io/build.gradle
@@ -5,17 +5,10 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-
-apply plugin: 'org.unbroken-dome.test-sets'
 apply plugin: 'call-site-instrumentation'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   testRuntimeOnly project(':dd-java-agent:instrumentation:iast-instrumenter')
 }
-

--- a/dd-java-agent/instrumentation/java-lang/build.gradle
+++ b/dd-java-agent/instrumentation/java-lang/build.gradle
@@ -5,15 +5,9 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-
-apply plugin: 'org.unbroken-dome.test-sets'
 apply plugin: 'call-site-instrumentation'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   testRuntimeOnly project(':dd-java-agent:instrumentation:iast-instrumenter')

--- a/dd-java-agent/instrumentation/java-lang/java-lang-11/build.gradle
+++ b/dd-java-agent/instrumentation/java-lang/java-lang-11/build.gradle
@@ -3,7 +3,6 @@ plugins {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
 apply plugin: 'call-site-instrumentation'
 
 muzzle {
@@ -31,11 +30,7 @@ csi {
   javaVersion = JavaLanguageVersion.of(11)
 }
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   testRuntimeOnly project(':dd-java-agent:instrumentation:iast-instrumenter')

--- a/dd-java-agent/instrumentation/java-lang/java-lang-9/build.gradle
+++ b/dd-java-agent/instrumentation/java-lang/java-lang-9/build.gradle
@@ -3,7 +3,6 @@ plugins {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
 apply plugin: 'call-site-instrumentation'
 
 muzzle {
@@ -22,11 +21,7 @@ csi {
   javaVersion = JavaLanguageVersion.of(11)
 }
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   testRuntimeOnly project(':dd-java-agent:instrumentation:iast-instrumenter')

--- a/dd-java-agent/instrumentation/java-net/build.gradle
+++ b/dd-java-agent/instrumentation/java-net/build.gradle
@@ -5,15 +5,9 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-
-apply plugin: 'org.unbroken-dome.test-sets'
 apply plugin: 'call-site-instrumentation'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   testRuntimeOnly project(':dd-java-agent:instrumentation:iast-instrumenter')

--- a/dd-java-agent/instrumentation/java-security/build.gradle
+++ b/dd-java-agent/instrumentation/java-security/build.gradle
@@ -5,15 +5,9 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-
-apply plugin: 'org.unbroken-dome.test-sets'
 apply plugin: 'call-site-instrumentation'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 tasks.withType(Test).configureEach {
   jvmArgs += ['-Ddd.iast.enabled=true']

--- a/dd-java-agent/instrumentation/javax-naming/build.gradle
+++ b/dd-java-agent/instrumentation/javax-naming/build.gradle
@@ -5,15 +5,9 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-
-apply plugin: 'org.unbroken-dome.test-sets'
 apply plugin: 'call-site-instrumentation'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   testRuntimeOnly project(':dd-java-agent:instrumentation:iast-instrumenter')

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/build.gradle
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/build.gradle
@@ -13,19 +13,10 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-
-  resteasy31Test {
-    dirName = 'test'
-  }
-
-  nestedTest
-}
+addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteForDir('resteasy31Test', 'test')
+addTestSuite('nestedTest')
 
 dependencies {
   compileOnly group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0'

--- a/dd-java-agent/instrumentation/jax-rs-client-1.1/build.gradle
+++ b/dd-java-agent/instrumentation/jax-rs-client-1.1/build.gradle
@@ -10,13 +10,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'com.sun.jersey', name: 'jersey-client', version: '1.1.4'

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/build.gradle
@@ -15,13 +15,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0.1'

--- a/dd-java-agent/instrumentation/jax-ws-annotations-2/build.gradle
+++ b/dd-java-agent/instrumentation/jax-ws-annotations-2/build.gradle
@@ -9,13 +9,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'javax.xml.ws', name: 'jaxws-api', version: '2.0'

--- a/dd-java-agent/instrumentation/jdbc/build.gradle
+++ b/dd-java-agent/instrumentation/jdbc/build.gradle
@@ -11,27 +11,12 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
 apply plugin: 'call-site-instrumentation'
 
-testSets {
-  oldH2Test {
-    dirName = 'test'
-  }
-
-  latestDepTest {
-    dirName = 'test'
-  }
-
-  oldPostgresTest {
-    dirName = 'test'
-  }
-
-  latestDepJava11Test {
-    extendsFrom latestDepTest
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('oldH2Test', 'test')
+addTestSuiteForDir('oldPostgresTest', 'test')
+addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteExtendingForDir('latestDepJava11Test', 'latestDepTest', 'test')
 
 dependencies {
   testImplementation(testFixtures(project(':dd-java-agent:agent-iast')))

--- a/dd-java-agent/instrumentation/jdbc/scalikejdbc/build.gradle
+++ b/dd-java-agent/instrumentation/jdbc/scalikejdbc/build.gradle
@@ -6,14 +6,9 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
 apply plugin: 'scala'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 tasks.named("compileTestGroovy").configure {
   dependsOn "compileTestScala"

--- a/dd-java-agent/instrumentation/jedis-1.4/build.gradle
+++ b/dd-java-agent/instrumentation/jedis-1.4/build.gradle
@@ -9,13 +9,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'redis.clients', name: 'jedis', version: '1.4.0'

--- a/dd-java-agent/instrumentation/jedis-3.0/build.gradle
+++ b/dd-java-agent/instrumentation/jedis-3.0/build.gradle
@@ -15,13 +15,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'redis.clients', name: 'jedis', version: '3.3.0'

--- a/dd-java-agent/instrumentation/jedis-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/jedis-4.0/build.gradle
@@ -15,13 +15,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'redis.clients', name: 'jedis', version: '4.0.0'

--- a/dd-java-agent/instrumentation/jetty-11/build.gradle
+++ b/dd-java-agent/instrumentation/jetty-11/build.gradle
@@ -14,13 +14,7 @@ apply from: "$rootDir/gradle/java.gradle"
 apply plugin: "idea"
 
 // TODO latestDepTest only works on Java8 for now
-//apply plugin: 'org.unbroken-dome.test-sets'
-//
-//testSets {
-//  latestDepTest {
-//    dirName = 'test'
-//  }
-//}
+//addTestSuiteForDir('latestDepTest', 'test')
 
 sourceSets {
   "main_java11" {

--- a/dd-java-agent/instrumentation/jetty-7.0/build.gradle
+++ b/dd-java-agent/instrumentation/jetty-7.0/build.gradle
@@ -10,13 +10,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.eclipse.jetty', name: 'jetty-server', version: '7.0.0.v20091005'

--- a/dd-java-agent/instrumentation/jetty-7.6/build.gradle
+++ b/dd-java-agent/instrumentation/jetty-7.6/build.gradle
@@ -10,13 +10,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.eclipse.jetty', name: 'jetty-server', version: '7.6.0.v20120127'

--- a/dd-java-agent/instrumentation/jetty-9/build.gradle
+++ b/dd-java-agent/instrumentation/jetty-9/build.gradle
@@ -9,19 +9,9 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  jetty92Test {
-    dirName = 'test'
-  }
-  jetty94Test {
-    dirName = 'test'
-  }
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('jetty92Test', 'test')
+addTestSuiteForDir('jetty94Test', 'test')
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.0.0.v20130308'

--- a/dd-java-agent/instrumentation/jetty-client-9.1/build.gradle
+++ b/dd-java-agent/instrumentation/jetty-client-9.1/build.gradle
@@ -16,13 +16,8 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.eclipse.jetty', name: 'jetty-client', version: '9.1.0.v20131115'

--- a/dd-java-agent/instrumentation/jetty-common/build.gradle
+++ b/dd-java-agent/instrumentation/jetty-common/build.gradle
@@ -1,12 +1,7 @@
 
 apply from: "$rootDir/gradle/java.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.eclipse.jetty', name: 'jetty-server', version: '7.0.0.v20091005'

--- a/dd-java-agent/instrumentation/jetty-util/build.gradle
+++ b/dd-java-agent/instrumentation/jetty-util/build.gradle
@@ -5,13 +5,8 @@ muzzle {
   }
 }
 apply from: "$rootDir/gradle/java.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.eclipse.jetty', name: 'jetty-util', version: '9.4.31.v20200723'

--- a/dd-java-agent/instrumentation/jms/build.gradle
+++ b/dd-java-agent/instrumentation/jms/build.gradle
@@ -21,17 +21,8 @@ repositories {
   }
 }
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-  }
-
-  latestDepForkedTest {
-    extendsFrom latestDepTest
-    dirName = 'test'
-  }
-}
+addTestSuite('latestDepTest')
+addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'test')
 
 apply from: "$rootDir/gradle/configure_tests.gradle"
 

--- a/dd-java-agent/instrumentation/jsp-2.3/build.gradle
+++ b/dd-java-agent/instrumentation/jsp-2.3/build.gradle
@@ -9,13 +9,7 @@ muzzle {
   }
 }
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   // compiling against tomcat 7.0.20 because there seems to be some issues with Tomcat's dependency < 7.0.20

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/build.gradle
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/build.gradle
@@ -9,11 +9,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest
-}
+addTestSuite('latestDepTest')
 
 dependencies {
   compileOnly group: 'org.apache.kafka', name: 'kafka-clients', version: '0.11.0.0'

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/build.gradle
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/build.gradle
@@ -9,11 +9,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest
-}
+addTestSuite('latestDepTest')
 
 dependencies {
   compileOnly group: 'org.apache.kafka', name: 'kafka-streams', version: '0.11.0.0'

--- a/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.3/build.gradle
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.3/build.gradle
@@ -19,13 +19,8 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/test-with-kotlin.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 tasks.named("compileLatestDepTestGroovy").configure {
   classpath += files(compileLatestDepTestKotlin.destinationDirectory)

--- a/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.5/build.gradle
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.5/build.gradle
@@ -19,13 +19,8 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/test-with-kotlin.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 tasks.named("compileLatestDepTestGroovy").configure {
   classpath += files(compileLatestDepTestKotlin.destinationDirectory)

--- a/dd-java-agent/instrumentation/lettuce-4/build.gradle
+++ b/dd-java-agent/instrumentation/lettuce-4/build.gradle
@@ -10,13 +10,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'biz.paluch.redis', name: 'lettuce', version: '4.0.Final'

--- a/dd-java-agent/instrumentation/lettuce-5/build.gradle
+++ b/dd-java-agent/instrumentation/lettuce-5/build.gradle
@@ -10,13 +10,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'io.lettuce', name: 'lettuce-core', version: '5.0.0.RELEASE'

--- a/dd-java-agent/instrumentation/micronaut/http-server-netty-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/micronaut/http-server-netty-2.0/build.gradle
@@ -9,13 +9,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'io.micronaut', name: 'micronaut-http-server-netty', version: '2.0.0'

--- a/dd-java-agent/instrumentation/micronaut/http-server-netty-3.0/build.gradle
+++ b/dd-java-agent/instrumentation/micronaut/http-server-netty-3.0/build.gradle
@@ -9,13 +9,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'io.micronaut', name: 'micronaut-http-server-netty', version: '3.0.0'

--- a/dd-java-agent/instrumentation/mongo/bson-document/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/bson-document/build.gradle
@@ -9,8 +9,6 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
 dependencies {
   compileOnly group: 'org.mongodb', name: 'mongo-java-driver', version: '3.1.0'
 

--- a/dd-java-agent/instrumentation/mongo/driver-3.1-core-test/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1-core-test/build.gradle
@@ -1,12 +1,7 @@
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
+addTestSuiteForDir('latestDepTest', 'test')
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
 dependencies {
   testImplementation project(':dd-java-agent:instrumentation:mongo').sourceSets.test.output
   testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '4.5.1'

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/build.gradle
@@ -20,13 +20,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.mongodb', name: 'mongo-java-driver', version: '3.1.0'

--- a/dd-java-agent/instrumentation/mongo/driver-3.10-sync-test/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-3.10-sync-test/build.gradle
@@ -1,13 +1,7 @@
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   testImplementation(project(':dd-java-agent:instrumentation:mongo:common')) {

--- a/dd-java-agent/instrumentation/mongo/driver-3.3-async-test/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-3.3-async-test/build.gradle
@@ -1,13 +1,7 @@
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   testImplementation(project(':dd-java-agent:instrumentation:mongo:common')) {

--- a/dd-java-agent/instrumentation/mongo/driver-3.4/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-3.4/build.gradle
@@ -27,13 +27,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.mongodb', name: 'mongo-java-driver', version: '3.4.0'

--- a/dd-java-agent/instrumentation/mongo/driver-3.7-core-test/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-3.7-core-test/build.gradle
@@ -1,12 +1,6 @@
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   testImplementation project(':dd-java-agent:instrumentation:mongo').sourceSets.test.output

--- a/dd-java-agent/instrumentation/mongo/driver-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-4.0/build.gradle
@@ -16,13 +16,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.0.0'

--- a/dd-java-agent/instrumentation/netty-3.8/build.gradle
+++ b/dd-java-agent/instrumentation/netty-3.8/build.gradle
@@ -20,11 +20,7 @@ muzzle {
   }
 }
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest
-}
+addTestSuite('latestDepTest')
 
 dependencies {
   compileOnly group: 'io.netty', name: 'netty', version: '3.8.0.Final'

--- a/dd-java-agent/instrumentation/netty-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/netty-4.0/build.gradle
@@ -33,13 +33,7 @@ muzzle {
   }
 }
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'io.netty', name: 'netty-codec-http', version: '4.0.0.Final'

--- a/dd-java-agent/instrumentation/netty-4.1/build.gradle
+++ b/dd-java-agent/instrumentation/netty-4.1/build.gradle
@@ -27,13 +27,7 @@ muzzle {
   }
 }
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'io.netty', name: 'netty-codec-http', version: '4.1.0.Final'

--- a/dd-java-agent/instrumentation/netty-buffer-4/build.gradle
+++ b/dd-java-agent/instrumentation/netty-buffer-4/build.gradle
@@ -9,16 +9,8 @@ muzzle {
   }
 }
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDep4Test {
-    dirName = 'test'
-  }
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDep4Test', 'test')
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'io.netty', name: 'netty-buffer', version: '4.0.0.Final'

--- a/dd-java-agent/instrumentation/netty-promise-4/build.gradle
+++ b/dd-java-agent/instrumentation/netty-promise-4/build.gradle
@@ -9,16 +9,8 @@ muzzle {
   }
 }
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDep4Test {
-    dirName = 'test'
-  }
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDep4Test', 'test')
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'io.netty', name: 'netty-common', version: '4.0.0.Final'

--- a/dd-java-agent/instrumentation/okhttp-2/build.gradle
+++ b/dd-java-agent/instrumentation/okhttp-2/build.gradle
@@ -13,13 +13,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly(group: 'com.squareup.okhttp', name: 'okhttp', version: '2.2.0')

--- a/dd-java-agent/instrumentation/okhttp-3/build.gradle
+++ b/dd-java-agent/instrumentation/okhttp-3/build.gradle
@@ -9,13 +9,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly(group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.0.0')

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/build.gradle
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/build.gradle
@@ -13,13 +13,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'io.opentelemetry', name: 'opentelemetry-api', version: otelVersion

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/build.gradle
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/build.gradle
@@ -9,13 +9,8 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'io.opentelemetry', name: 'opentelemetry-api', version: openTelemetryVersion

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/build.gradle
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/build.gradle
@@ -9,13 +9,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   implementation project(':dd-java-agent:instrumentation:opentracing')

--- a/dd-java-agent/instrumentation/play-2.3/build.gradle
+++ b/dd-java-agent/instrumentation/play-2.3/build.gradle
@@ -34,13 +34,7 @@ repositories {
 
 apply from: "$rootDir/gradle/test-with-scala.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'com.typesafe.play', name: 'play_2.11', version: '2.3.9'

--- a/dd-java-agent/instrumentation/play-2.4/build.gradle
+++ b/dd-java-agent/instrumentation/play-2.4/build.gradle
@@ -33,13 +33,7 @@ repositories {
   }
 }
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'com.typesafe.play', name: 'play_2.11', version: '2.4.0'

--- a/dd-java-agent/instrumentation/play-2.6/build.gradle
+++ b/dd-java-agent/instrumentation/play-2.6/build.gradle
@@ -38,13 +38,7 @@ repositories {
   }
 }
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'com.typesafe.play', name: "play_$scalaVersion", version: playVersion

--- a/dd-java-agent/instrumentation/play-ws-1/build.gradle
+++ b/dd-java-agent/instrumentation/play-ws-1/build.gradle
@@ -1,14 +1,7 @@
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
-
+addTestSuiteForDir('latestDepTest', 'test')
 muzzle {
   pass {
     group = 'com.typesafe.play'

--- a/dd-java-agent/instrumentation/play-ws-2.1/build.gradle
+++ b/dd-java-agent/instrumentation/play-ws-2.1/build.gradle
@@ -1,13 +1,7 @@
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 muzzle {
 

--- a/dd-java-agent/instrumentation/play-ws-2/build.gradle
+++ b/dd-java-agent/instrumentation/play-ws-2/build.gradle
@@ -1,14 +1,7 @@
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
-
+addTestSuiteForDir('latestDepTest', 'test')
 muzzle {
 
   pass {

--- a/dd-java-agent/instrumentation/play-ws/build.gradle
+++ b/dd-java-agent/instrumentation/play-ws/build.gradle
@@ -1,8 +1,6 @@
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
 def scalaVersion = '2.12'
 
 configurations {

--- a/dd-java-agent/instrumentation/quartz-2/build.gradle
+++ b/dd-java-agent/instrumentation/quartz-2/build.gradle
@@ -9,13 +9,8 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.quartz-scheduler', name: 'quartz', version: '2.0.0'

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/build.gradle
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/build.gradle
@@ -9,13 +9,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'com.rabbitmq', name: 'amqp-client', version: '2.7.0'

--- a/dd-java-agent/instrumentation/ratpack-1.5/build.gradle
+++ b/dd-java-agent/instrumentation/ratpack-1.5/build.gradle
@@ -11,13 +11,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'io.ratpack', name: 'ratpack-core', version: '1.5.0'

--- a/dd-java-agent/instrumentation/reactor-core-3.1/build.gradle
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/build.gradle
@@ -10,13 +10,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'io.projectreactor', name: 'reactor-core', version: '3.1.0.RELEASE'

--- a/dd-java-agent/instrumentation/reactor-netty-1/build.gradle
+++ b/dd-java-agent/instrumentation/reactor-netty-1/build.gradle
@@ -15,11 +15,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest
-}
+addTestSuite('latestDepTest')
 
 dependencies {
   compileOnly group: 'io.projectreactor.netty', name: 'reactor-netty-http', version: '1.0.0'

--- a/dd-java-agent/instrumentation/rediscala-1.8.0/build.gradle
+++ b/dd-java-agent/instrumentation/rediscala-1.8.0/build.gradle
@@ -45,13 +45,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'com.github.etaty', name: 'rediscala_2.11', version: '1.8.0'

--- a/dd-java-agent/instrumentation/redisson-2.0.0/build.gradle
+++ b/dd-java-agent/instrumentation/redisson-2.0.0/build.gradle
@@ -11,36 +11,13 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
+addTestSuiteForDir('latestRedisson20Test', 'test/redisson20')
+addTestSuiteExtendingForDir('latestRedisson20ForkedTest', 'latestRedisson20Test', 'test/redisson20')
+addTestSuiteForDir('latestRedisson23Test', 'test/redisson23')
+addTestSuiteExtendingForDir('latestRedisson23ForkedTest', 'latestRedisson23Test', 'test/redisson23')
+addTestSuiteForDir('latestDepTest', 'test/redissonLatest')
+addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'test/redissonLatest')
 
-testSets {
-  latestRedisson20Test {
-    dirName = 'test/redisson20'
-  }
-
-  latestRedisson20ForkedTest {
-    dirName = 'test/redisson20'
-    extendsFrom latestRedisson20Test
-  }
-
-  latestRedisson23Test {
-    dirName = 'test/redisson23'
-  }
-
-  latestRedisson23ForkedTest {
-    dirName = 'test/redisson23'
-    extendsFrom latestRedisson23Test
-  }
-
-  latestDepTest {
-    dirName = 'test/redissonLatest'
-  }
-
-  latestDepForkedTest {
-    dirName = 'test/redissonLatest'
-    extendsFrom latestDepTest
-  }
-}
 latestRedisson20Test {
   finalizedBy latestRedisson20ForkedTest
 }

--- a/dd-java-agent/instrumentation/resteasy-appsec/build.gradle
+++ b/dd-java-agent/instrumentation/resteasy-appsec/build.gradle
@@ -7,13 +7,11 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
 apply plugin: 'java-test-fixtures'
 
-testSets {
-  nettyTest
-  jettyAsyncTest
-}
+addTestSuite('nettyTest')
+addTestSuite('jettyAsyncTest')
+
 //check.dependsOn nettyTest, jettyAsyncTest
 // CI invocations are only for test/latestDepTest
 test.finalizedBy nettyTest, jettyAsyncTest

--- a/dd-java-agent/instrumentation/restlet-2.2/build.gradle
+++ b/dd-java-agent/instrumentation/restlet-2.2/build.gradle
@@ -17,14 +17,9 @@ repositories {
   }
 }
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  // Header classes have moved around versions, so we need to split out parts of the test code
-  baseForkedTest {dirName "baseTest"}
-
-  latestDepTest
-}
+// Header classes have moved around versions, so we need to split out parts of the test code
+addTestSuiteForDir('baseForkedTest', 'baseTest')
+addTestSuite('latestDepTest')
 
 tasks.named("test").configure {
   dependsOn "baseForkedTest"

--- a/dd-java-agent/instrumentation/rxjava-1/build.gradle
+++ b/dd-java-agent/instrumentation/rxjava-1/build.gradle
@@ -1,12 +1,6 @@
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'io.reactivex', name: 'rxjava', version: '1.0.7'

--- a/dd-java-agent/instrumentation/rxjava-2/build.gradle
+++ b/dd-java-agent/instrumentation/rxjava-2/build.gradle
@@ -9,13 +9,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.reactivestreams', name: 'reactive-streams', version: '1.0.0'

--- a/dd-java-agent/instrumentation/scala-concurrent/build.gradle
+++ b/dd-java-agent/instrumentation/scala-concurrent/build.gradle
@@ -11,21 +11,14 @@ muzzle {
 apply from: "$rootDir/gradle/java.gradle"
 apply plugin: 'scala' // Don't use test-with-scala since we want to pick our own version.
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
 /**
  * This project has instrumentation to support Scala's copy of ForkJoinPool which was added in 2.8 and removed in 2.11.
  * It also has additional generic tests for scala context propagation support beyond 2.11 which are covered in latest12Test and latestDepTest.
  */
-testSets {
-  latestDepTest
-  latest12Test {
-    dirName = 'latestDepTest'
-  }
-  latest11Test {
-    dirName = 'test'
-  }
-}
+addTestSuite('latestDepTest')
+addTestSuiteForDir('latest12Test', 'latestDepTest')
+addTestSuiteForDir('latest11Test', 'test')
+
 tasks.named("compileTestGroovy").configure {
   classpath += files(sourceSets.test.scala.classesDirectory)
 }

--- a/dd-java-agent/instrumentation/scala-promise/scala-promise-2.10/build.gradle
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise-2.10/build.gradle
@@ -25,17 +25,8 @@ project.ext.groovySkipJavaExclude = true
 apply from: "$rootDir/gradle/java.gradle"
 apply plugin: 'scala' // Don't use test-with-scala since we want to pick our own version.
 
-apply plugin: 'org.unbroken-dome.test-sets'
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-
-  latestDepForkedTest {
-    extendsFrom latestDepTest
-    dirName = 'forkedTest'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'forkedTest')
 
 apply from: "$rootDir/gradle/configure_tests.gradle"
 

--- a/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/build.gradle
+++ b/dd-java-agent/instrumentation/scala-promise/scala-promise-2.13/build.gradle
@@ -25,17 +25,8 @@ project.ext.groovySkipJavaExclude = true
 apply from: "$rootDir/gradle/java.gradle"
 apply plugin: 'scala' // Don't use test-with-scala since we want to pick our own version.
 
-apply plugin: 'org.unbroken-dome.test-sets'
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-
-  latestDepForkedTest {
-    extendsFrom latestDepTest
-    dirName = 'forkedTest'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'forkedTest')
 
 apply from: "$rootDir/gradle/configure_tests.gradle"
 

--- a/dd-java-agent/instrumentation/servlet/request-2/build.gradle
+++ b/dd-java-agent/instrumentation/servlet/request-2/build.gradle
@@ -22,13 +22,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'javax.servlet', name: 'servlet-api', version: '2.2'

--- a/dd-java-agent/instrumentation/servlet/request-3/build.gradle
+++ b/dd-java-agent/instrumentation/servlet/request-3/build.gradle
@@ -25,15 +25,9 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-
-apply plugin: 'org.unbroken-dome.test-sets'
 apply plugin: 'call-site-instrumentation'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   testRuntimeOnly project(':dd-java-agent:instrumentation:iast-instrumenter')

--- a/dd-java-agent/instrumentation/servlet/request-5/build.gradle
+++ b/dd-java-agent/instrumentation/servlet/request-5/build.gradle
@@ -9,8 +9,6 @@ muzzle {
 }
 
 apply from: "$rootDir/gradle/java.gradle"
-
-apply plugin: 'org.unbroken-dome.test-sets'
 apply plugin: 'call-site-instrumentation'
 
 // jakarta.servlet-api dependencies are compiled with Java 11 and

--- a/dd-java-agent/instrumentation/slick/build.gradle
+++ b/dd-java-agent/instrumentation/slick/build.gradle
@@ -8,13 +8,7 @@ muzzle {
 apply from: "$rootDir/gradle/java.gradle"
 apply plugin: 'scala'
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 tasks.named("compileTestGroovy").configure {
   dependsOn "compileTestScala"

--- a/dd-java-agent/instrumentation/sparkjava-2.3/build.gradle
+++ b/dd-java-agent/instrumentation/sparkjava-2.3/build.gradle
@@ -11,13 +11,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'com.sparkjava', name: 'spark-core', version: '2.3'

--- a/dd-java-agent/instrumentation/spray-1.3/build.gradle
+++ b/dd-java-agent/instrumentation/spray-1.3/build.gradle
@@ -12,8 +12,6 @@ muzzle {
 apply from: "${rootDir}/gradle/java.gradle"
 apply from: "${rootDir}/gradle/test-with-scala.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
 dependencies {
   compileOnly group: 'com.typesafe.akka', name: "akka-actor_$scalaVersion", version: '2.3.14'
   compileOnly group: 'io.spray', name: "spray-can_$scalaVersion", version: '1.3.1'

--- a/dd-java-agent/instrumentation/spring-data-1.8/build.gradle
+++ b/dd-java-agent/instrumentation/spring-data-1.8/build.gradle
@@ -25,13 +25,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 // DQH - API changes that impact instrumentation occurred in spring-data-commons in March 2014.
 // For now, that limits support to spring-data-commons 1.9.0 (maybe 1.8.0).

--- a/dd-java-agent/instrumentation/spring-jms-3.1/build.gradle
+++ b/dd-java-agent/instrumentation/spring-jms-3.1/build.gradle
@@ -9,18 +9,8 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-
-  latestDepForkedTest {
-    extendsFrom latestDepTest
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'test')
 
 apply from: "$rootDir/gradle/configure_tests.gradle"
 

--- a/dd-java-agent/instrumentation/spring-rabbit/build.gradle
+++ b/dd-java-agent/instrumentation/spring-rabbit/build.gradle
@@ -10,13 +10,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'org.springframework.amqp', name: 'spring-rabbit', version: '2.0.0.RELEASE'

--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/build.gradle
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/build.gradle
@@ -10,13 +10,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   // choose a recent version so that we can test both lambdas (JDK8)

--- a/dd-java-agent/instrumentation/spring-webflux-5/build.gradle
+++ b/dd-java-agent/instrumentation/spring-webflux-5/build.gradle
@@ -52,41 +52,15 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-
-  latestBoot20Test {
-    dirName = 'bootTest'
-  }
-
-  latestBoot24Test {
-    dirName = 'bootTest'
-  }
-
-  latestBoot2LatestTest {
-    dirName = 'bootTest'
-  }
-
-  iastTest {
-    dirName = 'iastTest'
-  }
-
-  latestIast24Test {
-    dirName = 'iastTest'
-  }
-
-  latestIastTest {
-    dirName = 'iastTest'
-  }
-
-  latestIast3Test {
-    dirName = 'iastTest'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteForDir('latestBoot20Test', 'bootTest')
+addTestSuiteForDir('latestBoot24Test', 'bootTest')
+addTestSuiteForDir('latestBoot2LatestTest', 'bootTest')
+addTestSuite('iastTest')
+addTestSuiteForDir('latestIast24Test', 'iastTest')
+addTestSuiteForDir('latestIastTest', 'iastTest')
+addTestSuiteForDir('latestIast3Test', 'iastTest')
 
 configurations {
   latestIast24TestImplementation.extendsFrom(iastTestImplementation)

--- a/dd-java-agent/instrumentation/spring-webflux-6/build.gradle
+++ b/dd-java-agent/instrumentation/spring-webflux-6/build.gradle
@@ -12,14 +12,8 @@ apply from: "$rootDir/gradle/java.gradle"
   }
 }
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
 // test that webflux5 instrumentation works for webflux6 too
-testSets {
-  iastTest {
-    dirName = 'iastTest'
-  }
-}
+addTestSuite('iastTest')
 
 tasks.named('muzzle').configure {
   enabled = false

--- a/dd-java-agent/instrumentation/spymemcached-2.12/build.gradle
+++ b/dd-java-agent/instrumentation/spymemcached-2.12/build.gradle
@@ -9,13 +9,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'net.spy', name: 'spymemcached', version: '2.12.0'

--- a/dd-java-agent/instrumentation/synapse-3/build.gradle
+++ b/dd-java-agent/instrumentation/synapse-3/build.gradle
@@ -8,14 +8,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
-
+addTestSuiteForDir('latestDepTest', 'test')
 configurations.all {
   // the version used by Synapse isn't available in a public repository - we don't need it, so exclude it
   exclude group: 'org.snmp4j', module: 'snmp4j'

--- a/dd-java-agent/instrumentation/tomcat-5.5/build.gradle
+++ b/dd-java-agent/instrumentation/tomcat-5.5/build.gradle
@@ -33,11 +33,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest
-}
+addTestSuite('latestDepTest')
 
 def tomcatVersion = '5.5.12' // earliest 5.5.x available in maven central (with all needed dependencies).
 

--- a/dd-java-agent/instrumentation/twilio/build.gradle
+++ b/dd-java-agent/instrumentation/twilio/build.gradle
@@ -8,11 +8,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest
-}
+addTestSuite('latestDepTest')
 
 dependencies {
   compileOnly group: 'com.twilio.sdk', name: 'twilio', version: '0.0.1'

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/build.gradle
@@ -9,13 +9,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'io.undertow', name: 'undertow-servlet', version: '2.0.0.Final'

--- a/dd-java-agent/instrumentation/undertow/undertow-2.2/build.gradle
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.2/build.gradle
@@ -9,13 +9,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'io.undertow', name: 'undertow-servlet-jakarta', version: '2.2.14.Final'

--- a/dd-java-agent/instrumentation/vertx-mysql-client-3.9/build.gradle
+++ b/dd-java-agent/instrumentation/vertx-mysql-client-3.9/build.gradle
@@ -15,18 +15,8 @@ muzzle {
   }
 }
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-
-  latestDepForkedTest {
-    extendsFrom latestDepTest
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'test')
 
 apply from: "$rootDir/gradle/configure_tests.gradle"
 

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/build.gradle
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/build.gradle
@@ -10,18 +10,8 @@ muzzle {
   }
 }
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-
-  latestDepForkedTest {
-    extendsFrom latestDepTest
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'test')
 
 apply from: "$rootDir/gradle/configure_tests.gradle"
 

--- a/dd-java-agent/instrumentation/vertx-rx-3.5/build.gradle
+++ b/dd-java-agent/instrumentation/vertx-rx-3.5/build.gradle
@@ -1,18 +1,8 @@
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-
-  latestDepForkedTest {
-    extendsFrom latestDepTest
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'test')
 
 apply from: "$rootDir/gradle/configure_tests.gradle"
 

--- a/dd-java-agent/instrumentation/vertx-web-3.4/build.gradle
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/build.gradle
@@ -6,8 +6,6 @@ ext {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
 muzzle {
   pass {
     group = 'io.vertx'
@@ -17,16 +15,8 @@ muzzle {
   }
 }
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-
-  latestDepForkedTest {
-    extendsFrom latestDepTest
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'test')
 
 apply from: "$rootDir/gradle/configure_tests.gradle"
 

--- a/dd-java-agent/instrumentation/vertx-web-3.5/build.gradle
+++ b/dd-java-agent/instrumentation/vertx-web-3.5/build.gradle
@@ -6,8 +6,6 @@ ext {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
 muzzle {
   pass {
     group = 'io.vertx'
@@ -17,16 +15,8 @@ muzzle {
   }
 }
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-
-  latestDepForkedTest {
-    extendsFrom latestDepTest
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'test')
 
 apply from: "$rootDir/gradle/configure_tests.gradle"
 

--- a/dd-java-agent/instrumentation/vertx-web-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/build.gradle
@@ -6,8 +6,6 @@ ext {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
 muzzle {
   pass {
     group = 'io.vertx'
@@ -17,11 +15,7 @@ muzzle {
   }
 }
 
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
+addTestSuiteForDir('latestDepTest', 'test')
 
 configurations {
   testArtifacts

--- a/dd-java-agent/instrumentation/zio/zio-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/zio/zio-2.0/build.gradle
@@ -25,14 +25,7 @@ muzzle {
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/test-with-scala.gradle"
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
-}
-
+addTestSuiteForDir('latestDepTest', 'test')
 tasks.named("compileLatestDepTestGroovy").configure {
   dependsOn "compileLatestDepTestScala"
   classpath += files(compileLatestDepTestScala.destinationDirectory)

--- a/dd-trace-core/build.gradle
+++ b/dd-trace-core/build.gradle
@@ -28,11 +28,7 @@ excludedClassesCoverage += [
   'datadog.trace.core.tagprocessor.QueryObfuscator.1'
 ]
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  traceAgentTest
-}
+addTestSuite('traceAgentTest')
 
 tasks.withType(Test).findByName('forkedTest').configure {
   // Needed for FootprintForkedTest on Java 17

--- a/dd-trace-ot/build.gradle
+++ b/dd-trace-ot/build.gradle
@@ -22,12 +22,8 @@ excludedClassesCoverage += [
   "datadog.opentracing.DDTracer.DDTracerBuilder"
 ]
 
-apply plugin: 'org.unbroken-dome.test-sets'
-
-testSets {
-  ot31CompatabilityTest
-  ot33CompatabilityTest
-}
+addTestSuite('ot31CompatabilityTest')
+addTestSuite('ot33CompatabilityTest')
 
 dependencies {
   annotationProcessor deps.autoserviceProcessor

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -1,3 +1,4 @@
+import org.gradle.api.plugins.jvm.JvmTestSuite
 import org.gradle.jvm.toolchain.internal.SpecificInstallationToolchainSpec
 
 apply plugin: 'java-library'
@@ -208,7 +209,7 @@ project.afterEvaluate {
       }
     }
 
-    if (project.plugins.hasPlugin('org.unbroken-dome.test-sets') && configurations.hasProperty("latestDepTestRuntime")) {
+    if (configurations.hasProperty("latestDepTestRuntimeClasspath")) {
       doFirst {
         def testArtifacts = configurations.testRuntimeClasspath.resolvedConfiguration.resolvedArtifacts
         def latestTestArtifacts = configurations.latestDepTestRuntimeClasspath.resolvedConfiguration.resolvedArtifacts
@@ -324,6 +325,80 @@ def isJdkExcluded(String javaName) {
 def getJavaHomePath(String path) {
   def javaHome = new File(path).toPath().toRealPath()
   return javaHome.endsWith("jre") ? javaHome.parent : javaHome
+}
+
+ext.addTestSuiteExtendingForDir = (String testSuiteName, String parentSuiteName, String dirName) -> {
+  testing {
+    suites {
+      create(testSuiteName, JvmTestSuite, {
+        sources {
+          java {
+            srcDirs = ["src/$dirName/java"]
+          }
+          resources {
+            srcDirs = ["src/$dirName/resources"]
+          }
+          if (project.plugins.hasPlugin('groovy')) {
+            groovy {
+              srcDirs = ["src/$dirName/groovy"]
+            }
+          }
+          if (project.plugins.hasPlugin('kotlin')) {
+            kotlin {
+              srcDirs = ["src/$dirName/kotlin"]
+            }
+          }
+          if (project.plugins.hasPlugin('scala')) {
+            scala {
+              srcDirs = ["src/$dirName/scala"]
+            }
+          }
+        }
+        dependencies {
+          implementation project
+        }
+      })
+    }
+  }
+
+  configurations {
+    def provider = named("${parentSuiteName}CompileOnly")
+    if (provider.present) {
+      named("${testSuiteName}CompileOnly").configure { extendsFrom(provider.get()) }
+    }
+    provider = named("${parentSuiteName}Implementation")
+    if (provider.present) {
+      named("${testSuiteName}Implementation").configure { extendsFrom(provider.get()) }
+    }
+    provider = named("${parentSuiteName}RuntimeOnly")
+    if (provider.present) {
+      named("${testSuiteName}RuntimeOnly").configure { extendsFrom(provider.get()) }
+    }
+    provider = named("${parentSuiteName}AnnotationProcessor")
+    if (provider.present) {
+      named("${testSuiteName}AnnotationProcessor").configure { extendsFrom(provider.get()) }
+    }
+  }
+
+  tasks.register("${testSuiteName}Jar", Jar) {
+    dependsOn(tasks.named("${testSuiteName}Classes").get())
+    from(sourceSets.named(testSuiteName).get().output)
+    archiveClassifier = testSuiteName
+  }
+}
+
+ext.addTestSuiteForDir = (String testSuiteName, String dirName) -> {
+  ext.addTestSuiteExtendingForDir(testSuiteName, 'test', dirName)
+}
+
+ext.addTestSuite = (String testSuiteName) -> {
+  ext.addTestSuiteForDir(testSuiteName, testSuiteName)
+}
+
+tasks.register('testJar', Jar) {
+  dependsOn(testClasses)
+  from sourceSets.test.output
+  archiveClassifier = 'test'
 }
 
 apply from: "$rootDir/gradle/configure_tests.gradle"


### PR DESCRIPTION
# What Does This Do

Removes the use of the abandoned `test-sets` plugin

# Motivation

It's incompatible with gradle 8

# Additional Notes
