### PR TITLE
Fix SpringBootOpenLibertySnapshotTest

### DIFF
--- a/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySnapshotTest.groovy
+++ b/dd-smoke-tests/springboot-openliberty/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySnapshotTest.groovy
@@ -22,6 +22,8 @@ class SpringBootOpenLibertySnapshotTest extends AbstractTestAgentSmokeTest {
     command.addAll((String[]) [
       "-Ddd.jmxfetch.enabled=false",
       '-Ddd.trace.integration.java-lang-appsec.enabled=false',
+      // The legacy mock agent we use here does not support v0.5.
+      "-Ddd.trace.agent.v0.5.enabled=false",
       "-jar",
       openLibertyShadowJar,
       "--server.port=${httpPort}"


### PR DESCRIPTION


# What Does This Do

# Motivation
We moved to trace protocol v0.5, but the mock agent used for this suite does not support it.

# Additional Notes
See https://github.com/DataDog/dd-trace-java/pull/5174