### PR TITLE
Bump ddprof lib to 0.33.0

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/build.gradle
@@ -29,7 +29,7 @@ excludedClassesCoverage += [
 dependencies {
   api project(':dd-java-agent:agent-profiling:profiling-controller')
   api project(':dd-java-agent:agent-profiling:profiling-utils')
-  implementation project.hasProperty('jplib.jar') ? files(project.getProperty('jplib.jar')) : deps.jplib
+  implementation project.hasProperty('ddprof.jar') ? files(project.getProperty('ddprof.jar')) : deps.ddprof
 
   annotationProcessor deps.autoserviceProcessor
   compileOnly deps.autoserviceAnnotation
@@ -47,8 +47,8 @@ shadowJar {
     rslt |= it.path == "com" || it.path == "com/datadog"
     || it.path.startsWith("com/datadog/") || it.path == "com/datadoghq" || it.path == "com/datadoghq/profiler"
     || it.path.startsWith("com/datadoghq/profiler")
-    rslt |= it.path == "META-INF" || it.path == "META-INF/services" || it.path.startsWith("META-INF/services/") || it.path.startsWith("META-INF/native/")
-    rslt |= (it.path.contains("jplib") && it.path.endsWith(".jar"))
+    rslt |= it.path == "META-INF" || it.path == "META-INF/services" || it.path.startsWith("META-INF/services/") || it.path.startsWith("META-INF/native-libs/")
+    rslt |= (it.path.contains("ddprof") && it.path.endsWith(".jar"))
     return rslt
   }
 }

--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -239,7 +239,7 @@ tasks.register('checkAgentJarSize').configure {
   doLast {
     // Arbitrary limit to prevent unintentional increases to the agent jar size
     // Raise or lower as required
-    def megs = (project.rootProject.hasProperty("agentIncludeCwsTls") && agentIncludeCwsTls) ? 26 : 25
+    def megs = (project.rootProject.hasProperty("agentIncludeCwsTls") && agentIncludeCwsTls) ? 27 : 26
     assert shadowJar.archiveFile.get().getAsFile().length() <= megs * 1024 * 1024
   }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    jplib         : "0.30.0",
+    ddprof        : "0.33.0",
     asm           : "9.5"
   ]
 
@@ -51,7 +51,7 @@ final class CachedData {
     autoserviceProcessor : "com.google.auto.service:auto-service:${versions.autoservice}",
     autoserviceAnnotation: "com.google.auto.service:auto-service-annotations:${versions.autoservice}",
     commonsMath          : "org.apache.commons:commons-math3:${versions.commons}",
-    jplib                : "com.datadoghq:jplib:${versions.jplib}",
+    ddprof               : "com.datadoghq:ddprof:${versions.ddprof}",
     asm                  : "org.ow2.asm:asm:${versions.asm}",
     asmcommons           : "org.ow2.asm:asm-commons:${versions.asm}",
     dogstatsd            : "com.datadoghq:java-dogstatsd-client:${versions.dogstatsd}",


### PR DESCRIPTION
# What Does This Do
Brings the ddprof dependency to the latest version

# Motivation

# Additional Notes
## ddprof release notes
https://github.com/DataDog/java-profiler/releases/tag/v_0.33.0
---
- Use gradle as the build system
- Update J9 checks for commercial IBM JDK 8 versioning
- Adjust JVM version parsing for IBM JDK 8 quirks
- Use stripped release binaries

## Artifact id changes
The artifact name changed from `jplib` to `ddprof` so the dependencies were updated accordingly