### PR TITLE
uniform v1 database naming to otel

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
@@ -10,17 +10,19 @@ import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
-import java.util.function.Function;
 
 public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorator {
-
-  private static class NamingEntry {
+  protected static class NamingEntry {
     private final String service;
     private final CharSequence operation;
 
-    private NamingEntry(String service, CharSequence operation) {
-      this.service = service;
-      this.operation = operation;
+    private final String dbType;
+
+    private NamingEntry(String rawDbType) {
+      final NamingSchema.ForDatabase schema = SpanNaming.instance().namingSchema().database();
+      this.dbType = schema.normalizedName(rawDbType);
+      this.service = schema.service(Config.get().getServiceName(), dbType);
+      this.operation = UTF8BytesString.create(schema.operation(dbType));
     }
 
     public String getService() {
@@ -30,19 +32,16 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
     public CharSequence getOperation() {
       return operation;
     }
+
+    public String getDbType() {
+      return dbType;
+    }
   }
 
   // The total number of entries in the cache will normally be less than 4, since
   // most applications only have one or two DBs, and "jdbc" itself is also used as
   // one DB_TYPE, but set the cache size to 16 to help avoid collisions.
   private static final DDCache<String, NamingEntry> CACHE = DDCaches.newFixedSizeCache(16);
-  private static final Function<String, NamingEntry> APPEND_OPERATION =
-      dbType -> {
-        final NamingSchema.ForDatabase schema = SpanNaming.instance().namingSchema().database();
-        return new NamingEntry(
-            schema.service(Config.get().getServiceName(), dbType),
-            UTF8BytesString.create(schema.operation(dbType)));
-      };
 
   protected abstract String dbType();
 
@@ -82,7 +81,7 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
     if (instanceName != null && Config.get().isDbClientSplitByInstance()) {
       return dbClientService(instanceName);
     }
-    final NamingEntry entry = CACHE.computeIfAbsent(dbType, APPEND_OPERATION);
+    final NamingEntry entry = CACHE.computeIfAbsent(dbType, NamingEntry::new);
     return entry.getService();
   }
 
@@ -103,13 +102,10 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
   }
 
   protected void processDatabaseType(AgentSpan span, String dbType) {
-    span.setTag(DB_TYPE, dbType);
-    postProcessServiceAndOperationName(span, dbType);
+    final NamingEntry namingEntry = CACHE.computeIfAbsent(dbType, NamingEntry::new);
+    span.setTag(DB_TYPE, namingEntry.dbType);
+    postProcessServiceAndOperationName(span, namingEntry);
   }
 
-  protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {
-    final NamingEntry namingEntry = CACHE.computeIfAbsent(dbType, APPEND_OPERATION);
-    span.setServiceName(namingEntry.getService());
-    span.setOperationName(namingEntry.getOperation());
-  }
+  protected void postProcessServiceAndOperationName(AgentSpan span, NamingEntry namingEntry) {}
 }

--- a/dd-java-agent/instrumentation/aerospike-4/src/main/java/datadog/trace/instrumentation/aerospike4/AerospikeClientDecorator.java
+++ b/dd-java-agent/instrumentation/aerospike-4/src/main/java/datadog/trace/instrumentation/aerospike4/AerospikeClientDecorator.java
@@ -109,7 +109,4 @@ public class AerospikeClientDecorator extends DBTypeProcessingDatabaseClientDeco
     beforeFinish(span);
     span.finish();
   }
-
-  @Override
-  protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {}
 }

--- a/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseClientDecorator.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseClientDecorator.java
@@ -2,7 +2,6 @@ package datadog.trace.instrumentation.couchbase.client;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
@@ -61,7 +60,4 @@ class CouchbaseClientDecorator extends DBTypeProcessingDatabaseClientDecorator {
   protected String dbHostname(Object o) {
     return null;
   }
-
-  @Override
-  protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {}
 }

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/main/java/datadog/trace/instrumentation/couchbase_31/client/CouchbaseClientDecorator.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/main/java/datadog/trace/instrumentation/couchbase_31/client/CouchbaseClientDecorator.java
@@ -4,7 +4,6 @@ import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_TYPE;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
@@ -60,7 +59,4 @@ class CouchbaseClientDecorator extends DBTypeProcessingDatabaseClientDecorator {
   protected String dbHostname(Object o) {
     return null;
   }
-
-  @Override
-  protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {}
 }

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/CouchbaseClientDecorator.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/CouchbaseClientDecorator.java
@@ -4,7 +4,6 @@ import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_TYPE;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
@@ -60,7 +59,4 @@ class CouchbaseClientDecorator extends DBTypeProcessingDatabaseClientDecorator {
   protected String dbHostname(Object o) {
     return null;
   }
-
-  @Override
-  protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {}
 }

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/CassandraClientDecorator.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/CassandraClientDecorator.java
@@ -71,7 +71,4 @@ public class CassandraClientDecorator extends DBTypeProcessingDatabaseClientDeco
     }
     return span;
   }
-
-  @Override
-  protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {}
 }

--- a/dd-java-agent/instrumentation/datastax-cassandra-4/src/main/java/datadog/trace/instrumentation/datastax/cassandra4/CassandraClientDecorator.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra-4/src/main/java/datadog/trace/instrumentation/datastax/cassandra4/CassandraClientDecorator.java
@@ -105,7 +105,4 @@ public class CassandraClientDecorator extends DBTypeProcessingDatabaseClientDeco
 
     return span;
   }
-
-  @Override
-  protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {}
 }

--- a/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchRestClientDecorator.java
+++ b/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchRestClientDecorator.java
@@ -81,7 +81,4 @@ public class ElasticsearchRestClientDecorator extends DBTypeProcessingDatabaseCl
     }
     return span;
   }
-
-  @Override
-  protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {}
 }

--- a/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchTransportClientDecorator.java
+++ b/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchTransportClientDecorator.java
@@ -80,7 +80,4 @@ public class ElasticsearchTransportClientDecorator extends DBTypeProcessingDatab
     }
     return span;
   }
-
-  @Override
-  protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {}
 }

--- a/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/cache/IgniteCacheDecorator.java
+++ b/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/cache/IgniteCacheDecorator.java
@@ -163,7 +163,4 @@ public class IgniteCacheDecorator extends DBTypeProcessingDatabaseClientDecorato
   public AgentSpan onResult(AgentSpan span, Object result) {
     return span;
   }
-
-  @Override
-  protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {}
 }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
@@ -222,4 +222,11 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
     sb.append(samplingPriority > 0 ? "-01" : "-00");
     return sb.toString();
   }
+
+  @Override
+  protected void postProcessServiceAndOperationName(
+      AgentSpan span, DatabaseClientDecorator.NamingEntry namingEntry) {
+    span.setServiceName(namingEntry.getService());
+    span.setOperationName(namingEntry.getOperation());
+  }
 }

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTestBase.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTestBase.groovy
@@ -825,7 +825,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
   protected abstract boolean dbmTraceInjected()
 }
 
-class JDBCInstrumentationV0ForkedTest extends JDBCInstrumentationTest {
+class JDBCInstrumentationV0Test extends JDBCInstrumentationTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
@@ -516,7 +516,7 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
   protected abstract boolean dbmTraceInjected()
 }
 
-class RemoteJDBCInstrumentationV0ForkedTest extends RemoteJDBCInstrumentationTest {
+class RemoteJDBCInstrumentationV0Test extends RemoteJDBCInstrumentationTest {
 
   @Override
   int version() {
@@ -541,13 +541,6 @@ class RemoteJDBCInstrumentationV0ForkedTest extends RemoteJDBCInstrumentationTes
 
 class RemoteJDBCInstrumentationV1ForkedTest extends RemoteJDBCInstrumentationTest {
 
-  def remapDbType(String dbType) {
-    if ("postgresql" == dbType) {
-      return "postgres"
-    }
-    return dbType
-  }
-
   @Override
   int version() {
     return 1
@@ -560,7 +553,7 @@ class RemoteJDBCInstrumentationV1ForkedTest extends RemoteJDBCInstrumentationTes
 
   @Override
   protected String operation(String dbType) {
-    return "${remapDbType(dbType)}.query"
+    return "${dbType}.query"
   }
 
   @Override
@@ -570,13 +563,6 @@ class RemoteJDBCInstrumentationV1ForkedTest extends RemoteJDBCInstrumentationTes
 }
 
 class RemoteDBMTraceInjectedForkedTest extends RemoteJDBCInstrumentationTest {
-
-  def remapDbType(String dbType) {
-    if ("postgresql" == dbType) {
-      return "postgres"
-    }
-    return dbType
-  }
 
   @Override
   void configurePreAgent() {
@@ -601,6 +587,6 @@ class RemoteDBMTraceInjectedForkedTest extends RemoteJDBCInstrumentationTest {
 
   @Override
   protected String operation(String dbType) {
-    return "${remapDbType(dbType)}.query"
+    return "${dbType}.query"
   }
 }

--- a/dd-java-agent/instrumentation/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisClientDecorator.java
+++ b/dd-java-agent/instrumentation/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisClientDecorator.java
@@ -2,7 +2,6 @@ package datadog.trace.instrumentation.jedis;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
@@ -56,7 +55,4 @@ public class JedisClientDecorator extends DBTypeProcessingDatabaseClientDecorato
   protected String dbHostname(Connection connection) {
     return connection.getHost();
   }
-
-  @Override
-  protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {}
 }

--- a/dd-java-agent/instrumentation/jedis-3.0/src/main/java/datadog/trace/instrumentation/jedis30/JedisClientDecorator.java
+++ b/dd-java-agent/instrumentation/jedis-3.0/src/main/java/datadog/trace/instrumentation/jedis30/JedisClientDecorator.java
@@ -2,7 +2,6 @@ package datadog.trace.instrumentation.jedis30;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
@@ -57,7 +56,4 @@ public class JedisClientDecorator extends DBTypeProcessingDatabaseClientDecorato
   protected String dbHostname(final Connection connection) {
     return connection.getHost();
   }
-
-  @Override
-  protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {}
 }

--- a/dd-java-agent/instrumentation/jedis-4.0/src/main/java/redis/clients/jedis/JedisClientDecorator.java
+++ b/dd-java-agent/instrumentation/jedis-4.0/src/main/java/redis/clients/jedis/JedisClientDecorator.java
@@ -2,7 +2,6 @@ package redis.clients.jedis;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
@@ -57,7 +56,4 @@ public class JedisClientDecorator extends DBTypeProcessingDatabaseClientDecorato
     // getHostAndPort is protected hence the decorator sits in the same package
     return connection.getHostAndPort().getHost();
   }
-
-  @Override
-  protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {}
 }

--- a/dd-java-agent/instrumentation/lettuce-4/src/main/java/datadog/trace/instrumentation/lettuce4/LettuceClientDecorator.java
+++ b/dd-java-agent/instrumentation/lettuce-4/src/main/java/datadog/trace/instrumentation/lettuce4/LettuceClientDecorator.java
@@ -70,9 +70,6 @@ public class LettuceClientDecorator extends DBTypeProcessingDatabaseClientDecora
     return super.onConnection(span, connection);
   }
 
-  @Override
-  protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {}
-
   public AgentSpan onCommand(final AgentSpan span, final RedisCommand<?, ?, ?> command) {
     span.setResourceName(
         null == command ? "Redis Command" : getCommandResourceName(command.getType()));

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceClientDecorator.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceClientDecorator.java
@@ -58,9 +58,6 @@ public class LettuceClientDecorator extends DBTypeProcessingDatabaseClientDecora
   }
 
   @Override
-  protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {}
-
-  @Override
   public AgentSpan onConnection(final AgentSpan span, final RedisURI connection) {
     if (connection != null) {
       setPeerPort(span, connection.getPort());

--- a/dd-java-agent/instrumentation/mongo/common/src/main/java/datadog/trace/instrumentation/mongo/MongoDecorator.java
+++ b/dd-java-agent/instrumentation/mongo/common/src/main/java/datadog/trace/instrumentation/mongo/MongoDecorator.java
@@ -21,7 +21,8 @@ import org.bson.ByteBuf;
 
 public abstract class MongoDecorator
     extends DBTypeProcessingDatabaseClientDecorator<CommandStartedEvent> {
-  private static final String DB_TYPE = "mongo";
+  private static final String DB_TYPE =
+      SpanNaming.instance().namingSchema().database().normalizedName("mongo");
   private static final String SERVICE_NAME =
       SpanNaming.instance()
           .namingSchema()
@@ -106,9 +107,6 @@ public abstract class MongoDecorator
     // Fallback to db name.
     return event.getDatabaseName();
   }
-
-  @Override
-  protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {}
 
   protected abstract BsonScrubber newScrubber();
 

--- a/dd-java-agent/instrumentation/mongo/driver-3.1-core-test/src/test/groovy/MongoCore31ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1-core-test/src/test/groovy/MongoCore31ClientTest.groovy
@@ -261,6 +261,11 @@ class MongoCore31ClientV0ForkedTest extends MongoCore31ClientTest {
   String operation() {
     return V0_OPERATION
   }
+
+  @Override
+  String dbType() {
+    return V0_DB_TYPE
+  }
 }
 
 class MongoCore31ClientV1ForkedTest extends MongoCore31ClientTest {
@@ -278,5 +283,10 @@ class MongoCore31ClientV1ForkedTest extends MongoCore31ClientTest {
   @Override
   String operation() {
     return V1_OPERATION
+  }
+
+  @Override
+  String dbType() {
+    return V1_DB_TYPE
   }
 }

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoJava31ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoJava31ClientTest.groovy
@@ -263,6 +263,11 @@ class MongoJava31ClientV0ForkedTest extends MongoJava31ClientTest {
   String operation() {
     return V0_OPERATION
   }
+
+  @Override
+  String dbType() {
+    return V0_DB_TYPE
+  }
 }
 
 class MongoJava31ClientV1ForkedTest extends MongoJava31ClientTest {
@@ -280,5 +285,10 @@ class MongoJava31ClientV1ForkedTest extends MongoJava31ClientTest {
   @Override
   String operation() {
     return V1_OPERATION
+  }
+
+  @Override
+  String dbType() {
+    return V1_DB_TYPE
   }
 }

--- a/dd-java-agent/instrumentation/mongo/driver-3.10-sync-test/src/test/groovy/MongoSyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.10-sync-test/src/test/groovy/MongoSyncClientTest.groovy
@@ -248,6 +248,11 @@ class MongoSyncClientV0ForkedTest extends MongoSyncClientTest {
   String operation() {
     return V0_OPERATION
   }
+
+  @Override
+  String dbType() {
+    return V0_DB_TYPE
+  }
 }
 
 class MongoSyncClientV1ForkedTest extends MongoSyncClientTest {
@@ -265,5 +270,10 @@ class MongoSyncClientV1ForkedTest extends MongoSyncClientTest {
   @Override
   String operation() {
     return V1_OPERATION
+  }
+
+  @Override
+  String dbType() {
+    return V1_DB_TYPE
   }
 }

--- a/dd-java-agent/instrumentation/mongo/driver-3.3-async-test/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.3-async-test/src/test/groovy/MongoAsyncClientTest.groovy
@@ -245,6 +245,11 @@ class MongoAsyncClientV0ForkedTest extends MongoAsyncClientTest {
   String operation() {
     return V0_OPERATION
   }
+
+  @Override
+  String dbType() {
+    return V0_DB_TYPE
+  }
 }
 
 class MongoAsyncClientV1ForkedTest extends MongoAsyncClientTest {
@@ -262,5 +267,10 @@ class MongoAsyncClientV1ForkedTest extends MongoAsyncClientTest {
   @Override
   String operation() {
     return V1_OPERATION
+  }
+
+  @Override
+  String dbType() {
+    return V1_DB_TYPE
   }
 }

--- a/dd-java-agent/instrumentation/mongo/driver-3.4/src/test/groovy/MongoJava34ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.4/src/test/groovy/MongoJava34ClientTest.groovy
@@ -261,6 +261,11 @@ class MongoJava34ClientV0ForkedTest extends MongoJava34ClientTest {
   String operation() {
     return V0_OPERATION
   }
+
+  @Override
+  String dbType() {
+    return V0_DB_TYPE
+  }
 }
 
 class MongoJava34ClientV1ForkedTest extends MongoJava34ClientTest {
@@ -278,5 +283,10 @@ class MongoJava34ClientV1ForkedTest extends MongoJava34ClientTest {
   @Override
   String operation() {
     return V1_OPERATION
+  }
+
+  @Override
+  String dbType() {
+    return V1_DB_TYPE
   }
 }

--- a/dd-java-agent/instrumentation/mongo/driver-3.7-core-test/src/test/groovy/MongoCore37ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.7-core-test/src/test/groovy/MongoCore37ClientTest.groovy
@@ -248,6 +248,11 @@ class MongoCore37ClientV0ForkedTest extends MongoCore37ClientTest {
   String operation() {
     return V0_OPERATION
   }
+
+  @Override
+  String dbType() {
+    return V0_DB_TYPE
+  }
 }
 
 class MongoCore37ClientV1ForkedTest extends MongoCore37ClientTest {
@@ -265,5 +270,10 @@ class MongoCore37ClientV1ForkedTest extends MongoCore37ClientTest {
   @Override
   String operation() {
     return V1_OPERATION
+  }
+
+  @Override
+  String dbType() {
+    return V1_DB_TYPE
   }
 }

--- a/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/Mongo4ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/Mongo4ClientTest.groovy
@@ -248,6 +248,11 @@ class Mongo4ClientV0ForkedTest extends Mongo4ClientTest {
   String operation() {
     return V0_OPERATION
   }
+
+  @Override
+  String dbType() {
+    return V0_DB_TYPE
+  }
 }
 
 class Mongo4ClientV1ForkedTest extends Mongo4ClientTest {
@@ -265,5 +270,10 @@ class Mongo4ClientV1ForkedTest extends Mongo4ClientTest {
   @Override
   String operation() {
     return V1_OPERATION
+  }
+
+  @Override
+  String dbType() {
+    return V1_DB_TYPE
   }
 }

--- a/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/MongoReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/MongoReactiveClientTest.groovy
@@ -412,6 +412,11 @@ class MongoReactiveClientV0ForkedTest extends MongoReactiveClientTest {
   String operation() {
     return V0_OPERATION
   }
+
+  @Override
+  String dbType() {
+    return V0_DB_TYPE
+  }
 }
 
 class MongoReactiveClientV1ForkedTest extends MongoReactiveClientTest {
@@ -429,5 +434,10 @@ class MongoReactiveClientV1ForkedTest extends MongoReactiveClientTest {
   @Override
   String operation() {
     return V1_OPERATION
+  }
+
+  @Override
+  String dbType() {
+    return V1_DB_TYPE
   }
 }

--- a/dd-java-agent/instrumentation/mongo/src/test/groovy/MongoBaseTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/src/test/groovy/MongoBaseTest.groovy
@@ -28,11 +28,13 @@ import java.nio.file.StandardOpenOption
  */
 @Flaky("Fails sometimes with java.io.IOException https://github.com/DataDog/dd-trace-java/issues/3884")
 abstract class MongoBaseTest extends VersionedNamingTestBase {
-
+  public static final String V0_DB_TYPE = "mongo"
   public static final String V0_SERVICE = "mongo"
   public static final String V0_OPERATION = "mongo.query"
   public static final String V1_SERVICE = Config.get().getServiceName()
   public static final String V1_OPERATION = "mongodb.query"
+  public static final String V1_DB_TYPE = "mongodb"
+
 
   @Shared
   def databaseName = "database"
@@ -44,6 +46,8 @@ abstract class MongoBaseTest extends VersionedNamingTestBase {
   int port
   @Shared
   RunningMongodProcess mongodProcess
+
+  abstract String dbType()
 
   def setupSpec() throws Exception {
     // The embedded MongoDB library will fail if it starts preparing the
@@ -101,6 +105,7 @@ abstract class MongoBaseTest extends VersionedNamingTestBase {
   }
 
   def mongoSpan(TraceAssert trace, int index, String mongoOp, String statement, boolean renameService = false, String instance = "some-description", Object parentSpan = null, Throwable exception = null) {
+    def dbType = dbType()
     trace.span(index) {
       serviceName renameService ? instance : service()
       operationName operation()
@@ -117,7 +122,7 @@ abstract class MongoBaseTest extends VersionedNamingTestBase {
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
         "$Tags.PEER_HOSTNAME" "localhost"
         "$Tags.PEER_PORT" port
-        "$Tags.DB_TYPE" "mongo"
+        "$Tags.DB_TYPE" dbType
         "$Tags.DB_INSTANCE" instance
         "$Tags.DB_OPERATION" mongoOp
         defaultTags()

--- a/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaClientDecorator.java
+++ b/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaClientDecorator.java
@@ -60,9 +60,6 @@ public class RediscalaClientDecorator
   }
 
   @Override
-  protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {}
-
-  @Override
   public AgentSpan onConnection(final AgentSpan span, final RedisConnectionInfo connection) {
     if (connection != null) {
       setPeerPort(span, connection.port);

--- a/dd-java-agent/instrumentation/redisson-2.0.0/src/main/java/datadog/trace/instrumentation/redisson/RedissonClientDecorator.java
+++ b/dd-java-agent/instrumentation/redisson-2.0.0/src/main/java/datadog/trace/instrumentation/redisson/RedissonClientDecorator.java
@@ -2,7 +2,6 @@ package datadog.trace.instrumentation.redisson;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabaseClientDecorator;
@@ -58,7 +57,4 @@ public class RedissonClientDecorator
   protected CharSequence dbHostname(CommandData<?, ?> commandData) {
     return null;
   }
-
-  @Override
-  protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {}
 }

--- a/dd-java-agent/instrumentation/spymemcached-2.10/src/main/java/datadog/trace/instrumentation/spymemcached/MemcacheClientDecorator.java
+++ b/dd-java-agent/instrumentation/spymemcached-2.10/src/main/java/datadog/trace/instrumentation/spymemcached/MemcacheClientDecorator.java
@@ -60,9 +60,6 @@ public class MemcacheClientDecorator
     return null;
   }
 
-  @Override
-  protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {}
-
   public AgentSpan onOperation(final AgentSpan span, final String methodName) {
 
     // optimization over string.replaceFirst()

--- a/dd-java-agent/instrumentation/vertx-mysql-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_sql_client/VertxSqlClientDecorator.java
+++ b/dd-java-agent/instrumentation/vertx-mysql-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_sql_client/VertxSqlClientDecorator.java
@@ -101,4 +101,11 @@ public class VertxSqlClientDecorator extends DatabaseClientDecorator<DBInfo> {
 
     return span;
   }
+
+  @Override
+  protected void postProcessServiceAndOperationName(
+      AgentSpan span, DatabaseClientDecorator.NamingEntry namingEntry) {
+    span.setServiceName(namingEntry.getService());
+    span.setOperationName(namingEntry.getOperation());
+  }
 }

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/VertxRedisClientDecorator.java
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/VertxRedisClientDecorator.java
@@ -70,9 +70,6 @@ public class VertxRedisClientDecorator
     return socketAddress.host();
   }
 
-  @Override
-  protected void postProcessServiceAndOperationName(AgentSpan span, String dbType) {}
-
   public AgentSpan startAndDecorateSpan(String command) {
     UTF8BytesString upperCase =
         commandCache.computeIfAbsent(command, key -> UTF8BytesString.create(key.toUpperCase()));

--- a/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
@@ -124,6 +124,14 @@ public interface NamingSchema {
 
   interface ForDatabase {
     /**
+     * Normalize the cache name from the raw parsed one.
+     *
+     * @param rawName the raw name
+     * @return the normalized one
+     */
+    String normalizedName(@Nonnull String rawName);
+
+    /**
      * Calculate the operation name for a database span.
      *
      * @param databaseType the database type (e.g. postgres, elasticsearch,..)

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/DatabaseNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/DatabaseNamingV0.java
@@ -4,6 +4,11 @@ import datadog.trace.api.naming.NamingSchema;
 import javax.annotation.Nonnull;
 
 public class DatabaseNamingV0 implements NamingSchema.ForDatabase {
+  @Override
+  public String normalizedName(@Nonnull String rawName) {
+    return rawName;
+  }
+
   @Nonnull
   @Override
   public String operation(@Nonnull String databaseType) {

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/DatabaseNamingV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/DatabaseNamingV1.java
@@ -4,25 +4,25 @@ import datadog.trace.api.naming.NamingSchema;
 import javax.annotation.Nonnull;
 
 public class DatabaseNamingV1 implements NamingSchema.ForDatabase {
-  @Nonnull
-  private String normalizeDatabaseType(@Nonnull String databaseType) {
-    // there will more entries (e.g. postgres,..) since the name we use is not always
-    // the one chosen for v1 naming conventions
-    switch (databaseType) {
+  @Override
+  public String normalizedName(@Nonnull String rawName) {
+    switch (rawName) {
       case "mongo":
         return "mongodb";
-      case "elasticsearch.rest":
-        return "elasticsearch";
-      case "postgresql":
-        return "postgres";
+      case "sqlserver":
+        return "mssql";
     }
-    return databaseType;
+    return rawName;
   }
 
   @Nonnull
   @Override
   public String operation(@Nonnull String databaseType) {
-    return normalizeDatabaseType(databaseType) + ".query";
+    if ("elasticsearch.rest".equals(databaseType)) {
+      return "elasticsearch.query";
+    }
+    // already normalized when calling dbType on the decorator. It saves one operation
+    return databaseType + ".query";
   }
 
   @Nonnull


### PR DESCRIPTION
# What Does This Do

Basically align v1 database naming to OTEL standards (table [here](https://opentelemetry.io/docs/specification/otel/trace/semantic_conventions/database/))

Notable changes:
* postgres -> postgresql
* mongo -> mongodb
* sqlserver -> mssql

This normalized name is used as part of operation (e.g. `postgresql.query`) and also to set the `db.type` tag.

Changes are only for v1 (v0 is not impacted)

The PR takes also the occasion to do a quick refactor  to avoid erasing the method `postProcessServiceAndOperationName`  in each decorator since it's only used on jdbc and vertx-jdbc. Instead, it's only declared in those 2 decorators.

# Motivation

# Additional Notes
