### PR TITLE
Add missing request headers in telemetry

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/RequestBuilder.java
+++ b/telemetry/src/main/java/datadog/telemetry/RequestBuilder.java
@@ -108,6 +108,8 @@ public class RequestBuilder {
         .addHeader("Content-Type", JSON.toString())
         .addHeader("DD-Telemetry-API-Version", API_VERSION.toString())
         .addHeader("DD-Telemetry-Request-Type", requestType.toString())
+        .addHeader("DD-Client-Library-Language", "jvm")
+        .addHeader("DD-Client-Library-Version", TracerVersion.TRACER_VERSION)
         .post(body)
         .build();
   }

--- a/telemetry/src/test/groovy/datadog/telemetry/RequestBuilderSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/RequestBuilderSpecification.groovy
@@ -27,6 +27,15 @@ class RequestBuilderSpecification extends DDSpecification {
     SLURPER.parse(bytes)
   }
 
+  void assertCommonHeaders(Request req) {
+    assert req.header('Content-Type') == 'application/json; charset=utf-8'
+    assert req.header('DD-Telemetry-API-Version') == 'v1'
+    assert req.header('DD-Client-Library-Language') == 'jvm'
+    assert !req.header('DD-Client-Library-Version').isEmpty()
+    assert req.header('DD-Agent-Env') == null
+    assert req.header('DD-Agent-Hostname') == null
+  }
+
   void 'appStarted request'() {
     Request req
     def body
@@ -44,8 +53,7 @@ class RequestBuilderSpecification extends DDSpecification {
     body = parseBody req.body()
 
     then:
-    req.header('Content-type') == 'application/json; charset=utf-8'
-    req.header('DD-Telemetry-API-Version') == 'v1'
+    assertCommonHeaders(req)
     req.header('DD-Telemetry-Request-Type') == 'app-started'
     body['api_version'] == 'v1'
     with(body['application']) {
@@ -101,8 +109,7 @@ class RequestBuilderSpecification extends DDSpecification {
     def body = parseBody req.body()
 
     then:
-    req.header('Content-type') == 'application/json; charset=utf-8'
-    req.header('DD-Telemetry-API-Version') == 'v1'
+    assertCommonHeaders(req)
     req.header('DD-Telemetry-Request-Type') == 'generate-metrics'
     body['api_version'] == 'v1'
     body['request_type'] == 'generate-metrics'


### PR DESCRIPTION
# What Does This Do
Add missing headers in telemetry requests, according to the spec.

# Motivation

# Additional Notes
