### PR TITLE
[Spark] Instrument YARN application end to not drop traces

### DIFF
--- a/dd-java-agent/instrumentation/spark/build.gradle
+++ b/dd-java-agent/instrumentation/spark/build.gradle
@@ -23,7 +23,9 @@ dependencies {
 
   testImplementation group: 'org.apache.spark', name: 'spark-core_2.12', version: '2.4.0'
   testImplementation group: 'org.apache.spark', name: 'spark-sql_2.12', version: '2.4.0' // Needed to instantiate spark in tests
+  testImplementation group: 'org.apache.spark', name: 'spark-yarn_2.12', version: '2.4.0'
 
   latestDepTestImplementation group: 'org.apache.spark', name: 'spark-core_2.12', version: '+'
   latestDepTestImplementation group: 'org.apache.spark', name: 'spark-sql_2.12', version: '+' // Needed to instantiate spark in tests
+  latestDepTestImplementation group: 'org.apache.spark', name: 'spark-yarn_2.12', version: '+'
 }

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkInstrumentation.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkInstrumentation.java
@@ -67,11 +67,6 @@ public class SparkInstrumentation extends Instrumenter.Tracing
     public static void enter(@Advice.Argument(1) int exitCode, @Advice.Argument(2) String msg) {
       if (DatadogSparkListener.listener != null) {
         DatadogSparkListener.listener.finishApplication(System.currentTimeMillis(), exitCode, msg);
-        try {
-          // So that traces have the time to be submitted to the agent before the JVM gets shutdown
-          Thread.sleep(150);
-        } catch (InterruptedException ignored) {
-        }
       }
     }
   }

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkInstrumentation.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkInstrumentation.java
@@ -10,7 +10,7 @@ import org.apache.spark.SparkContext;
 
 @AutoService(Instrumenter.class)
 public class SparkInstrumentation extends Instrumenter.Tracing
-    implements Instrumenter.ForSingleType {
+    implements Instrumenter.ForKnownTypes {
 
   public SparkInstrumentation() {
     super("spark", "apache-spark");
@@ -22,8 +22,10 @@ public class SparkInstrumentation extends Instrumenter.Tracing
   }
 
   @Override
-  public String instrumentedType() {
-    return "org.apache.spark.SparkContext";
+  public String[] knownMatchingTypes() {
+    return new String[] {
+      "org.apache.spark.SparkContext", "org.apache.spark.deploy.yarn.ApplicationMaster"
+    };
   }
 
   @Override
@@ -39,15 +41,38 @@ public class SparkInstrumentation extends Instrumenter.Tracing
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(
-        isMethod().and(named("setupAndStartListenerBus")).and(takesNoArguments()),
+        isMethod()
+            .and(named("setupAndStartListenerBus"))
+            .and(isDeclaredBy(named("org.apache.spark.SparkContext")))
+            .and(takesNoArguments()),
         SparkInstrumentation.class.getName() + "$InjectListener");
+
+    transformation.applyAdvice(
+        isMethod()
+            .and(named("finish"))
+            .and(isDeclaredBy(named("org.apache.spark.deploy.yarn.ApplicationMaster"))),
+        SparkInstrumentation.class.getName() + "$YarnFinishAdvice");
   }
 
   public static class InjectListener {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void enter(@Advice.This SparkContext sparkContext) {
-      DatadogSparkListener listener = new DatadogSparkListener(sparkContext);
-      sparkContext.listenerBus().addToSharedQueue(listener);
+      DatadogSparkListener.listener = new DatadogSparkListener(sparkContext);
+      sparkContext.listenerBus().addToSharedQueue(DatadogSparkListener.listener);
+    }
+  }
+
+  public static class YarnFinishAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void enter(@Advice.Argument(1) int exitCode, @Advice.Argument(2) String msg) {
+      if (DatadogSparkListener.listener != null) {
+        DatadogSparkListener.listener.finishApplication(System.currentTimeMillis(), exitCode, msg);
+        try {
+          // So that traces have the time to be submitted to the agent before the JVM gets shutdown
+          Thread.sleep(150);
+        } catch (InterruptedException ignored) {
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
# What Does This Do

Instrument the spark [yarn.ApplicationMaster.finish()](https://github.com/apache/spark/blob/master/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala#L378) function in order to
- catch the exit code and exit message of the application
- make sure the `spark.application` span is finished before the trace processor is exited

### Capturing exit code

An application can fail during spark computations (when performing operations on the data) or in the user code (like trying to select a column that does not exists)

Failures during spark computations are caught by the SparkListener, but not the errors in the user code so instrumenting the finish function allows to also capture those

### Finish the `spark.application` span

The spark.application span is the local root span and is finished when the event `onApplicationEnd` is received. However if the sparkContext is not stopped explicitly by the user (using `spark.stop()`), spark is stopped in a shutdown hook. In this case, the `onApplicationEnd` event can be received after the trace processor was exited, leading to the trace being dropped, with the following logs

```
23/05/17 13:11:23 INFO ApplicationMaster: Final app status: SUCCEEDED, exitCode: 0
23/05/17 13:11:23 INFO SparkContext: Invoking stop() from shutdown hook
[dd.trace 2023-05-17 13:11:23:205 +0000] [dd-trace-processor] DEBUG datadog.trace.agent.common.writer.TraceProcessingWorker - Datadog trace processor exited. Publishing traces stopped
[dd.trace 2023-05-17 13:11:23:212 +0000] [spark-listener-group-shared] DEBUG datadog.trace.agent.common.writer.RemoteWriter - Trace written after shutdown.. Counted but dropping trace
```

By manually calling the function behind `onApplicationEnd`, we can make sure that the trace is always finished before the tracer is exited