### PR TITLE
Add double-quoted string literal in sqlite to IAST redaction

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sensitive/SqlRegexpTokenizer.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sensitive/SqlRegexpTokenizer.java
@@ -93,6 +93,7 @@ public class SqlRegexpTokenizer extends AbstractRegexTokenizer {
         "mysql"::equalsIgnoreCase,
         () -> buildPattern(NUMERIC_LITERAL, MYSQL_STRING_LITERAL, LINE_COMMENT, BLOCK_COMMENT)),
     MARIADB("mariadb"::equalsIgnoreCase, MYSQL::buildPattern),
+    SQLITE("sqlite"::equalsIgnoreCase, MYSQL::buildPattern),
     ANSI(
         dialect -> true,
         () -> buildPattern(NUMERIC_LITERAL, STRING_LITERAL, LINE_COMMENT, BLOCK_COMMENT));

--- a/dd-java-agent/agent-iast/src/test/resources/redaction/evidence-redaction-suite.yml
+++ b/dd-java-agent/agent-iast/src/test/resources/redaction/evidence-redaction-suite.yml
@@ -208,7 +208,7 @@ suite:
         ]
       }
   - type: 'VULNERABILITIES'
-    description: 'Query with string literal $1'
+    description: 'Query with single quoted string literal $1'
     parameters:
       $1:
         - john
@@ -248,11 +248,12 @@ suite:
         ]
       }
   - type: 'VULNERABILITIES'
-    description: '$1 query with string literal $2'
+    description: '$1 query with double quoted string literal $2'
     parameters:
       $1:
         - MYSQL
         - MARIADB
+        - SQLITE
       $2:
         - john
         - username with 🌉 surrogate
@@ -332,6 +333,7 @@ suite:
       $1:
         - MYSQL
         - MARIADB
+        - SQLITE
     context: >
       { "DATABASE": "$1" }
     input: >


### PR DESCRIPTION
# What Does This Do
Add support for double quoted string literals in SQLite to IAST redaction

# Motivation

# Additional Notes
