### PR TITLE
[data streams] Remove partition tag from latency metrics

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/latestDepTest/groovy/KafkaClientTest.groovy
@@ -180,11 +180,10 @@ class KafkaClientTest extends AgentTestRunner {
       edgeTags == [
         "direction:in",
         "group:sender",
-        "partition:" + received.partition(),
         "topic:$SHARED_TOPIC".toString(),
         "type:kafka"
       ]
-      edgeTags.size() == 5
+      edgeTags.size() == 4
     }
 
     cleanup:
@@ -310,11 +309,10 @@ class KafkaClientTest extends AgentTestRunner {
       edgeTags == [
         "direction:in",
         "group:sender",
-        "partition:" + received.partition(),
         "topic:$SHARED_TOPIC".toString(),
         "type:kafka"
       ]
-      edgeTags.size() == 5
+      edgeTags.size() == 4
     }
 
     cleanup:
@@ -802,7 +800,6 @@ class KafkaClientTest extends AgentTestRunner {
     conditions.eventually {
       assert !records.isEmpty()
     }
-    int partition = records.first().partition()
     def receivedSet = greetings.toSet()
     greetings.eachWithIndex { g, i ->
       def received = records.poll(5, TimeUnit.SECONDS)
@@ -949,11 +946,10 @@ class KafkaClientTest extends AgentTestRunner {
       edgeTags == [
         "direction:in",
         "group:sender",
-        "partition:" + partition,
         "topic:$SHARED_TOPIC".toString(),
         "type:kafka"
       ]
-      edgeTags.size() == 5
+      edgeTags.size() == 4
     }
 
     cleanup:

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -7,7 +7,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_OUT;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
-import static datadog.trace.core.datastreams.TagsProcessor.PARTITION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TOPIC_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TYPE_TAG;
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.KAFKA_LEGACY_TRACING;
@@ -94,9 +93,6 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Tracing
           && !Config.get().isKafkaClientPropagationDisabledForTopic(record.topic())) {
         LinkedHashMap<String, String> sortedTags = new LinkedHashMap<>();
         sortedTags.put(DIRECTION_TAG, DIRECTION_OUT);
-        if (record.partition() != null) {
-          sortedTags.put(PARTITION_TAG, record.partition().toString());
-        }
         sortedTags.put(TOPIC_TAG, record.topic());
         sortedTags.put(TYPE_TAG, "kafka");
         try {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
@@ -7,7 +7,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_IN;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.GROUP_TAG;
-import static datadog.trace.core.datastreams.TagsProcessor.PARTITION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TOPIC_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TYPE_TAG;
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.BROKER_DECORATE;
@@ -92,7 +91,6 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
           LinkedHashMap<String, String> sortedTags = new LinkedHashMap<>();
           sortedTags.put(DIRECTION_TAG, DIRECTION_IN);
           sortedTags.put(GROUP_TAG, group);
-          sortedTags.put(PARTITION_TAG, String.valueOf(val.partition()));
           sortedTags.put(TOPIC_TAG, val.topic());
           sortedTags.put(TYPE_TAG, "kafka");
           AgentTracer.get().setDataStreamCheckpoint(span, sortedTags);

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
@@ -187,11 +187,10 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
         edgeTags == [
           "direction:in",
           "group:sender",
-          "partition:" + received.partition(),
           "topic:$SHARED_TOPIC".toString(),
           "type:kafka"
         ]
-        edgeTags.size() == 5
+        edgeTags.size() == 4
       }
       List<String> produce = ["partition:"+received.partition(), "topic:"+SHARED_TOPIC, "type:kafka_produce"]
       List<String> commit = [
@@ -322,11 +321,10 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
         edgeTags == [
           "direction:in",
           "group:sender",
-          "partition:" + received.partition(),
           "topic:$SHARED_TOPIC".toString(),
           "type:kafka"
         ]
-        edgeTags.size() == 5
+        edgeTags.size() == 4
       }
       List<String> produce = ["partition:"+received.partition(), "topic:"+SHARED_TOPIC, "type:kafka_produce"]
       List<String> commit = [
@@ -733,7 +731,6 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
     }
 
     then:
-    int partition = records.first().partition()
     def receivedSet = greetings.toSet()
     greetings.eachWithIndex { g, i ->
       def received = records.poll(5, TimeUnit.SECONDS)
@@ -792,8 +789,8 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
 
       StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == first.hash }
       verifyAll(second) {
-        edgeTags == ["group:sender", "partition:" + partition, "topic:$SHARED_TOPIC".toString(), "type:kafka"]
-        edgeTags.size() == 4
+        edgeTags == ["group:sender", "topic:$SHARED_TOPIC".toString(), "type:kafka"]
+        edgeTags.size() == 3
       }
     }
 

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/latestDepTest/groovy/KafkaStreamsTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/latestDepTest/groovy/KafkaStreamsTest.groovy
@@ -231,11 +231,10 @@ class KafkaStreamsTest extends AgentTestRunner {
         edgeTags == [
           "direction:in",
           "group:test-application",
-          "partition:0",
           "topic:$STREAM_PENDING".toString(),
           "type:kafka"
         ]
-        edgeTags.size() == 5
+        edgeTags.size() == 4
       }
 
       StatsGroup kafkaStreamsProducerPoint = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == kafkaStreamsConsumerPoint.hash }
@@ -246,8 +245,8 @@ class KafkaStreamsTest extends AgentTestRunner {
 
       StatsGroup finalConsumerPoint = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == kafkaStreamsProducerPoint.hash }
       verifyAll(finalConsumerPoint) {
-        edgeTags == ["direction:in", "group:sender", "partition:0", "topic:$STREAM_PROCESSED".toString(), "type:kafka"]
-        edgeTags.size() == 5
+        edgeTags == ["direction:in", "group:sender", "topic:$STREAM_PROCESSED".toString(), "type:kafka"]
+        edgeTags.size() == 4
       }
     }
 

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
@@ -7,7 +7,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_IN;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.GROUP_TAG;
-import static datadog.trace.core.datastreams.TagsProcessor.PARTITION_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TOPIC_TAG;
 import static datadog.trace.core.datastreams.TagsProcessor.TYPE_TAG;
 import static datadog.trace.instrumentation.kafka_streams.KafkaStreamsDecorator.BROKER_DECORATE;
@@ -244,7 +243,6 @@ public class KafkaStreamTaskInstrumentation extends Instrumenter.Tracing
             sortedTags.put(GROUP_TAG, applicationId);
           }
         }
-        sortedTags.put(PARTITION_TAG, String.valueOf(record.partition()));
         sortedTags.put(TOPIC_TAG, record.topic());
         sortedTags.put(TYPE_TAG, "kafka");
         AgentTracer.get().setDataStreamCheckpoint(span, sortedTags);
@@ -310,7 +308,6 @@ public class KafkaStreamTaskInstrumentation extends Instrumenter.Tracing
             sortedTags.put(GROUP_TAG, applicationId);
           }
         }
-        sortedTags.put(PARTITION_TAG, String.valueOf(record.partition()));
         sortedTags.put(TOPIC_TAG, record.topic());
         sortedTags.put(TYPE_TAG, "kafka");
         AgentTracer.get().setDataStreamCheckpoint(span, sortedTags);

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTestBase.groovy
@@ -294,11 +294,10 @@ abstract class KafkaStreamsTestBase extends VersionedNamingTestBase {
         edgeTags == [
           "direction:in",
           "group:test-application",
-          "partition:0",
           "topic:$STREAM_PENDING".toString(),
           "type:kafka"
         ]
-        edgeTags.size() == 5
+        edgeTags.size() == 4
       }
 
       StatsGroup kafkaStreamsProducerPoint = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == kafkaStreamsConsumerPoint.hash }
@@ -309,8 +308,8 @@ abstract class KafkaStreamsTestBase extends VersionedNamingTestBase {
 
       StatsGroup finalConsumerPoint = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == kafkaStreamsProducerPoint.hash }
       verifyAll(finalConsumerPoint) {
-        edgeTags == ["direction:in", "group:sender", "partition:0", "topic:$STREAM_PROCESSED".toString(), "type:kafka"]
-        edgeTags.size() == 5
+        edgeTags == ["direction:in", "group:sender", "topic:$STREAM_PROCESSED".toString(), "type:kafka"]
+        edgeTags.size() == 4
       }
     }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
@@ -53,7 +53,6 @@ public class DefaultPathwayContext implements PathwayContext {
   private static final Set<String> hashableTagKeys =
       new HashSet<String>(
           Arrays.asList(
-              TagsProcessor.GROUP_TAG,
               TagsProcessor.TYPE_TAG,
               TagsProcessor.DIRECTION_TAG,
               TagsProcessor.TOPIC_TAG,


### PR DESCRIPTION
# What Does This Do

partition tag on this metric is making cardinality really high.
We have data by partition on consumer lag, so removing it from here.
We also don't use that information in the UI.

# Motivation

# Additional Notes
