### PR TITLE
Disable embedded Git metadata extraction

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/git/GitInfoProvider.java
+++ b/internal-api/src/main/java/datadog/trace/api/git/GitInfoProvider.java
@@ -20,7 +20,6 @@ public class GitInfoProvider {
   static {
     INSTANCE = new GitInfoProvider();
     INSTANCE.registerGitInfoBuilder(new UserSuppliedGitInfoBuilder());
-    INSTANCE.registerGitInfoBuilder(new EmbeddedGitInfoBuilder());
   }
 
   private volatile Collection<GitInfoBuilder> builders = Collections.emptyList();


### PR DESCRIPTION
# What Does This Do
Disables [embedded Git metadata extraction](https://github.com/DataDog/dd-trace-java/pull/4951).

# Motivation
Component that extracts embedded Git metadata looks for it in `git.properties` files that are available on the classpath.
The idea is that customers should configure build system plugins that would add this file to their release artifacts.

The problem is that these files can be found inside 3rd party libraries too, and there is no telling whether a file comes from the customer's jar or from a dependency.

# Additional Notes
The feature is disabled temporarily until a long-term solution is agreed upon (most likely the filename will be changed to a non-standard one).
