### PR TITLE
[netty] don't create two root spans if 100 continue is expected

### DIFF
--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/HttpServerResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/HttpServerResponseTracingHandler.java
@@ -12,6 +12,7 @@ import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.MessageEvent;
 import org.jboss.netty.channel.SimpleChannelDownstreamHandler;
 import org.jboss.netty.handler.codec.http.HttpResponse;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
 public class HttpServerResponseTracingHandler extends SimpleChannelDownstreamHandler {
 
@@ -45,9 +46,11 @@ public class HttpServerResponseTracingHandler extends SimpleChannelDownstreamHan
         span.finish(); // Finish the span manually since finishSpanOnClose was false
         throw throwable;
       }
-      DECORATE.onResponse(span, response);
-      DECORATE.beforeFinish(span);
-      span.finish(); // Finish the span manually since finishSpanOnClose was false
+      if (response.getStatus() != HttpResponseStatus.CONTINUE) {
+        DECORATE.onResponse(span, response);
+        DECORATE.beforeFinish(span);
+        span.finish(); // Finish the span manually since finishSpanOnClose was false
+      }
     }
   }
 }

--- a/dd-java-agent/instrumentation/netty-3.8/src/test/groovy/datadog/trace/instrumentation/netty38/Netty38ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-3.8/src/test/groovy/datadog/trace/instrumentation/netty38/Netty38ServerTest.groovy
@@ -1,35 +1,5 @@
 package datadog.trace.instrumentation.netty38
 
-import datadog.appsec.api.blocking.Blocking
-import datadog.trace.agent.test.base.HttpServer
-import datadog.trace.agent.test.base.HttpServerTest
-import datadog.trace.agent.test.naming.TestingNettyHttpNamingConventions
-import datadog.trace.instrumentation.netty38.server.NettyHttpServerDecorator
-import org.jboss.netty.bootstrap.ServerBootstrap
-import org.jboss.netty.buffer.ChannelBuffer
-import org.jboss.netty.buffer.ChannelBuffers
-import org.jboss.netty.channel.ChannelHandlerContext
-import org.jboss.netty.channel.ChannelPipeline
-import org.jboss.netty.channel.ChannelPipelineFactory
-import org.jboss.netty.channel.DefaultChannelPipeline
-import org.jboss.netty.channel.DownstreamMessageEvent
-import org.jboss.netty.channel.ExceptionEvent
-import org.jboss.netty.channel.FailedChannelFuture
-import org.jboss.netty.channel.MessageEvent
-import org.jboss.netty.channel.SimpleChannelHandler
-import org.jboss.netty.channel.SucceededChannelFuture
-import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory
-import org.jboss.netty.handler.codec.http.DefaultHttpResponse
-import org.jboss.netty.handler.codec.http.HttpRequest
-import org.jboss.netty.handler.codec.http.HttpResponse
-import org.jboss.netty.handler.codec.http.HttpResponseStatus
-import org.jboss.netty.handler.codec.http.HttpServerCodec
-import org.jboss.netty.handler.logging.LoggingHandler
-import org.jboss.netty.logging.InternalLogLevel
-import org.jboss.netty.logging.InternalLoggerFactory
-import org.jboss.netty.logging.Slf4JLoggerFactory
-import org.jboss.netty.util.CharsetUtil
-import spock.lang.Ignore
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
@@ -46,6 +16,39 @@ import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGT
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.LOCATION
 import static org.jboss.netty.handler.codec.http.HttpVersion.HTTP_1_1
+
+import datadog.appsec.api.blocking.Blocking
+import datadog.trace.agent.test.base.HttpServer
+import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.agent.test.naming.TestingNettyHttpNamingConventions
+import datadog.trace.bootstrap.instrumentation.api.URIUtils
+import datadog.trace.instrumentation.netty38.server.NettyHttpServerDecorator
+import org.jboss.netty.bootstrap.ServerBootstrap
+import org.jboss.netty.buffer.ChannelBuffer
+import org.jboss.netty.buffer.ChannelBuffers
+import org.jboss.netty.channel.ChannelHandlerContext
+import org.jboss.netty.channel.ChannelPipeline
+import org.jboss.netty.channel.ChannelPipelineFactory
+import org.jboss.netty.channel.DefaultChannelPipeline
+import org.jboss.netty.channel.DownstreamMessageEvent
+import org.jboss.netty.channel.ExceptionEvent
+import org.jboss.netty.channel.FailedChannelFuture
+import org.jboss.netty.channel.MessageEvent
+import org.jboss.netty.channel.SimpleChannelHandler
+import org.jboss.netty.channel.SucceededChannelFuture
+import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory
+import org.jboss.netty.handler.codec.http.DefaultHttpResponse
+import org.jboss.netty.handler.codec.http.HttpHeaders
+import org.jboss.netty.handler.codec.http.HttpRequest
+import org.jboss.netty.handler.codec.http.HttpResponse
+import org.jboss.netty.handler.codec.http.HttpResponseStatus
+import org.jboss.netty.handler.codec.http.HttpServerCodec
+import org.jboss.netty.handler.logging.LoggingHandler
+import org.jboss.netty.logging.InternalLogLevel
+import org.jboss.netty.logging.InternalLoggerFactory
+import org.jboss.netty.logging.Slf4JLoggerFactory
+import org.jboss.netty.util.CharsetUtil
+import spock.lang.Ignore
 
 abstract class Netty38ServerTest extends HttpServerTest<ServerBootstrap> {
 
@@ -65,7 +68,18 @@ abstract class Netty38ServerTest extends HttpServerTest<ServerBootstrap> {
         void messageReceived(ChannelHandlerContext ctx, MessageEvent msg) throws Exception {
           if (msg.getMessage() instanceof HttpRequest) {
             def request = msg.getMessage() as HttpRequest
-            def uri = URI.create(request.getUri())
+            if (HttpHeaders.is100ContinueExpected(request)) {
+              ctx.sendDownstream(new DownstreamMessageEvent(ctx.getChannel(),
+                new SucceededChannelFuture(ctx.getChannel()), new DefaultHttpResponse(HTTP_1_1, HttpResponseStatus.CONTINUE),
+                ctx.getChannel().getRemoteAddress()))
+            }
+            def uri = URIUtils.safeParse(request.uri)
+            if (uri == null) {
+              ctx.sendDownstream(new DownstreamMessageEvent(ctx.getChannel(),
+                new SucceededChannelFuture(ctx.getChannel()), new DefaultHttpResponse(request.protocolVersion, HttpResponseStatus.BAD_REQUEST),
+                ctx.getChannel().getRemoteAddress()))
+              return
+            }
             HttpServerTest.ServerEndpoint endpoint = forPath(uri.rawPath)
             ctx.sendDownstream controller(endpoint) {
               HttpResponse response
@@ -197,7 +211,7 @@ abstract class Netty38ServerTest extends HttpServerTest<ServerBootstrap> {
   }
 }
 
-class Netty38ServerV0ForkedTest extends Netty38ServerTest implements TestingNettyHttpNamingConventions.ServerV0 {
+class Netty38ServerV0Test extends Netty38ServerTest implements TestingNettyHttpNamingConventions.ServerV0 {
 }
 
 class Netty38ServerV1ForkedTest extends Netty38ServerTest implements TestingNettyHttpNamingConventions.ServerV1 {

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerResponseTracingHandler.java
@@ -11,6 +11,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
 
 @ChannelHandler.Sharable
 public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdapter {
@@ -35,9 +36,11 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
         span.finish(); // Finish the span manually since finishSpanOnClose was false
         throw throwable;
       }
-      DECORATE.onResponse(span, response);
-      DECORATE.beforeFinish(span);
-      span.finish(); // Finish the span manually since finishSpanOnClose was false
+      if (response.getStatus() != HttpResponseStatus.CONTINUE) {
+        DECORATE.onResponse(span, response);
+        DECORATE.beforeFinish(span);
+        span.finish(); // Finish the span manually since finishSpanOnClose was false
+      }
     }
   }
 }

--- a/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
@@ -1,7 +1,25 @@
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_BOTH
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_QUERY
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE
+import static io.netty.handler.codec.http.HttpHeaders.is100ContinueExpected
+import static io.netty.handler.codec.http.HttpResponseStatus.CONTINUE
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1
+
 import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.agent.test.naming.TestingNettyHttpNamingConventions
+import datadog.trace.bootstrap.instrumentation.api.URIUtils
 import datadog.trace.instrumentation.netty40.server.NettyHttpServerDecorator
 import io.netty.bootstrap.ServerBootstrap
 import io.netty.buffer.ByteBuf
@@ -24,21 +42,6 @@ import io.netty.handler.logging.LogLevel
 import io.netty.handler.logging.LoggingHandler
 import io.netty.util.CharsetUtil
 import spock.lang.Ignore
-
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_BOTH
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_QUERY
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE
-import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR
-import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1
 
 abstract class Netty40ServerTest extends HttpServerTest<EventLoopGroup> {
 
@@ -64,7 +67,14 @@ abstract class Netty40ServerTest extends HttpServerTest<EventLoopGroup> {
               channelRead0       : { ChannelHandlerContext ctx, msg ->
                 if (msg instanceof HttpRequest) {
                   def request = msg as HttpRequest
-                  def uri = URI.create(request.uri)
+                  if (is100ContinueExpected(request)) {
+                    ctx.write(new DefaultFullHttpResponse(HTTP_1_1, CONTINUE))
+                  }
+                  def uri = URIUtils.safeParse(request.uri)
+                  if (uri == null) {
+                    ctx.write(new DefaultFullHttpResponse(request.protocolVersion, HttpResponseStatus.BAD_REQUEST))
+                    return
+                  }
                   HttpServerTest.ServerEndpoint endpoint = HttpServerTest.ServerEndpoint.forPath(uri.path)
                   ctx.write controller(endpoint) {
                     ByteBuf content = null
@@ -166,7 +176,7 @@ abstract class Netty40ServerTest extends HttpServerTest<EventLoopGroup> {
   }
 }
 
-class Netty40ServerV0ForkedTest extends Netty40ServerTest implements TestingNettyHttpNamingConventions.ServerV0 {
+class Netty40ServerV0Test extends Netty40ServerTest implements TestingNettyHttpNamingConventions.ServerV0 {
 }
 
 class Netty40ServerV1ForkedTest extends Netty40ServerTest implements TestingNettyHttpNamingConventions.ServerV1 {

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerResponseTracingHandler.java
@@ -11,6 +11,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
 
 @ChannelHandler.Sharable
 public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdapter {
@@ -35,9 +36,11 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
         span.finish(); // Finish the span manually since finishSpanOnClose was false
         throw throwable;
       }
-      DECORATE.onResponse(span, response);
-      DECORATE.beforeFinish(span);
-      span.finish(); // Finish the span manually since finishSpanOnClose was false
+      if (response.status() != HttpResponseStatus.CONTINUE) {
+        DECORATE.onResponse(span, response);
+        DECORATE.beforeFinish(span);
+        span.finish(); // Finish the span manually since finishSpanOnClose was false
+      }
     }
   }
 }

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
@@ -1,3 +1,8 @@
+import static datadog.trace.agent.test.utils.PortUtils.UNUSABLE_PORT
+import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static org.asynchttpclient.Dsl.asyncHttpClient
+
 import datadog.trace.agent.test.base.HttpClientTest
 import datadog.trace.agent.test.naming.TestingNettyHttpNamingConventions
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -10,17 +15,16 @@ import io.netty.handler.codec.http.HttpRequestEncoder
 import io.netty.handler.codec.http.HttpVersion
 import io.netty.handler.ssl.SslContextBuilder
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory
-import org.asynchttpclient.*
+import org.asynchttpclient.AsyncCompletionHandler
+import org.asynchttpclient.AsyncHttpClient
+import org.asynchttpclient.BoundRequestBuilder
+import org.asynchttpclient.DefaultAsyncHttpClientConfig
+import org.asynchttpclient.Response
 import org.asynchttpclient.proxy.ProxyServer
 import spock.lang.AutoCleanup
 import spock.lang.Timeout
 
 import java.util.concurrent.ExecutionException
-
-import static datadog.trace.agent.test.utils.PortUtils.UNUSABLE_PORT
-import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
-import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static org.asynchttpclient.Dsl.asyncHttpClient
 
 @Timeout(5)
 abstract class Netty41ClientTest extends HttpClientTest {

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ServerTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ServerTest.groovy
@@ -1,7 +1,26 @@
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_URLENCODED
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_BOTH
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_QUERY
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE
+import static io.netty.handler.codec.http.HttpResponseStatus.CONTINUE
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR
+import static io.netty.handler.codec.http.HttpUtil.is100ContinueExpected
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1
+
 import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.agent.test.naming.TestingNettyHttpNamingConventions
+import datadog.trace.bootstrap.instrumentation.api.URIUtils
 import datadog.trace.instrumentation.netty41.server.NettyHttpServerDecorator
 import io.netty.bootstrap.ServerBootstrap
 import io.netty.buffer.ByteBuf
@@ -27,22 +46,6 @@ import io.netty.handler.logging.LogLevel
 import io.netty.handler.logging.LoggingHandler
 import io.netty.util.CharsetUtil
 
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_URLENCODED
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_BOTH
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_QUERY
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
-import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH
-import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE
-import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR
-import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1
-
 abstract class Netty41ServerTest extends HttpServerTest<EventLoopGroup> {
 
   static final LoggingHandler LOGGING_HANDLER = new LoggingHandler(SERVER_LOGGER.name, LogLevel.DEBUG)
@@ -67,7 +70,14 @@ abstract class Netty41ServerTest extends HttpServerTest<EventLoopGroup> {
               channelRead0       : { ChannelHandlerContext ctx, msg ->
                 if (msg instanceof HttpRequest) {
                   def request = msg as HttpRequest
-                  def uri = URI.create(request.uri)
+                  if (is100ContinueExpected(request)) {
+                    ctx.write(new DefaultFullHttpResponse(HTTP_1_1, CONTINUE))
+                  }
+                  def uri = URIUtils.safeParse(request.uri)
+                  if (uri == null) {
+                    ctx.write(new DefaultFullHttpResponse(request.protocolVersion(),HttpResponseStatus.BAD_REQUEST))
+                    return
+                  }
                   HttpServerTest.ServerEndpoint endpoint = HttpServerTest.ServerEndpoint.forPath(uri.path)
                   ctx.write controller(endpoint) {
                     ByteBuf content = null
@@ -200,7 +210,7 @@ abstract class Netty41ServerTest extends HttpServerTest<EventLoopGroup> {
   }
 }
 
-class Netty41ServerV0ForkedTest extends Netty41ServerTest implements TestingNettyHttpNamingConventions.ServerV0 {
+class Netty41ServerV0Test extends Netty41ServerTest implements TestingNettyHttpNamingConventions.ServerV0 {
 
 }
 

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowDispatcherTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowDispatcherTest.groovy
@@ -22,7 +22,7 @@ abstract class UndertowDispatcherTest extends HttpServerTest<Undertow> {
       undertowServer = Undertow.builder()
         .addHttpListener(port, "localhost")
         .setServerOption(UndertowOptions.DECODE_URL, true)
-        .setHandler(Handlers.path()
+        .setHandler(Handlers.httpContinueRead (Handlers.path()
         .addExactPath(SUCCESS.getPath()) { exchange ->
           exchange.dispatch(
             new Runnable() {
@@ -121,7 +121,7 @@ abstract class UndertowDispatcherTest extends HttpServerTest<Undertow> {
             }
           }
         }
-        ).build()
+        )).build()
     }
 
     @Override

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowServletTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowServletTest.groovy
@@ -1,17 +1,29 @@
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.LOGIN
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_HERE
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_BOTH
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_QUERY
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
+
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import io.undertow.Handlers
 import io.undertow.Undertow
 import io.undertow.UndertowOptions
-import io.undertow.server.handlers.PathHandler
 import io.undertow.servlet.api.DeploymentInfo
 import io.undertow.servlet.api.DeploymentManager
 import io.undertow.servlet.api.ServletContainer
 import io.undertow.servlet.api.ServletInfo
-
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.*
 
 abstract class UndertowServletTest extends HttpServerTest<Undertow> {
   private static final CONTEXT = "ctx"
@@ -21,7 +33,7 @@ abstract class UndertowServletTest extends HttpServerTest<Undertow> {
     Undertow undertowServer
 
     UndertowServer() {
-      final PathHandler root = new PathHandler()
+      def root = Handlers.path()
       final ServletContainer container = ServletContainer.Factory.newInstance()
 
       DeploymentInfo builder = new DeploymentInfo()
@@ -46,7 +58,7 @@ abstract class UndertowServletTest extends HttpServerTest<Undertow> {
       undertowServer = Undertow.builder()
         .addHttpListener(port, "localhost")
         .setServerOption(UndertowOptions.DECODE_URL, true)
-        .setHandler(root)
+        .setHandler(Handlers.httpContinueRead(root))
         .build()
     }
 

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowTest.groovy
@@ -26,7 +26,7 @@ class UndertowTest extends HttpServerTest<Undertow> {
       undertowServer = Undertow.builder()
         .addHttpListener(port, "localhost")
         .setServerOption(UndertowOptions.DECODE_URL, true)
-        .setHandler(Handlers.path()
+        .setHandler(Handlers.httpContinueRead(Handlers.path()
         .addExactPath(SUCCESS.getPath()) { exchange ->
           controller(SUCCESS) {
             exchange.getResponseSender().send(SUCCESS.body)
@@ -125,7 +125,7 @@ class UndertowTest extends HttpServerTest<Undertow> {
             }
           }
         }
-        ).build()
+        )).build()
     }
 
     @Override

--- a/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowDispatcherTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowDispatcherTest.groovy
@@ -21,7 +21,7 @@ class UndertowDispatcherTest extends HttpServerTest<Undertow> {
       undertowServer = Undertow.builder()
         .addHttpListener(port, "localhost")
         .setServerOption(UndertowOptions.DECODE_URL, true)
-        .setHandler(Handlers.path()
+        .setHandler(Handlers.httpContinueRead(Handlers.path()
         .addExactPath(SUCCESS.getPath()) { exchange ->
           exchange.dispatch(
             new Runnable() {
@@ -121,7 +121,7 @@ class UndertowDispatcherTest extends HttpServerTest<Undertow> {
             }
           }
         }
-        ).build()
+        )).build()
     }
 
     @Override

--- a/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowServletTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowServletTest.groovy
@@ -1,14 +1,3 @@
-import datadog.trace.agent.test.asserts.TraceAssert
-import datadog.trace.agent.test.base.HttpServer
-import datadog.trace.agent.test.base.HttpServerTest
-import io.undertow.Undertow
-import io.undertow.UndertowOptions
-import io.undertow.server.handlers.PathHandler
-import io.undertow.servlet.api.DeploymentInfo
-import io.undertow.servlet.api.DeploymentManager
-import io.undertow.servlet.api.ServletContainer
-import io.undertow.servlet.api.ServletInfo
-
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
@@ -20,6 +9,17 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRE
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 
+import datadog.trace.agent.test.asserts.TraceAssert
+import datadog.trace.agent.test.base.HttpServer
+import datadog.trace.agent.test.base.HttpServerTest
+import io.undertow.Handlers
+import io.undertow.Undertow
+import io.undertow.UndertowOptions
+import io.undertow.servlet.api.DeploymentInfo
+import io.undertow.servlet.api.DeploymentManager
+import io.undertow.servlet.api.ServletContainer
+import io.undertow.servlet.api.ServletInfo
+
 class UndertowServletTest extends HttpServerTest<Undertow> {
   private static final CONTEXT = "ctx"
 
@@ -28,7 +28,7 @@ class UndertowServletTest extends HttpServerTest<Undertow> {
     Undertow undertowServer
 
     UndertowServer() {
-      final PathHandler root = new PathHandler()
+      def root = Handlers.path()
       final ServletContainer container = ServletContainer.Factory.newInstance()
 
       DeploymentInfo builder = new DeploymentInfo()
@@ -53,7 +53,7 @@ class UndertowServletTest extends HttpServerTest<Undertow> {
       undertowServer = Undertow.builder()
         .addHttpListener(port, "localhost")
         .setServerOption(UndertowOptions.DECODE_URL, true)
-        .setHandler(root)
+        .setHandler(Handlers.httpContinueRead (root))
         .build()
     }
 

--- a/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowTest.groovy
@@ -26,7 +26,7 @@ class UndertowTest extends HttpServerTest<Undertow> {
       undertowServer = Undertow.builder()
         .addHttpListener(port, "localhost")
         .setServerOption(UndertowOptions.DECODE_URL, true)
-        .setHandler(Handlers.path()
+        .setHandler(Handlers.httpContinueRead(Handlers.path()
         .addExactPath(SUCCESS.getPath()) { exchange ->
           controller(SUCCESS) {
             exchange.getResponseSender().send(SUCCESS.body)
@@ -119,7 +119,7 @@ class UndertowTest extends HttpServerTest<Undertow> {
             }
           }
         }
-        ).build()
+        )).build()
     }
 
     @Override

--- a/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/server/VertxRxCircuitBreakerHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/server/VertxRxCircuitBreakerHttpServerForkedTest.groovy
@@ -4,6 +4,7 @@ import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServerTest
 import io.vertx.circuitbreaker.CircuitBreakerOptions
 import io.vertx.core.Future
+import io.vertx.core.http.HttpServerOptions
 import io.vertx.reactivex.circuitbreaker.CircuitBreaker
 import io.vertx.reactivex.core.AbstractVerticle
 import io.vertx.reactivex.core.MultiMap
@@ -207,7 +208,7 @@ class VertxRxCircuitBreakerHttpServerForkedTest extends VertxHttpServerForkedTes
         })
       }
 
-      super.@vertx.createHttpServer()
+      super.@vertx.createHttpServer(new HttpServerOptions().setHandle100ContinueAutomatically(true))
         .requestHandler { router.accept(it) }
         .listen(port) { startFuture.complete() }
     }

--- a/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/server/VertxRxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/server/VertxRxHttpServerForkedTest.groovy
@@ -2,6 +2,7 @@ package server
 
 import io.vertx.core.AbstractVerticle
 import io.vertx.core.Future
+import io.vertx.core.http.HttpServerOptions
 import io.vertx.ext.web.Router
 import spock.lang.Ignore
 
@@ -71,7 +72,7 @@ class VertxRxHttpServerForkedTest extends VertxHttpServerForkedTest {
         }
       }
 
-      super.@vertx.createHttpServer()
+      super.@vertx.createHttpServer(new HttpServerOptions().setHandle100ContinueAutomatically(true))
         .requestHandler { router.accept(it) }
         .listen(port) { startFuture.complete() }
     }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -1,5 +1,13 @@
 package server
 
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.LOGIN
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static server.VertxTestServer.CONFIG_HTTP_SERVER_PORT
+
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
@@ -15,14 +23,6 @@ import io.vertx.core.impl.VertxInternal
 import io.vertx.core.json.JsonObject
 
 import java.util.concurrent.CompletableFuture
-
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.LOGIN
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-import static server.VertxTestServer.CONFIG_HTTP_SERVER_PORT
 
 class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
 

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/java/server/VertxTestServer.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/java/server/VertxTestServer.java
@@ -25,6 +25,7 @@ import datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
@@ -200,7 +201,7 @@ public class VertxTestServer extends AbstractVerticle {
     router = customizeAfterRoutes(router);
 
     vertx
-        .createHttpServer()
+        .createHttpServer(new HttpServerOptions().setHandle100ContinueAutomatically(true))
         .requestHandler(router::accept)
         .listen(port, event -> startFuture.complete());
   }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/server/VertxHttpServerForkedTest.groovy
@@ -1,5 +1,13 @@
 package server
 
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.LOGIN
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static server.VertxTestServer.CONFIG_HTTP_SERVER_PORT
+
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
@@ -14,14 +22,6 @@ import io.vertx.core.impl.VertxInternal
 import io.vertx.core.json.JsonObject
 
 import java.util.concurrent.CompletableFuture
-
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.LOGIN
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-import static server.VertxTestServer.CONFIG_HTTP_SERVER_PORT
 
 class VertxHttpServerForkedTest extends HttpServerTest<Vertx> {
 

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/java/server/IastSourcesVerticle.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/java/server/IastSourcesVerticle.java
@@ -139,6 +139,7 @@ public class IastSourcesVerticle extends AbstractVerticle {
       serverOptions.setTrustOptions(certificate.trustOptions());
       serverOptions.setKeyCertOptions(certificate.keyCertOptions());
     }
+    serverOptions.setHandle100ContinueAutomatically(true);
     vertx
         .createHttpServer(serverOptions)
         .requestHandler(router)

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/java/server/VertxTestServer.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/java/server/VertxTestServer.java
@@ -25,6 +25,7 @@ import datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
+import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
@@ -203,7 +204,7 @@ public class VertxTestServer extends AbstractVerticle {
     router = customizeAfterRoutes(router);
 
     vertx
-        .createHttpServer()
+        .createHttpServer(new HttpServerOptions().setHandle100ContinueAutomatically(true))
         .requestHandler(router)
         .listen(
             port,

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/OkHttpUtils.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/OkHttpUtils.java
@@ -3,7 +3,9 @@ package datadog.trace.agent.test.utils;
 import datadog.trace.agent.test.server.http.TestHttpServer;
 import java.net.ProxySelector;
 import java.util.concurrent.TimeUnit;
+import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
+import okhttp3.Request;
 import okhttp3.logging.HttpLoggingInterceptor;
 import okhttp3.logging.HttpLoggingInterceptor.Level;
 import org.slf4j.Logger;
@@ -24,6 +26,15 @@ public class OkHttpUtils {
   private static final HttpLoggingInterceptor LOGGING_INTERCEPTOR =
       new HttpLoggingInterceptor(CLIENT_LOGGER::debug);
 
+  private static final Interceptor EXPECT_CONTINUE_INTERCEPTOR =
+      chain -> {
+        final Request.Builder builder = chain.request().newBuilder();
+        if (chain.request().body() != null) {
+          builder.addHeader("Expect", "100-continue");
+        }
+        return chain.proceed(builder.build());
+      };
+
   static {
     LOGGING_INTERCEPTOR.setLevel(Level.BASIC);
   }
@@ -31,6 +42,7 @@ public class OkHttpUtils {
   public static OkHttpClient.Builder clientBuilder() {
     final TimeUnit unit = TimeUnit.MINUTES;
     return new OkHttpClient.Builder()
+        .addInterceptor(EXPECT_CONTINUE_INTERCEPTOR)
         .addInterceptor(LOGGING_INTERCEPTOR)
         .connectTimeout(1, unit)
         .writeTimeout(1, unit)

--- a/dd-smoke-tests/vertx-3.4/application/src/main/java/datadog/vertx_3_4/IastVerticle.java
+++ b/dd-smoke-tests/vertx-3.4/application/src/main/java/datadog/vertx_3_4/IastVerticle.java
@@ -5,6 +5,7 @@ import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.http.HttpServerOptions;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.ext.web.handler.CookieHandler;
@@ -34,7 +35,7 @@ public class IastVerticle extends AbstractVerticle {
               router.route(handler.path).handler(handler);
             });
     vertx
-        .createHttpServer()
+        .createHttpServer(new HttpServerOptions().setHandle100ContinueAutomatically(true))
         .requestHandler(router::accept)
         .listen(
             Integer.getInteger("vertx.http.port", 8080),

--- a/dd-smoke-tests/vertx-3.4/application/src/main/java/datadog/vertx_3_4/MainVerticle.java
+++ b/dd-smoke-tests/vertx-3.4/application/src/main/java/datadog/vertx_3_4/MainVerticle.java
@@ -4,6 +4,7 @@ import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.http.HttpServerOptions;
 import io.vertx.ext.web.Router;
 import java.math.BigInteger;
 import java.util.concurrent.ThreadLocalRandom;
@@ -43,7 +44,7 @@ public class MainVerticle extends AbstractVerticle {
                     .end(randomFactorial().toString()));
 
     vertx
-        .createHttpServer()
+        .createHttpServer(new HttpServerOptions().setHandle100ContinueAutomatically(true))
         .requestHandler(
             req -> {
               if (req.path().startsWith("/routes")) {

--- a/dd-smoke-tests/vertx-3.9/application/src/main/java/datadog/vertx_3_9/IastVerticle.java
+++ b/dd-smoke-tests/vertx-3.9/application/src/main/java/datadog/vertx_3_9/IastVerticle.java
@@ -5,6 +5,7 @@ import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.http.HttpServerOptions;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.BodyHandler;
 import java.util.Arrays;
@@ -32,7 +33,7 @@ public class IastVerticle extends AbstractVerticle {
               router.route(handler.path).handler(handler);
             });
     vertx
-        .createHttpServer()
+        .createHttpServer(new HttpServerOptions().setHandle100ContinueAutomatically(true))
         .requestHandler(router)
         .listen(
             Integer.getInteger("vertx.http.port", 8080),

--- a/dd-smoke-tests/vertx-3.9/application/src/main/java/datadog/vertx_3_9/MainVerticle.java
+++ b/dd-smoke-tests/vertx-3.9/application/src/main/java/datadog/vertx_3_9/MainVerticle.java
@@ -4,6 +4,7 @@ import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.http.HttpServerOptions;
 import io.vertx.ext.web.Router;
 import java.math.BigInteger;
 import java.util.concurrent.ThreadLocalRandom;
@@ -43,7 +44,7 @@ public class MainVerticle extends AbstractVerticle {
                     .end(randomFactorial().toString()));
 
     vertx
-        .createHttpServer()
+        .createHttpServer(new HttpServerOptions().setHandle100ContinueAutomatically(true))
         .requestHandler(
             req -> {
               if (req.path().startsWith("/routes")) {


### PR DESCRIPTION
# What Does This Do

When the client request a 100 continue to early check the validity of the request without sending the full body, the netty server can send downstream its pipeline a http response with the 100 continue status.

However, this is not the final http response status since there will be another upon termination.
The issue with our instrumentation is that we set the status once and we finish the span. This will cause to create two root spans with wrong information

Example: 

![image](https://github.com/DataDog/dd-trace-java/assets/7393723/a9c8468b-b12c-4c72-bdc7-f275c8e3f882)

# Motivation

# Additional Notes
