### PR TITLE
upgrade to ddprof 0.41.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.40.0",
+    ddprof        : "0.41.0",
     asm           : "9.5"
   ]
 


### PR DESCRIPTION
# What Does This Do
* Removes lock tracer
* Reverts change which attaches wallclock sampler thread for JVMTI, which made it a participant in safepoints

# Motivation

# Additional Notes
