### PR TITLE
Changed OBFUSCATION_QUERY_STRING_REGEXP config variable to match the public documentation

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -90,7 +90,7 @@ public final class TraceInstrumentationConfig {
 
   public static final String IGNITE_CACHE_INCLUDE_KEYS = "ignite.cache.include_keys";
 
-  public static final String OBFUSCATION_QUERY_STRING_REGEXP = "obfuscation.query.string.regexp";
+  public static final String OBFUSCATION_QUERY_STRING_REGEXP = "trace.obfuscation.query.string.regexp";
 
   public static final String PLAY_REPORT_HTTP_STATUS = "trace.play.report-http-status";
 


### PR DESCRIPTION
# What Does This Do
Changes the "obfuscation.query.string.regexp" to "trace.obfuscation.query.string.regexp" which is the publicly documented name.
# Motivation
This is to match the config functionality to the public docs
# Additional Notes
