### PR TITLE
Add initial DynamicConfig API and use it to maintain service mappings

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -340,7 +340,7 @@ public class DDSpanContext
   }
 
   public void setServiceName(final String serviceName) {
-    this.serviceName = trace.getTracer().mapServiceName(serviceName);
+    this.serviceName = trace.mapServiceName(serviceName);
     this.topLevel = isTopLevel(parentServiceName, this.serviceName);
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -2,6 +2,7 @@ package datadog.trace.core;
 
 import datadog.communication.monitor.Recording;
 import datadog.trace.api.DDTraceId;
+import datadog.trace.api.TraceConfig;
 import datadog.trace.api.time.TimeSource;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentTrace;
@@ -72,6 +73,8 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
   private final TimeSource timeSource;
   private final boolean strictTraceWrites;
   private final HealthMetrics healthMetrics;
+  private final TraceConfig traceConfig;
+
   private final ConcurrentLinkedDeque<DDSpan> finishedSpans = new ConcurrentLinkedDeque<>();
 
   // We must maintain a separate count because ConcurrentLinkedDeque.size() is a linear operation.
@@ -121,10 +124,15 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
     this.timeSource = timeSource;
     this.strictTraceWrites = strictTraceWrites;
     this.healthMetrics = healthMetrics;
+    this.traceConfig = tracer.captureTraceConfig();
   }
 
   CoreTracer getTracer() {
     return tracer;
+  }
+
+  String mapServiceName(String serviceName) {
+    return traceConfig.getServiceMapping().getOrDefault(serviceName, serviceName);
   }
 
   /**

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
@@ -263,8 +263,8 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
 
   def createMinimalContext() {
     def tracer = Mock(CoreTracer)
-    tracer.mapServiceName(_) >> { String serviceName -> serviceName }
     def trace = Mock(PendingTrace)
+    trace.mapServiceName(_) >> { String serviceName -> serviceName }
     trace.getTracer() >> tracer
     return new DDSpanContext(
       DDTraceId.ONE,

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
@@ -191,8 +191,8 @@ class DDAgentWriterTest extends DDCoreSpecification {
 
   def newSpan() {
     CoreTracer tracer = Mock(CoreTracer)
-    tracer.mapServiceName(_) >> { String serviceName -> serviceName }
     PendingTrace trace = Mock(PendingTrace)
+    trace.mapServiceName(_) >> { String serviceName -> serviceName }
     trace.getTracer() >> tracer
     def context = new DDSpanContext(
       DDTraceId.ONE,

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
@@ -730,8 +730,8 @@ class DDIntakeWriterCombinedTest extends DDCoreSpecification {
 
   def createMinimalContext() {
     def tracer = Mock(CoreTracer)
-    tracer.mapServiceName(_) >> { String serviceName -> serviceName }
     def trace = Mock(PendingTrace)
+    trace.mapServiceName(_) >> { String serviceName -> serviceName }
     trace.getTracer() >> tracer
     return new DDSpanContext(
       DDTraceId.ONE,

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterTest.groovy
@@ -181,8 +181,8 @@ class DDIntakeWriterTest extends DDCoreSpecification{
 
   def newSpan() {
     CoreTracer tracer = Mock(CoreTracer)
-    tracer.mapServiceName(_) >> { String serviceName -> serviceName }
     PendingTrace trace = Mock(PendingTrace)
+    trace.mapServiceName(_) >> { String serviceName -> serviceName }
     trace.getTracer() >> tracer
     def context = new DDSpanContext(
       DDTraceId.ONE,

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherTest.groovy
@@ -149,11 +149,9 @@ class PayloadDispatcherTest extends DDSpecification {
 
   def realSpan() {
     CoreTracer tracer = Mock(CoreTracer)
-    tracer.mapServiceName(_) >> { String serviceName ->
-      serviceName
-    }
     PendingTrace trace = Mock(PendingTrace)
     trace.getTracer() >> tracer
+    trace.mapServiceName(_) >> { String serviceName -> serviceName }
     def context = new DDSpanContext(
       DDTraceId.ONE,
       1,

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -173,7 +173,7 @@ class CoreTracerTest extends DDCoreSpecification {
 
     then:
     tracer.defaultSpanTags == map
-    tracer.serviceNameMappings == map
+    tracer.captureTraceConfig().serviceMapping == map
     taggedHeaders == map
 
     cleanup:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.core
 
 import datadog.trace.api.DDTraceId
+import datadog.trace.api.TraceConfig
 import datadog.trace.api.sampling.PrioritySampling
 import datadog.trace.api.time.TimeSource
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
@@ -66,8 +67,11 @@ class PendingTraceTest extends PendingTraceTestBase {
   def "verify healthmetrics called"() {
     setup:
     def tracer = Mock(CoreTracer)
+    def traceConfig = Mock(TraceConfig)
     def buffer = Mock(PendingTraceBuffer)
     def healthMetrics = Mock(HealthMetrics)
+    tracer.captureTraceConfig() >> traceConfig
+    traceConfig.getServiceMapping() >> [:]
     PendingTrace trace = new PendingTrace(tracer,DDTraceId.from(0),buffer,Mock(TimeSource),false,healthMetrics)
     when:
     rootSpan = createSimpleSpan(trace)

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/TypeConverterTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/TypeConverterTest.groovy
@@ -70,8 +70,8 @@ class TypeConverterTest extends DDSpecification {
 
   def createTestSpanContext() {
     def tracer = Mock(CoreTracer)
-    tracer.mapServiceName(_) >> { String serviceName -> serviceName }
     def trace = Mock(PendingTrace)
+    trace.mapServiceName(_) >> { String serviceName -> serviceName }
     trace.getTracer() >> tracer
 
     return new DDSpanContext(

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -114,6 +114,9 @@ excludedClassesCoverage += [
   "datadog.trace.api.ConfigCollector.Holder",
   "datadog.trace.api.Config.HostNameHolder",
   "datadog.trace.api.Config.RuntimeIdHolder",
+  "datadog.trace.api.DynamicConfig",
+  "datadog.trace.api.DynamicConfig.Builder",
+  "datadog.trace.api.DynamicConfig.State",
   "datadog.trace.api.InstrumenterConfig",
   // can't reliably force same identity hash for different instance to cover branch
   "datadog.trace.api.cache.FixedSizeCache.IdentityHash",

--- a/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
@@ -1,0 +1,62 @@
+package datadog.trace.api;
+
+import static datadog.trace.util.CollectionUtils.tryMakeImmutableMap;
+
+import java.util.Collections;
+import java.util.Map;
+
+/** Manages dynamic configuration for a particular {@link Tracer} instance. */
+public final class DynamicConfig {
+  private volatile State currentState;
+
+  private DynamicConfig() {}
+
+  public static Builder create() {
+    return new DynamicConfig().prepare();
+  }
+
+  /** Captures a snapshot of the configuration at the start of a trace. */
+  public TraceConfig captureTraceConfig() {
+    return currentState;
+  }
+
+  public Builder prepare() {
+    return new Builder(currentState);
+  }
+
+  public final class Builder {
+    Map<String, String> serviceMapping;
+
+    Builder(State state) {
+      if (null == state) {
+        this.serviceMapping = Collections.emptyMap();
+      } else {
+        this.serviceMapping = state.serviceMapping;
+      }
+    }
+
+    public Builder setServiceMapping(Map<String, String> serviceMapping) {
+      this.serviceMapping = tryMakeImmutableMap(serviceMapping);
+      return this;
+    }
+
+    /** Overwrites the current configuration with a new snapshot. */
+    public DynamicConfig apply() {
+      DynamicConfig.this.currentState = new State(this);
+      return DynamicConfig.this;
+    }
+  }
+
+  /** Immutable snapshot of the configuration. */
+  static final class State implements TraceConfig {
+    final Map<String, String> serviceMapping;
+
+    State(Builder builder) {
+      this.serviceMapping = builder.serviceMapping;
+    }
+
+    public Map<String, String> getServiceMapping() {
+      return serviceMapping;
+    }
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/TraceConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/TraceConfig.java
@@ -1,0 +1,9 @@
+package datadog.trace.api;
+
+import java.util.Map;
+
+/** Snapshot of dynamic configuration; valid for the duration of a trace. */
+public interface TraceConfig {
+
+  Map<String, String> getServiceMapping();
+}


### PR DESCRIPTION
# What Does This Do

Initial API for dynamic configuration which supports capturing a snapshot for the duration of a trace.
More elements will be added to `TraceConfig` as selected static config elements are made dynamic.
