### PR TITLE
implement endpoint profiling for JDKs which don't have JFR

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -862,25 +862,35 @@ public class Agent {
             new WithGlobalTracer.Callback() {
               @Override
               public void withTracer(TracerAPI tracer) {
+                // TODO simplify this by reworking module boundaries
                 log.debug("Initializing profiler tracer integrations");
+                String checkpointerClassName =
+                    Config.get().isDatadogProfilerEnabled()
+                        ? "com.datadog.profiling.controller.ddprof.DatadogProfilerCheckpointer"
+                        : Platform.isOracleJDK8() || Platform.isJ9()
+                            ? null
+                            : "com.datadog.profiling.controller.openjdk.JFRCheckpointer";
+                String timerClassName =
+                    Platform.isOracleJDK8() || Platform.isJ9()
+                        ? null
+                        : "com.datadog.profiling.controller.openjdk.JFRTimer";
                 try {
-                  if (Platform.isOracleJDK8() || Platform.isJ9()) {
-                    return;
+                  if (checkpointerClassName != null) {
+                    tracer.registerCheckpointer(
+                        (EndpointCheckpointer)
+                            AGENT_CLASSLOADER
+                                .loadClass(checkpointerClassName)
+                                .getDeclaredConstructor()
+                                .newInstance());
                   }
-                  EndpointCheckpointer endpointCheckpointer =
-                      (EndpointCheckpointer)
-                          AGENT_CLASSLOADER
-                              .loadClass("com.datadog.profiling.controller.openjdk.JFRCheckpointer")
-                              .getDeclaredConstructor()
-                              .newInstance();
-                  tracer.registerCheckpointer(endpointCheckpointer);
-                  Timer timer =
-                      (Timer)
-                          AGENT_CLASSLOADER
-                              .loadClass("com.datadog.profiling.controller.openjdk.JFRTimer")
-                              .getDeclaredConstructor()
-                              .newInstance();
-                  tracer.registerTimer(timer);
+                  if (timerClassName != null) {
+                    tracer.registerTimer(
+                        (Timer)
+                            AGENT_CLASSLOADER
+                                .loadClass(timerClassName)
+                                .getDeclaredConstructor()
+                                .newInstance());
+                  }
                 } catch (Throwable e) {
                   if (e instanceof InvocationTargetException) {
                     e = e.getCause();

--- a/dd-java-agent/agent-profiling/profiling-controller-ddprof/src/main/java/com/datadog/profiling/controller/ddprof/DatadogProfilerCheckpointer.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-ddprof/src/main/java/com/datadog/profiling/controller/ddprof/DatadogProfilerCheckpointer.java
@@ -1,0 +1,54 @@
+package com.datadog.profiling.controller.ddprof;
+
+import com.datadog.profiling.ddprof.DatadogProfiler;
+import datadog.trace.api.EndpointCheckpointer;
+import datadog.trace.api.EndpointTracker;
+import datadog.trace.api.config.ProfilingConfig;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+
+public class DatadogProfilerCheckpointer implements EndpointCheckpointer {
+
+  private final DatadogProfiler datadogProfiler;
+  private final boolean isEndpointCollectionEnabled;
+
+  public DatadogProfilerCheckpointer(
+      DatadogProfiler datadogProfiler, ConfigProvider configProvider) {
+    this.datadogProfiler = datadogProfiler;
+    this.isEndpointCollectionEnabled =
+        configProvider.getBoolean(
+            ProfilingConfig.PROFILING_ENDPOINT_COLLECTION_ENABLED,
+            ProfilingConfig.PROFILING_ENDPOINT_COLLECTION_ENABLED_DEFAULT);
+  }
+
+  public DatadogProfilerCheckpointer() {
+    this(DatadogProfiler.getInstance(), ConfigProvider.getInstance());
+  }
+
+  @Override
+  public void onRootSpanFinished(AgentSpan rootSpan, EndpointTracker tracker) {
+    if (isEndpointCollectionEnabled && rootSpan != null) {
+      CharSequence resourceName = rootSpan.getResourceName();
+      if (resourceName != null) {
+        datadogProfiler.recordTraceRoot(rootSpan.getSpanId(), resourceName.toString());
+      }
+    }
+  }
+
+  @Override
+  public EndpointTracker onRootSpanStarted(AgentSpan rootSpan) {
+    return NoOpEndpointTracker.INSTANCE;
+  }
+
+  /**
+   * This implementation is actually stateless, so we don't actually need a tracker object, but
+   * we'll create a singleton to avoid returning null and risking NPEs elsewhere.
+   */
+  private static final class NoOpEndpointTracker implements EndpointTracker {
+
+    public static final NoOpEndpointTracker INSTANCE = new NoOpEndpointTracker();
+
+    @Override
+    public void endpointWritten(AgentSpan span) {}
+  }
+}

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -55,6 +55,8 @@ public final class DatadogProfiler {
 
   private static final String OPERATION = "_dd.trace.operation";
 
+  private static final int MAX_NUM_ENDPOINTS = 8192;
+
   private static final class Singleton {
     private static final DatadogProfiler INSTANCE = newInstance();
   }
@@ -333,6 +335,17 @@ public final class DatadogProfiler {
     String cmdString = cmd.toString();
     log.debug("Datadog profiler command line: {}", cmdString);
     return cmdString;
+  }
+
+  public void recordTraceRoot(long rootSpanId, String endpoint) {
+    if (profiler != null) {
+      if (!profiler.recordTraceRoot(rootSpanId, endpoint, MAX_NUM_ENDPOINTS)) {
+        log.debug(
+            "Endpoint event not written because more than {} distinct endpoints have been encountered."
+                + " This avoids excessive memory overhead.",
+            MAX_NUM_ENDPOINTS);
+      }
+    }
   }
 
   public int operationNameOffset() {


### PR DESCRIPTION
# What Does This Do

Implements and registers an `EndpointCheckpointer` which doesn't use JFR to record the endpoint events required for endpoint profiling to work. This means endpoint profiling can be used on non-OpenJDK JVMs such as J9. This is simple glue code for a component which is well tested across a range of architectures/libc/JDK distributions in the java-profiler repository, so no new tests beyond the existing smoke tests are added.

# Motivation

# Additional Notes
