### PR TITLE
Enable v0.5 protocol by default

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -62,7 +62,7 @@ public final class ConfigDefaults {
   static final int DEFAULT_PARTIAL_FLUSH_MIN_SPANS = 1000;
   static final boolean DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED = false;
   static final boolean DEFAULT_JMX_FETCH_ENABLED = true;
-  static final boolean DEFAULT_TRACE_AGENT_V05_ENABLED = false;
+  static final boolean DEFAULT_TRACE_AGENT_V05_ENABLED = true;
 
   static final boolean DEFAULT_CLIENT_IP_ENABLED = false;
 


### PR DESCRIPTION
# What Does This Do
Enables the v0.5 trace agent protocol by default

# Motivation

v0.5 brings significant performance improvements over previous version. v0.5 was implemented ~3 years ago.
