### PR TITLE
Remove MDCTagsInjectionEnabled config

### DIFF
--- a/dd-java-agent/instrumentation/jboss-logmanager/src/main/java/datadog/trace/instrumentation/jbosslogmanager/ExtLogRecordInstrumentation.java
+++ b/dd-java-agent/instrumentation/jboss-logmanager/src/main/java/datadog/trace/instrumentation/jbosslogmanager/ExtLogRecordInstrumentation.java
@@ -145,42 +145,36 @@ public class ExtLogRecordInstrumentation extends Instrumenter.Tracing
         return;
       }
 
-      InstrumenterConfig instrumenterConfig = InstrumenterConfig.get();
       AgentSpan.Context context =
           InstrumentationContext.get(ExtLogRecord.class, AgentSpan.Context.class).get(record);
-      boolean mdcTagsInjectionEnabled = instrumenterConfig.isLogsMDCTagsInjectionEnabled();
 
       // Nothing to add so return early
-      if (context == null && !mdcTagsInjectionEnabled) {
+      if (context == null) {
         return;
       }
 
       Map<String, String> correlationValues = new HashMap<>(8);
 
-      if (context != null) {
-        DDTraceId traceId = context.getTraceId();
-        String traceIdValue =
-            instrumenterConfig.isLogs128bTraceIdEnabled() && traceId.toHighOrderLong() != 0
-                ? traceId.toHexString()
-                : traceId.toString();
-        correlationValues.put(CorrelationIdentifier.getTraceIdKey(), traceIdValue);
-        correlationValues.put(
-            CorrelationIdentifier.getSpanIdKey(), DDSpanId.toString(context.getSpanId()));
-      }
+      DDTraceId traceId = context.getTraceId();
+      String traceIdValue =
+          InstrumenterConfig.get().isLogs128bTraceIdEnabled() && traceId.toHighOrderLong() != 0
+              ? traceId.toHexString()
+              : traceId.toString();
+      correlationValues.put(CorrelationIdentifier.getTraceIdKey(), traceIdValue);
+      correlationValues.put(
+          CorrelationIdentifier.getSpanIdKey(), DDSpanId.toString(context.getSpanId()));
 
-      if (mdcTagsInjectionEnabled) {
-        String serviceName = Config.get().getServiceName();
-        if (null != serviceName && !serviceName.isEmpty()) {
-          correlationValues.put(Tags.DD_SERVICE, serviceName);
-        }
-        String env = Config.get().getEnv();
-        if (null != env && !env.isEmpty()) {
-          correlationValues.put(Tags.DD_ENV, env);
-        }
-        String version = Config.get().getVersion();
-        if (null != version && !version.isEmpty()) {
-          correlationValues.put(Tags.DD_VERSION, version);
-        }
+      String serviceName = Config.get().getServiceName();
+      if (null != serviceName && !serviceName.isEmpty()) {
+        correlationValues.put(Tags.DD_SERVICE, serviceName);
+      }
+      String env = Config.get().getEnv();
+      if (null != env && !env.isEmpty()) {
+        correlationValues.put(Tags.DD_ENV, env);
+      }
+      String version = Config.get().getVersion();
+      if (null != version && !version.isEmpty()) {
+        correlationValues.put(Tags.DD_VERSION, version);
       }
 
       mdc = null != mdc ? new UnionMap<>(mdc, correlationValues) : correlationValues;

--- a/dd-java-agent/instrumentation/log4j-2.7/src/main/java/datadog/trace/instrumentation/log4j27/SpanDecoratingContextDataInjector.java
+++ b/dd-java-agent/instrumentation/log4j-2.7/src/main/java/datadog/trace/instrumentation/log4j27/SpanDecoratingContextDataInjector.java
@@ -34,20 +34,17 @@ public final class SpanDecoratingContextDataInjector implements ContextDataInjec
     // We're at most adding 5 tags
     StringMap newContextData = new SortedArrayStringMap(contextData.size() + 5);
 
-    InstrumenterConfig instrumenterConfig = InstrumenterConfig.get();
-    if (instrumenterConfig.isLogsMDCTagsInjectionEnabled()) {
-      String env = Config.get().getEnv();
-      if (null != env && !env.isEmpty()) {
-        newContextData.putValue(Tags.DD_ENV, env);
-      }
-      String serviceName = Config.get().getServiceName();
-      if (null != serviceName && !serviceName.isEmpty()) {
-        newContextData.putValue(Tags.DD_SERVICE, serviceName);
-      }
-      String version = Config.get().getVersion();
-      if (null != version && !version.isEmpty()) {
-        newContextData.putValue(Tags.DD_VERSION, version);
-      }
+    String env = Config.get().getEnv();
+    if (null != env && !env.isEmpty()) {
+      newContextData.putValue(Tags.DD_ENV, env);
+    }
+    String serviceName = Config.get().getServiceName();
+    if (null != serviceName && !serviceName.isEmpty()) {
+      newContextData.putValue(Tags.DD_SERVICE, serviceName);
+    }
+    String version = Config.get().getVersion();
+    if (null != version && !version.isEmpty()) {
+      newContextData.putValue(Tags.DD_VERSION, version);
     }
 
     AgentSpan span = activeSpan();
@@ -55,7 +52,7 @@ public final class SpanDecoratingContextDataInjector implements ContextDataInjec
     if (span != null) {
       DDTraceId traceId = span.context().getTraceId();
       String traceIdValue =
-          instrumenterConfig.isLogs128bTraceIdEnabled() && traceId.toHighOrderLong() != 0
+          InstrumenterConfig.get().isLogs128bTraceIdEnabled() && traceId.toHighOrderLong() != 0
               ? traceId.toHexString()
               : traceId.toString();
       newContextData.putValue(CorrelationIdentifier.getTraceIdKey(), traceIdValue);

--- a/dd-java-agent/instrumentation/log4j1/src/main/java/datadog/trace/instrumentation/log4j1/LoggingEventInstrumentation.java
+++ b/dd-java-agent/instrumentation/log4j1/src/main/java/datadog/trace/instrumentation/log4j1/LoggingEventInstrumentation.java
@@ -128,20 +128,17 @@ public class LoggingEventInstrumentation extends Instrumenter.Tracing
 
         Hashtable mdc = new Hashtable();
 
-        InstrumenterConfig instrumenterConfig = InstrumenterConfig.get();
-        if (instrumenterConfig.isLogsMDCTagsInjectionEnabled()) {
-          String serviceName = Config.get().getServiceName();
-          if (null != serviceName && !serviceName.isEmpty()) {
-            mdc.put(Tags.DD_SERVICE, serviceName);
-          }
-          String env = Config.get().getEnv();
-          if (null != env && !env.isEmpty()) {
-            mdc.put(Tags.DD_ENV, env);
-          }
-          String version = Config.get().getVersion();
-          if (null != version && !version.isEmpty()) {
-            mdc.put(Tags.DD_VERSION, version);
-          }
+        String serviceName = Config.get().getServiceName();
+        if (null != serviceName && !serviceName.isEmpty()) {
+          mdc.put(Tags.DD_SERVICE, serviceName);
+        }
+        String env = Config.get().getEnv();
+        if (null != env && !env.isEmpty()) {
+          mdc.put(Tags.DD_ENV, env);
+        }
+        String version = Config.get().getVersion();
+        if (null != version && !version.isEmpty()) {
+          mdc.put(Tags.DD_VERSION, version);
         }
 
         AgentSpan.Context context =
@@ -149,7 +146,7 @@ public class LoggingEventInstrumentation extends Instrumenter.Tracing
         if (context != null) {
           DDTraceId traceId = context.getTraceId();
           String traceIdValue =
-              instrumenterConfig.isLogs128bTraceIdEnabled() && traceId.toHighOrderLong() != 0
+              InstrumenterConfig.get().isLogs128bTraceIdEnabled() && traceId.toHighOrderLong() != 0
                   ? traceId.toHexString()
                   : traceId.toString();
           mdc.put(CorrelationIdentifier.getTraceIdKey(), traceIdValue);

--- a/dd-java-agent/instrumentation/logback-1/src/main/java/datadog/trace/instrumentation/logback/LoggingEventInstrumentation.java
+++ b/dd-java-agent/instrumentation/logback-1/src/main/java/datadog/trace/instrumentation/logback/LoggingEventInstrumentation.java
@@ -80,42 +80,36 @@ public class LoggingEventInstrumentation extends Instrumenter.Tracing
         return;
       }
 
-      InstrumenterConfig instrumenterConfig = InstrumenterConfig.get();
       AgentSpan.Context context =
           InstrumentationContext.get(ILoggingEvent.class, AgentSpan.Context.class).get(event);
-      boolean mdcTagsInjectionEnabled = instrumenterConfig.isLogsMDCTagsInjectionEnabled();
 
       // Nothing to add so return early
-      if (context == null && !mdcTagsInjectionEnabled) {
+      if (context == null) {
         return;
       }
 
       Map<String, String> correlationValues = new HashMap<>(8);
 
-      if (context != null) {
-        DDTraceId traceId = context.getTraceId();
-        String traceIdValue =
-            instrumenterConfig.isLogs128bTraceIdEnabled() && traceId.toHighOrderLong() != 0
-                ? traceId.toHexString()
-                : traceId.toString();
-        correlationValues.put(CorrelationIdentifier.getTraceIdKey(), traceIdValue);
-        correlationValues.put(
-            CorrelationIdentifier.getSpanIdKey(), DDSpanId.toString(context.getSpanId()));
-      }
+      DDTraceId traceId = context.getTraceId();
+      String traceIdValue =
+          InstrumenterConfig.get().isLogs128bTraceIdEnabled() && traceId.toHighOrderLong() != 0
+              ? traceId.toHexString()
+              : traceId.toString();
+      correlationValues.put(CorrelationIdentifier.getTraceIdKey(), traceIdValue);
+      correlationValues.put(
+          CorrelationIdentifier.getSpanIdKey(), DDSpanId.toString(context.getSpanId()));
 
-      if (mdcTagsInjectionEnabled) {
-        String serviceName = Config.get().getServiceName();
-        if (null != serviceName && !serviceName.isEmpty()) {
-          correlationValues.put(Tags.DD_SERVICE, serviceName);
-        }
-        String env = Config.get().getEnv();
-        if (null != env && !env.isEmpty()) {
-          correlationValues.put(Tags.DD_ENV, env);
-        }
-        String version = Config.get().getVersion();
-        if (null != version && !version.isEmpty()) {
-          correlationValues.put(Tags.DD_VERSION, version);
-        }
+      String serviceName = Config.get().getServiceName();
+      if (null != serviceName && !serviceName.isEmpty()) {
+        correlationValues.put(Tags.DD_SERVICE, serviceName);
+      }
+      String env = Config.get().getEnv();
+      if (null != env && !env.isEmpty()) {
+        correlationValues.put(Tags.DD_ENV, env);
+      }
+      String version = Config.get().getVersion();
+      if (null != version && !version.isEmpty()) {
+        correlationValues.put(Tags.DD_VERSION, version);
       }
 
       mdc = null != mdc ? new UnionMap<>(mdc, correlationValues) : correlationValues;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -57,7 +57,6 @@ public final class TraceInstrumentationConfig {
       "trace.serialversionuid.field.injection";
 
   public static final String LOGS_INJECTION_ENABLED = "logs.injection";
-  public static final String LOGS_MDC_TAGS_INJECTION_ENABLED = "logs.mdc.tags.injection";
   public static final String TRACE_128_BIT_TRACEID_LOGGING_ENABLED =
       "trace.128.bit.traceid.logging.enabled";
 

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -31,7 +31,6 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_CONNECTIO
 import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_PREPARED_STATEMENT_CLASS_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.LEGACY_INSTALLER_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_INJECTION_ENABLED;
-import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_MDC_TAGS_INJECTION_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.MEASURE_METHODS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_CACHE_CONFIG;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_CACHE_DIR;
@@ -70,7 +69,6 @@ public class InstrumenterConfig {
   private final boolean traceEnabled;
   private final boolean traceOtelEnabled;
   private final boolean logsInjectionEnabled;
-  private final boolean logsMDCTagsInjectionEnabled;
   private final boolean logs128bTraceIdEnabled;
   private final boolean profilingEnabled;
   private final boolean ciVisibilityEnabled;
@@ -124,7 +122,6 @@ public class InstrumenterConfig {
     traceOtelEnabled = configProvider.getBoolean(TRACE_OTEL_ENABLED, DEFAULT_TRACE_OTEL_ENABLED);
     logsInjectionEnabled =
         configProvider.getBoolean(LOGS_INJECTION_ENABLED, DEFAULT_LOGS_INJECTION_ENABLED);
-    logsMDCTagsInjectionEnabled = configProvider.getBoolean(LOGS_MDC_TAGS_INJECTION_ENABLED, true);
     logs128bTraceIdEnabled =
         configProvider.getBoolean(
             TRACE_128_BIT_TRACEID_LOGGING_ENABLED, DEFAULT_TRACE_128_BIT_TRACEID_LOGGING_ENABLED);
@@ -220,10 +217,6 @@ public class InstrumenterConfig {
 
   public boolean isLogsInjectionEnabled() {
     return logsInjectionEnabled;
-  }
-
-  public boolean isLogsMDCTagsInjectionEnabled() {
-    return logsMDCTagsInjectionEnabled && !Platform.isNativeImageBuilder();
   }
 
   public boolean isLogs128bTraceIdEnabled() {
@@ -391,8 +384,6 @@ public class InstrumenterConfig {
         + traceOtelEnabled
         + ", logsInjectionEnabled="
         + logsInjectionEnabled
-        + ", logsMDCTagsInjectionEnabled="
-        + logsMDCTagsInjectionEnabled
         + ", logs128bTraceIdEnabled="
         + logs128bTraceIdEnabled
         + ", profilingEnabled="


### PR DESCRIPTION
# What Does This Do

Removes `dd.logs.mdc.tags.injection` config

# Motivation
It complicates the log injection logic and doesn't have a use case