### PR TITLE
Update tag names for WAF metrics

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/metric/MetricPeriodicAction.java
+++ b/telemetry/src/main/java/datadog/telemetry/metric/MetricPeriodicAction.java
@@ -34,8 +34,8 @@ public class MetricPeriodicAction implements TelemetryRunnable.TelemetryPeriodic
         metric.addTagsItem("event_rules_version:" + ((WafUpdatesRawMetric) raw).rulesVersion);
       }
       if (raw instanceof WafRequestsRawMetric) {
-        metric.addTagsItem("triggered:" + ((WafRequestsRawMetric) raw).triggered);
-        metric.addTagsItem("blocked:" + ((WafRequestsRawMetric) raw).blocked);
+        metric.addTagsItem("rule_triggered:" + ((WafRequestsRawMetric) raw).triggered);
+        metric.addTagsItem("request_blocked:" + ((WafRequestsRawMetric) raw).blocked);
       }
 
       service.addMetric(metric);

--- a/telemetry/src/test/groovy/datadog/telemetry/metric/MetricPeriodicActionSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/metric/MetricPeriodicActionSpecification.groovy
@@ -57,19 +57,19 @@ class MetricPeriodicActionSpecification extends DDSpecification {
       metric.namespace == 'appsec' &&
         metric.metric == 'waf.requests' &&
         metric.points[0][1] == 3 &&
-        metric.tags == ['triggered:false', 'blocked:false']
+        metric.tags == ['rule_triggered:false', 'request_blocked:false']
     } )
     1 * telemetryService.addMetric( { Metric metric ->
       metric.namespace == 'appsec' &&
         metric.metric == 'waf.requests' &&
         metric.points[0][1] == 2 &&
-        metric.tags == ['triggered:true', 'blocked:false']
+        metric.tags == ['rule_triggered:true', 'request_blocked:false']
     } )
     1 * telemetryService.addMetric( { Metric metric ->
       metric.namespace == 'appsec' &&
         metric.metric == 'waf.requests' &&
         metric.points[0][1] == 1 &&
-        metric.tags == ['triggered:true', 'blocked:true']
+        metric.tags == ['rule_triggered:true', 'request_blocked:true']
     } )
     0 * _._
   }


### PR DESCRIPTION


# What Does This Do

# Motivation
Last version of the spec changed triggered/blocked to rules_triggered/request_blocked.

# Additional Notes
