### PR TITLE
upgrade to ddprof 0.35.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.34.0",
+    ddprof        : "0.35.0",
     asm           : "9.5"
   ]
 


### PR DESCRIPTION
# What Does This Do

* Contains a fix for a crash in the beta contextual allocation profiler (disabled by default)
* [Profiler release notes](https://github.com/DataDog/java-profiler/releases/tag/v_0.35.0)

# Motivation

# Additional Notes
