### PR TITLE
Instrumentation api for TraceConfig

### DIFF
--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/ProcessImplStartAdvice.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/ProcessImplStartAdvice.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.java.lang;
 
+import datadog.trace.api.TraceConfig;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
@@ -22,7 +23,7 @@ class ProcessImplStartAdvice {
     AgentTracer.TracerAPI tracer = AgentTracer.get();
 
     Map<String, String> tags = ProcessImplInstrumentationHelpers.createTags(command);
-    TagContext tagContext = new TagContext("appsec", tags);
+    TagContext tagContext = new TagContext("appsec", tags, AgentTracer.traceConfig());
     AgentSpan span = tracer.startSpan("command_execution", tagContext);
     span.setSpanType("system");
     span.setResourceName(ProcessImplInstrumentationHelpers.determineResource(command));

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -644,8 +644,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
    *
    * @return a PendingTrace
    */
-  public PendingTrace createTrace(DDTraceId id) {
-    return pendingTraceFactory.create(id);
+  public PendingTrace createTrace(DDTraceId id, TraceConfig traceConfig) {
+    return pendingTraceFactory.create(id, traceConfig);
   }
 
   /**
@@ -1430,6 +1430,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         propagationTags = propagationTagsFactory.empty();
       } else {
         long endToEndStartTime;
+        final TraceConfig traceConfig;
 
         if (parentContext instanceof ExtractedContext) {
           // Propagate external trace
@@ -1466,6 +1467,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
           requestContextDataAppSec = tc.getRequestContextDataAppSec();
           requestContextDataIast = tc.getRequestContextDataIast();
           ciVisibilityContextData = tc.getCiVisibilityContextData();
+          traceConfig = tc.getTraceConfig();
         } else {
           coreTags = null;
           origin = null;
@@ -1473,11 +1475,12 @@ public class CoreTracer implements AgentTracer.TracerAPI {
           requestContextDataAppSec = null;
           requestContextDataIast = null;
           ciVisibilityContextData = null;
+          traceConfig = captureTraceConfig();
         }
 
         rootSpanTags = localRootSpanTags;
 
-        parentTrace = createTrace(traceId);
+        parentTrace = createTrace(traceId, traceConfig);
 
         if (endToEndStartTime > 0) {
           parentTrace.beginEndToEnd(endToEndStartTime);

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -6,6 +6,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.Functions;
+import datadog.trace.api.TraceConfig;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
 import datadog.trace.api.config.TracerConfig;
@@ -844,5 +845,10 @@ public class DDSpanContext
     // TODO is this decided?
     String tagKey = "_dd." + key + ".json";
     this.setTag(tagKey, value);
+  }
+
+  @Override
+  public TraceConfig getTraceConfig() {
+    return trace.getTraceConfig();
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -59,9 +59,9 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
       this.healthMetrics = healthMetrics;
     }
 
-    PendingTrace create(@Nonnull DDTraceId traceId) {
+    PendingTrace create(@Nonnull DDTraceId traceId, TraceConfig traceConfig) {
       return new PendingTrace(
-          tracer, traceId, pendingTraceBuffer, timeSource, strictTraceWrites, healthMetrics);
+          tracer, traceId, pendingTraceBuffer, timeSource, strictTraceWrites, healthMetrics, traceConfig);
     }
   }
 
@@ -117,14 +117,15 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
       @Nonnull PendingTraceBuffer pendingTraceBuffer,
       @Nonnull TimeSource timeSource,
       boolean strictTraceWrites,
-      HealthMetrics healthMetrics) {
+      HealthMetrics healthMetrics,
+      TraceConfig traceConfig) {
     this.tracer = tracer;
     this.traceId = traceId;
     this.pendingTraceBuffer = pendingTraceBuffer;
     this.timeSource = timeSource;
     this.strictTraceWrites = strictTraceWrites;
     this.healthMetrics = healthMetrics;
-    this.traceConfig = tracer.captureTraceConfig();
+    this.traceConfig = traceConfig;
   }
 
   CoreTracer getTracer() {
@@ -152,6 +153,10 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
 
   public TimeSource getTimeSource() {
     return timeSource;
+  }
+
+  public TraceConfig getTraceConfig() {
+    return traceConfig;
   }
 
   public void touch() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -54,6 +54,8 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
   private final boolean clientIpWithoutAppSec;
   private boolean collectIpHeaders;
 
+  private TraceConfig traceConfig;
+
   protected static final boolean LOG_EXTRACT_HEADER_NAMES = Config.get().isLogExtractHeaderNames();
   private static final DDCache<String, String> CACHE = DDCaches.newFixedSizeCache(64);
 
@@ -221,6 +223,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
             || this.clientIpResolutionEnabled && ActiveSubsystems.APPSEC_ACTIVE;
     taggedHeaders = traceConfig.getTaggedHeaders();
     baggageMapping = traceConfig.getBaggageMapping();
+    this.traceConfig = traceConfig;
     return this;
   }
 
@@ -238,7 +241,8 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
                 baggage,
                 tags,
                 httpHeaders,
-                propagationTags);
+                propagationTags,
+                traceConfig);
         return context;
       } else if (origin != null
           || !tags.isEmpty()
@@ -246,7 +250,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
           || !baggage.isEmpty()
           || samplingPriority != PrioritySampling.UNSET) {
         return new TagContext(
-            origin, tags, httpHeaders, baggage, samplingPriorityOrDefault(samplingPriority));
+            origin, tags, httpHeaders, baggage, samplingPriorityOrDefault(samplingPriority), traceConfig);
       }
     }
     return null;

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
@@ -1,6 +1,7 @@
 package datadog.trace.core.propagation;
 
 import datadog.trace.api.DDTraceId;
+import datadog.trace.api.TraceConfig;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import java.util.Map;
 
@@ -22,8 +23,9 @@ public class ExtractedContext extends TagContext {
       final Map<String, String> baggage,
       final Map<String, String> tags,
       final HttpHeaders httpHeaders,
-      final PropagationTags propagationTags) {
-    super(origin, tags, httpHeaders, baggage, samplingPriority);
+      final PropagationTags propagationTags,
+      final TraceConfig traceConfig) {
+    super(origin, tags, httpHeaders, baggage, samplingPriority, traceConfig);
     this.traceId = traceId;
     this.spanId = spanId;
     this.endToEndStartTime = endToEndStartTime;

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -1,6 +1,7 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
 import datadog.trace.api.DDTraceId;
+import datadog.trace.api.TraceConfig;
 import datadog.trace.api.gateway.IGSpanInfo;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.interceptor.MutableSpan;
@@ -179,6 +180,8 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo {
     Iterable<Map.Entry<String, String>> baggageItems();
 
     PathwayContext getPathwayContext();
+
+    TraceConfig getTraceConfig();
 
     interface Extracted extends Context {
       String getForwarded();

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -6,6 +6,7 @@ import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.EndpointCheckpointer;
 import datadog.trace.api.EndpointTracker;
+import datadog.trace.api.TraceConfig;
 import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.api.experimental.DataStreamsCheckpointer;
 import datadog.trace.api.experimental.DataStreamsContextCarrier;
@@ -93,6 +94,15 @@ public class AgentTracer {
 
   public static AgentSpan noopSpan() {
     return get().noopSpan();
+  }
+
+  public static TraceConfig traceConfig() {
+    AgentSpan span = activeSpan();
+    if (span != null) {
+      return span.context().getTraceConfig();
+    } else {
+      return get().captureTraceConfig();
+    }
   }
 
   public static final TracerAPI NOOP_TRACER = new NoopTracerAPI();
@@ -184,6 +194,8 @@ public class AgentTracer {
     void notifyExtensionEnd(AgentSpan span, Object result, boolean isError);
 
     DataStreamsMonitoring getDataStreamsMonitoring();
+
+    TraceConfig captureTraceConfig();
   }
 
   public interface SpanBuilder {
@@ -310,6 +322,12 @@ public class AgentTracer {
 
     @Override
     public TraceSegment getTraceSegment() {
+      return null;
+    }
+
+    @Override
+    public TraceConfig captureTraceConfig() {
+      // FIXME: what to return here?
       return null;
     }
 
@@ -931,6 +949,12 @@ public class AgentTracer {
 
     @Override
     public String getCustomIpHeader() {
+      return null;
+    }
+
+    @Override
+    public TraceConfig getTraceConfig() {
+      // FIXME What to do here?
       return null;
     }
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
@@ -2,6 +2,7 @@ package datadog.trace.bootstrap.instrumentation.api;
 
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
+import datadog.trace.api.TraceConfig;
 import datadog.trace.api.sampling.PrioritySampling;
 import java.util.Collections;
 import java.util.Map;
@@ -24,12 +25,15 @@ public class TagContext implements AgentSpan.Context.Extracted {
 
   private final int samplingPriority;
 
+  private final TraceConfig traceConfig;
+
   public TagContext() {
-    this(null, null);
+    // FIXME: remove no-arg constructor and take trace config?
+    this(null, null, null);
   }
 
-  public TagContext(final String origin, final Map<String, String> tags) {
-    this(origin, tags, null, null, PrioritySampling.UNSET);
+  public TagContext(final String origin, final Map<String, String> tags, TraceConfig traceConfig) {
+    this(origin, tags, null, null, PrioritySampling.UNSET, traceConfig);
   }
 
   public TagContext(
@@ -37,12 +41,14 @@ public class TagContext implements AgentSpan.Context.Extracted {
       final Map<String, String> tags,
       HttpHeaders httpHeaders,
       final Map<String, String> baggage,
-      int samplingPriority) {
+      int samplingPriority,
+      TraceConfig traceConfig) {
     this.origin = origin;
     this.tags = tags;
     this.httpHeaders = httpHeaders == null ? EMPTY_HTTP_HEADERS : httpHeaders;
     this.baggage = baggage == null ? Collections.emptyMap() : baggage;
     this.samplingPriority = samplingPriority;
+    this.traceConfig = traceConfig;
   }
 
   public final CharSequence getOrigin() {
@@ -192,6 +198,11 @@ public class TagContext implements AgentSpan.Context.Extracted {
   @Override
   public PathwayContext getPathwayContext() {
     return null;
+  }
+
+  @Override
+  public TraceConfig getTraceConfig() {
+    return traceConfig;
   }
 
   public static class HttpHeaders {


### PR DESCRIPTION
**non-compiling POC**
In preparation for dynamic config, this PR adds some necessary machinery for instrumentation.

**AgentTracer, Context, TracerAPI**
* Adds `getTraceConfig()` to `Context`
* A static helper is added to `AgentTracer` so that instrumentations can get the TraceConfig easily from the active context (or a new snapshot if there is no active context)

**`TagContext`/`ExtractedContext`**
* The `TraceConfig` used during extraction is kept so that the resulting trace uses the same config. 
* Previous to this PR, one config could be used for extraction while a new config is assigned to the trace.

**`PendingTrace`**
The `TraceConfig` is passed in as a parameter. `CoreTracer` determines if there should be a new snapshot or the previously created one.

**Open questions**
* What object to return for the "Noop" context