### PR TITLE
[USM] - Fix SSLSocket instrumentation ForTypeHierarchy filter

### DIFF
--- a/dd-java-agent/instrumentation/sslsocket/src/main/java/datadog/trace/instrumentation/sslsocket/SslSocketInstrumentation.java
+++ b/dd-java-agent/instrumentation/sslsocket/src/main/java/datadog/trace/instrumentation/sslsocket/SslSocketInstrumentation.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.sslsocket;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
@@ -32,7 +33,8 @@ public final class SslSocketInstrumentation extends Instrumenter.Usm
 
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
-    return HierarchyMatchers.extendsClass(named("javax.net.ssl.SSLSocket"));
+    return HierarchyMatchers.extendsClass(named("javax.net.ssl.SSLSocket"))
+        .and(not(HierarchyMatchers.abstractClass()));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/sslsocket/src/main/java/datadog/trace/instrumentation/sslsocket/SslSocketInstrumentation.java
+++ b/dd-java-agent/instrumentation/sslsocket/src/main/java/datadog/trace/instrumentation/sslsocket/SslSocketInstrumentation.java
@@ -1,13 +1,13 @@
 package datadog.trace.instrumentation.sslsocket;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.concreteClass;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers;
 import datadog.trace.bootstrap.instrumentation.usm.UsmConnection;
 import datadog.trace.bootstrap.instrumentation.usm.UsmExtractor;
 import datadog.trace.bootstrap.instrumentation.usm.UsmMessage;
@@ -33,8 +33,7 @@ public final class SslSocketInstrumentation extends Instrumenter.Usm
 
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
-    return HierarchyMatchers.extendsClass(named("javax.net.ssl.SSLSocket"))
-        .and(not(HierarchyMatchers.abstractClass()));
+    return extendsClass(named("javax.net.ssl.SSLSocket")).and(concreteClass());
   }
 
   @Override

--- a/dd-java-agent/instrumentation/sslsocket/src/main/java/datadog/trace/instrumentation/sslsocket/SslSocketStreamsInstrumentation.java
+++ b/dd-java-agent/instrumentation/sslsocket/src/main/java/datadog/trace/instrumentation/sslsocket/SslSocketStreamsInstrumentation.java
@@ -1,12 +1,12 @@
 package datadog.trace.instrumentation.sslsocket;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.concreteClass;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers;
 import datadog.trace.bootstrap.instrumentation.sslsocket.UsmFilterInputStream;
 import datadog.trace.bootstrap.instrumentation.sslsocket.UsmFilterOutputStream;
 import java.io.InputStream;
@@ -32,8 +32,7 @@ public final class SslSocketStreamsInstrumentation extends Instrumenter.Usm
 
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
-    return HierarchyMatchers.extendsClass(named("javax.net.ssl.SSLSocket"))
-        .and(not(HierarchyMatchers.abstractClass()));
+    return extendsClass(named("javax.net.ssl.SSLSocket")).and(concreteClass());
   }
 
   @Override

--- a/dd-java-agent/instrumentation/sslsocket/src/main/java/datadog/trace/instrumentation/sslsocket/SslSocketStreamsInstrumentation.java
+++ b/dd-java-agent/instrumentation/sslsocket/src/main/java/datadog/trace/instrumentation/sslsocket/SslSocketStreamsInstrumentation.java
@@ -33,8 +33,7 @@ public final class SslSocketStreamsInstrumentation extends Instrumenter.Usm
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
     return HierarchyMatchers.extendsClass(named("javax.net.ssl.SSLSocket"))
-    .and(not(HierarchyMatchers.abstractClass()));
-
+        .and(not(HierarchyMatchers.abstractClass()));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/sslsocket/src/main/java/datadog/trace/instrumentation/sslsocket/SslSocketStreamsInstrumentation.java
+++ b/dd-java-agent/instrumentation/sslsocket/src/main/java/datadog/trace/instrumentation/sslsocket/SslSocketStreamsInstrumentation.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.sslsocket;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
@@ -31,7 +32,9 @@ public final class SslSocketStreamsInstrumentation extends Instrumenter.Usm
 
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
-    return HierarchyMatchers.extendsClass(named("javax.net.ssl.SSLSocket"));
+    return HierarchyMatchers.extendsClass(named("javax.net.ssl.SSLSocket"))
+    .and(not(HierarchyMatchers.abstractClass()));
+
   }
 
   @Override


### PR DESCRIPTION
Avoid instrumenting abstract `BaseSSLSocketImpl` 

# What Does This Do

added additional condition to `hierarchyMatcher` function

# Motivation

# Additional Notes
