### PR TITLE
Add support for OpenTelemetry programmatic context propagation

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OpenTelemetryContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OpenTelemetryContextInstrumentation.java
@@ -57,6 +57,7 @@ public class OpenTelemetryContextInstrumentation extends Instrumenter.Tracing
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".OtelContext",
+      packageName + ".OtelExtractedContext",
       packageName + ".OtelScope",
       packageName + ".OtelSpan",
       packageName + ".OtelSpan$NoopSpan",

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OpenTelemetryInstrumentation.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OpenTelemetryInstrumentation.java
@@ -53,6 +53,7 @@ public class OpenTelemetryInstrumentation extends Instrumenter.Tracing
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".OtelContext",
+      packageName + ".OtelExtractedContext",
       packageName + ".OtelScope",
       packageName + ".OtelSpan",
       packageName + ".OtelSpan$NoopSpan",

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelExtractedContext.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelExtractedContext.java
@@ -50,7 +50,7 @@ class OtelExtractedContext implements AgentSpan.Context {
 
   @Override
   public AgentTrace getTrace() {
-    return null;
+    return AgentTracer.NoopAgentTrace.INSTANCE;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelExtractedContext.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelExtractedContext.java
@@ -1,0 +1,70 @@
+package datadog.trace.instrumentation.opentelemetry14;
+
+import datadog.trace.api.DDSpanId;
+import datadog.trace.api.DDTraceId;
+import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTrace;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.PathwayContext;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.context.Context;
+import java.util.Map;
+
+class OtelExtractedContext implements AgentSpan.Context {
+  private final DDTraceId traceId;
+  private final long spanId;
+  private final int prioritySampling;
+
+  private OtelExtractedContext(SpanContext context) {
+    this.traceId = DDTraceId.fromHex(context.getTraceId());
+    this.spanId = DDSpanId.fromHex(context.getSpanId());
+    this.prioritySampling =
+        context.isSampled() ? PrioritySampling.SAMPLER_KEEP : PrioritySampling.UNSET;
+  }
+
+  static AgentSpan.Context extract(Context context) {
+    Span span = Span.fromContext(context);
+    SpanContext spanContext = span.getSpanContext();
+    if (spanContext instanceof OtelSpanContext) {
+      return ((OtelSpanContext) spanContext).delegate;
+    } else {
+      try {
+        return new OtelExtractedContext(spanContext);
+      } catch (NumberFormatException e) {
+        return AgentTracer.NoopContext.INSTANCE;
+      }
+    }
+  }
+
+  @Override
+  public DDTraceId getTraceId() {
+    return this.traceId;
+  }
+
+  @Override
+  public long getSpanId() {
+    return this.spanId;
+  }
+
+  @Override
+  public AgentTrace getTrace() {
+    return null;
+  }
+
+  @Override
+  public int getSamplingPriority() {
+    return this.prioritySampling;
+  }
+
+  @Override
+  public Iterable<Map.Entry<String, String>> baggageItems() {
+    return null;
+  }
+
+  @Override
+  public PathwayContext getPathwayContext() {
+    return null;
+  }
+}

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelSpanBuilder.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelSpanBuilder.java
@@ -1,5 +1,7 @@
 package datadog.trace.instrumentation.opentelemetry14;
 
+import static datadog.trace.instrumentation.opentelemetry14.OtelExtractedContext.extract;
+
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -23,13 +25,7 @@ public class OtelSpanBuilder implements SpanBuilder {
 
   @Override
   public SpanBuilder setParent(Context context) {
-    Span span = Span.fromContext(context);
-    SpanContext spanContext = span.getSpanContext();
-    AgentSpan.Context ddContext = AgentTracer.NoopContext.INSTANCE;
-    if (spanContext instanceof OtelSpanContext) {
-      ddContext = ((OtelSpanContext) spanContext).delegate;
-    }
-    this.delegate.asChildOf(ddContext);
+    this.delegate.asChildOf(extract(context));
     return this;
   }
 

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
@@ -1,6 +1,7 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTags
+import datadog.trace.api.DDTraceId
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.opentelemetry14.OtelContext
 import datadog.trace.instrumentation.opentelemetry14.OtelSpan
@@ -10,9 +11,14 @@ import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.ContextKey
+import io.opentelemetry.context.propagation.TextMapGetter
+import io.opentelemetry.context.propagation.TextMapSetter
 import spock.lang.Subject
+
+import javax.annotation.Nullable
 
 import static datadog.trace.bootstrap.instrumentation.api.ScopeSource.MANUAL
 import static io.opentelemetry.api.trace.StatusCode.ERROR
@@ -470,5 +476,61 @@ class OpenTelemetry14Test extends AgentTestRunner {
     cleanup:
     parentScope.close()
     parentSpan.end()
+  }
+
+  def "test context extraction and injection"() {
+    setup:
+    def propagator = W3CTraceContextPropagator.getInstance()
+    def httpHeaders = ['traceparent': traceparent]
+    def context = propagator.extract(Context.root(), httpHeaders, new TextMapGetter<Map<String, String>>() {
+        @Override
+        Iterable<String> keys(Map<String, String> carrier) {
+          return carrier.keySet()
+        }
+
+        @Override
+        String get(@Nullable Map<String, String> carrier, String key) {
+          return carrier.get(key)
+        }
+      })
+
+    def localSpan = tracer.spanBuilder("some-name")
+      .setParent(context)
+      .startSpan()
+
+    when:
+    def localSpanContext = localSpan.getSpanContext()
+    def localSpanId = localSpanContext.getSpanId()
+    def spanSampled = localSpanContext.getTraceFlags().isSampled()
+    def scope = localSpan.makeCurrent()
+    Map<String, String> injectedHeaders = [:]
+    propagator.inject(Context.current(), injectedHeaders, new TextMapSetter<Map<String, String>>() {
+        @Override
+        void set(@Nullable Map<String, String> carrier, String key, String value) {
+          carrier.put(key, value)
+        }
+      })
+    scope.close()
+    localSpan.end()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "some-name"
+          traceDDId(DDTraceId.fromHex(traceId))
+          parentSpanId(DDSpanId.fromHex(spanId).toLong() as BigInteger)
+        }
+      }
+    }
+    spanSampled == sampled
+    injectedHeaders == ['traceparent': "00-$traceId-$localSpanId-$sampleFlag" as String]
+
+    where:
+    traceId | spanId | sampled
+    '00000000000000001111111111111111' | '2222222222222222' | true
+    '00000000000000001111111111111111' | '2222222222222222' | false
+    sampleFlag = sampled ? '01' : '00'
+    traceparent = "00-$traceId-$spanId-$sampleFlag" as String
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1432,6 +1432,13 @@ public class CoreTracer implements AgentTracer.TracerAPI {
           samplingPriority = extractedContext.getSamplingPriority();
           endToEndStartTime = extractedContext.getEndToEndStartTime();
           propagationTags = extractedContext.getPropagationTags();
+        } else if (parentContext instanceof AgentSpan.Context) {
+          final AgentSpan.Context spanContext = (AgentSpan.Context) parentContext;
+          traceId = spanContext.getTraceId();
+          parentSpanId = spanContext.getSpanId();
+          samplingPriority = spanContext.getSamplingPriority();
+          endToEndStartTime = 0;
+          propagationTags = propagationTagsFactory.empty();
         } else {
           // Start a new trace
           traceId = idGenerationStrategy.generateTraceId();

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -499,9 +499,7 @@ public class DDSpanContext
     return true;
   }
 
-  /**
-   * @return the trace sampling priority of this span's trace, or null if no priority has been set
-   */
+  @Override
   public int getSamplingPriority() {
     return getRootSpanContextOrThis().samplingPriority;
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -4,6 +4,7 @@ import datadog.trace.api.DDTraceId;
 import datadog.trace.api.gateway.IGSpanInfo;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.interceptor.MutableSpan;
+import datadog.trace.api.sampling.PrioritySampling;
 import java.util.Map;
 
 public interface AgentSpan extends MutableSpan, IGSpanInfo {
@@ -148,6 +149,16 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo {
     long getSpanId();
 
     AgentTrace getTrace();
+
+    /**
+     * Get the trace sampling priority of the span's trace.
+     *
+     * <p>Check {@link PrioritySampling} for possible values.
+     *
+     * @return The trace sampling priority of the span's trace, or {@link PrioritySampling#UNSET} if
+     *     no priority has been set.
+     */
+    int getSamplingPriority();
 
     Iterable<Map.Entry<String, String>> baggageItems();
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -144,14 +144,30 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo {
   Integer forceSamplingDecision();
 
   interface Context {
+    /**
+     * Gets the TraceId of the span's trace.
+     *
+     * @return The TraceId of the span's trace, or {@link DDTraceId#ZERO} if not set.
+     */
     DDTraceId getTraceId();
 
+    /**
+     * Gets the SpanId.
+     *
+     * @return The span identifier, or {@link datadog.trace.api.DDSpanId#ZERO} if not set.
+     */
     long getSpanId();
 
+    /**
+     * Get the span's trace.
+     *
+     * @return The span's trace, or a noop {@link AgentTracer.NoopAgentTrace#INSTANCE} if the trace
+     *     is not valid.
+     */
     AgentTrace getTrace();
 
     /**
-     * Get the trace sampling priority of the span's trace.
+     * Gets the trace sampling priority of the span's trace.
      *
      * <p>Check {@link PrioritySampling} for possible values.
      *

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -840,6 +840,11 @@ public class AgentTracer {
     }
 
     @Override
+    public int getSamplingPriority() {
+      return PrioritySampling.UNSET;
+    }
+
+    @Override
     public Iterable<Map.Entry<String, String>> baggageItems() {
       return Collections.emptyList();
     }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
@@ -133,6 +133,7 @@ public class TagContext implements AgentSpan.Context.Extracted {
     return tags;
   }
 
+  @Override
   public final int getSamplingPriority() {
     return samplingPriority;
   }


### PR DESCRIPTION
# What Does This Do

This PR brings the support of OpenTelemetry ContextPropagator API.
It will allow to inject and extract context using OpenTelemetry API.

# Motivation

Improve the support of OpenTelemetry Tracing APIs.

# Additional Notes
