### PR TITLE
Fix automatic demo application deploy on release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,6 +116,8 @@ deploy_to_di_backend:automatic:
       when: never
     - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
       when: on_success
+    - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/'
+      when: on_success
   trigger:
     project: DataDog/debugger-backend
     branch: main


### PR DESCRIPTION
# What Does This Do
Currently, the demo applications deployment to the backend is not triggered when a new version is released. 
This is because the deployment is only triggered for the default branch, and the new version is committed to the release branch. 
The current PR fix this issue by adding a trigger from the release branch to ensure that the deployment is also triggered when a new version is released.