### PR TITLE
Change default telemetry metrics namespace to "tracers"

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/TelemetryServiceImpl.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryServiceImpl.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 public class TelemetryServiceImpl implements TelemetryService {
 
   private static final Logger log = LoggerFactory.getLogger(TelemetryServiceImpl.class);
+  private static final String TELEMETRY_NAMESPACE_TAG_TRACER = "tracers";
 
   private static final int MAX_ELEMENTS_PER_REQUEST = 100;
 
@@ -186,7 +187,7 @@ public class TelemetryServiceImpl implements TelemetryService {
     while (!metrics.isEmpty()) {
       Payload payload =
           new GenerateMetrics()
-              .namespace("tracer")
+              .namespace(TELEMETRY_NAMESPACE_TAG_TRACER)
               .series(drainOrEmpty(metrics, maxElementsPerReq));
       Request request =
           requestBuilderSupplier
@@ -210,7 +211,7 @@ public class TelemetryServiceImpl implements TelemetryService {
     while (!distributionSeries.isEmpty()) {
       Payload payload =
           new Distributions()
-              .namespace("tracer")
+              .namespace(TELEMETRY_NAMESPACE_TAG_TRACER)
               .series(drainOrEmpty(distributionSeries, maxElementsPerReq));
       Request request =
           requestBuilderSupplier

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
@@ -190,7 +190,7 @@ class TelemetryServiceSpecification extends DDSpecification {
     then:
     1 * requestBuilder.build(RequestType.GENERATE_METRICS, { GenerateMetrics p ->
       p.requestType == RequestType.GENERATE_METRICS &&
-        p.namespace == 'tracer' &&  // top level namespace is "tracer" by default
+        p.namespace == 'tracers' &&  // top level namespace is "tracers" by default
         p.requestType &&
         p.series.first().is(metric)
     }) >> REQUEST
@@ -209,7 +209,7 @@ class TelemetryServiceSpecification extends DDSpecification {
     then:
     1 * requestBuilder.build(RequestType.DISTRIBUTIONS, { Distributions p ->
       p.requestType == RequestType.DISTRIBUTIONS &&
-        p.namespace == 'tracer' &&  // top level namespace is "tracer" by default
+        p.namespace == 'tracers' &&  // top level namespace is "tracers" by default
         p.requestType &&
         p.series.first().is(series)
     }) >> REQUEST


### PR DESCRIPTION
# What Does This Do

# Motivation
The default namespace is `tracers`, not `tracer`. The backend is rejecting payloads if they have this namespace at payload-level, even if the individual metrics are in separate, valid namespaces.

# Additional Notes
