### PR TITLE
Fix enablement of the ddprof profiler in standalone mode

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-ddprof/src/main/java/com/datadog/profiling/controller/ddprof/DatadogProfilerController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-ddprof/src/main/java/com/datadog/profiling/controller/ddprof/DatadogProfilerController.java
@@ -18,6 +18,7 @@ package com.datadog.profiling.controller.ddprof;
 import com.datadog.profiling.controller.Controller;
 import com.datadog.profiling.controller.UnsupportedEnvironmentException;
 import com.datadog.profiling.ddprof.DatadogProfiler;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import java.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +38,10 @@ public final class DatadogProfilerController implements Controller {
    */
   public DatadogProfilerController() {
     this(DatadogProfiler.getInstance());
+  }
+
+  public DatadogProfilerController(ConfigProvider configProvider) {
+    this(DatadogProfiler.newInstance(configProvider));
   }
 
   DatadogProfilerController(DatadogProfiler datadogProfiler) {

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ControllerFactory.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ControllerFactory.java
@@ -100,7 +100,7 @@ public final class ControllerFactory {
     }
 
     try {
-      log.debug("Trying to load " + impl.className());
+      log.debug("Trying to load {}", impl.className());
       return Class.forName(impl.className())
           .asSubclass(Controller.class)
           .getDeclaredConstructor(ConfigProvider.class)

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -87,7 +87,13 @@ public final class DatadogProfiler {
     return instance;
   }
 
-  static DatadogProfiler newInstance(ConfigProvider configProvider) {
+  public static DatadogProfiler newInstance(ConfigProvider configProvider) {
+    // do not recreate the default instance
+    // it is ok to use identity check as we are requiring the exact same instance
+    if (configProvider == Singleton.INSTANCE.configProvider) {
+      return Singleton.INSTANCE;
+    }
+
     DatadogProfiler instance = null;
     try {
       instance = new DatadogProfiler(configProvider);


### PR DESCRIPTION
# What Does This Do
Fixes the logic used to detect and instantiate a standalone ddprof profiler (when OpenJDK profiler is not available eg.)

# Motivation
Currently it is not possible to use profiler on non-OpenJDK and non-OracleJDK platforms.

# Additional Notes
