### PR TITLE
[Spark] Refactor DatadogSparkListener constructor to not require the full sparkContext

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import java.util.Properties;
 import org.apache.spark.ExceptionFailure;
 import org.apache.spark.SparkConf;
-import org.apache.spark.SparkContext;
 import org.apache.spark.TaskFailedReason;
 import org.apache.spark.scheduler.*;
 import scala.Tuple2;
@@ -59,11 +58,12 @@ public class DatadogSparkListener extends SparkListener {
 
   private boolean applicationEnded = false;
 
-  public DatadogSparkListener(SparkContext sparkContext) {
+  public DatadogSparkListener(SparkConf sparkConf, String appId, String sparkVersion) {
     tracer = AgentTracer.get();
-    sparkConf = sparkContext.getConf();
-    sparkVersion = sparkContext.version();
-    appId = sparkContext.applicationId();
+
+    this.sparkConf = sparkConf;
+    this.appId = appId;
+    this.sparkVersion = sparkVersion;
 
     isRunningOnDatabricks = sparkConf.contains("spark.databricks.sparkContextId");
   }

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkInstrumentation.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkInstrumentation.java
@@ -57,7 +57,9 @@ public class SparkInstrumentation extends Instrumenter.Tracing
   public static class InjectListener {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void enter(@Advice.This SparkContext sparkContext) {
-      DatadogSparkListener.listener = new DatadogSparkListener(sparkContext);
+      DatadogSparkListener.listener =
+          new DatadogSparkListener(
+              sparkContext.getConf(), sparkContext.applicationId(), sparkContext.version());
       sparkContext.listenerBus().addToSharedQueue(DatadogSparkListener.listener);
     }
   }

--- a/dd-java-agent/instrumentation/spark/src/test/groovy/SparkListenerTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/test/groovy/SparkListenerTest.groovy
@@ -1,0 +1,87 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.instrumentation.spark.DatadogSparkListener
+import org.apache.spark.SparkConf
+import org.apache.spark.scheduler.SparkListenerApplicationEnd
+import org.apache.spark.scheduler.SparkListenerApplicationStart
+import org.apache.spark.scheduler.SparkListenerExecutorAdded
+import org.apache.spark.scheduler.SparkListenerExecutorRemoved
+import org.apache.spark.scheduler.cluster.ExecutorInfo
+import scala.Option
+import scala.collection.immutable.HashMap
+
+class SparkListenerTest extends AgentTestRunner {
+
+  private getTestDatadogSparkListener() {
+    def conf = new SparkConf()
+    return new DatadogSparkListener(conf, "some_app_id", "some_version")
+  }
+
+  private applicationStartEvent(time=0L) {
+    // Constructor of SparkListenerApplicationStart changed starting spark 3.0
+    if (TestSparkComputation.getSparkVersion() < "3") {
+      return new SparkListenerApplicationStart(
+        "some_app_name",
+        Option.apply("some_app_id"),
+        time,
+        "some_user",
+        Option.apply("1"),
+        Option.empty()
+        )
+    }
+
+    return new SparkListenerApplicationStart(
+      "some_app_name",
+      Option.apply("some_app_id"),
+      time,
+      "some_user",
+      Option.apply("1"),
+      Option.empty(),
+      Option.empty()
+      )
+  }
+
+  private executorAddedEvent(time=0L, executorId="executor-0", totalCores=0) {
+    new SparkListenerExecutorAdded(
+      time,
+      executorId,
+      new ExecutorInfo(
+      "some_host",
+      totalCores,
+      new HashMap<String, String>()
+      )
+      )
+  }
+
+  private executorRemovedEvent(time=0L, executorId="0") {
+    new SparkListenerExecutorRemoved(
+      time,
+      executorId,
+      "some_reason"
+      )
+  }
+
+  def "compute available executor time"() {
+    setup:
+    def listener = getTestDatadogSparkListener()
+
+    listener.onApplicationStart(applicationStartEvent(1000L))
+
+    listener.onExecutorAdded(executorAddedEvent(2000L, "executor-1", 4))
+    listener.onExecutorAdded(executorAddedEvent(3000L, "executor-2", 5))
+    listener.onExecutorRemoved(executorRemovedEvent(4000L, "executor-2"))
+
+    listener.onApplicationEnd(new SparkListenerApplicationEnd(5000L))
+
+    expect:
+    def expectedExecutorTime = (5000 - 2000) * 4 + (4000 - 3000) * 5
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "spark.application"
+          spanType "spark"
+          assert span.tags["spark_application_metrics.available_executor_time"] == expectedExecutorTime
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/spark/src/test/java/TestSparkComputation.java
+++ b/dd-java-agent/instrumentation/spark/src/test/java/TestSparkComputation.java
@@ -20,4 +20,8 @@ public class TestSparkComputation {
         .map(x -> ((Long) null).toString())
         .collect();
   }
+
+  public static String getSparkVersion() {
+    return org.apache.spark.package$.MODULE$.SPARK_VERSION();
+  }
 }


### PR DESCRIPTION
# What Does This Do

Change the `DatadogSparkListener` to not require the full sparkContext and make is easier to instantiate during tests