### PR TITLE
Try enabling smoke test for the latest OpenJ9

### DIFF
--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/DisableOnJ9Condition.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/DisableOnJ9Condition.java
@@ -8,8 +8,15 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 public final class DisableOnJ9Condition implements ExecutionCondition {
   @Override
   public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-    return Platform.isJ9()
-        ? ConditionEvaluationResult.disabled("Profiling context is not supported for J9")
-        : ConditionEvaluationResult.enabled("");
+    return isDdprofSupported()
+        ? ConditionEvaluationResult.enabled("")
+        : ConditionEvaluationResult.disabled("Profiling context is not supported for J9");
+  }
+
+  private static boolean isDdprofSupported() {
+    return !Platform.isJ9()
+        || (Platform.isJavaVersion(8) && Platform.isJavaVersion(8, 0, 361))
+        || Platform.isJavaVersionAtLeast(11, 0, 18)
+        || Platform.isJavaVersionAtLeast(17, 0, 6);
   }
 }


### PR DESCRIPTION
# What Does This Do
Re-enables CodeHotspot profiler smoke test for recent J9 JDKs

# Motivation
The recent update to OpenJ9 (and J9 based JDKs) made it possible to use the ddprof library for profiling so it makes sense to assert the functionality.

# Additional Notes
