### PR TITLE
Improve support for SQL escaped literals in redaction

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sensitive/SqlRegexpTokenizer.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sensitive/SqlRegexpTokenizer.java
@@ -12,8 +12,10 @@ import java.util.regex.Pattern;
 public class SqlRegexpTokenizer extends AbstractRegexTokenizer {
 
   private static final String STRING_LITERAL = "'(?:''|[^'])*'";
-  private static final String ORACLE_ESCAPED_LITERAL = "q'\\S.*\\S'";
-  private static final String POSTGRESQL_ESCAPED_LITERAL = "\\$([^$]*)\\$.*?\\$\\1\\$";
+  private static final String ORACLE_ESCAPED_LITERAL =
+      "q'<.*?>'|q'\\(.*?\\)'|q'\\{.*?\\}'|q'\\[.*?\\]'|q'(?<ESCAPE>.).*?\\k<ESCAPE>'";
+  private static final String POSTGRESQL_ESCAPED_LITERAL =
+      "\\$(?<ESCAPE>[^$]*?)\\$.*?\\$\\k<ESCAPE>\\$";
   private static final String MYSQL_STRING_LITERAL = "\"(?:\\\"|[^\"])*\"|'(?:\\'|[^'])*'";
   private static final String LINE_COMMENT = "--.*$";
   private static final String BLOCK_COMMENT = "/\\*[\\s\\S]*\\*/";

--- a/dd-java-agent/agent-iast/src/test/resources/redaction/evidence-redaction-suite.yml
+++ b/dd-java-agent/agent-iast/src/test/resources/redaction/evidence-redaction-suite.yml
@@ -369,7 +369,54 @@ suite:
         ]
       }
   - type: 'VULNERABILITIES'
-    description: '$1 query with escaped string literal'
+    description: '$1 query with arbitrary escaped string literal'
+    parameters:
+      $1:
+        - ORACLE
+      $2:
+        - '%'
+        - '$'
+        - 'Z'
+    context: >
+      { "DATABASE": "$1" }
+    input: >
+      [
+        {
+          "type": "SQL_INJECTION",
+          "evidence": {
+            "value": "select * from users where username = q'$2I'm an escaped string$2' and common_name = 'doe' or last_name = q'$2I'm another escaped string$2'",
+            "ranges": [
+              { "start" : 14, "length" : 5, "source": { "origin": "http.request.parameter", "name": "table", "value": "users" } }
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.parameter", "name": "table", "value": "users" }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "SQL_INJECTION",
+            "evidence": {
+              "valueParts": [
+                { "value": "select * from " },
+                { "source": 0, "value": "users" },
+                { "value": " where username = q'$2" },
+                { "redacted": true },
+                { "value": "$2' and common_name = '" },
+                { "redacted": true },
+                { "value": "' or last_name = q'$2" },
+                { "redacted": true },
+                { "value": "$2'" }
+              ]
+            }
+          }
+        ]
+      }
+  - type: 'VULNERABILITIES'
+    description: '$1 query with matched escaped string literal (< and >)'
     parameters:
       $1:
         - ORACLE
@@ -380,7 +427,7 @@ suite:
         {
           "type": "SQL_INJECTION",
           "evidence": {
-            "value": "select * from users where username = q'<I'm an escaped string>'",
+            "value": "select * from users where username = q'<I'm an escaped string>' and common_name = 'doe' or last_name = q'!I'm another escaped string!'",
             "ranges": [
               { "start" : 14, "length" : 5, "source": { "origin": "http.request.parameter", "name": "table", "value": "users" } }
             ]
@@ -401,7 +448,11 @@ suite:
                 { "source": 0, "value": "users" },
                 { "value": " where username = q'<" },
                 { "redacted": true },
-                { "value": ">'" }
+                { "value": ">' and common_name = '" },
+                { "redacted": true },
+                { "value": "' or last_name = q'!" },
+                { "redacted": true },
+                { "value": "!'" }
               ]
             }
           }
@@ -422,7 +473,7 @@ suite:
         {
           "type": "SQL_INJECTION",
           "evidence": {
-            "value": "select * from users where username = $2I'm an escaped string$2",
+            "value": "select * from users where username = $2I'm an escaped string$2 and common_name = 'doe' or last_name = $TEST$I'm another escaped string$$$TEST$",
             "ranges": [
               { "start" : 14, "length" : 5, "source": { "origin": "http.request.parameter", "name": "table", "value": "users" } }
             ]
@@ -443,7 +494,11 @@ suite:
                 { "source": 0, "value": "users" },
                 { "value": " where username = $2" },
                 { "redacted": true },
-                { "value": "$2" }
+                { "value": "$2 and common_name = '" },
+                { "redacted": true },
+                { "value": "' or last_name = $TEST$" },
+                { "redacted": true },
+                { "value": "$TEST$" }
               ]
             }
           }
@@ -861,6 +916,50 @@ suite:
                 { "redacted": true },
                 { "value": "' and user_id_123 > " },
                 { "redacted": true } 
+              ]
+            }
+          }
+        ]
+      }
+
+  - type: 'VULNERABILITIES'
+    description: 'Query with tainted range in two LIKEs with not tainted % char'
+    input: >
+      [
+        {
+          "type": "SQL_INJECTION",
+          "evidence": {
+            "value": "select * from table where name LIKE '%searchparam%' OR description LIKE '%searchparam%'",
+            "ranges": [
+              {
+                "start": 38, "length": 11, "source": { "origin": "http.request.parameter", "name": "query", "value": "searchparam" }
+              },
+              {
+                "start": 74, "length": 11, "source": { "origin": "http.request.parameter", "name": "query", "value": "searchparam" }
+              }
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.parameter", "name": "query", "redacted": true }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "SQL_INJECTION",
+            "evidence": {
+              "valueParts": [
+                { "value": "select * from table where name LIKE '" },
+                { "redacted": true },
+                { "source": 0, "redacted": true },
+                { "redacted": true },
+                { "value": "' OR description LIKE '" },
+                { "redacted": true },
+                { "source": 0, "redacted": true },
+                { "redacted": true },
+                { "value": "'" }
               ]
             }
           }


### PR DESCRIPTION
# What Does This Do
Fix issue with SQL tokenizer being too greedy when dealing with oracle and postgresql escaped strings

# Motivation

# Additional Notes
