### PR TITLE
Fix path parameter vulnerability source in resteasy

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
@@ -27,6 +27,12 @@ public class WebModuleImpl implements WebModule {
   }
 
   @Override
+  public void onPathParameterValue(
+      @Nullable final String paramName, @Nullable final String paramValue) {
+    onNamed(paramName, paramValue, SourceTypes.REQUEST_PATH_PARAMETER);
+  }
+
+  @Override
   public void onParameterValues(
       @Nullable final String paramName, @Nullable final String[] paramValues) {
     onNamed(paramName, paramValues, SourceTypes.REQUEST_PARAMETER_VALUE);

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/PathParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/PathParamInjectorAdvice.java
@@ -21,11 +21,12 @@ public class PathParamInjectorAdvice {
             Collection collection = (Collection) result;
             for (Object o : collection) {
               if (o instanceof String) {
-                module.onParameterValue(paramName, (String) o);
+
+                module.onPathParameterValue(paramName, (String) o);
               }
             }
           } else {
-            module.onParameterValue(paramName, (String) result);
+            module.onPathParameterValue(paramName, (String) result);
           }
         } catch (final Throwable e) {
           module.onUnexpectedException("PathParamInjectorAdvice.onExit threw", e);

--- a/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
@@ -19,6 +19,8 @@ public interface WebModule extends IastModule {
    */
   void onParameterValue(@Nullable String paramName, @Nullable String paramValue);
 
+  void onPathParameterValue(@Nullable String paramName, @Nullable String paramValue);
+
   void onParameterValues(@Nullable String paramName, @Nullable String[] paramValue);
 
   void onParameterValues(@Nullable String paramName, @Nullable Collection<String> paramValues);


### PR DESCRIPTION
# What Does This Do
Fixes the vulnerability source when reporting vulnerabilities if the source is parameter path since it was wrongly reported

# Motivation
Reporting the correct parameter source to the user so he can understand the vulnerability properly.

# Additional Notes
