### PR TITLE
Move PathwayContext from Span.Context to ScopeContext

### DIFF
--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpSingleRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpSingleRequestInstrumentation.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.akkahttp;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeContext;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.akkahttp.AkkaHttpClientDecorator.AKKA_CLIENT_REQUEST;
@@ -80,7 +81,7 @@ public final class AkkaHttpSingleRequestInstrumentation extends Instrumenter.Tra
         propagate().inject(span, request, headers);
         propagate()
             .injectPathwayContext(
-                span, request, headers, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
+                activeContext(), request, headers, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
         // Request is immutable, so we have to assign new value once we update headers
         request = headers.getRequest();
       }

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
@@ -92,7 +92,8 @@ public class ApacheHttpAsyncClientInstrumentation extends Instrumenter.Tracing
       final AgentSpan clientSpan = startSpan(HTTP_REQUEST);
       DECORATE.afterStart(clientSpan);
 
-      requestProducer = new DelegatingRequestProducer(clientSpan, requestProducer);
+      requestProducer =
+          new DelegatingRequestProducer(parentScope.context(), clientSpan, requestProducer);
       futureCallback =
           new TraceContinuedFutureCallback(parentScope, clientSpan, context, futureCallback);
 

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/DelegatingRequestProducer.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/DelegatingRequestProducer.java
@@ -4,6 +4,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator.DECORATE;
 import static datadog.trace.instrumentation.apachehttpasyncclient.HttpHeadersInjectAdapter.SETTER;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScopeContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
 import java.io.IOException;
@@ -16,10 +17,15 @@ import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
 import org.apache.http.protocol.HttpContext;
 
 public class DelegatingRequestProducer implements HttpAsyncRequestProducer {
+  final AgentScopeContext context;
   final AgentSpan span;
   final HttpAsyncRequestProducer delegate;
 
-  public DelegatingRequestProducer(final AgentSpan span, final HttpAsyncRequestProducer delegate) {
+  public DelegatingRequestProducer(
+      final AgentScopeContext context,
+      final AgentSpan span,
+      final HttpAsyncRequestProducer delegate) {
+    this.context = context;
     this.span = span;
     this.delegate = delegate;
   }
@@ -36,7 +42,8 @@ public class DelegatingRequestProducer implements HttpAsyncRequestProducer {
 
     propagate().inject(span, request, SETTER);
     propagate()
-        .injectPathwayContext(span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
+        .injectPathwayContext(
+            context, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
 
     return request;
   }

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HelperMethods.java
@@ -65,7 +65,7 @@ public class HelperMethods {
       propagate().inject(span, request, SETTER);
       propagate()
           .injectPathwayContext(
-              span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
+              scope.context(), request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
     }
 
     return scope;

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpAsyncClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpAsyncClientInstrumentation.java
@@ -97,7 +97,8 @@ public class ApacheHttpAsyncClientInstrumentation extends Instrumenter.Tracing
       final AgentScope clientScope = activateSpan(clientSpan);
       DECORATE.afterStart(clientSpan);
 
-      requestProducer = new DelegatingRequestProducer(clientSpan, requestProducer);
+      requestProducer =
+          new DelegatingRequestProducer(parentScope.context(), clientSpan, requestProducer);
       futureCallback =
           new TraceContinuedFutureCallback<>(parentScope, clientSpan, context, futureCallback);
 

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/DelegatingRequestProducer.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/DelegatingRequestProducer.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.apachehttpclient5;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentScopeContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.io.IOException;
 import org.apache.hc.core5.http.HttpException;
@@ -9,10 +10,13 @@ import org.apache.hc.core5.http.nio.RequestChannel;
 import org.apache.hc.core5.http.protocol.HttpContext;
 
 public class DelegatingRequestProducer implements AsyncRequestProducer {
+  final AgentScopeContext context;
   final AgentSpan span;
   final AsyncRequestProducer delegate;
 
-  public DelegatingRequestProducer(final AgentSpan span, final AsyncRequestProducer delegate) {
+  public DelegatingRequestProducer(
+      final AgentScopeContext context, final AgentSpan span, final AsyncRequestProducer delegate) {
+    this.context = context;
     this.span = span;
     this.delegate = delegate;
   }
@@ -25,7 +29,8 @@ public class DelegatingRequestProducer implements AsyncRequestProducer {
   @Override
   public void sendRequest(RequestChannel channel, HttpContext context)
       throws HttpException, IOException {
-    DelegatingRequestChannel requestChannel = new DelegatingRequestChannel(channel, span);
+    DelegatingRequestChannel requestChannel =
+        new DelegatingRequestChannel(channel, this.context, span);
     delegate.sendRequest(requestChannel, context);
   }
 

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HelperMethods.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HelperMethods.java
@@ -64,7 +64,7 @@ public class HelperMethods {
       propagate().inject(span, request, SETTER);
       propagate()
           .injectPathwayContext(
-              span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
+              scope.context(), request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
     }
 
     return scope;

--- a/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/CommonsHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/CommonsHttpClientInstrumentation.java
@@ -67,7 +67,7 @@ public class CommonsHttpClientInstrumentation extends Instrumenter.Tracing
       propagate().inject(span, httpMethod, SETTER);
       propagate()
           .injectPathwayContext(
-              span, httpMethod, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
+              scope.context(), httpMethod, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
 
       return scope;
     }

--- a/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.googlehttpclient;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeContext;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.instrumentation.googlehttpclient.HeadersInjectAdapter.SETTER;
 
@@ -39,7 +40,8 @@ public class GoogleHttpClientDecorator extends HttpClientDecorator<HttpRequest, 
     DECORATE.onRequest(span, request);
     propagate().inject(span, request, SETTER);
     propagate()
-        .injectPathwayContext(span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
+        .injectPathwayContext(
+            activeContext(), request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
     return span;
   }
 

--- a/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/AsyncHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/AsyncHttpClientInstrumentation.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.grizzly.client;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeContext;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
@@ -73,7 +74,7 @@ public final class AsyncHttpClientInstrumentation extends Instrumenter.Tracing
       propagate().inject(span, request, SETTER);
       propagate()
           .injectPathwayContext(
-              span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
+              activeContext(), request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
       InstrumentationContext.get(AsyncHandler.class, Pair.class)
           .put(handler, Pair.of(parentSpan, span));
     }

--- a/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.http_url_connection;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeContext;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.httpurlconnection.HeadersInjectAdapter.SETTER;
 import static java.util.Collections.singletonMap;
@@ -75,7 +76,7 @@ public class HttpUrlConnectionInstrumentation extends Instrumenter.Tracing
             propagate().inject(span, thiz, SETTER);
             propagate()
                 .injectPathwayContext(
-                    span, thiz, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
+                    activeContext(), thiz, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
           }
         }
         return state;

--- a/dd-java-agent/instrumentation/java-http-client/src/main/java11/datadog/trace/instrumentation/httpclient/HeadersAdvice.java
+++ b/dd-java-agent/instrumentation/java-http-client/src/main/java11/datadog/trace/instrumentation/httpclient/HeadersAdvice.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.httpclient;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeContext;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.instrumentation.httpclient.HttpHeadersInjectAdapter.KEEP;
@@ -21,7 +22,7 @@ public class HeadersAdvice {
     propagate().inject(span, headerMap, SETTER);
     propagate()
         .injectPathwayContext(
-            span, headerMap, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
+            activeContext(), headerMap, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
     headers = HttpHeaders.of(headerMap, KEEP);
   }
 }

--- a/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Instrumentation.java
@@ -4,6 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.ex
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeContext;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
@@ -77,7 +78,10 @@ public final class JaxRsClientV1Instrumentation extends Instrumenter.Tracing
         propagate().inject(span, request.getHeaders(), SETTER);
         propagate()
             .injectPathwayContext(
-                span, request.getHeaders(), SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
+                activeContext(),
+                request.getHeaders(),
+                SETTER,
+                HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
         return activateSpan(span);
       }
       return null;

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/ClientTracingFilter.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/ClientTracingFilter.java
@@ -31,7 +31,7 @@ public class ClientTracingFilter implements ClientRequestFilter, ClientResponseF
       propagate().inject(span, requestContext.getHeaders(), SETTER);
       propagate()
           .injectPathwayContext(
-              span,
+              scope.context(),
               requestContext.getHeaders(),
               SETTER,
               HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);

--- a/dd-java-agent/instrumentation/jetty-client-9.1/src/main/java/datadog/trace/instrumentation/jetty_client/JettyClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-client-9.1/src/main/java/datadog/trace/instrumentation/jetty_client/JettyClientInstrumentation.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.jetty_client;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeContext;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
@@ -88,7 +89,7 @@ public class JettyClientInstrumentation extends Instrumenter.Tracing
       propagate().inject(span, request, SETTER);
       propagate()
           .injectPathwayContext(
-              span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
+              activeContext(), request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
       return span;
     }
 

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientRequestTracingHandler.java
@@ -68,7 +68,10 @@ public class HttpClientRequestTracingHandler extends SimpleChannelDownstreamHand
       propagate().inject(span, request.headers(), SETTER);
       propagate()
           .injectPathwayContext(
-              span, request.headers(), SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
+              scope.context(),
+              request.headers(),
+              SETTER,
+              HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
 
       channelTraceContext.setClientSpan(span);
 

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientRequestTracingHandler.java
@@ -92,7 +92,10 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
         propagate().inject(span, request.headers(), SETTER);
         propagate()
             .injectPathwayContext(
-                span, request.headers(), SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
+                scope.context(),
+                request.headers(),
+                SETTER,
+                HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
       }
 
       ctx.channel().attr(SPAN_ATTRIBUTE_KEY).set(span);

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientRequestTracingHandler.java
@@ -92,7 +92,10 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
         propagate().inject(span, request.headers(), SETTER);
         propagate()
             .injectPathwayContext(
-                span, request.headers(), SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
+                scope.context(),
+                request.headers(),
+                SETTER,
+                HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
       }
 
       ctx.channel().attr(SPAN_ATTRIBUTE_KEY).set(span);

--- a/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/TracingInterceptor.java
+++ b/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/TracingInterceptor.java
@@ -29,7 +29,10 @@ public class TracingInterceptor implements Interceptor {
       propagate().inject(span, requestBuilder, SETTER);
       propagate()
           .injectPathwayContext(
-              span, requestBuilder, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
+              scope.context(),
+              requestBuilder,
+              SETTER,
+              HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
 
       final Response response;
       try {

--- a/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/TracingInterceptor.java
+++ b/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/TracingInterceptor.java
@@ -32,7 +32,10 @@ public class TracingInterceptor implements Interceptor {
       propagate().inject(span, requestBuilder, SETTER);
       propagate()
           .injectPathwayContext(
-              span, requestBuilder, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
+              scope.context(),
+              requestBuilder,
+              SETTER,
+              HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
 
       final Response response;
       try {

--- a/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/PlayWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/PlayWSClientInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.playws1;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeContext;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.playws.HeadersInjectAdapter.SETTER;
@@ -32,7 +33,7 @@ public class PlayWSClientInstrumentation extends BasePlayWSClientInstrumentation
       propagate().inject(span, request, SETTER);
       propagate()
           .injectPathwayContext(
-              span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
+              activeContext(), request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
 
       if (asyncHandler instanceof StreamedAsyncHandler) {
         asyncHandler = new StreamedAsyncHandlerWrapper((StreamedAsyncHandler) asyncHandler, span);

--- a/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/PlayWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/PlayWSClientInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.playws21;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeContext;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.playws.HeadersInjectAdapter.SETTER;
@@ -32,7 +33,7 @@ public class PlayWSClientInstrumentation extends BasePlayWSClientInstrumentation
       propagate().inject(span, request, SETTER);
       propagate()
           .injectPathwayContext(
-              span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
+              activeContext(), request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
 
       if (asyncHandler instanceof StreamedAsyncHandler) {
         asyncHandler = new StreamedAsyncHandlerWrapper((StreamedAsyncHandler) asyncHandler, span);

--- a/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/PlayWSClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/PlayWSClientInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.playws2;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeContext;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.playws.HeadersInjectAdapter.SETTER;
@@ -32,7 +33,7 @@ public class PlayWSClientInstrumentation extends BasePlayWSClientInstrumentation
       propagate().inject(span, request, SETTER);
       propagate()
           .injectPathwayContext(
-              span, request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
+              activeContext(), request, SETTER, HttpClientDecorator.CLIENT_PATHWAY_EDGE_TAGS);
 
       if (asyncHandler instanceof StreamedAsyncHandler) {
         asyncHandler = new StreamedAsyncHandlerWrapper((StreamedAsyncHandler) asyncHandler, span);

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -5,6 +5,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.nameEnd
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeContext;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
@@ -181,7 +182,7 @@ public class RabbitChannelInstrumentation extends Instrumenter.Tracing
           && !config.isRabbitPropagationDisabledForDestination(exchange)) {
         // We need to copy the BasicProperties and provide a header map we can modify
         Map<String, Object> headers = props.getHeaders();
-        headers = (headers == null) ? new HashMap<String, Object>() : new HashMap<>(headers);
+        headers = (headers == null) ? new HashMap<>() : new HashMap<>(headers);
         if (TIME_IN_QUEUE_ENABLED) {
           RabbitDecorator.injectTimeInQueueStart(headers);
         }
@@ -192,7 +193,7 @@ public class RabbitChannelInstrumentation extends Instrumenter.Tracing
         sortedTags.put(
             HAS_ROUTING_KEY_TAG, routingKey == null || routingKey.equals("") ? "false" : "true");
         sortedTags.put(TYPE_TAG, "rabbitmq");
-        propagate().injectPathwayContext(span, headers, SETTER, sortedTags);
+        propagate().injectPathwayContext(activeContext(), headers, SETTER, sortedTags);
         props =
             new AMQP.BasicProperties(
                 props.getContentType(),

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -4,7 +4,6 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_ASYNC_PROPAGATING;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentSpan;
 import static datadog.trace.bootstrap.instrumentation.api.ScopeSource.INSTRUMENTATION;
 import static datadog.trace.bootstrap.instrumentation.api.ScopeSource.ITERATION;
-import static datadog.trace.core.scopemanager.ScopeContext.SPAN_KEY;
 import static datadog.trace.core.scopemanager.ScopeContext.fromSpan;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -210,7 +209,7 @@ public final class ContinuableScopeManager implements AgentScopeManager {
     final ContinuableScope top = scopeStack.top;
 
     AgentScopeContext context =
-        (top == null ? ScopeContext.empty() : top.context).with(SPAN_KEY, span);
+        (top == null ? ScopeContext.empty() : top.context).with(AgentSpan.CONTEXT_KEY, span);
 
     boolean asyncPropagation =
         inheritAsyncPropagation && top != null
@@ -243,7 +242,6 @@ public final class ContinuableScopeManager implements AgentScopeManager {
 
   @Override
   public AgentScope activateContext(AgentScopeContext context) {
-
     return this.activate(context, INSTRUMENTATION.id(), false, false);
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeContext.java
@@ -19,8 +19,8 @@ import java.util.Objects;
  * and can be retrieved using {@link AgentScopeManager#active()}.
  */
 public class ScopeContext implements AgentScopeContext {
-  public static final ContextKey<AgentSpan> SPAN_KEY = named("dd-span-key");
   public static final ContextKey<Baggage> BAGGAGE_KEY = named("dd-baggage-key");
+  private static final ScopeContext EMPTY = new ScopeContext(null, null, null);
   private final AgentSpan span;
   private final Baggage baggage;
   /**
@@ -41,7 +41,7 @@ public class ScopeContext implements AgentScopeContext {
    * @return An empty {@link ScopeContext} instance.
    */
   public static ScopeContext empty() {
-    return new ScopeContext(null, null, null);
+    return EMPTY;
   }
 
   /**
@@ -69,7 +69,7 @@ public class ScopeContext implements AgentScopeContext {
   public <T> T get(ContextKey<T> key) {
     if (key == null) {
       return null;
-    } else if (key == SPAN_KEY) {
+    } else if (key == AgentSpan.CONTEXT_KEY) {
       return (T) this.span;
     } else if (key == BAGGAGE_KEY) {
       return (T) this.baggage;
@@ -91,7 +91,7 @@ public class ScopeContext implements AgentScopeContext {
     AgentSpan newSpan = this.span;
     Baggage newBaggage = this.baggage;
     Object[] newStore = this.store;
-    if (key == SPAN_KEY) {
+    if (key == AgentSpan.CONTEXT_KEY) {
       newSpan = (AgentSpan) value;
     } else if (key == BAGGAGE_KEY) {
       newBaggage = (Baggage) value;

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
@@ -15,11 +15,17 @@ public interface AgentPropagation {
 
   // The input tags should be sorted.
   <C> void injectBinaryPathwayContext(
-      AgentSpan span, C carrier, BinarySetter<C> setter, LinkedHashMap<String, String> sortedTags);
+      AgentScopeContext context,
+      C carrier,
+      BinarySetter<C> setter,
+      LinkedHashMap<String, String> sortedTags);
 
   // The input tags should be sorted.
   <C> void injectPathwayContext(
-      AgentSpan span, C carrier, Setter<C> setter, LinkedHashMap<String, String> sortedTags);
+      AgentScopeContext context,
+      C carrier,
+      Setter<C> setter,
+      LinkedHashMap<String, String> sortedTags);
 
   interface Setter<C> {
     void set(C carrier, String key, String value);
@@ -31,9 +37,11 @@ public interface AgentPropagation {
 
   <C> AgentSpan.Context.Extracted extract(C carrier, ContextVisitor<C> getter);
 
-  <C> PathwayContext extractBinaryPathwayContext(C carrier, BinaryContextVisitor<C> getter);
+  <C> AgentScopeContext extractBinaryPathwayContext(
+      AgentScopeContext context, C carrier, BinaryContextVisitor<C> getter);
 
-  <C> PathwayContext extractPathwayContext(C carrier, ContextVisitor<C> getter);
+  <C> AgentScopeContext extractPathwayContext(
+      AgentScopeContext context, C carrier, ContextVisitor<C> getter);
 
   interface KeyClassifier {
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -1,5 +1,7 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
+import static datadog.trace.bootstrap.instrumentation.api.ContextKey.named;
+
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.TraceConfig;
 import datadog.trace.api.gateway.IGSpanInfo;
@@ -9,6 +11,7 @@ import datadog.trace.api.sampling.PrioritySampling;
 import java.util.Map;
 
 public interface AgentSpan extends MutableSpan, IGSpanInfo {
+  ContextKey<AgentSpan> CONTEXT_KEY = named("dd-span-key");
 
   DDTraceId getTraceId();
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -88,6 +88,25 @@ public class AgentTracer {
     return get().activeScope();
   }
 
+  /**
+   * Actives a scoped context.
+   *
+   * @param context The context to activate.
+   * @return The scope of the newly activated context.
+   */
+  public static AgentScope activateContext(AgentScopeContext context) {
+    return get().activateContext(context);
+  }
+
+  /**
+   * Gets the active context.
+   *
+   * @return The active context, or an empty context if no active scope.
+   */
+  public static AgentScopeContext activeContext() {
+    return get().activeContext();
+  }
+
   public static AgentPropagation propagate() {
     return get().propagate();
   }
@@ -151,6 +170,13 @@ public class AgentTracer {
     AgentSpan activeSpan();
 
     AgentScope activeScope();
+
+    /**
+     * Gets the active context.
+     *
+     * @return The active context, or an empty context if no active scope.
+     */
+    AgentScopeContext activeContext();
 
     AgentPropagation propagate();
 
@@ -288,6 +314,11 @@ public class AgentTracer {
     }
 
     @Override
+    public AgentScopeContext activeContext() {
+      return NoopAgentScopeContext.INSTANCE;
+    }
+
+    @Override
     public AgentPropagation propagate() {
       return NoopAgentPropagation.INSTANCE;
     }
@@ -393,14 +424,17 @@ public class AgentTracer {
 
     @Override
     public <C> void injectBinaryPathwayContext(
-        AgentSpan span,
+        AgentScopeContext context,
         C carrier,
         BinarySetter<C> setter,
         LinkedHashMap<String, String> sortedTags) {}
 
     @Override
     public <C> void injectPathwayContext(
-        AgentSpan span, C carrier, Setter<C> setter, LinkedHashMap<String, String> sortedTags) {}
+        AgentScopeContext context,
+        C carrier,
+        Setter<C> setter,
+        LinkedHashMap<String, String> sortedTags) {}
 
     @Override
     public <C> Context.Extracted extract(final C carrier, final ContextVisitor<C> getter) {
@@ -408,14 +442,15 @@ public class AgentTracer {
     }
 
     @Override
-    public <C> PathwayContext extractBinaryPathwayContext(
-        C carrier, BinaryContextVisitor<C> getter) {
-      return null;
+    public <C> AgentScopeContext extractBinaryPathwayContext(
+        AgentScopeContext context, C carrier, BinaryContextVisitor<C> getter) {
+      return NoopAgentScopeContext.INSTANCE;
     }
 
     @Override
-    public <C> PathwayContext extractPathwayContext(C carrier, ContextVisitor<C> getter) {
-      return null;
+    public <C> AgentScopeContext extractPathwayContext(
+        AgentScopeContext context, C carrier, ContextVisitor<C> getter) {
+      return NoopAgentScopeContext.INSTANCE;
     }
 
     @Override
@@ -832,14 +867,17 @@ public class AgentTracer {
 
     @Override
     public <C> void injectBinaryPathwayContext(
-        AgentSpan span,
+        AgentScopeContext context,
         C carrier,
         BinarySetter<C> setter,
         LinkedHashMap<String, String> sortedTags) {}
 
     @Override
     public <C> void injectPathwayContext(
-        AgentSpan span, C carrier, Setter<C> setter, LinkedHashMap<String, String> sortedTags) {}
+        AgentScopeContext context,
+        C carrier,
+        Setter<C> setter,
+        LinkedHashMap<String, String> sortedTags) {}
 
     @Override
     public <C> Context.Extracted extract(final C carrier, final ContextVisitor<C> getter) {
@@ -847,14 +885,15 @@ public class AgentTracer {
     }
 
     @Override
-    public <C> PathwayContext extractBinaryPathwayContext(
-        C carrier, BinaryContextVisitor<C> getter) {
-      return null;
+    public <C> AgentScopeContext extractBinaryPathwayContext(
+        AgentScopeContext context, C carrier, BinaryContextVisitor<C> getter) {
+      return NoopAgentScopeContext.INSTANCE;
     }
 
     @Override
-    public <C> PathwayContext extractPathwayContext(C carrier, ContextVisitor<C> getter) {
-      return null;
+    public <C> AgentScopeContext extractPathwayContext(
+        AgentScopeContext context, C carrier, ContextVisitor<C> getter) {
+      return NoopAgentScopeContext.INSTANCE;
     }
   }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/PathwayContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/PathwayContext.java
@@ -5,6 +5,7 @@ import java.util.LinkedHashMap;
 import java.util.function.Consumer;
 
 public interface PathwayContext {
+  ContextKey<PathwayContext> CONTEXT_KEY = ContextKey.named("dd-pathway-context");
   String PROPAGATION_KEY = "dd-pathway-ctx";
   String PROPAGATION_KEY_BASE64 = "dd-pathway-ctx-base64";
 


### PR DESCRIPTION
# What Does This Do

Add cache for empty ScopeContext.
Move Span context key to internal-api to be accessible by instrumentations.
Update instrumentations to the new Pathway inject/extract API.

# Motivation

# Additional Notes

Do not remove PathwayContext from Span.Context yet to prevent conflict.
