### PR TITLE
Limit Quartz versions to < 2.4

### DIFF
--- a/dd-java-agent/instrumentation/quartz-2/build.gradle
+++ b/dd-java-agent/instrumentation/quartz-2/build.gradle
@@ -3,7 +3,7 @@ muzzle {
   pass {
     group = 'org.quartz-scheduler'
     module = 'quartz'
-    versions = "[2.0.0,)"
+    versions = "[2.0.0,2.4.0)"
     assertInverse = true
   }
 }
@@ -16,8 +16,8 @@ dependencies {
   compileOnly group: 'org.quartz-scheduler', name: 'quartz', version: '2.0.0'
   testImplementation group: 'org.quartz-scheduler', name: 'quartz', version: '2.0.0'
 
-  latestDepTestImplementation group: 'org.quartz-scheduler', name: 'quartz', version: '+'
+  latestDepTestImplementation group: 'org.quartz-scheduler', name: 'quartz', version: '2.3.+'
   // these dependencies are required for XML configurations when quartz version > 2.2+
-  latestDepTestImplementation group: 'org.quartz-scheduler', name: 'quartz-jobs', version: '+'
+  latestDepTestImplementation group: 'org.quartz-scheduler', name: 'quartz-jobs', version: '2.3.+'
   latestDepTestImplementation group: 'javax.transaction', name: 'jta', version: '1.1'
 }


### PR DESCRIPTION
# What Does This Do

Limit Quartz versions to < 2.4

# Motivation

Quartz 2.4.0-rc1 is not compatible

# Additional Notes
