### PR TITLE
Fix addCookie instrumentation in Jetty

### DIFF
--- a/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
@@ -1,23 +1,22 @@
 package datadog.trace.instrumentation.servlet;
 
-import com.google.auto.service.AutoService;
-import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.iast.InstrumentationBridge;
-import datadog.trace.api.iast.propagation.PropagationModule;
-import datadog.trace.api.iast.sink.InsecureCookieModule;
-import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
-import net.bytebuddy.asm.Advice;
-import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.matcher.ElementMatcher;
-
-import javax.servlet.http.Cookie;
-
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.api.iast.sink.InsecureCookieModule;
+import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
+import javax.servlet.http.Cookie;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(Instrumenter.class)
 public final class HttpServletResponseInstrumentation extends Instrumenter.Iast
@@ -44,7 +43,9 @@ public final class HttpServletResponseInstrumentation extends Instrumenter.Iast
 
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
-    transformation.applyAdvice(named("addCookie").and(takesArguments(Cookie.class)), getClass().getName() + "$AddCookieAdvice");
+    transformation.applyAdvice(
+        named("addCookie").and(takesArguments(Cookie.class)),
+        getClass().getName() + "$AddCookieAdvice");
     transformation.applyAdvice(
         namedOneOf("setHeader", "addHeader").and(takesArguments(String.class, String.class)),
         getClass().getName() + "$AddHeaderAdvice");

--- a/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
@@ -1,17 +1,5 @@
 package datadog.trace.instrumentation.servlet;
 
-import com.google.auto.service.AutoService;
-import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.iast.InstrumentationBridge;
-import datadog.trace.api.iast.propagation.PropagationModule;
-import datadog.trace.api.iast.sink.InsecureCookieModule;
-import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
-import net.bytebuddy.asm.Advice;
-import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.matcher.ElementMatcher;
-
-import javax.servlet.http.Cookie;
-
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
@@ -19,6 +7,17 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOn
 import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.api.iast.sink.InsecureCookieModule;
+import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
+import javax.servlet.http.Cookie;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(Instrumenter.class)
 public final class HttpServletResponseInstrumentation extends Instrumenter.Iast

--- a/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
@@ -1,22 +1,24 @@
 package datadog.trace.instrumentation.servlet;
 
-import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
-import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
-import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
-import static net.bytebuddy.matcher.ElementMatchers.not;
-import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
-
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.sink.InsecureCookieModule;
 import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
-import javax.servlet.http.Cookie;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
+
+import javax.servlet.http.Cookie;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 @AutoService(Instrumenter.class)
 public final class HttpServletResponseInstrumentation extends Instrumenter.Iast
@@ -43,7 +45,9 @@ public final class HttpServletResponseInstrumentation extends Instrumenter.Iast
 
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
-    transformation.applyAdvice(named("addCookie"), getClass().getName() + "$AddCookieAdvice");
+    transformation.applyAdvice(
+        named("addCookie").and(takesArgument(0, named("javax.servlet.http.Cookie"))),
+        getClass().getName() + "$AddCookieAdvice");
     transformation.applyAdvice(
         namedOneOf("setHeader", "addHeader").and(takesArguments(String.class, String.class)),
         getClass().getName() + "$AddHeaderAdvice");
@@ -54,14 +58,11 @@ public final class HttpServletResponseInstrumentation extends Instrumenter.Iast
 
   public static class AddCookieAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void onEnter(@Advice.Argument(0) final Object o) {
+    public static void onEnter(@Advice.Argument(0) final Cookie cookie) {
       final InsecureCookieModule module = InstrumentationBridge.INSECURE_COOKIE;
       if (module != null) {
-        if (null != o) {
-          if (o instanceof Cookie) {
-            Cookie cookie = (Cookie) o;
-            module.onCookie(cookie.getName(), cookie.getSecure());
-          }
+        if (null != cookie) {
+          module.onCookie(cookie.getName(), cookie.getSecure());
         }
       }
     }

--- a/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
@@ -1,22 +1,23 @@
 package datadog.trace.instrumentation.servlet;
 
-import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
-import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
-import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
-import static net.bytebuddy.matcher.ElementMatchers.not;
-import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
-
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.sink.InsecureCookieModule;
 import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
-import javax.servlet.http.Cookie;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
+
+import javax.servlet.http.Cookie;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 @AutoService(Instrumenter.class)
 public final class HttpServletResponseInstrumentation extends Instrumenter.Iast
@@ -43,7 +44,7 @@ public final class HttpServletResponseInstrumentation extends Instrumenter.Iast
 
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
-    transformation.applyAdvice(named("addCookie"), getClass().getName() + "$AddCookieAdvice");
+    transformation.applyAdvice(named("addCookie").and(takesArguments(Cookie.class)), getClass().getName() + "$AddCookieAdvice");
     transformation.applyAdvice(
         namedOneOf("setHeader", "addHeader").and(takesArguments(String.class, String.class)),
         getClass().getName() + "$AddHeaderAdvice");

--- a/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
@@ -43,9 +43,7 @@ public final class HttpServletResponseInstrumentation extends Instrumenter.Iast
 
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
-    transformation.applyAdvice(
-        named("addCookie").and(takesArguments(Cookie.class)),
-        getClass().getName() + "$AddCookieAdvice");
+    transformation.applyAdvice(named("addCookie"), getClass().getName() + "$AddCookieAdvice");
     transformation.applyAdvice(
         namedOneOf("setHeader", "addHeader").and(takesArguments(String.class, String.class)),
         getClass().getName() + "$AddHeaderAdvice");
@@ -56,11 +54,14 @@ public final class HttpServletResponseInstrumentation extends Instrumenter.Iast
 
   public static class AddCookieAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void onEnter(@Advice.Argument(0) final Cookie cookie) {
+    public static void onEnter(@Advice.Argument(0) final Object o) {
       final InsecureCookieModule module = InstrumentationBridge.INSECURE_COOKIE;
       if (module != null) {
-        if (null != cookie) {
-          module.onCookie(cookie.getName(), cookie.getSecure());
+        if (null != o) {
+          if (o instanceof Cookie) {
+            Cookie cookie = (Cookie) o;
+            module.onCookie(cookie.getName(), cookie.getSecure());
+          }
         }
       }
     }


### PR DESCRIPTION
# What Does This Do
Fix a problem in cookie instrumentation where it would not instrument jetty response object because addCookie signature takes a different cookie class.

# Motivation
To make sure Response is always instrumented

# Additional Notes
See https://github.com/DataDog/dd-trace-java/pull/5117