### PR TITLE
chore: Use GHCR for docker build images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 defaults: &defaults
   working_directory: ~/dd-trace-java
   docker:
-    - image: &default_container datadog/dd-trace-java-docker-build:latest
+    - image: &default_container ghcr.io/datadog/dd-trace-java-docker-build:base
 
 # The caching setup of the build dependencies is somewhat involved because of how CircleCI works.
 # 1) Caches are immutable, so you can not reuse a cache key (the save will simply be ignored)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ cache: &default_cache
 
 .gradle_build: &gradle_build
   <<: *common
-  image: datadog/dd-trace-java-docker-build:latest
+  image: ghcr.io/datadog/dd-trace-java-docker-build:base
   before_script:
     - export GRADLE_USER_HOME=`pwd`/.gradle
 

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/aws-java-sqs-1.0.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/aws-java-sqs-1.0.gradle
@@ -36,5 +36,5 @@ dependencies {
   testImplementation group: 'com.amazonaws', name: 'amazon-sqs-java-messaging-lib', version: '1.0.8'
 
   latestDepTestImplementation group: 'com.amazonaws', name: 'aws-java-sdk-sqs', version: '+'
-  latestDepTestImplementation group: 'com.amazonaws', name: 'amazon-sqs-java-messaging-lib', version: '1.+'
+  latestDepTestImplementation group: 'com.amazonaws', name: 'amazon-sqs-java-messaging-lib', version: '1.1.2'
 }


### PR DESCRIPTION
# What Does This Do

Use GitHub Container Registry to get docker build images from.
Images are now published to GHCR rather than Docker Hub.

# Motivation

# Additional Notes

Backport #5127