### PR TITLE
resteasy and jersey unvalidated redirect instrumentation

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/UnvalidatedRedirectModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/UnvalidatedRedirectModuleImpl.java
@@ -7,14 +7,15 @@ import com.datadog.iast.model.VulnerabilityType;
 import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.net.URI;
 import javax.annotation.Nullable;
 
 public class UnvalidatedRedirectModuleImpl extends SinkModuleBase
     implements UnvalidatedRedirectModule {
 
   @Override
-  public void onRedirect(final @Nullable Object value) {
-    if (value instanceof String && !canBeTainted((String) value)) {
+  public void onRedirect(final @Nullable String value) {
+    if (!canBeTainted(value)) {
       return;
     }
     final AgentSpan span = AgentTracer.activeSpan();
@@ -23,6 +24,19 @@ public class UnvalidatedRedirectModuleImpl extends SinkModuleBase
       return;
     }
     checkInjection(span, ctx, VulnerabilityType.UNVALIDATED_REDIRECT, value);
+  }
+
+  @Override
+  public void onURIRedirect(@Nullable URI uri) {
+    if (uri == null) {
+      return;
+    }
+    final AgentSpan span = AgentTracer.activeSpan();
+    final IastRequestContext ctx = IastRequestContext.get(span);
+    if (ctx == null) {
+      return;
+    }
+    checkInjection(span, ctx, VulnerabilityType.UNVALIDATED_REDIRECT, uri);
   }
 
   @Override

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/UnvalidatedRedirectModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/UnvalidatedRedirectModuleImpl.java
@@ -13,8 +13,8 @@ public class UnvalidatedRedirectModuleImpl extends SinkModuleBase
     implements UnvalidatedRedirectModule {
 
   @Override
-  public void onRedirect(final @Nullable String value) {
-    if (!canBeTainted(value)) {
+  public void onRedirect(final @Nullable Object value) {
+    if (value instanceof String && !canBeTainted((String) value)) {
       return;
     }
     final AgentSpan span = AgentTracer.activeSpan();

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/JakartaWSResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/JakartaWSResponseInstrumentation.java
@@ -1,0 +1,67 @@
+package datadog.trace.instrumentation.jersey;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(Instrumenter.class)
+public class JakartaWSResponseInstrumentation extends Instrumenter.Iast
+    implements Instrumenter.ForTypeHierarchy {
+
+  public JakartaWSResponseInstrumentation() {
+    super("jersey");
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("header").and(isPublic().and(takesArguments(String.class, Object.class))),
+        JakartaWSResponseInstrumentation.class.getName() + "$HeaderAdvice");
+    transformation.applyAdvice(
+        named("location"), JakartaWSResponseInstrumentation.class.getName() + "$RedirectionAdvice");
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "jakarta.ws.rs.core.Response$ResponseBuilder";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return extendsClass(named(hierarchyMarkerType()));
+  }
+
+  public static class HeaderAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onExit(
+        @Advice.Argument(0) String headerName, @Advice.Argument(1) Object headerValue) {
+      if (null != headerValue && headerValue instanceof String) {
+        String value = (String) headerValue;
+        if (value.length() > 0) {
+          InstrumentationBridge.onHeader(headerName, value);
+        }
+      }
+    }
+  }
+
+  public static class RedirectionAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter(@Advice.Argument(0) final Object location) {
+      final UnvalidatedRedirectModule module = InstrumentationBridge.UNVALIDATED_REDIRECT;
+      if (module != null) {
+        if (null != location) {
+          module.onRedirect(location);
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/JakartaWSResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/JakartaWSResponseInstrumentation.java
@@ -9,6 +9,7 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
+import java.net.URI;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -55,11 +56,11 @@ public class JakartaWSResponseInstrumentation extends Instrumenter.Iast
 
   public static class RedirectionAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void onEnter(@Advice.Argument(0) final Object location) {
+    public static void onEnter(@Advice.Argument(0) final URI location) {
       final UnvalidatedRedirectModule module = InstrumentationBridge.UNVALIDATED_REDIRECT;
       if (module != null) {
         if (null != location) {
-          module.onRedirect(location);
+          module.onURIRedirect(location);
         }
       }
     }

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/JakartaWSResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/JakartaWSResponseInstrumentation.java
@@ -28,7 +28,8 @@ public class JakartaWSResponseInstrumentation extends Instrumenter.Iast
         named("header").and(isPublic().and(takesArguments(String.class, Object.class))),
         JakartaWSResponseInstrumentation.class.getName() + "$HeaderAdvice");
     transformation.applyAdvice(
-        named("location"), JakartaWSResponseInstrumentation.class.getName() + "$RedirectionAdvice");
+        named("location").and(isPublic().and(takesArguments(URI.class))),
+        JakartaWSResponseInstrumentation.class.getName() + "$RedirectionAdvice");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jersey/src/test/groovy/datadog/trace/instrumentation/jersey/JakartaWSResponseInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jersey/src/test/groovy/datadog/trace/instrumentation/jersey/JakartaWSResponseInstrumentationTest.groovy
@@ -13,7 +13,7 @@ class JakartaWSResponseInstrumentationTest extends AgentTestRunner {
     injectSysConfig("dd.iast.enabled", "true")
   }
 
-  def 'change location header triggers onHeader callback'() {
+  void 'change location header triggers onHeader callback'() {
     setup:
     final module = Mock(UnvalidatedRedirectModule)
     InstrumentationBridge.registerIastModule(module)
@@ -25,7 +25,7 @@ class JakartaWSResponseInstrumentationTest extends AgentTestRunner {
     1 * module.onHeader('Location', 'https://dummy.location.com/test')
   }
 
-  def 'change location triggers onRedirect callback'() {
+  void 'change location triggers onRedirect callback'() {
     setup:
     final module = Mock(UnvalidatedRedirectModule)
     InstrumentationBridge.registerIastModule(module)
@@ -35,6 +35,6 @@ class JakartaWSResponseInstrumentationTest extends AgentTestRunner {
     Response.status(Response.Status.TEMPORARY_REDIRECT).location(uri)
 
     then:
-    1 * module.onRedirect(uri)
+    1 * module.onURIRedirect(uri)
   }
 }

--- a/dd-java-agent/instrumentation/jersey/src/test/groovy/datadog/trace/instrumentation/jersey/JakartaWSResponseInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jersey/src/test/groovy/datadog/trace/instrumentation/jersey/JakartaWSResponseInstrumentationTest.groovy
@@ -1,0 +1,40 @@
+package datadog.trace.instrumentation.jersey
+
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.sink.UnvalidatedRedirectModule
+import jakarta.ws.rs.core.Response
+
+class JakartaWSResponseInstrumentationTest extends AgentTestRunner {
+
+
+  @Override
+  protected void configurePreAgent() {
+    injectSysConfig("dd.iast.enabled", "true")
+  }
+
+  def 'change location header triggers onHeader callback'() {
+    setup:
+    final module = Mock(UnvalidatedRedirectModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    Response.status(Response.Status.TEMPORARY_REDIRECT).header("Location", "https://dummy.location.com/test")
+
+    then:
+    1 * module.onHeader('Location', 'https://dummy.location.com/test')
+  }
+
+  def 'change location triggers onRedirect callback'() {
+    setup:
+    final module = Mock(UnvalidatedRedirectModule)
+    InstrumentationBridge.registerIastModule(module)
+    final uri = new URI("https://dummy.location.com/test")
+
+    when:
+    Response.status(Response.Status.TEMPORARY_REDIRECT).location(uri)
+
+    then:
+    1 * module.onRedirect(uri)
+  }
+}

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/JavaxWSResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/JavaxWSResponseInstrumentation.java
@@ -28,7 +28,8 @@ public class JavaxWSResponseInstrumentation extends Instrumenter.Iast
         named("header").and(isPublic().and(takesArguments(String.class, Object.class))),
         JavaxWSResponseInstrumentation.class.getName() + "$HeaderAdvice");
     transformation.applyAdvice(
-        named("location"), JavaxWSResponseInstrumentation.class.getName() + "$RedirectionAdvice");
+        named("location").and(isPublic().and(takesArguments(URI.class))),
+        JavaxWSResponseInstrumentation.class.getName() + "$RedirectionAdvice");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/JavaxWSResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/JavaxWSResponseInstrumentation.java
@@ -1,0 +1,67 @@
+package datadog.trace.instrumentation.resteasy;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(Instrumenter.class)
+public class JavaxWSResponseInstrumentation extends Instrumenter.Iast
+    implements Instrumenter.ForTypeHierarchy {
+
+  public JavaxWSResponseInstrumentation() {
+    super("resteasy");
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("header").and(isPublic().and(takesArguments(String.class, Object.class))),
+        JavaxWSResponseInstrumentation.class.getName() + "$HeaderAdvice");
+    transformation.applyAdvice(
+        named("location"), JavaxWSResponseInstrumentation.class.getName() + "$RedirectionAdvice");
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "javax.ws.rs.core.Response$ResponseBuilder";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return extendsClass(named(hierarchyMarkerType()));
+  }
+
+  public static class HeaderAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onExit(
+        @Advice.Argument(0) String headerName, @Advice.Argument(1) Object headerValue) {
+      if (null != headerValue && headerValue instanceof String) {
+        String value = (String) headerValue;
+        if (value.length() > 0) {
+          InstrumentationBridge.onHeader(headerName, value);
+        }
+      }
+    }
+  }
+
+  public static class RedirectionAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter(@Advice.Argument(0) final Object location) {
+      final UnvalidatedRedirectModule module = InstrumentationBridge.UNVALIDATED_REDIRECT;
+      if (module != null) {
+        if (null != location) {
+          module.onRedirect(location);
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/JavaxWSResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/JavaxWSResponseInstrumentation.java
@@ -9,6 +9,7 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
+import java.net.URI;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -55,11 +56,11 @@ public class JavaxWSResponseInstrumentation extends Instrumenter.Iast
 
   public static class RedirectionAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void onEnter(@Advice.Argument(0) final Object location) {
+    public static void onEnter(@Advice.Argument(0) final URI location) {
       final UnvalidatedRedirectModule module = InstrumentationBridge.UNVALIDATED_REDIRECT;
       if (module != null) {
         if (null != location) {
-          module.onRedirect(location);
+          module.onURIRedirect(location);
         }
       }
     }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/test/groovy/JavaxWSResponseInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/test/groovy/JavaxWSResponseInstrumentationTest.groovy
@@ -1,0 +1,39 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.sink.UnvalidatedRedirectModule
+
+import javax.ws.rs.core.Response
+
+class JavaxWSResponseInstrumentationTest extends AgentTestRunner {
+
+
+  @Override
+  protected void configurePreAgent() {
+    injectSysConfig("dd.iast.enabled", "true")
+  }
+
+  def 'change location header triggers onHeader callback'() {
+    setup:
+    final module = Mock(UnvalidatedRedirectModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    Response.status(Response.Status.TEMPORARY_REDIRECT).header("Location", "https://dummy.location.com/test")
+
+    then:
+    1 * module.onHeader('Location', 'https://dummy.location.com/test')
+  }
+
+  def 'change location triggers onRedirect callback'() {
+    setup:
+    final module = Mock(UnvalidatedRedirectModule)
+    InstrumentationBridge.registerIastModule(module)
+    final uri = new URI("https://dummy.location.com/test")
+
+    when:
+    Response.status(Response.Status.TEMPORARY_REDIRECT).location(uri)
+
+    then:
+    1 * module.onRedirect(uri)
+  }
+}

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/test/groovy/JavaxWSResponseInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/test/groovy/JavaxWSResponseInstrumentationTest.groovy
@@ -12,7 +12,7 @@ class JavaxWSResponseInstrumentationTest extends AgentTestRunner {
     injectSysConfig("dd.iast.enabled", "true")
   }
 
-  def 'change location header triggers onHeader callback'() {
+  void 'change location header triggers onHeader callback'() {
     setup:
     final module = Mock(UnvalidatedRedirectModule)
     InstrumentationBridge.registerIastModule(module)
@@ -24,7 +24,7 @@ class JavaxWSResponseInstrumentationTest extends AgentTestRunner {
     1 * module.onHeader('Location', 'https://dummy.location.com/test')
   }
 
-  def 'change location triggers onRedirect callback'() {
+  void 'change location triggers onRedirect callback'() {
     setup:
     final module = Mock(UnvalidatedRedirectModule)
     InstrumentationBridge.registerIastModule(module)
@@ -34,6 +34,6 @@ class JavaxWSResponseInstrumentationTest extends AgentTestRunner {
     Response.status(Response.Status.TEMPORARY_REDIRECT).location(uri)
 
     then:
-    1 * module.onRedirect(uri)
+    1 * module.onURIRedirect(uri)
   }
 }

--- a/dd-smoke-tests/jersey-3/src/main/java/smoketest/resource/MyResource.java
+++ b/dd-smoke-tests/jersey-3/src/main/java/smoketest/resource/MyResource.java
@@ -8,6 +8,9 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.sql.SQLException;
 import smoketest.DB;
 
@@ -50,5 +53,17 @@ public class MyResource {
   public String byCookie(@CookieParam("cookieName") String param) throws SQLException {
     DB.store(param);
     return "Jersey: hello " + param;
+  }
+
+  @Path("/setlocationheader")
+  @GET
+  public Response locationHeader(@QueryParam("param") String param) {
+    return Response.status(Response.Status.TEMPORARY_REDIRECT).header("Location", param).build();
+  }
+
+  @Path("/setresponselocation")
+  @GET
+  public Response responseLocation(@QueryParam("param") String param) throws URISyntaxException {
+    return Response.status(Response.Status.TEMPORARY_REDIRECT).location(new URI(param)).build();
   }
 }

--- a/dd-smoke-tests/jersey-3/src/test/groovy/datadog/smoketest/Jersey3SmokeTest.groovy
+++ b/dd-smoke-tests/jersey-3/src/test/groovy/datadog/smoketest/Jersey3SmokeTest.groovy
@@ -50,7 +50,7 @@ class Jersey3SmokeTest extends AbstractServerSmokeTest {
     processBuilder.directory(new File(buildDirectory))
   }
 
-  def "Test path parameter in Jersey"() {
+  void "Test path parameter in Jersey"() {
     setup:
     def url = "http://localhost:${httpPort}/hello/bypathparam/pathParamValue"
 
@@ -68,7 +68,7 @@ class Jersey3SmokeTest extends AbstractServerSmokeTest {
     hasVulnerability(type('SQL_INJECTION').and(evidence('pathParamValue'))))
   }
 
-  def "Test query parameter in Jersey"() {
+  void "Test query parameter in Jersey"() {
     setup:
     def url = "http://localhost:${httpPort}/hello/byqueryparam?param=queryParamValue"
 
@@ -86,7 +86,7 @@ class Jersey3SmokeTest extends AbstractServerSmokeTest {
     hasVulnerability(type('SQL_INJECTION').and(evidence('queryParamValue'))))
   }
 
-  def "Test header in Jersey"() {
+  void "Test header in Jersey"() {
     setup:
     def url = "http://localhost:${httpPort}/hello/byheader"
 
@@ -104,7 +104,7 @@ class Jersey3SmokeTest extends AbstractServerSmokeTest {
     hasVulnerability(type('SQL_INJECTION').and(evidence('pepito'))))
   }
 
-  def "Test cookie in Jersey"() {
+  void "Test cookie in Jersey"() {
     setup:
     def url = "http://localhost:${httpPort}/hello/bycookie"
 
@@ -123,7 +123,7 @@ class Jersey3SmokeTest extends AbstractServerSmokeTest {
   }
 
 
-  def "unvalidated  redirect from location header is present"() {
+  void "unvalidated  redirect from location header is present"() {
     setup:
     def url = "http://localhost:${httpPort}/hello/setlocationheader?param=queryParamValue"
 
@@ -137,7 +137,7 @@ class Jersey3SmokeTest extends AbstractServerSmokeTest {
     hasVulnerability(type('UNVALIDATED_REDIRECT')))
   }
 
-  def "unvalidated  redirect from location is present"() {
+  void "unvalidated  redirect from location is present"() {
     setup:
     def url = "http://localhost:${httpPort}/hello/setresponselocation?param=queryParamValue"
 

--- a/dd-smoke-tests/resteasy/src/main/java/smoketest/resteasy/Resource.java
+++ b/dd-smoke-tests/resteasy/src/main/java/smoketest/resteasy/Resource.java
@@ -1,5 +1,7 @@
 package smoketest.resteasy;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Set;
@@ -12,6 +14,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 @Path("/hello")
 public class Resource {
@@ -80,5 +83,17 @@ public class Resource {
       throws SQLException {
     DB.store(param.iterator().next());
     return "RestEasy: hello " + param;
+  }
+
+  @Path("/setlocationheader")
+  @GET
+  public Response locationHeader(@QueryParam("param") String param) {
+    return Response.status(Response.Status.TEMPORARY_REDIRECT).header("Location", param).build();
+  }
+
+  @Path("/setresponselocation")
+  @GET
+  public Response responseLocation(@QueryParam("param") String param) throws URISyntaxException {
+    return Response.status(Response.Status.TEMPORARY_REDIRECT).location(new URI(param)).build();
   }
 }

--- a/dd-smoke-tests/resteasy/src/test/groovy/smoketest/ResteasySmokeTest.groovy
+++ b/dd-smoke-tests/resteasy/src/test/groovy/smoketest/ResteasySmokeTest.groovy
@@ -12,7 +12,7 @@ class ResteasySmokeTest extends AbstractServerSmokeTest {
 
 
   @Override
-  def logLevel(){
+  def logLevel() {
     return "debug"
   }
 
@@ -168,6 +168,34 @@ class ResteasySmokeTest extends AbstractServerSmokeTest {
     assert response.code() == 200
     processTestLogLines {
       it.contains("SQL_INJECTION") && it.contains("smoketest.resteasy.DB") && it.contains("sortedsetValue1")
+    }
+  }
+
+  def "unvalidated  redirect from location header is present"() {
+    setup:
+    def url = "http://localhost:${httpPort}/hello/setlocationheader?param=setheader"
+
+    when:
+    def request = new Request.Builder().url(url).get().build()
+    client.newCall(request).execute()
+
+    then:
+    processTestLogLines {
+      it.contains("UNVALIDATED_REDIRECT") && it.contains("setheader")
+    }
+  }
+
+  def "unvalidated  redirect from location header is present"() {
+    setup:
+    def url = "http://localhost:${httpPort}/hello/setresponselocation?param=setlocation"
+
+    when:
+    def request = new Request.Builder().url(url).get().build()
+    client.newCall(request).execute()
+
+    then:
+    processTestLogLines {
+      it.contains("UNVALIDATED_REDIRECT") && it.contains("setlocation")
     }
   }
 

--- a/dd-smoke-tests/resteasy/src/test/groovy/smoketest/ResteasySmokeTest.groovy
+++ b/dd-smoke-tests/resteasy/src/test/groovy/smoketest/ResteasySmokeTest.groovy
@@ -38,7 +38,7 @@ class ResteasySmokeTest extends AbstractServerSmokeTest {
     processBuilder.directory(new File(buildDirectory))
   }
 
-  def "test path parameter"() {
+  void "test path parameter"() {
     setup:
     def url = "http://localhost:${httpPort}/hello/bypathparam/pathParamValue"
 
@@ -57,7 +57,7 @@ class ResteasySmokeTest extends AbstractServerSmokeTest {
     }
   }
 
-  def "Test query parameter in RestEasy"() {
+  void "Test query parameter in RestEasy"() {
     setup:
     def url = "http://localhost:${httpPort}/hello/byqueryparam?param=queryParamValue"
 
@@ -76,7 +76,7 @@ class ResteasySmokeTest extends AbstractServerSmokeTest {
     }
   }
 
-  def "Test header in RestEasy"() {
+  void "Test header in RestEasy"() {
     setup:
     def url = "http://localhost:${httpPort}/hello/byheader"
 
@@ -95,7 +95,7 @@ class ResteasySmokeTest extends AbstractServerSmokeTest {
     }
   }
 
-  def "Test cookie in RestEasy"() {
+  void "Test cookie in RestEasy"() {
     setup:
     def url = "http://localhost:${httpPort}/hello/bycookie"
 
@@ -114,7 +114,7 @@ class ResteasySmokeTest extends AbstractServerSmokeTest {
     }
   }
 
-  def "Test collection injection in RestEasy"() {
+  void "Test collection injection in RestEasy"() {
     setup:
     def url = "http://localhost:${httpPort}/hello/collection?param=value1&param=value2"
 
@@ -133,7 +133,7 @@ class ResteasySmokeTest extends AbstractServerSmokeTest {
     }
   }
 
-  def "Test Set injection in RestEasy"() {
+  void "Test Set injection in RestEasy"() {
     setup:
     def url = "http://localhost:${httpPort}/hello/set?param=setValue1&param=setValue2"
 
@@ -152,7 +152,7 @@ class ResteasySmokeTest extends AbstractServerSmokeTest {
     }
   }
 
-  def "Test Sorted Set injection in RestEasy"() {
+  void "Test Sorted Set injection in RestEasy"() {
     setup:
     def url = "http://localhost:${httpPort}/hello/sortedset?param=sortedsetValue1&param=sortedsetValue2"
 
@@ -171,7 +171,7 @@ class ResteasySmokeTest extends AbstractServerSmokeTest {
     }
   }
 
-  def "unvalidated  redirect from location header is present"() {
+  void "unvalidated  redirect from location header is present"() {
     setup:
     def url = "http://localhost:${httpPort}/hello/setlocationheader?param=setheader"
 
@@ -185,7 +185,7 @@ class ResteasySmokeTest extends AbstractServerSmokeTest {
     }
   }
 
-  def "unvalidated  redirect from location header is present"() {
+  void "unvalidated  redirect from location header is present"() {
     setup:
     def url = "http://localhost:${httpPort}/hello/setresponselocation?param=setlocation"
 

--- a/internal-api/src/main/java/datadog/trace/api/iast/sink/UnvalidatedRedirectModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/sink/UnvalidatedRedirectModule.java
@@ -1,8 +1,11 @@
 package datadog.trace.api.iast.sink;
 
+import java.net.URI;
 import javax.annotation.Nullable;
 
 public interface UnvalidatedRedirectModule extends HttpHeaderModule {
 
-  void onRedirect(@Nullable Object value);
+  void onRedirect(@Nullable String value);
+
+  void onURIRedirect(@Nullable URI value);
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/sink/UnvalidatedRedirectModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/sink/UnvalidatedRedirectModule.java
@@ -4,5 +4,5 @@ import javax.annotation.Nullable;
 
 public interface UnvalidatedRedirectModule extends HttpHeaderModule {
 
-  void onRedirect(@Nullable String value);
+  void onRedirect(@Nullable Object value);
 }


### PR DESCRIPTION
# What Does This Do

Add jakarta.ws.rs.core.Response header and location instrumentation
Add javax.ws.rs.core.Response header and location instrumentation
Modify UnvalidatedRedirectModule to accept URI objects
Add new test cases to jersey and resteasy smoke tests

# Motivation

# Additional Notes
