### PR TITLE
Add flag DD_TELEMETRY_METRICS_ENABLED disabled by default

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastSystem.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastSystem.java
@@ -23,6 +23,7 @@ import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.SubscriptionService;
 import datadog.trace.api.iast.IastModule;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.telemetry.Verbosity;
 import datadog.trace.util.AgentTaskScheduler;
 import datadog.trace.util.stacktrace.StackWalkerFactory;
 import java.util.function.BiFunction;
@@ -57,7 +58,7 @@ public class IastSystem {
       overheadController = OverheadController.build(config, AgentTaskScheduler.INSTANCE);
     }
     if (telemetry == null) {
-      telemetry = IastTelemetry.build(config);
+      telemetry = IastTelemetry.build(Verbosity.getLevel());
     }
     final Dependencies dependencies =
         new Dependencies(

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/telemetry/IastTelemetry.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/telemetry/IastTelemetry.java
@@ -1,7 +1,6 @@
 package com.datadog.iast.telemetry;
 
 import com.datadog.iast.IastRequestContext;
-import datadog.trace.api.Config;
 import datadog.trace.api.iast.telemetry.Verbosity;
 import datadog.trace.api.internal.TraceSegment;
 import javax.annotation.Nonnull;
@@ -12,9 +11,8 @@ public interface IastTelemetry {
 
   void onRequestEnded(IastRequestContext context, TraceSegment trace);
 
-  static IastTelemetry build(@Nonnull final Config config) {
-    final Verbosity verbosity = config.getIastTelemetryVerbosity();
-    if (!config.isTelemetryEnabled() || verbosity == Verbosity.OFF) {
+  static IastTelemetry build(@Nonnull final Verbosity verbosity) {
+    if (verbosity == Verbosity.OFF) {
       return new NoOpTelemetry();
     }
     return new IastTelemetryImpl(verbosity);

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/telemetry/IastTelemetryTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/telemetry/IastTelemetryTest.groovy
@@ -1,7 +1,6 @@
 package com.datadog.iast.telemetry
 
 import com.datadog.iast.IastRequestContext
-import datadog.trace.api.Config
 import datadog.trace.api.internal.TraceSegment
 import datadog.trace.api.iast.telemetry.IastMetric
 import datadog.trace.api.iast.telemetry.IastTelemetryCollector
@@ -13,21 +12,14 @@ import groovy.transform.CompileDynamic
 class IastTelemetryTest extends DDSpecification {
 
   void 'test builder'() {
-    given:
-    final config = Mock(Config) {
-      isTelemetryEnabled() >> { verbosity != null }
-      getIastTelemetryVerbosity() >> verbosity
-    }
-
     when:
-    final telemetry = IastTelemetry.build(config)
+    final telemetry = IastTelemetry.build(verbosity)
 
     then:
     instance.isInstance(telemetry)
 
     where:
     verbosity             | instance
-    null                  | NoOpTelemetry
     Verbosity.OFF         | NoOpTelemetry
     Verbosity.MANDATORY   | IastTelemetryImpl
     Verbosity.INFORMATION | IastTelemetryImpl

--- a/dd-java-agent/instrumentation/iast-instrumenter/src/main/java/datadog/trace/instrumentation/iastinstrumenter/IastInstrumentation.java
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/main/java/datadog/trace/instrumentation/iastinstrumenter/IastInstrumentation.java
@@ -5,7 +5,6 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.csi.CallSiteInstrumentation;
 import datadog.trace.agent.tooling.bytebuddy.csi.CallSiteSupplier;
 import datadog.trace.agent.tooling.csi.CallSiteAdvice;
-import datadog.trace.api.Config;
 import datadog.trace.api.iast.IastAdvice;
 import datadog.trace.api.iast.telemetry.Verbosity;
 import datadog.trace.instrumentation.iastinstrumenter.telemetry.TelemetryCallSiteSupplier;
@@ -52,9 +51,8 @@ public class IastInstrumentation extends CallSiteInstrumentation {
 
     static {
       CallSiteSupplier supplier = new IastCallSiteSupplier(IastAdvice.class);
-      final Config config = Config.get();
-      final Verbosity verbosity = config.getIastTelemetryVerbosity();
-      if (config.isTelemetryEnabled() && verbosity != Verbosity.OFF) {
+      final Verbosity verbosity = Verbosity.getLevel();
+      if (verbosity != Verbosity.OFF) {
         supplier = new TelemetryCallSiteSupplier(verbosity, supplier);
       }
       INSTANCE = supplier;

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -147,6 +147,7 @@ public final class ConfigDefaults {
   static final int DEFAULT_TELEMETRY_HEARTBEAT_INTERVAL = 60; // in seconds
   static final int DEFAULT_TELEMETRY_METRICS_INTERVAL = 10; // in seconds
   static final boolean DEFAULT_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED = true;
+  static final boolean DEFAULT_TELEMETRY_METRICS_ENABLED = false;
 
   static final boolean DEFAULT_TRACE_128_BIT_TRACEID_GENERATION_ENABLED = false;
   static final boolean DEFAULT_TRACE_128_BIT_TRACEID_LOGGING_ENABLED = false;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -59,6 +59,7 @@ public final class GeneralConfig {
   public static final String TELEMETRY_METRICS_INTERVAL = "telemetry.metrics.interval";
   public static final String TELEMETRY_DEPENDENCY_COLLECTION_ENABLED =
       "telemetry.dependency-collection.enabled";
+  public static final String TELEMETRY_METRICS_ENABLED = "telemetry.metrics.enabled";
 
   private GeneralConfig() {}
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
@@ -121,6 +121,8 @@ public final class StatusLogger extends JsonAdapter<Config>
     writer.value(config.getAppSecRulesFile());
     writer.name("telemetry_enabled");
     writer.value(config.isTelemetryEnabled());
+    writer.name("telemetry_metrics_enabled");
+    writer.value(config.isTelemetryMetricsEnabled());
     writer.name("dd_version");
     writer.value(config.getVersion());
     writer.name("health_checks_enabled");

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -65,6 +65,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVLET_ROOT_CONTEXT_SERV
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SITE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TELEMETRY_HEARTBEAT_INTERVAL;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TELEMETRY_METRICS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TELEMETRY_METRICS_INTERVAL;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_128_BIT_TRACEID_GENERATION_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_PORT;
@@ -145,6 +146,7 @@ import static datadog.trace.api.config.GeneralConfig.SITE;
 import static datadog.trace.api.config.GeneralConfig.TAGS;
 import static datadog.trace.api.config.GeneralConfig.TELEMETRY_DEPENDENCY_COLLECTION_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.TELEMETRY_HEARTBEAT_INTERVAL;
+import static datadog.trace.api.config.GeneralConfig.TELEMETRY_METRICS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.TELEMETRY_METRICS_INTERVAL;
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_BUFFERING_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_ENABLED;
@@ -644,6 +646,7 @@ public class Config {
   private final int telemetryHeartbeatInterval;
   private final int telemetryMetricsInterval;
   private final boolean isTelemetryDependencyServiceEnabled;
+  private final boolean telemetryMetricsEnabled;
 
   private final boolean azureAppServices;
   private final String traceAgentPath;
@@ -1219,6 +1222,9 @@ public class Config {
         configProvider.getBoolean(
             TELEMETRY_DEPENDENCY_COLLECTION_ENABLED,
             DEFAULT_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED);
+
+    telemetryMetricsEnabled =
+        configProvider.getBoolean(TELEMETRY_METRICS_ENABLED, DEFAULT_TELEMETRY_METRICS_ENABLED);
 
     clientIpEnabled = configProvider.getBoolean(CLIENT_IP_ENABLED, DEFAULT_CLIENT_IP_ENABLED);
 
@@ -1953,6 +1959,10 @@ public class Config {
 
   public boolean isTelemetryDependencyServiceEnabled() {
     return isTelemetryDependencyServiceEnabled;
+  }
+
+  public boolean isTelemetryMetricsEnabled() {
+    return telemetryMetricsEnabled;
   }
 
   public boolean isClientIpEnabled() {

--- a/internal-api/src/main/java/datadog/trace/api/MetricCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/MetricCollector.java
@@ -31,29 +31,47 @@ public class MetricCollector {
   private static final AtomicRequestCounter wafBlockedRequestCounter = new AtomicRequestCounter();
 
   public boolean wafInit(String wafVersion, String rulesVersion) {
+    if (!Config.get().isTelemetryMetricsEnabled()) {
+      return true;
+    }
     return rawMetricsQueue.offer(
         new WafInitRawMetric(wafInitCounter.incrementAndGet(), wafVersion, rulesVersion));
   }
 
   public boolean wafUpdates(String rulesVersion) {
+    if (!Config.get().isTelemetryMetricsEnabled()) {
+      return true;
+    }
     return rawMetricsQueue.offer(
         new WafUpdatesRawMetric(wafUpdatesCounter.incrementAndGet(), rulesVersion));
   }
 
   public void wafRequest() {
+    if (!Config.get().isTelemetryMetricsEnabled()) {
+      return;
+    }
     wafRequestCounter.increment();
   }
 
   public void wafRequestTriggered() {
+    if (!Config.get().isTelemetryMetricsEnabled()) {
+      return;
+    }
     wafTriggeredRequestCounter.increment();
   }
 
   public void wafRequestBlocked() {
+    if (!Config.get().isTelemetryMetricsEnabled()) {
+      return;
+    }
     wafTriggeredRequestCounter.increment(); // Blocked requests are also triggered
     wafBlockedRequestCounter.increment();
   }
 
   public Collection<RawMetric> drain() {
+    if (!Config.get().isTelemetryMetricsEnabled()) {
+      return Collections.emptyList();
+    }
     if (!rawMetricsQueue.isEmpty()) {
       List<RawMetric> list = new LinkedList<>();
       int drained = rawMetricsQueue.drainTo(list);
@@ -65,6 +83,10 @@ public class MetricCollector {
   }
 
   public boolean prepareRequestMetrics() {
+    if (!Config.get().isTelemetryMetricsEnabled()) {
+      return true;
+    }
+
     // Requests
     if (wafRequestCounter.get() > 0) {
       if (!rawMetricsQueue.offer(

--- a/internal-api/src/main/java/datadog/trace/api/iast/telemetry/IastTelemetryCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/telemetry/IastTelemetryCollector.java
@@ -4,7 +4,6 @@ import static datadog.trace.api.iast.telemetry.IastMetric.Scope.REQUEST;
 import static datadog.trace.api.iast.telemetry.IastMetricHandler.aggregated;
 import static datadog.trace.api.iast.telemetry.IastMetricHandler.conflated;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -48,8 +47,7 @@ public interface IastTelemetryCollector {
 
     // visible for testing
     static IastTelemetryCollector globalCollector() {
-      final Config config = Config.get();
-      if (!config.isTelemetryEnabled() || config.getIastTelemetryVerbosity() == Verbosity.OFF) {
+      if (Verbosity.getLevel() == Verbosity.OFF) {
         return new NoOpTelemetryCollector();
       }
       return new IastTelemetryCollectorImpl(Holder::globalHandlerFor);

--- a/internal-api/src/main/java/datadog/trace/api/iast/telemetry/Verbosity.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/telemetry/Verbosity.java
@@ -1,5 +1,7 @@
 package datadog.trace.api.iast.telemetry;
 
+import datadog.trace.api.Config;
+
 public enum Verbosity {
   OFF,
   MANDATORY,
@@ -20,5 +22,14 @@ public enum Verbosity {
 
   public boolean isMandatoryEnabled() {
     return isEnabled(MANDATORY);
+  }
+
+  public static Verbosity getLevel() {
+    Config config = Config.get();
+    if (!config.isTelemetryEnabled() || !config.isTelemetryMetricsEnabled()) {
+      return Verbosity.OFF;
+    } else {
+      return config.getIastTelemetryVerbosity();
+    }
   }
 }

--- a/internal-api/src/test/groovy/datadog/trace/api/iast/telemetry/VerbosityTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/iast/telemetry/VerbosityTest.groovy
@@ -1,10 +1,10 @@
 package datadog.trace.api.iast.telemetry
 
+import datadog.trace.test.util.DDSpecification
 import groovy.transform.CompileDynamic
-import spock.lang.Specification
 
 @CompileDynamic
-class VerbosityTest extends Specification {
+class VerbosityTest extends DDSpecification {
 
   void 'test level is enabled'() {
     when:
@@ -16,6 +16,26 @@ class VerbosityTest extends Specification {
     debug == verbosity.ordinal() >= Verbosity.DEBUG.ordinal()
     info == verbosity.ordinal() >= Verbosity.INFORMATION.ordinal()
     mandatory == verbosity.ordinal() >= Verbosity.MANDATORY.ordinal()
+
+    where:
+    verbosity << Verbosity.values().toList()
+  }
+
+  void 'test get level'() {
+    given:
+    injectSysConfig('dd.iast.telemetry.verbosity', verbosity.name())
+
+    when:
+    injectSysConfig('dd.telemetry.metrics.enabled', 'true')
+
+    then:
+    Verbosity.getLevel() == verbosity
+
+    then:
+    injectSysConfig('dd.telemetry.metrics.enabled', 'false')
+
+    then:
+    Verbosity.getLevel() == Verbosity.OFF
 
     where:
     verbosity << Verbosity.values().toList()

--- a/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
@@ -45,8 +45,10 @@ public class TelemetrySystem {
 
     List<TelemetryPeriodicAction> actions = new ArrayList<>();
     actions.add(new IntegrationPeriodicAction());
-    actions.add(new MetricPeriodicAction());
-    if (Verbosity.OFF != Config.get().getIastTelemetryVerbosity()) {
+    if (Config.get().isTelemetryMetricsEnabled()) {
+      actions.add(new MetricPeriodicAction());
+    }
+    if (Verbosity.OFF != Verbosity.getLevel()) {
       actions.add(new IastTelemetryPeriodicAction());
     }
     if (null != dependencyService) {


### PR DESCRIPTION
# What Does This Do
Adds a new flag to disable telemetry metrics by default.

# Motivation
Disables the telemetry payloads until the telemetry-intake is ready.

# Additional Notes
