### PR TITLE
Refactor Metric instrumentation

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/ValueScript.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/ValueScript.java
@@ -30,6 +30,10 @@ public class ValueScript implements DebuggerScript<Value<?>> {
     return dsl;
   }
 
+  public ValueExpression<?> getExpr() {
+    return expr;
+  }
+
   @Override
   public Value<?> execute(ValueReferenceResolver valueRefResolver) {
     return expr.evaluate(valueRefResolver);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/DiagnosticMessage.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/DiagnosticMessage.java
@@ -58,7 +58,7 @@ public final class DiagnosticMessage {
         + kind
         + ", message='"
         + message
-        + ", throwable='"
+        + "', throwable='"
         + throwable
         + '\''
         + '}';

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
@@ -258,92 +258,92 @@ public class MetricInstrumentor extends Instrumentor {
 
     @Override
     public VisitorResult visit(BinaryExpression binaryExpression) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public VisitorResult visit(BinaryOperator operator) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public VisitorResult visit(ComparisonExpression comparisonExpression) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public VisitorResult visit(ComparisonOperator operator) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public VisitorResult visit(ContainsExpression containsExpression) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public VisitorResult visit(EndsWithExpression endsWithExpression) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public VisitorResult visit(FilterCollectionExpression filterCollectionExpression) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public VisitorResult visit(HasAllExpression hasAllExpression) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public VisitorResult visit(HasAnyExpression hasAnyExpression) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public VisitorResult visit(IfElseExpression ifElseExpression) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public VisitorResult visit(IfExpression ifExpression) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public VisitorResult visit(IsEmptyExpression isEmptyExpression) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public VisitorResult visit(IsUndefinedExpression isUndefinedExpression) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public VisitorResult visit(LenExpression lenExpression) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public VisitorResult visit(MatchesExpression matchesExpression) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public VisitorResult visit(NotExpression notExpression) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public VisitorResult visit(StartsWithExpression startsWithExpression) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public VisitorResult visit(SubStringExpression subStringExpression) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
@@ -379,27 +379,27 @@ public class MetricInstrumentor extends Instrumentor {
 
     @Override
     public VisitorResult visit(IndexExpression indexExpression) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public VisitorResult visit(WhenExpression whenExpression) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public VisitorResult visit(BooleanExpression booleanExpression) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public VisitorResult visit(ObjectValue objectValue) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public VisitorResult visit(StringValue stringValue) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
@@ -416,17 +416,17 @@ public class MetricInstrumentor extends Instrumentor {
 
     @Override
     public VisitorResult visit(BooleanValue booleanValue) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public VisitorResult visit(ListValue listValue) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     @Override
     public VisitorResult visit(MapValue mapValue) {
-      return null;
+      throw new UnsupportedOperationException();
     }
 
     private Type tryRetrieve(String name, InsnList insnList) {


### PR DESCRIPTION
# What Does This Do
use the expression visitor to emit byte code instructions and replace the valueRefResolver that was used before but was limiting the scope of values.

# Motivation
It will help to support for feature form the Expression Language like count/len on map/list/set, or array indexing

# Additional Notes
