### PR TITLE
Detect unvalidated redirect vulnerabilities in servlets

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastSystem.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastSystem.java
@@ -11,6 +11,7 @@ import com.datadog.iast.sink.LdapInjectionModuleImpl;
 import com.datadog.iast.sink.PathTraversalModuleImpl;
 import com.datadog.iast.sink.SqlInjectionModuleImpl;
 import com.datadog.iast.sink.SsrfModuleImpl;
+import com.datadog.iast.sink.UnvalidatedRedirectModuleImpl;
 import com.datadog.iast.sink.WeakCipherModuleImpl;
 import com.datadog.iast.sink.WeakHashModuleImpl;
 import com.datadog.iast.source.WebModuleImpl;
@@ -92,7 +93,8 @@ public class IastSystem {
         new LdapInjectionModuleImpl(),
         new PropagationModuleImpl(),
         new InsecureCookieModuleImpl(),
-        new SsrfModuleImpl());
+        new SsrfModuleImpl(),
+        new UnvalidatedRedirectModuleImpl());
   }
 
   private static void registerRequestStartedCallback(

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
@@ -16,6 +16,8 @@ public interface VulnerabilityType {
       new InjectionTypeImpl(VulnerabilityTypes.PATH_TRAVERSAL, File.separatorChar);
   InjectionType LDAP_INJECTION = new InjectionTypeImpl(VulnerabilityTypes.LDAP_INJECTION, ' ');
   InjectionType SSRF = new InjectionTypeImpl(VulnerabilityTypes.SSRF, ' ');
+  InjectionType UNVALIDATED_REDIRECT =
+      new InjectionTypeImpl(VulnerabilityTypes.UNVALIDATED_REDIRECT, ' ');
 
   String name();
 

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/InsecureCookieModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/InsecureCookieModuleImpl.java
@@ -53,4 +53,11 @@ public class InsecureCookieModuleImpl extends SinkModuleBase implements Insecure
       return;
     }
   }
+
+  @Override
+  public void onHeader(String name, String value) {
+    if ("Set-Cookie".equalsIgnoreCase(name)) {
+      onCookieHeader(value);
+    }
+  }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/UnvalidatedRedirectModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/UnvalidatedRedirectModuleImpl.java
@@ -1,0 +1,27 @@
+package com.datadog.iast.sink;
+
+import static com.datadog.iast.taint.Tainteds.canBeTainted;
+
+import com.datadog.iast.IastRequestContext;
+import com.datadog.iast.model.VulnerabilityType;
+import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import javax.annotation.Nullable;
+
+public class UnvalidatedRedirectModuleImpl extends SinkModuleBase
+    implements UnvalidatedRedirectModule {
+
+  @Override
+  public void onRedirect(final @Nullable String value) {
+    if (!canBeTainted(value)) {
+      return;
+    }
+    final AgentSpan span = AgentTracer.activeSpan();
+    final IastRequestContext ctx = IastRequestContext.get(span);
+    if (ctx == null) {
+      return;
+    }
+    checkInjection(span, ctx, VulnerabilityType.UNVALIDATED_REDIRECT, value);
+  }
+}

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/UnvalidatedRedirectModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/UnvalidatedRedirectModuleImpl.java
@@ -24,4 +24,11 @@ public class UnvalidatedRedirectModuleImpl extends SinkModuleBase
     }
     checkInjection(span, ctx, VulnerabilityType.UNVALIDATED_REDIRECT, value);
   }
+
+  @Override
+  public void onHeader(String name, String value) {
+    if ("Location".equalsIgnoreCase(name)) {
+      onRedirect(value);
+    }
+  }
 }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/UnvalidatedRedirectModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/UnvalidatedRedirectModuleTest.groovy
@@ -1,0 +1,74 @@
+package com.datadog.iast.sink
+
+import com.datadog.iast.IastModuleImplTestBase
+import com.datadog.iast.IastRequestContext
+import com.datadog.iast.model.Vulnerability
+import com.datadog.iast.model.VulnerabilityType
+import datadog.trace.api.gateway.RequestContext
+import datadog.trace.api.gateway.RequestContextSlot
+import datadog.trace.api.iast.sink.UnvalidatedRedirectModule
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+
+import static com.datadog.iast.taint.TaintUtils.addFromTaintFormat
+import static com.datadog.iast.taint.TaintUtils.taintFormat
+
+class UnvalidatedRedirectModuleTest extends IastModuleImplTestBase {
+
+  private UnvalidatedRedirectModule module
+
+  private List<Object> objectHolder
+
+  private IastRequestContext ctx
+
+  def setup() {
+    module = registerDependencies(new UnvalidatedRedirectModuleImpl())
+    objectHolder = []
+    ctx = new IastRequestContext()
+    final reqCtx = Mock(RequestContext) {
+      getData(RequestContextSlot.IAST) >> ctx
+    }
+    final span = Mock(AgentSpan) {
+      getSpanId() >> 123456
+      getRequestContext() >> reqCtx
+    }
+    tracer.activeSpan() >> span
+    overheadController.consumeQuota(_, _) >> true
+  }
+
+  void 'iast module detects redirect (#value)'(final String value, final String expected) {
+    setup:
+    final param = mapTainted(value)
+
+    when:
+    module.onRedirect(param)
+
+    then:
+    if (expected != null) {
+      1 * reporter.report(_, _) >> { args -> assertVulnerability(args[1] as Vulnerability, expected) }
+    } else {
+      0 * reporter.report(_, _)
+    }
+
+    where:
+    value        | expected
+    null         | null
+    '/var'       | null
+    '/==>var<==' | "/==>var<=="
+  }
+
+  private String mapTainted(final String value) {
+    final result = addFromTaintFormat(ctx.taintedObjects, value)
+    objectHolder.add(result)
+    return result
+  }
+
+  private static void assertVulnerability(final Vulnerability vuln, final String expected) {
+    assert vuln != null
+    assert vuln.getType() == VulnerabilityType.UNVALIDATED_REDIRECT
+    assert vuln.getLocation() != null
+    final evidence = vuln.getEvidence()
+    assert evidence != null
+    final formatted = taintFormat(evidence.getValue(), evidence.getRanges())
+    assert formatted == expected
+  }
+}

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/UnvalidatedRedirectModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/UnvalidatedRedirectModuleTest.groovy
@@ -6,6 +6,7 @@ import com.datadog.iast.model.Vulnerability
 import com.datadog.iast.model.VulnerabilityType
 import datadog.trace.api.gateway.RequestContext
 import datadog.trace.api.gateway.RequestContextSlot
+import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.sink.UnvalidatedRedirectModule
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 
@@ -54,6 +55,24 @@ class UnvalidatedRedirectModuleTest extends IastModuleImplTestBase {
     null         | null
     '/var'       | null
     '/==>var<==' | "/==>var<=="
+  }
+
+  void 'if onHeader receives a Location header call onRedirect'() {
+    setup:
+    final urm = Spy(UnvalidatedRedirectModuleImpl)
+    InstrumentationBridge.registerIastModule(urm)
+
+    when:
+    urm.onHeader(headerName, "value")
+
+    then:
+    expected * urm.onRedirect("value")
+
+    where:
+    headerName | expected
+    "blah"     | 0
+    "Location" | 1
+    "location" | 1
   }
 
   private String mapTainted(final String value) {

--- a/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
@@ -87,7 +87,7 @@ public final class HttpServletResponseInstrumentation extends Instrumenter.Iast
   }
 
   public static class EncodeURLAdvice {
-    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    @Advice.OnMethodExit(suppress = Throwable.class)
     public static void onExit(@Advice.Argument(0) final String url, @Advice.Return String encoded) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {

--- a/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
@@ -68,16 +68,8 @@ public final class HttpServletResponseInstrumentation extends Instrumenter.Iast
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void onEnter(
         @Advice.Argument(0) final String name, @Advice.Argument(1) String value) {
-      if ("Set-Cookie".equalsIgnoreCase(name) && null != value && value.length() > 0) {
-        final InsecureCookieModule module = InstrumentationBridge.INSECURE_COOKIE;
-        if (module != null) {
-          module.onCookieHeader(value);
-        }
-      } else if ("Location".equals(name) && null != value && value.length() > 0) {
-        final UnvalidatedRedirectModule module = InstrumentationBridge.UNVALIDATED_REDIRECT;
-        if (module != null) {
-          module.onRedirect(value);
-        }
+      if (null != value && value.length() > 0) {
+        InstrumentationBridge.onHeader(name, value);
       }
     }
   }

--- a/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
@@ -10,7 +10,9 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.sink.InsecureCookieModule;
+import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
 import javax.servlet.http.Cookie;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -41,10 +43,13 @@ public final class HttpServletResponseInstrumentation extends Instrumenter.Iast
 
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
-    transformation.applyAdvice(named("addCookie"), this.getClass().getName() + "$AddCookieAdvice");
+    transformation.applyAdvice(named("addCookie"), getClass().getName() + "$AddCookieAdvice");
     transformation.applyAdvice(
         namedOneOf("setHeader", "addHeader").and(takesArguments(String.class, String.class)),
-        this.getClass().getName() + "$AddHeaderAdvice");
+        getClass().getName() + "$AddHeaderAdvice");
+    transformation.applyAdvice(
+        namedOneOf("encodeRedirectURL", "encodeURL"), getClass().getName() + "$EncodeURLAdvice");
+    transformation.applyAdvice(named("sendRedirect"), getClass().getName() + "$SendRedirectAdvice");
   }
 
   public static class AddCookieAdvice {
@@ -63,10 +68,39 @@ public final class HttpServletResponseInstrumentation extends Instrumenter.Iast
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void onEnter(
         @Advice.Argument(0) final String name, @Advice.Argument(1) String value) {
-      final InsecureCookieModule module = InstrumentationBridge.INSECURE_COOKIE;
-      if (module != null) {
-        if ("Set-Cookie".equalsIgnoreCase(name) && null != value && value.length() > 0) {
+      if ("Set-Cookie".equalsIgnoreCase(name) && null != value && value.length() > 0) {
+        final InsecureCookieModule module = InstrumentationBridge.INSECURE_COOKIE;
+        if (module != null) {
           module.onCookieHeader(value);
+        }
+      } else if ("Location".equals(name) && null != value && value.length() > 0) {
+        final UnvalidatedRedirectModule module = InstrumentationBridge.UNVALIDATED_REDIRECT;
+        if (module != null) {
+          module.onRedirect(value);
+        }
+      }
+    }
+  }
+
+  public static class SendRedirectAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter(@Advice.Argument(0) final String location) {
+      final UnvalidatedRedirectModule module = InstrumentationBridge.UNVALIDATED_REDIRECT;
+      if (module != null) {
+        if (null != location && location.length() > 0) {
+          module.onRedirect(location);
+        }
+      }
+    }
+  }
+
+  public static class EncodeURLAdvice {
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void onExit(@Advice.Argument(0) final String url, @Advice.Return String encoded) {
+      final PropagationModule module = InstrumentationBridge.PROPAGATION;
+      if (module != null) {
+        if (null != url && url.length() > 0 && null != encoded && encoded.length() > 0) {
+          module.taintIfInputIsTainted(encoded, url);
         }
       }
     }

--- a/dd-java-agent/instrumentation/servlet-common/src/test/groovy/HttpServletResponseInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/servlet-common/src/test/groovy/HttpServletResponseInstrumentationTest.groovy
@@ -77,161 +77,15 @@ class HttpServletResponseInstrumentationTest extends AgentTestRunner {
 
   void 'insecure cookie added using addHeader'() {
     setup:
-    final cookieModule = Mock(InsecureCookieModule)
-    InstrumentationBridge.registerIastModule(cookieModule)
-    final redirectModule = Mock(UnvalidatedRedirectModule)
-    InstrumentationBridge.registerIastModule(redirectModule)
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
     final response = new DummyResponse()
 
     when:
     response.addHeader("Set-Cookie", "user-id=7")
 
     then:
-    1 * cookieModule.onCookieHeader('user-id=7')
-    0 * redirectModule.onRedirect(_)
-    0 * _
-  }
-
-  void 'unvalidated redirect added using addHeader'() {
-    setup:
-    final cookieModule = Mock(InsecureCookieModule)
-    InstrumentationBridge.registerIastModule(cookieModule)
-    final redirectModule = Mock(UnvalidatedRedirectModule)
-    InstrumentationBridge.registerIastModule(redirectModule)
-    final response = new DummyResponse()
-
-    when:
-    response.addHeader("Location", "http://dummy.location.com")
-
-    then:
-    1 * redirectModule.onRedirect('http://dummy.location.com')
-    0 * cookieModule.onCookieHeader(_)
-    0 * _
-  }
-
-  void 'null parameters added using addHeader'() {
-    setup:
-    final cookieModule = Mock(InsecureCookieModule)
-    InstrumentationBridge.registerIastModule(cookieModule)
-    final redirectModule = Mock(UnvalidatedRedirectModule)
-    InstrumentationBridge.registerIastModule(redirectModule)
-    final response = new DummyResponse()
-
-    when:
-    response.addHeader(null, null)
-
-    then:
-    noExceptionThrown()
-    0 * cookieModule.onCookieHeader(_)
-    0 * redirectModule.onRedirect(_)
-    0 * _
-  }
-
-  void 'null value added using addHeader to set cookies'() {
-    setup:
-    final cookieModule = Mock(InsecureCookieModule)
-    InstrumentationBridge.registerIastModule(cookieModule)
-    final redirectModule = Mock(UnvalidatedRedirectModule)
-    InstrumentationBridge.registerIastModule(redirectModule)
-    final response = new DummyResponse()
-
-    when:
-    response.addHeader("Set-Cookie", null)
-
-    then:
-    noExceptionThrown()
-    0 * cookieModule.onCookieHeader(_)
-    0 * redirectModule.onRedirect(_)
-    0 * _
-  }
-
-  void 'null value added using addHeader to set location'() {
-    setup:
-    final cookieModule = Mock(InsecureCookieModule)
-    InstrumentationBridge.registerIastModule(cookieModule)
-    final redirectModule = Mock(UnvalidatedRedirectModule)
-    InstrumentationBridge.registerIastModule(redirectModule)
-    final response = new DummyResponse()
-
-    when:
-    response.addHeader("Location", null)
-
-    then:
-    noExceptionThrown()
-    0 * cookieModule.onCookieHeader(_)
-    0 * redirectModule.onRedirect(_)
-    0 * _
-  }
-
-  void 'null header name added using addHeader'() {
-    setup:
-    final cookieModule = Mock(InsecureCookieModule)
-    InstrumentationBridge.registerIastModule(cookieModule)
-    final redirectModule = Mock(UnvalidatedRedirectModule)
-    InstrumentationBridge.registerIastModule(redirectModule)
-    final response = new DummyResponse()
-
-    when:
-    response.addHeader(null, "user-id=7")
-
-    then:
-    noExceptionThrown()
-    0 * cookieModule.onCookieHeader(_)
-    0 * redirectModule.onRedirect(_)
-    0 * _
-  }
-
-
-  void 'secure cookie added using addHeader'() {
-    setup:
-    final cookieModule = Mock(InsecureCookieModule)
-    InstrumentationBridge.registerIastModule(cookieModule)
-    final redirectModule = Mock(UnvalidatedRedirectModule)
-    InstrumentationBridge.registerIastModule(redirectModule)
-    final response = new DummyResponse()
-
-    when:
-    response.addHeader("Set-Cookie", "user-id=7; Secure")
-
-    then:
-    1 * cookieModule.onCookieHeader('user-id=7; Secure')
-    0 * redirectModule.onRedirect(_)
-    0 * _
-  }
-
-
-  void 'adding non cookie header'() {
-    setup:
-    final cookieModule = Mock(InsecureCookieModule)
-    InstrumentationBridge.registerIastModule(cookieModule)
-    final redirectModule = Mock(UnvalidatedRedirectModule)
-    InstrumentationBridge.registerIastModule(redirectModule)
-    final response = new DummyResponse()
-
-    when:
-    response.addHeader("Custom-Header", "user-id=7")
-
-    then:
-    0 * cookieModule.onCookieHeader(_)
-    0 * redirectModule.onRedirect(_)
-    0 * _
-  }
-
-  void 'cookie without name value pair'() {
-    setup:
-    final cookieModule = Mock(InsecureCookieModule)
-    InstrumentationBridge.registerIastModule(cookieModule)
-    final redirectModule = Mock(UnvalidatedRedirectModule)
-    InstrumentationBridge.registerIastModule(redirectModule)
-    final response = new DummyResponse()
-
-    when:
-    response.addHeader("Set-Cookie", "user-id")
-
-    then:
-    1 * cookieModule.onCookieHeader('user-id')
-    0 * redirectModule.onRedirect(_)
-    0 * _
+    1 * module.onHeader("Set-Cookie", 'user-id=7')
   }
 
 
@@ -247,44 +101,36 @@ class HttpServletResponseInstrumentationTest extends AgentTestRunner {
     response.setHeader("Set-Cookie", "user-id=7")
 
     then:
-    1 * cookieModule.onCookieHeader('user-id=7')
-    0 * redirectModule.onRedirect(_)
-    0 * _
+    1 * cookieModule.onHeader('Set-Cookie', 'user-id=7')
   }
 
-  void 'secure cookie added using setHeader'() {
+  void 'unvalidated redirect checked using addHeader'() {
     setup:
-    final cookieModule = Mock(InsecureCookieModule)
-    InstrumentationBridge.registerIastModule(cookieModule)
     final redirectModule = Mock(UnvalidatedRedirectModule)
     InstrumentationBridge.registerIastModule(redirectModule)
     final response = new DummyResponse()
 
     when:
-    response.setHeader("Set-Cookie", "user-id=7; Secure")
+    response.addHeader("Location", "http://dummy.url.com")
 
     then:
-    1 * cookieModule.onCookieHeader('user-id=7; Secure')
-    0 * redirectModule.onRedirect(_)
-    0 * _
+    1 * redirectModule.onHeader('Location', 'http://dummy.url.com')
   }
 
-  void 'secure cookie added using setHeader without spaces'() {
+
+  void 'unvalidated redirect checked setHeader'() {
     setup:
-    final cookieModule = Mock(InsecureCookieModule)
-    InstrumentationBridge.registerIastModule(cookieModule)
     final redirectModule = Mock(UnvalidatedRedirectModule)
     InstrumentationBridge.registerIastModule(redirectModule)
     final response = new DummyResponse()
 
     when:
-    response.setHeader("Set-Cookie", "user-id=7;Secure")
+    response.setHeader("Location", "http://dummy.url.com")
 
     then:
-    1 * cookieModule.onCookieHeader('user-id=7;Secure')
-    0 * redirectModule.onRedirect(_)
-    0 * _
+    1 * redirectModule.onHeader('Location', 'http://dummy.url.com')
   }
+
 
   void 'redirection added using sendRedirect'() {
     setup:

--- a/dd-java-agent/instrumentation/servlet-common/src/test/java/foo/bar/DummyResponse.java
+++ b/dd-java-agent/instrumentation/servlet-common/src/test/java/foo/bar/DummyResponse.java
@@ -18,12 +18,12 @@ public class DummyResponse implements HttpServletResponse {
 
   @Override
   public String encodeURL(String url) {
-    return null;
+    return "Encoded_" + url;
   }
 
   @Override
   public String encodeRedirectURL(String url) {
-    return null;
+    return "Encoded_" + url;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletResponseInstrumentation.java
@@ -9,7 +9,9 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.sink.InsecureCookieModule;
+import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
 import jakarta.servlet.http.Cookie;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -35,9 +37,12 @@ public final class JakartaHttpServletResponseInstrumentation extends Instrumente
 
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
-    transformation.applyAdvice(named("addCookie"), this.getClass().getName() + "$AddCookieAdvice");
+    transformation.applyAdvice(named("addCookie"), getClass().getName() + "$AddCookieAdvice");
     transformation.applyAdvice(
-        namedOneOf("setHeader", "addHeader"), this.getClass().getName() + "$AddHeaderAdvice");
+        namedOneOf("setHeader", "addHeader"), getClass().getName() + "$AddHeaderAdvice");
+    transformation.applyAdvice(
+        namedOneOf("encodeRedirectURL", "encodeURL"), getClass().getName() + "$EncodeURLAdvice");
+    transformation.applyAdvice(named("sendRedirect"), getClass().getName() + "$SendRedirectAdvice");
   }
 
   public static class AddCookieAdvice {
@@ -56,10 +61,31 @@ public final class JakartaHttpServletResponseInstrumentation extends Instrumente
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void onEnter(
         @Advice.Argument(0) final String name, @Advice.Argument(1) String value) {
-      final InsecureCookieModule module = InstrumentationBridge.INSECURE_COOKIE;
+      if (null != value && value.length() > 0) {
+        InstrumentationBridge.onHeader(name, value);
+      }
+    }
+  }
+
+  public static class SendRedirectAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter(@Advice.Argument(0) final String location) {
+      final UnvalidatedRedirectModule module = InstrumentationBridge.UNVALIDATED_REDIRECT;
       if (module != null) {
-        if ("Set-Cookie".equalsIgnoreCase(name) && null != value && value.length() > 0) {
-          module.onCookieHeader(value);
+        if (null != location && location.length() > 0) {
+          module.onRedirect(location);
+        }
+      }
+    }
+  }
+
+  public static class EncodeURLAdvice {
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void onExit(@Advice.Argument(0) final String url, @Advice.Return String encoded) {
+      final PropagationModule module = InstrumentationBridge.PROPAGATION;
+      if (module != null) {
+        if (null != url && url.length() > 0 && null != encoded && encoded.length() > 0) {
+          module.taintIfInputIsTainted(encoded, url);
         }
       }
     }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletResponseInstrumentation.java
@@ -80,7 +80,7 @@ public final class JakartaHttpServletResponseInstrumentation extends Instrumente
   }
 
   public static class EncodeURLAdvice {
-    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    @Advice.OnMethodExit(suppress = Throwable.class)
     public static void onExit(@Advice.Argument(0) final String url, @Advice.Return String encoded) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {

--- a/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaHttpServletResponseInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaHttpServletResponseInstrumentationTest.groovy
@@ -1,18 +1,20 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.propagation.PropagationModule
 import datadog.trace.api.iast.sink.InsecureCookieModule
+import datadog.trace.api.iast.sink.UnvalidatedRedirectModule
 import foo.bar.smoketest.DummyResponse
 import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletResponse
 import jakarta.servlet.http.HttpServletResponseWrapper
 
-class JakartaHttpServletResponseInstrumentationTest  extends AgentTestRunner {
+class JakartaHttpServletResponseInstrumentationTest extends AgentTestRunner {
   @Override
   protected void configurePreAgent() {
     injectSysConfig('dd.iast.enabled', 'true')
   }
 
-  void 'insecure cookie added using addCookie'(){
+  void 'insecure cookie added using addCookie'() {
     setup:
     final module = Mock(InsecureCookieModule)
     InstrumentationBridge.registerIastModule(module)
@@ -27,7 +29,7 @@ class JakartaHttpServletResponseInstrumentationTest  extends AgentTestRunner {
     0 * _
   }
 
-  void 'make sure we do not instrument subclasses of HttpServletResponseWrapper'(){
+  void 'make sure we do not instrument subclasses of HttpServletResponseWrapper'() {
     setup:
     final module = Mock(InsecureCookieModule)
     InstrumentationBridge.registerIastModule(module)
@@ -43,7 +45,7 @@ class JakartaHttpServletResponseInstrumentationTest  extends AgentTestRunner {
     0 * _
   }
 
-  void 'secure cookie added using addCookie'(){
+  void 'secure cookie added using addCookie'() {
     setup:
     final module = Mock(InsecureCookieModule)
     InstrumentationBridge.registerIastModule(module)
@@ -59,7 +61,7 @@ class JakartaHttpServletResponseInstrumentationTest  extends AgentTestRunner {
     0 * _
   }
 
-  void 'null cookie added using addCookie'(){
+  void 'null cookie added using addCookie'() {
     setup:
     final module = Mock(InsecureCookieModule)
     InstrumentationBridge.registerIastModule(module)
@@ -72,7 +74,7 @@ class JakartaHttpServletResponseInstrumentationTest  extends AgentTestRunner {
     0 * _
   }
 
-  void 'insecure cookie added using addHeader'(){
+  void 'insecure cookie added using addHeader'() {
     setup:
     final module = Mock(InsecureCookieModule)
     InstrumentationBridge.registerIastModule(module)
@@ -82,11 +84,10 @@ class JakartaHttpServletResponseInstrumentationTest  extends AgentTestRunner {
     response.addHeader("Set-Cookie", "user-id=7")
 
     then:
-    1 * module.onCookieHeader('user-id=7')
-    0 * _
+    1 * module.onHeader('Set-Cookie', 'user-id=7')
   }
 
-  void 'null parameters added using addHeader'(){
+  void 'null parameters added using addHeader'() {
     setup:
     final module = Mock(InsecureCookieModule)
     InstrumentationBridge.registerIastModule(module)
@@ -97,84 +98,10 @@ class JakartaHttpServletResponseInstrumentationTest  extends AgentTestRunner {
 
     then:
     noExceptionThrown()
-    0 * module.onCookieHeader(_)
-    0 * _
+    0 * module.onHeader(null, null)
   }
 
-  void 'null value added using addHeader'(){
-    setup:
-    final module = Mock(InsecureCookieModule)
-    InstrumentationBridge.registerIastModule(module)
-    final response = new DummyResponse()
-
-    when:
-    response.addHeader("Set-Cookie", null)
-
-    then:
-    noExceptionThrown()
-    0 * module.onCookieHeader(_)
-    0 * _
-  }
-
-  void 'null header name added using addHeader'(){
-    setup:
-    final module = Mock(InsecureCookieModule)
-    InstrumentationBridge.registerIastModule(module)
-    final response = new DummyResponse()
-
-    when:
-    response.addHeader(null, "user-id=7")
-
-    then:
-    noExceptionThrown()
-    0 * module.onCookieHeader(_)
-    0 * _
-  }
-
-
-  void 'secure cookie added using addHeader'(){
-    setup:
-    final module = Mock(InsecureCookieModule)
-    InstrumentationBridge.registerIastModule(module)
-    final response = new DummyResponse()
-
-    when:
-    response.addHeader("Set-Cookie", "user-id=7; Secure")
-
-    then:
-    1 * module.onCookieHeader('user-id=7; Secure')
-    0 * _
-  }
-
-  void 'adding non cookie header'(){
-    setup:
-    final module = Mock(InsecureCookieModule)
-    InstrumentationBridge.registerIastModule(module)
-    final response = new DummyResponse()
-
-    when:
-    response.addHeader("Custom-Header", "user-id=7")
-
-    then:
-    0 * _
-  }
-
-  void 'cookie without name value pair'(){
-    setup:
-    final module = Mock(InsecureCookieModule)
-    InstrumentationBridge.registerIastModule(module)
-    final response = new DummyResponse()
-
-    when:
-    response.addHeader("Set-Cookie", "user-id")
-
-    then:
-    1 * module.onCookieHeader('user-id')
-    0 * _
-  }
-
-
-  void 'insecure cookie added using setHeader'(){
+  void 'insecure cookie added using setHeader'() {
     setup:
     final module = Mock(InsecureCookieModule)
     InstrumentationBridge.registerIastModule(module)
@@ -184,35 +111,107 @@ class JakartaHttpServletResponseInstrumentationTest  extends AgentTestRunner {
     response.setHeader("Set-Cookie", "user-id=7")
 
     then:
-    1 * module.onCookieHeader('user-id=7')
-    0 * _
+    1 * module.onHeader('Set-Cookie', 'user-id=7')
   }
 
-  void 'secure cookie added using setHeader'(){
+  void 'null parameters added using setHeader'() {
     setup:
     final module = Mock(InsecureCookieModule)
     InstrumentationBridge.registerIastModule(module)
     final response = new DummyResponse()
 
     when:
-    response.setHeader("Set-Cookie", "user-id=7; Secure")
+    response.setHeader(null, null)
 
     then:
-    1 * module.onCookieHeader('user-id=7; Secure')
+    noExceptionThrown()
+    0 * module.onHeader(null, null)
+  }
+
+  void 'unvalidated redirect checked using addHeader'() {
+    setup:
+    final redirectModule = Mock(UnvalidatedRedirectModule)
+    InstrumentationBridge.registerIastModule(redirectModule)
+    final response = new DummyResponse()
+
+    when:
+    response.addHeader("Location", "http://dummy.url.com")
+
+    then:
+    1 * redirectModule.onHeader('Location', 'http://dummy.url.com')
+  }
+
+
+  void 'unvalidated redirect checked setHeader'() {
+    setup:
+    final redirectModule = Mock(UnvalidatedRedirectModule)
+    InstrumentationBridge.registerIastModule(redirectModule)
+    final response = new DummyResponse()
+
+    when:
+    response.setHeader("Location", "http://dummy.url.com")
+
+    then:
+    1 * redirectModule.onHeader('Location', 'http://dummy.url.com')
+  }
+
+
+  void 'redirection added using sendRedirect'() {
+    setup:
+    final redirectModule = Mock(UnvalidatedRedirectModule)
+    InstrumentationBridge.registerIastModule(redirectModule)
+    final response = new DummyResponse()
+
+    when:
+    response.sendRedirect("http://dummy.location.com")
+
+    then:
+    1 * redirectModule.onRedirect('http://dummy.location.com')
     0 * _
   }
 
-  void 'secure cookie added using setHeader without spaces'(){
+  void 'null location added using sendRedirect'() {
     setup:
-    final module = Mock(InsecureCookieModule)
+    final redirectModule = Mock(UnvalidatedRedirectModule)
+    InstrumentationBridge.registerIastModule(redirectModule)
+    final response = new DummyResponse()
+
+    when:
+    response.sendRedirect(null)
+
+    then:
+    noExceptionThrown()
+    0 * redirectModule.onRedirect(_)
+    0 * _
+  }
+
+  void 'taint encoded url using encodeRedirectURL'() {
+    setup:
+    final module = Mock(PropagationModule)
     InstrumentationBridge.registerIastModule(module)
     final response = new DummyResponse()
 
     when:
-    response.setHeader("Set-Cookie", "user-id=7;Secure")
+    response.encodeRedirectURL("http://dummy.url.com")
 
     then:
-    1 * module.onCookieHeader('user-id=7;Secure')
+    noExceptionThrown()
+    1 * module.taintIfInputIsTainted(_, "http://dummy.url.com")
+    0 * _
+  }
+
+  void 'taint encoded url using encodeURL'() {
+    setup:
+    final module = Mock(PropagationModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.encodeURL("http://dummy.url.com")
+
+    then:
+    noExceptionThrown()
+    1 * module.taintIfInputIsTainted(_, "http://dummy.url.com")
     0 * _
   }
 }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/test/java/foo/bar/smoketest/DummyResponse.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/test/java/foo/bar/smoketest/DummyResponse.java
@@ -19,12 +19,12 @@ public class DummyResponse implements HttpServletResponse {
 
   @Override
   public String encodeURL(String url) {
-    return null;
+    return "Encoded_" + url;
   }
 
   @Override
   public String encodeRedirectURL(String url) {
-    return null;
+    return "Encoded_" + url;
   }
 
   @Override

--- a/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -86,7 +86,6 @@ public class IastWebController {
   public String unvalidatedRedirectFromSendRedirect(
       @RequestParam String param, HttpServletResponse response) throws IOException {
     response.sendRedirect(param);
-    response.setStatus(HttpStatus.FOUND.value());
     return "Unvalidated redirect";
   }
 
@@ -187,7 +186,6 @@ public class IastWebController {
     return "ok User Principal name: " + userPrincipal.getName();
   }
 
-  @SuppressWarnings("CatchMayIgnoreException")
   @PostMapping("/ssrf")
   public String ssrf(@RequestParam("url") final String url) {
     try {

--- a/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/springboot/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -4,6 +4,7 @@ import datadog.smoketest.springboot.TestBean;
 import ddtest.client.sources.Hasher;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
+import java.io.IOException;
 import java.net.HttpCookie;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -71,6 +72,22 @@ public class IastWebController {
     response.addHeader("Set-Cookie", cookie.toString());
     response.setStatus(HttpStatus.OK.value());
     return "Insecure cookie page";
+  }
+
+  @GetMapping("/unvalidated_redirect_from_header")
+  public String unvalidatedRedirectFromHeader(
+      @RequestParam String param, HttpServletResponse response) {
+    response.addHeader("Location", param);
+    response.setStatus(HttpStatus.FOUND.value());
+    return "Unvalidated redirect";
+  }
+
+  @GetMapping("/unvalidated_redirect_from_send_redirect")
+  public String unvalidatedRedirectFromSendRedirect(
+      @RequestParam String param, HttpServletResponse response) throws IOException {
+    response.sendRedirect(param);
+    response.setStatus(HttpStatus.FOUND.value());
+    return "Unvalidated redirect";
   }
 
   @RequestMapping("/async_weakhash")

--- a/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/AbstractSpringBootIastTest.groovy
+++ b/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/AbstractSpringBootIastTest.groovy
@@ -1,0 +1,110 @@
+package datadog.smoketest
+
+import datadog.trace.test.agent.decoder.DecodedSpan
+import groovy.json.JsonSlurper
+import okhttp3.MediaType
+
+import java.util.concurrent.TimeoutException
+import java.util.function.Function
+import java.util.function.Predicate
+
+abstract class AbstractSpringBootIastTest extends AbstractServerSmokeTest {
+
+  protected static final String TAG_NAME = '_dd.iast.json'
+
+  protected static final MediaType JSON = MediaType.parse("application/json; charset=utf-8")
+
+  protected static Function<DecodedSpan, Boolean> hasMetric(final String name, final Object value) {
+    return { span -> value == span.metrics.get(name) }
+  }
+
+  protected static Function<DecodedSpan, Boolean> hasVulnerability(final Predicate<?> predicate) {
+    return { span ->
+      final iastMeta = span.meta.get(TAG_NAME)
+      if (!iastMeta) {
+        return false
+      }
+      final vulnerabilities = parseVulnerabilities(iastMeta)
+      return vulnerabilities.stream().anyMatch(predicate)
+    }
+  }
+
+  protected boolean hasVulnerabilityInLogs(final Predicate<?> predicate) {
+    def found = false
+    checkLogPostExit { final String log ->
+      final index = log.indexOf(TAG_NAME)
+      if (index >= 0) {
+        final vulnerabilities = parseVulnerabilities(log, index)
+        found |= vulnerabilities.stream().anyMatch(predicate)
+      }
+    }
+    return found
+  }
+
+  protected void hasTainted(final Closure<Boolean> matcher) {
+    final slurper = new JsonSlurper()
+    final tainteds = []
+    try {
+      processTestLogLines { String log ->
+        final index = log.indexOf('tainted=')
+        if (index >= 0) {
+          final tainted = slurper.parse(new StringReader(log.substring(index + 8)))
+          tainteds.add(tainted)
+          if (matcher.call(tainted)) {
+            return true // found
+          }
+        }
+      }
+    } catch (TimeoutException toe) {
+      throw new AssertionError("No matching tainted found. Tainteds found: ${tainteds}")
+    }
+  }
+
+
+  protected static Collection<?> parseVulnerabilities(final String log, final int startIndex) {
+    final chars = log.toCharArray()
+    final builder = new StringBuilder()
+    def level = 0
+    for (int i = log.indexOf('{', startIndex); i < chars.length; i++) {
+      final current = chars[i]
+      if (current == '{' as char) {
+        level++
+      } else if (current == '}' as char) {
+        level--
+      }
+      builder.append(chars[i])
+      if (level == 0) {
+        break
+      }
+    }
+    return parseVulnerabilities(builder.toString())
+  }
+
+  protected static Collection<?> parseVulnerabilities(final String iastJson) {
+    final slurper = new JsonSlurper()
+    final parsed = slurper.parseText(iastJson)
+    return parsed['vulnerabilities'] as Collection
+  }
+
+  protected static Predicate<?> type(final String type) {
+    return { vul ->
+      vul.type == type
+    }
+  }
+
+  protected static Predicate<?> evidence(final String value) {
+    return { vul ->
+      vul.evidence.value == value
+    }
+  }
+
+  protected static Predicate<?> withSpan() {
+    return { vul ->
+      vul.location.spanId > 0
+    }
+  }
+
+  protected static String withSystemProperty(final String config, final Object value) {
+    return "-Ddd.${config}=${value}"
+  }
+}

--- a/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootRedirectSmokeTest.groovy
+++ b/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootRedirectSmokeTest.groovy
@@ -1,8 +1,6 @@
 package datadog.smoketest
 
-
 import groovy.transform.CompileDynamic
-import okhttp3.MediaType
 import okhttp3.Request
 import spock.util.concurrent.PollingConditions
 
@@ -13,10 +11,6 @@ import static datadog.trace.api.config.IastConfig.IAST_REQUEST_SAMPLING
 
 @CompileDynamic
 class IastSpringBootRedirectSmokeTest extends AbstractSpringBootIastTest {
-
-  private static final String TAG_NAME = '_dd.iast.json'
-
-  private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8")
 
   @Override
   def logLevel() {

--- a/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootRedirectSmokeTest.groovy
+++ b/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootRedirectSmokeTest.groovy
@@ -1,0 +1,79 @@
+package datadog.smoketest
+
+
+import groovy.transform.CompileDynamic
+import okhttp3.MediaType
+import okhttp3.Request
+import spock.util.concurrent.PollingConditions
+
+import static datadog.trace.api.config.IastConfig.IAST_DEBUG_ENABLED
+import static datadog.trace.api.config.IastConfig.IAST_ENABLED
+import static datadog.trace.api.config.IastConfig.IAST_REDACTION_ENABLED
+import static datadog.trace.api.config.IastConfig.IAST_REQUEST_SAMPLING
+
+@CompileDynamic
+class IastSpringBootRedirectSmokeTest extends AbstractSpringBootIastTest {
+
+  private static final String TAG_NAME = '_dd.iast.json'
+
+  private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8")
+
+  @Override
+  def logLevel() {
+    return "debug"
+  }
+
+  @Override
+  Closure decodedTracesCallback() {
+    return {} // force traces decoding
+  }
+
+  @Override
+  ProcessBuilder createProcessBuilder() {
+    String springBootShadowJar = System.getProperty("datadog.smoketest.springboot.shadowJar.path")
+
+    List<String> command = new ArrayList<>()
+    command.add(javaPath())
+    command.addAll(defaultJavaProperties)
+    command.addAll([
+      withSystemProperty(IAST_ENABLED, true),
+      withSystemProperty(IAST_REQUEST_SAMPLING, 100),
+      withSystemProperty(IAST_DEBUG_ENABLED, true),
+      withSystemProperty(IAST_REDACTION_ENABLED, false)
+    ])
+    command.addAll((String[]) ["-jar", springBootShadowJar, "--server.port=${httpPort}"])
+    ProcessBuilder processBuilder = new ProcessBuilder(command)
+    processBuilder.directory(new File(buildDirectory))
+    // Spring will print all environment variables to the log, which may pollute it and affect log assertions.
+    processBuilder.environment().clear()
+    processBuilder
+  }
+
+  def "unvalidated  redirect from addheader is present"() {
+    setup:
+    String url = "http://localhost:${httpPort}/unvalidated_redirect_from_header?param=redirected"
+    def request = new Request.Builder().url(url).get().build()
+
+    when:
+    def response = client.newCall(request).execute()
+
+    then:
+    response.isRedirect()
+    response.header("Location").contains("redirected")
+    waitForSpan(new PollingConditions(timeout: 5),
+    hasVulnerability(type('UNVALIDATED_REDIRECT')))
+  }
+
+  def "unvalidated  redirect from sendRedirect is present"() {
+    setup:
+    String url = "http://localhost:${httpPort}/unvalidated_redirect_from_send_redirect?param=redirected"
+    def request = new Request.Builder().url(url).get().build()
+
+    when:
+    def response = client.newCall(request).execute()
+
+    then:
+    response.isRedirect()
+    hasVulnerabilityInLogs(type('UNVALIDATED_REDIRECT').and(withSpan()))
+  }
+}

--- a/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
@@ -1,18 +1,11 @@
 package datadog.smoketest
 
-import datadog.trace.test.agent.decoder.DecodedSpan
-import groovy.json.JsonSlurper
 import groovy.transform.CompileDynamic
 import okhttp3.FormBody
-import okhttp3.MediaType
 import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.Response
 import spock.util.concurrent.PollingConditions
-
-import java.util.concurrent.TimeoutException
-import java.util.function.Function
-import java.util.function.Predicate
 
 import static datadog.trace.api.config.IastConfig.IAST_DEBUG_ENABLED
 import static datadog.trace.api.config.IastConfig.IAST_ENABLED
@@ -20,11 +13,7 @@ import static datadog.trace.api.config.IastConfig.IAST_REDACTION_ENABLED
 import static datadog.trace.api.config.IastConfig.IAST_REQUEST_SAMPLING
 
 @CompileDynamic
-class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
-
-  private static final String TAG_NAME = '_dd.iast.json'
-
-  private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8")
+class IastSpringBootSmokeTest extends AbstractSpringBootIastTest {
 
   @Override
   def logLevel() {
@@ -42,7 +31,6 @@ class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
 
     List<String> command = new ArrayList<>()
     command.add(javaPath())
-    //command.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005")
     command.addAll(defaultJavaProperties)
     command.addAll([
       withSystemProperty(IAST_ENABLED, true),
@@ -159,34 +147,6 @@ class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
     response.header("Set-Cookie").contains("user-id")
     waitForSpan(new PollingConditions(timeout: 5),
     hasVulnerability(type('INSECURE_COOKIE').and(evidence('user-id'))))
-  }
-
-  def "unvalidated  redirect from addheader is present"() {
-    setup:
-    String url = "http://localhost:${httpPort}/unvalidated_redirect_from_header?param=redirected"
-    def request = new Request.Builder().url(url).get().build()
-
-    when:
-    def response = client.newCall(request).execute()
-
-    then:
-    response.isRedirect()
-    response.header("Location").contains("redirected")
-    waitForSpan(new PollingConditions(timeout: 5),
-    hasVulnerability(type('UNVALIDATED_REDIRECT')))
-  }
-
-  def "unvalidated  redirect from sendRedirect is present"() {
-    setup:
-    String url = "http://localhost:${httpPort}/unvalidated_redirect_from_send_redirect?param=redirected"
-    def request = new Request.Builder().url(url).get().build()
-
-    when:
-    def response = client.newCall(request).execute()
-
-    then:
-    response.isRedirect()
-    hasVulnerabilityInLogs(type('UNVALIDATED_REDIRECT').and(withSpan()))
   }
 
 
@@ -488,97 +448,4 @@ class IastSpringBootSmokeTest extends AbstractServerSmokeTest {
     hasMetric('_dd.iast.telemetry.executed.sink.command_injection', 1))
   }
 
-  private static Function<DecodedSpan, Boolean> hasMetric(final String name, final Object value) {
-    return { span -> value == span.metrics.get(name) }
-  }
-
-  private static Function<DecodedSpan, Boolean> hasVulnerability(final Predicate<?> predicate) {
-    return { span ->
-      final iastMeta = span.meta.get(TAG_NAME)
-      if (!iastMeta) {
-        return false
-      }
-      final vulnerabilities = parseVulnerabilities(iastMeta)
-      return vulnerabilities.stream().anyMatch(predicate)
-    }
-  }
-
-  private boolean hasVulnerabilityInLogs(final Predicate<?> predicate) {
-    def found = false
-    checkLogPostExit { final String log ->
-      final index = log.indexOf(TAG_NAME)
-      if (index >= 0) {
-        final vulnerabilities = parseVulnerabilities(log, index)
-        found |= vulnerabilities.stream().anyMatch(predicate)
-      }
-    }
-    return found
-  }
-
-  private void hasTainted(final Closure<Boolean> matcher) {
-    final slurper = new JsonSlurper()
-    final tainteds = []
-    try {
-      processTestLogLines { String log ->
-        final index = log.indexOf('tainted=')
-        if (index >= 0) {
-          final tainted = slurper.parse(new StringReader(log.substring(index + 8)))
-          tainteds.add(tainted)
-          if (matcher.call(tainted)) {
-            return true // found
-          }
-        }
-      }
-    } catch (TimeoutException toe) {
-      throw new AssertionError("No matching tainted found. Tainteds found: ${tainteds}")
-    }
-  }
-
-
-  private static Collection<?> parseVulnerabilities(final String log, final int startIndex) {
-    final chars = log.toCharArray()
-    final builder = new StringBuilder()
-    def level = 0
-    for (int i = log.indexOf('{', startIndex); i < chars.length; i++) {
-      final current = chars[i]
-      if (current == '{' as char) {
-        level++
-      } else if (current == '}' as char) {
-        level--
-      }
-      builder.append(chars[i])
-      if (level == 0) {
-        break
-      }
-    }
-    return parseVulnerabilities(builder.toString())
-  }
-
-  private static Collection<?> parseVulnerabilities(final String iastJson) {
-    final slurper = new JsonSlurper()
-    final parsed = slurper.parseText(iastJson)
-    return parsed['vulnerabilities'] as Collection
-  }
-
-  private static Predicate<?> type(final String type) {
-    return { vul ->
-      vul.type == type
-    }
-  }
-
-  private static Predicate<?> evidence(final String value) {
-    return { vul ->
-      vul.evidence.value == value
-    }
-  }
-
-  private static Predicate<?> withSpan() {
-    return { vul ->
-      vul.location.spanId > 0
-    }
-  }
-
-  private static String withSystemProperty(final String config, final Object value) {
-    return "-Ddd.${config}=${value}"
-  }
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/InstrumentationBridge.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/InstrumentationBridge.java
@@ -125,4 +125,13 @@ public abstract class InstrumentationBridge {
     SSRF = null;
     UNVALIDATED_REDIRECT = null;
   }
+
+  public static void onHeader(final String name, final String value) {
+    if (INSECURE_COOKIE != null) {
+      INSECURE_COOKIE.onHeader(name, value);
+    }
+    if (UNVALIDATED_REDIRECT != null) {
+      UNVALIDATED_REDIRECT.onHeader(name, value);
+    }
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/InstrumentationBridge.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/InstrumentationBridge.java
@@ -9,6 +9,7 @@ import datadog.trace.api.iast.sink.LdapInjectionModule;
 import datadog.trace.api.iast.sink.PathTraversalModule;
 import datadog.trace.api.iast.sink.SqlInjectionModule;
 import datadog.trace.api.iast.sink.SsrfModule;
+import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
 import datadog.trace.api.iast.sink.WeakCipherModule;
 import datadog.trace.api.iast.sink.WeakHashModule;
 import datadog.trace.api.iast.source.WebModule;
@@ -28,6 +29,7 @@ public abstract class InstrumentationBridge {
   public static volatile PropagationModule PROPAGATION;
   public static volatile InsecureCookieModule INSECURE_COOKIE;
   public static volatile SsrfModule SSRF;
+  public static volatile UnvalidatedRedirectModule UNVALIDATED_REDIRECT;
 
   private InstrumentationBridge() {}
 
@@ -56,6 +58,8 @@ public abstract class InstrumentationBridge {
       INSECURE_COOKIE = (InsecureCookieModule) module;
     } else if (module instanceof SsrfModule) {
       SSRF = (SsrfModule) module;
+    } else if (module instanceof UnvalidatedRedirectModule) {
+      UNVALIDATED_REDIRECT = (UnvalidatedRedirectModule) module;
     } else {
       throw new UnsupportedOperationException("Module not yet supported: " + module);
     }
@@ -99,6 +103,9 @@ public abstract class InstrumentationBridge {
     if (type == SsrfModule.class) {
       return (E) SSRF;
     }
+    if (type == UnvalidatedRedirectModule.class) {
+      return (E) UNVALIDATED_REDIRECT;
+    }
     throw new UnsupportedOperationException("Module not yet supported: " + type);
   }
 
@@ -115,5 +122,7 @@ public abstract class InstrumentationBridge {
     LDAP_INJECTION = null;
     PROPAGATION = null;
     INSECURE_COOKIE = null;
+    SSRF = null;
+    UNVALIDATED_REDIRECT = null;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityTypes.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityTypes.java
@@ -12,4 +12,5 @@ public abstract class VulnerabilityTypes {
   public static final String LDAP_INJECTION = "LDAP_INJECTION";
   public static final String SSRF = "SSRF";
   public static final String INSECURE_COOKIE = "INSECURE_COOKIE";
+  public static final String UNVALIDATED_REDIRECT = "UNVALIDATED_REDIRECT";
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/sink/HttpHeaderModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/sink/HttpHeaderModule.java
@@ -1,0 +1,8 @@
+package datadog.trace.api.iast.sink;
+
+import datadog.trace.api.iast.IastModule;
+
+public interface HttpHeaderModule extends IastModule {
+
+  void onHeader(final String name, final String value);
+}

--- a/internal-api/src/main/java/datadog/trace/api/iast/sink/InsecureCookieModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/sink/InsecureCookieModule.java
@@ -1,8 +1,6 @@
 package datadog.trace.api.iast.sink;
 
-import datadog.trace.api.iast.IastModule;
-
-public interface InsecureCookieModule extends IastModule {
+public interface InsecureCookieModule extends HttpHeaderModule {
   public void onCookie(String cookieName, boolean secure);
 
   public void onCookieHeader(String headerValue);

--- a/internal-api/src/main/java/datadog/trace/api/iast/sink/UnvalidatedRedirectModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/sink/UnvalidatedRedirectModule.java
@@ -1,9 +1,8 @@
 package datadog.trace.api.iast.sink;
 
-import datadog.trace.api.iast.IastModule;
 import javax.annotation.Nullable;
 
-public interface UnvalidatedRedirectModule extends IastModule {
+public interface UnvalidatedRedirectModule extends HttpHeaderModule {
 
   void onRedirect(@Nullable String value);
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/sink/UnvalidatedRedirectModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/sink/UnvalidatedRedirectModule.java
@@ -1,0 +1,9 @@
+package datadog.trace.api.iast.sink;
+
+import datadog.trace.api.iast.IastModule;
+import javax.annotation.Nullable;
+
+public interface UnvalidatedRedirectModule extends IastModule {
+
+  void onRedirect(@Nullable String value);
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/iast/InstrumentationBridgeTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/iast/InstrumentationBridgeTest.groovy
@@ -1,11 +1,14 @@
 package datadog.trace.api.iast
 
-import datadog.trace.api.iast.propagation.StringModule
+
 import datadog.trace.api.iast.propagation.CodecModule
+import datadog.trace.api.iast.propagation.StringModule
 import datadog.trace.api.iast.sink.CommandInjectionModule
+import datadog.trace.api.iast.sink.InsecureCookieModule
 import datadog.trace.api.iast.sink.LdapInjectionModule
 import datadog.trace.api.iast.sink.PathTraversalModule
 import datadog.trace.api.iast.sink.SqlInjectionModule
+import datadog.trace.api.iast.sink.UnvalidatedRedirectModule
 import datadog.trace.api.iast.sink.WeakCipherModule
 import datadog.trace.api.iast.sink.WeakHashModule
 import datadog.trace.api.iast.source.WebModule
@@ -56,5 +59,33 @@ class InstrumentationBridgeTest extends DDSpecification {
 
     then:
     thrown(UnsupportedOperationException)
+  }
+
+  void 'registered HttpHeaderModules are called on header callback'() {
+    setup:
+    final insecureCookieModule = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(insecureCookieModule)
+    final unvalidatedRedirectModule = Mock(UnvalidatedRedirectModule)
+    InstrumentationBridge.registerIastModule(unvalidatedRedirectModule)
+
+    when:
+    InstrumentationBridge.onHeader("name", "value")
+
+    then:
+    1 * insecureCookieModule.onHeader("name", "value")
+    1 * unvalidatedRedirectModule.onHeader("name", "value")
+  }
+
+  void 'unregistered HttpHeaderModules are not called on header callback'() {
+    setup:
+    final insecureCookieModule = Mock(InsecureCookieModule)
+    final unvalidatedRedirectModule = Mock(UnvalidatedRedirectModule)
+
+    when:
+    InstrumentationBridge.onHeader("name", "value")
+
+    then:
+    0 * insecureCookieModule.onHeader("name", "value")
+    0 * unvalidatedRedirectModule.onHeader("name", "value")
   }
 }


### PR DESCRIPTION
# What Does This Do
Add instrumentation to javax.servlet.http.HttpServletResponse:
- addHeader/setHeader for location headers
- sendRedirect

Add tainting support to javax.servlet.http.HttpServletResponse:
- encodeURL
- encodeRedirectURL

Unify Header instrumentation callbacks, we need to analice the headers with multiple sink modules at the same time

# Motivation
- Support Unvalidated redirect vulnerability

# Additional Notes
This is a first iteration, only supports servlet unvalidated redirect vulnerability