### PR TITLE
Provide access to the trace's TraceConfig given a span from that trace

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -14,6 +14,7 @@ import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.EndpointTracker;
+import datadog.trace.api.TraceConfig;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.profiling.TransientProfilingContextHolder;
@@ -758,5 +759,10 @@ public class DDSpan
   @Override
   public Object getWrapper() {
     return WRAPPER_FIELD_UPDATER.get(this);
+  }
+
+  @Override
+  public TraceConfig getTraceConfig() {
+    return context.getTrace().getTraceConfig();
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -131,6 +131,10 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
     return tracer;
   }
 
+  TraceConfig getTraceConfig() {
+    return traceConfig;
+  }
+
   String mapServiceName(String serviceName) {
     return traceConfig.getServiceMapping().getOrDefault(serviceName, serviceName);
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -1,6 +1,7 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
 import datadog.trace.api.DDTraceId;
+import datadog.trace.api.TraceConfig;
 import datadog.trace.api.gateway.IGSpanInfo;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.interceptor.MutableSpan;
@@ -142,6 +143,8 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo {
   void mergePathwayContext(PathwayContext pathwayContext);
 
   Integer forceSamplingDecision();
+
+  TraceConfig getTraceConfig();
 
   interface Context {
     /**

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -6,6 +6,7 @@ import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.EndpointCheckpointer;
 import datadog.trace.api.EndpointTracker;
+import datadog.trace.api.TraceConfig;
 import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.api.experimental.DataStreamsCheckpointer;
 import datadog.trace.api.experimental.DataStreamsContextCarrier;
@@ -716,6 +717,11 @@ public class AgentTracer {
     @Override
     public byte getResourceNamePriority() {
       return Byte.MAX_VALUE;
+    }
+
+    @Override
+    public TraceConfig getTraceConfig() {
+      return null;
     }
   }
 


### PR DESCRIPTION
Instrumentations will typically have spans to hand, but if they don't then they can use the usual API to find if there's an active span and from that get the appropriate `TraceConfig`.

No-op spans have no `TraceConfig` since there is no trace associated with them.
