### PR TITLE
Skip leading whitespaces in CMDi evidences

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sensitive/CommandRegexpTokenizer.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sensitive/CommandRegexpTokenizer.java
@@ -8,7 +8,7 @@ public class CommandRegexpTokenizer extends AbstractRegexTokenizer {
 
   private static final Pattern COMMAND_PATTERN =
       Pattern.compile(
-          "^(?:\\s*(?:sudo|doas)\\s+)?\\b\\S+\\b(.*)", Pattern.MULTILINE | Pattern.DOTALL);
+          "^(?:\\s*(?:sudo|doas)\\s+)?\\b\\S+\\b\\s*(.*)", Pattern.MULTILINE | Pattern.DOTALL);
 
   public CommandRegexpTokenizer(final Evidence evidence) {
     super(COMMAND_PATTERN, evidence.getValue());

--- a/dd-java-agent/agent-iast/src/test/resources/redaction/evidence-redaction-suite.yml
+++ b/dd-java-agent/agent-iast/src/test/resources/redaction/evidence-redaction-suite.yml
@@ -1077,7 +1077,7 @@ suite:
             "type": "COMMAND_INJECTION",
             "evidence": {
               "valueParts": [
-                { "value": "cat" },
+                { "value": "cat " },
                 { "redacted": true },
                 { "source": 0, "redacted": true}
               ]
@@ -1113,9 +1113,43 @@ suite:
             "type": "COMMAND_INJECTION",
             "evidence": {
               "valueParts": [
-                { "value": "$1 cat" },
+                { "value": "$1 cat " },
                 { "redacted": true },
                 { "source": 0, "redacted": true}
+              ]
+            }
+          }
+        ]
+      }
+  - type: 'VULNERABILITIES'
+    description: 'Command injection does not redact ranges with only whitespaces'
+    input: >
+      [
+        {
+          "type": "COMMAND_INJECTION",
+          "evidence": {
+            "value": "ls -lah",
+            "ranges": [
+              { "start" : 0, "length" : 2, "source": { "origin": "http.request.parameter", "name": "command", "value": "ls" } },
+              { "start" : 3, "length" : 4, "source": { "origin": "http.request.parameter", "name": "argument", "value": "-lah" } }
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.parameter", "name": "command", "value": "ls" },
+          { "origin": "http.request.parameter", "name": "argument", "redacted": true }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "COMMAND_INJECTION",
+            "evidence": {
+              "valueParts": [
+                { "source": 0, "value": "ls" },
+                { "value": " " },
+                { "source": 1, "redacted": true}
               ]
             }
           }


### PR DESCRIPTION
# What Does This Do
Skip leading whitespaces in CMDi evidences as they can cause weird redacted evidences

# Motivation

# Additional Notes
