### PR TITLE
Improve telemetry intervals behavior

### DIFF
--- a/telemetry/build.gradle
+++ b/telemetry/build.gradle
@@ -10,6 +10,7 @@ ext {
     'datadog.telemetry.dependency.LocationsCollectingTransformer',
     'datadog.telemetry.dependency.JbossVirtualFileHelper',
     'datadog.telemetry.RequestBuilder.NumberJsonAdapter',
+    'datadog.telemetry.RequestBuilderSupplier',
     'datadog.telemetry.TelemetrySystem',
     'datadog.telemetry.api.*',
   ]

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
@@ -40,8 +40,8 @@ public class TelemetryRunnable implements Runnable {
     this.actionsAtMetricsInterval = findMetricPeriodicActions(actions);
     this.sleeper = sleeper;
     this.timeSource = timeSource;
-    this.metricsIntervalMs = (int) (Config.get().getTelemetryMetricsInterval() * 1000);
-    this.heartbeatIntervalMs = (int) (Config.get().getTelemetryHeartbeatInterval() * 1000);
+    this.metricsIntervalMs = (long) (Config.get().getTelemetryMetricsInterval() * 1000);
+    this.heartbeatIntervalMs = (long) (Config.get().getTelemetryHeartbeatInterval() * 1000);
     this.lastMetricsIntervalMs = 0;
     this.lastHeartbeatIntervalMs = 0;
   }

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
@@ -19,8 +19,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Supplier;
@@ -55,8 +53,6 @@ public class TelemetryService {
 
   private final BlockingQueue<DistributionSeries> distributionSeries =
       new LinkedBlockingQueue<>(1024);
-
-  private final Queue<Request> queue = new ArrayBlockingQueue<>(16);
 
   private boolean sentAppStarted;
 

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
@@ -14,9 +14,9 @@ import datadog.telemetry.api.Logs;
 import datadog.telemetry.api.Metric;
 import datadog.telemetry.api.Payload;
 import datadog.telemetry.api.RequestType;
-import datadog.trace.api.time.TimeSource;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -24,7 +24,10 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,12 +41,10 @@ public class TelemetryService {
   // https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v2/producing-telemetry.md#when-to-use-it-1
   private static final int MAX_DEPENDENCIES_PER_REQUEST = 2000;
 
+  private final OkHttpClient httpClient;
   private final Supplier<RequestBuilder> requestBuilderSupplier;
-  private final TimeSource timeSource;
   private final int maxElementsPerReq;
   private final int maxDepsPerReq;
-  private final int heartbeatIntervalMs;
-  private final int metricsIntervalMs;
   private final BlockingQueue<KeyValue> configurations = new LinkedBlockingQueue<>();
   private final BlockingQueue<Integration> integrations = new LinkedBlockingQueue<>();
   private final BlockingQueue<Dependency> dependencies = new LinkedBlockingQueue<>();
@@ -57,7 +58,8 @@ public class TelemetryService {
 
   private final Queue<Request> queue = new ArrayBlockingQueue<>(16);
 
-  private long lastHeartBeatTimestamp;
+  private boolean sentAppStarted;
+
   /*
    * Keep track of Open Tracing and Open Telemetry integrations activation as they are mutually exclusive.
    */
@@ -65,50 +67,24 @@ public class TelemetryService {
   private boolean openTelemetryIntegrationEnabled;
 
   public TelemetryService(
-      Supplier<RequestBuilder> requestBuilderSupplier,
-      TimeSource timeSource,
-      float heartBeatIntervalSec,
-      float metricsIntervalSec) {
+      final OkHttpClient httpClient, final Supplier<RequestBuilder> requestBuilderSupplier) {
     this(
-        requestBuilderSupplier,
-        timeSource,
-        heartBeatIntervalSec,
-        metricsIntervalSec,
-        MAX_ELEMENTS_PER_REQUEST,
-        MAX_DEPENDENCIES_PER_REQUEST);
+        httpClient, requestBuilderSupplier, MAX_ELEMENTS_PER_REQUEST, MAX_DEPENDENCIES_PER_REQUEST);
   }
 
-  // For testing purpose
+  // For testing purposes
   TelemetryService(
-      Supplier<RequestBuilder> requestBuilderSupplier,
-      TimeSource timeSource,
-      float heartBeatIntervalSec,
-      float metricsIntervalSec,
-      int maxElementsPerReq,
-      int maxDepsPerReq) {
+      final OkHttpClient httpClient,
+      final Supplier<RequestBuilder> requestBuilderSupplier,
+      final int maxElementsPerReq,
+      final int maxDepsPerReq) {
+    this.httpClient = httpClient;
     this.requestBuilderSupplier = requestBuilderSupplier;
-    this.timeSource = timeSource;
-    this.heartbeatIntervalMs = (int) (heartBeatIntervalSec * 1000); // we use time in milliseconds
-    this.metricsIntervalMs = (int) (metricsIntervalSec * 1000);
+    this.sentAppStarted = false;
     this.openTracingIntegrationEnabled = false;
     this.openTelemetryIntegrationEnabled = false;
     this.maxElementsPerReq = maxElementsPerReq;
     this.maxDepsPerReq = maxDepsPerReq;
-  }
-
-  public void addStartedRequest() {
-    Payload payload =
-        new AppStarted()
-            ._configuration(drainOrNull(configurations)) // absent if nothing
-            .integrations(drainOrEmpty(integrations, maxElementsPerReq)) // empty list if nothing
-            .dependencies(drainOrEmpty(dependencies, maxDepsPerReq)) // empty list if nothing
-            .requestType(RequestType.APP_STARTED);
-
-    queue.offer(requestBuilderSupplier.get().build(RequestType.APP_STARTED, payload));
-  }
-
-  public Request appClosingRequest() {
-    return requestBuilderSupplier.get().build(RequestType.APP_CLOSING);
   }
 
   public boolean addConfiguration(Map<String, Object> configuration) {
@@ -147,87 +123,148 @@ public class TelemetryService {
     return this.distributionSeries.offer(series);
   }
 
-  public Queue<Request> prepareRequests() {
-    // New integrations
-    while (!integrations.isEmpty()) {
-      Payload payload =
-          new AppIntegrationsChange().integrations(drainOrEmpty(integrations, maxElementsPerReq));
-      Request request =
-          requestBuilderSupplier
-              .get()
-              .build(
-                  RequestType.APP_INTEGRATIONS_CHANGE,
-                  payload.requestType(RequestType.APP_INTEGRATIONS_CHANGE));
-      queue.offer(request);
+  public void sendAppClosingRequest() {
+    sendRequest(RequestType.APP_CLOSING, null);
+  }
+
+  public void sendIntervalRequests() {
+    final State state =
+        new State(
+            configurations, integrations, dependencies, metrics, distributionSeries, logMessages);
+    if (!sentAppStarted) {
+      final Payload payload =
+          new AppStarted()
+              ._configuration(state.configurations.getOrNull()) // absent if nothing
+              .integrations(state.integrations.get(maxElementsPerReq)) // empty list if nothing
+              .dependencies(state.dependencies.get(maxDepsPerReq)) // empty list if nothing
+              .requestType(RequestType.APP_STARTED);
+      if (sendRequest(RequestType.APP_STARTED, payload) != SendResult.SUCCESS) {
+        // Do not send other telemetry messages unless app-started has been sent successfully.
+        state.rollback();
+        return;
+      }
+      sentAppStarted = true;
+      state.commit();
     }
 
-    // New dependencies
-    while (!dependencies.isEmpty()) {
-      Payload payload =
-          new AppDependenciesLoaded().dependencies(drainOrEmpty(dependencies, maxDepsPerReq));
-      Request request =
-          requestBuilderSupplier
-              .get()
-              .build(
-                  RequestType.APP_DEPENDENCIES_LOADED,
-                  payload.requestType(RequestType.APP_DEPENDENCIES_LOADED));
-      queue.offer(request);
+    if (sendRequest(RequestType.APP_HEARTBEAT, null) == SendResult.NOT_FOUND) {
+      state.rollback();
+      return;
     }
 
-    // New metrics
-    while (!metrics.isEmpty()) {
-      Payload payload =
+    while (!state.integrations.isEmpty()) {
+      final Payload payload =
+          new AppIntegrationsChange()
+              .integrations(state.integrations.get(maxElementsPerReq))
+              .requestType(RequestType.APP_INTEGRATIONS_CHANGE);
+      final SendResult result = sendRequest(RequestType.APP_INTEGRATIONS_CHANGE, payload);
+      if (result == SendResult.SUCCESS) {
+        state.commit();
+      } else if (result == SendResult.NOT_FOUND) {
+        state.rollback();
+        return;
+      } else {
+        state.integrations.rollback();
+        break;
+      }
+    }
+
+    while (!state.dependencies.isEmpty()) {
+      final Payload payload =
+          new AppDependenciesLoaded()
+              .dependencies(state.dependencies.get(maxDepsPerReq))
+              .requestType(RequestType.APP_DEPENDENCIES_LOADED);
+      final SendResult result = sendRequest(RequestType.APP_DEPENDENCIES_LOADED, payload);
+      if (result == SendResult.SUCCESS) {
+        state.commit();
+      } else if (result == SendResult.NOT_FOUND) {
+        state.rollback();
+        return;
+      } else {
+        state.integrations.rollback();
+        break;
+      }
+    }
+
+    while (!state.metrics.isEmpty()) {
+      final Payload payload =
           new GenerateMetrics()
               .namespace(TELEMETRY_NAMESPACE_TAG_TRACER)
-              .series(drainOrEmpty(metrics, maxElementsPerReq));
-      Request request =
-          requestBuilderSupplier
-              .get()
-              .build(
-                  RequestType.GENERATE_METRICS, payload.requestType(RequestType.GENERATE_METRICS));
-      queue.offer(request);
+              .series(state.metrics.get(maxElementsPerReq))
+              .requestType(RequestType.GENERATE_METRICS);
+      final SendResult result = sendRequest(RequestType.GENERATE_METRICS, payload);
+      if (result == SendResult.SUCCESS) {
+        state.commit();
+      } else if (result == SendResult.NOT_FOUND) {
+        state.rollback();
+        return;
+      } else {
+        state.metrics.rollback();
+        break;
+      }
     }
 
-    // New messages
-    while (!logMessages.isEmpty()) {
-      Payload payload = new Logs().messages(drainOrEmpty(logMessages, maxElementsPerReq));
-      Request request =
-          requestBuilderSupplier
-              .get()
-              .build(RequestType.LOGS, payload.requestType(RequestType.LOGS));
-      queue.offer(request);
-    }
-
-    // New Distributions
-    while (!distributionSeries.isEmpty()) {
-      Payload payload =
+    while (!state.distributionSeries.isEmpty()) {
+      final Payload payload =
           new Distributions()
               .namespace(TELEMETRY_NAMESPACE_TAG_TRACER)
-              .series(drainOrEmpty(distributionSeries, maxElementsPerReq));
-      Request request =
-          requestBuilderSupplier
-              .get()
-              .build(RequestType.DISTRIBUTIONS, payload.requestType(RequestType.DISTRIBUTIONS));
-      queue.offer(request);
+              .series(state.distributionSeries.get(maxElementsPerReq))
+              .requestType(RequestType.DISTRIBUTIONS);
+      final SendResult result = sendRequest(RequestType.DISTRIBUTIONS, payload);
+      if (result == SendResult.SUCCESS) {
+        state.commit();
+      } else if (result == SendResult.NOT_FOUND) {
+        state.rollback();
+        return;
+      } else {
+        state.distributionSeries.rollback();
+        break;
+      }
     }
 
-    // Heartbeat request if needed
-    final long curTime = this.timeSource.getCurrentTimeMillis();
-    if (curTime - lastHeartBeatTimestamp >= heartbeatIntervalMs) {
-      Request request = requestBuilderSupplier.get().build(RequestType.APP_HEARTBEAT);
-      queue.offer(request);
-      lastHeartBeatTimestamp = curTime;
+    while (!state.logMessages.isEmpty()) {
+      final Payload payload =
+          new Logs()
+              .messages(state.logMessages.get(maxElementsPerReq))
+              .requestType(RequestType.LOGS);
+      final SendResult result = sendRequest(RequestType.LOGS, payload);
+      if (result == SendResult.SUCCESS) {
+        state.commit();
+      } else if (result == SendResult.NOT_FOUND) {
+        state.rollback();
+        return;
+      } else {
+        state.logMessages.rollback();
+        break;
+      }
+    }
+  }
+
+  private SendResult sendRequest(final RequestType type, final Payload payload) {
+    final Request request = requestBuilderSupplier.get().build(type, payload);
+    try (Response response = httpClient.newCall(request).execute()) {
+      if (response.code() == 404) {
+        log.debug("Telemetry endpoint is disabled, dropping {} message", type);
+        return SendResult.NOT_FOUND;
+      }
+      if (response.code() != 202) {
+        log.debug(
+            "Telemetry message {} failed with: {} {} ", type, response.code(), response.message());
+        return SendResult.FAILURE;
+      }
+    } catch (IOException e) {
+      log.debug("Telemetry message {} failed with exception: {}", type, e.toString());
+      return SendResult.FAILURE;
     }
 
-    return queue;
+    log.debug("Telemetry message {} sent successfully", type);
+    return SendResult.SUCCESS;
   }
 
-  public int getHeartbeatInterval() {
-    return heartbeatIntervalMs;
-  }
-
-  public int getMetricsInterval() {
-    return metricsIntervalMs;
+  enum SendResult {
+    SUCCESS,
+    FAILURE,
+    NOT_FOUND
   }
 
   private void warnAboutExclusiveIntegrations() {
@@ -237,21 +274,105 @@ public class TelemetryService {
     }
   }
 
-  private static <T> List<T> drainOrNull(BlockingQueue<T> srcQueue) {
-    return drainOrDefault(srcQueue, null, Integer.MAX_VALUE);
-  }
+  private static class StateList<T> {
+    private final BlockingQueue<T> queue;
+    private List<T> batch;
+    private int consumed;
 
-  private static <T> List<T> drainOrEmpty(BlockingQueue<T> srcQueue, int maxItems) {
-    return drainOrDefault(srcQueue, Collections.<T>emptyList(), maxItems);
-  }
-
-  private static <T> List<T> drainOrDefault(
-      BlockingQueue<T> srcQueue, List<T> defaultList, int maxItems) {
-    List<T> list = new LinkedList<>();
-    int drained = srcQueue.drainTo(list, maxItems);
-    if (drained > 0) {
-      return list;
+    public StateList(final BlockingQueue<T> queue) {
+      this.queue = queue;
+      final int size = queue.size();
+      this.batch = new ArrayList<>(size);
+      queue.drainTo(this.batch);
+      this.consumed = 0;
     }
-    return defaultList;
+
+    public boolean isEmpty() {
+      return consumed >= batch.size();
+    }
+
+    @Nullable
+    public List<T> getOrNull() {
+      final List<T> result = get();
+      if (result.isEmpty()) {
+        return null;
+      }
+      return result;
+    }
+
+    public List<T> get() {
+      return get(batch.size());
+    }
+
+    public List<T> get(final int maxSize) {
+      if (consumed >= batch.size()) {
+        return Collections.emptyList();
+      }
+      final int toIndex = Math.min(batch.size(), consumed + maxSize);
+      final List<T> result = batch.subList(consumed, toIndex);
+      consumed += result.size();
+      return result;
+    }
+
+    public void commit() {
+      if (consumed >= batch.size()) {
+        batch = Collections.emptyList();
+      } else {
+        batch = batch.subList(consumed, batch.size());
+      }
+      consumed = 0;
+    }
+
+    public void rollback() {
+      for (final T element : batch) {
+        // Ignore result, if the queue is full, we'll just lose data.
+        // TODO: Emit a metric when data is lost.
+        queue.offer(element);
+      }
+      batch = Collections.emptyList();
+      consumed = 0;
+    }
+  }
+
+  private static class State {
+    private final StateList<KeyValue> configurations;
+    private final StateList<Integration> integrations;
+    private final StateList<Dependency> dependencies;
+    private final StateList<Metric> metrics;
+    private final StateList<DistributionSeries> distributionSeries;
+    private final StateList<LogMessage> logMessages;
+
+    public State(
+        BlockingQueue<KeyValue> configurations,
+        BlockingQueue<Integration> integrations,
+        BlockingQueue<Dependency> dependencies,
+        BlockingQueue<Metric> metrics,
+        BlockingQueue<DistributionSeries> distributionSeries,
+        BlockingQueue<LogMessage> logMessages) {
+      this.configurations = new StateList<>(configurations);
+      this.integrations = new StateList<>(integrations);
+      this.dependencies = new StateList<>(dependencies);
+      this.metrics = new StateList<>(metrics);
+      this.distributionSeries = new StateList<>(distributionSeries);
+      this.logMessages = new StateList<>(logMessages);
+    }
+
+    public void rollback() {
+      this.configurations.rollback();
+      this.integrations.rollback();
+      this.dependencies.rollback();
+      this.metrics.rollback();
+      this.distributionSeries.rollback();
+      this.logMessages.rollback();
+    }
+
+    public void commit() {
+      this.configurations.commit();
+      this.integrations.commit();
+      this.dependencies.commit();
+      this.metrics.commit();
+      this.distributionSeries.commit();
+      this.logMessages.commit();
+    }
   }
 }

--- a/telemetry/src/main/java/datadog/telemetry/api/KeyValue.java
+++ b/telemetry/src/main/java/datadog/telemetry/api/KeyValue.java
@@ -9,6 +9,8 @@
  */
 package datadog.telemetry.api;
 
+import java.util.Objects;
+
 public class KeyValue {
 
   @com.squareup.moshi.Json(name = "name")
@@ -65,5 +67,18 @@ public class KeyValue {
     sb.append("    value: ").append(value).append("\n");
     sb.append("}");
     return sb.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    KeyValue keyValue = (KeyValue) o;
+    return Objects.equals(name, keyValue.name) && Objects.equals(value, keyValue.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, value);
   }
 }

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryRunnableSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryRunnableSpecification.groovy
@@ -26,7 +26,7 @@ class TelemetryRunnableSpecification extends DDSpecification {
   Thread t = null
 
   void cleanup() {
-    if (t != null && t.isAlive()) {
+    if (t?.isAlive()) {
       t.interrupt()
       t.join()
     }

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryRunnableSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryRunnableSpecification.groovy
@@ -1,201 +1,173 @@
 package datadog.telemetry
 
+import datadog.telemetry.metric.MetricPeriodicAction
+import datadog.trace.api.telemetry.MetricCollector
+import datadog.trace.api.time.TimeSource
 import datadog.trace.test.util.DDSpecification
-import okhttp3.Call
-import okhttp3.OkHttpClient
-import okhttp3.Protocol
-import okhttp3.Request
-import okhttp3.Response
-import okhttp3.ResponseBody
+
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.TimeUnit
 
 class TelemetryRunnableSpecification extends DDSpecification {
-  private static final Request REQUEST = new Request.Builder()
-  .url('https://example.com').build()
 
-  def okResponse() {
-    testResponse("msg", 202)
-  }
-  def badResponse() {
-    testResponse("msg", 500)
-  }
-  def notFoundResponse() {
-    testResponse("msg", 404)
-  }
+  static class TickSleeper implements TelemetryRunnable.ThreadSleeper {
+    CyclicBarrier sleeped = new CyclicBarrier(2)
+    CyclicBarrier go = new CyclicBarrier(2)
+    TelemetryRunnable.ThreadSleeper delegate
 
-  def testResponse(String msg, int code) {
-    return new Response.Builder().request(REQUEST).protocol(Protocol.HTTP_1_0)
-      .body(ResponseBody.create(null, new byte[0]))
-      .message(msg).code(code).build()
+    @Override
+    void sleep(long timeoutMs) {
+      delegate?.sleep(timeoutMs)
+      sleeped.await(10, TimeUnit.SECONDS)
+      go.await(10, TimeUnit.SECONDS)
+    }
   }
 
-  OkHttpClient okHttpClient = Mock()
-  TelemetryRunnable.ThreadSleeper sleeper = Mock()
-  TelemetryService telemetryService = Mock()
-  TelemetryRunnable.TelemetryPeriodicAction periodicAction = Mock()
-  TelemetryRunnable runnable = new TelemetryRunnable(okHttpClient, telemetryService, [periodicAction], sleeper)
-  Thread t = new Thread(runnable)
+  Thread t = null
 
   void cleanup() {
-    if (t.isAlive()) {
+    if (t != null && t.isAlive()) {
       t.interrupt()
       t.join()
     }
   }
 
-  void 'one loop run with one request'() {
+  void 'happy path'() {
     setup:
-    def queue = new ArrayDeque<>([REQUEST])
-    Call call = Mock()
+    TelemetryRunnable.ThreadSleeper sleeperMock = Mock()
+    TickSleeper sleeper = new TickSleeper(delegate: sleeperMock)
+    TimeSource timeSource = Mock()
+    TelemetryService telemetryService = Mock(TelemetryService)
+    MetricCollector<MetricCollector.Metric> metricCollector = Mock(MetricCollector)
+    MetricPeriodicAction metricAction = Stub(MetricPeriodicAction) {
+      collector() >> metricCollector
+    }
+    TelemetryRunnable.TelemetryPeriodicAction periodicAction = Mock(TelemetryRunnable.TelemetryPeriodicAction)
+    TelemetryRunnable runnable = new TelemetryRunnable(telemetryService, [metricAction, periodicAction], sleeper, timeSource)
+    t = new Thread(runnable)
 
-    when:
+    when: 'initial iteration before the first sleep (metrics and heartbeat)'
     t.start()
-    t.join()
+    sleeper.sleeped.await(10, TimeUnit.SECONDS)
 
     then:
-    1 * telemetryService.addConfiguration(_)
+    1 * timeSource.getCurrentTimeMillis() >> 60 * 1000
+    _ * telemetryService.addConfiguration(_)
+
+    then:
+    1 * metricCollector.prepareMetrics()
+
+    then:
+    1 * metricCollector.drain() >> []
     1 * periodicAction.doIteration(telemetryService)
-    1 * telemetryService.addStartedRequest()
-    1 * telemetryService.getMetricsInterval()
 
     then:
-    1 * periodicAction.doIteration(telemetryService)
-    1 * telemetryService.prepareRequests() >> queue
-    1 * okHttpClient.newCall(REQUEST) >> call
-    1 * call.execute() >> okResponse()
-    queue.size() == 0
-
-    then:
-    1 * telemetryService.getHeartbeatInterval() >> 10_000L
-    1 * telemetryService.getMetricsInterval() >> 10_000L
-    1 * sleeper.sleep(10_000L) >> { t.interrupt() }
-
-    then:
-    1 * telemetryService.appClosingRequest() >> REQUEST
-    1 * okHttpClient.newCall(REQUEST) >> call
-    1 * call.execute() >> okResponse()
+    1 * telemetryService.sendIntervalRequests()
+    1 * timeSource.getCurrentTimeMillis() >> 60 * 1000 + 1
+    1 * sleeperMock.sleep(9999)
     0 * _
-  }
 
-  void 'one loop run with two requests'() {
-    setup:
-    def request1 = new Request.Builder()
-      .url('https://example.com/1').build()
-    def request2 = new Request.Builder()
-      .url('https://example.com/2').build()
-    def request3 = new Request.Builder()
-      .url('https://example.com/3').build()
-    def queue = new ArrayDeque<>([request1, request2])
-    Call call1 = Mock()
-    Call call2 = Mock()
-    Call call3 = Mock()
-
-    when:
-    t.start()
-    t.join()
+    when: 'second iteration (10 seconds, metrics)'
+    sleeper.go.await(10, TimeUnit.SECONDS)
+    sleeper.sleeped.await(10, TimeUnit.SECONDS)
 
     then:
-    1 * telemetryService.addConfiguration(_)
-    1 * periodicAction.doIteration(telemetryService)
-    1 * telemetryService.addStartedRequest()
-    1 * telemetryService.getMetricsInterval()
+    1 * timeSource.getCurrentTimeMillis() >> 70 * 1000
 
     then:
-    1 * periodicAction.doIteration(telemetryService)
-    1 * telemetryService.prepareRequests() >> queue
-    1 * okHttpClient.newCall(request1) >> call1
-    1 * call1.execute() >> okResponse()
-    1 * okHttpClient.newCall(request2) >> call2
-    1 * call2.execute() >> okResponse()
-    queue.size() == 0
+    1 * metricCollector.prepareMetrics()
 
     then:
-    1 * telemetryService.getHeartbeatInterval() >> 10_000L
-    1 * telemetryService.getMetricsInterval() >> 10_000L
-    1 * sleeper.sleep(10_000L) >> { t.interrupt() }
-
-    then:
-    1 * telemetryService.appClosingRequest() >> request3
-    1 * okHttpClient.newCall(request3) >> call3
-    1 * call3.execute() >> okResponse()
+    1 * timeSource.getCurrentTimeMillis() >> 70 * 1000 + 2
+    1 * sleeperMock.sleep(9998)
     0 * _
-  }
 
-  void 'endpoint not found'() {
-    setup:
-    def queue = new ArrayDeque<>([REQUEST, REQUEST])
-    Call call = Mock()
-
-    when:
-    t.start()
-    t.join()
+    when: 'third iteration (20 seconds, metrics)'
+    sleeper.go.await(10, TimeUnit.SECONDS)
+    sleeper.sleeped.await(10, TimeUnit.SECONDS)
 
     then:
-    1 * telemetryService.addConfiguration(_)
-    1 * periodicAction.doIteration(telemetryService)
-    1 * telemetryService.addStartedRequest()
-    1 * telemetryService.getMetricsInterval()
+    1 * timeSource.getCurrentTimeMillis() >> 80 * 1000
 
     then:
-    1 * periodicAction.doIteration(telemetryService)
-    1 * telemetryService.prepareRequests() >> queue
-    1 * okHttpClient.newCall(REQUEST) >> call
-    1 * call.execute() >> notFoundResponse()
-    queue.size() == 0
+    1 * metricCollector.prepareMetrics()
 
     then:
-    1 * telemetryService.getHeartbeatInterval() >> 10_000L
-    1 * telemetryService.getMetricsInterval() >> 10_000L
-    1 * sleeper.sleep(10_000L) >> { t.interrupt() }
-
-    then:
-    1 * telemetryService.appClosingRequest() >> REQUEST
-    1 * okHttpClient.newCall(REQUEST) >> call
-    1 * call.execute() >> okResponse()
+    1 * timeSource.getCurrentTimeMillis() >> 80 * 1000 + 3
+    1 * sleeperMock.sleep(9997)
     0 * _
-  }
 
-  void 'backoff time increases'() {
-    setup:
-    def queue = new ArrayDeque<>([REQUEST])
-    Call call = Mock()
+    when: 'fourth iteration (30 seconds, metrics)'
+    sleeper.go.await(10, TimeUnit.SECONDS)
+    sleeper.sleeped.await(10, TimeUnit.SECONDS)
+
+    then:
+    1 * timeSource.getCurrentTimeMillis() >> 90 * 1000
+
+    then:
+    1 * metricCollector.prepareMetrics()
+
+    then:
+    1 * timeSource.getCurrentTimeMillis() >> 90 * 1000 + 4
+    1 * sleeperMock.sleep(9996)
+    0 * _
+
+    when: 'fifth iteration (40 seconds, metrics)'
+    sleeper.go.await(10, TimeUnit.SECONDS)
+    sleeper.sleeped.await(10, TimeUnit.SECONDS)
+
+    then:
+    1 * timeSource.getCurrentTimeMillis() >> 100 * 1000
+
+    then:
+    1 * metricCollector.prepareMetrics()
+
+    then:
+    1 * timeSource.getCurrentTimeMillis() >> 100 * 1000 + 5
+    1 * sleeperMock.sleep(9995)
+    0 * _
+
+    when: 'sixth iteration (50 seconds, metrics)'
+    sleeper.go.await(10, TimeUnit.SECONDS)
+    sleeper.sleeped.await(10, TimeUnit.SECONDS)
+
+    then:
+    1 * timeSource.getCurrentTimeMillis() >> 110 * 1000
+
+    then:
+    1 * metricCollector.prepareMetrics()
+
+    then:
+    1 * timeSource.getCurrentTimeMillis() >> 110 * 1000 + 6
+    1 * sleeperMock.sleep(9994)
+    0 * _
+
+    when: 'seventh iteration (60 seconds, metrics, heartbeat)'
+    sleeper.go.await(10, TimeUnit.SECONDS)
+    sleeper.sleeped.await(10, TimeUnit.SECONDS)
+
+    then:
+    1 * timeSource.getCurrentTimeMillis() >> 120 * 1000
+
+    then:
+    1 * metricCollector.prepareMetrics()
+
+    then:
+    1 * metricCollector.drain() >> []
+    1 * periodicAction.doIteration(telemetryService)
+
+    then:
+    1 * telemetryService.sendIntervalRequests()
+    1 * timeSource.getCurrentTimeMillis() >> 120 * 1000 + 7
+    1 * sleeperMock.sleep(9993)
+    0 * _
 
     when:
-    t.start()
+    t.interrupt()
     t.join()
 
     then:
-    1 * telemetryService.addConfiguration(_)
-    1 * periodicAction.doIteration(telemetryService)
-    1 * telemetryService.addStartedRequest()
-    1 * telemetryService.getMetricsInterval()
-
-    then:
-    1 * periodicAction.doIteration(telemetryService)
-    1 * telemetryService.prepareRequests() >> queue
-
-    then:
-    1 * okHttpClient.newCall(REQUEST) >> call
-    1 * call.execute() >> badResponse()
-    queue.size() == 1
-
-    then:
-    1 * sleeper.sleep(3_000)
-
-    then:
-    1 * telemetryService.getMetricsInterval()
-    1 * periodicAction.doIteration(telemetryService)
-    1 * telemetryService.prepareRequests() >> queue
-    1 * okHttpClient.newCall(REQUEST) >> call
-    1 * call.execute() >> badResponse()
-    queue.size() == 1
-
-    then:
-    1 * sleeper.sleep(9_000) >> { t.interrupt() }
-
-    then:
-    1 * telemetryService.appClosingRequest() >> REQUEST
-    1 * okHttpClient.newCall(REQUEST) >> call
-    1 * call.execute() >> okResponse()
+    1 * telemetryService.sendAppClosingRequest()
     0 * _
   }
 }

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
@@ -29,7 +29,7 @@ class TelemetryServiceSpecification extends DDSpecification {
 
   OkHttpClient httpClient = Mock()
   RequestBuilder requestBuilder = Spy(new RequestBuilder(HttpUrl.get("https://example.com")))
-  Supplier<RequestBuilder> requestBuilderSupplier = () -> requestBuilder
+  Supplier<RequestBuilder> requestBuilderSupplier = { requestBuilder }
   TelemetryService telemetryService = new TelemetryService(httpClient, requestBuilderSupplier)
 
   def dummyRequest = new Request.Builder().url(HttpUrl.get("https://example.com")).build()
@@ -38,12 +38,12 @@ class TelemetryServiceSpecification extends DDSpecification {
     Stub(Call) {
       execute() >> {
         new Response.Builder()
-        .request(dummyRequest)
-        .protocol(Protocol.HTTP_1_1)
-        .message("OK")
-        .body(ResponseBody.create(MediaType.get("text/plain"), "OK"))
-        .code(code)
-        .build()
+          .request(dummyRequest)
+          .protocol(Protocol.HTTP_1_1)
+          .message("OK")
+          .body(ResponseBody.create(MediaType.get("text/plain"), "OK"))
+          .code(code)
+          .build()
       }
     }
   }
@@ -66,8 +66,7 @@ class TelemetryServiceSpecification extends DDSpecification {
     telemetryService.sendIntervalRequests()
 
     then: 'app-started'
-    1 * requestBuilder.build(RequestType.APP_STARTED, {
-      AppStarted p ->
+    1 * requestBuilder.build(RequestType.APP_STARTED, { AppStarted p ->
       p.requestType == RequestType.APP_STARTED
       p.configuration == null
       p.dependencies.isEmpty()
@@ -102,8 +101,7 @@ class TelemetryServiceSpecification extends DDSpecification {
     telemetryService.sendIntervalRequests()
 
     then:
-    1 * requestBuilder.build(RequestType.APP_STARTED, {
-      AppStarted p ->
+    1 * requestBuilder.build(RequestType.APP_STARTED, { AppStarted p ->
       p.requestType == RequestType.APP_STARTED
       p.configuration == [confKeyValue]
       p.dependencies == [dependency]
@@ -116,22 +114,19 @@ class TelemetryServiceSpecification extends DDSpecification {
     1 * httpClient.newCall(_) >> okResponse
 
     then:
-    1 * requestBuilder.build(RequestType.GENERATE_METRICS, {
-      GenerateMetrics p ->
+    1 * requestBuilder.build(RequestType.GENERATE_METRICS, { GenerateMetrics p ->
       p.series == [metric]
     })
     1 * httpClient.newCall(_) >> okResponse
 
     then:
-    1 * requestBuilder.build(RequestType.DISTRIBUTIONS, {
-      Distributions p ->
+    1 * requestBuilder.build(RequestType.DISTRIBUTIONS, { Distributions p ->
       p.series == [distribution]
     })
     1 * httpClient.newCall(_) >> okResponse
 
     then:
-    1 * requestBuilder.build(RequestType.LOGS, {
-      Logs p ->
+    1 * requestBuilder.build(RequestType.LOGS, { Logs p ->
       p.messages == [logMessage]
     })
     1 * httpClient.newCall(_) >> okResponse
@@ -145,8 +140,7 @@ class TelemetryServiceSpecification extends DDSpecification {
     telemetryService.sendIntervalRequests()
 
     then:
-    1 * requestBuilder.build(RequestType.APP_STARTED, {
-      AppStarted p ->
+    1 * requestBuilder.build(RequestType.APP_STARTED, { AppStarted p ->
       p.requestType == RequestType.APP_STARTED
       p.configuration == null
       p.dependencies == []
@@ -175,36 +169,31 @@ class TelemetryServiceSpecification extends DDSpecification {
     1 * httpClient.newCall(_) >> okResponse
 
     then:
-    1 * requestBuilder.build(RequestType.APP_INTEGRATIONS_CHANGE, {
-      AppIntegrationsChange p ->
+    1 * requestBuilder.build(RequestType.APP_INTEGRATIONS_CHANGE, { AppIntegrationsChange p ->
       p.integrations == [integration]
     })
     1 * httpClient.newCall(_) >> okResponse
 
     then:
-    1 * requestBuilder.build(RequestType.APP_DEPENDENCIES_LOADED, {
-      AppDependenciesLoaded p ->
+    1 * requestBuilder.build(RequestType.APP_DEPENDENCIES_LOADED, { AppDependenciesLoaded p ->
       p.dependencies == [dependency]
     })
     1 * httpClient.newCall(_) >> okResponse
 
     then:
-    1 * requestBuilder.build(RequestType.GENERATE_METRICS, {
-      GenerateMetrics p ->
+    1 * requestBuilder.build(RequestType.GENERATE_METRICS, { GenerateMetrics p ->
       p.series == [metric]
     })
     1 * httpClient.newCall(_) >> okResponse
 
     then:
-    1 * requestBuilder.build(RequestType.DISTRIBUTIONS, {
-      Distributions p ->
+    1 * requestBuilder.build(RequestType.DISTRIBUTIONS, { Distributions p ->
       p.series == [distribution]
     })
     1 * httpClient.newCall(_) >> okResponse
 
     then:
-    1 * requestBuilder.build(RequestType.LOGS, {
-      Logs p ->
+    1 * requestBuilder.build(RequestType.LOGS, { Logs p ->
       p.messages == [logMessage]
     })
     1 * httpClient.newCall(_) >> okResponse
@@ -218,8 +207,7 @@ class TelemetryServiceSpecification extends DDSpecification {
     telemetryService.sendIntervalRequests()
 
     then: 'app-started is attempted'
-    1 * requestBuilder.build(RequestType.APP_STARTED, {
-      AppStarted p ->
+    1 * requestBuilder.build(RequestType.APP_STARTED, { AppStarted p ->
       p.requestType == RequestType.APP_STARTED
       p.configuration == null
       p.dependencies.isEmpty()
@@ -232,8 +220,7 @@ class TelemetryServiceSpecification extends DDSpecification {
     telemetryService.sendIntervalRequests()
 
     then: 'app-started is attempted'
-    1 * requestBuilder.build(RequestType.APP_STARTED, {
-      AppStarted p ->
+    1 * requestBuilder.build(RequestType.APP_STARTED, { AppStarted p ->
       p.requestType == RequestType.APP_STARTED
       p.configuration == null
       p.dependencies.isEmpty()
@@ -246,8 +233,7 @@ class TelemetryServiceSpecification extends DDSpecification {
     telemetryService.sendIntervalRequests()
 
     then: 'app-started is attempted'
-    1 * requestBuilder.build(RequestType.APP_STARTED, {
-      AppStarted p ->
+    1 * requestBuilder.build(RequestType.APP_STARTED, { AppStarted p ->
       p.requestType == RequestType.APP_STARTED
       p.configuration == null
       p.dependencies.isEmpty()
@@ -260,8 +246,7 @@ class TelemetryServiceSpecification extends DDSpecification {
     telemetryService.sendIntervalRequests()
 
     then:
-    1 * requestBuilder.build(RequestType.APP_STARTED, {
-      AppStarted p ->
+    1 * requestBuilder.build(RequestType.APP_STARTED, { AppStarted p ->
       p.requestType == RequestType.APP_STARTED
       p.configuration == null
       p.dependencies.isEmpty()

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
@@ -4,308 +4,358 @@ import datadog.telemetry.api.AppDependenciesLoaded
 import datadog.telemetry.api.AppIntegrationsChange
 import datadog.telemetry.api.AppStarted
 import datadog.telemetry.api.Dependency
-import datadog.telemetry.api.DependencyType
 import datadog.telemetry.api.DistributionSeries
 import datadog.telemetry.api.Distributions
 import datadog.telemetry.api.GenerateMetrics
 import datadog.telemetry.api.Integration
+import datadog.telemetry.api.KeyValue
 import datadog.telemetry.api.LogMessage
-import datadog.telemetry.api.LogMessageLevel
 import datadog.telemetry.api.Logs
 import datadog.telemetry.api.Metric
 import datadog.telemetry.api.RequestType
-import datadog.trace.api.time.TimeSource
 import datadog.trace.test.util.DDSpecification
+import okhttp3.Call
 import okhttp3.HttpUrl
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
 import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody
 
 import java.util.function.Supplier
 
 class TelemetryServiceSpecification extends DDSpecification {
-  private static final Request REQUEST = new Request.Builder()
-  .url('https://example.com')
-  .build()
 
-  TimeSource timeSource = Mock()
+  OkHttpClient httpClient = Mock()
   RequestBuilder requestBuilder = Spy(new RequestBuilder(HttpUrl.get("https://example.com")))
   Supplier<RequestBuilder> requestBuilderSupplier = () -> requestBuilder
-  TelemetryService telemetryService =
-  new TelemetryService(requestBuilderSupplier, timeSource, 60, 10)
+  TelemetryService telemetryService = new TelemetryService(httpClient, requestBuilderSupplier)
 
-  String getRequestType(Request request) {
-    request.header("DD-Telemetry-Request-Type")
+  def dummyRequest = new Request.Builder().url(HttpUrl.get("https://example.com")).build()
+
+  Call mockResponse(int code) {
+    Stub(Call) {
+      execute() >> {
+        new Response.Builder()
+        .request(dummyRequest)
+        .protocol(Protocol.HTTP_1_1)
+        .message("OK")
+        .body(ResponseBody.create(MediaType.get("text/plain"), "OK"))
+        .code(code)
+        .build()
+      }
+    }
   }
 
-  void 'heartbeat message on every heartbeat interval'() {
-    // Time: 0 seconds - no packets yet
-    when:
-    def queue = telemetryService.prepareRequests()
+  def okResponse = mockResponse(202)
+  def okButNotReallyResponse = mockResponse(200)
+  def notFoundResponse = mockResponse(404)
+  def serverErrorResponse = mockResponse(500)
 
-    then:
-    1 * timeSource.getCurrentTimeMillis() >> 0
-    queue.isEmpty()
+  def configuration = ["confkey": "confvalue"]
+  def confKeyValue = new KeyValue().name("confkey").value("confvalue")
+  def integration = new Integration().name("integration").enabled(true)
+  def dependency = new Dependency().name("dependency").version("1.0.0")
+  def metric = new Metric().namespace("tracers").metric("metric").points([[1, 2]])
+  def distribution = new DistributionSeries().namespace("tracers").metric("distro").points([1, 2, 3])
+  def logMessage = new LogMessage().message("log-message")
 
-    // Time +9999ms : less that 10 seconds passed (below metrics interval) - still no packets
-    when:
-    queue = telemetryService.prepareRequests()
+  void 'happy path without data'() {
+    when: 'first iteration'
+    telemetryService.sendIntervalRequests()
 
-    then:
-    1 * timeSource.getCurrentTimeMillis() >> 9999
-    queue.isEmpty()
-
-    // Time +59999ms : less that 60 seconds passed (below heartbeat interval) - still no packets
-    when:
-    queue = telemetryService.prepareRequests()
-
-    then:
-    1 * timeSource.getCurrentTimeMillis() >> 59999
-    queue.isEmpty()
-
-    // Time +1001ms : more than 60 seconds passed (above heartbeat interval) - heart beat generated
-    when:
-    queue = telemetryService.prepareRequests()
-
-    then:
-    1 * timeSource.getCurrentTimeMillis() >> 60001
-    queue.size() == 1
-    getRequestType(queue.poll()) == "app-heartbeat"
-    queue.clear()
-
-    // Time +120002ms : more than 120 seconds passed - another heart beat generated
-    when:
-    queue = telemetryService.prepareRequests()
-
-    then:
-    1 * timeSource.getCurrentTimeMillis() >> 120002
-    queue.size() == 1
-    getRequestType(queue.poll()) == "app-heartbeat"
-  }
-
-  void 'heartbeat is sent even if there are other messages'() {
-    setup:
-    final logMessage = new LogMessage(message: 'hello world', level: LogMessageLevel.DEBUG)
-
-    when:
-    telemetryService.addLogMessage(logMessage)
-    def queue = telemetryService.prepareRequests()
-
-    then:
-    1 * timeSource.getCurrentTimeMillis() >> 60001
-    queue.size() == 2
-    queue.collect {
-      getRequestType(it)
-    }.toSet() == ["logs", "app-heartbeat"].toSet()
-  }
-
-  void 'addStartedRequest adds app-started event'() {
-    when:
-    telemetryService.addStartedRequest()
-
-    then:
+    then: 'app-started'
     1 * requestBuilder.build(RequestType.APP_STARTED, {
-      it.requestType.is(RequestType.APP_STARTED)
+      AppStarted p ->
+      p.requestType == RequestType.APP_STARTED
+      p.configuration == null
+      p.dependencies.isEmpty()
+      p.integrations.isEmpty()
     })
+    1 * httpClient.newCall(_) >> okResponse
+
+    then: 'and app-heartbeat'
+    1 * requestBuilder.build(RequestType.APP_HEARTBEAT, null)
+    1 * httpClient.newCall(_) >> okResponse
     0 * _
-    getRequestType(telemetryService.queue.poll()) == "app-started"
+
+    when: 'second iteration'
+    telemetryService.sendIntervalRequests()
+
+    then: 'only heartbeat'
+    1 * requestBuilder.build(RequestType.APP_HEARTBEAT, null)
+    1 * httpClient.newCall(_) >> okResponse
+    0 * _
   }
 
-  void 'appClosingRequests returns an app-closing event'() {
-    when:
-    Request req = telemetryService.appClosingRequest()
-
-    then:
-    1 * requestBuilder.build(RequestType.APP_CLOSING)
-    getRequestType(req) == "app-closing"
-  }
-
-  void 'added configuration pairs are reported in app-started'() {
-    when:
-    telemetryService.addConfiguration('my name': 'my value')
-    telemetryService.addStartedRequest()
-
-    then:
-    1 * requestBuilder.build(RequestType.APP_STARTED, {
-      AppStarted p ->
-      p.requestType == RequestType.APP_STARTED &&
-      p.configuration.first().with {
-        return it.name == 'my name' && it.value == 'my value'
-      }
-    })
-    0 * requestBuilder._
-    getRequestType(telemetryService.queue.poll()) == "app-started"
-  }
-
-  void 'added dependencies are report in app-started'() {
-    when:
-    def dep = new Dependency(
-    hash: 'deadbeef', name: 'dep name', version: '1.2.3', type: DependencyType.SHARED_SYSTEM_LIBRARY)
-    telemetryService.addDependency(dep)
-    telemetryService.addStartedRequest()
-
-    then:
-    1 * requestBuilder.build(RequestType.APP_STARTED, {
-      AppStarted p ->
-      p.requestType == RequestType.APP_STARTED &&
-      p.dependencies.first().with {
-        return it.name == 'dep name' && it.hash == 'deadbeef' &&
-        version == '1.2.3' && it.type.is(DependencyType.SHARED_SYSTEM_LIBRARY)
-      }
-    })
-    0 * requestBuilder._
-    getRequestType(telemetryService.queue.poll()) == "app-started"
-  }
-
-  void 'added dependencies are reported in app-dependencies-loaded'() {
-    when:
-    def dep = new Dependency(
-    hash: 'deadbeef', name: 'dep name', version: '1.2.3', type: DependencyType.SHARED_SYSTEM_LIBRARY)
-    telemetryService.addDependency(dep)
-    def queue = telemetryService.prepareRequests()
-
-    then:
-    1 * requestBuilder.build(RequestType.APP_DEPENDENCIES_LOADED, {
-      AppDependenciesLoaded p ->
-      p.requestType == RequestType.APP_DEPENDENCIES_LOADED &&
-      p.dependencies.first().with {
-        return it.name == 'dep name' && it.hash == 'deadbeef' &&
-        version == '1.2.3' && it.type.is(DependencyType.SHARED_SYSTEM_LIBRARY)
-      }
-    })
-    0 * requestBuilder._
-    getRequestType(queue.poll()) == "app-dependencies-loaded"
-  }
-
-  void 'added integration is reported in app-started'() {
-    def integration
-
-    when:
-    integration = new Integration(
-    autoEnabled: true, compatible: true, enabled: true, name: 'my integration', version: '1.2.3')
+  void 'happy path with data before app-started'() {
+    when: 'add data before first iteration'
+    telemetryService.addConfiguration(configuration)
     telemetryService.addIntegration(integration)
-    telemetryService.addStartedRequest()
-
-    then:
-    1 * requestBuilder.build(RequestType.APP_STARTED, {
-      AppStarted p ->
-      p.requestType == RequestType.APP_STARTED &&
-      p.integrations.first().is(integration)
-    })
-    0 * requestBuilder._
-    getRequestType(telemetryService.queue.poll()) == "app-started"
-  }
-
-  void 'added integration is reported in app-integrations-change'() {
-    def integration
-
-    when:
-    integration = new Integration(
-    autoEnabled: true, compatible: true, enabled: true, name: 'my integration', version: '1.2.3')
-    telemetryService.addIntegration(integration)
-    def queue = telemetryService.prepareRequests()
-
-    then:
-    1 * requestBuilder.build(RequestType.APP_INTEGRATIONS_CHANGE, {
-      AppIntegrationsChange p ->
-      p.requestType == RequestType.APP_INTEGRATIONS_CHANGE &&
-      p.integrations.first().is(integration)
-    })
-    0 * requestBuilder._
-    queue.size() == 1
-    getRequestType(queue.poll()) == "app-integrations-change"
-  }
-
-  void 'added metrics are reported in generate-metrics'() {
-    def metric
-
-    when:
-    metric = new Metric(namespace: 'appsec', metric: 'my metric', tags: ['my tag'],
-    type: Metric.TypeEnum.GAUGE, points: [[0.1, 0.2], [0.2, 0.1]])
+    telemetryService.addDependency(dependency)
     telemetryService.addMetric(metric)
-    def queue = telemetryService.prepareRequests()
+    telemetryService.addDistributionSeries(distribution)
+    telemetryService.addLogMessage(logMessage)
+
+    and: 'send messages'
+    telemetryService.sendIntervalRequests()
+
+    then:
+    1 * requestBuilder.build(RequestType.APP_STARTED, {
+      AppStarted p ->
+      p.requestType == RequestType.APP_STARTED
+      p.configuration == [confKeyValue]
+      p.dependencies == [dependency]
+      p.integrations == [integration]
+    })
+    1 * httpClient.newCall(_) >> okResponse
+
+    then:
+    1 * requestBuilder.build(RequestType.APP_HEARTBEAT, null)
+    1 * httpClient.newCall(_) >> okResponse
 
     then:
     1 * requestBuilder.build(RequestType.GENERATE_METRICS, {
       GenerateMetrics p ->
-      p.requestType == RequestType.GENERATE_METRICS &&
-      p.namespace == 'tracers' &&  // top level namespace is "tracers" by default
-      p.requestType &&
-      p.series.first().is(metric)
+      p.series == [metric]
     })
-    0 * requestBuilder._
-    getRequestType(queue.poll()) == "generate-metrics"
-  }
-
-  void 'added distribution series are reported in distributions'() {
-    def series
-
-    when:
-    series = new DistributionSeries(namespace: 'appsec', metric: 'my metric', tags: ['my tag'], points: [1, 2, 2, 3])
-    telemetryService.addDistributionSeries(series)
-    def queue = telemetryService.prepareRequests()
+    1 * httpClient.newCall(_) >> okResponse
 
     then:
     1 * requestBuilder.build(RequestType.DISTRIBUTIONS, {
       Distributions p ->
-      p.requestType == RequestType.DISTRIBUTIONS &&
-      p.namespace == 'tracers' &&  // top level namespace is "tracers" by default
-      p.requestType &&
-      p.series.first().is(series)
+      p.series == [distribution]
     })
-    0 * requestBuilder._
-    getRequestType(queue.poll()) == "distributions"
-  }
-
-  void 'send #messages log messages in #requests requests'() {
-    def logMessage
-
-    when:
-    def telemetry = new TelemetryService(requestBuilderSupplier, timeSource, 1, 1, 10, 1)
-    logMessage = new LogMessage(message: 'hello world', level: LogMessageLevel.DEBUG)
-    for (int i=0; i<messages; i++) {
-      telemetry.addLogMessage(logMessage)
-    }
-    def queue = telemetry.prepareRequests()
+    1 * httpClient.newCall(_) >> okResponse
 
     then:
-    requests * requestBuilder.build(RequestType.LOGS, {
+    1 * requestBuilder.build(RequestType.LOGS, {
       Logs p ->
-      p.requestType == RequestType.LOGS &&
-      p.messages.first().is(logMessage)
+      p.messages == [logMessage]
     })
-    0 * requestBuilder._
-    getRequestType(queue.poll()) == "logs"
+    1 * httpClient.newCall(_) >> okResponse
+
+    then:
+    0 * _
+  }
+
+  void 'happy path with data after app-started'() {
+    when: 'send messages'
+    telemetryService.sendIntervalRequests()
+
+    then:
+    1 * requestBuilder.build(RequestType.APP_STARTED, {
+      AppStarted p ->
+      p.requestType == RequestType.APP_STARTED
+      p.configuration == null
+      p.dependencies == []
+      p.integrations == []
+    })
+    1 * httpClient.newCall(_) >> okResponse
+
+    then:
+    1 * requestBuilder.build(RequestType.APP_HEARTBEAT, null)
+    1 * httpClient.newCall(_) >> okResponse
+    0 * _
+
+    when: 'add data after first iteration'
+    telemetryService.addConfiguration(configuration)
+    telemetryService.addIntegration(integration)
+    telemetryService.addDependency(dependency)
+    telemetryService.addMetric(metric)
+    telemetryService.addDistributionSeries(distribution)
+    telemetryService.addLogMessage(logMessage)
+
+    and: 'send messages'
+    telemetryService.sendIntervalRequests()
+
+    then:
+    1 * requestBuilder.build(RequestType.APP_HEARTBEAT, null)
+    1 * httpClient.newCall(_) >> okResponse
+
+    then:
+    1 * requestBuilder.build(RequestType.APP_INTEGRATIONS_CHANGE, {
+      AppIntegrationsChange p ->
+      p.integrations == [integration]
+    })
+    1 * httpClient.newCall(_) >> okResponse
+
+    then:
+    1 * requestBuilder.build(RequestType.APP_DEPENDENCIES_LOADED, {
+      AppDependenciesLoaded p ->
+      p.dependencies == [dependency]
+    })
+    1 * httpClient.newCall(_) >> okResponse
+
+    then:
+    1 * requestBuilder.build(RequestType.GENERATE_METRICS, {
+      GenerateMetrics p ->
+      p.series == [metric]
+    })
+    1 * httpClient.newCall(_) >> okResponse
+
+    then:
+    1 * requestBuilder.build(RequestType.DISTRIBUTIONS, {
+      Distributions p ->
+      p.series == [distribution]
+    })
+    1 * httpClient.newCall(_) >> okResponse
+
+    then:
+    1 * requestBuilder.build(RequestType.LOGS, {
+      Logs p ->
+      p.messages == [logMessage]
+    })
+    1 * httpClient.newCall(_) >> okResponse
+
+    then:
+    0 * _
+  }
+
+  void 'no message before app-started'() {
+    when: 'attempt with 404 error'
+    telemetryService.sendIntervalRequests()
+
+    then: 'app-started is attempted'
+    1 * requestBuilder.build(RequestType.APP_STARTED, {
+      AppStarted p ->
+      p.requestType == RequestType.APP_STARTED
+      p.configuration == null
+      p.dependencies.isEmpty()
+      p.integrations.isEmpty()
+    })
+    1 * httpClient.newCall(_) >> notFoundResponse
+    0 * _
+
+    when: 'attempt with 500 error'
+    telemetryService.sendIntervalRequests()
+
+    then: 'app-started is attempted'
+    1 * requestBuilder.build(RequestType.APP_STARTED, {
+      AppStarted p ->
+      p.requestType == RequestType.APP_STARTED
+      p.configuration == null
+      p.dependencies.isEmpty()
+      p.integrations.isEmpty()
+    })
+    1 * httpClient.newCall(_) >> serverErrorResponse
+    0 * _
+
+    when: 'attempt with unexpected 200 code (not valid)'
+    telemetryService.sendIntervalRequests()
+
+    then: 'app-started is attempted'
+    1 * requestBuilder.build(RequestType.APP_STARTED, {
+      AppStarted p ->
+      p.requestType == RequestType.APP_STARTED
+      p.configuration == null
+      p.dependencies.isEmpty()
+      p.integrations.isEmpty()
+    })
+    1 * httpClient.newCall(_) >> okButNotReallyResponse
+    0 * _
+
+    when: 'attempt with success'
+    telemetryService.sendIntervalRequests()
+
+    then:
+    1 * requestBuilder.build(RequestType.APP_STARTED, {
+      AppStarted p ->
+      p.requestType == RequestType.APP_STARTED
+      p.configuration == null
+      p.dependencies.isEmpty()
+      p.integrations.isEmpty()
+    })
+    1 * httpClient.newCall(_) >> okResponse
+
+    then:
+    1 * requestBuilder.build(RequestType.APP_HEARTBEAT, null)
+    1 * httpClient.newCall(_) >> okResponse
+    0 * _
+  }
+
+  void '404 at #requestType prevents further messages'() {
+    when: 'initial iteration'
+    telemetryService.sendIntervalRequests()
+
+    then:
+    2 * requestBuilder.build(_, _)
+    2 * httpClient.newCall(_) >> okResponse
+    0 * _
+
+    when: 'add data'
+    telemetryService.addConfiguration(configuration)
+    telemetryService.addIntegration(integration)
+    telemetryService.addDependency(dependency)
+    telemetryService.addMetric(metric)
+    telemetryService.addDistributionSeries(distribution)
+    telemetryService.addLogMessage(logMessage)
+
+    and:
+    telemetryService.sendIntervalRequests()
+
+    then:
+    prevCalls * requestBuilder.build(_, _)
+    prevCalls * httpClient.newCall(_) >> okResponse
+
+    then:
+    1 * requestBuilder.build(requestType, _)
+    1 * httpClient.newCall(_) >> notFoundResponse
+
+    then: 'no further requests after the first 404'
+    0 * _
 
     where:
-    messages    | requests
-    10        | 1
-    11        | 2
-    100       | 10
+    requestType                         | prevCalls
+    RequestType.APP_HEARTBEAT           | 0
+    RequestType.APP_INTEGRATIONS_CHANGE | 1
+    RequestType.APP_DEPENDENCIES_LOADED | 2
+    RequestType.GENERATE_METRICS        | 3
+    RequestType.DISTRIBUTIONS           | 4
+    RequestType.LOGS                    | 5
   }
 
-  void 'send max 10 dependencies per request'() {
-    def dep
-    def telemetry
-
-    when:
-    telemetry = new TelemetryService(requestBuilderSupplier, timeSource, 1, 1, 1, 10)
-    dep = new Dependency(name: 'dep')
-    for (int i=0; i<15; i++) {
-      telemetry.addDependency(dep)
-    }
-    def queue = telemetry.prepareRequests()
+  void '500 at #requestType does not prevents further messages'() {
+    when: 'initial iteration'
+    telemetryService.sendIntervalRequests()
 
     then:
-    1 * requestBuilder.build(RequestType.APP_DEPENDENCIES_LOADED, {
-      AppDependenciesLoaded p ->
-      p.requestType == RequestType.APP_DEPENDENCIES_LOADED &&
-      p.dependencies.size() == 10
-    })
-    1 * requestBuilder.build(RequestType.APP_DEPENDENCIES_LOADED, {
-      AppDependenciesLoaded p ->
-      p.requestType == RequestType.APP_DEPENDENCIES_LOADED &&
-      p.dependencies.size() == 5
-    })
-    0 * requestBuilder._
-    getRequestType(queue.poll()) == "app-dependencies-loaded"
+    2 * requestBuilder.build(_, _)
+    2 * httpClient.newCall(_) >> okResponse
+    0 * _
+
+    when: 'add data'
+    telemetryService.addConfiguration(configuration)
+    telemetryService.addIntegration(integration)
+    telemetryService.addDependency(dependency)
+    telemetryService.addMetric(metric)
+    telemetryService.addDistributionSeries(distribution)
+    telemetryService.addLogMessage(logMessage)
+
+    and:
+    telemetryService.sendIntervalRequests()
+
+    then:
+    prevCalls * requestBuilder.build(_, _)
+    prevCalls * httpClient.newCall(_) >> okResponse
+
+    then:
+    1 * requestBuilder.build(requestType, _)
+    1 * httpClient.newCall(_) >> serverErrorResponse
+
+    then: 'no further requests after the first 404'
+    afterCalls * requestBuilder.build(_, _)
+    afterCalls * httpClient.newCall(_) >> okResponse
+    0 * _
+
+    where:
+    requestType                         | prevCalls | afterCalls
+    RequestType.APP_HEARTBEAT           | 0         | 5
+    RequestType.APP_INTEGRATIONS_CHANGE | 1         | 4
+    RequestType.APP_DEPENDENCIES_LOADED | 2         | 3
+    RequestType.GENERATE_METRICS        | 3         | 2
+    RequestType.DISTRIBUTIONS           | 4         | 1
+    RequestType.LOGS                    | 5         | 0
   }
 }

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetrySystemSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetrySystemSpecification.groovy
@@ -28,11 +28,10 @@ class TelemetrySystemSpecification extends DDSpecification {
   void 'create telemetry thread'() {
     setup:
     def telemetryService = Mock(TelemetryService)
-    def okHttpClient = Mock(OkHttpClient)
     def depService = Mock(DependencyService)
 
     when:
-    def thread = TelemetrySystem.createTelemetryRunnable(telemetryService, okHttpClient, depService)
+    def thread = TelemetrySystem.createTelemetryRunnable(telemetryService, depService)
 
     then:
     thread != null

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetrySystemSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetrySystemSpecification.groovy
@@ -35,6 +35,8 @@ class TelemetrySystemSpecification extends DDSpecification {
 
     then:
     thread != null
+
+    cleanup:
     TelemetrySystem.stop()
   }
 

--- a/telemetry/src/test/groovy/datadog/telemetry/metric/MetricPeriodicActionTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/metric/MetricPeriodicActionTest.groovy
@@ -14,7 +14,7 @@ class MetricPeriodicActionTest extends Specification {
   void 'test that common metrics are joined before being sent to telemetry'() {
     given:
     final service = Mock(TelemetryService)
-    final metricCollector = Mock(MetricCollector<MetricCollector.Metric>)
+    final MetricCollector<MetricCollector.Metric> metricCollector = Mock()
     final action = new DefaultMetricPeriodicAction(metricCollector)
 
     when:
@@ -22,10 +22,9 @@ class MetricPeriodicActionTest extends Specification {
 
     then:
     metricCollector.drain() >> metrics
-    expected.each {
-      Metric metric ->
-      1 * service.addMetric({
-        it -> assertMetric(it, metric)
+    expected.each { Metric metric ->
+      1 * service.addMetric({ it ->
+        assertMetric(it, metric)
       })
     }
     0 * _


### PR DESCRIPTION

# What Does This Do
Functional changes:
* Telemetry messages should be sent only at the heartbeat interval.
* The metrics interval is used to accumulate metrics, not sending messages.
* Remove all retry logic, no backoff.

Refactor:
* Separate concerns: `TelemetryRunnable` knows about timing, not HTTP requests. `TelemetryService` knows about HTTP requests, not about timing.

# Motivation

# Additional Notes
