### PR TITLE
Added alias for OBFUSCATION_QUERY_STRING_REGEXP to prevent breaking c…

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1466,7 +1466,9 @@ public class Config {
 
     igniteCacheIncludeKeys = configProvider.getBoolean(IGNITE_CACHE_INCLUDE_KEYS, false);
 
-    obfuscationQueryRegexp = configProvider.getString(OBFUSCATION_QUERY_STRING_REGEXP);
+    obfuscationQueryRegexp =
+        configProvider.getString(
+            OBFUSCATION_QUERY_STRING_REGEXP, null, "obfuscation.query.string.regexp");
 
     playReportHttpStatus = configProvider.getBoolean(PLAY_REPORT_HTTP_STATUS, false);
 


### PR DESCRIPTION
…hange

# What Does This Do

Provides an alias for the config variable changed in https://github.com/DataDog/dd-trace-java/pull/5280

# Motivation
Prevents the config change from being a breaking change by allowing customers to use the old config variable through an alias.

# Additional Notes
