### PR TITLE
[Spark] Link databricks spark jobs to databricks workflow tasks

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatabricksParentContext.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatabricksParentContext.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.spark;
 
+import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -39,7 +40,7 @@ public class DatabricksParentContext implements AgentSpan.Context {
       spanId = computeSpanId(digest, jobId, taskRunId);
     } else {
       traceId = DDTraceId.ZERO;
-      spanId = 0;
+      spanId = DDSpanId.ZERO;
     }
   }
 

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatabricksParentContext.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatabricksParentContext.java
@@ -80,7 +80,7 @@ public class DatabricksParentContext implements AgentSpan.Context {
 
   @Override
   public int getSamplingPriority() {
-    return PrioritySampling.USER_KEEP;
+    return PrioritySampling.SAMPLER_KEEP;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatabricksParentContext.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatabricksParentContext.java
@@ -1,0 +1,95 @@
+package datadog.trace.instrumentation.spark;
+
+import datadog.trace.api.DDTraceId;
+import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTrace;
+import datadog.trace.bootstrap.instrumentation.api.PathwayContext;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * In the case of databricks, spark jobs are linked to the databricks task that launched them.
+ *
+ * <p>Databricks spark spans are generated from this spark instrumentation, while databricks
+ * workflow task spans are generated from the databricks API. The traceId/spanId is computed using
+ * the same hash on both sides to link everything in the same trace
+ */
+public class DatabricksParentContext implements AgentSpan.Context {
+  private static final Logger log = LoggerFactory.getLogger(DatabricksParentContext.class);
+
+  private final DDTraceId traceId;
+  private final long spanId;
+
+  public DatabricksParentContext(String jobId, String jobRunId, String taskRunId) {
+    MessageDigest digest = null;
+    try {
+      digest = MessageDigest.getInstance("SHA-1");
+    } catch (NoSuchAlgorithmException e) {
+      log.debug("Unable to find SHA-1 algorithm", e);
+    }
+
+    if (digest != null && jobId != null && taskRunId != null) {
+      traceId = computeTraceId(digest, jobId, jobRunId, taskRunId);
+      spanId = computeSpanId(digest, jobId, taskRunId);
+    } else {
+      traceId = DDTraceId.ZERO;
+      spanId = 0;
+    }
+  }
+
+  private DDTraceId computeTraceId(
+      MessageDigest digest, String jobId, String jobRunId, String taskRunId) {
+    byte[] inputBytes;
+
+    if (jobRunId != null) {
+      inputBytes = (jobId + jobRunId).getBytes(StandardCharsets.UTF_8);
+    } else {
+      inputBytes = (jobId + taskRunId).getBytes(StandardCharsets.UTF_8);
+    }
+
+    byte[] hash = digest.digest(inputBytes);
+    long traceIdLong = ByteBuffer.wrap(hash).getLong();
+    return DDTraceId.from(traceIdLong);
+  }
+
+  private long computeSpanId(MessageDigest digest, String jobId, String taskRunId) {
+    byte[] hash = digest.digest((jobId + taskRunId).getBytes(StandardCharsets.UTF_8));
+    return ByteBuffer.wrap(hash).getLong();
+  }
+
+  @Override
+  public DDTraceId getTraceId() {
+    return traceId;
+  }
+
+  @Override
+  public long getSpanId() {
+    return spanId;
+  }
+
+  @Override
+  public AgentTrace getTrace() {
+    return null;
+  }
+
+  @Override
+  public int getSamplingPriority() {
+    return PrioritySampling.USER_KEEP;
+  }
+
+  @Override
+  public Iterable<Map.Entry<String, String>> baggageItems() {
+    return null;
+  }
+
+  @Override
+  public PathwayContext getPathwayContext() {
+    return null;
+  }
+}

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.spark;
 
 import datadog.trace.api.DDTags;
+import datadog.trace.api.DDTraceId;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
@@ -135,7 +136,10 @@ public class DatadogSparkListener extends SparkListener {
 
         AgentSpan.Context parentContext =
             new DatabricksParentContext(databricksJobId, databricksJobRunId, databricksTaskRunId);
-        jobSpanBuilder.asChildOf(parentContext);
+
+        if (parentContext.getTraceId() != DDTraceId.ZERO) {
+          jobSpanBuilder.asChildOf(parentContext);
+        }
       }
     } else {
       // In non-databricks env, the spark application is the local root spans

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkInstrumentation.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkInstrumentation.java
@@ -29,6 +29,7 @@ public class SparkInstrumentation extends Instrumenter.Tracing
   @Override
   public String[] helperClassNames() {
     return new String[] {
+      packageName + ".DatabricksParentContext",
       packageName + ".DatadogSparkListener",
       packageName + ".SparkAggregatedTaskMetrics",
       packageName + ".SparkConfAllowList",

--- a/dd-java-agent/instrumentation/spark/src/test/groovy/SparkTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/test/groovy/SparkTest.groovy
@@ -70,7 +70,7 @@ class SparkTest extends AgentTestRunner {
 
     sparkSession.sparkContext().setLocalProperty("spark.databricks.job.id", "1234")
     sparkSession.sparkContext().setLocalProperty("spark.databricks.job.runId", "9012")
-    sparkSession.sparkContext().setLocalProperty("spark.databricks.clusterUsageTags.clusterName", "job-1234-run-5678-Job_cluster>")
+    sparkSession.sparkContext().setLocalProperty("spark.databricks.clusterUsageTags.clusterName", "job-1234-run-5678-Job_cluster")
     TestSparkComputation.generateTestSparkComputation(sparkSession)
 
     expect:
@@ -81,8 +81,8 @@ class SparkTest extends AgentTestRunner {
           resourceName "count at TestSparkComputation.java:12"
           spanType "spark"
           errored false
-          traceId new BigInteger("8944764253919609482")
-          parentSpanId new BigInteger("15104224823446433673")
+          traceId 8944764253919609482G
+          parentSpanId 15104224823446433673G
         }
         span {
           operationName "spark.stage"

--- a/dd-java-agent/instrumentation/spark/src/test/groovy/SparkTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/test/groovy/SparkTest.groovy
@@ -74,8 +74,13 @@ class SparkTest extends AgentTestRunner {
     sparkSession.sparkContext().setLocalProperty("spark.databricks.clusterUsageTags.clusterName", "job-1234-run-5678-Job_cluster")
     TestSparkComputation.generateTestSparkComputation(sparkSession)
 
+    sparkSession.sparkContext().setLocalProperty("spark.databricks.job.id", null)
+    sparkSession.sparkContext().setLocalProperty("spark.databricks.job.runId", null)
+    sparkSession.sparkContext().setLocalProperty("spark.databricks.clusterUsageTags.clusterName", null)
+    TestSparkComputation.generateTestSparkComputation(sparkSession)
+
     expect:
-    assertTraces(1) {
+    assertTraces(2) {
       trace(3) {
         span {
           operationName "spark.job"
@@ -84,6 +89,29 @@ class SparkTest extends AgentTestRunner {
           errored false
           traceId 8944764253919609482G
           parentSpanId 15104224823446433673G
+        }
+        span {
+          operationName "spark.stage"
+          resourceName "count at TestSparkComputation.java:12"
+          spanType "spark"
+          errored false
+          childOf(span(0))
+        }
+        span {
+          operationName "spark.stage"
+          resourceName "distinct at TestSparkComputation.java:12"
+          spanType "spark"
+          errored false
+          childOf(span(0))
+        }
+      }
+      trace(3) {
+        span {
+          operationName "spark.job"
+          resourceName "count at TestSparkComputation.java:12"
+          spanType "spark"
+          errored false
+          parent()
         }
         span {
           operationName "spark.stage"

--- a/dd-java-agent/instrumentation/spark/src/test/groovy/SparkTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/test/groovy/SparkTest.groovy
@@ -1,4 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.DDTraceId
+import datadog.trace.instrumentation.spark.DatabricksParentContext
 import org.apache.spark.sql.SparkSession
 
 class SparkTest extends AgentTestRunner {
@@ -55,5 +57,69 @@ class SparkTest extends AgentTestRunner {
         }
       }
     }
+  }
+
+  def "generate databricks spans"() {
+    setup:
+    def sparkSession = SparkSession.builder()
+      .config("spark.master", "local")
+      .config("spark.default.parallelism", "2") // Small parallelism to speed up tests
+      .config("spark.sql.shuffle.partitions", "2")
+      .config("spark.databricks.sparkContextId", "some_id")
+      .getOrCreate()
+
+    sparkSession.sparkContext().setLocalProperty("spark.databricks.job.id", "1234")
+    sparkSession.sparkContext().setLocalProperty("spark.databricks.job.runId", "9012")
+    sparkSession.sparkContext().setLocalProperty("spark.databricks.clusterUsageTags.clusterName", "job-1234-run-5678-Job_cluster>")
+    TestSparkComputation.generateTestSparkComputation(sparkSession)
+
+    expect:
+    assertTraces(1) {
+      trace(3) {
+        span {
+          operationName "spark.job"
+          resourceName "count at TestSparkComputation.java:12"
+          spanType "spark"
+          errored false
+          traceId new BigInteger("8944764253919609482")
+          parentSpanId new BigInteger("15104224823446433673")
+        }
+        span {
+          operationName "spark.stage"
+          resourceName "count at TestSparkComputation.java:12"
+          spanType "spark"
+          errored false
+          childOf(span(0))
+        }
+        span {
+          operationName "spark.stage"
+          resourceName "distinct at TestSparkComputation.java:12"
+          spanType "spark"
+          errored false
+          childOf(span(0))
+        }
+      }
+    }
+  }
+
+  def "compute the databricks parent context"() {
+    setup:
+    def contextWithJobRunId = new DatabricksParentContext("1234", "5678", "9012")
+    def contextWithoutJobRunId = new DatabricksParentContext("1234", null, "9012")
+    def contextWithoutJobId = new DatabricksParentContext(null, "5678", "9012")
+    def contextWithoutTaskRunId = new DatabricksParentContext(null, "5678", null)
+
+    expect:
+    contextWithJobRunId.getTraceId() == DDTraceId.from("8944764253919609482")
+    contextWithJobRunId.getSpanId() == -3342519250263117943L
+
+    contextWithoutJobRunId.getTraceId() == DDTraceId.from("15104224823446433673")
+    contextWithoutJobRunId.getSpanId() == -3342519250263117943L
+
+    contextWithoutJobId.getTraceId() == DDTraceId.ZERO
+    contextWithoutJobId.getSpanId() == 0
+
+    contextWithoutTaskRunId.getTraceId() == DDTraceId.ZERO
+    contextWithoutTaskRunId.getSpanId() == 0
   }
 }

--- a/dd-java-agent/instrumentation/spark/src/test/groovy/SparkTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/test/groovy/SparkTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTraceId
 import datadog.trace.instrumentation.spark.DatabricksParentContext
 import org.apache.spark.sql.SparkSession
@@ -111,15 +112,15 @@ class SparkTest extends AgentTestRunner {
 
     expect:
     contextWithJobRunId.getTraceId() == DDTraceId.from("8944764253919609482")
-    contextWithJobRunId.getSpanId() == -3342519250263117943L
+    contextWithJobRunId.getSpanId() == DDSpanId.from("15104224823446433673")
 
     contextWithoutJobRunId.getTraceId() == DDTraceId.from("15104224823446433673")
-    contextWithoutJobRunId.getSpanId() == -3342519250263117943L
+    contextWithoutJobRunId.getSpanId() == DDSpanId.from("15104224823446433673")
 
     contextWithoutJobId.getTraceId() == DDTraceId.ZERO
-    contextWithoutJobId.getSpanId() == 0
+    contextWithoutJobId.getSpanId() == DDSpanId.ZERO
 
     contextWithoutTaskRunId.getTraceId() == DDTraceId.ZERO
-    contextWithoutTaskRunId.getSpanId() == 0
+    contextWithoutTaskRunId.getSpanId() == DDSpanId.ZERO
   }
 }


### PR DESCRIPTION
# What Does This Do

Databricks spark spans are generated from this spark instrumentation, while databricks workflow task spans are generated from the databricks API. The traceId/spanId is computed using the same hash on both sides to link everything in the same trace

Those hash are computed using a combinaison of the `job_id`, `job_run_id` and `task_run_id`

