### PR TITLE
Fix for Vert.x 4.0 null path case

### DIFF
--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapper.java
@@ -58,9 +58,10 @@ public class RouteHandlerWrapper implements Handler<RoutingContext> {
     final String method = routingContext.request().method().name();
     final String mountPoint = routingContext.mountPoint();
 
-    String path = routingContext.currentRoute().getPath();
+    // getName returns the name of the route, if not path or the pattern or null
+    String path = routingContext.currentRoute().getName();
 
-    if (mountPoint != null) {
+    if (mountPoint != null && path != null) {
       final String noBackslashhMountPoint =
           mountPoint.endsWith("/")
               ? mountPoint.substring(0, mountPoint.lastIndexOf("/"))


### PR DESCRIPTION
# What Does This Do

Fixes use case when the current route path is null

# Motivation

`routingContext.currentRoute().getPath()` can be null

# Additional Notes

#5177