### PR TITLE
IAST insecure cookie - vertx instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/vertx-web-3.4/build.gradle
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/build.gradle
@@ -38,6 +38,8 @@ dependencies {
 
   testImplementation project(':dd-java-agent:instrumentation:netty-4.1')
   testImplementation project(':dd-java-agent:instrumentation:trace-annotation')
+  testImplementation(testFixtures(project(':dd-java-agent:agent-iast')))
+
 
   testImplementation group: 'io.vertx', name: 'vertx-web', version: '3.4.0'
   testImplementation group: 'io.vertx', name: 'vertx-web-client', version: '3.4.0'

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/HttpServerResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/HttpServerResponseInstrumentation.java
@@ -56,7 +56,7 @@ public class HttpServerResponseInstrumentation extends Instrumenter.Iast
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void onEnter(
         @Advice.Argument(0) final CharSequence name, @Advice.Argument(1) CharSequence value) {
-      if (null != name && null != value) {
+      if (null != name) {
         InstrumentationBridge.onHeader(name.toString(), value.toString());
       }
     }
@@ -66,10 +66,12 @@ public class HttpServerResponseInstrumentation extends Instrumenter.Iast
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void onEnter(
         @Advice.Argument(0) final CharSequence name, @Advice.Argument(1) Iterable values) {
-      for (Object value : values) {
-        if (value instanceof CharSequence && null != value) {
-          String stValue = ((CharSequence) value).toString();
-          InstrumentationBridge.onHeader(name.toString(), stValue);
+      if (null != values) {
+        for (Object value : values) {
+          if (value instanceof CharSequence && null != value) {
+            String stValue = ((CharSequence) value).toString();
+            InstrumentationBridge.onHeader(name.toString(), stValue);
+          }
         }
       }
     }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/HttpServerResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/HttpServerResponseInstrumentation.java
@@ -30,13 +30,15 @@ public class HttpServerResponseInstrumentation extends Instrumenter.Iast
   public void adviceTransformations(final AdviceTransformation transformation) {
     transformation.applyAdvice(
         named("putHeader")
-            .and(takesArguments(CharSequence.class, CharSequence.class)
-            .or(takesArguments(String.class, String.class))),
+            .and(
+                takesArguments(CharSequence.class, CharSequence.class)
+                    .or(takesArguments(String.class, String.class))),
         HttpServerResponseInstrumentation.class.getName() + "$PutHeaderAdvice1");
     transformation.applyAdvice(
         named("putHeader")
-            .and(takesArguments(CharSequence.class, Iterable.class)
-            .or(takesArguments(String.class, Iterable.class))),
+            .and(
+                takesArguments(CharSequence.class, Iterable.class)
+                    .or(takesArguments(String.class, Iterable.class))),
         HttpServerResponseInstrumentation.class.getName() + "$PutHeaderAdvice2");
   }
 

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/HttpServerResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/HttpServerResponseInstrumentation.java
@@ -1,0 +1,75 @@
+package datadog.trace.instrumentation.vertx_3_4.server;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.instrumentation.vertx_3_4.server.VertxVersionMatcher.PARSABLE_HEADER_VALUE;
+import static datadog.trace.instrumentation.vertx_3_4.server.VertxVersionMatcher.VIRTUAL_HOST_HANDLER;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.muzzle.Reference;
+import datadog.trace.api.iast.InstrumentationBridge;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(Instrumenter.class)
+public class HttpServerResponseInstrumentation extends Instrumenter.Iast
+    implements Instrumenter.ForTypeHierarchy {
+  @Override
+  public Reference[] additionalMuzzleReferences() {
+    return new Reference[] {PARSABLE_HEADER_VALUE, VIRTUAL_HOST_HANDLER};
+  }
+
+  public HttpServerResponseInstrumentation() {
+    super("vertx", "vertx-3.4");
+  }
+
+  @Override
+  public void adviceTransformations(final AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("putHeader")
+            .and(takesArguments(CharSequence.class, CharSequence.class)
+            .or(takesArguments(String.class, String.class))),
+        HttpServerResponseInstrumentation.class.getName() + "$PutHeaderAdvice1");
+    transformation.applyAdvice(
+        named("putHeader")
+            .and(takesArguments(CharSequence.class, Iterable.class)
+            .or(takesArguments(String.class, Iterable.class))),
+        HttpServerResponseInstrumentation.class.getName() + "$PutHeaderAdvice2");
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "io.vertx.core.http.HttpServerResponse";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return implementsInterface(named(hierarchyMarkerType()));
+  }
+
+  public static class PutHeaderAdvice1 {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter(
+        @Advice.Argument(0) final CharSequence name, @Advice.Argument(1) CharSequence value) {
+      if (null != name && null != value) {
+        InstrumentationBridge.onHeader(name.toString(), value.toString());
+      }
+    }
+  }
+
+  public static class PutHeaderAdvice2 {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter(
+        @Advice.Argument(0) final CharSequence name, @Advice.Argument(1) Iterable values) {
+      for (Object value : values) {
+        if (value instanceof CharSequence && null != value) {
+          String stValue = ((CharSequence) value).toString();
+          InstrumentationBridge.onHeader(name.toString(), stValue);
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/server/IastVertx34Server.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/server/IastVertx34Server.groovy
@@ -1,0 +1,72 @@
+package server
+
+import com.datadog.iast.test.IastHttpServerTest
+import datadog.trace.agent.test.base.HttpServer
+import io.vertx.core.AbstractVerticle
+import io.vertx.core.DeploymentOptions
+import io.vertx.core.Vertx
+import io.vertx.core.VertxOptions
+import io.vertx.core.impl.VertxInternal
+import io.vertx.core.json.JsonObject
+
+import java.util.concurrent.CompletableFuture
+
+import static server.VertxTestServer.CONFIG_HTTP_SERVER_PORT
+
+class IastVertx34Server extends IastHttpServerTest<Vertx> {
+
+  private class VertxServer implements HttpServer {
+    private VertxInternal server
+    private int port = 0
+    private String routerBasePath
+
+    VertxServer(String routerBasePath) {
+      this.routerBasePath = routerBasePath
+    }
+
+    @Override
+    void start() {
+      server = Vertx.vertx(new VertxOptions()
+        // Useful for debugging:
+        // .setBlockedThreadCheckInterval(Integer.MAX_VALUE)
+        .setClusterPort(0))
+      final CompletableFuture<Void> future = new CompletableFuture<>()
+      server.deployVerticle(verticle().name,
+        new DeploymentOptions()
+        .setConfig(new JsonObject().put(CONFIG_HTTP_SERVER_PORT, port))
+        .setInstances(1)) { res ->
+          if (!res.succeeded()) {
+            throw new RuntimeException("Cannot deploy server Verticle", res.cause())
+          }
+          future.complete(null)
+        }
+      future.get()
+      port = server.sharedHttpServers().values().first().actualPort()
+    }
+
+    @Override
+    void stop() {
+      server.close()
+    }
+
+    @Override
+    URI address() {
+      return new URI("http://localhost:$port$routerBasePath")
+    }
+  }
+
+  @Override
+  HttpServer server() {
+    return new VertxServer(routerBasePath())
+  }
+
+  protected Class<AbstractVerticle> verticle() {
+    IastVertxTestVerticle
+  }
+
+  String routerBasePath() {
+    return "/"
+  }
+
+
+}

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/server/Vertx34InsecureCookieTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/server/Vertx34InsecureCookieTest.groovy
@@ -1,0 +1,31 @@
+package server
+
+import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.sink.InsecureCookieModule
+import groovy.transform.CompileStatic
+import okhttp3.Request
+
+class Vertx34InsecureCookieTest extends IastVertx34Server {
+
+  @CompileStatic
+  void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig('dd.iast.enabled', 'true')
+  }
+
+  void 'test insecure Cookie'(){
+    given:
+    final module = Mock(InsecureCookieModule)
+    InstrumentationBridge.registerIastModule(module)
+    final url = "${address}/vulnerability/setHeaderString?name=Set-Cookie&value=user-id%3D7"
+    final request = new Request.Builder().url(url).build()
+
+    when:
+    final response = client.newCall(request).execute()
+
+    then:
+    response.code() == 200
+    response.body().string() == 'success'
+    1 * module.onHeader('Set-Cookie', 'user-id=7')
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/java/server/IastVertxTestVerticle.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/java/server/IastVertxTestVerticle.java
@@ -1,0 +1,245 @@
+package server;
+
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_JSON;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_URLENCODED;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.CREATED;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_BOTH;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_QUERY;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.UNKNOWN;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK;
+import static datadog.trace.agent.test.utils.TraceUtils.runnableUnderTraceAsync;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+
+import datadog.appsec.api.blocking.Blocking;
+import datadog.trace.agent.test.base.HttpServerTest;
+import datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+import io.vertx.core.MultiMap;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
+
+public class IastVertxTestVerticle extends AbstractVerticle {
+  public static final String CONFIG_HTTP_SERVER_PORT = "http.server.port";
+
+  @Override
+  public void start(final Future<Void> startFuture) {
+    final int port = config().getInteger(CONFIG_HTTP_SERVER_PORT);
+    Router router = Router.router(vertx);
+
+    customizeBeforeRoutes(router);
+    router
+        .route("/vulnerability/setHeaderString")
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    SUCCESS,
+                    () -> {
+                      final String headerName = ctx.request().getParam("name");
+                      final String headerValue = ctx.request().getParam("value");
+                      ctx.response()
+                          .setStatusCode(SUCCESS.getStatus())
+                          .putHeader(headerName, headerValue)
+                          .end(SUCCESS.getBody());
+                    }));
+    router
+        .route(SUCCESS.getPath())
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    SUCCESS,
+                    () ->
+                        ctx.response().setStatusCode(SUCCESS.getStatus()).end(SUCCESS.getBody())));
+    router
+        .route(FORWARDED.getPath())
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    FORWARDED,
+                    () ->
+                        ctx.response()
+                            .setStatusCode(FORWARDED.getStatus())
+                            .end(ctx.request().getHeader("x-forwarded-for"))));
+    router
+        .route(CREATED.getPath())
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    CREATED,
+                    () ->
+                        ctx.request()
+                            .bodyHandler(
+                                body ->
+                                    ctx.response()
+                                        .setStatusCode(CREATED.getStatus())
+                                        .end(CREATED.getBody() + ": " + body.toString()))));
+    router.route(BODY_URLENCODED.getPath()).handler(BodyHandler.create());
+    router
+        .route(BODY_URLENCODED.getPath())
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    BODY_URLENCODED,
+                    () -> {
+                      String res = "[";
+                      MultiMap entries = ctx.request().formAttributes();
+                      for (String name : entries.names()) {
+                        if (name.equals("ignore")) {
+                          continue;
+                        }
+                        if (res.length() > 1) {
+                          res += ", ";
+                        }
+                        res += name;
+                        res += ":[";
+                        int i = 0;
+                        for (String s : entries.getAll(name)) {
+                          if (i++ > 0) {
+                            res += ", ";
+                          }
+                          res += s;
+                        }
+                        res += ']';
+                      }
+                      res += ']';
+                      ctx.response().setStatusCode(BODY_URLENCODED.getStatus()).end(res);
+                    }));
+    router.route(BODY_JSON.getPath()).handler(BodyHandler.create());
+    router
+        .route(BODY_JSON.getPath())
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    BODY_JSON,
+                    () -> {
+                      JsonObject json = ctx.getBodyAsJson();
+                      ctx.response().setStatusCode(BODY_JSON.getStatus()).end(json.toString());
+                    }));
+    router
+        .route(QUERY_ENCODED_BOTH.getRawPath())
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    QUERY_ENCODED_BOTH,
+                    () ->
+                        ctx.response()
+                            .setStatusCode(QUERY_ENCODED_BOTH.getStatus())
+                            .end(QUERY_ENCODED_BOTH.bodyForQuery(ctx.request().query()))));
+    router
+        .route(QUERY_ENCODED_QUERY.getPath())
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    QUERY_ENCODED_QUERY,
+                    () ->
+                        ctx.response()
+                            .setStatusCode(QUERY_ENCODED_QUERY.getStatus())
+                            .end(QUERY_ENCODED_QUERY.bodyForQuery(ctx.request().query()))));
+    router
+        .route(QUERY_PARAM.getPath())
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    QUERY_PARAM,
+                    () ->
+                        ctx.response()
+                            .setStatusCode(QUERY_PARAM.getStatus())
+                            .end(ctx.request().query())));
+    router
+        .route(USER_BLOCK.getPath())
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    USER_BLOCK,
+                    () -> {
+                      Blocking.forUser("user-to-block").blockIfMatch();
+                      ctx.response().end("Should not be reached");
+                    }));
+    router
+        .route("/path/:id/param")
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    PATH_PARAM,
+                    () ->
+                        ctx.response()
+                            .setStatusCode(PATH_PARAM.getStatus())
+                            .end(ctx.request().getParam("id"))));
+    router
+        .route(REDIRECT.getPath())
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    REDIRECT,
+                    () ->
+                        ctx.response()
+                            .setStatusCode(REDIRECT.getStatus())
+                            .putHeader("location", REDIRECT.getBody())
+                            .end()));
+    router
+        .route(ERROR.getPath())
+        .handler(
+            ctx ->
+                controller(
+                    ctx,
+                    ERROR,
+                    () -> ctx.response().setStatusCode(ERROR.getStatus()).end(ERROR.getBody())));
+    router
+        .route(EXCEPTION.getPath())
+        .handler(ctx -> controller(ctx, EXCEPTION, IastVertxTestVerticle::exception));
+
+    router = customizeAfterRoutes(router);
+
+    vertx
+        .createHttpServer()
+        .requestHandler(router::accept)
+        .listen(port, event -> startFuture.complete());
+  }
+
+  protected void customizeBeforeRoutes(Router router) {}
+
+  protected Router customizeAfterRoutes(final Router router) {
+    return router;
+  }
+
+  private static void exception() {
+    throw new RuntimeException(EXCEPTION.getBody());
+  }
+
+  private static void controller(
+      RoutingContext ctx, final ServerEndpoint endpoint, final Runnable runnable) {
+    assert activeSpan() != null : "Controller should have a parent span.";
+    assert activeScope().isAsyncPropagating() : "Scope should be propagating async.";
+    ctx.response()
+        .putHeader(
+            HttpServerTest.getIG_RESPONSE_HEADER(), HttpServerTest.getIG_RESPONSE_HEADER_VALUE());
+    if (endpoint == NOT_FOUND || endpoint == UNKNOWN) {
+      runnable.run();
+      return;
+    }
+    runnableUnderTraceAsync("controller", runnable);
+  }
+}

--- a/dd-smoke-tests/vertx-3.4/application/src/main/java/datadog/smoketest/vertx_3_4/IastHandler.java
+++ b/dd-smoke-tests/vertx-3.4/application/src/main/java/datadog/smoketest/vertx_3_4/IastHandler.java
@@ -8,6 +8,7 @@ import io.vertx.ext.web.Cookie;
 import io.vertx.ext.web.RoutingContext;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.Vector;
 
 public enum IastHandler implements Handler<RoutingContext> {
   HEADER("/header") {
@@ -80,6 +81,21 @@ public enum IastHandler implements Handler<RoutingContext> {
     @Override
     public void handle(final RoutingContext rc) {
       rc.response().end("Received " + rc.getBodyAsJsonArray());
+    }
+  },
+  INSECURE_COOKIE_HEADER("/insecurecookieheader") {
+    @Override
+    public void handle(final RoutingContext rc) {
+      rc.response().putHeader("Set-Cookie", "user-id=7").end("Received ");
+    }
+  },
+  INSECURE_COOKIE_HEADER2("/insecurecookieheader2") {
+    @Override
+    public void handle(final RoutingContext rc) {
+      Vector<String> values = new Vector<>();
+      values.add("firstcookie=b");
+      values.add("user-id=7");
+      rc.response().putHeader("Set-cookie", values).end("Received ");
     }
   },
   EVENT_BUS("/eventBus") {

--- a/dd-smoke-tests/vertx-3.9/application/src/main/java/datadog/smoketest/vertx_3_9/IastHandler.java
+++ b/dd-smoke-tests/vertx-3.9/application/src/main/java/datadog/smoketest/vertx_3_9/IastHandler.java
@@ -8,6 +8,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.Vector;
 
 /** The datadog.smoketest package is needed so the class is instrumented */
 public enum IastHandler implements Handler<RoutingContext> {
@@ -81,6 +82,27 @@ public enum IastHandler implements Handler<RoutingContext> {
     @Override
     public void handle(final RoutingContext rc) {
       rc.response().end("Received " + rc.getBodyAsJsonArray());
+    }
+  },
+  INSECURE_COOKIE("/insecurecookie") {
+    @Override
+    public void handle(final RoutingContext rc) {
+      rc.response().addCookie(Cookie.cookie("userA-id", "7")).end("Received ");
+    }
+  },
+  INSECURE_COOKIE_HEADER("/insecurecookieheader") {
+    @Override
+    public void handle(final RoutingContext rc) {
+      rc.response().putHeader("Set-Cookie", "user-id=7").end("Received ");
+    }
+  },
+  INSECURE_COOKIE_HEADER2("/insecurecookieheader2") {
+    @Override
+    public void handle(final RoutingContext rc) {
+      Vector<String> values = new Vector<>();
+      values.add("firstcookie=b");
+      values.add("user-id=7");
+      rc.response().putHeader("Set-cookie", values).end("Received ");
     }
   },
   EVENT_BUS("/eventBus") {

--- a/dd-smoke-tests/vertx-3.9/src/test/groovy/datadog/smoketest/IastVertxSmokeTest.groovy
+++ b/dd-smoke-tests/vertx-3.9/src/test/groovy/datadog/smoketest/IastVertxSmokeTest.groovy
@@ -2,11 +2,47 @@ package datadog.smoketest
 
 
 import groovy.transform.CompileDynamic
+import okhttp3.Request
 
 import static datadog.trace.api.config.IastConfig.*
 
 @CompileDynamic
 class IastVertxSmokeTest extends AbstractIastVertxSmokeTest {
+
+  void 'test insecure cookie set using putHeader'() {
+    setup:
+    final url = "http://localhost:${httpPort}/insecurecookieheader"
+    final request = new Request.Builder().url(url).get().build()
+
+    when:
+    def response = client.newCall(request).execute()
+
+    then:
+    response.isSuccessful()
+    response.headers().toString().contains("user-id")
+    hasVulnerability { vul ->
+      vul.type == 'INSECURE_COOKIE' &&
+        vul.evidence.value == 'user-id'
+    }
+  }
+
+  void 'test insecure cookie set using putHeader with Iterator'() {
+    setup:
+    final url = "http://localhost:${httpPort}/insecurecookieheader2"
+    final request = new Request.Builder().url(url).get().build()
+
+    when:
+    def response = client.newCall(request).execute()
+
+    then:
+    response.isSuccessful()
+    response.headers().toString().contains("user-id")
+    response.headers().toString().contains("firstcookie")
+    hasVulnerability { vul ->
+      vul.type == 'INSECURE_COOKIE' &&
+        vul.evidence.value == 'firstcookie'
+    }
+  }
 
   @Override
   ProcessBuilder createProcessBuilder() {


### PR DESCRIPTION
# What Does This Do
Instruments Vertx's SeverResponse in order to detect insecure cookies.

# Motivation
Insecure cookie detection needs to cover the main frameworks.

# Additional Notes
