### PR TITLE
Bump ddprof lib to 0.44.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.42.0",
+    ddprof        : "0.44.0",
     asm           : "9.5"
   ]
 


### PR DESCRIPTION
# What Does This Do
Bumps the ddprof lib to 0.44.0

# Motivation

# Additional Notes
* Improved thread-local thread state
* Record heap usage events to help recovering live heap size

**Full Changelog**: https://github.com/DataDog/java-profiler/compare/v_0.42.0...v_0.44.0