### PR TITLE
Avoid holding onto JMS spans too long if client-ack is delayed/absent

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/SessionState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jms/SessionState.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
@@ -40,9 +39,9 @@ public final class SessionState {
         }
       };
 
-  // hard bound at 8192 captured spans, degrade to finishing spans early
+  // hard bound of captured spans, degrade to finishing spans early
   // if transactions are very large, rather than use lots of space
-  static final int MAX_CAPTURED_SPANS = 8192;
+  static final int MAX_CAPTURED_SPANS = 512;
 
   private static final int MAX_TRACKED_THREADS = 100;
   private static final int MIN_EVICTED_THREADS = 10;
@@ -272,7 +271,7 @@ public final class SessionState {
     // didn't find enough stopped threads, so evict oldest N time-in-queue spans
     if (evictedThreads < MIN_EVICTED_THREADS) {
       for (Map.Entry<Thread, TimeInQueue> entry : oldestEntries) {
-        if (((ConcurrentMap<?, ?>) timeInQueueSpans).remove(entry.getKey(), entry.getValue())) {
+        if (timeInQueueSpans.remove(entry.getKey(), entry.getValue())) {
           maybeFinishTimeInQueueSpan(entry.getValue());
         }
       }


### PR DESCRIPTION
# What Does This Do

Introduces an extra check for client-ack JMS sessions: if the oldest captured span is over an hour old then assume we missed a client-ack event.  Proceed to clean-up and finish previously captured spans before capturing the new message span.

This PR also reduces the maximum number of captured message spans per JMS session to 512.

# Motivation

Reduces the chance of client-ack sessions from holding onto JMS spans too long, which might otherwise lead to increased memory usage. 

# Additional Notes

I did consider tracking the age of the most recent captured span, to try and detect when there's a big enough gap between messages to infer there should be an acknowledgement, but it's hard to decide how large that gap might be. If the allowed gap is too big then periodic messages could keep the captured spans alive for a long time. If the allowed gap is too short then we risk finishing spans too early, making the traces harder to interpret.