### PR TITLE
Fix InsecureCookieModuleTest

### DIFF
--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/InsecureCookieModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/InsecureCookieModuleTest.groovy
@@ -104,7 +104,7 @@ class InsecureCookieModuleTest  extends IastModuleImplTestBase {
   void 'cases where nothing is reported during InsecureCookieModule.onCookieHeader'() {
 
     when:
-    module.onCookie(cookieValue)
+    module.onCookieHeader(cookieValue)
 
     then:
     0 * tracer.activeSpan()


### PR DESCRIPTION
# What Does This Do
Fix a mistake on a unit test in iast-agent. The test is failing, but CI is not reporting it as failed. It passes after the fix.

# Motivation
To make sure that all tests work in master

# Additional Notes
