### PR TITLE
Couchbase 3.x: extract seed nodes info

### DIFF
--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/main/java/datadog/trace/instrumentation/couchbase_31/client/CoreEnvironmentBuilderAdvice.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/main/java/datadog/trace/instrumentation/couchbase_31/client/CoreEnvironmentBuilderAdvice.java
@@ -1,12 +1,16 @@
 package datadog.trace.instrumentation.couchbase_31.client;
 
+import com.couchbase.client.core.Core;
 import com.couchbase.client.core.env.CoreEnvironment;
+import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import net.bytebuddy.asm.Advice;
 
 public class CoreEnvironmentBuilderAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
   public static void onExit(@Advice.This CoreEnvironment.Builder<?> builder) {
-    builder.requestTracer(new DatadogRequestTracer(AgentTracer.get()));
+    builder.requestTracer(
+        new DatadogRequestTracer(
+            AgentTracer.get(), InstrumentationContext.get(Core.class, String.class)));
   }
 }

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/main/java/datadog/trace/instrumentation/couchbase_31/client/CoreEnvironmentBuilderInstrumentation.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/main/java/datadog/trace/instrumentation/couchbase_31/client/CoreEnvironmentBuilderInstrumentation.java
@@ -5,6 +5,8 @@ import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.muzzle.Reference;
+import java.util.Collections;
+import java.util.Map;
 
 @AutoService(Instrumenter.class)
 public class CoreEnvironmentBuilderInstrumentation extends Instrumenter.Tracing
@@ -20,7 +22,13 @@ public class CoreEnvironmentBuilderInstrumentation extends Instrumenter.Tracing
       packageName + ".CouchbaseClientDecorator",
       packageName + ".DatadogRequestSpan",
       packageName + ".DatadogRequestTracer",
+      packageName + ".SeedNodeHelper",
     };
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return Collections.singletonMap("com.couchbase.client.core.Core", String.class.getName());
   }
 
   @Override

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/main/java/datadog/trace/instrumentation/couchbase_31/client/CoreInstrumentation.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/main/java/datadog/trace/instrumentation/couchbase_31/client/CoreInstrumentation.java
@@ -1,0 +1,71 @@
+package datadog.trace.instrumentation.couchbase_31.client;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.couchbase.client.core.Core;
+import com.couchbase.client.core.env.SeedNode;
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.muzzle.Reference;
+import datadog.trace.bootstrap.InstrumentationContext;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import net.bytebuddy.asm.Advice;
+
+@AutoService(Instrumenter.class)
+public class CoreInstrumentation extends Instrumenter.Tracing
+    implements Instrumenter.ForSingleType {
+
+  private static final Reference TRACING_IDENTIFIERS_REFERENCE =
+      new Reference.Builder("com.couchbase.client.core.cnc.TracingIdentifiers").build();
+
+  private static final Reference SUSPICIOUS_EXPIRY_REFERENCE =
+      new Reference.Builder(
+              "com.couchbase.client.core.cnc.events.request.SuspiciousExpiryDurationEvent")
+          .build();
+
+  public CoreInstrumentation() {
+    super("couchbase");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "com.couchbase.client.core.Core";
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return Collections.singletonMap("com.couchbase.client.core.Core", String.class.getName());
+  }
+
+  @Override
+  public Reference[] additionalMuzzleReferences() {
+    return new Reference[] {TRACING_IDENTIFIERS_REFERENCE, SUSPICIOUS_EXPIRY_REFERENCE};
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".SeedNodeHelper",
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isConstructor().and(takesArgument(2, named("java.util.Set"))),
+        CoreInstrumentation.class.getName() + "$CoreConstructorAdvice");
+  }
+
+  public static class CoreConstructorAdvice {
+    @Advice.OnMethodExit
+    public static void afterConstruct(
+        @Advice.Argument(2) final Set<SeedNode> seedNodes, @Advice.This final Core core) {
+      InstrumentationContext.get(Core.class, String.class)
+          .put(core, SeedNodeHelper.toStringForm(seedNodes));
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/main/java/datadog/trace/instrumentation/couchbase_31/client/DatadogRequestSpan.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/main/java/datadog/trace/instrumentation/couchbase_31/client/DatadogRequestSpan.java
@@ -1,9 +1,12 @@
 package datadog.trace.instrumentation.couchbase_31.client;
 
+import com.couchbase.client.core.Core;
 import com.couchbase.client.core.cnc.RequestSpan;
 import com.couchbase.client.core.msg.RequestContext;
 import datadog.trace.api.DDTags;
+import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
 import datadog.trace.bootstrap.instrumentation.api8.java.concurrent.StatusSettable;
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -15,6 +18,8 @@ public class DatadogRequestSpan implements RequestSpan, StatusSettable<Integer> 
   // We need to keep track of the paren spans to propagate error information
   private DatadogRequestSpan parent;
 
+  private final ContextStore<Core, String> coreContext;
+
   // The interaction between error setting in StatusSettingCompletableFuture and the span is a bit
   // involved since we need to make sure that we don't finish the span before we have set the error
   // on it. That's why we have a counter here and let the status setting code finish the span if
@@ -25,12 +30,14 @@ public class DatadogRequestSpan implements RequestSpan, StatusSettable<Integer> 
   // future, so we need to ensure that the completion of the future does not overwrite the error
   private AtomicBoolean statusSet = new AtomicBoolean(false);
 
-  private DatadogRequestSpan(AgentSpan span) {
+  private DatadogRequestSpan(AgentSpan span, final ContextStore<Core, String> coreContext) {
     this.span = span;
+    this.coreContext = coreContext;
   }
 
-  public static DatadogRequestSpan wrap(AgentSpan span) {
-    return new DatadogRequestSpan(span);
+  public static DatadogRequestSpan wrap(
+      AgentSpan span, final ContextStore<Core, String> coreContext) {
+    return new DatadogRequestSpan(span, coreContext);
   }
 
   public static AgentSpan unwrap(RequestSpan span) {
@@ -109,7 +116,7 @@ public class DatadogRequestSpan implements RequestSpan, StatusSettable<Integer> 
 
   @Override
   public void requestContext(RequestContext requestContext) {
-    // TODO should we add tags/metrics based on the request context when the span ends?
+    span.setTag(InstrumentationTags.COUCHBASE_SEED_NODES, coreContext.get(requestContext.core()));
   }
 
   private boolean shouldSetStatus() {

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/main/java/datadog/trace/instrumentation/couchbase_31/client/SeedNodeHelper.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/main/java/datadog/trace/instrumentation/couchbase_31/client/SeedNodeHelper.java
@@ -1,0 +1,11 @@
+package datadog.trace.instrumentation.couchbase_31.client;
+
+import com.couchbase.client.core.env.SeedNode;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class SeedNodeHelper {
+  public static String toStringForm(final Set<SeedNode> seedNodes) {
+    return seedNodes.stream().map(SeedNode::address).distinct().collect(Collectors.joining(","));
+  }
+}

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/test/groovy/CouchbaseClient31Test.groovy
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/test/groovy/CouchbaseClient31Test.groovy
@@ -395,10 +395,9 @@ abstract class CouchbaseClient31Test extends VersionedNamingTestBase {
         if (isLatestDepTest && extraTags != null) {
           tag('db.system','couchbase')
           addTags(extraTags)
-          peerServiceFrom(Tags.PEER_HOSTNAME)
         }
-        //fixme: check peer service from seed nodes when the info will be available
-        defaultTags(false, isLatestDepTest && extraTags != null)
+        peerServiceFrom(InstrumentationTags.COUCHBASE_SEED_NODES)
+        defaultTags()
       }
     }
   }

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/test/groovy/CouchbaseClient31Test.groovy
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/test/groovy/CouchbaseClient31Test.groovy
@@ -13,6 +13,7 @@ import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
+import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
 import java.time.Duration
@@ -389,6 +390,8 @@ abstract class CouchbaseClient31Test extends VersionedNamingTestBase {
           it.tag(DDTags.ERROR_TYPE, ex.class.name)
           it.tag(DDTags.ERROR_STACK, String)
         }
+        "$InstrumentationTags.COUCHBASE_SEED_NODES" { it =="localhost" || it == "127.0.0.1" }
+
         if (isLatestDepTest && extraTags != null) {
           tag('db.system','couchbase')
           addTags(extraTags)
@@ -418,7 +421,7 @@ abstract class CouchbaseClient31Test extends VersionedNamingTestBase {
   }
 }
 
-class CouchbaseClient31V0ForkedTest extends CouchbaseClient31Test {
+class CouchbaseClient31V0Test extends CouchbaseClient31Test {
   @Override
   int version() {
     return 0

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/ConnectionStringHelper.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/ConnectionStringHelper.java
@@ -1,0 +1,26 @@
+package datadog.trace.instrumentation.couchbase_32.client;
+
+import com.couchbase.client.core.util.ConnectionString;
+import datadog.trace.api.cache.DDCache;
+import datadog.trace.api.cache.DDCaches;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class ConnectionStringHelper {
+  private static final DDCache<ConnectionString, String> CONNECTION_STRING_STRING_CACHE =
+      DDCaches.newFixedSizeCache(8);
+
+  private static final Function<ConnectionString, String> ADDER =
+      cs ->
+          cs.hosts().stream()
+              .map(ConnectionString.UnresolvedSocket::hostname)
+              .distinct()
+              .collect(Collectors.joining(","));
+
+  public static String toHostPortList(final ConnectionString connectionString) {
+    if (connectionString == null) {
+      return null;
+    }
+    return CONNECTION_STRING_STRING_CACHE.computeIfAbsent(connectionString, ADDER);
+  }
+}

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/CoreEnvironmentBuilderAdvice.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/CoreEnvironmentBuilderAdvice.java
@@ -1,12 +1,16 @@
 package datadog.trace.instrumentation.couchbase_32.client;
 
+import com.couchbase.client.core.Core;
 import com.couchbase.client.core.env.CoreEnvironment;
+import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import net.bytebuddy.asm.Advice;
 
 public class CoreEnvironmentBuilderAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
   public static void onExit(@Advice.This CoreEnvironment.Builder<?> builder) {
-    builder.requestTracer(new DatadogRequestTracer(AgentTracer.get()));
+    builder.requestTracer(
+        new DatadogRequestTracer(
+            AgentTracer.get(), InstrumentationContext.get(Core.class, String.class)));
   }
 }

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/CoreEnvironmentBuilderInstrumentation.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/CoreEnvironmentBuilderInstrumentation.java
@@ -4,6 +4,8 @@ import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import java.util.Collections;
+import java.util.Map;
 
 @AutoService(Instrumenter.class)
 public class CoreEnvironmentBuilderInstrumentation extends Instrumenter.Tracing
@@ -21,6 +23,11 @@ public class CoreEnvironmentBuilderInstrumentation extends Instrumenter.Tracing
       packageName + ".DatadogRequestSpan$1",
       packageName + ".DatadogRequestTracer",
     };
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return Collections.singletonMap("com.couchbase.client.core.Core", String.class.getName());
   }
 
   @Override

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/CoreInstrumentation.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/CoreInstrumentation.java
@@ -1,0 +1,75 @@
+package datadog.trace.instrumentation.couchbase_32.client;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.couchbase.client.core.Core;
+import com.couchbase.client.core.cnc.RequestSpan;
+import com.couchbase.client.core.env.SeedNode;
+import com.couchbase.client.core.util.ConnectionString;
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.InstrumentationContext;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import net.bytebuddy.asm.Advice;
+
+@AutoService(Instrumenter.class)
+public class CoreInstrumentation extends Instrumenter.Tracing
+    implements Instrumenter.ForSingleType {
+  public CoreInstrumentation() {
+    super("couchbase");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "com.couchbase.client.core.Core";
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return Collections.singletonMap("com.couchbase.client.core.Core", String.class.getName());
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".SeedNodeHelper", packageName + ".ConnectionStringHelper",
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isConstructor().and(takesArgument(2, named("java.util.Set"))),
+        CoreInstrumentation.class.getName() + "$CoreConstructorSeedNodeAdvice");
+    transformation.applyAdvice(
+        isConstructor()
+            .and(takesArgument(2, named("com.couchbase.client.core.util.ConnectionString"))),
+        CoreInstrumentation.class.getName() + "$CoreConstructorConnectionStringAdvice");
+  }
+
+  public static class CoreConstructorSeedNodeAdvice {
+    @Advice.OnMethodExit
+    public static void afterConstruct(
+        @Advice.Argument(2) final Set<SeedNode> seedNodes, @Advice.This final Core core) {
+      InstrumentationContext.get(Core.class, String.class)
+          .put(core, SeedNodeHelper.toStringForm(seedNodes));
+    }
+
+    public static void muzzleCheck(RequestSpan requestSpan) {
+      requestSpan.status(RequestSpan.StatusCode.ERROR);
+    }
+  }
+
+  public static class CoreConstructorConnectionStringAdvice {
+    @Advice.OnMethodExit
+    public static void afterConstruct(
+        @Advice.Argument(2) final ConnectionString connectionString, @Advice.This final Core core) {
+      InstrumentationContext.get(Core.class, String.class)
+          .put(core, ConnectionStringHelper.toHostPortList(connectionString));
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/DatadogRequestSpan.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/DatadogRequestSpan.java
@@ -1,9 +1,12 @@
 package datadog.trace.instrumentation.couchbase_32.client;
 
+import com.couchbase.client.core.Core;
 import com.couchbase.client.core.cnc.RequestSpan;
 import com.couchbase.client.core.msg.RequestContext;
 import datadog.trace.api.DDTags;
+import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
 import datadog.trace.bootstrap.instrumentation.api8.java.concurrent.StatusSettable;
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -11,6 +14,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class DatadogRequestSpan implements RequestSpan, StatusSettable<Integer> {
   private final AgentSpan span;
+  private final ContextStore<Core, String> coreContext;
+
   // When a QueryRequest is converted into a prepare or execute request, then we need to close
   // the parent span as well, since Couchbase drops it on the floor
   private DatadogRequestSpan convertedParent;
@@ -26,12 +31,14 @@ public class DatadogRequestSpan implements RequestSpan, StatusSettable<Integer> 
   // future, so we need to ensure that the completion of the future does not overwrite the error
   private AtomicBoolean statusSet = new AtomicBoolean(false);
 
-  private DatadogRequestSpan(AgentSpan span) {
+  private DatadogRequestSpan(AgentSpan span, final ContextStore<Core, String> coreContext) {
     this.span = span;
+    this.coreContext = coreContext;
   }
 
-  public static DatadogRequestSpan wrap(AgentSpan span) {
-    return new DatadogRequestSpan(span);
+  public static DatadogRequestSpan wrap(
+      AgentSpan span, final ContextStore<Core, String> coreContext) {
+    return new DatadogRequestSpan(span, coreContext);
   }
 
   public static AgentSpan unwrap(RequestSpan span) {
@@ -122,7 +129,7 @@ public class DatadogRequestSpan implements RequestSpan, StatusSettable<Integer> 
 
   @Override
   public void requestContext(RequestContext requestContext) {
-    // TODO should we add tags/metrics based on the request context when the span ends?
+    span.setTag(InstrumentationTags.COUCHBASE_SEED_NODES, coreContext.get(requestContext.core()));
   }
 
   private boolean shouldSetStatus() {

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/SeedNodeHelper.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/SeedNodeHelper.java
@@ -1,0 +1,15 @@
+package datadog.trace.instrumentation.couchbase_32.client;
+
+import com.couchbase.client.core.env.SeedNode;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class SeedNodeHelper {
+  public static String toStringForm(final Set<SeedNode> seedNodes) {
+    return seedNodes.stream()
+        .map(SeedNode::address)
+        .sorted()
+        .distinct()
+        .collect(Collectors.joining(","));
+  }
+}

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/test/groovy/CouchbaseClient32Test.groovy
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/test/groovy/CouchbaseClient32Test.groovy
@@ -1,3 +1,6 @@
+import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+
 import com.couchbase.client.core.env.TimeoutConfig
 import com.couchbase.client.core.error.CouchbaseException
 import com.couchbase.client.core.error.DocumentNotFoundException
@@ -13,6 +16,7 @@ import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
+import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
 import org.testcontainers.couchbase.BucketDefinition
@@ -20,9 +24,6 @@ import org.testcontainers.couchbase.CouchbaseContainer
 import spock.lang.Shared
 
 import java.time.Duration
-
-import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
-import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 abstract class CouchbaseClient32Test extends VersionedNamingTestBase {
   static final String BUCKET = 'test-bucket'
@@ -396,6 +397,7 @@ abstract class CouchbaseClient32Test extends VersionedNamingTestBase {
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
         "$Tags.DB_TYPE" 'couchbase'
         'db.system' 'couchbase'
+        "$InstrumentationTags.COUCHBASE_SEED_NODES" { it =="localhost" || it == "127.0.0.1" }
         if (isErrored) {
           it.tag(DDTags.ERROR_MSG, { exMessage.length() > 0 && ((String) it).startsWith(exMessage) })
           it.tag(DDTags.ERROR_TYPE, ex.class.name)
@@ -431,7 +433,7 @@ abstract class CouchbaseClient32Test extends VersionedNamingTestBase {
   }
 }
 
-class CouchbaseClient32V0ForkedTest extends CouchbaseClient32Test {
+class CouchbaseClient32V0Test extends CouchbaseClient32Test {
   @Override
   int version() {
     return 0

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/test/groovy/CouchbaseClient32Test.groovy
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/test/groovy/CouchbaseClient32Test.groovy
@@ -373,7 +373,7 @@ abstract class CouchbaseClient32Test extends VersionedNamingTestBase {
     assertCouchbaseCall(trace, name, extraTags, null, internal, ex)
   }
 
-  void assertCouchbaseCall(TraceAssert trace, String name, Map<String, Serializable> extraTags, Object parentSpan, boolean internal = false, Throwable ex = null, boolean checkPeerService = false) {
+  void assertCouchbaseCall(TraceAssert trace, String name, Map<String, Serializable> extraTags, Object parentSpan, boolean internal = false, Throwable ex = null) {
     def opName = internal ? 'couchbase.internal' : operation()
     def isMeasured = !internal
     def isErrored = ex != null
@@ -406,11 +406,8 @@ abstract class CouchbaseClient32Test extends VersionedNamingTestBase {
         if (extraTags != null) {
           addTags(extraTags)
         }
-        //fixme: check peer service from seed nodes when the info will be available
-        if (checkPeerService) {
-          peerServiceFrom('net.peer.name')
-        }
-        defaultTags(false, checkPeerService)
+        peerServiceFrom(InstrumentationTags.COUCHBASE_SEED_NODES)
+        defaultTags()
       }
     }
   }
@@ -429,7 +426,7 @@ abstract class CouchbaseClient32Test extends VersionedNamingTestBase {
     if (extraTags != null) {
       allExtraTags.putAll(extraTags)
     }
-    assertCouchbaseCall(trace, 'dispatch_to_server', allExtraTags, parentSpan, true, null, true)
+    assertCouchbaseCall(trace, 'dispatch_to_server', allExtraTags, parentSpan, true, null)
   }
 }
 

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/PeerServiceNamingV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/PeerServiceNamingV1.java
@@ -20,8 +20,11 @@ public class PeerServiceNamingV1 implements NamingSchema.ForPeerService {
     ret.put("java-kafka", new String[] {InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS});
     // database
     ret.put("hazelcast-sdk", new String[] {"hazelcast.instance", Tags.PEER_HOSTNAME});
-    // todo: add couchbase seed nodes when the precursor will be available
-    ret.put("couchbase-client", new String[] {"net.peer.name", Tags.PEER_HOSTNAME});
+    ret.put(
+        "couchbase-client",
+        new String[] {
+          InstrumentationTags.COUCHBASE_SEED_NODES, "net.peer.name", Tags.PEER_HOSTNAME
+        });
 
     // fixme: cassandra instance is the keyspace and it's not adapted for the peer.service. Replace
     // with seed nodes when available

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InstrumentationTags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InstrumentationTags.java
@@ -37,6 +37,7 @@ public class InstrumentationTags {
 
   public static final String BUCKET = "bucket";
   public static final String COUCHBASE_OPERATION_ID = "couchbase.operation_id";
+  public static final String COUCHBASE_SEED_NODES = "db.couchbase.seed.nodes";
   public static final String ELASTICSEARCH_REQUEST_INDICES = "elasticsearch.request.indices";
   public static final String ELASTICSEARCH_REQUEST_SEARCH_TYPES =
       "elasticsearch.request.search.types";


### PR DESCRIPTION
# What Does This Do

Extract the couchbase seed nodes information (provided as part of the connection string) under the tag `db.couchbase.seed.nodes`


# Motivation

# Additional Notes
