### PR TITLE
[Spark] Add appId and sparkVersion tags to all spark spans

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
@@ -351,12 +351,7 @@ public class DatadogSparkListener extends SparkListener {
   }
 
   private AgentTracer.SpanBuilder buildSparkSpan(String spanName) {
-    return tracer
-        .buildSpan(spanName)
-        .withSpanType("spark")
-        // The volume is quite low and dropping a trace can will to incomplete data
-        .withTag(DDTags.MANUAL_KEEP, true)
-        .withTag("app_id", appId);
+    return tracer.buildSpan(spanName).withSpanType("spark").withTag("app_id", appId);
   }
 
   private long stageSpanKey(int stageId, int attemptId) {

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
 import org.apache.spark.TaskFailedReason;
 import org.apache.spark.scheduler.*;
 import scala.Tuple2;
@@ -21,6 +22,8 @@ public class DatadogSparkListener extends SparkListener {
   private final int MAX_COLLECTION_SIZE = 1000;
 
   private final SparkConf sparkConf;
+  private final String sparkVersion;
+  private final String appId;
 
   private final AgentTracer.TracerAPI tracer;
 
@@ -44,9 +47,11 @@ public class DatadogSparkListener extends SparkListener {
   private int maxExecutorCount = 0;
   private long availableExecutorTime = 0;
 
-  public DatadogSparkListener(SparkConf _sparkConf) {
+  public DatadogSparkListener(SparkContext sparkContext) {
     tracer = AgentTracer.get();
-    sparkConf = _sparkConf;
+    sparkConf = sparkContext.getConf();
+    sparkVersion = sparkContext.version();
+    appId = sparkContext.applicationId();
 
     isRunningOnDatabricks = sparkConf.contains("spark.databricks.sparkContextId");
   }
@@ -54,18 +59,14 @@ public class DatadogSparkListener extends SparkListener {
   @Override
   public void onApplicationStart(SparkListenerApplicationStart applicationStart) {
     applicationSpan =
-        tracer
-            .buildSpan("spark.application")
+        buildSparkSpan("spark.application")
             .withStartTimestamp(applicationStart.time() * 1000)
             .withTag("application_name", applicationStart.appName())
             .withTag("spark_user", applicationStart.sparkUser())
-            .withSpanType("spark")
             .start();
 
     applicationSpan.setMeasured(true);
 
-    if (applicationStart.appId().isDefined())
-      applicationSpan.setTag("app_id", applicationStart.appId().get());
     if (applicationStart.appAttemptId().isDefined())
       applicationSpan.setTag("app_attempt_id", applicationStart.appAttemptId().get());
 
@@ -104,12 +105,10 @@ public class DatadogSparkListener extends SparkListener {
     }
 
     AgentTracer.SpanBuilder jobSpanBuilder =
-        tracer
-            .buildSpan("spark.job")
+        buildSparkSpan("spark.job")
             .withStartTimestamp(jobStart.time() * 1000)
             .withTag("job_id", jobStart.jobId())
-            .withTag("stage_count", jobStart.stageInfos().size())
-            .withSpanType("spark");
+            .withTag("stage_count", jobStart.stageInfos().size());
 
     if (isRunningOnDatabricks) {
       // In databricks, the spark jobs are the local root spans so adding the spark conf parameters
@@ -211,8 +210,7 @@ public class DatadogSparkListener extends SparkListener {
     }
 
     AgentSpan stageSpan =
-        tracer
-            .buildSpan("spark.stage")
+        buildSparkSpan("spark.stage")
             .asChildOf(jobSpan.context())
             .withStartTimestamp(submissionTimeMs * 1000)
             .withTag("stage_id", stageId)
@@ -221,7 +219,6 @@ public class DatadogSparkListener extends SparkListener {
             .withTag("parent_stages_ids", stageSubmitted.stageInfo().parentIds())
             .withTag("details", stageSubmitted.stageInfo().details())
             .withTag(DDTags.RESOURCE_NAME, stageSubmitted.stageInfo().name())
-            .withSpanType("spark")
             .start();
 
     stageSpan.setMeasured(true);
@@ -303,8 +300,7 @@ public class DatadogSparkListener extends SparkListener {
 
   private void sendTaskSpan(AgentSpan stageSpan, SparkListenerTaskEnd taskEnd) {
     AgentSpan taskSpan =
-        tracer
-            .buildSpan("spark.task")
+        buildSparkSpan("spark.task")
             .asChildOf(stageSpan.context())
             .withStartTimestamp(taskEnd.taskInfo().launchTime() * 1000)
             .withTag("task_id", taskEnd.taskInfo().taskId())
@@ -317,7 +313,6 @@ public class DatadogSparkListener extends SparkListener {
             .withTag("task_locality", taskEnd.taskInfo().taskLocality().toString())
             .withTag("speculative", taskEnd.taskInfo().speculative())
             .withTag("status", taskEnd.taskInfo().status())
-            .withSpanType("spark")
             .start();
 
     if (taskEnd.reason() instanceof TaskFailedReason) {
@@ -351,6 +346,16 @@ public class DatadogSparkListener extends SparkListener {
       availableExecutorTime +=
           (executorRemoved.time() - executor.time()) * executor.executorInfo().totalCores();
     }
+  }
+
+  private AgentTracer.SpanBuilder buildSparkSpan(String spanName) {
+    return tracer
+        .buildSpan(spanName)
+        .withSpanType("spark")
+        // The volume is quite low and dropping a trace can will to incomplete data
+        .withTag(DDTags.MANUAL_KEEP, true)
+        .withTag("app_id", appId)
+        .withTag("spark_version", sparkVersion);
   }
 
   private long stageSpanKey(int stageId, int attemptId) {

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
@@ -75,6 +75,7 @@ public class DatadogSparkListener extends SparkListener {
         applicationSpan.setTag("config." + conf._1.replace(".", "_"), conf._2);
       }
     }
+    applicationSpan.setTag("config.spark_version", sparkVersion);
   }
 
   @Override
@@ -151,6 +152,7 @@ public class DatadogSparkListener extends SparkListener {
         }
       }
     }
+    jobSpan.setTag("config.spark_version", sparkVersion);
 
     jobStart.stageInfos().foreach(stage -> stageToJob.put(stage.stageId(), jobStart.jobId()));
 
@@ -354,8 +356,7 @@ public class DatadogSparkListener extends SparkListener {
         .withSpanType("spark")
         // The volume is quite low and dropping a trace can will to incomplete data
         .withTag(DDTags.MANUAL_KEEP, true)
-        .withTag("app_id", appId)
-        .withTag("spark_version", sparkVersion);
+        .withTag("app_id", appId);
   }
 
   private long stageSpanKey(int stageId, int attemptId) {

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkInstrumentation.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkInstrumentation.java
@@ -45,7 +45,7 @@ public class SparkInstrumentation extends Instrumenter.Tracing
   public static class InjectListener {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void enter(@Advice.This SparkContext sparkContext) {
-      DatadogSparkListener listener = new DatadogSparkListener(sparkContext.getConf());
+      DatadogSparkListener listener = new DatadogSparkListener(sparkContext);
       sparkContext.listenerBus().addToSharedQueue(listener);
     }
   }


### PR DESCRIPTION
# What Does This Do

Adding the tags `app_id` and `spark_version` to all spark spans. Before this PR `app_id` was only present on the application span, adding it to all the spark spans will make it easier to get all the spans of a given execution and `spark_version` was not present
