### PR TITLE
fix http resource mapping

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -6,6 +6,7 @@ import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.agent.test.server.http.HttpProxy
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
+import datadog.trace.api.config.TracerConfig
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
 import datadog.trace.core.datastreams.StatsGroup
@@ -91,6 +92,15 @@ abstract class HttpClientTest extends VersionedNamingTestBase {
   @Override
   boolean isDataStreamsEnabled() {
     true
+  }
+
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+    // we inject this config because it's statically assigned and we cannot inject this at test level without forking
+    // not starting with "/" made full url (http://..) matching but not the path portion (because starting with /)
+    // this settings should not affect test results
+    injectSysConfig(TracerConfig.TRACE_HTTP_CLIENT_PATH_RESOURCE_NAME_MAPPING, "**/success:*")
   }
 
   def setupSpec() {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -11,6 +11,7 @@ import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.api.ProductActivation
 import datadog.trace.api.config.GeneralConfig
+import datadog.trace.api.config.TracerConfig
 import datadog.trace.api.env.CapturedEnvironment
 import datadog.trace.api.function.TriConsumer
 import datadog.trace.api.function.TriFunction
@@ -127,7 +128,11 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
   @Override
   protected void configurePreAgent() {
     super.configurePreAgent()
-
+    // we inject this config because it's statically assigned and we cannot inject this at test level without forking
+    // not starting with "/" made full url (http://..) matching but not the path portion (because starting with /)
+    // this settings should not affect test results
+    injectSysConfig(TracerConfig.TRACE_HTTP_CLIENT_PATH_RESOURCE_NAME_MAPPING, "**/success:*")
+    
     injectSysConfig(HEADER_TAGS, 'x-datadog-test-both-header:both_header_tag')
     injectSysConfig(REQUEST_HEADER_TAGS, 'x-datadog-test-request-header:request_header_tag')
     // We don't inject a matching response header tag here since it would be always on and show up in all the tests

--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/TagInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/TagInterceptor.java
@@ -27,9 +27,13 @@ import datadog.trace.api.sampling.SamplingMechanism;
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags;
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.bootstrap.instrumentation.api.URIUtils;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.core.DDSpanContext;
+import java.net.URI;
 import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class TagInterceptor {
 
@@ -118,20 +122,34 @@ public class TagInterceptor {
   private boolean interceptUrlResourceAsNameRule(DDSpanContext span, String tag, Object value) {
     if (shouldSetUrlResourceAsName) {
       if (HTTP_METHOD.equals(tag)) {
-        if (span.getTags().containsValue(HTTP_URL)) {
-          Pair<CharSequence, Byte> normalized =
-              HttpResourceNames.computeForServer(
-                  value.toString(), span.getTags().get(HTTP_URL).toString(), false);
-          span.setResourceName(normalized.getLeft(), normalized.getRight());
+        final Object url = span.unsafeGetTag(HTTP_URL);
+        if (url != null) {
+          setResourceFromUrl(span, value.toString(), url.toString());
         }
       } else if (HTTP_URL.equals(tag)) {
-        Pair<CharSequence, Byte> normalized =
-            HttpResourceNames.computeForServer(
-                (CharSequence) span.getTags().get(HTTP_METHOD), value.toString(), false);
-        span.setResourceName(normalized.getLeft(), normalized.getRight());
+        final Object method = span.unsafeGetTag(HTTP_METHOD);
+        setResourceFromUrl(span, method != null ? method.toString() : null, value.toString());
       }
     }
     return false;
+  }
+
+  private static void setResourceFromUrl(
+      @Nonnull final DDSpanContext span, @Nullable final String method, @Nonnull final String url) {
+    final URI uri = URIUtils.safeParse(url);
+    if (uri != null && uri.getPath() != null) {
+      final boolean isClient = Tags.SPAN_KIND_CLIENT.equals(span.unsafeGetTag(Tags.SPAN_KIND));
+      Pair<CharSequence, Byte> normalized =
+          isClient
+              ? HttpResourceNames.computeForClient(method, uri.getPath(), false)
+              : HttpResourceNames.computeForServer(method, uri.getPath(), false);
+      if (normalized.hasLeft()) {
+        span.setResourceName(normalized.getLeft(), normalized.getRight());
+      }
+    } else {
+      span.setResourceName(
+          HttpResourceNames.DEFAULT_RESOURCE_NAME, ResourceNamePriorities.HTTP_PATH_NORMALIZER);
+    }
   }
 
   private boolean intercept(DDSpanContext span, String tag, Object value) {


### PR DESCRIPTION
# What Does This Do

Fixes the urlAsAResource rule on the tag interceptor. A couple of things:

1.  Uses the path and not the full url to match against the http resource mapping ant patterns
2. Uses the client settings for http client spans (currently uses always the server patterns which is wrong)


# Motivation

# Additional Notes
