### PR TITLE
Provide 'traceConfig(span)' and 'traceConfig()' static helpers

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -210,6 +210,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
   private final PropagationTags.Factory propagationTagsFactory;
 
+  @Override
   public TraceConfig captureTraceConfig() {
     return dynamicConfig.captureTraceConfig();
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -778,7 +778,7 @@ public class DDSpan
   }
 
   @Override
-  public TraceConfig getTraceConfig() {
+  public TraceConfig traceConfig() {
     return context.getTrace().getTraceConfig();
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -144,7 +144,7 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo {
 
   Integer forceSamplingDecision();
 
-  TraceConfig getTraceConfig();
+  TraceConfig traceConfig();
 
   interface Context {
     /**

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -81,6 +81,20 @@ public class AgentTracer {
     return get().activateNext(span);
   }
 
+  public static TraceConfig traceConfig(final AgentSpan span) {
+    if (null != span) {
+      TraceConfig traceConfig = span.traceConfig();
+      if (null != traceConfig) {
+        return traceConfig;
+      }
+    }
+    return get().captureTraceConfig();
+  }
+
+  public static TraceConfig traceConfig() {
+    return get().captureTraceConfig();
+  }
+
   public static AgentSpan activeSpan() {
     return get().activeSpan();
   }
@@ -194,6 +208,8 @@ public class AgentTracer {
     String getTraceId(AgentSpan span);
 
     String getSpanId(AgentSpan span);
+
+    TraceConfig captureTraceConfig();
   }
 
   public interface SpanBuilder {
@@ -459,6 +475,11 @@ public class AgentTracer {
     @Override
     public Timer getTimer() {
       return Timer.NoOp.INSTANCE;
+    }
+
+    @Override
+    public TraceConfig captureTraceConfig() {
+      return null;
     }
   }
 
@@ -747,7 +768,7 @@ public class AgentTracer {
     }
 
     @Override
-    public TraceConfig getTraceConfig() {
+    public TraceConfig traceConfig() {
       return null;
     }
   }


### PR DESCRIPTION
If the span is missing or doesn't have a trace config then the tracer will return its current trace config.

Users can therefore rely on these always returning a non-null trace config when using our core tracer.