### PR TITLE
Use GHCR for docker build images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ cache: &default_cache
 
 .gradle_build: &gradle_build
   <<: *common
-  image: datadog/dd-trace-java-docker-build:latest
+  image: ghcr.io/datadog/dd-trace-java-docker-build:base
   before_script:
     - export GRADLE_USER_HOME=`pwd`/.gradle
 


### PR DESCRIPTION
# What Does This Do

Use GitHub Container Registry to get docker build images from.
Images are now published to GHCR rather than Docker Hub.

# Motivation

# Additional Notes
