### PR TITLE
Fix missing path parameter source from Jersey framework

### DIFF
--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/ParamValueFactoryWithSourceInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/ParamValueFactoryWithSourceInstrumentation.java
@@ -42,7 +42,7 @@ public class ParamValueFactoryWithSourceInstrumentation extends Instrumenter.Ias
           ThreadLocalSourceType.set(SourceTypes.REQUEST_COOKIE_VALUE);
           break;
         case "PATH":
-          ThreadLocalSourceType.set(SourceTypes.REQUEST_PARAMETER_VALUE);
+          ThreadLocalSourceType.set(SourceTypes.REQUEST_PATH_PARAMETER);
           break;
         case "QUERY":
           ThreadLocalSourceType.set(SourceTypes.REQUEST_PARAMETER_VALUE);

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/PathParamValueFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/PathParamValueFactoryInstrumentation.java
@@ -1,0 +1,42 @@
+package datadog.trace.instrumentation.jersey;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.SourceTypes;
+import net.bytebuddy.asm.Advice;
+
+@AutoService(Instrumenter.class)
+public class PathParamValueFactoryInstrumentation extends Instrumenter.Iast
+    implements Instrumenter.ForSingleType {
+
+  public PathParamValueFactoryInstrumentation() {
+    super("jersey");
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("get").and(takesArguments(1)),
+        PathParamValueFactoryInstrumentation.class.getName() + "$InstrumenterAdvice");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {packageName + ".ThreadLocalSourceType"};
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.glassfish.jersey.server.internal.inject.PathParamValueFactoryProvider$PathParamValueFactory";
+  }
+
+  public static class InstrumenterAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onExit() {
+      ThreadLocalSourceType.set(SourceTypes.REQUEST_PATH_PARAMETER);
+    }
+  }
+}

--- a/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractJerseySmokeTest.groovy
+++ b/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractJerseySmokeTest.groovy
@@ -2,12 +2,9 @@ package datadog.smoketest
 
 import okhttp3.FormBody
 import okhttp3.Request
-import spock.lang.Ignore
 
 class AbstractJerseySmokeTest extends AbstractIastServerSmokeTest {
 
-  // TODO @IAST support this source in jersey 2 and 3
-  @Ignore
   void 'path parameter'() {
     setup:
     def url = "http://localhost:${httpPort}/hello/bypathparam/pathParamValue"


### PR DESCRIPTION
# What Does This Do
Adds instrumentation for the path parameters injector in the Jersey framework

# Motivation
IAST needs to report the correct sources for vulnerabilities and this allows us to set the correct source in the case of path parameters

# Additional Notes
