### PR TITLE
Insecure cookies detection for servlet

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastSystem.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastSystem.java
@@ -6,6 +6,7 @@ import com.datadog.iast.propagation.FastCodecModule;
 import com.datadog.iast.propagation.PropagationModuleImpl;
 import com.datadog.iast.propagation.StringModuleImpl;
 import com.datadog.iast.sink.CommandInjectionModuleImpl;
+import com.datadog.iast.sink.InsecureCookieModuleImpl;
 import com.datadog.iast.sink.LdapInjectionModuleImpl;
 import com.datadog.iast.sink.PathTraversalModuleImpl;
 import com.datadog.iast.sink.SqlInjectionModuleImpl;
@@ -88,7 +89,8 @@ public class IastSystem {
         new WeakCipherModuleImpl(),
         new WeakHashModuleImpl(),
         new LdapInjectionModuleImpl(),
-        new PropagationModuleImpl());
+        new PropagationModuleImpl(),
+        new InsecureCookieModuleImpl());
   }
 
   private static void registerRequestStartedCallback(

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
@@ -8,6 +8,7 @@ import javax.annotation.Nonnull;
 public interface VulnerabilityType {
   VulnerabilityType WEAK_CIPHER = new VulnerabilityTypeImpl(VulnerabilityTypes.WEAK_CIPHER);
   VulnerabilityType WEAK_HASH = new VulnerabilityTypeImpl(VulnerabilityTypes.WEAK_HASH);
+  VulnerabilityType INSECURE_COOKIE = new VulnerabilityTypeImpl(VulnerabilityTypes.INSECURE_COOKIE);
   InjectionType SQL_INJECTION = new InjectionTypeImpl(VulnerabilityTypes.SQL_INJECTION, ' ');
   InjectionType COMMAND_INJECTION =
       new InjectionTypeImpl(VulnerabilityTypes.COMMAND_INJECTION, ' ');

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/InsecureCookieModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/InsecureCookieModuleImpl.java
@@ -7,10 +7,9 @@ import datadog.trace.api.Config;
 import datadog.trace.api.iast.sink.InsecureCookieModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-
-import javax.annotation.Nonnull;
 import java.net.HttpCookie;
 import java.util.List;
+import javax.annotation.Nonnull;
 
 public class InsecureCookieModuleImpl extends SinkModuleBase implements InsecureCookieModule {
 
@@ -35,9 +34,16 @@ public class InsecureCookieModuleImpl extends SinkModuleBase implements Insecure
 
   @Override
   public void onCookieHeader(String value) {
-    List<HttpCookie> cookies = HttpCookie.parse(value);
-    for (HttpCookie cookie:cookies){
-      if (!cookie.getSecure()){
+    if (null == value) {
+      return;
+    }
+    try {
+      List<HttpCookie> cookies = HttpCookie.parse(value);
+    } catch (IllegalArgumentException e) {
+      return;
+    }
+    for (HttpCookie cookie : cookies) {
+      if (!cookie.getSecure()) {
         final AgentSpan span = AgentTracer.activeSpan();
         if (!overheadController.consumeQuota(Operations.REPORT_VULNERABILITY, span)) {
           return;

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/InsecureCookieModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/InsecureCookieModuleImpl.java
@@ -1,0 +1,50 @@
+package com.datadog.iast.sink;
+
+import com.datadog.iast.model.Evidence;
+import com.datadog.iast.model.VulnerabilityType;
+import com.datadog.iast.overhead.Operations;
+import datadog.trace.api.Config;
+import datadog.trace.api.iast.sink.InsecureCookieModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+
+import javax.annotation.Nonnull;
+import java.net.HttpCookie;
+import java.util.List;
+
+public class InsecureCookieModuleImpl extends SinkModuleBase implements InsecureCookieModule {
+
+  private Config config;
+
+  @Override
+  public void registerDependencies(@Nonnull Dependencies dependencies) {
+    super.registerDependencies(dependencies);
+    config = dependencies.getConfig();
+  }
+
+  @Override
+  public void onCookie(String cookieName, boolean secure) {
+    if (!secure && cookieName != null && cookieName.length() > 0) {
+      final AgentSpan span = AgentTracer.activeSpan();
+      if (!overheadController.consumeQuota(Operations.REPORT_VULNERABILITY, span)) {
+        return;
+      }
+      report(span, VulnerabilityType.INSECURE_COOKIE, new Evidence(cookieName));
+    }
+  }
+
+  @Override
+  public void onCookieHeader(String value) {
+    List<HttpCookie> cookies = HttpCookie.parse(value);
+    for (HttpCookie cookie:cookies){
+      if (!cookie.getSecure()){
+        final AgentSpan span = AgentTracer.activeSpan();
+        if (!overheadController.consumeQuota(Operations.REPORT_VULNERABILITY, span)) {
+          return;
+        }
+        report(span, VulnerabilityType.INSECURE_COOKIE, new Evidence(cookie.getName()));
+        return;
+      }
+    }
+  }
+}

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/InsecureCookieModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/InsecureCookieModuleImpl.java
@@ -7,10 +7,9 @@ import datadog.trace.api.Config;
 import datadog.trace.api.iast.sink.InsecureCookieModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-
-import javax.annotation.Nonnull;
 import java.net.HttpCookie;
 import java.util.List;
+import javax.annotation.Nonnull;
 
 public class InsecureCookieModuleImpl extends SinkModuleBase implements InsecureCookieModule {
 

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/InsecureCookieModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/InsecureCookieModuleTest.groovy
@@ -1,0 +1,123 @@
+package com.datadog.iast.sink
+
+import com.datadog.iast.IastModuleImplTestBase
+import com.datadog.iast.IastRequestContext
+import com.datadog.iast.model.Vulnerability
+import com.datadog.iast.model.VulnerabilityType
+import datadog.trace.api.gateway.RequestContext
+import datadog.trace.api.gateway.RequestContextSlot
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import groovy.transform.CompileDynamic
+
+@CompileDynamic
+class InsecureCookieModuleTest  extends IastModuleImplTestBase {
+
+  private List<Object> objectHolder
+
+  private IastRequestContext ctx
+
+  private InsecureCookieModuleImpl module
+
+  private AgentSpan span
+
+  def setup() {
+    module = registerDependencies(new InsecureCookieModuleImpl())
+    objectHolder = []
+    ctx = new IastRequestContext()
+    final reqCtx = Mock(RequestContext) {
+      getData(RequestContextSlot.IAST) >> ctx
+    }
+    span = Mock(AgentSpan) {
+      getSpanId() >> 123456
+      getRequestContext() >> reqCtx
+    }
+  }
+
+  void 'report insecure cookie with InsecureCookieModule.onCookieHeader'() {
+    given:
+    Vulnerability savedVul
+
+    when:
+    module.onCookieHeader(cookieValue)
+
+    then:
+    1 * tracer.activeSpan() >> span
+    1 * overheadController.consumeQuota(_, _) >> true
+    1 * reporter.report(_, _ as Vulnerability) >> { savedVul = it[1] }
+    with(savedVul) {
+      type == VulnerabilityType.INSECURE_COOKIE
+      location != null
+      with(evidence) {
+        value == expected
+      }
+    }
+
+    where:
+    cookieValue                     | expected
+    "user-id=7"                     | "user-id"
+  }
+
+  void 'report insecure cookie with InsecureCookieModule.onCookie'() {
+    given:
+    Vulnerability savedVul
+
+    when:
+    module.onCookie(cookieName, false)
+
+    then:
+    1 * tracer.activeSpan() >> span
+    1 * overheadController.consumeQuota(_, _) >> true
+    1 * reporter.report(_, _ as Vulnerability) >> { savedVul = it[1] }
+    with(savedVul) {
+      type == VulnerabilityType.INSECURE_COOKIE
+      location != null
+      with(evidence) {
+        value == expected
+      }
+    }
+
+    where:
+    cookieName                     | expected
+    "user-id"                     | "user-id"
+  }
+
+  void 'cases where nothing is reported during InsecureCookieModule.onCookie'() {
+
+    when:
+    module.onCookie(cookieValue, isSecure)
+
+    then:
+    0 * tracer.activeSpan()
+    0 * overheadController._
+    0 * reporter._
+
+    where:
+    cookieValue           | isSecure
+    "user-id"             | true
+    null                  | true
+    null                  | false
+    ""                    | false
+    ""                    | true
+  }
+
+
+  void 'cases where nothing is reported during InsecureCookieModule.onCookieHeader'() {
+
+    when:
+    module.onCookie(cookieValue)
+
+    then:
+    0 * tracer.activeSpan()
+    0 * overheadController._
+    0 * reporter._
+
+    where:
+    cookieValue           | _
+    null                  | _
+    "user-id=7; Secure"   | _
+    "user-id7; Secure"    | _
+    "user-id=7;Secure"    | _
+    "blah"                | _
+    ""                    | _
+  }
+}

--- a/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
@@ -1,0 +1,74 @@
+package datadog.trace.instrumentation.servlet;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.sink.InsecureCookieModule;
+import javax.servlet.http.Cookie;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(Instrumenter.class)
+public final class HttpServletResponseInstrumentation extends Instrumenter.Iast
+    implements Instrumenter.ForTypeHierarchy {
+  public HttpServletResponseInstrumentation() {
+    super("servlet", "servelet-response");
+  }
+
+  @Override
+  public String muzzleDirective() {
+    return "servlet-common";
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "javax.servlet.http.HttpServletResponse";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return implementsInterface(named(hierarchyMarkerType()))
+        .and(not(extendsClass(named("javax.servlet.http.HttpServletResponseWrapper"))));
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(named("addCookie"), this.getClass().getName() + "$AddCookieAdvice");
+    transformation.applyAdvice(
+        namedOneOf("setHeader", "addHeader").and(takesArguments(String.class, String.class)),
+        this.getClass().getName() + "$AddHeaderAdvice");
+  }
+
+  public static class AddCookieAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter(@Advice.Argument(0) final Cookie cookie) {
+      final InsecureCookieModule module = InstrumentationBridge.INSECURE_COOKIE;
+      if (module != null) {
+        if (null != cookie) {
+          module.onCookie(cookie.getName(), cookie.getSecure());
+        }
+      }
+    }
+  }
+
+  public static class AddHeaderAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter(
+        @Advice.Argument(0) final String name, @Advice.Argument(1) String value) {
+      final InsecureCookieModule module = InstrumentationBridge.INSECURE_COOKIE;
+      if (module != null) {
+        if ("Set-Cookie".equalsIgnoreCase(name) && null != value && value.length() > 0) {
+          module.onCookieHeader(value);
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/servlet-common/src/test/groovy/HttpServletResponseInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/servlet-common/src/test/groovy/HttpServletResponseInstrumentationTest.groovy
@@ -1,0 +1,218 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.sink.InsecureCookieModule
+import foo.bar.DummyResponse
+
+import javax.servlet.http.Cookie
+import javax.servlet.http.HttpServletResponse
+import javax.servlet.http.HttpServletResponseWrapper
+
+class HttpServletResponseInstrumentationTest  extends AgentTestRunner {
+  @Override
+  protected void configurePreAgent() {
+    injectSysConfig('dd.iast.enabled', 'true')
+  }
+
+  void 'insecure cookie added using addCookie'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+    final cookie = new Cookie("user-id", "7")
+
+    when:
+    response.addCookie(cookie)
+
+    then:
+    1 * module.onCookie("user-id", false)
+    0 * _
+  }
+
+  void 'make sure we do not instrument subclasses of HttpServletResponseWrapper'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final request = Mock(HttpServletResponse)
+    final wrapper = new HttpServletResponseWrapper(request)
+    final cookie = new Cookie("user-id", "7")
+
+    when:
+    wrapper.addCookie(cookie)
+
+    then:
+    1 * request.addCookie(cookie)
+    0 * _
+  }
+
+  void 'secure cookie added using addCookie'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+    final cookie = new Cookie("user-id", "7")
+    cookie.setSecure(true)
+
+    when:
+    response.addCookie(cookie)
+
+    then:
+    1 * module.onCookie('user-id', true)
+    0 * _
+  }
+
+  void 'null cookie added using addCookie'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.addCookie(null)
+
+    then:
+    0 * _
+  }
+
+  void 'insecure cookie added using addHeader'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.addHeader("Set-Cookie", "user-id=7")
+
+    then:
+    1 * module.onCookieHeader('user-id=7')
+    0 * _
+  }
+
+  void 'null parameters added using addHeader'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.addHeader(null, null)
+
+    then:
+    noExceptionThrown()
+    0 * _
+  }
+
+  void 'null value added using addHeader'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.addHeader("Set-Cookie", null)
+
+    then:
+    noExceptionThrown()
+    0 * module.onCookieHeader(_)
+    0 * _
+  }
+
+  void 'null header name added using addHeader'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.addHeader(null, "user-id=7")
+
+    then:
+    noExceptionThrown()
+    0 * module.onCookieHeader(_)
+    0 * _
+  }
+
+
+  void 'secure cookie added using addHeader'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.addHeader("Set-Cookie", "user-id=7; Secure")
+
+    then:
+    1 * module.onCookieHeader('user-id=7; Secure')
+    0 * _
+  }
+
+  void 'adding non cookie header'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.addHeader("Custom-Header", "user-id=7")
+
+    then:
+    0 * _
+  }
+
+  void 'cookie without name value pair'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.addHeader("Set-Cookie", "user-id")
+
+    then:
+    1 * module.onCookieHeader('user-id')
+    0 * _
+  }
+
+
+  void 'insecure cookie added using setHeader'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.setHeader("Set-Cookie", "user-id=7")
+
+    then:
+    1 * module.onCookieHeader('user-id=7')
+    0 * _
+  }
+
+  void 'secure cookie added using setHeader'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.setHeader("Set-Cookie", "user-id=7; Secure")
+
+    then:
+    1 * module.onCookieHeader('user-id=7; Secure')
+    0 * _
+  }
+
+  void 'secure cookie added using setHeader without spaces'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.setHeader("Set-Cookie", "user-id=7;Secure")
+
+    then:
+    1 * module.onCookieHeader('user-id=7;Secure')
+    0 * _
+  }
+}

--- a/dd-java-agent/instrumentation/servlet-common/src/test/java/foo/bar/DummyResponse.java
+++ b/dd-java-agent/instrumentation/servlet-common/src/test/java/foo/bar/DummyResponse.java
@@ -1,0 +1,122 @@
+package foo.bar;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Locale;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+
+public class DummyResponse implements HttpServletResponse {
+  @Override
+  public void addCookie(Cookie cookie) {}
+
+  @Override
+  public boolean containsHeader(String name) {
+    return false;
+  }
+
+  @Override
+  public String encodeURL(String url) {
+    return null;
+  }
+
+  @Override
+  public String encodeRedirectURL(String url) {
+    return null;
+  }
+
+  @Override
+  public String encodeUrl(String url) {
+    return null;
+  }
+
+  @Override
+  public String encodeRedirectUrl(String url) {
+    return null;
+  }
+
+  @Override
+  public void sendError(int sc, String msg) throws IOException {}
+
+  @Override
+  public void sendError(int sc) throws IOException {}
+
+  @Override
+  public void sendRedirect(String location) throws IOException {}
+
+  @Override
+  public void setDateHeader(String name, long date) {}
+
+  @Override
+  public void addDateHeader(String name, long date) {}
+
+  @Override
+  public void setHeader(String name, String value) {}
+
+  @Override
+  public void addHeader(String name, String value) {}
+
+  @Override
+  public void setIntHeader(String name, int value) {}
+
+  @Override
+  public void addIntHeader(String name, int value) {}
+
+  @Override
+  public void setStatus(int sc) {}
+
+  @Override
+  public void setStatus(int sc, String sm) {}
+
+  @Override
+  public String getCharacterEncoding() {
+    return null;
+  }
+
+  @Override
+  public ServletOutputStream getOutputStream() throws IOException {
+    return null;
+  }
+
+  @Override
+  public PrintWriter getWriter() throws IOException {
+    return null;
+  }
+
+  @Override
+  public void setContentLength(int len) {}
+
+  @Override
+  public void setContentType(String type) {}
+
+  @Override
+  public void setBufferSize(int size) {}
+
+  @Override
+  public int getBufferSize() {
+    return 0;
+  }
+
+  @Override
+  public void flushBuffer() throws IOException {}
+
+  @Override
+  public void resetBuffer() {}
+
+  @Override
+  public boolean isCommitted() {
+    return false;
+  }
+
+  @Override
+  public void reset() {}
+
+  @Override
+  public void setLocale(Locale loc) {}
+
+  @Override
+  public Locale getLocale() {
+    return null;
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/request-2/build.gradle
+++ b/dd-java-agent/instrumentation/servlet/request-2/build.gradle
@@ -11,6 +11,12 @@ muzzle {
     module = 'javax.servlet-api'
     versions = "[3.0,)"
   }
+  pass{
+    name = 'servlet-common'
+    group = "javax.servlet"
+    module = 'javax.servlet-api'
+    versions = "[2.0,)"
+  }
   pass {
     name = 'servlet-2.x-and-3.0.x' // for Servlet2RequestBodyInstrumentation
     group = "javax.servlet"

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletResponseInstrumentation.java
@@ -1,0 +1,67 @@
+package datadog.trace.instrumentation.servlet5;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.sink.InsecureCookieModule;
+import jakarta.servlet.http.Cookie;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(Instrumenter.class)
+public final class JakartaHttpServletResponseInstrumentation extends Instrumenter.Iast
+    implements Instrumenter.ForTypeHierarchy {
+  public JakartaHttpServletResponseInstrumentation() {
+    super("servlet", "servlet-5", "servlet-response");
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "jakarta.servlet.http.HttpServletResponse";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return implementsInterface(named(hierarchyMarkerType()))
+        .and(not(extendsClass(named("jakarta.servlet.http.HttpServletResponseWrapper"))));
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(named("addCookie"), this.getClass().getName() + "$AddCookieAdvice");
+    transformation.applyAdvice(
+        namedOneOf("setHeader", "addHeader"), this.getClass().getName() + "$AddHeaderAdvice");
+  }
+
+  public static class AddCookieAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter(@Advice.Argument(0) final Cookie cookie) {
+      final InsecureCookieModule module = InstrumentationBridge.INSECURE_COOKIE;
+      if (module != null) {
+        if (null != cookie) {
+          module.onCookie(cookie.getName(), cookie.getSecure());
+        }
+      }
+    }
+  }
+
+  public static class AddHeaderAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter(
+        @Advice.Argument(0) final String name, @Advice.Argument(1) String value) {
+      final InsecureCookieModule module = InstrumentationBridge.INSECURE_COOKIE;
+      if (module != null) {
+        if ("Set-Cookie".equalsIgnoreCase(name) && null != value && value.length() > 0) {
+          module.onCookieHeader(value);
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaHttpServletResponseInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaHttpServletResponseInstrumentationTest.groovy
@@ -1,0 +1,218 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.sink.InsecureCookieModule
+import foo.bar.smoketest.DummyResponse
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletResponse
+import jakarta.servlet.http.HttpServletResponseWrapper
+
+class JakartaHttpServletResponseInstrumentationTest  extends AgentTestRunner {
+  @Override
+  protected void configurePreAgent() {
+    injectSysConfig('dd.iast.enabled', 'true')
+  }
+
+  void 'insecure cookie added using addCookie'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+    final cookie = new Cookie("user-id", "7")
+
+    when:
+    response.addCookie(cookie)
+
+    then:
+    1 * module.onCookie("user-id", false)
+    0 * _
+  }
+
+  void 'make sure we do not instrument subclasses of HttpServletResponseWrapper'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final request = Mock(HttpServletResponse)
+    final wrapper = new HttpServletResponseWrapper(request)
+    final cookie = new Cookie("user-id", "7")
+
+    when:
+    wrapper.addCookie(cookie)
+
+    then:
+    1 * request.addCookie(cookie)
+    0 * _
+  }
+
+  void 'secure cookie added using addCookie'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+    final cookie = new Cookie("user-id", "7")
+    cookie.setSecure(true)
+
+    when:
+    response.addCookie(cookie)
+
+    then:
+    1 * module.onCookie('user-id', true)
+    0 * _
+  }
+
+  void 'null cookie added using addCookie'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.addCookie(null)
+
+    then:
+    0 * _
+  }
+
+  void 'insecure cookie added using addHeader'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.addHeader("Set-Cookie", "user-id=7")
+
+    then:
+    1 * module.onCookieHeader('user-id=7')
+    0 * _
+  }
+
+  void 'null parameters added using addHeader'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.addHeader(null, null)
+
+    then:
+    noExceptionThrown()
+    0 * module.onCookieHeader(_)
+    0 * _
+  }
+
+  void 'null value added using addHeader'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.addHeader("Set-Cookie", null)
+
+    then:
+    noExceptionThrown()
+    0 * module.onCookieHeader(_)
+    0 * _
+  }
+
+  void 'null header name added using addHeader'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.addHeader(null, "user-id=7")
+
+    then:
+    noExceptionThrown()
+    0 * module.onCookieHeader(_)
+    0 * _
+  }
+
+
+  void 'secure cookie added using addHeader'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.addHeader("Set-Cookie", "user-id=7; Secure")
+
+    then:
+    1 * module.onCookieHeader('user-id=7; Secure')
+    0 * _
+  }
+
+  void 'adding non cookie header'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.addHeader("Custom-Header", "user-id=7")
+
+    then:
+    0 * _
+  }
+
+  void 'cookie without name value pair'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.addHeader("Set-Cookie", "user-id")
+
+    then:
+    1 * module.onCookieHeader('user-id')
+    0 * _
+  }
+
+
+  void 'insecure cookie added using setHeader'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.setHeader("Set-Cookie", "user-id=7")
+
+    then:
+    1 * module.onCookieHeader('user-id=7')
+    0 * _
+  }
+
+  void 'secure cookie added using setHeader'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.setHeader("Set-Cookie", "user-id=7; Secure")
+
+    then:
+    1 * module.onCookieHeader('user-id=7; Secure')
+    0 * _
+  }
+
+  void 'secure cookie added using setHeader without spaces'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.setHeader("Set-Cookie", "user-id=7;Secure")
+
+    then:
+    1 * module.onCookieHeader('user-id=7;Secure')
+    0 * _
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/request-5/src/test/java/foo/bar/smoketest/DummyResponse.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/test/java/foo/bar/smoketest/DummyResponse.java
@@ -1,0 +1,154 @@
+package foo.bar.smoketest;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.Locale;
+
+public class DummyResponse implements HttpServletResponse {
+  @Override
+  public void addCookie(Cookie cookie) {}
+
+  @Override
+  public boolean containsHeader(String name) {
+    return false;
+  }
+
+  @Override
+  public String encodeURL(String url) {
+    return null;
+  }
+
+  @Override
+  public String encodeRedirectURL(String url) {
+    return null;
+  }
+
+  @Override
+  public String encodeUrl(String url) {
+    return null;
+  }
+
+  @Override
+  public String encodeRedirectUrl(String url) {
+    return null;
+  }
+
+  @Override
+  public void sendError(int sc, String msg) throws IOException {}
+
+  @Override
+  public void sendError(int sc) throws IOException {}
+
+  @Override
+  public void sendRedirect(String location) throws IOException {}
+
+  @Override
+  public void setDateHeader(String name, long date) {}
+
+  @Override
+  public void addDateHeader(String name, long date) {}
+
+  @Override
+  public void setHeader(String name, String value) {}
+
+  @Override
+  public void addHeader(String name, String value) {}
+
+  @Override
+  public void setIntHeader(String name, int value) {}
+
+  @Override
+  public void addIntHeader(String name, int value) {}
+
+  @Override
+  public void setStatus(int sc) {}
+
+  @Override
+  public void setStatus(int sc, String sm) {}
+
+  @Override
+  public int getStatus() {
+    return 0;
+  }
+
+  @Override
+  public String getHeader(String name) {
+    return null;
+  }
+
+  @Override
+  public Collection<String> getHeaders(String name) {
+    return null;
+  }
+
+  @Override
+  public Collection<String> getHeaderNames() {
+    return null;
+  }
+
+  @Override
+  public String getCharacterEncoding() {
+    return null;
+  }
+
+  @Override
+  public String getContentType() {
+    return null;
+  }
+
+  @Override
+  public ServletOutputStream getOutputStream() throws IOException {
+    return null;
+  }
+
+  @Override
+  public PrintWriter getWriter() throws IOException {
+    return null;
+  }
+
+  @Override
+  public void setCharacterEncoding(String charset) {}
+
+  @Override
+  public void setContentLength(int len) {}
+
+  @Override
+  public void setContentLengthLong(long len) {}
+
+  @Override
+  public void setContentType(String type) {}
+
+  @Override
+  public void setBufferSize(int size) {}
+
+  @Override
+  public int getBufferSize() {
+    return 0;
+  }
+
+  @Override
+  public void flushBuffer() throws IOException {}
+
+  @Override
+  public void resetBuffer() {}
+
+  @Override
+  public boolean isCommitted() {
+    return false;
+  }
+
+  @Override
+  public void reset() {}
+
+  @Override
+  public void setLocale(Locale loc) {}
+
+  @Override
+  public Locale getLocale() {
+    return null;
+  }
+}

--- a/dd-smoke-tests/springboot/build.gradle
+++ b/dd-smoke-tests/springboot/build.gradle
@@ -24,6 +24,7 @@ dependencies {
   implementation group: 'com.auth0', name: 'jwks-rsa', version: '0.21.1'
   implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.22'
 
+  implementation group: 'org.springframework', name: 'spring-web', version: '1.5.18.RELEASE'
 
   testImplementation project(':dd-smoke-tests')
   implementation project(':dd-smoke-tests:iast-util')
@@ -34,4 +35,3 @@ tasks.withType(Test).configureEach {
 
   jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }
-

--- a/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -4,12 +4,15 @@ import datadog.smoketest.springboot.TestBean;
 import ddtest.client.sources.Hasher;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
+import java.net.HttpCookie;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.security.Principal;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.websocket.server.PathParam;
+import org.springframework.http.HttpStatus;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.MatrixVariable;
@@ -40,6 +43,32 @@ public class IastWebController {
   public String weakhash() {
     hasher.md5().digest("Message body".getBytes(StandardCharsets.UTF_8));
     return "Weak Hash page";
+  }
+
+  @GetMapping("/insecure_cookie")
+  public String insecureCookie(HttpServletResponse response) {
+    Cookie cookie = new Cookie("user-id", "7");
+    response.addCookie(cookie);
+    response.setStatus(HttpStatus.OK.value());
+    return "Insecure cookie page";
+  }
+
+  @GetMapping("/secure_cookie")
+  public String secureCookie(HttpServletResponse response) {
+    Cookie cookie = new Cookie("user-id", "7");
+    cookie.setSecure(true);
+    response.addCookie(cookie);
+    response.setStatus(HttpStatus.OK.value());
+    return "Insecure cookie page";
+  }
+
+  @GetMapping("/insecure_cookie_from_header")
+  public String insecureCookieFromHeader(HttpServletResponse response) {
+    HttpCookie cookie = new HttpCookie("user-id", "7");
+
+    response.addHeader("Set-Cookie", cookie.toString());
+    response.setStatus(HttpStatus.OK.value());
+    return "Insecure cookie page";
   }
 
   @RequestMapping("/async_weakhash")

--- a/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
@@ -129,6 +129,37 @@ class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
     hasVulnerability(type('WEAK_HASH').and(evidence('MD5'))))
   }
 
+  def "insecure cookie vulnerability is present"() {
+    setup:
+    String url = "http://localhost:${httpPort}/insecure_cookie"
+    def request = new Request.Builder().url(url).get().build()
+
+    when:
+    def response = client.newCall(request).execute()
+
+    then:
+    response.isSuccessful()
+    response.header("Set-Cookie").contains("user-id")
+    waitForSpan(new PollingConditions(timeout: 5),
+    hasVulnerability(type('INSECURE_COOKIE').and(evidence('user-id'))))
+  }
+
+  def "insecure cookie  vulnerability from addheader is present"() {
+    setup:
+    String url = "http://localhost:${httpPort}/insecure_cookie_from_header"
+    def request = new Request.Builder().url(url).get().build()
+
+    when:
+    def response = client.newCall(request).execute()
+
+    then:
+    response.isSuccessful()
+    response.header("Set-Cookie").contains("user-id")
+    waitForSpan(new PollingConditions(timeout: 5),
+    hasVulnerability(type('INSECURE_COOKIE').and(evidence('user-id'))))
+  }
+
+
   def "weak hash vulnerability is present on boot"() {
     setup:
     String url = "http://localhost:${httpPort}/greeting"

--- a/internal-api/src/main/java/datadog/trace/api/iast/InstrumentationBridge.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/InstrumentationBridge.java
@@ -4,6 +4,7 @@ import datadog.trace.api.iast.propagation.CodecModule;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.propagation.StringModule;
 import datadog.trace.api.iast.sink.CommandInjectionModule;
+import datadog.trace.api.iast.sink.InsecureCookieModule;
 import datadog.trace.api.iast.sink.LdapInjectionModule;
 import datadog.trace.api.iast.sink.PathTraversalModule;
 import datadog.trace.api.iast.sink.SqlInjectionModule;
@@ -25,6 +26,7 @@ public abstract class InstrumentationBridge {
   public static volatile WeakHashModule WEAK_HASH;
   public static volatile LdapInjectionModule LDAP_INJECTION;
   public static volatile PropagationModule PROPAGATION;
+  public static volatile InsecureCookieModule INSECURE_COOKIE;
   public static volatile SsrfModule SSRF;
 
   private InstrumentationBridge() {}
@@ -50,6 +52,8 @@ public abstract class InstrumentationBridge {
       LDAP_INJECTION = (LdapInjectionModule) module;
     } else if (module instanceof PropagationModule) {
       PROPAGATION = (PropagationModule) module;
+    } else if (module instanceof InsecureCookieModule) {
+      INSECURE_COOKIE = (InsecureCookieModule) module;
     } else if (module instanceof SsrfModule) {
       SSRF = (SsrfModule) module;
     } else {
@@ -89,6 +93,9 @@ public abstract class InstrumentationBridge {
     if (type == PropagationModule.class) {
       return (E) PROPAGATION;
     }
+    if (type == InsecureCookieModule.class) {
+      return (E) INSECURE_COOKIE;
+    }
     if (type == SsrfModule.class) {
       return (E) SSRF;
     }
@@ -107,5 +114,6 @@ public abstract class InstrumentationBridge {
     WEAK_HASH = null;
     LDAP_INJECTION = null;
     PROPAGATION = null;
+    INSECURE_COOKIE = null;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityTypes.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityTypes.java
@@ -11,4 +11,5 @@ public abstract class VulnerabilityTypes {
   public static final String PATH_TRAVERSAL = "PATH_TRAVERSAL";
   public static final String LDAP_INJECTION = "LDAP_INJECTION";
   public static final String SSRF = "SSRF";
+  public static final String INSECURE_COOKIE = "INSECURE_COOKIE";
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/sink/InsecureCookieModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/sink/InsecureCookieModule.java
@@ -1,0 +1,9 @@
+package datadog.trace.api.iast.sink;
+
+import datadog.trace.api.iast.IastModule;
+
+public interface InsecureCookieModule extends IastModule {
+  public void onCookie(String cookieName, boolean secure);
+
+  public void onCookieHeader(String headerValue);
+}


### PR DESCRIPTION
# What Does This Do
Instrument HttpServletRequest so we can examine cookies and make sure they have the Secure flag enabled.

# Motivation
This enables IAST to report insecure cookie vulnerabilities

# Additional Notes
