### PR TITLE
IAST Insecure cookie detection for JAX-RS frameworks

### DIFF
--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/JavaxWSResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/JavaxWSResponseInstrumentation.java
@@ -15,10 +15,10 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(Instrumenter.class)
-public class JakartaWSResponseInstrumentation extends Instrumenter.Iast
+public class JavaxWSResponseInstrumentation extends Instrumenter.Iast
     implements Instrumenter.ForTypeHierarchy {
 
-  public JakartaWSResponseInstrumentation() {
+  public JavaxWSResponseInstrumentation() {
     super("jersey");
   }
 
@@ -26,15 +26,15 @@ public class JakartaWSResponseInstrumentation extends Instrumenter.Iast
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(
         named("header").and(isPublic().and(takesArguments(String.class, Object.class))),
-        JakartaWSResponseInstrumentation.class.getName() + "$HeaderAdvice");
+        JavaxWSResponseInstrumentation.class.getName() + "$HeaderAdvice");
     transformation.applyAdvice(
         named("location").and(isPublic().and(takesArguments(URI.class))),
-        JakartaWSResponseInstrumentation.class.getName() + "$RedirectionAdvice");
+        JavaxWSResponseInstrumentation.class.getName() + "$RedirectionAdvice");
   }
 
   @Override
   public String hierarchyMarkerType() {
-    return "jakarta.ws.rs.core.Response$ResponseBuilder";
+    return "javax.ws.rs.core.Response$ResponseBuilder";
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jersey/src/test/groovy/datadog/trace/instrumentation/jersey/JakartaWSResponseInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jersey/src/test/groovy/datadog/trace/instrumentation/jersey/JakartaWSResponseInstrumentationTest.groovy
@@ -2,7 +2,9 @@ package datadog.trace.instrumentation.jersey
 
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.sink.InsecureCookieModule
 import datadog.trace.api.iast.sink.UnvalidatedRedirectModule
+import jakarta.ws.rs.core.NewCookie
 import jakarta.ws.rs.core.Response
 
 class JakartaWSResponseInstrumentationTest extends AgentTestRunner {
@@ -15,14 +17,20 @@ class JakartaWSResponseInstrumentationTest extends AgentTestRunner {
 
   void 'change location header triggers onHeader callback'() {
     setup:
-    final module = Mock(UnvalidatedRedirectModule)
-    InstrumentationBridge.registerIastModule(module)
+    final redirectionModule = Mock(UnvalidatedRedirectModule)
+    InstrumentationBridge.registerIastModule(redirectionModule)
+    final insecureCookieModule = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(insecureCookieModule)
+
+
 
     when:
     Response.status(Response.Status.TEMPORARY_REDIRECT).header("Location", "https://dummy.location.com/test")
 
     then:
-    1 * module.onHeader('Location', 'https://dummy.location.com/test')
+    1 * redirectionModule.onHeader('Location', 'https://dummy.location.com/test')
+    1 * insecureCookieModule.onHeader('Location', 'https://dummy.location.com/test')
+    0 * _
   }
 
   void 'change location triggers onRedirect callback'() {
@@ -36,5 +44,32 @@ class JakartaWSResponseInstrumentationTest extends AgentTestRunner {
 
     then:
     1 * module.onURIRedirect(uri)
+  }
+
+  def 'insecure cookie added using Response.cookie'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    Response.ok().cookie(new NewCookie("user-id", "7"))
+
+    then:
+    1 * module.onHeader('Set-Cookie', 'user-id=7;Version=1')
+    0 * _
+  }
+
+  def 'insecure cookies added using Response.cookie'(){
+    setup:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    Response.ok().cookie(new NewCookie("user-id", "7"), new NewCookie("ttt", "1"))
+
+    then:
+    1 * module.onHeader('Set-Cookie', 'user-id=7;Version=1')
+    1 * module.onHeader('Set-Cookie', 'ttt=1;Version=1')
+    0 * _
   }
 }

--- a/dd-smoke-tests/jersey-2/src/main/java/com/restserver/Resource.java
+++ b/dd-smoke-tests/jersey-2/src/main/java/com/restserver/Resource.java
@@ -2,6 +2,7 @@ package com.restserver;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.sql.SQLException;
 import java.util.Map;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.CookieParam;
@@ -18,6 +19,7 @@ import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.Form;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
@@ -130,5 +132,11 @@ public class Resource {
   @GET
   public Response responseLocation(@QueryParam("param") String param) throws URISyntaxException {
     return Response.status(Response.Status.TEMPORARY_REDIRECT).location(new URI(param)).build();
+  }
+
+  @Path("/insecurecookie")
+  @GET
+  public Response getCookie() throws SQLException {
+    return Response.ok().cookie(new NewCookie("user-id", "7")).build();
   }
 }

--- a/dd-smoke-tests/jersey-3/src/main/java/smoketest/Resource.java
+++ b/dd-smoke-tests/jersey-3/src/main/java/smoketest/Resource.java
@@ -14,9 +14,11 @@ import jakarta.ws.rs.core.Cookie;
 import jakarta.ws.rs.core.Form;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.NewCookie;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.sql.SQLException;
 import java.util.Map;
 
 @Path("/hello")
@@ -120,5 +122,11 @@ public class Resource {
   @GET
   public Response responseLocation(@QueryParam("param") String param) throws URISyntaxException {
     return Response.status(Response.Status.TEMPORARY_REDIRECT).location(new URI(param)).build();
+  }
+
+  @Path("/insecurecookie")
+  @GET
+  public Response getCookie() throws SQLException {
+    return Response.ok().cookie(new NewCookie("user-id", "7")).build();
   }
 }

--- a/dd-smoke-tests/resteasy/src/main/java/smoketest/resteasy/Resource.java
+++ b/dd-smoke-tests/resteasy/src/main/java/smoketest/resteasy/Resource.java
@@ -2,6 +2,7 @@ package smoketest.resteasy;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
@@ -13,6 +14,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 
 @Path("/hello")
@@ -85,5 +87,11 @@ public class Resource {
   @GET
   public Response responseLocation(@QueryParam("param") String param) throws URISyntaxException {
     return Response.status(Response.Status.TEMPORARY_REDIRECT).location(new URI(param)).build();
+  }
+
+  @Path("/insecurecookie")
+  @GET
+  public Response getCookie() throws SQLException {
+    return Response.ok().cookie(new NewCookie("user-id", "7")).build();
   }
 }

--- a/dd-smoke-tests/resteasy/src/test/groovy/smoketest/ResteasySmokeTest.groovy
+++ b/dd-smoke-tests/resteasy/src/test/groovy/smoketest/ResteasySmokeTest.groovy
@@ -214,4 +214,16 @@ class ResteasySmokeTest extends AbstractIastServerSmokeTest {
     then:
     hasVulnerability { vul -> vul.type == 'UNVALIDATED_REDIRECT' }
   }
+
+  void "insecure cookie"() {
+    setup:
+    def url = "http://localhost:${httpPort}/hello/insecurecookie"
+
+    when:
+    def request = new Request.Builder().url(url).get().build()
+    client.newCall(request).execute()
+
+    then:
+    hasVulnerability { vul -> vul.type == 'INSECURE_COOKIE' }
+  }
 }


### PR DESCRIPTION
# What Does This Do
Instruments Response object in the javax.ws.rs and jakarta.ws.rs so we can report when insecure cookies are created

# Motivation
To increase the number of vulnerabilities that IAST monitors and reports

# Additional Notes
This PR depends on both https://github.com/DataDog/dd-trace-java/pull/5117 and https://github.com/DataDog/dd-trace-java/pull/4931 so I will keep it as draft until this two are merged.
