### PR TITLE
When the OpenTracing wrapper is closed, flush any traces but keep the wrapped tracer open

### DIFF
--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTTracer.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTTracer.java
@@ -82,7 +82,7 @@ public class OTTracer implements Tracer {
 
   @Override
   public void close() {
-    tracer.close();
+    tracer.flush(); // keep wrapped tracer open
   }
 
   public class OTSpanBuilder implements Tracer.SpanBuilder {


### PR DESCRIPTION
# Motivation

Avoids a situation when the OpenTracing `Tracer.close()` method is called when Wildfly applications are re-deployed, prematurely closing the wrapped Datadog tracer.