### PR TITLE
Prefer asserting concrete class status, rather than the negative 'not(abstract)'

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/DDElementMatchers.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/DDElementMatchers.java
@@ -1,5 +1,7 @@
 package datadog.trace.agent.tooling.bytebuddy.matcher;
 
+import static net.bytebuddy.matcher.ElementMatchers.not;
+
 import datadog.trace.agent.tooling.context.ShouldInjectFieldsMatcher;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import net.bytebuddy.description.NamedElement;
@@ -41,8 +43,8 @@ public class DDElementMatchers implements HierarchyMatchers.Supplier {
 
   @Override
   @SuppressForbidden
-  public ElementMatcher.Junction<TypeDescription> abstractClass() {
-    return ElementMatchers.isAbstract();
+  public ElementMatcher.Junction<TypeDescription> concreteClass() {
+    return not(ElementMatchers.isAbstract());
   }
 
   @Override

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/HierarchyMatchers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/HierarchyMatchers.java
@@ -1,6 +1,7 @@
 package datadog.trace.agent.tooling.bytebuddy.matcher;
 
 import static net.bytebuddy.matcher.ElementMatchers.none;
+import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import datadog.trace.agent.tooling.bytebuddy.SharedTypePools;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
@@ -39,8 +40,8 @@ public final class HierarchyMatchers {
     return SUPPLIER.declaresMethod(matcher);
   }
 
-  public static ElementMatcher.Junction<TypeDescription> abstractClass() {
-    return SUPPLIER.abstractClass();
+  public static ElementMatcher.Junction<TypeDescription> concreteClass() {
+    return SUPPLIER.concreteClass();
   }
 
   public static ElementMatcher.Junction<TypeDescription> extendsClass(
@@ -111,7 +112,7 @@ public final class HierarchyMatchers {
     ElementMatcher.Junction<TypeDescription> declaresMethod(
         ElementMatcher.Junction<? super MethodDescription> matcher);
 
-    ElementMatcher.Junction<TypeDescription> abstractClass();
+    ElementMatcher.Junction<TypeDescription> concreteClass();
 
     ElementMatcher.Junction<TypeDescription> extendsClass(
         ElementMatcher.Junction<? super TypeDescription> matcher);
@@ -158,8 +159,8 @@ public final class HierarchyMatchers {
 
       @Override
       @SuppressForbidden
-      public ElementMatcher.Junction<TypeDescription> abstractClass() {
-        return ElementMatchers.isAbstract();
+      public ElementMatcher.Junction<TypeDescription> concreteClass() {
+        return not(ElementMatchers.isAbstract());
       }
 
       @Override

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGradlePlugin.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGradlePlugin.java
@@ -1,9 +1,8 @@
 package datadog.trace.agent.tooling.muzzle;
 
-import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.abstractClass;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.concreteClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.SharedTypePools;
@@ -29,7 +28,7 @@ public class MuzzleGradlePlugin extends Plugin.ForElementMatcher {
   private final File targetDir;
 
   public MuzzleGradlePlugin(File targetDir) {
-    super(not(abstractClass()).and(extendsClass(named(Instrumenter.Default.class.getName()))));
+    super(concreteClass().and(extendsClass(named(Instrumenter.Default.class.getName()))));
     this.targetDir = targetDir;
   }
 

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/ServerErrorHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/ServerErrorHandlerInstrumentation.java
@@ -1,9 +1,8 @@
 package datadog.trace.instrumentation.ratpack;
 
-import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.abstractClass;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.concreteClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
@@ -26,7 +25,7 @@ public class ServerErrorHandlerInstrumentation extends Instrumenter.Tracing
 
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
-    return not(abstractClass()).and(implementsInterface(named(hierarchyMarkerType())));
+    return concreteClass().and(implementsInterface(named(hierarchyMarkerType())));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/HandlerAdapterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/HandlerAdapterInstrumentation.java
@@ -1,11 +1,10 @@
 package datadog.trace.instrumentation.springwebflux.server;
 
-import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.abstractClass;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.concreteClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
@@ -25,7 +24,7 @@ public final class HandlerAdapterInstrumentation extends AbstractWebfluxInstrume
 
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
-    return not(abstractClass()).and(implementsInterface(named(hierarchyMarkerType())));
+    return concreteClass().and(implementsInterface(named(hierarchyMarkerType())));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/RouterFunctionInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/RouterFunctionInstrumentation.java
@@ -1,11 +1,10 @@
 package datadog.trace.instrumentation.springwebflux.server;
 
-import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.abstractClass;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.concreteClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
@@ -30,7 +29,7 @@ public final class RouterFunctionInstrumentation extends AbstractWebfluxInstrume
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
     // TODO: this doesn't handle nested routes (DefaultNestedRouterFunction)
-    return not(abstractClass()).and(extendsClass(named(hierarchyMarkerType())));
+    return concreteClass().and(extendsClass(named(hierarchyMarkerType())));
   }
 
   @Override


### PR DESCRIPTION
# Motivation

This works better with memoization, because we end up asserting a positive fact rather than negative.