### PR TITLE
Improve OpenTelemetry instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelSpan.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelSpan.java
@@ -41,7 +41,7 @@ public class OtelSpan implements Span {
 
   @Override
   public <T> Span setAttribute(AttributeKey<T> key, T value) {
-    this.delegate.setTag(key.getKey(), value);
+    this.delegate.setAttribute(key.getKey(), value);
     return this;
   }
 

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelSpanContext.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelSpanContext.java
@@ -21,7 +21,9 @@ public class OtelSpanContext implements SpanContext {
 
   public static SpanContext fromLocalSpan(AgentSpan span) {
     AgentSpan.Context delegate = span.context();
-    boolean sampled = span.getSamplingPriority() != null && span.getSamplingPriority() > 0;
+    AgentSpan localRootSpan = span.getLocalRootSpan();
+    Integer samplingPriority = localRootSpan.getSamplingPriority();
+    boolean sampled = samplingPriority != null && samplingPriority > 0;
     return new OtelSpanContext(delegate, sampled, false);
   }
 

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
@@ -337,7 +337,7 @@ class OpenTelemetry14Test extends AgentTestRunner {
         span {
           parent()
           operationName "other-name"
-          resourceName "other-name"
+          resourceName "some-name"
         }
       }
     }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
@@ -154,6 +154,7 @@ class OpenTelemetry14Test extends AgentTestRunner {
     if (tagBuilder) {
       builder.setAttribute(DDTags.RESOURCE_NAME, "some-resource")
         .setAttribute("string", "a")
+        .setAttribute("empty_string", "")
         .setAttribute("number", 1)
         .setAttribute("boolean", true)
     }
@@ -161,6 +162,7 @@ class OpenTelemetry14Test extends AgentTestRunner {
     if (tagSpan) {
       result.setAttribute(DDTags.RESOURCE_NAME, "other-resource")
       result.setAttribute("string", "b")
+      result.setAttribute("empty_string", "")
       result.setAttribute("number", 2)
       result.setAttribute("boolean", false)
     }
@@ -185,10 +187,12 @@ class OpenTelemetry14Test extends AgentTestRunner {
           tags {
             if (tagSpan) {
               "string" "b"
+              "empty_string" ""
               "number" 2
               "boolean" false
             } else if (tagBuilder) {
               "string" "a"
+              "empty_string" ""
               "number" 1
               "boolean" true
             }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1328,7 +1328,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       if (tagMap == null) {
         tags = tagMap = new LinkedHashMap<>(); // Insertion order is important
       }
-      if (value == null || (value instanceof String && ((String) value).isEmpty())) {
+      if (value == null) {
         tagMap.remove(tag);
       } else {
         tagMap.put(tag, value);

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -327,13 +327,27 @@ public class DDSpan
 
   @Override
   public final DDSpan setTag(final String tag, final String value) {
-    context.setTag(tag, value);
+    if (value == null || value.isEmpty()) {
+      // Remove the tag
+      context.setTag(tag, null);
+    } else {
+      context.setTag(tag, value);
+    }
     return this;
   }
 
   @Override
   public final DDSpan setTag(final String tag, final boolean value) {
     context.setTag(tag, value);
+    return this;
+  }
+
+  @Override
+  public AgentSpan setAttribute(String key, Object value) {
+    if (key == null || key.isEmpty() || value == null) {
+      return this;
+    }
+    this.context.setTag(key, value);
     return this;
   }
 
@@ -408,7 +422,12 @@ public class DDSpan
 
   @Override
   public DDSpan setTag(final String tag, final CharSequence value) {
-    context.setTag(tag, value);
+    if (value == null || value.length() == 0) {
+      // Remove the tag
+      context.setTag(tag, null);
+    } else {
+      context.setTag(tag, value);
+    }
     return this;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -631,13 +631,16 @@ public class DDSpanContext
   }
 
   /**
-   * Add a tag to the span. Tags are not propagated to the children
+   * Sets a tag to the span. Tags are not propagated to the children.
    *
-   * @param tag the tag-name
-   * @param value the value of the tag. tags with null values are ignored.
+   * <p>Existing tag value with the same value will be replaced. Setting a tag with a {@code null}
+   * value will remove the tag from the span.
+   *
+   * @param tag The tag name.
+   * @param value The nullable tag value.
    */
   public void setTag(final String tag, final Object value) {
-    if (null == value || "".equals(value)) {
+    if (null == value) {
       synchronized (unsafeTags) {
         unsafeTags.remove(tag);
       }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -31,6 +31,18 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo {
   @Override
   AgentSpan setTag(String key, Number value);
 
+  /**
+   * Set a span attribute.
+   *
+   * <p>Existing attributes with the same name will be replaced. Setting a {@code null} value will
+   * do nothing.
+   *
+   * @param key The span attribute key.
+   * @param value The span attribute value.
+   * @return The span instance.
+   */
+  AgentSpan setAttribute(String key, Object value);
+
   @Override
   AgentSpan setMetric(CharSequence key, int value);
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -493,6 +493,11 @@ public class AgentTracer {
     }
 
     @Override
+    public AgentSpan setAttribute(String key, Object value) {
+      return this;
+    }
+
+    @Override
     public AgentSpan setMetric(final CharSequence key, final int value) {
       return this;
     }


### PR DESCRIPTION
# What Does This Do

Add empty string value support for span attribute,
Fix span context sampling flag,
Fix tests after RFC change.

# Motivation

Empty string value is a meaningful attribute value for OTel span.
So it should not be ignored nor cleared from span tags.

# Additional Notes
