### PR TITLE
Support AWS Lambda parent inheritance

### DIFF
--- a/dd-java-agent/instrumentation/aws-lambda-handler/src/main/java/datadog/trace/instrumentation/aws/v1/lambda/LambdaHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/src/main/java/datadog/trace/instrumentation/aws/v1/lambda/LambdaHandlerInstrumentation.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.aws.v1.lambda;
 
-import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.aws.v1.lambda.LambdaHandlerDecorator.INVOCATION_SPAN_NAME;
@@ -18,13 +18,13 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import net.bytebuddy.asm.Advice;
 
 @AutoService(Instrumenter.class)
 public class LambdaHandlerInstrumentation extends Instrumenter.Tracing
-    implements Instrumenter.ForTypeHierarchy  {
+    implements Instrumenter.ForTypeHierarchy {
 
   // these must remain as String literals so they can be easily be shared (copied) with the nested
   // advice classes
@@ -41,7 +41,9 @@ public class LambdaHandlerInstrumentation extends Instrumenter.Tracing
 
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
-    return implementsInterface(named(hierarchyMarkerType()));
+    return implementsInterface(
+        named(hierarchyMarkerType())
+            .or(named("com.amazonaws.services.lambda.runtime.RequestStreamHandler")));
   }
 
   @Override
@@ -72,7 +74,7 @@ public class LambdaHandlerInstrumentation extends Instrumenter.Tracing
             .and(takesArgument(2, named("com.amazonaws.services.lambda.runtime.Context"))),
         getClass().getName() + "$ExtensionCommunicationAdvice");
     // full spec here : https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
-    
+
   }
 
   public static class ExtensionCommunicationAdvice {

--- a/dd-java-agent/instrumentation/aws-lambda-handler/src/main/java/datadog/trace/instrumentation/aws/v1/lambda/LambdaHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/src/main/java/datadog/trace/instrumentation/aws/v1/lambda/LambdaHandlerInstrumentation.java
@@ -17,6 +17,7 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.asm.Advice;
 
 @AutoService(Instrumenter.class)

--- a/dd-java-agent/instrumentation/aws-lambda-handler/src/main/java/datadog/trace/instrumentation/aws/v1/lambda/LambdaHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/src/main/java/datadog/trace/instrumentation/aws/v1/lambda/LambdaHandlerInstrumentation.java
@@ -18,6 +18,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.asm.Advice;
 
 @AutoService(Instrumenter.class)

--- a/dd-java-agent/instrumentation/aws-lambda-handler/src/main/java/datadog/trace/instrumentation/aws/v1/lambda/LambdaHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/src/main/java/datadog/trace/instrumentation/aws/v1/lambda/LambdaHandlerInstrumentation.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.aws.v1.lambda;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.aws.v1.lambda.LambdaHandlerDecorator.INVOCATION_SPAN_NAME;

--- a/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/HandlerStreaming.java
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/HandlerStreaming.java
@@ -17,7 +17,5 @@ public class HandlerStreaming implements RequestStreamHandler {
             new BufferedWriter(new OutputStreamWriter(outputStream, Charset.forName("US-ASCII"))));
     writer.write("Hello World!");
     writer.close();
-
-    return "hello";
   }
 }

--- a/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/HandlerStreaming.java
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/HandlerStreaming.java
@@ -1,21 +1,12 @@
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
-import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.nio.charset.Charset;
 
 public class HandlerStreaming implements RequestStreamHandler {
   @Override
   public void handleRequest(InputStream inputStream, OutputStream outputStream, Context context)
       throws IOException {
-    PrintWriter writer =
-        new PrintWriter(
-            new BufferedWriter(new OutputStreamWriter(outputStream, Charset.forName("US-ASCII"))));
-    writer.write("Hello World!");
-    writer.close();
   }
 }

--- a/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/HandlerStreaming.java
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/HandlerStreaming.java
@@ -2,6 +2,7 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.IOException
 
 public class HandlerStreaming implements RequestStreamHandler {
   @Override

--- a/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/HandlerStreaming.java
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/HandlerStreaming.java
@@ -1,8 +1,8 @@
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.IOException
 
 public class HandlerStreaming implements RequestStreamHandler {
   @Override

--- a/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/HandlerStreaming.java
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/HandlerStreaming.java
@@ -7,6 +7,5 @@ import java.io.OutputStream;
 public class HandlerStreaming implements RequestStreamHandler {
   @Override
   public void handleRequest(InputStream inputStream, OutputStream outputStream, Context context)
-      throws IOException {
-  }
+      throws IOException {}
 }

--- a/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/HandlerStreaming.java
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/HandlerStreaming.java
@@ -1,11 +1,21 @@
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 
 public class HandlerStreaming implements RequestStreamHandler {
   @Override
   public void handleRequest(InputStream inputStream, OutputStream outputStream, Context context)
-      throws IOException {}
+      throws IOException {
+    PrintWriter writer =
+        new PrintWriter(
+            new BufferedWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)));
+    writer.write("Hello World!");
+    writer.close();
+  }
 }

--- a/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/HandlerStreaming.java
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/HandlerStreaming.java
@@ -1,0 +1,18 @@
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class HandlerStreaming implements RequestStreamHandler {
+  @Override
+  public String handleRequest(InputStream inputStream, OutputStream outputStream, Context context)
+      throws IOException {
+    PrintWriter writer =
+        new PrintWriter(
+            new BufferedWriter(new OutputStreamWriter(outputStream, Charset.forName("US-ASCII"))));
+    writer.write("Hello World!");
+    writer.close();
+
+    return "hello";
+  }
+}

--- a/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/HandlerStreaming.java
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/HandlerStreaming.java
@@ -1,8 +1,12 @@
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.charset.Charset;
 
 public class HandlerStreaming implements RequestStreamHandler {
   @Override

--- a/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/HandlerStreaming.java
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/HandlerStreaming.java
@@ -10,7 +10,7 @@ import java.nio.charset.Charset;
 
 public class HandlerStreaming implements RequestStreamHandler {
   @Override
-  public String handleRequest(InputStream inputStream, OutputStream outputStream, Context context)
+  public void handleRequest(InputStream inputStream, OutputStream outputStream, Context context)
       throws IOException {
     PrintWriter writer =
         new PrintWriter(

--- a/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/LambdaHandlerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/LambdaHandlerInstrumentationTest.groovy
@@ -1,9 +1,5 @@
 import datadog.trace.agent.test.naming.VersionedNamingTestBase
-import java.io.InputStream
-import java.io.OutputStream
 import java.nio.charset.StandardCharsets
-import java.io.ByteArrayOutputStream
-import java.io.ByteArrayInputStream
 
 abstract class LambdaHandlerInstrumentationTest extends VersionedNamingTestBase {
 

--- a/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/LambdaHandlerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/LambdaHandlerInstrumentationTest.groovy
@@ -22,6 +22,21 @@ abstract class LambdaHandlerInstrumentationTest extends VersionedNamingTestBase 
       }
     }
   }
+
+  def "test lambda streaming handler"() {
+    when:
+    new HandlerStreaming().handleRequest(null, null)
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName operation()
+          errored false
+        }
+      }
+    }
+  }
 }
 
 

--- a/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/LambdaHandlerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/LambdaHandlerInstrumentationTest.groovy
@@ -1,4 +1,9 @@
 import datadog.trace.agent.test.naming.VersionedNamingTestBase
+import java.io.InputStream
+import java.io.OutputStream
+import java.nio.charset.StandardCharsets
+import java.io.ByteArrayOutputStream
+import java.io.ByteArrayInputStream
 
 abstract class LambdaHandlerInstrumentationTest extends VersionedNamingTestBase {
 
@@ -24,7 +29,9 @@ abstract class LambdaHandlerInstrumentationTest extends VersionedNamingTestBase 
 
   def "test lambda streaming handler"() {
     when:
-    new HandlerStreaming().handleRequest(null, null)
+    def input = new ByteArrayInputStream(StandardCharsets.UTF_8.encode("Hello").array())
+    def output = new ByteArrayOutputStream()
+    new HandlerStreaming().handleRequest(input, output, null)
 
     then:
     assertTraces(1) {

--- a/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/LambdaHandlerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/LambdaHandlerInstrumentationTest.groovy
@@ -8,22 +8,6 @@ abstract class LambdaHandlerInstrumentationTest extends VersionedNamingTestBase 
     null
   }
 
-  def "test constructor"() {
-    when:
-    environmentVariables.set("_HANDLER", handlerEnv)
-    def objTest = new LambdaHandlerInstrumentation()
-
-    then:
-    objTest.configuredMatchingType() == instrumentedType
-    objTest.getMethodName() == methodName
-    environmentVariables.clear("_HANDLER")
-
-    where:
-    instrumentedType     | methodName        | handlerEnv
-    "example.Handler"    | "mySuperHandler"  | "example.Handler::mySuperHandler"
-    "package.type"       | "handleRequest"   | "package.type"
-  }
-
   def "test lambda handler"() {
     when:
     new Handler().handleRequest(null, null)

--- a/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/LambdaHandlerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/src/test/groovy/LambdaHandlerInstrumentationTest.groovy
@@ -1,5 +1,4 @@
 import datadog.trace.agent.test.naming.VersionedNamingTestBase
-import datadog.trace.instrumentation.aws.v1.lambda.LambdaHandlerInstrumentation
 
 abstract class LambdaHandlerInstrumentationTest extends VersionedNamingTestBase {
 


### PR DESCRIPTION
# What Does This Do

Fixes a bug with Lambda span generation, when using an abstract base class. 
Also fixes a bug where com.amazonaws.services.lambda.runtime.RequestStreamHandler was not being wrapped correctly, because it has a void return type, which the ExtensionAdvice class wasn't matching properly. I've added a test case for this.

Before:
<img width="1065" alt="Screenshot 2023-04-19 at 5 04 24 PM" src="https://user-images.githubusercontent.com/50632605/233199740-874fdb4e-c144-40ec-85c4-bf7ae3dd0c77.png">
After:
<img width="1065" alt="Screenshot 2023-04-19 at 4 52 58 PM" src="https://user-images.githubusercontent.com/50632605/233198501-43fb5126-05f6-4a21-b587-67d65214353a.png">

# Motivation

If a customer creates an Abstract Base Class, which implements the `com.amazonaws.services.lambda.runtime.RequestHandler`, currently our instrumentation won't correctly wrap the `handleRequest` method, leading to broken traces. This changes the instrumentation matcher to find all classes in the hierachy which implement the RequestHandler interface.

# Additional Notes
