### PR TITLE
Fix test targets in jetty other than 'test'

### DIFF
--- a/dd-java-agent/instrumentation/jetty-7.0/build.gradle
+++ b/dd-java-agent/instrumentation/jetty-7.0/build.gradle
@@ -10,7 +10,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteForDir('latestDepForkedTest', 'test')
 
 dependencies {
   compileOnly group: 'org.eclipse.jetty', name: 'jetty-server', version: '7.0.0.v20091005'

--- a/dd-java-agent/instrumentation/jetty-7.6/build.gradle
+++ b/dd-java-agent/instrumentation/jetty-7.6/build.gradle
@@ -10,7 +10,7 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteForDir('latestDepForkedTest', 'test')
 
 dependencies {
   compileOnly group: 'org.eclipse.jetty', name: 'jetty-server', version: '7.6.0.v20120127'

--- a/dd-java-agent/instrumentation/jetty-9/build.gradle
+++ b/dd-java-agent/instrumentation/jetty-9/build.gradle
@@ -9,9 +9,9 @@ muzzle {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-addTestSuiteForDir('jetty92Test', 'test')
-addTestSuiteForDir('jetty94Test', 'test')
-addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteForDir('jetty92ForkedTest', 'test')
+addTestSuiteForDir('jetty94ForkedTest', 'test')
+addTestSuiteForDir('latestDepForkedTest', 'test')
 
 dependencies {
   compileOnly group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.0.0.v20130308'

--- a/gradle/test-suites.gradle
+++ b/gradle/test-suites.gradle
@@ -35,30 +35,29 @@ ext.addTestSuiteExtendingForDir = (String testSuiteName, String parentSuiteName,
   }
 
   configurations {
-    def provider = named("${parentSuiteName}CompileOnly")
-    if (provider.present) {
-      named("${testSuiteName}CompileOnly").configure {
-        extendsFrom(provider.get())
+    def extendConf = {
+      String suffix ->
+      def config = named("${testSuiteName}${suffix}")
+      def parentConfig = named("${parentSuiteName}${suffix}")
+      if (parentConfig.present) {
+        config.configure {
+          extendsFrom(parentConfig.get())
+        }
+      }
+
+      if (testSuiteName ==~ /.*ForkedTest\z/) {
+        def nonForkedBaseConfName = testSuiteName - ~/Forked/
+        def nonForkedConfig = maybeCreate("${nonForkedBaseConfName}${suffix}")
+        config.configure {
+          extendsFrom(nonForkedConfig)
+        }
       }
     }
-    provider = named("${parentSuiteName}Implementation")
-    if (provider.present) {
-      named("${testSuiteName}Implementation").configure {
-        extendsFrom(provider.get())
-      }
-    }
-    provider = named("${parentSuiteName}RuntimeOnly")
-    if (provider.present) {
-      named("${testSuiteName}RuntimeOnly").configure {
-        extendsFrom(provider.get())
-      }
-    }
-    provider = named("${parentSuiteName}AnnotationProcessor")
-    if (provider.present) {
-      named("${testSuiteName}AnnotationProcessor").configure {
-        extendsFrom(provider.get())
-      }
-    }
+
+    extendConf('CompileOnly')
+    extendConf('Implementation')
+    extendConf('RuntimeOnly')
+    extendConf('AnnotationProcessor')
   }
 
   tasks.register("${testSuiteName}Jar", Jar) {


### PR DESCRIPTION
Two problems:

* The `addTestSuiteForDir` calls were for adding only targets that don't run the `*ForkedTest`s.
* When adding `ForkedTest` targets, the gradle "configurations"' name are based upon the sourceSet name. `DefaultJvmTestSuite` uses as the sourceSet name the name of the task. Consequently, if we add a target called `latestDepForkedTest`, the created configurations are named `latestDepForkedTestImplementation` and so on, whereas the current `dependencies {}` blocks are only adding dependencies on `latestDepTestImplementation`. Fix this by making the ForkedTest configurations extend from the non-Forked ones (e.g. `latestDepForkedTestImplementation` extends from `latestDepTestImplementation`; `latestDepTestImplementation` is created if it doesn't exist).