### PR TITLE
bump ddprof to 0.39.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.37.0",
+    ddprof        : "0.39.0",
     asm           : "9.5"
   ]
 


### PR DESCRIPTION
# What Does This Do
Contains fixes:
* thread states recorded more accurately on wallclock samples - [tag](https://github.com/DataDog/java-profiler/releases/tag/v_0.38.0)
* live heap profiling under ZGC - [tag](https://github.com/DataDog/java-profiler/releases/tag/v_0.39.0)

# Motivation

# Additional Notes
