### PR TITLE
Add support for private fields for metric values

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ReflectiveFieldValueResolver.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ReflectiveFieldValueResolver.java
@@ -4,7 +4,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
 /** A helper class to resolve a reference path using reflection. */
-public final class ReflectiveFieldValueResolver {
+public class ReflectiveFieldValueResolver {
   public static Object resolve(Object target, Class<?> targetType, String fldName) {
     Field fld = getField(targetType, fldName);
     if (fld == null) {
@@ -15,6 +15,62 @@ public final class ReflectiveFieldValueResolver {
     } catch (IllegalAccessException | IllegalArgumentException ignored) {
       return Values.UNDEFINED_OBJECT;
     }
+  }
+
+  public static Object getFieldValue(Object target, String fieldName)
+      throws NoSuchFieldException, IllegalAccessException {
+    return getField(target, fieldName).get(target);
+  }
+
+  public static long getFieldValueAsLong(Object target, String fieldName)
+      throws NoSuchFieldException, IllegalAccessException {
+    return getField(target, fieldName).getLong(target);
+  }
+
+  public static int getFieldValueAsInt(Object target, String fieldName)
+      throws NoSuchFieldException, IllegalAccessException {
+    return getField(target, fieldName).getInt(target);
+  }
+
+  public static double getFieldValueAsDouble(Object target, String fieldName)
+      throws NoSuchFieldException, IllegalAccessException {
+    return getField(target, fieldName).getDouble(target);
+  }
+
+  public static float getFieldValueAsFloat(Object target, String fieldName)
+      throws NoSuchFieldException, IllegalAccessException {
+    return getField(target, fieldName).getFloat(target);
+  }
+
+  public static float getFieldValueAsShort(Object target, String fieldName)
+      throws NoSuchFieldException, IllegalAccessException {
+    return getField(target, fieldName).getShort(target);
+  }
+
+  public static char getFieldValueAsChar(Object target, String fieldName)
+      throws NoSuchFieldException, IllegalAccessException {
+    return getField(target, fieldName).getChar(target);
+  }
+
+  public static byte getFieldValueAsByte(Object target, String fieldName)
+      throws NoSuchFieldException, IllegalAccessException {
+    return getField(target, fieldName).getByte(target);
+  }
+
+  public static boolean getFieldValueAsBoolean(Object target, String fieldName)
+      throws NoSuchFieldException, IllegalAccessException {
+    return getField(target, fieldName).getBoolean(target);
+  }
+
+  private static Field getField(Object target, String name) throws NoSuchFieldException {
+    if (target == null) {
+      throw new NullPointerException();
+    }
+    Field field = getField(target.getClass(), name);
+    if (field == null) {
+      throw new NoSuchFieldException(name);
+    }
+    return field;
   }
 
   private static Field getField(Class<?> container, String name) {
@@ -29,7 +85,7 @@ public final class ReflectiveFieldValueResolver {
         return null;
       } catch (Exception ignored) {
         // The only other exception allowed here is InaccessibleObjectException but since we compile
-        // against JDK 8 we can not use that type in the exeption handler
+        // against JDK 8 we can not use that type in the exception handler
         return null;
       }
     }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Types.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Types.java
@@ -22,6 +22,7 @@ import datadog.trace.bootstrap.debugger.CorrelationAccess;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.debugger.DebuggerSpan;
 import datadog.trace.bootstrap.debugger.MethodLocation;
+import datadog.trace.bootstrap.debugger.el.ReflectiveFieldValueResolver;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -64,6 +65,8 @@ public final class Types {
   public static final Type METHOD_LOCATION_TYPE = Type.getType(MethodLocation.class);
   public static final Type CLASS_TYPE = Type.getType(Class.class);
   public static final Type DEBUGGER_SPAN_TYPE = Type.getType(DebuggerSpan.class);
+  public static final Type REFLECTIVE_FIELD_VALUE_RESOLVER_TYPE =
+      Type.getType(ReflectiveFieldValueResolver.class);
 
   // special initialization methods
   public static final String CONSTRUCTOR = "<init>";

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -673,7 +673,7 @@ public class CapturedSnapshotTest {
     CapturedContext.CapturedValue simpleData =
         snapshot.getCaptures().getReturn().getLocals().get("simpleData");
     Map<String, CapturedContext.CapturedValue> simpleDataFields = getFields(simpleData);
-    Assertions.assertEquals(3, simpleDataFields.size());
+    Assertions.assertEquals(4, simpleDataFields.size());
     Assertions.assertEquals("foo", simpleDataFields.get("strValue").getValue());
     Assertions.assertEquals(42, simpleDataFields.get("intValue").getValue());
     Assertions.assertEquals(DEPTH_REASON, simpleDataFields.get("listValue").getNotCapturedReason());

--- a/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot04.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot04.java
@@ -28,6 +28,7 @@ public class CapturedSnapshot04 {
   public static class SimpleData {
     private final String strValue;
     final int intValue;
+    private final long longValue = 1042;
     private final List<String> listValue = new ArrayList<>();
 
     public SimpleData(String strValue, int intValue) {


### PR DESCRIPTION
# What Does This Do
Call helper methods when trying to access a field that is not accessible directly by GETFIELD bytecode. Those helpers will try by reflection to set accessible to true and get he value of the field For primitive access need special call for each type of primitive

# Motivation

# Additional Notes
