### PR TITLE
Fix scheduled deploys

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -88,7 +88,7 @@ package:
 deploy_to_reliability_env:
   stage: deploy
   rules:
-    - if: $CI_PIPELINE_SOURCE == "scheduled"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
       when: on_success
     - when: manual
       allow_failure: true


### PR DESCRIPTION
What does this PR do?
The correct value of CI_PIPELINE_SOURCE is schedule not scheduled. See https://docs.gitlab.com/ee/ci/variables/predefined_variables.html

Motivation

Typo from a previous commit
