### PR TITLE
[Spark] Compute skew time for spark application / job / stage

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
@@ -265,6 +265,7 @@ public class DatadogSparkListener extends SparkListener {
 
     SparkAggregatedTaskMetrics stageMetric = stageMetrics.remove(stageSpanKey);
     if (stageMetric != null) {
+      stageMetric.computeSkewTime();
       stageMetric.setSpanMetrics(span, "spark_stage_metrics");
       applicationMetrics.accumulateStageMetrics(stageMetric);
 


### PR DESCRIPTION
# What Does This Do

Skew is a common issue in apache spark when the data are not balanced between workers. It is defined as `max - median` tasks duration per stage.

The skew of an application / job is defined as the sum of the skew of its stages. This is an approximation since multiple stages can be running at the same time, but it gives an upper bound of the total skew

## Implementation details

Computing the median is an expensive operation, which can be done
- naively, by keeping all the durations in a list and sorting it
- approximately, like with the https://github.com/DataDog/sketches-java library

Since the number of tasks is generally moderate per stage (default in spark is 200), the overhead of injecting another library + creating the buckets for the approximate algorithm with 1% accuracy outweigh the benefits for 200 tasks, and becomes even around ~10k-20k tasks