### PR TITLE
SpanBuilder.withTag(name, "") should behave like span.setTag(name, "")

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1272,7 +1272,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
     @Override
     public CoreSpanBuilder withTag(final String tag, final String string) {
-      return withTag(tag, (Object) string);
+      return withTag(tag, (Object) (string == null || string.isEmpty() ? null : string));
     }
 
     @Override


### PR DESCRIPTION
and map empty strings to null, ie. remove the tag