### PR TITLE
Small type pool optimizations

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
@@ -18,7 +18,6 @@ import java.util.function.Function;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.description.type.TypeList;
 import net.bytebuddy.dynamic.ClassFileLocator;
-import net.bytebuddy.jar.asm.Type;
 import net.bytebuddy.pool.TypePool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,7 +43,7 @@ final class TypeFactory {
   private static final boolean fallBackToLoadClass =
       InstrumenterConfig.get().isResolverUseLoadClass();
 
-  private static final Map<String, TypeDescription> primitiveDescriptorTypes = new HashMap<>();
+  private static final Map<Character, TypeDescription> primitiveDescriptorTypes = new HashMap<>();
 
   private static final Map<String, TypeDescription> primitiveTypes = new HashMap<>();
 
@@ -62,7 +61,7 @@ final class TypeFactory {
           void.class
         }) {
       TypeDescription primitiveType = TypeDescription.ForLoadedType.of(primitive);
-      primitiveDescriptorTypes.put(Type.getDescriptor(primitive), primitiveType);
+      primitiveDescriptorTypes.put(primitiveType.getDescriptor().charAt(0), primitiveType);
       primitiveTypes.put(primitive.getName(), primitiveType);
     }
   }
@@ -186,14 +185,15 @@ final class TypeFactory {
   static TypeDescription findDescriptor(String descriptor) {
     TypeDescription type;
     int arity = 0;
-    while (descriptor.charAt(arity) == '[') {
-      arity++;
+    char c = descriptor.charAt(arity);
+    while (c == '[') {
+      c = descriptor.charAt(++arity);
     }
-    if (descriptor.charAt(arity) == 'L') {
+    if (c == 'L') {
       // discard leading 'L' and trailing ';'
       type = findType(descriptor.substring(arity + 1, descriptor.length() - 1).replace('/', '.'));
     } else {
-      type = primitiveDescriptorTypes.get(descriptor.substring(arity));
+      type = primitiveDescriptorTypes.get(c);
     }
     if (arity > 0 && null != type) {
       type = TypeDescription.ArrayProjection.of(type, arity);


### PR DESCRIPTION
* Keep 'java.lang.Object' outline in its own field as it's used a lot
* Avoid creating single-character strings when looking up primitive types by descriptor