### PR TITLE
Fix config id reporting in remote config

### DIFF
--- a/remote-config/src/main/java/datadog/remoteconfig/state/ProductState.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/state/ProductState.java
@@ -175,7 +175,7 @@ public class ProductState {
     RemoteConfigRequest.ClientInfo.ClientState.ConfigState newState =
         new RemoteConfigRequest.ClientInfo.ClientState.ConfigState();
     newState.setState(
-        configKey,
+        parsedConfigKey.getConfigId(),
         target.custom.version,
         product.name(),
         error != null ? error.getMessage() : null);


### PR DESCRIPTION
# What Does This Do
Report config id in the id field, rather than the config path.

# Motivation
Made some new system-test fail.

# Additional Notes
See https://github.com/DataDog/system-tests/pull/1074