### PR TITLE
Make embedded git.properties have lower priority than other git metadata sources

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/CILocalGitInfoBuilder.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/CILocalGitInfoBuilder.java
@@ -21,4 +21,9 @@ public class CILocalGitInfoBuilder implements GitInfoBuilder {
     return new LocalFSGitInfoExtractor()
         .headCommit(Paths.get(repositoryPath, gitFolderName).toFile().getAbsolutePath());
   }
+
+  @Override
+  public int order() {
+    return 2;
+  }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/CIProviderGitInfoBuilder.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/CIProviderGitInfoBuilder.java
@@ -16,4 +16,9 @@ public class CIProviderGitInfoBuilder implements GitInfoBuilder {
     CIProviderInfo ciProviderInfo = ciProviderInfoFactory.createCIProviderInfo(currentPath);
     return ciProviderInfo.buildCIGitInfo();
   }
+
+  @Override
+  public int order() {
+    return 1;
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/api/git/EmbeddedGitInfoBuilder.java
+++ b/internal-api/src/main/java/datadog/trace/api/git/EmbeddedGitInfoBuilder.java
@@ -67,4 +67,9 @@ public class EmbeddedGitInfoBuilder implements GitInfoBuilder {
                 committerTime),
             gitProperties.getProperty("git.commit.message.full")));
   }
+
+  @Override
+  public int order() {
+    return Integer.MAX_VALUE;
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/api/git/GitInfoBuilder.java
+++ b/internal-api/src/main/java/datadog/trace/api/git/GitInfoBuilder.java
@@ -4,4 +4,6 @@ import javax.annotation.Nullable;
 
 public interface GitInfoBuilder {
   GitInfo build(@Nullable String repositoryPath);
+
+  int order();
 }

--- a/internal-api/src/main/java/datadog/trace/api/git/UserSuppliedGitInfoBuilder.java
+++ b/internal-api/src/main/java/datadog/trace/api/git/UserSuppliedGitInfoBuilder.java
@@ -98,4 +98,9 @@ public class UserSuppliedGitInfoBuilder implements GitInfoBuilder {
 
     return gitInfo;
   }
+
+  @Override
+  public int order() {
+    return 0;
+  }
 }

--- a/internal-api/src/test/groovy/datadog/trace/api/git/GitInfoProviderTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/git/GitInfoProviderTest.groovy
@@ -32,12 +32,13 @@ class GitInfoProviderTest extends Specification {
       )
 
     def gitInfoBuilderB = givenABuilderReturning(
-      new GitInfo(null, "branch", "tag", new CommitInfo("sha"))
+      new GitInfo(null, "branch", "tag", new CommitInfo("sha")), 2
       )
 
     def gitInfoProvider = new GitInfoProvider()
-    gitInfoProvider.registerGitInfoBuilder(gitInfoBuilderA)
+    // registering provider with higher order first, to check that the registration logic will do proper reordering after the second registration
     gitInfoProvider.registerGitInfoBuilder(gitInfoBuilderB)
+    gitInfoProvider.registerGitInfoBuilder(gitInfoBuilderA)
 
     when:
     def actualGitInfo = gitInfoProvider.getGitInfo(REPO_PATH)
@@ -238,8 +239,13 @@ class GitInfoProviderTest extends Specification {
   }
 
   private GitInfoBuilder givenABuilderReturning(GitInfo gitInfo) {
+    givenABuilderReturning(gitInfo, 1)
+  }
+
+  private GitInfoBuilder givenABuilderReturning(GitInfo gitInfo, int order) {
     def gitInfoBuilder = Stub(GitInfoBuilder)
     gitInfoBuilder.build(REPO_PATH) >> gitInfo
-    return gitInfoBuilder
+    gitInfoBuilder.order() >> order
+    gitInfoBuilder
   }
 }


### PR DESCRIPTION
# What Does This Do
There is a component in the tracer that fetches git metadata associated with the traced code.
The component has a few sources that it uses to obtain the data:
- environment variables set explicitly by the user
- `git.properties` file available on the classpath (injected either manually or by a Maven/Gradle plugin)
- environment variables set by CI provider (e.g. Jenkins or CircleCI)
- `.git` folder that is available locally

The sources are listed in order of priority.
The last two sources are only available if CI Visibility subsystem is enabled in the tracer.

This PR changes the relative priorities of git metadata sources, making `git.properties` the least preferable one.

# Motivation
`git.properties` is the least reliable of the sources, as we have no way of ensuring that the file located on the classpath resides in the JAR that we want to trace, and not in some 3rd party dependency.
We want to try other more reliable sources before resorting to this one.

# Additional Notes
Embedded git metadata extraction was added in scope of [PR 4951](https://github.com/DataDog/dd-trace-java/pull/4951)
