### PR TITLE
Emit datadog.ProfilerSetting events on J9

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-ddprof/src/main/java/com/datadog/profiling/controller/ddprof/DatadogProfilerSettings.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-ddprof/src/main/java/com/datadog/profiling/controller/ddprof/DatadogProfilerSettings.java
@@ -1,0 +1,28 @@
+package com.datadog.profiling.controller.ddprof;
+
+import com.datadog.profiling.controller.ProfilerSettingsSupport;
+import com.datadog.profiling.ddprof.DatadogProfiler;
+
+public class DatadogProfilerSettings extends ProfilerSettingsSupport {
+
+  private final DatadogProfiler datadogProfiler;
+
+  public DatadogProfilerSettings(DatadogProfiler datadogProfiler) {
+    this.datadogProfiler = datadogProfiler;
+  }
+
+  public void publish() {
+    datadogProfiler.recordSetting("Upload Period", String.valueOf(uploadPeriod), "seconds");
+    datadogProfiler.recordSetting("Upload Timeout", String.valueOf(uploadTimeout), "seconds");
+    datadogProfiler.recordSetting("Upload Compression", uploadCompression);
+    datadogProfiler.recordSetting(
+        "Allocation Profiling", String.valueOf(allocationProfilingEnabled));
+    datadogProfiler.recordSetting("Heap Profiling", String.valueOf(heapProfilingEnabled));
+    datadogProfiler.recordSetting("Force Start-First", String.valueOf(startForceFirst));
+    datadogProfiler.recordSetting("Hotspots", String.valueOf(hotspotsEnabled));
+    datadogProfiler.recordSetting("Endpoints", String.valueOf(endpointsEnabled));
+    datadogProfiler.recordSetting("Auxiliary Profiler", auxiliaryProfiler);
+    datadogProfiler.recordSetting("perf_events_paranoid", perfEventsParanoid);
+    datadogProfiler.recordSetting("Native Stacks", String.valueOf(hasNativeStacks));
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -412,4 +412,16 @@ public final class DatadogProfiler {
     }
     return EMPTY;
   }
+
+  public void recordSetting(String name, String value) {
+    if (profiler != null) {
+      profiler.recordSetting(name, value);
+    }
+  }
+
+  public void recordSetting(String name, String value, String unit) {
+    if (profiler != null) {
+      profiler.recordSetting(name, value, unit);
+    }
+  }
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.39.0",
+    ddprof        : "0.40.0",
     asm           : "9.5"
   ]
 


### PR DESCRIPTION
# What Does This Do

Emits `datadog.ProfilerSetting` events when on J9 (which does not support JFR)

# Motivation

# Additional Notes
