### PR TITLE
Exclude jboss-logmanager 3.0.0-alpha1 from log-injection smoke tests

### DIFF
--- a/dd-smoke-tests/log-injection/build.gradle
+++ b/dd-smoke-tests/log-injection/build.gradle
@@ -115,7 +115,7 @@ dependencies {
 
   jbossInterface 'org.jboss.logging:jboss-logging:3.4.1.Final'
   jbossBackend 'org.jboss.logmanager:jboss-logmanager:1.2.0.GA'
-  jbossBackendLatest 'org.jboss.logmanager:jboss-logmanager:+'
+  jbossBackendLatest 'org.jboss.logmanager:jboss-logmanager:2.+'
 
   floggerInterface 'com.google.flogger:flogger:0.5.1'
   floggerJULBackend 'com.google.flogger:flogger-system-backend:0.5.1'


### PR DESCRIPTION
... as it requires Java11