### PR TITLE
Use built dd-java-agent in parametric tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -782,9 +782,9 @@ jobs:
           name: Copy jar files to system test binaries folder
           command: |
             ls -la ~/dd-trace-java/workspace/dd-trace-api/build/libs
-            ls -la ~/dd-trace-java/workspace/dd-trace-ot/build/libs
+            ls -la ~/dd-trace-java/workspace/dd-java-agent/build/libs
             cp ~/dd-trace-java/workspace/dd-trace-api/build/libs/*.jar system-tests/binaries/
-            cp ~/dd-trace-java/workspace/dd-trace-ot/build/libs/*.jar system-tests/binaries/
+            cp ~/dd-trace-java/workspace/dd-java-agent/build/libs/*.jar system-tests/binaries/
 
       - run:
           name: Install requirements

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -234,7 +234,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
             new ExtractedContext(
                 traceId,
                 spanId,
-                samplingPriorityOrDefault(samplingPriority),
+                samplingPriorityOrDefault(traceId, samplingPriority),
                 origin,
                 endToEndStartTime,
                 baggage,
@@ -253,7 +253,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
             tags,
             httpHeaders,
             baggage,
-            samplingPriorityOrDefault(samplingPriority),
+            samplingPriorityOrDefault(traceId, samplingPriority),
             traceConfig);
       }
     }
@@ -279,8 +279,8 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
     return httpHeaders;
   }
 
-  private int samplingPriorityOrDefault(int samplingPriority) {
-    return samplingPriority == PrioritySampling.UNSET
+  private int samplingPriorityOrDefault(DDTraceId traceId, int samplingPriority) {
+    return samplingPriority == PrioritySampling.UNSET || DDTraceId.ZERO.equals(traceId)
         ? defaultSamplingPriority()
         : samplingPriority;
   }


### PR DESCRIPTION
# What Does This Do

Uses the built `dd-java-agent` in the parametric tests.

# Motivation

Previous versions of the parametric build and test used `dd-trace-ot` to drive the test server, but that was changed to use pure OpenTracing/Datadog API, and the Java Tracer. The CI was missed in the update, making the parametric tests use a fixed version of `1.12.1`.

# Additional Notes
