### PR TITLE
Add runtimeId to probe statuses

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/JsonSnapshotSerializer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/JsonSnapshotSerializer.java
@@ -5,6 +5,7 @@ import com.datadog.debugger.util.MoshiHelper;
 import com.datadog.debugger.util.MoshiSnapshotHelper;
 import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.CapturedContext;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import java.util.Map;
@@ -174,6 +175,10 @@ public class JsonSnapshotSerializer implements DebuggerContext.ValueSerializer {
 
     public Snapshot getSnapshot() {
       return snapshot;
+    }
+
+    public String getRuntimeId() {
+      return Config.get().getRuntimeId();
     }
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ProbeStatus.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ProbeStatus.java
@@ -110,13 +110,15 @@ public class ProbeStatus {
 
     private final int probeVersion;
 
+    private final String runtimeId;
     private final Status status;
 
     private final ProbeException exception;
 
-    public Diagnostics(ProbeId probeId, Status status, ProbeException exception) {
+    public Diagnostics(ProbeId probeId, String runtimeId, Status status, ProbeException exception) {
       this.probeId = probeId != null ? probeId.getId() : null;
       this.probeVersion = probeId != null ? probeId.getVersion() : 0;
+      this.runtimeId = runtimeId;
       this.status = status;
       this.exception = exception;
     }
@@ -133,29 +135,33 @@ public class ProbeStatus {
       return exception;
     }
 
-    @Generated
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       Diagnostics that = (Diagnostics) o;
-      return probeId.equals(that.probeId)
+      return probeVersion == that.probeVersion
+          && Objects.equals(probeId, that.probeId)
+          && Objects.equals(runtimeId, that.runtimeId)
           && status == that.status
           && Objects.equals(exception, that.exception);
     }
 
-    @Generated
     @Override
     public int hashCode() {
-      return Objects.hash(probeId, status, exception);
+      return Objects.hash(probeId, probeVersion, runtimeId, status, exception);
     }
 
-    @Generated
     @Override
     public String toString() {
       return "Diagnostics{"
           + "probeId='"
           + probeId
+          + '\''
+          + ", probeVersion="
+          + probeVersion
+          + ", runtimeId='"
+          + runtimeId
           + '\''
           + ", status="
           + status
@@ -234,30 +240,32 @@ public class ProbeStatus {
 
     private final String serviceName;
 
-    public Builder(Config config) {
+    private final String runtimeId;
 
+    public Builder(Config config) {
       this.serviceName = TagsHelper.sanitize(config.getServiceName());
+      this.runtimeId = config.getRuntimeId();
     }
 
     public ProbeStatus receivedMessage(ProbeId probeId) {
       return new ProbeStatus(
           this.serviceName,
           "Received probe " + probeId + ".",
-          new Diagnostics(probeId, Status.RECEIVED, null));
+          new Diagnostics(probeId, runtimeId, Status.RECEIVED, null));
     }
 
     public ProbeStatus installedMessage(ProbeId probeId) {
       return new ProbeStatus(
           this.serviceName,
           "Installed probe " + probeId + ".",
-          new Diagnostics(probeId, Status.INSTALLED, null));
+          new Diagnostics(probeId, runtimeId, Status.INSTALLED, null));
     }
 
     public ProbeStatus blockedMessage(ProbeId probeId) {
       return new ProbeStatus(
           this.serviceName,
           "Blocked probe " + probeId + ".",
-          new Diagnostics(probeId, Status.BLOCKED, null));
+          new Diagnostics(probeId, runtimeId, Status.BLOCKED, null));
     }
 
     public ProbeStatus errorMessage(ProbeId probeId, Throwable ex) {
@@ -266,6 +274,7 @@ public class ProbeStatus {
           "Error installing probe " + probeId + ".",
           new Diagnostics(
               probeId,
+              runtimeId,
               Status.ERROR,
               new ProbeException(
                   ex.getClass().getTypeName(),
@@ -281,6 +290,7 @@ public class ProbeStatus {
           "Error installing probe " + probeId + ".",
           new Diagnostics(
               probeId,
+              runtimeId,
               Status.ERROR,
               new ProbeException("NO_TYPE", message, Collections.emptyList())));
     }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ProbeStatusTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ProbeStatusTest.java
@@ -29,6 +29,7 @@ class ProbeStatusTest {
   private static final String RECEIVED_MESSAGE = "Received probe " + PROBE_ID + ".";
   private static final String INSTALLED_MESSAGE = "Installed probe " + PROBE_ID + ".";
   private static final String ERROR_MESSAGE = "Error installing probe " + PROBE_ID + ".";
+  private static final String RUNTIME_ID = "foo";
 
   @Mock private Config config;
 
@@ -37,6 +38,7 @@ class ProbeStatusTest {
   @BeforeEach
   void setUp() {
     lenient().when(config.getServiceName()).thenReturn(SERVICE_NAME);
+    lenient().when(config.getRuntimeId()).thenReturn(RUNTIME_ID);
     builder = new Builder(config);
   }
 
@@ -44,7 +46,9 @@ class ProbeStatusTest {
   void builderReceived() {
     ProbeStatus expected =
         new ProbeStatus(
-            SERVICE_NAME, RECEIVED_MESSAGE, new Diagnostics(PROBE_ID, Status.RECEIVED, null));
+            SERVICE_NAME,
+            RECEIVED_MESSAGE,
+            new Diagnostics(PROBE_ID, RUNTIME_ID, Status.RECEIVED, null));
     ProbeStatus actual = builder.receivedMessage(PROBE_ID);
     assertEquals(expected, actual);
   }
@@ -61,7 +65,9 @@ class ProbeStatusTest {
   void builderInstalled() {
     ProbeStatus expected =
         new ProbeStatus(
-            SERVICE_NAME, INSTALLED_MESSAGE, new Diagnostics(PROBE_ID, Status.INSTALLED, null));
+            SERVICE_NAME,
+            INSTALLED_MESSAGE,
+            new Diagnostics(PROBE_ID, RUNTIME_ID, Status.INSTALLED, null));
     ProbeStatus actual = builder.installedMessage(PROBE_ID);
     assertEquals(expected, actual);
   }
@@ -75,6 +81,7 @@ class ProbeStatusTest {
             ERROR_MESSAGE,
             new Diagnostics(
                 PROBE_ID,
+                RUNTIME_ID,
                 Status.ERROR,
                 new ProbeException("NO_TYPE", exceptionMessage, Collections.emptyList())));
     ProbeStatus actual = builder.errorMessage(PROBE_ID, exceptionMessage);
@@ -95,6 +102,7 @@ class ProbeStatusTest {
             ERROR_MESSAGE,
             new Diagnostics(
                 PROBE_ID,
+                RUNTIME_ID,
                 Status.ERROR,
                 new ProbeException("java.lang.Exception", exceptionMessage, capturedStackFrames)));
     ProbeStatus actual = builder.errorMessage(PROBE_ID, exception);
@@ -103,7 +111,7 @@ class ProbeStatusTest {
 
   @Test
   void received() {
-    Diagnostics diagnostics = new Diagnostics(PROBE_ID, Status.RECEIVED, null);
+    Diagnostics diagnostics = new Diagnostics(PROBE_ID, RUNTIME_ID, Status.RECEIVED, null);
     ProbeStatus message = new ProbeStatus(SERVICE_NAME, RECEIVED_MESSAGE, diagnostics);
     assertEquals(SERVICE_NAME, message.getService());
     assertEquals(RECEIVED_MESSAGE, message.getMessage());
@@ -112,7 +120,7 @@ class ProbeStatusTest {
 
   @Test
   void installed() {
-    Diagnostics diagnostics = new Diagnostics(PROBE_ID, Status.INSTALLED, null);
+    Diagnostics diagnostics = new Diagnostics(PROBE_ID, RUNTIME_ID, Status.INSTALLED, null);
     ProbeStatus message = new ProbeStatus(SERVICE_NAME, INSTALLED_MESSAGE, diagnostics);
     assertEquals(SERVICE_NAME, message.getService());
     assertEquals(INSTALLED_MESSAGE, message.getMessage());
@@ -123,7 +131,7 @@ class ProbeStatusTest {
   void errorMessage() {
     ProbeException exception =
         new ProbeException("NO_TYPE", ERROR_MESSAGE, Collections.emptyList());
-    Diagnostics diagnostics = new Diagnostics(PROBE_ID, Status.ERROR, exception);
+    Diagnostics diagnostics = new Diagnostics(PROBE_ID, RUNTIME_ID, Status.ERROR, exception);
     ProbeStatus message = new ProbeStatus(SERVICE_NAME, ERROR_MESSAGE, diagnostics);
     assertEquals(SERVICE_NAME, message.getService());
     assertEquals(ERROR_MESSAGE, message.getMessage());
@@ -139,7 +147,7 @@ class ProbeStatusTest {
             .collect(Collectors.toList());
     ProbeException probeException =
         new ProbeException("java.lang.Exception", ERROR_MESSAGE, stackTrace);
-    Diagnostics diagnostics = new Diagnostics(PROBE_ID, Status.ERROR, probeException);
+    Diagnostics diagnostics = new Diagnostics(PROBE_ID, RUNTIME_ID, Status.ERROR, probeException);
     ProbeStatus message = new ProbeStatus(SERVICE_NAME, ERROR_MESSAGE, diagnostics);
     assertEquals(SERVICE_NAME, message.getService());
     assertEquals(ERROR_MESSAGE, message.getMessage());

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.sink;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.matches;
@@ -92,6 +93,11 @@ public class DebuggerSinkTest {
     assertEquals(PROBE_ID.getId(), intakeRequest.getDebugger().getSnapshot().getProbe().getId());
     assertEquals(
         PROBE_LOCATION, intakeRequest.getDebugger().getSnapshot().getProbe().getLocation());
+    assertTrue(
+        intakeRequest
+            .getDebugger()
+            .getRuntimeId()
+            .matches("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"));
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do

Adds the runtimeId to probe statuses.

# Motivation

Probe statuses can be different for a single probe in a service fleet. Probe status were originally introduced when only one instance per service was applying instrumentation. With DI logs, metrics and spans probe statuses are emitted from more instances of a service.

# Additional Notes
