### PR TITLE
Ensure StringBuilder.append(String, Object) is properly instrumented

### DIFF
--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
   testImplementation("org.objenesis", "objenesis", "3.0.1")
   testImplementation("org.codehaus.groovy", "groovy-all", "3.0.15")
   testImplementation("javax.servlet", "javax.servlet-api", "3.0.1")
+  testImplementation("com.github.spotbugs", "spotbugs-annotations", "4.2.0")
 }
 
 sourceSets {

--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringBuilderCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringBuilderCallSite.java
@@ -79,7 +79,9 @@ public class StringBuilderCallSite {
       }
       return result;
     } catch (final Throwable e) {
-      throw StackUtils.removeLast(e);
+      final String clazz = StringBuilderCallSite.class.getName();
+      throw StackUtils.filterUntil(
+          e, s -> s.getClassName().equals(clazz) && s.getMethodName().equals("aroundAppend"));
     }
   }
 

--- a/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestAbstractStringBuilderSuite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestAbstractStringBuilderSuite.java
@@ -10,5 +10,7 @@ public interface TestAbstractStringBuilderSuite<E> {
 
   void append(final E target, final CharSequence param);
 
+  void append(final E target, final Object param);
+
   String toString(final E target);
 }

--- a/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringBufferSuite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringBufferSuite.java
@@ -38,6 +38,13 @@ public class TestStringBufferSuite implements TestAbstractStringBuilderSuite<Str
   }
 
   @Override
+  public void append(final StringBuffer buffer, final Object param) {
+    LOGGER.debug("Before string buffer append {}", param);
+    final StringBuffer result = buffer.append(param);
+    LOGGER.debug("After string buffer append {}", result);
+  }
+
+  @Override
   public String toString(final StringBuffer buffer) {
     LOGGER.debug("Before string buffer toString {}", buffer);
     final String result = buffer.toString();

--- a/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringBuilderSuite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringBuilderSuite.java
@@ -39,6 +39,13 @@ public class TestStringBuilderSuite implements TestAbstractStringBuilderSuite<St
   }
 
   @Override
+  public void append(final StringBuilder builder, final Object param) {
+    LOGGER.debug("Before string builder append {}", param);
+    final StringBuilder result = builder.append(param);
+    LOGGER.debug("After string builder append {}", result);
+  }
+
+  @Override
   public String toString(final StringBuilder builder) {
     LOGGER.debug("Before string builder toString {}", builder);
     final String result = builder.toString();

--- a/internal-api/src/main/java/datadog/trace/util/stacktrace/StackUtils.java
+++ b/internal-api/src/main/java/datadog/trace/util/stacktrace/StackUtils.java
@@ -32,14 +32,20 @@ public abstract class StackUtils {
     return filterFirst(exception, AbstractStackWalker::isNotDatadogTraceStackElement);
   }
 
-  public static <E extends Throwable> E removeLast(final E exception) {
+  public static <E extends Throwable> E filterUntil(
+      final E exception, final Predicate<StackTraceElement> trace) {
     return update(
         exception,
         stack -> {
           final StackTraceElement[] source = exception.getStackTrace();
-          final StackTraceElement[] result = new StackTraceElement[source.length - 1];
-          System.arraycopy(source, 0, result, 0, result.length);
-          return result;
+          for (int i = 0; i < source.length; i++) {
+            if (trace.test(source[i])) {
+              final StackTraceElement[] result = new StackTraceElement[source.length - i - 1];
+              System.arraycopy(source, i + 1, result, 0, result.length);
+              return result;
+            }
+          }
+          return source;
         });
   }
 

--- a/internal-api/src/test/java/datadog/trace/util/stacktrace/StackUtilsTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/stacktrace/StackUtilsTest.java
@@ -60,7 +60,7 @@ public class StackUtilsTest {
   }
 
   @Test
-  public void test_remove_last() {
+  public void test_filter_until() {
     final StackTraceElement[] stack =
         new StackTraceElement[] {
           stack().className("org.junit.jupiter.api.Test").build(),
@@ -69,11 +69,16 @@ public class StackUtilsTest {
           stack().className("datadog.trace.util.stacktrace.StackUtils").build(),
           stack().className("com.google.common.truth.Truth").build()
         };
-    final StackTraceElement[] expected =
-        new StackTraceElement[] {stack[0], stack[1], stack[2], stack[3]};
 
-    final Throwable removed = StackUtils.removeLast(withStack(stack));
+    final StackTraceElement[] expected = new StackTraceElement[] {stack[4]};
+    final Throwable removed =
+        StackUtils.filterUntil(
+            withStack(stack),
+            entry -> entry.getClassName().equals("datadog.trace.util.stacktrace.StackUtils"));
     assertThat(removed.getStackTrace()).isEqualTo(expected);
+
+    final Throwable noRemoval = StackUtils.filterUntil(withStack(stack), entry -> false);
+    assertThat(noRemoval.getStackTrace()).isEqualTo(stack);
   }
 
   private static Throwable withStack(final StackTraceElement... stack) {


### PR DESCRIPTION
# What Does This Do
Makes sure that the `StringBuilder.append(String, Object)` is properly handled and propagation is not lost

# Motivation

# Additional Notes
