### PR TITLE
Safely parse URL and respect http server status code error rule

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -193,18 +193,24 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
       try {
         final URIDataAdapter url = url(request);
         if (url != null) {
+
           boolean supportsRaw = url.supportsRaw();
           boolean encoded = supportsRaw && config.isHttpServerRawResource();
+          boolean valid = url.isValid();
           String path = encoded ? url.rawPath() : url.path();
-
-          span.setTag(Tags.HTTP_URL, URIUtils.buildURL(url.scheme(), url.host(), url.port(), path));
+          if (valid) {
+            span.setTag(
+                Tags.HTTP_URL, URIUtils.buildURL(url.scheme(), url.host(), url.port(), path));
+          } else if (supportsRaw) {
+            span.setTag(Tags.HTTP_URL, url.raw());
+          }
           if (context != null && context.getXForwardedHost() != null) {
             span.setTag(Tags.HTTP_HOSTNAME, context.getXForwardedHost());
           } else if (url.host() != null) {
             span.setTag(Tags.HTTP_HOSTNAME, url.host());
           }
 
-          if (config.isHttpServerTagQueryString()) {
+          if (valid && config.isHttpServerTagQueryString()) {
             String query =
                 supportsRaw && config.isHttpServerRawQueryString() ? url.rawQuery() : url.query();
             span.setTag(DDTags.HTTP_QUERY, query);
@@ -214,7 +220,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
           if (flow.getAction() instanceof Flow.Action.RequestBlockingAction) {
             span.setRequestBlockingAction((Flow.Action.RequestBlockingAction) flow.getAction());
           }
-          if (SHOULD_SET_URL_RESOURCE_NAME) {
+          if (valid && SHOULD_SET_URL_RESOURCE_NAME) {
             HTTP_RESOURCE_DECORATOR.withServerPath(span, method, path, encoded);
           }
         } else if (SHOULD_SET_URL_RESOURCE_NAME) {
@@ -281,9 +287,10 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
       if (status > UNSET_STATUS) {
         span.setHttpStatusCode(status);
       }
-      if (SERVER_ERROR_STATUSES.get(status)) {
-        span.setError(true);
-      }
+      // explicitly set here because some other decorators might already set an error without
+      // looking at the status code
+      span.setError(SERVER_ERROR_STATUSES.get(status));
+
       if (SHOULD_SET_404_RESOURCE_NAME && status == 404) {
         span.setResourceName(NOT_FOUND_RESOURCE_NAME, ResourceNamePriorities.HTTP_404);
       }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpClientDecorator.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.akkahttp;
 
 import akka.http.scaladsl.model.HttpRequest;
 import akka.http.scaladsl.model.HttpResponse;
+import datadog.trace.bootstrap.instrumentation.api.URIUtils;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
 import java.net.URI;
@@ -30,7 +31,7 @@ public class AkkaHttpClientDecorator extends HttpClientDecorator<HttpRequest, Ht
 
   @Override
   protected URI url(final HttpRequest httpRequest) throws URISyntaxException {
-    return new URI(httpRequest.uri().toString());
+    return URIUtils.safeParse(httpRequest.uri().toString());
   }
 
   @Override

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientDecorator.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientDecorator.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.apachehttpasyncclient;
 
+import datadog.trace.bootstrap.instrumentation.api.URIUtils;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
 import java.net.URI;
@@ -52,7 +53,7 @@ public class ApacheHttpAsyncClientDecorator extends HttpClientDecorator<HttpRequ
       return ((HttpUriRequest) request).getURI();
     } else {
       final RequestLine requestLine = request.getRequestLine();
-      return requestLine == null ? null : new URI(requestLine.getUri());
+      return requestLine == null ? null : URIUtils.safeParse(requestLine.getUri());
     }
   }
 

--- a/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraDecorator.java
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraDecorator.java
@@ -4,10 +4,10 @@ import com.twitter.finagle.http.Request;
 import com.twitter.finagle.http.Response;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapterBase;
 import datadog.trace.bootstrap.instrumentation.api.URIDefaultDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
-import java.net.URI;
 
 public class FinatraDecorator extends HttpServerDecorator<Request, Request, Response, Void> {
 
@@ -46,7 +46,7 @@ public class FinatraDecorator extends HttpServerDecorator<Request, Request, Resp
 
   @Override
   protected URIDataAdapter url(final Request request) {
-    return new URIDefaultDataAdapter(URI.create(request.uri()));
+    return URIDataAdapterBase.fromURI(request.uri(), URIDefaultDataAdapter::new);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
@@ -6,6 +6,7 @@ import static datadog.trace.instrumentation.googlehttpclient.HeadersInjectAdapte
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.URIUtils;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
 import java.net.URI;
@@ -30,7 +31,7 @@ public class GoogleHttpClientDecorator extends HttpClientDecorator<HttpRequest, 
     // Add "+" back for consistency with the other http client instrumentations
     final String url = httpRequest.getUrl().build();
     final String fixedUrl = URL_REPLACEMENT.matcher(url).replaceAll("+");
-    return new URI(fixedUrl);
+    return URIUtils.safeParse(fixedUrl);
   }
 
   public AgentSpan prepareSpan(AgentSpan span, HttpRequest request) {

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/NettyHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/NettyHttpClientDecorator.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.netty38.client;
 
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.HOST;
 
+import datadog.trace.bootstrap.instrumentation.api.URIUtils;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
 import java.net.URI;
@@ -42,12 +43,11 @@ public class NettyHttpClientDecorator extends HttpClientDecorator<HttpRequest, H
 
   @Override
   protected URI url(final HttpRequest request) throws URISyntaxException {
-    final URI uri = new URI(request.getUri());
+    final URI uri = URIUtils.safeParse(request.getUri());
     if ((uri.getHost() == null || uri.getHost().equals("")) && request.headers().contains(HOST)) {
-      return new URI(uriPrefix + request.headers().get(HOST) + request.getUri());
-    } else {
-      return uri;
+      return URIUtils.safeParse(uriPrefix + request.headers().get(HOST) + request.getUri());
     }
+    return uri;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/NettyHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/NettyHttpClientDecorator.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.netty40.client;
 
 import static io.netty.handler.codec.http.HttpHeaders.Names.HOST;
 
+import datadog.trace.bootstrap.instrumentation.api.URIUtils;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
 import io.netty.handler.codec.http.HttpMethod;
@@ -44,11 +45,11 @@ public class NettyHttpClientDecorator extends HttpClientDecorator<HttpRequest, H
   @Override
   protected URI url(final HttpRequest request) throws URISyntaxException {
     if (request.getMethod().equals(HttpMethod.CONNECT)) {
-      return new URI(uriPrefix + request.getUri());
+      return URIUtils.safeParse(uriPrefix + request.getUri());
     }
-    final URI uri = new URI(request.getUri());
+    final URI uri = URIUtils.safeParse(request.getUri());
     if ((uri.getHost() == null || uri.getHost().equals("")) && request.headers().contains(HOST)) {
-      return new URI(uriPrefix + request.headers().get(HOST) + request.getUri());
+      return URIUtils.safeParse(uriPrefix + request.headers().get(HOST) + request.getUri());
     } else {
       return uri;
     }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/NettyHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/NettyHttpServerDecorator.java
@@ -7,6 +7,7 @@ import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.ContextVisitors;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapterBase;
 import datadog.trace.bootstrap.instrumentation.api.URIDefaultDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
@@ -20,7 +21,6 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.net.URI;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,13 +66,17 @@ public class NettyHttpServerDecorator
 
   @Override
   protected URIDataAdapter url(final HttpRequest request) {
-    final URI uri = URI.create(request.getUri());
-    if ((uri.getHost() == null || uri.getHost().equals("")) && request.headers().contains(HOST)) {
-      return new URIDefaultDataAdapter(
-          URI.create("http://" + request.headers().get(HOST) + request.getUri()));
-    } else {
-      return new URIDefaultDataAdapter(uri);
-    }
+    return URIDataAdapterBase.fromURI(
+        request.getUri(),
+        uri -> {
+          if ((uri.getHost() == null || uri.getHost().equals(""))
+              && request.headers().contains(HOST)) {
+            return URIDataAdapterBase.fromURI(
+                "http://" + request.headers().get(HOST) + request.getUri(),
+                URIDefaultDataAdapter::new);
+          }
+          return new URIDefaultDataAdapter(uri);
+        });
   }
 
   @Override

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/NettyHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/NettyHttpClientDecorator.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.netty41.client;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
 
+import datadog.trace.bootstrap.instrumentation.api.URIUtils;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
 import io.netty.handler.codec.http.HttpMethod;
@@ -44,11 +45,11 @@ public class NettyHttpClientDecorator extends HttpClientDecorator<HttpRequest, H
   @Override
   protected URI url(final HttpRequest request) throws URISyntaxException {
     if (request.method().equals(HttpMethod.CONNECT)) {
-      return new URI(uriPrefix + request.uri());
+      return URIUtils.safeParse(uriPrefix + request.uri());
     }
-    final URI uri = new URI(request.uri());
+    final URI uri = URIUtils.safeParse(request.uri());
     if ((uri.getHost() == null || uri.getHost().equals("")) && request.headers().contains(HOST)) {
-      return new URI(uriPrefix + request.headers().get(HOST) + request.uri());
+      return URIUtils.safeParse(uriPrefix + request.headers().get(HOST) + request.uri());
     } else {
       return uri;
     }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/NettyHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/NettyHttpServerDecorator.java
@@ -1,12 +1,11 @@
 package datadog.trace.instrumentation.netty41.server;
 
-import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
-
 import datadog.appsec.api.blocking.BlockingContentType;
 import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.ContextVisitors;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapterBase;
 import datadog.trace.bootstrap.instrumentation.api.URIDefaultDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
@@ -20,7 +19,6 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.net.URI;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,13 +64,17 @@ public class NettyHttpServerDecorator
 
   @Override
   protected URIDataAdapter url(final HttpRequest request) {
-    final URI uri = URI.create(request.uri());
-    if ((uri.getHost() == null || uri.getHost().equals("")) && request.headers().contains(HOST)) {
-      return new URIDefaultDataAdapter(
-          URI.create("http://" + request.headers().get(HOST) + request.getUri()));
-    } else {
-      return new URIDefaultDataAdapter(uri);
-    }
+    return URIDataAdapterBase.fromURI(
+        request.getUri(),
+        uri -> {
+          if ((uri.getHost() == null || uri.getHost().equals(""))
+              && request.headers().contains(HttpHeaders.Names.HOST)) {
+            return URIDataAdapterBase.fromURI(
+                "http://" + request.headers().get(HttpHeaders.Names.HOST) + request.getUri(),
+                URIDefaultDataAdapter::new);
+          }
+          return new URIDefaultDataAdapter(uri);
+        });
   }
 
   @Override

--- a/dd-java-agent/instrumentation/restlet-2.2/src/test/groovy/RestletTestBase.groovy
+++ b/dd-java-agent/instrumentation/restlet-2.2/src/test/groovy/RestletTestBase.groovy
@@ -109,6 +109,11 @@ abstract class RestletTestBase extends HttpServerTest<Component> {
   }
 
   @Override
+  boolean testBadUrl() {
+    false
+  }
+
+  @Override
   Serializable expectedServerSpanRoute(ServerEndpoint endpoint) {
     switch (endpoint) {
       case NOT_FOUND:

--- a/dd-java-agent/instrumentation/spray-1.3/src/test/groovy/SprayServerTest.groovy
+++ b/dd-java-agent/instrumentation/spray-1.3/src/test/groovy/SprayServerTest.groovy
@@ -34,6 +34,11 @@ abstract class SprayServerTest extends HttpServerTest<SprayHttpTestWebServer> {
   }
 
   @Override
+  boolean testBadUrl() {
+    false
+  }
+
+  @Override
   boolean hasExtraErrorInformation() {
     true
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -129,6 +129,11 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
   }
 
   @Override
+  boolean testBadUrl() {
+    false
+  }
+
+  @Override
   Serializable expectedServerSpanRoute(ServerEndpoint endpoint) {
     switch (endpoint) {
       case LOGIN:

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/dynamic/DynamicRoutingTest.groovy
@@ -104,6 +104,11 @@ class DynamicRoutingTest extends HttpServerTest<ConfigurableApplicationContext> 
   }
 
   @Override
+  boolean testBadUrl() {
+    false
+  }
+
+  @Override
   Map<String, Serializable> expectedExtraServerTags(ServerEndpoint endpoint) {
     ["servlet.path": endpoint.path]
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/filter/ServletFilterTest.groovy
@@ -98,6 +98,11 @@ class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> {
   }
 
   @Override
+  boolean testBadUrl() {
+    false
+  }
+
+  @Override
   boolean hasResponseSpan(ServerEndpoint endpoint) {
     return endpoint == REDIRECT || endpoint == ERROR
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/urlhandlermapping/UrlHandlerMappingTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/urlhandlermapping/UrlHandlerMappingTest.groovy
@@ -103,6 +103,11 @@ class UrlHandlerMappingTest extends HttpServerTest<ConfigurableApplicationContex
   }
 
   @Override
+  boolean testBadUrl() {
+    false
+  }
+
+  @Override
   Serializable expectedServerSpanRoute(ServerEndpoint endpoint) {
     switch (endpoint) {
       case LOGIN:

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/boot/SpringBootBasedTest.groovy
@@ -129,6 +129,11 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
   }
 
   @Override
+  boolean testBadUrl() {
+    false
+  }
+
+  @Override
   Serializable expectedServerSpanRoute(ServerEndpoint endpoint) {
     switch (endpoint) {
       case LOGIN:

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/urlhandlermapping/UrlHandlerMappingTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/urlhandlermapping/UrlHandlerMappingTest.groovy
@@ -106,6 +106,11 @@ class UrlHandlerMappingTest extends HttpServerTest<ConfigurableApplicationContex
   }
 
   @Override
+  boolean testBadUrl() {
+    false
+  }
+
+  @Override
   String expectedServiceName() {
     return ConfigDefaults.DEFAULT_SERVLET_ROOT_CONTEXT_SERVICE_NAME
   }

--- a/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerDecorator.java
+++ b/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseServerDecorator.java
@@ -8,10 +8,10 @@ import static datadog.trace.instrumentation.synapse3.ExtractAdapter.Response;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapterBase;
 import datadog.trace.bootstrap.instrumentation.api.URIDefaultDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
-import java.net.URI;
 import org.apache.http.HttpInetConnection;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
@@ -62,7 +62,8 @@ public final class SynapseServerDecorator
 
   @Override
   protected URIDataAdapter url(final HttpRequest request) {
-    return new URIDefaultDataAdapter(URI.create(request.getRequestLine().getUri()));
+    return URIDataAdapterBase.fromURI(
+        request.getRequestLine().getUri(), URIDefaultDataAdapter::new);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/latestDepTest/groovy/TomcatServletTest.groovy
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/latestDepTest/groovy/TomcatServletTest.groovy
@@ -1,3 +1,8 @@
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.CUSTOM_EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.TIMEOUT_ERROR
+import static org.junit.Assume.assumeTrue
+
 import com.google.common.io.Files
 import datadog.trace.agent.test.base.HttpServer
 import jakarta.servlet.Servlet
@@ -13,11 +18,6 @@ import org.apache.catalina.valves.RemoteIpValve
 import org.apache.tomcat.JarScanFilter
 import org.apache.tomcat.JarScanType
 import spock.lang.Unroll
-
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.CUSTOM_EXCEPTION
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.TIMEOUT_ERROR
-import static org.junit.Assume.assumeTrue
 
 @Unroll
 class TomcatServletTest extends AbstractServletTest<Tomcat, Context> {

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/RequestURIDataAdapter.java
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/RequestURIDataAdapter.java
@@ -40,4 +40,9 @@ final class RequestURIDataAdapter extends URIRawDataAdapter {
   protected String innerRawQuery() {
     return request.getQueryString();
   }
+
+  @Override
+  public boolean isValid() {
+    return request.getRequestURI() != null;
+  }
 }

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowDispatcherTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowDispatcherTest.groovy
@@ -173,6 +173,11 @@ abstract class UndertowDispatcherTest extends HttpServerTest<Undertow> {
   }
 
   @Override
+  boolean testBadUrl() {
+    false
+  }
+
+  @Override
   Map<String, Serializable> expectedExtraErrorInformation(ServerEndpoint endpoint) {
     if (endpoint.throwsException) {
       ["error.message"  : "${endpoint.body}",

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowServletTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowServletTest.groovy
@@ -92,6 +92,11 @@ abstract class UndertowServletTest extends HttpServerTest<Undertow> {
     true
   }
 
+  @Override
+  boolean testBadUrl() {
+    false
+  }
+
   boolean hasResponseSpan(ServerEndpoint endpoint) {
     return endpoint == REDIRECT || endpoint == NOT_FOUND
   }

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowTest.groovy
@@ -187,6 +187,11 @@ class UndertowTest extends HttpServerTest<Undertow> {
   }
 
   @Override
+  boolean testBadUrl() {
+    false
+  }
+
+  @Override
   Map<String, Serializable> expectedExtraErrorInformation(ServerEndpoint endpoint) {
     if (endpoint.throwsException) {
       ["error.message": "${endpoint.body}",

--- a/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowDispatcherTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowDispatcherTest.groovy
@@ -173,6 +173,11 @@ class UndertowDispatcherTest extends HttpServerTest<Undertow> {
   }
 
   @Override
+  boolean testBadUrl() {
+    false
+  }
+
+  @Override
   Map<String, Serializable> expectedExtraErrorInformation(ServerEndpoint endpoint) {
     if (endpoint.throwsException) {
       ["error.message"  : "${endpoint.body}",

--- a/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowServletTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowServletTest.groovy
@@ -100,6 +100,11 @@ class UndertowServletTest extends HttpServerTest<Undertow> {
     true
   }
 
+  @Override
+  boolean testBadUrl() {
+    false
+  }
+
   boolean hasResponseSpan(ServerEndpoint endpoint) {
     // FIXME: re-enable when jakarta servlet will be fully supported
     // return endpoint == REDIRECT || endpoint == NOT_FOUND

--- a/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowTest.groovy
@@ -181,6 +181,11 @@ class UndertowTest extends HttpServerTest<Undertow> {
   }
 
   @Override
+  boolean testBadUrl() {
+    false
+  }
+
+  @Override
   Map<String, Serializable> expectedExtraErrorInformation(ServerEndpoint endpoint) {
     if (endpoint.throwsException) {
       ["error.message": "${endpoint.body}",

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -320,6 +320,10 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     true
   }
 
+  boolean testBadUrl() {
+    true
+  }
+
   @Override
   int version() {
     return 0
@@ -1491,6 +1495,23 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
         edgeTags.size() == DSM_EDGE_TAGS.size()
       }
     }
+  }
+
+  def "test bad url not cause span marked as error"() {
+    setup:
+    assumeTrue(testBadUrl())
+
+    when:
+    def request = new okhttp3.Request.Builder()
+      .url(address.toString() + "success?file=\\abc")
+      .get()
+      .build()
+    client.newCall(request).execute()
+
+    then:
+    TEST_WRITER.waitForTraces(1)
+    def trace = TEST_WRITER.get(0)
+    assert trace.find {it.isError() } == null
   }
 
   def 'user blocking'() {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/URIDataAdapter.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/URIDataAdapter.java
@@ -33,4 +33,11 @@ public interface URIDataAdapter {
 
   /** The raw path(?query) of this URI. */
   String raw();
+
+  /**
+   * The URI is a valid one or not (looks malformed)
+   *
+   * @return
+   */
+  boolean isValid();
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/URIDataAdapterBase.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/URIDataAdapterBase.java
@@ -1,6 +1,8 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.net.URI;
+import java.util.function.Function;
 
 @SuppressFBWarnings(value = "DM_STRING_CTOR", justification = "Unique instance needs constructor")
 public abstract class URIDataAdapterBase implements URIDataAdapter {
@@ -31,5 +33,18 @@ public abstract class URIDataAdapterBase implements URIDataAdapter {
       this.raw = raw = builder.toString();
     }
     return raw;
+  }
+
+  @Override
+  public boolean isValid() {
+    return true;
+  }
+
+  public static URIDataAdapter fromURI(String uri, Function<URI, URIDataAdapter> mapper) {
+    final URI parsed = URIUtils.safeParse(uri);
+    if (parsed != null) {
+      return mapper.apply(parsed);
+    }
+    return new UnparseableURIDataAdapter(uri);
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/URIUtils.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/URIUtils.java
@@ -1,13 +1,18 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
+import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class URIUtils {
   private URIUtils() {}
 
   // This is the � character, which is also the default replacement for the UTF_8 charset
   private static final byte[] REPLACEMENT = {(byte) 0xEF, (byte) 0xBF, (byte) 0xBD};
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(URIUtils.class);
 
   /**
    * Decodes a %-encoded UTF-8 {@code String} into a regular {@code String}.
@@ -111,5 +116,17 @@ public class URIUtils {
       urlNoParams.append(path);
     }
     return urlNoParams.toString();
+  }
+
+  public static URI safeParse(final String unparsed) {
+    if (unparsed == null) {
+      return null;
+    }
+    try {
+      return URI.create(unparsed);
+    } catch (final IllegalArgumentException exception) {
+      LOGGER.debug("Unable to parse request uri {}", unparsed, exception);
+      return null;
+    }
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/UnparseableURIDataAdapter.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/UnparseableURIDataAdapter.java
@@ -1,0 +1,66 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+import javax.annotation.Nonnull;
+
+public class UnparseableURIDataAdapter extends URIDataAdapterBase {
+  private final String rawUri;
+
+  public UnparseableURIDataAdapter(@Nonnull String rawUri) {
+    this.rawUri = rawUri;
+  }
+
+  @Override
+  public boolean isValid() {
+    return false;
+  }
+
+  @Override
+  public String scheme() {
+    return null;
+  }
+
+  @Override
+  public String host() {
+    return null;
+  }
+
+  @Override
+  public int port() {
+    return 0;
+  }
+
+  @Override
+  public String path() {
+    return null;
+  }
+
+  @Override
+  public String fragment() {
+    return null;
+  }
+
+  @Override
+  public String query() {
+    return null;
+  }
+
+  @Override
+  public boolean supportsRaw() {
+    return true;
+  }
+
+  @Override
+  public String rawPath() {
+    return null;
+  }
+
+  @Override
+  public String rawQuery() {
+    return null;
+  }
+
+  @Override
+  public String raw() {
+    return rawUri;
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/api/URIDataAdapterTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/api/URIDataAdapterTest.groovy
@@ -14,8 +14,7 @@ abstract class URIDataAdapterTest extends DDSpecification {
   @Unroll
   def "test URI parts #input"() {
     setup:
-    def uri = new URI(input)
-    def adapter = adapter(uri)
+    def adapter = URIDataAdapterBase.fromURI(input, {adapter(it)})
 
     expect:
     adapter.scheme() == scheme
@@ -28,6 +27,7 @@ abstract class URIDataAdapterTest extends DDSpecification {
     adapter.rawPath() == (supportsRaw() ? rawPath : null)
     adapter.rawQuery() == (supportsRaw() ? rawQuery : null)
     adapter.raw() == (supportsRaw() ? raw : null)
+    adapter.isValid()
 
     where:
     // spotless:off
@@ -154,6 +154,27 @@ class URINoRawDataAdapterTest extends URIDataAdapterTest {
     @Override
     String rawQuery() {
       return null
+    }
+  }
+
+  static class UnparseableURIAdapterTest extends DDSpecification {
+    def "should return raw URI only"() {
+      setup:
+      def uriStr = "http://myurl/path?query=value#fragment"
+      def uriAdapter = new UnparseableURIDataAdapter(uriStr)
+
+      expect:
+      !uriAdapter.isValid()
+      uriAdapter.host() == null
+      uriAdapter.port() == 0
+      uriAdapter.fragment() == null
+      uriAdapter.path() == null
+      uriAdapter.path() == null
+      uriAdapter.query() == null
+      uriAdapter.rawQuery() == null
+      uriAdapter.scheme() == null
+      uriAdapter.rawPath() == null
+      uriAdapter.raw() == uriStr
     }
   }
 }


### PR DESCRIPTION
# What Does This Do

This PR is doing a couple of things:
* Safely parse the URL. If the URL is un parsable, when possible, tag the span with the raw uri (and not the parsed one since it will be null or broken)
* For tomcat, make sure that when an exception is captured, the span is marked as errored only if the http response code matches the related rule


# Motivation

tldr; on recent tomcat versions backslashes are not allowed (it's configurable with `org.apache.catalina.connector.CoyoteAdapter.ALLOW_BACKSLASH=true`) while before it was.

This parsing error is captured because reported among the servlet response parameters. While we should log the stacktrace on the span, we do not should (unless configured) mark the span as error because we have a 4XX error

# Additional Notes
