### PR TITLE
Fix Git info extraction logic to fall back to alternative providers when encountering empty or blank strings

### DIFF
--- a/internal-api/src/main/java/datadog/trace/util/Strings.java
+++ b/internal-api/src/main/java/datadog/trace/util/Strings.java
@@ -282,4 +282,21 @@ public final class Strings {
     json.append("]");
     return json.toString();
   }
+
+  public static boolean isNotBlank(String s) {
+    if (s == null || s.isEmpty()) {
+      return false;
+    }
+
+    final int length = s.length();
+    for (int offset = 0; offset < length; ) {
+      final int codepoint = s.codePointAt(offset);
+      if (!Character.isWhitespace(codepoint)) {
+        return true;
+      }
+      offset += Character.charCount(codepoint);
+    }
+
+    return false;
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/util/Strings.java
+++ b/internal-api/src/main/java/datadog/trace/util/Strings.java
@@ -283,13 +283,24 @@ public final class Strings {
     return json.toString();
   }
 
+  /**
+   * Checks that a string is not blank, i.e. contains at least one character that is not a
+   * whitespace
+   *
+   * @param s The string to be checked
+   * @return {@code true} if string is not blank, {@code false} otherwise (string is {@code null},
+   *     empty, or contains only whitespace characters)
+   */
   public static boolean isNotBlank(String s) {
     if (s == null || s.isEmpty()) {
       return false;
     }
 
+    // the code below traverses string characters one by one
+    // and checks if there is any character that is not a whitespace (space, tab, newline, etc);
     final int length = s.length();
     for (int offset = 0; offset < length; ) {
+      // codepoints are used instead of chars, to properly handle non-unicode symbols
       final int codepoint = s.codePointAt(offset);
       if (!Character.isWhitespace(codepoint)) {
         return true;

--- a/internal-api/src/test/groovy/datadog/trace/api/git/GitInfoProviderTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/git/GitInfoProviderTest.groovy
@@ -49,6 +49,54 @@ class GitInfoProviderTest extends Specification {
     actualGitInfo.commit.sha == "sha"
   }
 
+  def "test falls back to the second GitInfoBuilder for empty strings"() {
+    setup:
+    def gitInfoBuilderA = givenABuilderReturning(
+      new GitInfo("repoUrl", "", "", new CommitInfo(""))
+      )
+
+    def gitInfoBuilderB = givenABuilderReturning(
+      new GitInfo(null, "branch", "tag", new CommitInfo("sha"))
+      )
+
+    def gitInfoProvider = new GitInfoProvider()
+    gitInfoProvider.registerGitInfoBuilder(gitInfoBuilderA)
+    gitInfoProvider.registerGitInfoBuilder(gitInfoBuilderB)
+
+    when:
+    def actualGitInfo = gitInfoProvider.getGitInfo(REPO_PATH)
+
+    then:
+    actualGitInfo.repositoryURL == "repoUrl"
+    actualGitInfo.branch == "branch"
+    actualGitInfo.tag == "tag"
+    actualGitInfo.commit.sha == "sha"
+  }
+
+  def "test falls back to the second GitInfoBuilder for blank strings"() {
+    setup:
+    def gitInfoBuilderA = givenABuilderReturning(
+      new GitInfo("repoUrl", " ", " ", new CommitInfo(" "))
+      )
+
+    def gitInfoBuilderB = givenABuilderReturning(
+      new GitInfo(null, "branch", "tag", new CommitInfo("sha"))
+      )
+
+    def gitInfoProvider = new GitInfoProvider()
+    gitInfoProvider.registerGitInfoBuilder(gitInfoBuilderA)
+    gitInfoProvider.registerGitInfoBuilder(gitInfoBuilderB)
+
+    when:
+    def actualGitInfo = gitInfoProvider.getGitInfo(REPO_PATH)
+
+    then:
+    actualGitInfo.repositoryURL == "repoUrl"
+    actualGitInfo.branch == "branch"
+    actualGitInfo.tag == "tag"
+    actualGitInfo.commit.sha == "sha"
+  }
+
   def "test falls back to the second GitInfoBuilder for commit info"() {
     setup:
     def gitInfoBuilderA = givenABuilderReturning(
@@ -56,7 +104,7 @@ class GitInfoProviderTest extends Specification {
       new CommitInfo("sha",
       PersonInfo.NOOP,
       PersonInfo.NOOP,
-      "message")))
+      null)))
 
     def gitInfoBuilderB = givenABuilderReturning(
       new GitInfo("repoUrl", null, null,
@@ -84,7 +132,77 @@ class GitInfoProviderTest extends Specification {
     actualGitInfo.commit.committer.iso8601Date == "committer date"
   }
 
-  def "test does not falls back to the second GitInfoBuilder for commit info if SHAs do not match"() {
+  def "test falls back to the second GitInfoBuilder for empty strings in commit info"() {
+    setup:
+    def gitInfoBuilderA = givenABuilderReturning(
+      new GitInfo("repoUrl", null, null,
+      new CommitInfo("sha",
+      new PersonInfo("", "", ""),
+      new PersonInfo("", "", ""),
+      "")))
+
+    def gitInfoBuilderB = givenABuilderReturning(
+      new GitInfo("repoUrl", null, null,
+      new CommitInfo("sha",
+      new PersonInfo("author name", "author email", "author date"),
+      new PersonInfo("committer name", "committer email", "committer date"),
+      "message")))
+
+    def gitInfoProvider = new GitInfoProvider()
+    gitInfoProvider.registerGitInfoBuilder(gitInfoBuilderA)
+    gitInfoProvider.registerGitInfoBuilder(gitInfoBuilderB)
+
+    when:
+    def actualGitInfo = gitInfoProvider.getGitInfo(REPO_PATH)
+
+    then:
+    actualGitInfo.repositoryURL == "repoUrl"
+    actualGitInfo.commit.sha == "sha"
+    actualGitInfo.commit.fullMessage == "message"
+    actualGitInfo.commit.author.name == "author name"
+    actualGitInfo.commit.author.email == "author email"
+    actualGitInfo.commit.author.iso8601Date == "author date"
+    actualGitInfo.commit.committer.name == "committer name"
+    actualGitInfo.commit.committer.email == "committer email"
+    actualGitInfo.commit.committer.iso8601Date == "committer date"
+  }
+
+  def "test falls back to the second GitInfoBuilder for blank strings in commit info"() {
+    setup:
+    def gitInfoBuilderA = givenABuilderReturning(
+      new GitInfo("repoUrl", null, null,
+      new CommitInfo("sha",
+      new PersonInfo(" ", " ", " "),
+      new PersonInfo(" ", " ", " "),
+      " ")))
+
+    def gitInfoBuilderB = givenABuilderReturning(
+      new GitInfo("repoUrl", null, null,
+      new CommitInfo("sha",
+      new PersonInfo("author name", "author email", "author date"),
+      new PersonInfo("committer name", "committer email", "committer date"),
+      "message")))
+
+    def gitInfoProvider = new GitInfoProvider()
+    gitInfoProvider.registerGitInfoBuilder(gitInfoBuilderA)
+    gitInfoProvider.registerGitInfoBuilder(gitInfoBuilderB)
+
+    when:
+    def actualGitInfo = gitInfoProvider.getGitInfo(REPO_PATH)
+
+    then:
+    actualGitInfo.repositoryURL == "repoUrl"
+    actualGitInfo.commit.sha == "sha"
+    actualGitInfo.commit.fullMessage == "message"
+    actualGitInfo.commit.author.name == "author name"
+    actualGitInfo.commit.author.email == "author email"
+    actualGitInfo.commit.author.iso8601Date == "author date"
+    actualGitInfo.commit.committer.name == "committer name"
+    actualGitInfo.commit.committer.email == "committer email"
+    actualGitInfo.commit.committer.iso8601Date == "committer date"
+  }
+
+  def "test does not fall back to the second GitInfoBuilder for commit info if SHAs do not match"() {
     setup:
     def gitInfoBuilderA = givenABuilderReturning(
       new GitInfo("repoUrl", null, null,

--- a/internal-api/src/test/groovy/datadog/trace/util/StringsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/util/StringsTest.groovy
@@ -189,4 +189,26 @@ class StringsTest extends DDSpecification {
     ['value1', 'value2']   | "[\"value1\",\"value2\"]"
     ['va"lu"e1', 'value2'] | "[\"va\\\"lu\\\"e1\",\"value2\"]"
   }
+
+  def "test isNotBlank: #input"() {
+    when:
+    def notBlank = Strings.isNotBlank(input)
+
+    then:
+    notBlank == expected
+
+    where:
+    input      | expected
+    null       | false
+    ""         | false
+    " "        | false
+    "\t"       | false
+    "\n"       | false
+    " \t\n "   | false
+    "a"        | true
+    " a "      | true
+    "\n\t123 " | true
+    " 測 試 "  | true
+    "   𐢀𐢀𐢀𐢀"  | true
+  }
 }

--- a/internal-api/src/test/groovy/datadog/trace/util/StringsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/util/StringsTest.groovy
@@ -198,17 +198,17 @@ class StringsTest extends DDSpecification {
     notBlank == expected
 
     where:
-    input      | expected
-    null       | false
-    ""         | false
-    " "        | false
-    "\t"       | false
-    "\n"       | false
-    " \t\n "   | false
-    "a"        | true
-    " a "      | true
-    "\n\t123 " | true
-    " 測 試 "  | true
-    "   𐢀𐢀𐢀𐢀"  | true
+    input        | expected
+    null         | false
+    ""           | false
+    " "          | false
+    "\t"         | false
+    "\n"         | false
+    " \t\n "     | false
+    "a"          | true
+    " a "        | true
+    "\n\t123 "   | true
+    " 測 試    " | true
+    "   𐢀𐢀𐢀𐢀"    | true
   }
 }


### PR DESCRIPTION
# What Does This Do
There is a component in the tracer that handles Git metadata (repository URL, commit sha, commit author email, etc).
This component uses a variety of sources (env variables set by CI provider, local `.git` folder, user-supplied values, etc).
If a particular value is not available in one source, the component falls back to alternative sources.
This PR changes the notion of "not available": not only `null` strings, but also empty or blank strings will now result in fallback.

# Motivation
Some CI providers (e.g. Azure Pipelines) sometimes set Git-related environment variables to empty strings.
