### PR TITLE
Fix encoding of remote config capabilities

### DIFF
--- a/remote-config/src/main/java/datadog/remoteconfig/tuf/RemoteConfigRequest.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/tuf/RemoteConfigRequest.java
@@ -93,22 +93,12 @@ public class RemoteConfigRequest {
       this.products = productNames;
       this.tracerInfo = tracerInfo;
 
-      // Little-endian encoding of the `long` capabilities, stripping any trailing zero bytes
+      // Big-endian encoding of the `long` capabilities, stripping any trailing zero bytes
       // (except the first one)
-      int size = 1;
-      long accum = capabilities;
-      for (int i = 0; i < 8; i++) {
-        accum = accum >>> 8;
-        if (accum == 0) {
-          size = i + 1;
-          break;
-        }
-      }
+      final int size = Math.max(1, Long.BYTES - Long.numberOfLeadingZeros(capabilities) / 8);
       this.capabilities = new byte[size];
-      accum = capabilities;
-      for (int i = 0; i < size; i++) {
-        this.capabilities[i] = (byte) accum;
-        accum = accum >>> 8;
+      for (int i = size - 1; i >= 0; i--) {
+        this.capabilities[size - i - 1] = (byte) (capabilities >>> (i * 8));
       }
     }
 

--- a/remote-config/src/test/groovy/datadog/remoteconfig/ConfigurationPollerSpecification.groovy
+++ b/remote-config/src/test/groovy/datadog/remoteconfig/ConfigurationPollerSpecification.groovy
@@ -1404,9 +1404,9 @@ class ConfigurationPollerSpecification extends DDSpecification {
     capabilities          | encoded
     0                     | new byte[]{0}
     14L                   | new byte[]{14}
-    1 << 8                | new byte[]{0, 1}
-    1 << 9                | new byte[]{0, 2}
-    -9223372036854775807L | new byte[]{1, 0, 0, 0, 0, 0, 0, 128}
+    1 << 8                | new byte[]{1, 0}
+    1 << 9                | new byte[]{2, 0}
+    -9223372036854775807L | new byte[]{128, 0, 0, 0, 0, 0, 0, 1}
   }
 
   private static final String SAMPLE_RESP_BODY = """

--- a/remote-config/src/test/groovy/datadog/remoteconfig/ConfigurationPollerSpecification.groovy
+++ b/remote-config/src/test/groovy/datadog/remoteconfig/ConfigurationPollerSpecification.groovy
@@ -1377,13 +1377,14 @@ class ConfigurationPollerSpecification extends DDSpecification {
   }
 
 
-  void 'check setting of capabilities positive test'() {
+  void 'check setting of capabilities positive test #capabilities'() {
+    setup:
     ConfigurationDeserializer deserializer = { true } as ConfigurationDeserializer<Boolean>
     ConfigurationChangesTypedListener listener = { Object[] args -> } as ConfigurationChangesTypedListener
 
     when:
     poller.addListener(Product._UNKNOWN, deserializer, listener)
-    poller.addCapabilities(14L)
+    poller.addCapabilities(capabilities)
     poller.start()
 
     then:
@@ -1397,9 +1398,15 @@ class ConfigurationPollerSpecification extends DDSpecification {
     1 * call.execute() >> { buildOKResponse(FEATURES_RESP_BODY) }
     0 * _._
     def body = parseBody(request.body())
-    with(body.client) {
-      capabilities[0] == 14
-    }
+    body.client.capabilities as byte[] == encoded
+
+    where:
+    capabilities          | encoded
+    0                     | new byte[]{0}
+    14L                   | new byte[]{14}
+    1 << 8                | new byte[]{0, 1}
+    1 << 9                | new byte[]{0, 2}
+    -9223372036854775807L | new byte[]{1, 0, 0, 0, 0, 0, 0, 128}
   }
 
   private static final String SAMPLE_RESP_BODY = """


### PR DESCRIPTION
# What Does This Do


# Motivation
Only the first remote config capabilities were sent, others were truncated.

# Additional Notes
