### PR TITLE
Fix CI for parametric tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -778,7 +778,7 @@ jobs:
       - run:
           name: Install requirements
           command: |
-            cd system-tests/parametric
+            cd system-tests
             pyenv local system
             python3.9 --version
             python3.9 -m pip install wheel


### PR DESCRIPTION


# What Does This Do

Fix CI for parametric tests. They now rely on the requirements.txt in the root directory.

# Motivation
After this PR https://github.com/DataDog/system-tests/pull/1190 we need to use the `requirements.txt` in the root directory of system tests.

# Additional Notes
