### PR TITLE
Fix potential issue with apache-httpclient call-depth tracking

### DIFF
--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
@@ -12,6 +12,8 @@ import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -27,6 +29,31 @@ public class HelperMethods {
       return null;
     }
 
+    final int callDepth = CallDepthThreadLocalMap.incrementCallDepth(HttpClient.class);
+    if (callDepth > 0) {
+      return null;
+    }
+
+    return activateHttpSpan(request, awsClientCall);
+  }
+
+  public static AgentScope doMethodEnter(HttpHost host, HttpRequest request) {
+    boolean awsClientCall = request.containsHeader("amz-sdk-invocation-id");
+    if (!AWS_LEGACY_TRACING && awsClientCall) {
+      // avoid creating an extra HTTP client span beneath the AWS client call
+      return null;
+    }
+
+    final int callDepth = CallDepthThreadLocalMap.incrementCallDepth(HttpClient.class);
+    if (callDepth > 0) {
+      return null;
+    }
+
+    return activateHttpSpan(new HostAndRequestAsHttpUriRequest(host, request), awsClientCall);
+  }
+
+  private static AgentScope activateHttpSpan(
+      final HttpUriRequest request, final boolean awsClientCall) {
     final AgentSpan span = startSpan(HTTP_REQUEST);
     final AgentScope scope = activateSpan(span);
 

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HelperMethods.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HelperMethods.java
@@ -13,6 +13,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
 import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
 
@@ -27,6 +28,31 @@ public class HelperMethods {
       return null;
     }
 
+    final int callDepth = CallDepthThreadLocalMap.incrementCallDepth(HttpClient.class);
+    if (callDepth > 0) {
+      return null;
+    }
+
+    return activateHttpSpan(request, awsClientCall);
+  }
+
+  public static AgentScope doMethodEnter(HttpHost host, HttpRequest request) {
+    boolean awsClientCall = request.containsHeader("amz-sdk-invocation-id");
+    if (!AWS_LEGACY_TRACING && awsClientCall) {
+      // avoid creating an extra HTTP client span beneath the AWS client call
+      return null;
+    }
+
+    final int callDepth = CallDepthThreadLocalMap.incrementCallDepth(HttpClient.class);
+    if (callDepth > 0) {
+      return null;
+    }
+
+    return activateHttpSpan(new HostAndRequestAsHttpUriRequest(host, request), awsClientCall);
+  }
+
+  private static AgentScope activateHttpSpan(
+      final HttpRequest request, final boolean awsClientCall) {
     final AgentSpan span = startSpan(HTTP_REQUEST);
     final AgentScope scope = activateSpan(span);
 


### PR DESCRIPTION
# What Does This Do

We only reset the call-depth when we're finishing an HTTP span, so we must only increment it when we know we'll create and activate an HTTP span.

# Motivation

Previously it was possible the call-depth would be incremented, but an HTTP span might then not be created if the request came from the AWS SDK.

# Additional Notes

Workaround when using versions of the tracer without this fix - either add this JVM option:
```
-Ddd.aws-sdk.legacy.tracing.enabled=true
```
or set this environment variable:
```
DD_AWS_SDK_LEGACY_TRACING_ENABLED=true
```