### PR TITLE
Add probe id and eval errors as _dd tags

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
@@ -32,8 +32,8 @@ import org.slf4j.LoggerFactory;
 
 public class SpanDecorationProbe extends ProbeDefinition {
   private static final Logger LOGGER = LoggerFactory.getLogger(SpanDecorationProbe.class);
-  private static final String PROBEID_DD_TAGS_FORMAT = "_dd.%s.probe_id";
-  private static final String EVALERROR_DD_TAGS_FORMAT = "_dd.%s.evaluation_error";
+  private static final String PROBEID_DD_TAGS_FORMAT = "_dd.di.%s.probe_id";
+  private static final String EVALERROR_DD_TAGS_FORMAT = "_dd.di.%s.evaluation_error";
 
   public enum TargetSpan {
     ACTIVE,

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
@@ -157,7 +157,7 @@ public class SpanDecorationProbe extends ProbeDefinition {
         } catch (EvaluationException ex) {
           LOGGER.debug("Evaluation error: ", ex);
           status.addError(new EvaluationError(ex.getExpr(), ex.getMessage()));
-          spanStatus.addTag(String.format(EVALERROR_DD_TAGS_FORMAT, tagName), ex.toString());
+          spanStatus.addTag(String.format(EVALERROR_DD_TAGS_FORMAT, tagName), ex.getMessage());
         }
       }
     }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ProbeInstrumentationTest.java
@@ -29,9 +29,12 @@ public class ProbeInstrumentationTest {
   protected static class MockSink implements Sink {
 
     private final List<DiagnosticMessage> currentDiagnostics = new ArrayList<>();
+    private final List<Snapshot> snapshots = new ArrayList<>();
 
     @Override
-    public void addSnapshot(Snapshot snapshot) {}
+    public void addSnapshot(Snapshot snapshot) {
+      snapshots.add(snapshot);
+    }
 
     @Override
     public void skipSnapshot(String probeId, DebuggerContext.SkipCause cause) {}
@@ -46,6 +49,10 @@ public class ProbeInstrumentationTest {
 
     public List<DiagnosticMessage> getCurrentDiagnostics() {
       return currentDiagnostics;
+    }
+
+    public List<Snapshot> getSnapshots() {
+      return snapshots;
     }
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
@@ -78,7 +78,7 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     SpanDecorationProbe.Decoration deco4 =
         createDecoration("tag4", index(ref("strList"), value(1)), "strList[1]");
     SpanDecorationProbe.Decoration deco5 =
-        createDecoration("tag5", index(ref("map"), value("foo3")), "map['foo3']");
+        createDecoration("Tag+5", index(ref("map"), value("foo3")), "map['foo3']");
     installSingleSpanDecoration(
         CLASS_NAME,
         ACTIVE,
@@ -93,7 +93,7 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     assertEquals("42", span.getTags().get("tag2"));
     assertEquals("hello", span.getTags().get("tag3"));
     assertEquals("foobar2", span.getTags().get("tag4"));
-    assertEquals("bar3", span.getTags().get("tag5"));
+    assertEquals("bar3", span.getTags().get("tag_5")); // tag name sanitized
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
@@ -65,7 +65,7 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     assertEquals(42, result);
     MutableSpan span = traceInterceptor.getFirstSpan();
     assertEquals("1", span.getTags().get("tag1"));
-    assertEquals(PROBE_ID.getId(), span.getTags().get("_dd.tag1.probe_id"));
+    assertEquals(PROBE_ID.getId(), span.getTags().get("_dd.di.tag1.probe_id"));
   }
 
   @Test
@@ -151,7 +151,7 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     assertNull(span.getTags().get("tag1"));
     assertEquals(
         "com.datadog.debugger.el.EvaluationException: Cannot find symbol: noarg",
-        span.getTags().get("_dd.tag1.evaluation_error"));
+        span.getTags().get("_dd.di.tag1.evaluation_error"));
   }
 
   @Test
@@ -181,7 +181,7 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     assertEquals(42, result);
     MutableSpan span = traceInterceptor.getFirstSpan();
     assertEquals("1", span.getTags().get("tag1"));
-    assertEquals(PROBE_ID.getId(), span.getTags().get("_dd.tag1.probe_id"));
+    assertEquals(PROBE_ID.getId(), span.getTags().get("_dd.di.tag1.probe_id"));
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
@@ -149,9 +149,7 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     assertEquals(42, result);
     MutableSpan span = traceInterceptor.getFirstSpan();
     assertNull(span.getTags().get("tag1"));
-    assertEquals(
-        "com.datadog.debugger.el.EvaluationException: Cannot find symbol: noarg",
-        span.getTags().get("_dd.di.tag1.evaluation_error"));
+    assertEquals("Cannot find symbol: noarg", span.getTags().get("_dd.di.tag1.evaluation_error"));
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do
Add probe id as `_dd.di.dynamictag.probe_id` tag
Add evaluation error as `_dd.di.dynamictag.evaluation_error` tag send snapshot containing evaluation errors when decoration condition evaluation has errors

# Motivation
correlation between probe and span tags
report evaluation errors
# Additional Notes
