### PR TITLE
Aggregate tests in check, allTests and allLatestDepTests targets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -808,7 +808,7 @@ build_test_jobs: &build_test_jobs
       cacheType: inst
   - build:
       name: build_latestdep
-      gradleTarget: latestDepTest
+      gradleTarget: :instrumentationLatestDepTest
       cacheType: latestdep
   - build:
       name: build_smoke
@@ -927,7 +927,7 @@ build_test_jobs: &build_test_jobs
         - ok_to_test
         - build_latestdep
       name: test_8_inst_latest
-      gradleTarget: "latestDepTest"
+      gradleTarget: ":instrumentationLatestDepTest"
       gradleParameters: "-PskipFlakyTests"
       triggeredBy: *instrumentation_modules
       stage: instrumentation
@@ -1199,7 +1199,7 @@ workflows:
           cacheType: inst
       - build_clean_cache:
           name: build_cache_latestdep
-          gradleTarget: latestDepTest
+          gradleTarget: :instrumentationLatestDepTest
           cacheType: latestdep
       - build_clean_cache:
           name: build_cache_smoke

--- a/build.gradle
+++ b/build.gradle
@@ -160,31 +160,22 @@ allprojects { project ->
 
 
 def testAggregate(String baseTaskName, includePrefixes, excludePrefixes) {
-  final testTaskName = "${baseTaskName}Test"
-  tasks.register(testTaskName) { aggTest ->
-    subprojects { subproject ->
-      if (subproject.property("activePartition") && includePrefixes.any { subproject.path.startsWith(it) } && !excludePrefixes.any { subproject.path.startsWith(it) }) {
-        println(subproject.path)
-        def testTask = subproject.tasks.findByName("test")
-        if (testTask != null) {
-          aggTest.dependsOn(testTask)
+  def createRootTask = { rootTaskName, subProjTaskName ->
+    tasks.register(rootTaskName) { aggTest ->
+      subprojects { subproject ->
+        if (subproject.property("activePartition") && includePrefixes.any { subproject.path.startsWith(it) } && !excludePrefixes.any { subproject.path.startsWith(it) }) {
+          def testTask = subproject.tasks.findByName(subProjTaskName)
+          if (testTask != null) {
+            aggTest.dependsOn(testTask)
+          }
         }
       }
     }
   }
 
-  final checkTaskName = "${baseTaskName}Check"
-  tasks.register(checkTaskName) { aggCheck ->
-    subprojects { subproject ->
-      if (subproject.property("activePartition") && includePrefixes.any { subproject.path.startsWith(it) } && !excludePrefixes.any { subproject.path.startsWith(it) }) {
-        println(subproject.path)
-        def checkTask = subproject.tasks.findByName("check")
-        if (checkTask != null) {
-          aggCheck.dependsOn(checkTask)
-        }
-      }
-    }
-  }
+  createRootTask "${baseTaskName}Test", 'allTests'
+  createRootTask "${baseTaskName}LatestDepTest", 'allLatestDepTests'
+  createRootTask "${baseTaskName}Check", 'check'
 }
 
 testAggregate("smoke", [":dd-smoke-tests"], [])

--- a/gradle/configure_tests.gradle
+++ b/gradle/configure_tests.gradle
@@ -65,6 +65,20 @@ tasks.withType(Test).configureEach {
   }
 
   timeout = testTimeoutDuration
+
+  check.dependsOn it
+}
+
+Task allTestsTask = tasks.maybeCreate('allTests')
+Task allLatestDepTestsTask = tasks.maybeCreate('allLatestDepTests')
+project.afterEvaluate {
+  tasks.withType(Test).each {
+    if (it.name.containsIgnoreCase('latest')) {
+      allLatestDepTestsTask.dependsOn it
+    } else {
+      allTestsTask.dependsOn it
+    }
+  }
 }
 
 // Setup flaky tests jobs. Done in afterEvaluate so that it applies to latestDepTest.

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -22,10 +22,6 @@ if (tasks.matching({it.name == 'forkedTest'}).empty) {
   }
 }
 
-test {
-  finalizedBy "forkedTest"
-}
-
 def applyCodeCoverage = !(
   project.path.startsWith(":dd-smoke-tests") ||
   project.path == ":dd-java-agent" ||


### PR DESCRIPTION
# What Does This Do

* Add all test targets to the `check` target.
* Create the targets `allTests` and `allLatestDepTests`, aggregating forking and non-forking tests depending on whether they include `test` in the name
* Create new task on the root project named `baseLatestDepTest`, which is partition-aware. Run the latest dep tests on CI using that instead on relying on disabling test tasks, in order to avoid the dependencies of the test tasks from being executed.