### PR TITLE
Add exploration tests for debugger

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,12 +2,14 @@ include:
   - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/ci_authenticated_job.yml
   - remote: https://gitlab-templates.ddbuild.io/apm/packaging.yml
   - local: ".gitlab/benchmarks.yml"
+  - local: ".gitlab/exploration-tests.yml"
 
 stages:
   - build
   - package
   - deploy
   - benchmarks
+  - exploration-tests
   - generate-signing-key
 
 variables:

--- a/.gitlab/exploration-tests.yml
+++ b/.gitlab/exploration-tests.yml
@@ -20,6 +20,7 @@ build-exploration-tests-image:
   after_script:
     - cd $CI_PROJECT_DIR
     - cp /exploration-tests/$PROJECT/agent.log agent.log
+    - gzip agent.log
   stage: exploration-tests
   when: manual
   tags: [ "runner:main"]
@@ -27,7 +28,7 @@ build-exploration-tests-image:
   image: $EXPLORATION_TESTS_IMAGE
   artifacts:
     paths:
-      - agent.log
+      - agent.log.gz
 
 
 exploration-tests-jackson-core:

--- a/.gitlab/exploration-tests.yml
+++ b/.gitlab/exploration-tests.yml
@@ -1,0 +1,45 @@
+variables:
+  EXPLORATION_TESTS_IMAGE: $REGISTRY/ci/dd-trace-java:exploration-tests
+
+build-exploration-tests-image:
+  stage: exploration-tests
+  when: manual
+  needs: []
+  tags: [ "runner:docker" ]
+  image: $REGISTRY/docker:20.10.3
+  script:
+    - docker build --tag $EXPLORATION_TESTS_IMAGE -f dd-java-agent/agent-debugger/exploration-tests/Dockerfile.exploration-tests dd-java-agent/agent-debugger/exploration-tests
+    - docker push $EXPLORATION_TESTS_IMAGE
+
+.common-exploration-tests: &common-exploration-tests
+  before_script:
+    - source $HOME/.sdkman/bin/sdkman-init.sh
+    - cp dd-java-agent/agent-debugger/exploration-tests/run-exploration-tests.sh /exploration-tests
+    - cp dd-java-agent/agent-debugger/exploration-tests/exclude.txt /exploration-tests
+    - cd /exploration-tests
+  after_script:
+    - cd $CI_PROJECT_DIR
+    - cp /exploration-tests/$PROJECT/agent.log agent.log
+  stage: exploration-tests
+  when: manual
+  tags: [ "runner:main"]
+  needs: []
+  image: $EXPLORATION_TESTS_IMAGE
+  artifacts:
+    paths:
+      - agent.log
+
+
+exploration-tests-jackson-core:
+  <<: *common-exploration-tests
+  variables:
+    PROJECT: jackson-core
+  script:
+    - ./run-exploration-tests.sh "$PROJECT" "./mvnw verify" || exit_code=$?
+
+exploration-tests-jackson-databind:
+  <<: *common-exploration-tests
+  variables:
+    PROJECT: jackson-databind
+  script:
+    - ./run-exploration-tests.sh "$PROJECT" "./mvnw verify" || exit_code=$?

--- a/dd-java-agent/agent-debugger/exploration-tests/Dockerfile.exploration-tests
+++ b/dd-java-agent/agent-debugger/exploration-tests/Dockerfile.exploration-tests
@@ -1,0 +1,33 @@
+FROM debian:bookworm-slim
+
+ARG JAVA_VERSION="8.0.332-tem"
+ARG MAVEN_VERSION=3.8.4
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y procps tini build-essential git curl unzip zip && \
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# install sdkman
+RUN curl -s "https://get.sdkman.io" | bash
+RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \
+    yes | sdk install java $JAVA_VERSION && \
+    yes | sdk install maven $MAVEN_VERSION && \
+    rm -rf $HOME/.sdkman/archives/* && \
+    rm -rf $HOME/.sdkman/tmp/*"
+
+RUN mkdir exploration-tests
+WORKDIR /exploration-tests
+# Jackson
+RUN git clone https://github.com/FasterXML/jackson-core.git
+RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && cd jackson-core && ./mvnw dependency:resolve dependency:resolve-plugins"
+RUN git clone https://github.com/FasterXML/jackson-databind.git
+RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && cd jackson-databind && ./mvnw dependency:resolve dependency:resolve-plugins"
+# Netty
+RUN git clone https://github.com/netty/netty.git
+RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && cd netty && ./mvnw dependency:resolve dependency:resolve-plugins"
+
+# Guava
+RUN git clone https://github.com/google/guava.git
+RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && cd guava && mvn -B -P!standard-with-extra-repos verify -U -Dmaven.javadoc.skip=true -DskipTests=true"
+

--- a/dd-java-agent/agent-debugger/exploration-tests/exclude.txt
+++ b/dd-java-agent/agent-debugger/exploration-tests/exclude.txt
@@ -1,0 +1,7 @@
+org/junit/internal/Throwables
+org/jacoco/agent/rt/*
+datadog/trace/bootstrap/debugger/*
+datadog/slf4j/*
+datadog/trace/logging/*
+datadog/trace/api/sampling/*
+datadog/trace/util/*

--- a/dd-java-agent/agent-debugger/exploration-tests/run-exploration-tests.sh
+++ b/dd-java-agent/agent-debugger/exploration-tests/run-exploration-tests.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -uo pipefail
+NAME=$1
+COMMAND=$2
+echo " === running debugger java exploration tests === "
+echo "Downloading java agent..."
+curl -OL https://binaries.ddbuild.io/slydog-dd-trace-java/e0daeff9258b19b2e071c8a7382d902bc46b46ea/dd-java-agent-debugger.jar
+export JAVA_TOOL_OPTIONS="-javaagent:`pwd`/dd-java-agent-debugger.jar -Ddatadog.slf4j.simpleLogger.log.com.datadog.debugger=debug -Ddd.trace.enabled=false -Ddd.debugger.enabled=true -Ddd.debugger.instrument.the.world=true -Ddd.debugger.classfile.dump.enabled=false -Ddd.debugger.verify.bytecode=true -Ddd.debugger.exclude.file=/exploration-tests/exclude.txt"
+echo "$JAVA_TOOL_OPTIONS"
+cd $NAME
+echo "Building repository $NAME..."
+eval "$COMMAND 2>agent.log"
+exit_code=$?
+echo "exit_code=$exit_code"
+if [ -n "$exit_code" ] && [ $exit_code -ne 0 ]; then cat $NAME/target/surefire-reports/*.dumpstream; fi
+

--- a/dd-java-agent/agent-debugger/exploration-tests/run-exploration-tests.sh
+++ b/dd-java-agent/agent-debugger/exploration-tests/run-exploration-tests.sh
@@ -4,8 +4,8 @@ NAME=$1
 COMMAND=$2
 echo " === running debugger java exploration tests === "
 echo "Downloading java agent..."
-curl -OL https://binaries.ddbuild.io/slydog-dd-trace-java/e0daeff9258b19b2e071c8a7382d902bc46b46ea/dd-java-agent-debugger.jar
-export JAVA_TOOL_OPTIONS="-javaagent:`pwd`/dd-java-agent-debugger.jar -Ddatadog.slf4j.simpleLogger.log.com.datadog.debugger=debug -Ddd.trace.enabled=false -Ddd.debugger.enabled=true -Ddd.debugger.instrument.the.world=true -Ddd.debugger.classfile.dump.enabled=false -Ddd.debugger.verify.bytecode=true -Ddd.debugger.exclude.file=/exploration-tests/exclude.txt"
+curl -Lo dd-java-agent.jar https://dtdg.co/latest-java-tracer
+export JAVA_TOOL_OPTIONS="-javaagent:`pwd`/dd-java-agent.jar -Ddatadog.slf4j.simpleLogger.log.com.datadog.debugger=debug -Ddd.trace.enabled=false -Ddd.dynamic.instrumentation.enabled=true -Ddd.dynamic.instrumentation.instrument.the.world=true -Ddd.dynamic.instrumentation.classfile.dump.enabled=false -Ddd.dynamic.instrumentation.verify.bytecode=true -Ddd.dynamic.instrumentation.exclude.file=/exploration-tests/exclude.txt"
 echo "$JAVA_TOOL_OPTIONS"
 cd $NAME
 echo "Building repository $NAME..."


### PR DESCRIPTION
# What Does This Do
Special mode for dd-java-agent instrumenting every methods in loaded class. We run tests from jackson library with dd-trace-java and this mode enabled and expect no error.
Running those tests with Gitlab. Each job generate an agent.log file containing debug logs of instrumentation

# Motivation

# Additional Notes
