### PR TITLE
Optimize CSI advices when fetching class file buffers

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/Advices.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/Advices.java
@@ -8,6 +8,7 @@ import datadog.trace.agent.tooling.bytebuddy.ClassFileLocators;
 import datadog.trace.agent.tooling.csi.CallSiteAdvice;
 import datadog.trace.agent.tooling.csi.Pointcut;
 import datadog.trace.api.Platform;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -17,6 +18,8 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.ClassFileLocator;
+import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.dynamic.scaffold.inline.AbstractInliningDynamicTypeBuilder;
 import net.bytebuddy.jar.asm.Handle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,7 +34,7 @@ public class Advices {
 
   public static final Advices EMPTY =
       new Advices(
-          Collections.<String, Map<String, Map<String, CallSiteAdvice>>>emptyMap(),
+          Collections.emptyMap(),
           new String[0],
           0,
           AdviceIntrospector.NoOpAdviceInstrospector.INSTANCE) {
@@ -40,6 +43,8 @@ public class Advices {
           return true;
         }
       };
+
+  private static final Field BUILDER_CLASS_LOCATOR_FIELD = resolveClassFileLocatorField();
 
   private final Map<String, Map<String, Map<String, CallSiteAdvice>>> advices;
 
@@ -129,11 +134,56 @@ public class Advices {
    * The method will try to discover the {@link CallSiteAdvice} that should be applied to a specific
    * type by using the assigned {@link AdviceIntrospector}
    */
-  public Advices findAdvices(@Nonnull final TypeDescription type, final ClassLoader loader) {
+  public Advices findAdvices(
+      @Nonnull final DynamicType.Builder<?> builder,
+      @Nonnull final TypeDescription type,
+      final ClassLoader loader) {
     if (advices.isEmpty()) {
       return this;
     }
-    return introspector.findAdvices(this, type, loader);
+    byte[] classFile = resolveFromBuilder(type, builder);
+    if (classFile == null) {
+      classFile = resolveFromLoader(type, loader);
+    }
+    if (classFile == null) {
+      return this; // do not do any filtering if we don't have access to the class file buffer
+    }
+    return introspector.findAdvices(this, classFile);
+  }
+
+  /**
+   * Try to fetch the class file buffer from the actual builder via introspection to improve
+   * performance
+   */
+  private byte[] resolveFromBuilder(
+      @Nonnull final TypeDescription type, @Nonnull final DynamicType.Builder<?> builder) {
+    if (builder instanceof AbstractInliningDynamicTypeBuilder
+        && BUILDER_CLASS_LOCATOR_FIELD != null) {
+      try {
+        final ClassFileLocator locator =
+            (ClassFileLocator) BUILDER_CLASS_LOCATOR_FIELD.get(builder);
+        final ClassFileLocator.Resolution resolution = locator.locate(type.getName());
+        return resolution.isResolved() ? resolution.resolve() : null;
+      } catch (Throwable e) {
+        if (LOG.isWarnEnabled()) {
+          LOG.warn("Failed to fetch type {} from builder", type.getName(), e);
+        }
+      }
+    }
+    return null;
+  }
+
+  /** Use the default class loader strategy to resolve the class file buffer */
+  private byte[] resolveFromLoader(@Nonnull final TypeDescription type, final ClassLoader loader) {
+    try (final ClassFileLocator locator = ClassFileLocators.classFileLocator(loader)) {
+      final ClassFileLocator.Resolution resolution = locator.locate(type.getName());
+      return resolution.isResolved() ? resolution.resolve() : null;
+    } catch (Throwable e) {
+      if (LOG.isWarnEnabled()) {
+        LOG.warn("Failed to fetch type {} from class loader", type.getName(), e);
+      }
+    }
+    return null;
   }
 
   // used for testing
@@ -187,6 +237,21 @@ public class Advices {
     return hasFlag(COMPUTE_MAX_STACK);
   }
 
+  private static Field resolveClassFileLocatorField() {
+    Field field;
+    try {
+      field = AbstractInliningDynamicTypeBuilder.class.getDeclaredField("classFileLocator");
+      field.setAccessible(true);
+      return field;
+    } catch (Throwable e) {
+      LOG.error(
+          "Failed to resolve field \"classFileLocator\" in {}",
+          AbstractInliningDynamicTypeBuilder.class,
+          e);
+    }
+    return null;
+  }
+
   /**
    * Instance of this class will try to discover the advices required to instrument a class before
    * visiting it
@@ -194,10 +259,7 @@ public class Advices {
   public interface AdviceIntrospector {
 
     @Nonnull
-    Advices findAdvices(
-        @Nonnull final Advices advices,
-        @Nonnull final TypeDescription type,
-        final ClassLoader classLoader);
+    Advices findAdvices(@Nonnull final Advices advices, @Nonnull final byte[] classFile);
 
     class NoOpAdviceInstrospector implements AdviceIntrospector {
 
@@ -205,9 +267,7 @@ public class Advices {
 
       @Override
       public @Nonnull Advices findAdvices(
-          final @Nonnull Advices advices,
-          final @Nonnull TypeDescription type,
-          final ClassLoader classLoader) {
+          final @Nonnull Advices advices, final @Nonnull byte[] classFile) {
         return advices;
       }
     }
@@ -232,30 +292,17 @@ public class Advices {
 
       @Override
       public @Nonnull Advices findAdvices(
-          final @Nonnull Advices advices,
-          final @Nonnull TypeDescription type,
-          final ClassLoader classLoader) {
-        try (final ClassFileLocator classFile = ClassFileLocators.classFileLocator(classLoader)) {
-          final ClassFileLocator.Resolution resolution = classFile.locate(type.getName());
-          if (!resolution.isResolved()) {
-            return advices; // cannot resolve class file so don't apply any filtering
+          final @Nonnull Advices advices, final @Nonnull byte[] classFile) {
+        final ConstantPool cp = new ConstantPool(classFile);
+        for (int index = 1; index < cp.getCount(); index++) {
+          final int referenceType = cp.getType(index);
+          final ConstantPoolHandler handler = CP_HANDLERS.get(referenceType);
+          // short circuit when any advice is found
+          if (handler != null && handler.findAdvice(advices, cp, index) != null) {
+            return advices;
           }
-          final ConstantPool cp = new ConstantPool(resolution.resolve());
-          for (int index = 1; index < cp.getCount(); index++) {
-            final int referenceType = cp.getType(index);
-            final ConstantPoolHandler handler = CP_HANDLERS.get(referenceType);
-            // short circuit when any advice is found
-            if (handler != null && handler.findAdvice(advices, cp, index) != null) {
-              return advices;
-            }
-          }
-          return EMPTY;
-        } catch (final Throwable e) {
-          if (LOG.isErrorEnabled()) {
-            LOG.error(String.format("Failed to introspect %s constant pool", type), e);
-          }
-          return advices; // in case of error we should continue without filtering
         }
+        return EMPTY;
       }
 
       /** Handler for a particular type of constant pool type (MethodRef, InvokeDynamic, ...) */

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteTransformer.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteTransformer.java
@@ -41,7 +41,7 @@ public class CallSiteTransformer implements Instrumenter.AdviceTransformer {
       final ClassLoader classLoader,
       final JavaModule module,
       final ProtectionDomain pd) {
-    Advices discovered = advices.findAdvices(type, classLoader);
+    Advices discovered = advices.findAdvices(builder, type, classLoader);
     return discovered.isEmpty() ? builder : builder.visit(new CallSiteVisitorWrapper(discovered));
   }
 

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/AdvicesInvokeDynamicTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/AdvicesInvokeDynamicTest.groovy
@@ -1,7 +1,6 @@
 package datadog.trace.agent.tooling.csi
 
 import datadog.trace.agent.tooling.bytebuddy.csi.Advices
-import net.bytebuddy.description.type.TypeDescription
 import spock.lang.Requires
 
 @Requires({
@@ -9,20 +8,15 @@ import spock.lang.Requires
 })
 class AdvicesInvokeDynamicTest extends BaseCallSiteTest {
 
-  def 'test constant pool introspector with invoke dynamic'(final Pointcut pointcutMock,
-    final boolean emptyAdvices,
-    final boolean adviceFound) {
+  void 'test constant pool introspector with invoke dynamic'() {
     setup:
-    final target = StringPlusExample
-    final targetType = Mock(TypeDescription) {
-      getName() >> target.name
-    }
+    final clazz = loadClass(StringPlusExample)
     final advice = mockInvokeDynamicAdvice(pointcutMock)
     final advices = Advices.fromCallSites(advice)
     final introspector = Advices.AdviceIntrospector.ConstantPoolInstrospector.INSTANCE
 
     when:
-    final result = introspector.findAdvices(advices, targetType, StringPlusExample.classLoader)
+    final result = introspector.findAdvices(advices, clazz)
     final found = result.findAdvice(pointcutMock) != null
 
     then:
@@ -35,20 +29,15 @@ class AdvicesInvokeDynamicTest extends BaseCallSiteTest {
     stringConcatFactoryPointcut() | false        | true
   }
 
-  def 'test constant pool introspector with invoke dynamic and constants'(final Pointcut pointcutMock,
-    final boolean emptyAdvices,
-    final boolean adviceFound) {
+  void 'test constant pool introspector with invoke dynamic and constants'() {
     setup:
-    final target = StringPlusConstantsExample
-    final targetType = Mock(TypeDescription) {
-      getName() >> target.name
-    }
+    final clazz = loadClass(StringPlusConstantsExample)
     final advice = mockInvokeDynamicAdvice(pointcutMock)
     final advices = Advices.fromCallSites(advice)
     final introspector = Advices.AdviceIntrospector.ConstantPoolInstrospector.INSTANCE
 
     when:
-    final result = introspector.findAdvices(advices, targetType, StringPlusConstantsExample.classLoader)
+    final result = introspector.findAdvices(advices, clazz)
     final found = result.findAdvice(pointcutMock) != null
 
     then:
@@ -59,5 +48,9 @@ class AdvicesInvokeDynamicTest extends BaseCallSiteTest {
     pointcutMock                  | emptyAdvices | adviceFound
     stringConcatPointcut()        | true         | false
     stringConcatFactoryPointcut() | false        | true
+  }
+
+  private static byte[] loadClass(final Class<?> clazz) {
+    return clazz.getResourceAsStream("${clazz.simpleName}.class").bytes
   }
 }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/AdvicesTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/AdvicesTest.groovy
@@ -1,7 +1,6 @@
 package datadog.trace.agent.tooling.csi
 
 import datadog.trace.agent.tooling.bytebuddy.csi.Advices
-import net.bytebuddy.description.type.TypeDescription
 
 import static datadog.trace.agent.tooling.csi.CallSiteAdvice.HasFlags.COMPUTE_MAX_STACK
 
@@ -98,26 +97,21 @@ class AdvicesTest extends BaseCallSiteTest {
     final advices = Advices.fromCallSites()
 
     when:
-    final result = introspector.findAdvices(advices, Mock(TypeDescription), Mock(ClassLoader))
+    final result = introspector.findAdvices(advices, [] as byte[])
 
     then:
     result == advices
   }
 
-  def 'test constant pool introspector'(final Pointcut pointcutMock,
-    final boolean emptyAdvices,
-    final boolean adviceFound) {
+  void 'test constant pool introspector'() {
     setup:
-    final target = StringConcatExample
-    final targetType = Mock(TypeDescription) {
-      getName() >> target.name
-    }
+    final target = loadClass(StringConcatExample)
     final advice = mockInvokeAdvice(pointcutMock)
     final advices = Advices.fromCallSites(advice)
     final introspector = Advices.AdviceIntrospector.ConstantPoolInstrospector.INSTANCE
 
     when:
-    final result = introspector.findAdvices(advices, targetType, StringConcatExample.classLoader)
+    final result = introspector.findAdvices(advices, target)
     final found = result.findAdvice(pointcutMock) != null
 
     then:
@@ -152,5 +146,9 @@ class AdvicesTest extends BaseCallSiteTest {
 
     then:
     advices.computeMaxStack()
+  }
+
+  private static byte[] loadClass(final Class<?> clazz) {
+    return clazz.getResourceAsStream("${clazz.simpleName}.class").bytes
   }
 }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/BaseCallSiteTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/BaseCallSiteTest.groovy
@@ -100,7 +100,7 @@ class BaseCallSiteTest extends DDSpecification {
     }
     return Mock(Advices) {
       isEmpty() >> advices.isEmpty()
-      findAdvices(_ as TypeDescription, _ as ClassLoader) >> it
+      findAdvices(_ as DynamicType.Builder, _ as TypeDescription, _ as ClassLoader) >> it
       findAdvice(_ as Pointcut) >> { params ->
         final pointcut = (params as Object[])[0] as Pointcut
         adviceFinder.call(pointcut.type(), pointcut.method(), pointcut.descriptor())


### PR DESCRIPTION
# What Does This Do
This PR reuses the class file buffer present in the `AbstractInliningDynamicTypeBuilder` via reflection before attempting a resolution of the class file before doing the constant pool analysis for the call sites

# Motivation
The main motivation for this PR is to reduce the time it takes for the CSI instrumentation to decide if a class has to be instrumented or not.

# Additional Notes
