### PR TITLE
Pass captured TraceConfig from extractor to trace

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/OpenTelemetryTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/OpenTelemetryTest.groovy
@@ -135,11 +135,11 @@ class OpenTelemetryTest extends AgentTestRunner {
     setup:
     def builder = tracer.spanBuilder("some name")
     if (parentId) {
-      def ctx = new ExtractedContext(DDTraceId.ONE, parentId, SAMPLER_DROP, null, 0, [:], [:], null, PropagationTags.factory().empty())
+      def ctx = new ExtractedContext(DDTraceId.ONE, parentId, SAMPLER_DROP, null, PropagationTags.factory().empty())
       builder.setParent(tracer.converter.toSpanContext(ctx))
     }
     if (linkId) {
-      def ctx = new ExtractedContext(DDTraceId.ONE, linkId, SAMPLER_DROP, null, 0, [:], [:], null, PropagationTags.factory().empty())
+      def ctx = new ExtractedContext(DDTraceId.ONE, linkId, SAMPLER_DROP, null, PropagationTags.factory().empty())
       builder.addLink(tracer.converter.toSpanContext(ctx))
     }
     def result = builder.startSpan()

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -45,7 +45,7 @@ class OpenTracing31Test extends AgentTestRunner {
         .withTag("boolean", true)
     }
     if (addReference) {
-      def ctx = new ExtractedContext(DDTraceId.ONE, 2, SAMPLER_DROP, null, 0, [:], [:], null, PropagationTags.factory().empty())
+      def ctx = new ExtractedContext(DDTraceId.ONE, 2, SAMPLER_DROP, null, PropagationTags.factory().empty())
       builder.addReference(addReference, tracer.tracer.converter.toSpanContext(ctx))
     }
     def result = builder.start()

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -50,7 +50,7 @@ class OpenTracing32Test extends AgentTestRunner {
         .withTag("boolean", true)
     }
     if (addReference) {
-      def ctx = new ExtractedContext(DDTraceId.ONE, 2, SAMPLER_DROP, null, 0, [:], [:], null, PropagationTags.factory().empty())
+      def ctx = new ExtractedContext(DDTraceId.ONE, 2, SAMPLER_DROP, null, PropagationTags.factory().empty())
       builder.addReference(addReference, tracer.tracer.converter.toSpanContext(ctx))
     }
     def result = builder.start()

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -648,6 +648,10 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     return pendingTraceFactory.create(id);
   }
 
+  PendingTrace createTrace(DDTraceId id, TraceConfig traceConfig) {
+    return pendingTraceFactory.create(id, traceConfig);
+  }
+
   /**
    * If an application is using a non-system classloader, that classloader should be registered
    * here. Due to the way Spring Boot structures its' executable jar, this might log some warnings.
@@ -1457,9 +1461,12 @@ public class CoreTracer implements AgentTracer.TracerAPI {
           propagationTags = propagationTagsFactory.empty();
         }
 
+        TraceConfig traceConfig;
+
         // Get header tags and set origin whether propagating or not.
         if (parentContext instanceof TagContext) {
           TagContext tc = (TagContext) parentContext;
+          traceConfig = tc.getTraceConfig();
           coreTags = tc.getTags();
           origin = tc.getOrigin();
           baggage = tc.getBaggage();
@@ -1467,6 +1474,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
           requestContextDataIast = tc.getRequestContextDataIast();
           ciVisibilityContextData = tc.getCiVisibilityContextData();
         } else {
+          traceConfig = null;
           coreTags = null;
           origin = null;
           baggage = null;
@@ -1477,7 +1485,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
         rootSpanTags = localRootSpanTags;
 
-        parentTrace = createTrace(traceId);
+        parentTrace = createTrace(traceId, traceConfig);
 
         if (endToEndStartTime > 0) {
           parentTrace.beginEndToEnd(endToEndStartTime);

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -59,9 +59,20 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
       this.healthMetrics = healthMetrics;
     }
 
+    /** Used by tests and benchmarks. */
     PendingTrace create(@Nonnull DDTraceId traceId) {
+      return create(traceId, null);
+    }
+
+    PendingTrace create(@Nonnull DDTraceId traceId, TraceConfig traceConfig) {
       return new PendingTrace(
-          tracer, traceId, pendingTraceBuffer, timeSource, strictTraceWrites, healthMetrics);
+          tracer,
+          traceId,
+          pendingTraceBuffer,
+          timeSource,
+          traceConfig,
+          strictTraceWrites,
+          healthMetrics);
     }
   }
 
@@ -116,15 +127,16 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
       @Nonnull DDTraceId traceId,
       @Nonnull PendingTraceBuffer pendingTraceBuffer,
       @Nonnull TimeSource timeSource,
+      TraceConfig traceConfig,
       boolean strictTraceWrites,
       HealthMetrics healthMetrics) {
     this.tracer = tracer;
     this.traceId = traceId;
     this.pendingTraceBuffer = pendingTraceBuffer;
     this.timeSource = timeSource;
+    this.traceConfig = traceConfig != null ? traceConfig : tracer.captureTraceConfig();
     this.strictTraceWrites = strictTraceWrites;
     this.healthMetrics = healthMetrics;
-    this.traceConfig = tracer.captureTraceConfig();
   }
 
   CoreTracer getTracer() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 public abstract class ContextInterpreter implements AgentPropagation.KeyClassifier {
+  private TraceConfig traceConfig;
 
   protected Map<String, String> taggedHeaders;
   protected Map<String, String> baggageMapping;
@@ -206,6 +207,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
   }
 
   public ContextInterpreter reset(TraceConfig traceConfig) {
+    this.traceConfig = traceConfig;
     traceId = DDTraceId.ZERO;
     spanId = DDSpanId.ZERO;
     samplingPriority = PrioritySampling.UNSET;
@@ -238,7 +240,8 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
                 baggage,
                 tags,
                 httpHeaders,
-                propagationTags);
+                propagationTags,
+                traceConfig);
         return context;
       } else if (origin != null
           || !tags.isEmpty()
@@ -246,7 +249,12 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
           || !baggage.isEmpty()
           || samplingPriority != PrioritySampling.UNSET) {
         return new TagContext(
-            origin, tags, httpHeaders, baggage, samplingPriorityOrDefault(samplingPriority));
+            origin,
+            tags,
+            httpHeaders,
+            baggage,
+            samplingPriorityOrDefault(samplingPriority),
+            traceConfig);
       }
     }
     return null;

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
@@ -1,6 +1,7 @@
 package datadog.trace.core.propagation;
 
 import datadog.trace.api.DDTraceId;
+import datadog.trace.api.TraceConfig;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import java.util.Map;
 
@@ -18,12 +19,22 @@ public class ExtractedContext extends TagContext {
       final long spanId,
       final int samplingPriority,
       final CharSequence origin,
+      final PropagationTags propagationTags) {
+    this(traceId, spanId, samplingPriority, origin, 0, null, null, null, propagationTags, null);
+  }
+
+  public ExtractedContext(
+      final DDTraceId traceId,
+      final long spanId,
+      final int samplingPriority,
+      final CharSequence origin,
       final long endToEndStartTime,
       final Map<String, String> baggage,
       final Map<String, String> tags,
       final HttpHeaders httpHeaders,
-      final PropagationTags propagationTags) {
-    super(origin, tags, httpHeaders, baggage, samplingPriority);
+      final PropagationTags propagationTags,
+      final TraceConfig traceConfig) {
+    super(origin, tags, httpHeaders, baggage, samplingPriority, traceConfig);
     this.traceId = traceId;
     this.spanId = spanId;
     this.endToEndStartTime = endToEndStartTime;

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaHandler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaHandler.java
@@ -91,15 +91,7 @@ public class LambdaHandler {
               propagationTagsFactory.fromHeaderValue(
                   PropagationTags.HeaderType.DATADOG, response.headers().get(DATADOG_TAGS_KEY));
           return new ExtractedContext(
-              DDTraceId.from(traceID),
-              DDSpanId.ZERO,
-              samplingPriority,
-              null,
-              0,
-              null,
-              null,
-              null,
-              propagationTags);
+              DDTraceId.from(traceID), DDSpanId.ZERO, samplingPriority, null, propagationTags);
         } else {
           log.debug(
               "could not find traceID or sampling priority in notifyStartInvocation, not injecting the context");

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -333,9 +333,9 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
     span.context().propagationTags.headerValue(PropagationTags.HeaderType.DATADOG) == extractedContext.propagationTags.headerValue(PropagationTags.HeaderType.DATADOG)
 
     where:
-    extractedContext                                                                                                                                                                                                          | _
-    new ExtractedContext(DDTraceId.ONE, 2, PrioritySampling.SAMPLER_DROP, null, 0, [:], [:], null, PropagationTags.factory().fromHeaderValue(PropagationTags.HeaderType.DATADOG, "_dd.p.dm=934086a686-4,_dd.p.anytag=value")) | _
-    new ExtractedContext(DDTraceId.from(3), 4, PrioritySampling.SAMPLER_KEEP, "some-origin", 0, ["asdf": "qwer"], [(ORIGIN_KEY): "some-origin", "zxcv": "1234"], null, PropagationTags.factory().empty())                     | _
+    extractedContext                                                                                                                                                                                                                | _
+    new ExtractedContext(DDTraceId.ONE, 2, PrioritySampling.SAMPLER_DROP, null, 0, [:], [:], null, PropagationTags.factory().fromHeaderValue(PropagationTags.HeaderType.DATADOG, "_dd.p.dm=934086a686-4,_dd.p.anytag=value"), null) | _
+    new ExtractedContext(DDTraceId.from(3), 4, PrioritySampling.SAMPLER_KEEP, "some-origin", 0, ["asdf": "qwer"], [(ORIGIN_KEY): "some-origin", "zxcv": "1234"], null, PropagationTags.factory().empty(), null)                     | _
   }
 
   def "TagContext should populate default span details"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextPropagationTagsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextPropagationTagsTest.groovy
@@ -23,8 +23,8 @@ class DDSpanContextPropagationTagsTest extends DDCoreSpecification {
     setup:
     tracer = tracerBuilder().writer(writer).build()
     def propagationTags = tracer.propagationTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, header)
-    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", 0, [:], [:], null, propagationTags)
-    .withRequestContextDataAppSec("dummy")
+    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", propagationTags)
+      .withRequestContextDataAppSec("dummy")
     def span = (DDSpan) tracer.buildSpan("top")
       .asChildOf((AgentSpan.Context) extracted)
       .start()
@@ -52,8 +52,8 @@ class DDSpanContextPropagationTagsTest extends DDCoreSpecification {
     setup:
     tracer = tracerBuilder().writer(writer).build()
     def propagationTags = tracer.propagationTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, header)
-    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", 0, [:], [:], null, propagationTags)
-    .withRequestContextDataAppSec("dummy")
+    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", propagationTags)
+      .withRequestContextDataAppSec("dummy")
     def rootSpan = (DDSpan) tracer.buildSpan("top")
       .asChildOf((AgentSpan.Context) extracted)
       .start()
@@ -82,8 +82,8 @@ class DDSpanContextPropagationTagsTest extends DDCoreSpecification {
     setup:
     tracer = tracerBuilder().writer(writer).build()
     def propagationTags = tracer.propagationTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, header)
-    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", 0, [:], [:], null, propagationTags)
-    .withRequestContextDataAppSec("dummy")
+    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", propagationTags)
+      .withRequestContextDataAppSec("dummy")
     def span = (DDSpan) tracer.buildSpan("top")
       .asChildOf((AgentSpan.Context) extracted)
       .start()
@@ -109,8 +109,8 @@ class DDSpanContextPropagationTagsTest extends DDCoreSpecification {
     setup:
     tracer = tracerBuilder().writer(writer).build()
     def propagationTags = tracer.propagationTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, header)
-    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", 0, [:], [:], null, propagationTags)
-    .withRequestContextDataAppSec("dummy")
+    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", propagationTags)
+      .withRequestContextDataAppSec("dummy")
     def rootSpan = (DDSpan) tracer.buildSpan("top")
       .asChildOf((AgentSpan.Context) extracted)
       .start()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
@@ -180,8 +180,8 @@ class DDSpanContextTest extends DDCoreSpecification {
 
   def "set TraceSegment tags and data on correct span"() {
     setup:
-    def extracted = new ExtractedContext(DDTraceId.from(123), 456, SAMPLER_KEEP, "789", 0, [:], [:], null, tracer.getPropagationTagsFactory().empty())
-    .withRequestContextDataAppSec("dummy")
+    def extracted = new ExtractedContext(DDTraceId.from(123), 456, SAMPLER_KEEP, "789", tracer.getPropagationTagsFactory().empty())
+      .withRequestContextDataAppSec("dummy")
 
     def top = tracer.buildSpan("top").asChildOf((AgentSpan.Context) extracted).start()
     def topC = (DDSpanContext) top.context()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -273,7 +273,7 @@ class DDSpanTest extends DDCoreSpecification {
     where:
     extractedContext                                                                                                                           | _
     new TagContext("some-origin", [:])                                                                                                         | _
-    new ExtractedContext(DDTraceId.ONE, 2, PrioritySampling.SAMPLER_DROP, "some-origin", 0, [:], [:], null, propagationTagsFactory.empty()) | _
+    new ExtractedContext(DDTraceId.ONE, 2, PrioritySampling.SAMPLER_DROP, "some-origin", propagationTagsFactory.empty()) | _
   }
 
   def "isRootSpan() in and not in the context of distributed tracing"() {
@@ -292,7 +292,7 @@ class DDSpanTest extends DDCoreSpecification {
     where:
     extractedContext                                                                                                                        | isTraceRootSpan
     null                                                                                                                                    | true
-    new ExtractedContext(DDTraceId.from(123), 456, PrioritySampling.SAMPLER_KEEP, "789", 0, [:], [:], null, propagationTagsFactory.empty()) | false
+    new ExtractedContext(DDTraceId.from(123), 456, PrioritySampling.SAMPLER_KEEP, "789", propagationTagsFactory.empty()) | false
   }
 
   def "getApplicationRootSpan() in and not in the context of distributed tracing"() {
@@ -314,7 +314,7 @@ class DDSpanTest extends DDCoreSpecification {
     where:
     extractedContext                                                                                                                          | isTraceRootSpan
     null                                                                                                                                      | true
-    new ExtractedContext(DDTraceId.from(123), 456, PrioritySampling.SAMPLER_KEEP, "789", 0, [:], [:], null, propagationTagsFactory.empty()) | false
+    new ExtractedContext(DDTraceId.from(123), 456, PrioritySampling.SAMPLER_KEEP, "789", propagationTagsFactory.empty()) | false
   }
 
   def 'publishing of root span closes the request context data'() {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
@@ -2,6 +2,7 @@ package datadog.trace.bootstrap.instrumentation.api;
 
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
+import datadog.trace.api.TraceConfig;
 import datadog.trace.api.sampling.PrioritySampling;
 import java.util.Collections;
 import java.util.Map;
@@ -21,28 +22,34 @@ public class TagContext implements AgentSpan.Context.Extracted {
   private Object ciVisibilityContextData;
   private final HttpHeaders httpHeaders;
   private final Map<String, String> baggage;
-
   private final int samplingPriority;
+  private final TraceConfig traceConfig;
 
   public TagContext() {
     this(null, null);
   }
 
   public TagContext(final String origin, final Map<String, String> tags) {
-    this(origin, tags, null, null, PrioritySampling.UNSET);
+    this(origin, tags, null, null, PrioritySampling.UNSET, null);
   }
 
   public TagContext(
       final CharSequence origin,
       final Map<String, String> tags,
-      HttpHeaders httpHeaders,
+      final HttpHeaders httpHeaders,
       final Map<String, String> baggage,
-      int samplingPriority) {
+      final int samplingPriority,
+      final TraceConfig traceConfig) {
     this.origin = origin;
     this.tags = tags;
     this.httpHeaders = httpHeaders == null ? EMPTY_HTTP_HEADERS : httpHeaders;
     this.baggage = baggage == null ? Collections.emptyMap() : baggage;
     this.samplingPriority = samplingPriority;
+    this.traceConfig = traceConfig;
+  }
+
+  public TraceConfig getTraceConfig() {
+    return traceConfig;
   }
 
   public final CharSequence getOrigin() {


### PR DESCRIPTION
Avoids capturing the trace config twice and ensures config consistency between extract/trace/inject