### PR TITLE
Set a resolved Undertow servlet route

### DIFF
--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/ServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/ServletInstrumentation.java
@@ -4,6 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.SERVLET_CONTEXT;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.SERVLET_PATH;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
+import static datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourceDecorator.HTTP_RESOURCE_DECORATOR;
 import static datadog.trace.instrumentation.undertow.UndertowDecorator.DD_UNDERTOW_CONTINUATION;
 import static datadog.trace.instrumentation.undertow.UndertowDecorator.SERVLET_REQUEST;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -13,8 +14,10 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import io.undertow.server.HttpServerExchange;
+import io.undertow.servlet.handlers.ServletPathMatch;
 import io.undertow.servlet.handlers.ServletRequestContext;
 import javax.servlet.ServletRequest;
+import javax.servlet.http.MappingMatch;
 import net.bytebuddy.asm.Advice;
 
 @AutoService(Instrumenter.class)
@@ -62,7 +65,20 @@ public final class ServletInstrumentation extends Instrumenter.Tracing
         undertowSpan.setSpanName(SERVLET_REQUEST);
 
         undertowSpan.setTag(SERVLET_CONTEXT, request.getServletContext().getContextPath());
-        undertowSpan.setTag(SERVLET_PATH, exchange.getRelativePath());
+        String relativePath = exchange.getRelativePath();
+
+        ServletPathMatch servletPathMatch = servletRequestContext.getServletPathMatch();
+        if (servletPathMatch != null
+            && servletPathMatch.getMappingMatch() != MappingMatch.DEFAULT) {
+          // Set the route unless the mapping match is default, this way we prevent setting route
+          // for a non-existing resource. Otherwise, it'd set a non-existing resource name with
+          // higher priority than 404 resource, so it wouldn't be able to set resource 404 later in
+          // the onResponse instrumentation.
+          HTTP_RESOURCE_DECORATOR.withRoute(
+              undertowSpan, exchange.getRequestMethod().toString(), relativePath, false);
+        }
+        // The servlet.path tag is expected even for a non-existing resource.
+        undertowSpan.setTag(SERVLET_PATH, relativePath);
       }
     }
   }

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/NotHereServlet.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/NotHereServlet.groovy
@@ -1,0 +1,16 @@
+import javax.servlet.ServletException
+import javax.servlet.http.HttpServlet
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_HERE
+import static datadog.trace.agent.test.base.HttpServerTest.controller
+
+class NotHereServlet extends HttpServlet {
+  @Override
+  protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+    controller(NOT_HERE) {
+      resp.sendError(NOT_HERE.status)
+    }
+  }
+}


### PR DESCRIPTION
# What Does This Do

Sets the server request span's resource name to a resolved Undertow servlet route and sets the `http.route` tag.

Adds a test for a servlet returning 404 explicitly to make sure it won't use 404 as for non-existing resource.

# Motivation

Excluding the servlet context from the resource name.

# Additional Notes

#4999
