### PR TITLE
Fix Diagnostic Messages on multi probes

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/InstrumentationResult.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/InstrumentationResult.java
@@ -1,7 +1,11 @@
 package com.datadog.debugger.instrumentation;
 
+import com.datadog.debugger.probe.ProbeDefinition;
+import datadog.trace.bootstrap.debugger.ProbeId;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.MethodNode;
 
@@ -14,7 +18,7 @@ public class InstrumentationResult {
   }
 
   private final Status status;
-  private final List<DiagnosticMessage> diagnostics;
+  private final Map<ProbeId, List<DiagnosticMessage>> diagnostics;
   private String typeName;
   private String methodName;
 
@@ -23,31 +27,29 @@ public class InstrumentationResult {
       return new InstrumentationResult(Status.BLOCKED, null, className, null);
     }
 
-    public static InstrumentationResult blocked(String className, DiagnosticMessage... messages) {
-      return new InstrumentationResult(Status.BLOCKED, Arrays.asList(messages), className, null);
-    }
-
-    public static InstrumentationResult installed(
-        ClassNode classNode, MethodNode methodNode, List<DiagnosticMessage> diagnostics) {
-      return new InstrumentationResult(Status.INSTALLED, diagnostics, classNode, methodNode);
-    }
-
-    public static InstrumentationResult error(
-        ClassNode classNode, MethodNode methodNode, List<DiagnosticMessage> diagnostics) {
-      return new InstrumentationResult(Status.ERROR, diagnostics, classNode, methodNode);
+    public static InstrumentationResult blocked(
+        String className, List<ProbeDefinition> definitions, DiagnosticMessage... messages) {
+      Map<ProbeId, List<DiagnosticMessage>> diagnostics = new HashMap<>();
+      definitions.forEach(
+          probeDefinition ->
+              diagnostics.put(probeDefinition.getProbeId(), Arrays.asList(messages)));
+      return new InstrumentationResult(Status.BLOCKED, diagnostics, className, null);
     }
   }
 
   public InstrumentationResult(
       Status status,
-      List<DiagnosticMessage> diagnostics,
+      Map<ProbeId, List<DiagnosticMessage>> diagnostics,
       ClassNode classNode,
       MethodNode methodNode) {
     this(status, diagnostics, classNode.name.replace('/', '.'), methodNode.name);
   }
 
   public InstrumentationResult(
-      Status status, List<DiagnosticMessage> diagnostics, String className, String methodName) {
+      Status status,
+      Map<ProbeId, List<DiagnosticMessage>> diagnostics,
+      String className,
+      String methodName) {
     this.status = status;
     this.diagnostics = diagnostics;
     this.typeName = className;
@@ -62,7 +64,7 @@ public class InstrumentationResult {
     return status == Status.INSTALLED;
   }
 
-  public List<DiagnosticMessage> getDiagnostics() {
+  public Map<ProbeId, List<DiagnosticMessage>> getDiagnostics() {
     return diagnostics;
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationComparerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationComparerTest.java
@@ -422,7 +422,7 @@ class ConfigurationComparerTest {
           PROBE_ID.getId(),
           new InstrumentationResult(
               InstrumentationResult.Status.INSTALLED,
-              Collections.emptyList(),
+              Collections.emptyMap(),
               classNode,
               new MethodNode()));
     }


### PR DESCRIPTION
# What Does This Do
Dispatch diagnostic messages per probe id as multiple probes can be instrumented independently on the same location (example metric probes).
We need to keep a list of diagnostic messages per probe id for a location so we change list by a map.

# Motivation

# Additional Notes
