### PR TITLE
Bump ddprof lib to 0.34.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.33.0",
+    ddprof        : "0.34.0",
     asm           : "9.5"
   ]
 


### PR DESCRIPTION
# What Does This Do
Bumps ddprof to 0.34.0

# Motivation
A severe bug is fixed in 0.34.0 which might lead to incorrect data or JVM crash

# Additional Notes

## Ddprof 0.34.0 release notes
* Allow sanitizers to run with unit tests
* Remove object sampler's dependency on JVM symbols
* Test with Ubuntu OpenJDK
* Set pointers to NULL when cleaning dictionary
* Add JMH stresstests
* Add 'scan-build' run to build/CI
* Add counters for thread filter size
* Add and remove thread for wallclock filtering before and after tasks in ContextExecutor

**Full Changelog**: https://github.com/DataDog/java-profiler/compare/v_0.33.0...v_0.34.0
