### PR TITLE
Fix :dd-smoke-tests:wildfly build

### DIFF
--- a/dd-smoke-tests/wildfly/build.gradle
+++ b/dd-smoke-tests/wildfly/build.gradle
@@ -84,6 +84,7 @@ def wildflyDir="${buildDir}/${serverName}-${serverModule}-${serverVersion}"
 
 tasks.register("unzip", Copy) {
   dependsOn tasks.earBuild
+  mustRunAfter tasks.compileTestGroovy
   def zipFileNamePrefix = "servlet"
   def zipPath = project.configurations.serverFile.find {
     it.name.startsWith(zipFileNamePrefix)


### PR DESCRIPTION


# What Does This Do

# Motivation
See:
```
A problem was found with the configuration of task ':dd-smoke-tests:wildfly:unzip' (type 'Copy').
  - Gradle detected a problem with the following location: '/home/circleci/dd-trace-java/workspace/dd-smoke-tests/wildfly/build'.

    Reason: Task ':dd-smoke-tests:wildfly:compileTestGroovy' uses this output of task ':dd-smoke-tests:wildfly:unzip' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.

    Possible solutions:
      1. Declare task ':dd-smoke-tests:wildfly:unzip' as an input of ':dd-smoke-tests:wildfly:compileTestGroovy'.
      2. Declare an explicit dependency on ':dd-smoke-tests:wildfly:unzip' from ':dd-smoke-tests:wildfly:compileTestGroovy' using Task#dependsOn. 3. Declare an explicit dependency on ':dd-smoke-tests:wildfly:unzip' from ':dd-smoke-tests:wildfly:compileTestGroovy' using Task#mustRunAfter.

    Please refer to https://docs.gradle.org/8.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```
# Additional Notes
