### PR TITLE
Upgrade ddprof to 0.36.0, change profiler defaults

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -112,7 +112,7 @@ public final class ProfilingConfig {
   public static final String PROFILING_DATADOG_PROFILER_STACKDEPTH = "profiling.ddprof.stackdepth";
   public static final int PROFILING_DATADOG_PROFILER_STACKDEPTH_DEFAULT = 512;
   public static final String PROFILING_DATADOG_PROFILER_CSTACK = "profiling.ddprof.cstack";
-  public static final String PROFILING_DATADOG_PROFILER_CSTACK_DEFAULT = "no";
+  public static final String PROFILING_DATADOG_PROFILER_CSTACK_DEFAULT = "fp";
   public static final String PROFILING_DATADOG_PROFILER_SAFEMODE = "profiling.ddprof.safemode";
   public static final int PROFILING_DATADOG_PROFILER_SAFEMODE_DEFAULT =
       12; // POP_METHOD|UNWIND_NATIVE

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.35.0",
+    ddprof        : "0.36.0",
     asm           : "9.5"
   ]
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -92,7 +92,6 @@ import static datadog.trace.api.DDTags.RUNTIME_VERSION_TAG;
 import static datadog.trace.api.DDTags.SCHEMA_VERSION_TAG_KEY;
 import static datadog.trace.api.DDTags.SERVICE;
 import static datadog.trace.api.DDTags.SERVICE_TAG;
-import static datadog.trace.api.Platform.GC.Z;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_HTTP_BLOCKED_TEMPLATE_HTML;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_HTTP_BLOCKED_TEMPLATE_JSON;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_IP_ADDR_HEADER;
@@ -2020,14 +2019,12 @@ public class Config {
   public static boolean isDatadogProfilerSafeInCurrentEnvironment() {
     // don't want to put this logic (which will evolve) in the public ProfilingConfig, and can't
     // access Platform there
-    // we encountered AsyncGetCallTrace bugs when ZGC is enabled
-
     boolean result =
-        Platform.activeGarbageCollector() != Z
-            && (Platform.isJ9()
-                || Platform.isJavaVersionAtLeast(17, 0, 5)
-                || (Platform.isJavaVersion(11) && Platform.isJavaVersionAtLeast(11, 0, 17))
-                || (Platform.isJavaVersion(8) && Platform.isJavaVersionAtLeast(8, 0, 352)));
+        Platform.isJ9()
+            || !Platform.isJavaVersion(18) // missing AGCT fixes
+            || Platform.isJavaVersionAtLeast(17, 0, 5)
+            || (Platform.isJavaVersion(11) && Platform.isJavaVersionAtLeast(11, 0, 17))
+            || (Platform.isJavaVersion(8) && Platform.isJavaVersionAtLeast(8, 0, 352));
 
     if (result && Platform.isJ9()) {
       // Semeru JDK 11 and JDK 17 have problems with unloaded classes and jmethodids, leading to JVM


### PR DESCRIPTION
# What Does This Do

* Fall back to JFR on JDK18 because it does not contain AsyncGetCallTrace fixes from 17.0.5
* Default to unwinding native portions of stacks via frame pointers
* No longer fall back to JFR because ZGC is active
* Upgrade profiler to [0.36.0](https://github.com/DataDog/java-profiler/releases/tag/v_0.36.0)

# Motivation

# Additional Notes
