### PR TITLE
Fix timestamp units in WAF telemetry metrics

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/WafMetricCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/WafMetricCollector.java
@@ -129,7 +129,7 @@ public class WafMetricCollector {
 
     public WafMetric(String metricName, long counter, final String... tags) {
       this.metricName = metricName;
-      this.timestamp = System.currentTimeMillis();
+      this.timestamp = System.currentTimeMillis() / 1000;
       this.counter = counter;
       this.namespace = NAMESPACE;
       this.tags = Arrays.asList(tags);


### PR DESCRIPTION
# What Does This Do
Convert timestamps in WAF telemetry metric points from milliseconds to seconds.

# Motivation
Timestamps for telemetry metrics are defined in seconds (as a double). We can just encode it as an integer, since the sub-second resolution seems to be pointless here.

# Additional Notes
