### PR TITLE
Don't use strictly for testng dependency

### DIFF
--- a/dd-java-agent/instrumentation/testng/build.gradle
+++ b/dd-java-agent/instrumentation/testng/build.gradle
@@ -9,9 +9,13 @@ dependencies {
 
   testFixturesApi testFixtures(project(':dd-java-agent:agent-ci-visibility'))
 
-  testFixturesImplementation(group: 'org.testng', name: 'testng') {
-    version {
-      strictly '6.4'
-    }
-  }
+  testFixturesImplementation group: 'org.testng', name: 'testng', version: '6.4'
 }
+
+// gradle can't downgrade the testng dependencies with `strictly` and IntelliJ IDEA reports
+// an error when importing the project, so pretty please DON'T change this back to strictly
+configurations.matching({ it.name.startsWith('test') }).each({
+  it.resolutionStrategy {
+    force group: 'org.testng', name: 'testng', version: '6.4'
+  }
+})


### PR DESCRIPTION
# What Does This Do

Changes back a `strictly` directive to a `force` clause

# Motivation

When running `dependencies` on the `testng` project `gradle` reports a `FAILURE` and IntelliJ IDEA will report an `ERROR` when importing the project.

# Additional Notes
