### PR TITLE
[Spark] Separate the error stack trace from the error message

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
@@ -440,6 +440,10 @@ public class DatadogSparkListener extends SparkListener {
   }
 
   private String getErrorMessageWithoutStackTrace(String errorMessage) {
+    if (errorMessage == null) {
+      return null;
+    }
+
     int stackTraceIndex = errorMessage.indexOf("\tat ");
     if (stackTraceIndex != -1) {
       return errorMessage.substring(0, stackTraceIndex);

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
@@ -105,7 +105,10 @@ public class DatadogSparkListener extends SparkListener {
       applicationSpan.setError(true);
       applicationSpan.setTag(
           DDTags.ERROR_TYPE, "Spark Application Failed with exit code " + exitCode);
-      applicationSpan.setTag(DDTags.ERROR_MSG, msg);
+
+      String errorMessage = getErrorMessageWithoutStackTrace(msg);
+      applicationSpan.setTag(DDTags.ERROR_MSG, errorMessage);
+      applicationSpan.setTag(DDTags.ERROR_STACK, msg);
     } else if (lastJobFailed) {
       applicationSpan.setError(true);
       applicationSpan.setTag(DDTags.ERROR_TYPE, "Spark Application Failed");

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
@@ -5,9 +5,12 @@ import datadog.trace.api.DDTraceId;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import org.apache.spark.ExceptionFailure;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.TaskFailedReason;
@@ -49,6 +52,7 @@ public class DatadogSparkListener extends SparkListener {
 
   private boolean lastJobFailed = false;
   private String lastJobFailedMessage;
+  private String lastJobFailedStackTrace;
   private int currentExecutorCount = 0;
   private int maxExecutorCount = 0;
   private long availableExecutorTime = 0;
@@ -106,6 +110,7 @@ public class DatadogSparkListener extends SparkListener {
       applicationSpan.setError(true);
       applicationSpan.setTag(DDTags.ERROR_TYPE, "Spark Application Failed");
       applicationSpan.setTag(DDTags.ERROR_MSG, lastJobFailedMessage);
+      applicationSpan.setTag(DDTags.ERROR_STACK, lastJobFailedStackTrace);
     }
 
     for (SparkListenerExecutorAdded executor : liveExecutors.values()) {
@@ -199,12 +204,18 @@ public class DatadogSparkListener extends SparkListener {
     lastJobFailed = false;
     if (jobEnd.jobResult() instanceof JobFailed) {
       JobFailed jobFailed = (JobFailed) jobEnd.jobResult();
+      Exception exception = jobFailed.exception();
+
+      String errorMessage = getErrorMessageWithoutStackTrace(exception.getMessage());
+      String errorStackTrace = stackTraceToString(exception);
 
       jobSpan.setError(true);
-      jobSpan.setErrorMessage(jobFailed.exception().toString());
+      jobSpan.setErrorMessage(errorMessage);
+      jobSpan.setTag(DDTags.ERROR_STACK, errorStackTrace);
       jobSpan.setTag(DDTags.ERROR_TYPE, "Spark Job Failed");
       lastJobFailed = true;
-      lastJobFailedMessage = jobFailed.exception().toString();
+      lastJobFailedMessage = errorMessage;
+      lastJobFailedStackTrace = errorStackTrace;
     }
 
     SparkAggregatedTaskMetrics metrics = jobMetrics.remove(jobEnd.jobId());
@@ -277,7 +288,8 @@ public class DatadogSparkListener extends SparkListener {
 
     if (stageInfo.failureReason().isDefined()) {
       span.setError(true);
-      span.setErrorMessage(stageInfo.failureReason().get());
+      span.setErrorMessage(getErrorMessageWithoutStackTrace(stageInfo.failureReason().get()));
+      span.setTag(DDTags.ERROR_STACK, stageInfo.failureReason().get());
       span.setTag(DDTags.ERROR_TYPE, "Spark Stage Failed");
     }
 
@@ -322,6 +334,12 @@ public class DatadogSparkListener extends SparkListener {
       return;
     }
 
+    // Only sending tasks that can lead to failure
+    TaskFailedReason reason = (TaskFailedReason) taskEnd.reason();
+    if (!reason.countTowardsTaskFailures()) {
+      return;
+    }
+
     AgentSpan stageSpan = stageSpans.get(stageSpanKey);
     if (stageSpan == null) {
       return;
@@ -351,8 +369,18 @@ public class DatadogSparkListener extends SparkListener {
       TaskFailedReason reason = (TaskFailedReason) taskEnd.reason();
 
       taskSpan.setError(true);
-      taskSpan.setErrorMessage(reason.toErrorString());
       taskSpan.setTag(DDTags.ERROR_TYPE, "Spark Task Failed");
+
+      if (reason instanceof ExceptionFailure) {
+        ExceptionFailure exceptionFailure = (ExceptionFailure) reason;
+
+        taskSpan.setErrorMessage(
+            String.format("%s: %s", exceptionFailure.className(), exceptionFailure.description()));
+        taskSpan.setTag(DDTags.ERROR_STACK, exceptionFailure.fullStackTrace());
+      } else {
+        taskSpan.setErrorMessage(reason.toErrorString());
+      }
+
       taskSpan.setTag("count_towards_task_failures", reason.countTowardsTaskFailures());
     }
 
@@ -403,5 +431,20 @@ public class DatadogSparkListener extends SparkListener {
     }
 
     return null;
+  }
+
+  private String stackTraceToString(Throwable e) {
+    StringWriter stringWriter = new StringWriter();
+    e.printStackTrace(new PrintWriter(stringWriter));
+    return stringWriter.toString();
+  }
+
+  private String getErrorMessageWithoutStackTrace(String errorMessage) {
+    int stackTraceIndex = errorMessage.indexOf("\tat ");
+    if (stackTraceIndex != -1) {
+      return errorMessage.substring(0, stackTraceIndex);
+    }
+
+    return errorMessage;
   }
 }

--- a/dd-java-agent/instrumentation/spark/src/test/groovy/SparkTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/test/groovy/SparkTest.groovy
@@ -102,6 +102,64 @@ class SparkTest extends AgentTestRunner {
     spark.stop()
   }
 
+  def "generate error tags in failed spans"() {
+    def sparkSession = SparkSession.builder()
+      .config("spark.master", "local")
+      .getOrCreate()
+
+    try {
+      TestSparkComputation.generateTestFailingSparkComputation(sparkSession)
+    }
+    catch (Exception ignored) {}
+
+    sparkSession.stop()
+
+    expect:
+    assertTraces(1) {
+      trace(4) {
+        span {
+          operationName "spark.application"
+          resourceName "spark.application"
+          spanType "spark"
+          errored true
+          parent()
+          assert span.tags["error.type"] == "Spark Application Failed"
+          assert span.tags["error.message"] =~ /^Job aborted due to stage failure.*java.lang.NullPointerException$/
+          assert span.tags["error.stack"] =~ /(?s)^org.apache.spark.SparkException.*Caused by: java.lang.NullPointerException.*$/
+        }
+        span {
+          operationName "spark.job"
+          resourceName "collect at TestSparkComputation.java:21"
+          spanType "spark"
+          errored true
+          childOf(span(0))
+          assert span.tags["error.type"] == "Spark Job Failed"
+          assert span.tags["error.message"] =~ /^Job aborted due to stage failure.*java.lang.NullPointerException$/
+          assert span.tags["error.stack"] =~ /(?s)^org.apache.spark.SparkException.*Caused by: java.lang.NullPointerException.*$/
+        }
+        span {
+          operationName "spark.stage"
+          resourceName "collect at TestSparkComputation.java:21"
+          spanType "spark"
+          errored true
+          childOf(span(1))
+          assert span.tags["error.type"] == "Spark Stage Failed"
+          assert span.tags["error.message"] =~ /^Job aborted due to stage failure.*java.lang.NullPointerException$/
+          assert span.tags["error.stack"] =~ /(?s).*\n\tat TestSparkComputation.{500,}\$/
+        }
+        span {
+          operationName "spark.task"
+          spanType "spark"
+          errored true
+          childOf(span(2))
+          assert span.tags["error.type"] == "Spark Task Failed"
+          assert span.tags["error.message"] == "java.lang.NullPointerException: null"
+          assert span.tags["error.stack"] =~ /(?s)^java.lang.NullPointerException\n\tat TestSparkComputation.{500,}\$/
+        }
+      }
+    }
+  }
+
   def "generate databricks spans"() {
     setup:
     def sparkSession = SparkSession.builder()
@@ -171,6 +229,9 @@ class SparkTest extends AgentTestRunner {
         }
       }
     }
+
+    cleanup:
+    sparkSession.stop()
   }
 
   def "compute the databricks parent context"() {

--- a/dd-java-agent/instrumentation/spark/src/test/java/TestSparkComputation.java
+++ b/dd-java-agent/instrumentation/spark/src/test/java/TestSparkComputation.java
@@ -11,4 +11,13 @@ public class TestSparkComputation {
     // - the second one triggered by the count() action
     sparkSession.sparkContext().range(1, 10, 1, 2).distinct().count();
   }
+
+  public static void generateTestFailingSparkComputation(SparkSession sparkSession) {
+    sparkSession
+        .sparkContext()
+        .range(1, 10, 1, 2)
+        .toJavaRDD()
+        .map(x -> ((Long) null).toString())
+        .collect();
+  }
 }


### PR DESCRIPTION
# What Does This Do

Before this PR, the full error message from spark (which also contained the stack trace) was added to the `span.setErrorMessage`. Changing that to separate the message from the stack trace in the span so it can be better represented in the UI

Another change is to only send task errors that `countTowardsTaskFailures` as the ones that don't count as a failure tend to be very noisy (`FetchFailed`, `Resubmitted`, ...)