### PR TITLE
record time spent in TPE work queue

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -32,6 +32,7 @@ import datadog.trace.api.config.TracerConfig;
 import datadog.trace.api.config.UsmConfig;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.gateway.SubscriptionService;
+import datadog.trace.api.profiling.Timer;
 import datadog.trace.api.scopemanager.ScopeListener;
 import datadog.trace.bootstrap.benchmark.StaticEventLogger;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -873,6 +874,13 @@ public class Agent {
                               .getDeclaredConstructor()
                               .newInstance();
                   tracer.registerCheckpointer(endpointCheckpointer);
+                  Timer timer =
+                      (Timer)
+                          AGENT_CLASSLOADER
+                              .loadClass("com.datadog.profiling.controller.openjdk.JFRTimer")
+                              .getDeclaredConstructor()
+                              .newInstance();
+                  tracer.registerTimer(timer);
                 } catch (Throwable e) {
                   if (e instanceof InvocationTargetException) {
                     e = e.getCause();

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/TaskWrapper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/TaskWrapper.java
@@ -1,0 +1,15 @@
+package datadog.trace.bootstrap;
+
+public interface TaskWrapper {
+  static Class<?> getUnwrappedType(Object task) {
+    int depth = 0;
+    Object inspected = task;
+    while (depth < 3 && inspected instanceof TaskWrapper) {
+      inspected = ((TaskWrapper) inspected).$$DD$$__unwrap();
+      depth++;
+    }
+    return inspected == null ? null : inspected.getClass();
+  }
+
+  Object $$DD$$__unwrap();
+}

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
@@ -24,6 +24,7 @@ public class AdviceUtils {
 
   public static AgentScope startTaskScope(State state, boolean migrated) {
     if (state != null) {
+      state.stopTiming();
       final AgentScope.Continuation continuation = state.getAndResetContinuation();
       if (continuation != null) {
         final AgentScope scope = continuation.activate();

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/TPEHelper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/TPEHelper.java
@@ -1,12 +1,17 @@
 package datadog.trace.bootstrap.instrumentation.java.concurrent;
 
+import static datadog.trace.bootstrap.TaskWrapper.getUnwrappedType;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.exclude;
 
+import datadog.trace.api.Config;
 import datadog.trace.api.GenericClassValue;
 import datadog.trace.api.InstrumenterConfig;
+import datadog.trace.api.profiling.QueueTiming;
+import datadog.trace.api.profiling.Timer;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.Set;
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -117,5 +122,21 @@ public final class TPEHelper {
       return;
     }
     AdviceUtils.cancelTask(contextStore, task);
+  }
+
+  @SuppressWarnings("deprecation")
+  public static void startQueuingTimer(
+      ContextStore<Runnable, State> taskContextStore, ThreadPoolExecutor executor, Runnable task) {
+    if (Config.get().isProfilingQueueingTimeEnabled()) {
+      State state = taskContextStore.get(task);
+      if (task != null && state != null) {
+        QueueTiming timing =
+            (QueueTiming) AgentTracer.get().getTimer().start(Timer.TimerType.QUEUEING);
+        timing.setTask(getUnwrappedType(task));
+        timing.setQueue(executor.getQueue().getClass());
+        timing.setScheduler(executor.getClass());
+        state.setTiming(timing);
+      }
+    }
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/TaskWrapperTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/TaskWrapperTest.groovy
@@ -1,0 +1,68 @@
+package datadog.trace.bootstrap
+
+import datadog.trace.test.util.DDSpecification
+
+class TaskWrapperTest extends DDSpecification {
+
+  def "test unwrapping"() {
+    when: "direct wrapping"
+    def directWrapper = new DirectWrapper()
+    then:
+    TaskWrapper.getUnwrappedType(directWrapper) == Integer
+
+    when: "wrapped value is null"
+    def nullWrapper = new RecursiveWrapper()
+    then:
+    TaskWrapper.getUnwrappedType(nullWrapper) == null
+
+    when: "recursive wrapped value within depth limit"
+    def shallowRecursiveWrapper = new RecursiveWrapper()
+    shallowRecursiveWrapper.wrapped = new DirectWrapper()
+    then:
+    TaskWrapper.getUnwrappedType(shallowRecursiveWrapper) == Integer
+
+    when: "recursive wrapped value exceeds depth limit"
+    def l1 = new DirectWrapper()
+    def l2 = new RecursiveWrapper()
+    l2.wrapped = l1
+    def l3 = new RecursiveWrapper()
+    l3.wrapped = l2
+    def l4 = new RecursiveWrapper()
+    l4.wrapped = l3
+    def deepRecursiveWrapper = l4
+    then: "terminate at max depth"
+    TaskWrapper.getUnwrappedType(deepRecursiveWrapper) == DirectWrapper
+
+    when: "cycle"
+    def outer = new RecursiveWrapper()
+    def inner = new RecursiveWrapper()
+    outer.wrapped = inner
+    inner.wrapped = outer
+    then: "terminate at max depth"
+    TaskWrapper.getUnwrappedType(outer) == RecursiveWrapper
+    TaskWrapper.getUnwrappedType(inner) == RecursiveWrapper
+  }
+
+
+  class RecursiveWrapper implements TaskWrapper {
+
+    TaskWrapper wrapped
+
+    @SuppressWarnings('MethodName')
+    @Override
+    Object $$DD$$__unwrap() {
+      return wrapped
+    }
+  }
+
+  class DirectWrapper implements TaskWrapper {
+
+    Integer field = 1
+
+    @SuppressWarnings('MethodName')
+    @Override
+    Object $$DD$$__unwrap() {
+      return field
+    }
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/resources/jfr/dd.jfp
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/resources/jfr/dd.jfp
@@ -246,3 +246,5 @@ datadog.ExceptionSample#enabled=true
 datadog.ExceptionCount#enabled=true
 datadog.ProfilerSetting#enabled=true
 datadog.ContextInterval#enabled=true
+datadog.QueueTime#enabled=true
+datadog.QueueTime#threshold=100 ms

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/JFRTimer.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/JFRTimer.java
@@ -1,0 +1,23 @@
+package com.datadog.profiling.controller.openjdk;
+
+import com.datadog.profiling.controller.openjdk.events.QueueTimeEvent;
+import com.datadog.profiling.utils.ExcludedVersions;
+import datadog.trace.api.profiling.Timer;
+import datadog.trace.api.profiling.Timing;
+import jdk.jfr.EventType;
+
+public class JFRTimer implements Timer {
+
+  public JFRTimer() {
+    ExcludedVersions.checkVersionExclusion();
+    EventType.getEventType(QueueTimeEvent.class);
+  }
+
+  @Override
+  public Timing start(TimerType type) {
+    if (type == TimerType.QUEUEING) {
+      return new QueueTimeEvent();
+    }
+    return Timing.NoOp.INSTANCE;
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/QueueTimeEvent.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/events/QueueTimeEvent.java
@@ -1,0 +1,71 @@
+package com.datadog.profiling.controller.openjdk.events;
+
+import datadog.trace.api.profiling.QueueTiming;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+@Name("datadog.QueueTime")
+@Label("QueueTime")
+@Description("Datadog queueing time event.")
+@Category("Datadog")
+@StackTrace(false)
+public class QueueTimeEvent extends Event implements QueueTiming {
+
+  @Label("Local Root Span Id")
+  private long localRootSpanId;
+
+  @Label("Span Id")
+  private long spanId;
+
+  @Label("Origin")
+  private Thread origin;
+
+  @Label("Task")
+  private Class<?> task;
+
+  @Label("Queue")
+  private Class<?> queue;
+
+  @Label("Scheduler")
+  private Class<?> scheduler;
+
+  public QueueTimeEvent() {
+    this.origin = Thread.currentThread();
+    AgentSpan activeSpan = AgentTracer.activeSpan();
+    if (activeSpan != null) {
+      long spanId = activeSpan.getSpanId();
+      AgentSpan rootSpan = activeSpan.getLocalRootSpan();
+      this.localRootSpanId = rootSpan == null ? spanId : rootSpan.getSpanId();
+      this.spanId = spanId;
+    }
+    begin();
+  }
+
+  public void setQueue(Class<?> queue) {
+    this.queue = queue;
+  }
+
+  @Override
+  public void setTask(Class<?> task) {
+    this.task = task;
+  }
+
+  @Override
+  public void setScheduler(Class<?> scheduler) {
+    this.scheduler = scheduler;
+  }
+
+  @Override
+  public void close() {
+    end();
+    if (shouldCommit()) {
+      commit();
+    }
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/JFRTimerTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/JFRTimerTest.java
@@ -1,0 +1,68 @@
+package com.datadog.profiling.controller.openjdk;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datadog.profiling.controller.openjdk.events.QueueTimeEvent;
+import com.datadog.profiling.utils.ExcludedVersions;
+import datadog.trace.api.profiling.Timer;
+import datadog.trace.api.profiling.Timing;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.ThreadPoolExecutor;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class JFRTimerTest {
+
+  private Recording recording;
+  Instant start;
+
+  @BeforeEach
+  public void setupRecording() {
+    Assumptions.assumeFalse(ExcludedVersions.isVersionExcluded());
+    start = Instant.now();
+    recording = new Recording();
+    recording.enable("datadog.QueueTime");
+    recording.setSettings(Collections.singletonMap("datadog.QueueTime#threshold", "0 ms"));
+    recording.start();
+  }
+
+  @Test
+  public void testTimer() throws IOException {
+    Assumptions.assumeFalse(ExcludedVersions.isVersionExcluded());
+    JFRTimer timer = new JFRTimer();
+    Timing timing = timer.start(Timer.TimerType.QUEUEING);
+    assertTrue(timing instanceof QueueTimeEvent);
+    QueueTimeEvent queueTimeEvent = (QueueTimeEvent) timing;
+    queueTimeEvent.setQueue(ArrayBlockingQueue.class);
+    queueTimeEvent.setScheduler(ThreadPoolExecutor.class);
+    queueTimeEvent.setTask(FutureTask.class);
+    Thread thread = new Thread(queueTimeEvent::close);
+    thread.setName("something completely different");
+    thread.start();
+    Path output = Files.createTempFile("recording", ".jfr");
+    output.toFile().deleteOnExit();
+    recording.dump(output);
+    recording.close();
+    RecordedEvent event =
+        RecordingFile.readAllEvents(output).stream()
+            .filter(it -> it.getEventType().getName().equalsIgnoreCase("datadog.QueueTime"))
+            .findFirst()
+            .orElseThrow(AssertionError::new);
+    assertEquals(FutureTask.class.getName(), event.getClass("task").getName());
+    assertEquals(ThreadPoolExecutor.class.getName(), event.getClass("scheduler").getName());
+    assertEquals(ArrayBlockingQueue.class.getName(), event.getClass("queue").getName());
+    assertEquals(Thread.currentThread().getName(), event.getThread("origin").getJavaName());
+    assertEquals(thread.getName(), event.getThread().getJavaName());
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/SafeToLoadJFRCheckpointerTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/SafeToLoadJFRCheckpointerTest.java
@@ -12,5 +12,6 @@ public class SafeToLoadJFRCheckpointerTest {
   public void testSafeToLoad() {
     Assumptions.assumeTrue(ExcludedVersions.isVersionExcluded());
     assertThrows(IllegalArgumentException.class, JFRCheckpointer::new);
+    assertThrows(IllegalArgumentException.class, JFRTimer::new);
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/profiling/UnwrappingVisitor.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/profiling/UnwrappingVisitor.java
@@ -1,0 +1,135 @@
+package datadog.trace.agent.tooling.bytebuddy.profiling;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import net.bytebuddy.asm.AsmVisitorWrapper;
+import net.bytebuddy.description.field.FieldDescription;
+import net.bytebuddy.description.field.FieldList;
+import net.bytebuddy.description.method.MethodList;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.jar.asm.ClassVisitor;
+import net.bytebuddy.jar.asm.FieldVisitor;
+import net.bytebuddy.jar.asm.MethodVisitor;
+import net.bytebuddy.jar.asm.Opcodes;
+import net.bytebuddy.pool.TypePool;
+import net.bytebuddy.utility.OpenedClassReader;
+
+public class UnwrappingVisitor implements AsmVisitorWrapper {
+
+  private final Map<String, String> classNameToDelegateFieldNames;
+
+  public UnwrappingVisitor(String... classAndDelegateFieldNames) {
+    assert classAndDelegateFieldNames.length % 2 == 0;
+    classNameToDelegateFieldNames = new HashMap<>(classAndDelegateFieldNames.length);
+    for (int i = 0; i < classAndDelegateFieldNames.length; i += 2) {
+      classNameToDelegateFieldNames.put(
+          classAndDelegateFieldNames[i], classAndDelegateFieldNames[i + 1]);
+    }
+  }
+
+  @Override
+  public int mergeWriter(int flags) {
+    return flags;
+  }
+
+  @Override
+  public int mergeReader(int flags) {
+    return flags;
+  }
+
+  @Override
+  public ClassVisitor wrap(
+      TypeDescription instrumentedType,
+      ClassVisitor classVisitor,
+      Implementation.Context implementationContext,
+      TypePool typePool,
+      FieldList<FieldDescription.InDefinedShape> fields,
+      MethodList<?> methods,
+      int writerFlags,
+      int readerFlags) {
+    String fieldName = classNameToDelegateFieldNames.get(instrumentedType.getName());
+    return fieldName == null
+        ? classVisitor
+        : new ImplementTaskWrapperClassVisitor(
+            classVisitor, instrumentedType.getInternalName(), fieldName);
+  }
+
+  private static class ImplementTaskWrapperClassVisitor extends ClassVisitor {
+
+    private static final String TASK_WRAPPER = "datadog/trace/bootstrap/TaskWrapper";
+
+    private final String className;
+    private final String fieldName;
+    private boolean modify = false;
+    private String descriptor;
+
+    protected ImplementTaskWrapperClassVisitor(
+        ClassVisitor classVisitor, String className, String fieldName) {
+      super(OpenedClassReader.ASM_API, classVisitor);
+      this.className = className;
+      this.fieldName = fieldName;
+    }
+
+    @Override
+    public void visit(
+        int version,
+        int access,
+        String name,
+        String signature,
+        String superName,
+        String[] interfaces) {
+      if (interfaces == null || !Arrays.asList(interfaces).contains(TASK_WRAPPER)) {
+        interfaces = append(interfaces, TASK_WRAPPER);
+        modify = true;
+      }
+      super.visit(version, access, name, signature, superName, interfaces);
+    }
+
+    private static String[] append(String[] strings, String toAppend) {
+      if (strings == null || strings.length == 0) {
+        return new String[] {toAppend};
+      }
+      String[] appended = Arrays.copyOf(strings, strings.length + 1);
+      appended[strings.length] = toAppend;
+      return appended;
+    }
+
+    @Override
+    public FieldVisitor visitField(
+        int access, String name, String descriptor, String signature, Object value) {
+      if (fieldName.equals(name)) {
+        this.descriptor = descriptor;
+      }
+      return super.visitField(access, name, descriptor, signature, value);
+    }
+
+    @Override
+    public void visitEnd() {
+      if (modify) {
+        addUnwrap();
+      }
+    }
+
+    private void addUnwrap() {
+      MethodVisitor mv =
+          cv.visitMethod(Opcodes.ACC_PUBLIC, "$$DD$$__unwrap", "()Ljava/lang/Object;", null, null);
+      mv.visitCode();
+      if (descriptor != null) {
+        // we found the field so can return it
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitFieldInsn(Opcodes.GETFIELD, className, fieldName, descriptor);
+        mv.visitInsn(Opcodes.ARETURN);
+        mv.visitMaxs(1, 1);
+      } else {
+        // we've added the interface but haven't found the field we wanted to unwrap,
+        // so we have to generate the method, so just return null
+        mv.visitInsn(Opcodes.ACONST_NULL);
+        mv.visitInsn(Opcodes.ARETURN);
+        mv.visitMaxs(1, 1);
+      }
+      mv.visitEnd();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/TaskWrapperInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/TaskWrapperInstrumentation.java
@@ -1,0 +1,33 @@
+package datadog.trace.instrumentation.java.concurrent;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.bytebuddy.profiling.UnwrappingVisitor;
+
+@AutoService(Instrumenter.class)
+public class TaskWrapperInstrumentation extends Instrumenter.Profiling
+    implements Instrumenter.ForKnownTypes {
+  public TaskWrapperInstrumentation() {
+    super("java_concurrent", "wrapper-task");
+  }
+
+  @Override
+  public AdviceTransformer transformer() {
+    return new VisitingTransformer(
+        new UnwrappingVisitor(
+            "java.util.concurrent.FutureTask",
+            "callable",
+            "java.util.concurrent.Executors$RunnableAdapter",
+            "task"));
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {}
+
+  @Override
+  public String[] knownMatchingTypes() {
+    return new String[] {
+      "java.util.concurrent.FutureTask", "java.util.concurrent.Executors$RunnableAdapter"
+    };
+  }
+}

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorInstrumentation.java
@@ -16,6 +16,7 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.ExcludeFilterProvider;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.Platform;
+import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
@@ -89,7 +90,7 @@ public final class ThreadPoolExecutorInstrumentation extends Instrumenter.Tracin
   public Map<String, String> contextStore() {
     final Map<String, String> stores = new HashMap<>();
     stores.put(TPE, Boolean.class.getName());
-    stores.put("java.lang.Runnable", State.class.getName());
+    stores.put(Runnable.class.getName(), State.class.getName());
     return Collections.unmodifiableMap(stores);
   }
 
@@ -141,14 +142,17 @@ public final class ThreadPoolExecutorInstrumentation extends Instrumenter.Tracin
   public static final class Execute {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void capture(
-        @Advice.This final ThreadPoolExecutor zis,
+        @Advice.This final ThreadPoolExecutor tpe,
         @Advice.Argument(readOnly = false, value = 0) Runnable task) {
       if (TPEHelper.shouldPropagate(
-          InstrumentationContext.get(ThreadPoolExecutor.class, Boolean.class), zis)) {
+          InstrumentationContext.get(ThreadPoolExecutor.class, Boolean.class), tpe)) {
         if (TPEHelper.useWrapping(task)) {
           task = Wrapper.wrap(task);
         } else {
-          TPEHelper.capture(InstrumentationContext.get(Runnable.class, State.class), task);
+          ContextStore<Runnable, State> contextStore =
+              InstrumentationContext.get(Runnable.class, State.class);
+          TPEHelper.capture(contextStore, task);
+          TPEHelper.startQueuingTimer(contextStore, tpe, task);
         }
       }
     }

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ExecutorInstrumentationTest.groovy
@@ -26,6 +26,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScop
 import static org.junit.Assume.assumeTrue
 
 abstract class ExecutorInstrumentationTest extends AgentTestRunner {
+
   @Shared
   def executeRunnable = { e, c -> e.execute((Runnable) c) }
   @Shared
@@ -65,6 +66,9 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
 
     injectSysConfig("dd.trace.executors", "CustomThreadPoolExecutor")
     injectSysConfig("trace.thread-pool-executors.exclude", "ExecutorInstrumentationTest\$ToBeIgnoredExecutor")
+    // FIXME settings not being applied, which means the task unwrapping is not being tested
+    injectSysConfig("dd.profiling.enabled", "true")
+    injectSysConfig("dd.profiling.experimental.queueing.time.enabled", "true")
   }
 
   @Unroll

--- a/dd-smoke-tests/profiling-integration-tests/src/main/java/datadog/smoketest/profiling/ProfilingTestApplication.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/main/java/datadog/smoketest/profiling/ProfilingTestApplication.java
@@ -6,21 +6,33 @@ import datadog.trace.api.experimental.ProfilingContextSetter;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
+import java.util.List;
 import java.util.Random;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class ProfilingTestApplication {
   private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
 
-  public static void main(final String[] args) throws InterruptedException {
+  private static final ExecutorService EXECUTOR_SERVICE = Executors.newSingleThreadExecutor();
+
+  public static void main(final String[] args) throws InterruptedException, ExecutionException {
     ProfilingContextSetter foo = Profiling.get().createContextSetter("foo");
     long duration = -1;
     if (args.length > 0) {
       duration = TimeUnit.SECONDS.toMillis(Long.parseLong(args[0]));
     }
     setupDeadlock();
+    submitWorkToTPE();
     final long startTime = System.currentTimeMillis();
     int counter = 0;
     while (true) {
@@ -62,6 +74,20 @@ public class ProfilingTestApplication {
       }
     }
     System.out.println("accumulated: " + accumulator);
+  }
+
+  private static void submitWorkToTPE() throws ExecutionException, InterruptedException {
+    AtomicInteger it = new AtomicInteger();
+    for (int i = 0; i < 100; i++) {
+      EXECUTOR_SERVICE.submit(it::getAndIncrement).get();
+    }
+    List<Callable<Integer>> runnables =
+        IntStream.range(0, 100)
+            .mapToObj(i -> (Callable<Integer>) it::getAndIncrement)
+            .collect(Collectors.toList());
+    for (Future f : EXECUTOR_SERVICE.invokeAll(runnables)) {
+      f.get();
+    }
   }
 
   private static void setupDeadlock() {

--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/JFRBasedProfilingIntegrationTest.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/JFRBasedProfilingIntegrationTest.java
@@ -603,6 +603,7 @@ class JFRBasedProfilingIntegrationTest {
     assertEquals(Runtime.getRuntime().availableProcessors(), val);
 
     assertTrue(events.apply(ItemFilters.type("datadog.ProfilerSetting")).hasItems());
+    assertTrue(events.apply(ItemFilters.type("datadog.QueueTime")).hasItems());
   }
 
   private static <T> T getParameter(
@@ -687,7 +688,7 @@ class JFRBasedProfilingIntegrationTest {
             "-Ddd.profiling.endpoint.collection.enabled=" + endpointCollectionEnabled,
             "-Ddd.profiling.upload.timeout=" + PROFILING_UPLOAD_TIMEOUT_SECONDS,
             "-Ddd.profiling.debug.dump_path=/tmp/dd-profiler",
-            "-Ddd.profiling.ddprof.experimental.queueing.time.enabled=true",
+            "-Ddd.profiling.experimental.queueing.time.enabled=true",
             "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug",
             "-Ddd.profiling.experimental.context.attributes=foo,bar",
             "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug",

--- a/dd-smoke-tests/profiling-integration-tests/src/test/resources/overrides.jfp
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/resources/overrides.jfp
@@ -1,1 +1,3 @@
 datadog.Deadlock#period=1 s
+datadog.QueueTime#enabled=true
+datadog.QueueTime#threshold=0 ms

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -151,7 +151,7 @@ public final class ProfilingConfig {
       "profiling.experimental.context.attributes.span.name.enabled";
 
   public static final String PROFILING_QUEUEING_TIME_ENABLED =
-      "profiling.ddprof.experimental.queueing.time.enabled";
+      "profiling.experimental.queueing.time.enabled";
 
   public static final boolean PROFILING_QUEUEING_TIME_ENABLED_DEFAULT = false;
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -45,6 +45,7 @@ import datadog.trace.api.gateway.SubscriptionService;
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.api.interceptor.TraceInterceptor;
 import datadog.trace.api.internal.TraceSegment;
+import datadog.trace.api.profiling.Timer;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.api.scopemanager.ScopeListener;
 import datadog.trace.api.time.SystemTimeSource;
@@ -177,6 +178,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   private final boolean disableSamplingMechanismValidation;
   private final TimeSource timeSource;
   private final ProfilingContextIntegration profilingContextIntegration;
+
+  private Timer timer = Timer.NoOp.INSTANCE;
 
   /**
    * JVM shutdown callback, keeping a reference to it to remove this if DDTracer gets destroyed
@@ -886,6 +889,11 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     return dataStreamsMonitoring;
   }
 
+  @Override
+  public Timer getTimer() {
+    return timer;
+  }
+
   private final RatelimitedLogger rlLog = new RatelimitedLogger(log, 1, MINUTES);
 
   /**
@@ -1083,6 +1091,11 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   @Override
   public void registerCheckpointer(EndpointCheckpointer implementation) {
     endpointCheckpointer.register(implementation);
+  }
+
+  @Override
+  public void registerTimer(Timer timer) {
+    this.timer = timer;
   }
 
   @Override

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -114,6 +114,10 @@ excludedClassesCoverage += [
   "datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration.NoOp",
   // debug
   'datadog.trace.api.iast.Taintable.DebugLogger',
+  // stubs
+  'datadog.trace.api.profiling.Timing.NoOp',
+  'datadog.trace.api.profiling.Timer.NoOp',
+  'datadog.trace.api.profiling.Timer.TimerType'
 ]
 
 excludedClassesBranchCoverage = [

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -205,6 +205,8 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_PASSWORD;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_PORT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_PORT_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_USERNAME;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_START_DELAY;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_START_DELAY_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_START_FORCE_FIRST;
@@ -536,6 +538,8 @@ public class Config {
   private final boolean profilingExcludeAgentThreads;
   private final boolean profilingUploadSummaryOn413Enabled;
   private final boolean profilingRecordExceptionMessage;
+
+  private final boolean profilingQueueingTimeEnabled;
 
   private final boolean crashTrackingAgentless;
   private final Map<String, String> crashTrackingTags;
@@ -1215,6 +1219,10 @@ public class Config {
     profilingRecordExceptionMessage =
         configProvider.getBoolean(
             PROFILING_EXCEPTION_RECORD_MESSAGE, PROFILING_EXCEPTION_RECORD_MESSAGE_DEFAULT);
+
+    profilingQueueingTimeEnabled =
+        configProvider.getBoolean(
+            PROFILING_QUEUEING_TIME_ENABLED, PROFILING_QUEUEING_TIME_ENABLED_DEFAULT);
 
     profilingUploadSummaryOn413Enabled =
         configProvider.getBoolean(
@@ -1970,6 +1978,10 @@ public class Config {
 
   public boolean isDatadogProfilerEnabled() {
     return isDatadogProfilerEnabled;
+  }
+
+  public boolean isProfilingQueueingTimeEnabled() {
+    return profilingQueueingTimeEnabled;
   }
 
   public static boolean isDatadogProfilerSafeInCurrentEnvironment() {

--- a/internal-api/src/main/java/datadog/trace/api/profiling/QueueTiming.java
+++ b/internal-api/src/main/java/datadog/trace/api/profiling/QueueTiming.java
@@ -1,0 +1,9 @@
+package datadog.trace.api.profiling;
+
+public interface QueueTiming extends Timing {
+  void setQueue(Class<?> queue);
+
+  void setTask(Class<?> task);
+
+  void setScheduler(Class<?> scheduler);
+}

--- a/internal-api/src/main/java/datadog/trace/api/profiling/Timer.java
+++ b/internal-api/src/main/java/datadog/trace/api/profiling/Timer.java
@@ -1,0 +1,20 @@
+package datadog.trace.api.profiling;
+
+public interface Timer {
+
+  enum TimerType {
+    QUEUEING
+  }
+
+  Timing start(TimerType type);
+
+  final class NoOp implements Timer {
+
+    public static final Timer INSTANCE = new NoOp();
+
+    @Override
+    public Timing start(TimerType type) {
+      return Timing.NoOp.INSTANCE;
+    }
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/profiling/Timing.java
+++ b/internal-api/src/main/java/datadog/trace/api/profiling/Timing.java
@@ -1,0 +1,22 @@
+package datadog.trace.api.profiling;
+
+public interface Timing extends AutoCloseable {
+  @Override
+  void close();
+
+  class NoOp implements Timing, QueueTiming {
+    public static final Timing INSTANCE = new NoOp();
+
+    @Override
+    public void close() {}
+
+    @Override
+    public void setQueue(Class<?> queue) {}
+
+    @Override
+    public void setTask(Class<?> task) {}
+
+    @Override
+    public void setScheduler(Class<?> scheduler) {}
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -18,6 +18,7 @@ import datadog.trace.api.gateway.SubscriptionService;
 import datadog.trace.api.interceptor.TraceInterceptor;
 import datadog.trace.api.internal.InternalTracer;
 import datadog.trace.api.internal.TraceSegment;
+import datadog.trace.api.profiling.Timer;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.api.scopemanager.ScopeListener;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context;
@@ -171,6 +172,8 @@ public class AgentTracer {
      */
     void registerCheckpointer(EndpointCheckpointer checkpointer);
 
+    void registerTimer(Timer timer);
+
     SubscriptionService getSubscriptionService(RequestContextSlot slot);
 
     CallbackProvider getCallbackProvider(RequestContextSlot slot);
@@ -184,6 +187,8 @@ public class AgentTracer {
     void notifyExtensionEnd(AgentSpan span, Object result, boolean isError);
 
     DataStreamsMonitoring getDataStreamsMonitoring();
+
+    Timer getTimer();
 
     String getTraceId(AgentSpan span);
 
@@ -354,6 +359,9 @@ public class AgentTracer {
     public void registerCheckpointer(EndpointCheckpointer checkpointer) {}
 
     @Override
+    public void registerTimer(Timer timer) {}
+
+    @Override
     public SubscriptionService getSubscriptionService(RequestContextSlot slot) {
       return SubscriptionService.SubscriptionServiceNoop.INSTANCE;
     }
@@ -446,6 +454,11 @@ public class AgentTracer {
     @Override
     public void setProduceCheckpoint(
         String type, String target, DataStreamsContextCarrier carrier) {}
+
+    @Override
+    public Timer getTimer() {
+      return Timer.NoOp.INSTANCE;
+    }
   }
 
   public static final class NoopAgentSpan implements AgentSpan {


### PR DESCRIPTION
# What Does This Do

Records time spent in the `ThreadPoolExecutor` work queue and emits an event before the scheduled task runs if a threshold of 100ms is breached.

This is the first step in better accounting for time spent off-CPU. Currently we have some profiling for off-CPU time in our wallclock profiler, but this only can only records samples when a thread is blocked. Reactive frameworks tend to avoid blocking, so instead we emit latency thresholded events. The timer itself currently emits an OpenJDK JFR event for ease of development, but in the future this will be moved into our native profiler to better support non-OpenJDK JVMs such as J9. 

The timer state is propagated as a field in `State`. This was chosen over `Continuation` to have more control over which context switches are timed, since there can be multiple individual `Continutation`s per context switch (e.g. `CompletableFuture` can create a `FutureTask`s, creating stacked `Continuation`s) we only want to time a subset of `Continuation`s. 

We record various fields on the events:
* the class name of the queue implementation
* the class name of the task (which is intended to help users to figure out which task was waiting in the queue
* the name of the scheduler (in this case, `ThreadPoolExecutor`, but this will encompass at least the FJP and netty in the future). 

Getting access to the task name is tricky because there is generally a lot of wrapping involved in asynchronous task submission, and we want to record the name of the user's `Runnable` or `Callable`, not some `FutureTask` or some other adapter. To achieve this, certain known wrapper classes (currently there are two: `FutureTask` and `Executors$RunnableAdapter`) are modified to implement `TaskWrapper`, which exposes the field we want to unwrap. The interface has static functionality to recursively unwrap the type. Care needs to be taken here to avoid cycles or very deep delegation chains.

The new instrumentation is disabled unless profiling is enabled, and the events are disabled unless `-Ddd.profiling.experimental.queueing.time.enabled=true` is set.

# Motivation

# Additional Notes

I have some concerns about the unwrapping approach in light of [JDK-8180450](https://bugs.openjdk.org/browse/JDK-8180450). Successful interface checks on a type lead to updating `secondary_super_cache`, and we currently do at least 2 interface checks on certain types used in context propagation: against `RunnableFuture` in various places and against `FieldBackedContextAccessor` before accessing the context fields. This PR adds another interface check which will not make the status quo any worse, but will make it harder to get down to one (I think most `RunnableFuture` checks could be refactored away).
