### PR TITLE
Switch reliability env deploys to be scheduled

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,7 +72,10 @@ deploy_to_reliability_env:
   rules:
     - if: '$POPULATE_CACHE'
       when: never
-    - when: on_success
+    - if: $CI_PIPELINE_SOURCE == "scheduled"
+      when: on_success
+    - when: manual
+      allow_failure: true
   trigger:
     project: DataDog/apm-reliability/datadog-reliability-env
     branch: $DOWNSTREAM_BRANCH

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,8 +70,6 @@ build_with_cache:
 deploy_to_reliability_env:
   stage: deploy
   rules:
-    - if: '$POPULATE_CACHE'
-      when: never
     - if: $CI_PIPELINE_SOURCE == "scheduled"
       when: on_success
     - when: manual


### PR DESCRIPTION
# What Does This Do
Changes reliability env deployments to only happen when scheduled or manually triggered

# Motivation
Deploy on master commit is too noisy. Switching to a scheduled deploy should help
