### PR TITLE
allow removal of fake services in v0

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
@@ -27,8 +27,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
   public static final boolean AWS_LEGACY_TRACING =
       Config.get().isLegacyTracingEnabled(false, "aws-sdk");
 
-  public static final boolean SQS_LEGACY_TRACING =
-      Config.get().isLegacyTracingEnabled(SpanNaming.instance().version() == 0, "sqs");
+  public static final boolean SQS_LEGACY_TRACING = Config.get().isLegacyTracingEnabled(true, "sqs");
 
   private static final String SQS_SERVICE_NAME =
       AWS_LEGACY_TRACING || SQS_LEGACY_TRACING ? "sqs" : Config.get().getServiceName();

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
@@ -36,8 +36,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
   public static final boolean AWS_LEGACY_TRACING =
       Config.get().isLegacyTracingEnabled(false, "aws-sdk");
 
-  public static final boolean SQS_LEGACY_TRACING =
-      Config.get().isLegacyTracingEnabled(SpanNaming.instance().version() == 0, "sqs");
+  public static final boolean SQS_LEGACY_TRACING = Config.get().isLegacyTracingEnabled(true, "sqs");
 
   private static final String SQS_SERVICE_NAME =
       AWS_LEGACY_TRACING || SQS_LEGACY_TRACING ? "sqs" : Config.get().getServiceName();

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsDecorator.java
@@ -20,11 +20,9 @@ public class SqsDecorator extends MessagingClientDecorator {
   public static final CharSequence SQS_DELIVER = UTF8BytesString.create("SQS.DeliverMessage");
   public static final CharSequence SQS_TIME_IN_QUEUE_OPERATION =
       SpanNaming.instance().namingSchema().messaging().timeInQueueOperation("sqs");
-  public static final boolean SQS_LEGACY_TRACING =
-      Config.get().isLegacyTracingEnabled(SpanNaming.instance().version() == 0, "sqs");
+  public static final boolean SQS_LEGACY_TRACING = Config.get().isLegacyTracingEnabled(true, "sqs");
   public static final boolean TIME_IN_QUEUE_ENABLED =
-      Config.get()
-          .isTimeInQueueEnabled(!SQS_LEGACY_TRACING && SpanNaming.instance().version() == 0, "sqs");
+      Config.get().isTimeInQueueEnabled(!SQS_LEGACY_TRACING, "sqs");
   private final String spanKind;
   private final CharSequence spanType;
   private final String serviceName;

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsDecorator.java
@@ -20,12 +20,10 @@ public class SqsDecorator extends MessagingClientDecorator {
   public static final CharSequence SQS_DELIVER = UTF8BytesString.create("Sqs.DeliverMessage");
   public static final CharSequence SQS_TIME_IN_QUEUE_OPERATION =
       SpanNaming.instance().namingSchema().messaging().timeInQueueOperation("sqs");
-  public static final boolean SQS_LEGACY_TRACING =
-      Config.get().isLegacyTracingEnabled(SpanNaming.instance().version() == 0, "sqs");
+  public static final boolean SQS_LEGACY_TRACING = Config.get().isLegacyTracingEnabled(true, "sqs");
 
   public static final boolean TIME_IN_QUEUE_ENABLED =
-      Config.get()
-          .isTimeInQueueEnabled(!SQS_LEGACY_TRACING && SpanNaming.instance().version() == 0, "sqs");
+      Config.get().isTimeInQueueEnabled(!SQS_LEGACY_TRACING, "sqs");
   private final String spanKind;
   private final CharSequence spanType;
   private final String serviceName;

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
@@ -36,12 +36,10 @@ public final class JMSDecorator extends MessagingClientDecorator {
           SpanNaming.instance().namingSchema().messaging().outboundOperation(JMS.toString()));
   public static final CharSequence JMS_DELIVER = UTF8BytesString.create("jms.deliver");
 
-  public static final boolean JMS_LEGACY_TRACING =
-      Config.get().isLegacyTracingEnabled(SpanNaming.instance().version() == 0, "jms");
+  public static final boolean JMS_LEGACY_TRACING = Config.get().isLegacyTracingEnabled(true, "jms");
 
   public static final boolean TIME_IN_QUEUE_ENABLED =
-      Config.get()
-          .isTimeInQueueEnabled(!JMS_LEGACY_TRACING && SpanNaming.instance().version() == 0, "jms");
+      Config.get().isTimeInQueueEnabled(!JMS_LEGACY_TRACING, "jms");
   public static final String JMS_PRODUCED_KEY = "x_datadog_jms_produced";
   public static final String JMS_BATCH_ID_KEY = "x_datadog_jms_batch_id";
 

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
@@ -1,6 +1,7 @@
-import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.agent.test.asserts.TraceAssert
+import datadog.trace.agent.test.naming.VersionedNamingTestBase
+import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.Trace
 import datadog.trace.api.config.TraceInstrumentationConfig
@@ -25,7 +26,7 @@ import javax.jms.TopicSession
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicReference
 
-class JMS1Test extends AgentTestRunner {
+abstract class JMS1Test extends VersionedNamingTestBase {
   @Shared
   EmbeddedActiveMQBroker broker = new EmbeddedActiveMQBroker()
   @Shared
@@ -51,6 +52,10 @@ class JMS1Test extends AgentTestRunner {
   ActiveMQTextMessage message1 = session.createTextMessage(messageText1)
   ActiveMQTextMessage message2 = session.createTextMessage(messageText2)
   ActiveMQTextMessage message3 = session.createTextMessage(messageText3)
+
+  abstract String operationForProducer()
+
+  abstract String operationForConsumer()
 
   def setupSpec() {
     broker.start()
@@ -95,11 +100,11 @@ class JMS1Test extends AgentTestRunner {
     receivedMessage3.text == messageText3
     // only two consume traces will be finished at this point
     assertTraces(5) {
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      consumerTrace(it, jmsResourceName, trace(0)[0])
-      consumerTrace(it, jmsResourceName, trace(1)[0])
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      consumerTraceWithNaming(it, jmsResourceName, trace(0)[0])
+      consumerTraceWithNaming(it, jmsResourceName, trace(1)[0])
     }
 
     when:
@@ -108,12 +113,12 @@ class JMS1Test extends AgentTestRunner {
     then:
     // now the last consume trace will also be finished
     assertTraces(6) {
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      consumerTrace(it, jmsResourceName, trace(0)[0])
-      consumerTrace(it, jmsResourceName, trace(1)[0])
-      consumerTrace(it, jmsResourceName, trace(2)[0])
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      consumerTraceWithNaming(it, jmsResourceName, trace(0)[0])
+      consumerTraceWithNaming(it, jmsResourceName, trace(1)[0])
+      consumerTraceWithNaming(it, jmsResourceName, trace(2)[0])
     }
 
     cleanup:
@@ -142,8 +147,8 @@ class JMS1Test extends AgentTestRunner {
     expect:
     receivedMessage.text == messageText1
     assertTraces(2) {
-      producerTrace(it, jmsResourceName)
-      consumerTrace(it, jmsResourceName, trace(0)[0])
+      producerTraceWithNaming(it, jmsResourceName)
+      consumerTraceWithNaming(it, jmsResourceName, trace(0)[0])
     }
 
     where:
@@ -176,11 +181,11 @@ class JMS1Test extends AgentTestRunner {
     receivedMessage3.text == messageText3
     // only two consume traces will be finished at this point
     assertTraces(5) {
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      consumerTrace(it, jmsResourceName, trace(0)[0])
-      consumerTrace(it, jmsResourceName, trace(1)[0])
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      consumerTraceWithNaming(it, jmsResourceName, trace(0)[0])
+      consumerTraceWithNaming(it, jmsResourceName, trace(1)[0])
     }
 
     when:
@@ -189,12 +194,12 @@ class JMS1Test extends AgentTestRunner {
     then:
     // now the last consume trace will also be finished
     assertTraces(6) {
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      consumerTrace(it, jmsResourceName, trace(0)[0])
-      consumerTrace(it, jmsResourceName, trace(1)[0])
-      consumerTrace(it, jmsResourceName, trace(2)[0])
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      consumerTraceWithNaming(it, jmsResourceName, trace(0)[0])
+      consumerTraceWithNaming(it, jmsResourceName, trace(1)[0])
+      consumerTraceWithNaming(it, jmsResourceName, trace(2)[0])
     }
 
     cleanup:
@@ -233,11 +238,11 @@ class JMS1Test extends AgentTestRunner {
     receivedMessage3.text == messageText3
     // only two consume traces will be finished at this point
     assertTraces(5) {
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      consumerTrace(it, jmsResourceName, trace(0)[0])
-      consumerTrace(it, jmsResourceName, trace(1)[0])
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      consumerTraceWithNaming(it, jmsResourceName, trace(0)[0])
+      consumerTraceWithNaming(it, jmsResourceName, trace(1)[0])
     }
 
     when:
@@ -246,12 +251,12 @@ class JMS1Test extends AgentTestRunner {
     then:
     // now the last consume trace will also be finished
     assertTraces(6) {
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      consumerTrace(it, jmsResourceName, trace(0)[0])
-      consumerTrace(it, jmsResourceName, trace(1)[0])
-      consumerTrace(it, jmsResourceName, trace(2)[0])
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      consumerTraceWithNaming(it, jmsResourceName, trace(0)[0])
+      consumerTraceWithNaming(it, jmsResourceName, trace(1)[0])
+      consumerTraceWithNaming(it, jmsResourceName, trace(2)[0])
     }
 
     cleanup:
@@ -288,11 +293,11 @@ class JMS1Test extends AgentTestRunner {
     receivedMessage2.text == messageText2
     // two consume traces will be finished at this point
     assertTraces(5) {
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      consumerTrace(it, jmsResourceName, trace(0)[0])
-      consumerTrace(it, jmsResourceName, trace(1)[0])
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      consumerTraceWithNaming(it, jmsResourceName, trace(0)[0])
+      consumerTraceWithNaming(it, jmsResourceName, trace(1)[0])
     }
 
     when:
@@ -307,14 +312,14 @@ class JMS1Test extends AgentTestRunner {
     receivedMessage3.text == messageText3
     // the two consume traces plus three more will be finished at this point
     assertTraces(8) {
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      consumerTrace(it, jmsResourceName, trace(0)[0])
-      consumerTrace(it, jmsResourceName, trace(1)[0])
-      consumerTrace(it, jmsResourceName, trace(0)[0]) // redelivered message
-      consumerTrace(it, jmsResourceName, trace(1)[0]) // redelivered message
-      consumerTrace(it, jmsResourceName, trace(2)[0])
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      consumerTraceWithNaming(it, jmsResourceName, trace(0)[0])
+      consumerTraceWithNaming(it, jmsResourceName, trace(1)[0])
+      consumerTraceWithNaming(it, jmsResourceName, trace(0)[0]) // redelivered message
+      consumerTraceWithNaming(it, jmsResourceName, trace(1)[0]) // redelivered message
+      consumerTraceWithNaming(it, jmsResourceName, trace(2)[0])
     }
 
     cleanup:
@@ -350,8 +355,8 @@ class JMS1Test extends AgentTestRunner {
 
     expect:
     assertTraces(2) {
-      producerTrace(it, jmsResourceName)
-      consumerTrace(it, jmsResourceName, trace(0)[0])
+      producerTraceWithNaming(it, jmsResourceName)
+      consumerTraceWithNaming(it, jmsResourceName, trace(0)[0])
     }
     // This check needs to go after all traces have been accounted for
     messageRef.get().text == messageText1
@@ -378,7 +383,7 @@ class JMS1Test extends AgentTestRunner {
 
     expect:
     assertTraces(1) {
-      producerTrace(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
     }
 
     cleanup:
@@ -462,13 +467,13 @@ class JMS1Test extends AgentTestRunner {
     // write properties in MessagePropertyTextMap when readOnlyProperties = true.
     // The consumer span will also not be linked to the parent.
     assertTraces(2) {
-      producerTrace(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
       trace(1) {
         // Consumer trace
         span {
           parent()
-          serviceName "jms"
-          operationName "jms.consume"
+          serviceName service()
+          operationName operationForConsumer()
           resourceName "Consumed from $jmsResourceName"
           spanType DDSpanTypes.MESSAGE_CONSUMER
           errored false
@@ -510,8 +515,8 @@ class JMS1Test extends AgentTestRunner {
 
     expect:
     assertTraces(2) {
-      producerTrace(it, "Queue someQueue")
-      consumerTrace(it, "Queue someQueue", trace(0)[0], isTimeStampDisabled)
+      producerTraceWithNaming(it, "Queue someQueue")
+      consumerTraceWithNaming(it, "Queue someQueue", trace(0)[0], isTimeStampDisabled)
     }
 
     cleanup:
@@ -535,9 +540,9 @@ class JMS1Test extends AgentTestRunner {
     expect:
     receivedMessage.text == messageText1
     assertTraces(2) {
-      producerTrace(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
       trace(2) {
-        consumerSpan(it, jmsResourceName, trace(0)[0])
+        consumerSpan(it, jmsResourceName, trace(0)[0], false, service(), operationForConsumer())
         span {
           operationName "do.stuff"
           childOf(trace(1)[0])
@@ -573,17 +578,17 @@ class JMS1Test extends AgentTestRunner {
     receivedMessage.text == messageText1
     if (expected) {
       assertTraces(2) {
-        producerTrace(it, jmsResourceName)
-        consumerTrace(it, jmsResourceName, trace(0)[0])
+        producerTraceWithNaming(it, jmsResourceName)
+        consumerTraceWithNaming(it, jmsResourceName, trace(0)[0])
       }
     } else {
       assertTraces(2) {
-        producerTrace(it, jmsResourceName)
+        producerTraceWithNaming(it, jmsResourceName)
         trace(1) {
           span {
             parentSpanId(0 as BigInteger)
-            serviceName "jms"
-            operationName "jms.consume"
+            serviceName service()
+            operationName operationForConsumer()
             resourceName "Consumed from $jmsResourceName"
             spanType DDSpanTypes.MESSAGE_CONSUMER
             errored false
@@ -626,17 +631,17 @@ class JMS1Test extends AgentTestRunner {
     receivedMessage.text == messageText1
     if (expected) {
       assertTraces(2) {
-        producerTrace(it, jmsResourceName)
-        consumerTrace(it, jmsResourceName, trace(0)[0])
+        producerTraceWithNaming(it, jmsResourceName)
+        consumerTraceWithNaming(it, jmsResourceName, trace(0)[0])
       }
     } else {
       assertTraces(2) {
-        producerTrace(it, jmsResourceName)
+        producerTraceWithNaming(it, jmsResourceName)
         trace(1) {
           span {
             parentSpanId(0 as BigInteger)
-            serviceName "jms"
-            operationName "jms.consume"
+            serviceName service()
+            operationName operationForConsumer()
             resourceName "Consumed from $jmsResourceName"
             spanType DDSpanTypes.MESSAGE_CONSUMER
             errored false
@@ -686,17 +691,17 @@ class JMS1Test extends AgentTestRunner {
     expect:
     if (expected) {
       assertTraces(2) {
-        producerTrace(it, jmsResourceName)
-        consumerTrace(it, jmsResourceName, trace(0)[0])
+        producerTraceWithNaming(it, jmsResourceName)
+        consumerTraceWithNaming(it, jmsResourceName, trace(0)[0])
       }
     } else {
       assertTraces(2) {
-        producerTrace(it, jmsResourceName)
+        producerTraceWithNaming(it, jmsResourceName)
         trace(1) {
           span {
             parentSpanId(0 as BigInteger)
-            serviceName "jms"
-            operationName "jms.consume"
+            serviceName service()
+            operationName operationForConsumer()
             resourceName "Consumed from $jmsResourceName"
             spanType DDSpanTypes.MESSAGE_CONSUMER
             errored false
@@ -745,11 +750,11 @@ class JMS1Test extends AgentTestRunner {
     receivedMessage3.text == messageText3
     // only two consume traces will be finished at this point
     assertTraces(5) {
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      consumerTrace(it, jmsResourceName, trace(0)[0])
-      consumerTrace(it, jmsResourceName, trace(1)[0])
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      consumerTraceWithNaming(it, jmsResourceName, trace(0)[0])
+      consumerTraceWithNaming(it, jmsResourceName, trace(1)[0])
     }
 
     when:
@@ -758,12 +763,12 @@ class JMS1Test extends AgentTestRunner {
     then:
     // now the last consume trace will also be finished
     assertTraces(6) {
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      consumerTrace(it, jmsResourceName, trace(0)[0])
-      consumerTrace(it, jmsResourceName, trace(1)[0])
-      consumerTrace(it, jmsResourceName, trace(2)[0])
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      consumerTraceWithNaming(it, jmsResourceName, trace(0)[0])
+      consumerTraceWithNaming(it, jmsResourceName, trace(1)[0])
+      consumerTraceWithNaming(it, jmsResourceName, trace(2)[0])
     }
 
     cleanup:
@@ -796,11 +801,11 @@ class JMS1Test extends AgentTestRunner {
     receivedMessage3.text == messageText3
     // only two consume traces will be finished at this point
     assertTraces(5) {
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      consumerTrace(it, jmsResourceName, trace(0)[0])
-      consumerTrace(it, jmsResourceName, trace(1)[0])
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      consumerTraceWithNaming(it, jmsResourceName, trace(0)[0])
+      consumerTraceWithNaming(it, jmsResourceName, trace(1)[0])
     }
 
     when:
@@ -809,12 +814,12 @@ class JMS1Test extends AgentTestRunner {
     then:
     // now the last consume trace will also be finished
     assertTraces(6) {
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      consumerTrace(it, jmsResourceName, trace(0)[0])
-      consumerTrace(it, jmsResourceName, trace(1)[0])
-      consumerTrace(it, jmsResourceName, trace(2)[0])
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      consumerTraceWithNaming(it, jmsResourceName, trace(0)[0])
+      consumerTraceWithNaming(it, jmsResourceName, trace(1)[0])
+      consumerTraceWithNaming(it, jmsResourceName, trace(2)[0])
     }
 
     cleanup:
@@ -847,11 +852,11 @@ class JMS1Test extends AgentTestRunner {
     receivedMessage3.text == messageText3
     // only two consume traces will be finished at this point
     assertTraces(5) {
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      consumerTrace(it, jmsResourceName, trace(0)[0])
-      consumerTrace(it, jmsResourceName, trace(1)[0])
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      consumerTraceWithNaming(it, jmsResourceName, trace(0)[0])
+      consumerTraceWithNaming(it, jmsResourceName, trace(1)[0])
     }
 
     when:
@@ -860,12 +865,12 @@ class JMS1Test extends AgentTestRunner {
     then:
     // now the last consume trace will also be finished
     assertTraces(6) {
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      producerTrace(it, jmsResourceName)
-      consumerTrace(it, jmsResourceName, trace(0)[0])
-      consumerTrace(it, jmsResourceName, trace(1)[0])
-      consumerTrace(it, jmsResourceName, trace(2)[0])
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      producerTraceWithNaming(it, jmsResourceName)
+      consumerTraceWithNaming(it, jmsResourceName, trace(0)[0])
+      consumerTraceWithNaming(it, jmsResourceName, trace(1)[0])
+      consumerTraceWithNaming(it, jmsResourceName, trace(2)[0])
     }
 
     cleanup:
@@ -877,16 +882,20 @@ class JMS1Test extends AgentTestRunner {
     topicSession.createTopic("someTopic") | "Topic someTopic"
   }
 
-  static producerTrace(ListWriterAssert writer, String jmsResourceName) {
+  def producerTraceWithNaming(ListWriterAssert writer, String jmsResourceName) {
+    producerTrace(writer, jmsResourceName, service(), operationForProducer())
+  }
+
+  static producerTrace(ListWriterAssert writer, String jmsResourceName, String producerService = "jms", String producerOperation = "jms.produce") {
     writer.trace(1) {
-      producerSpan(it, jmsResourceName)
+      producerSpan(it, jmsResourceName, producerService, producerOperation)
     }
   }
 
-  static producerSpan(TraceAssert traceAssert, String jmsResourceName) {
+  static producerSpan(TraceAssert traceAssert, String jmsResourceName, String producerService = "jms", String producerOperation = "jms.produce") {
     return traceAssert.span {
-      serviceName "jms"
-      operationName "jms.produce"
+      serviceName producerService
+      operationName producerOperation
       resourceName "Produced for $jmsResourceName"
       spanType DDSpanTypes.MESSAGE_PRODUCER
       errored false
@@ -901,16 +910,22 @@ class JMS1Test extends AgentTestRunner {
     }
   }
 
-  static consumerTrace(ListWriterAssert writer, String jmsResourceName, DDSpan parentSpan, boolean isTimestampDisabled = false) {
+  def consumerTraceWithNaming(ListWriterAssert writer, String jmsResourceName, DDSpan parentSpan, boolean isTimestampDisabled = false) {
+    consumerTrace(writer, jmsResourceName, parentSpan, isTimestampDisabled, service(), operationForConsumer())
+  }
+
+  static consumerTrace(ListWriterAssert writer, String jmsResourceName, DDSpan parentSpan, boolean isTimestampDisabled = false,
+    String consumerService = "jms", String consumerOperation = "jms.consume") {
     writer.trace(1) {
-      consumerSpan(it, jmsResourceName, parentSpan, isTimestampDisabled)
+      consumerSpan(it, jmsResourceName, parentSpan, isTimestampDisabled, consumerService, consumerOperation)
     }
   }
 
-  static consumerSpan(TraceAssert traceAssert, String jmsResourceName, DDSpan parentSpan, boolean isTimestampDisabled = false) {
+  static consumerSpan(TraceAssert traceAssert, String jmsResourceName, DDSpan parentSpan, boolean isTimestampDisabled = false,
+    String consumerService = "jms", String consumerOperation = "jms.consume") {
     return traceAssert.span {
-      serviceName "jms"
-      operationName "jms.consume"
+      serviceName consumerService
+      operationName consumerOperation
       resourceName "Consumed from $jmsResourceName"
       spanType DDSpanTypes.MESSAGE_CONSUMER
       errored false
@@ -931,5 +946,61 @@ class JMS1Test extends AgentTestRunner {
   @Trace(operationName = "do.stuff")
   def doStuff() {
 
+  }
+}
+
+class JMS1V0Test extends JMS1Test {
+
+  @Override
+  int version() {
+    0
+  }
+
+  @Override
+  String service() {
+    "jms"
+  }
+
+  @Override
+  String operation() {
+    null
+  }
+
+  @Override
+  String operationForProducer() {
+    "jms.produce"
+  }
+
+  @Override
+  String operationForConsumer() {
+    "jms.consume"
+  }
+}
+
+class JMS1V1ForkedTest extends JMS1Test {
+
+  @Override
+  int version() {
+    1
+  }
+
+  @Override
+  String service() {
+    Config.get().getServiceName()
+  }
+
+  @Override
+  String operation() {
+    null
+  }
+
+  @Override
+  String operationForProducer() {
+    "jms.send"
+  }
+
+  @Override
+  String operationForConsumer() {
+    "jms.process"
   }
 }

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/TimeInQueueForkedTest.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/TimeInQueueForkedTest.groovy
@@ -701,46 +701,12 @@ abstract class TimeInQueueForkedTestBase extends VersionedNamingTestBase {
   }
 }
 
-abstract class TimeInQueueForkedTest extends TimeInQueueForkedTestBase {
+class TimeInQueueForkedTest extends TimeInQueueForkedTestBase {
   @Override
   boolean splitByDestination() {
     return false
   }
 }
-
-class TimeInQueueV0ForkedTest extends TimeInQueueForkedTest {
-
-}
-
-class TimeInQueueV1ForkedTest extends TimeInQueueForkedTest {
-
-  @Override
-  void configurePreAgent() {
-    super.configurePreAgent()
-    injectSysConfig("dd.jms.time-in-queue.enabled", "true")
-  }
-
-  @Override
-  String operationForProducer() {
-    "jms.send"
-  }
-
-  @Override
-  String operationForConsumer() {
-    "jms.process"
-  }
-
-  @Override
-  String serviceForTimeInQueue() {
-    "jms-queue"
-  }
-
-  @Override
-  int version() {
-    1
-  }
-}
-
 
 class TimeInQueueSplitByDestinationForkedTest extends TimeInQueueForkedTestBase {
   @Override

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
@@ -34,11 +34,9 @@ public class KafkaDecorator extends MessagingClientDecorator {
           SpanNaming.instance().namingSchema().messaging().outboundOperation(KAFKA));
   public static final CharSequence KAFKA_DELIVER = UTF8BytesString.create("kafka.deliver");
   public static final boolean KAFKA_LEGACY_TRACING =
-      Config.get().isLegacyTracingEnabled(SpanNaming.instance().version() == 0, KAFKA);
+      Config.get().isLegacyTracingEnabled(true, KAFKA);
   public static final boolean TIME_IN_QUEUE_ENABLED =
-      Config.get()
-          .isTimeInQueueEnabled(
-              !KAFKA_LEGACY_TRACING && SpanNaming.instance().version() == 0, KAFKA);
+      Config.get().isTimeInQueueEnabled(!KAFKA_LEGACY_TRACING, KAFKA);
   public static final String KAFKA_PRODUCED_KEY = "x_datadog_kafka_produced";
   private final String spanKind;
   private final CharSequence spanType;

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
@@ -5,6 +5,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.naming.VersionedNamingTestBase
+import datadog.trace.api.Config
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
@@ -1097,8 +1098,8 @@ class KafkaClientLegacyTracingV1ForkedTest extends KafkaClientLegacyTracingForke
   }
 
   @Override
-  String serviceForTimeInQueue() {
-    "kafka-queue"
+  String service() {
+    return Config.get().getServiceName()
   }
 }
 

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsDecorator.java
@@ -27,11 +27,9 @@ public class KafkaStreamsDecorator extends MessagingClientDecorator {
   public static final CharSequence KAFKA_DELIVER = UTF8BytesString.create("kafka.deliver");
 
   public static final boolean KAFKA_LEGACY_TRACING =
-      Config.get().isLegacyTracingEnabled(SpanNaming.instance().version() == 0, KAFKA);
+      Config.get().isLegacyTracingEnabled(true, KAFKA);
   public static final boolean TIME_IN_QUEUE_ENABLED =
-      Config.get()
-          .isTimeInQueueEnabled(
-              !KAFKA_LEGACY_TRACING && SpanNaming.instance().version() == 0, KAFKA);
+      Config.get().isTimeInQueueEnabled(!KAFKA_LEGACY_TRACING, KAFKA);
   public static final String KAFKA_PRODUCED_KEY = "x_datadog_kafka_produced";
 
   private final String spanKind;

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
@@ -47,15 +47,10 @@ public class RabbitDecorator extends MessagingClientDecorator {
   public static final CharSequence RABBITMQ_AMQP = UTF8BytesString.create("rabbitmq-amqp");
 
   public static final boolean RABBITMQ_LEGACY_TRACING =
-      Config.get()
-          .isLegacyTracingEnabled(SpanNaming.instance().version() == 0, "rabbit", "rabbitmq");
+      Config.get().isLegacyTracingEnabled(true, "rabbit", "rabbitmq");
 
   public static final boolean TIME_IN_QUEUE_ENABLED =
-      Config.get()
-          .isTimeInQueueEnabled(
-              !RABBITMQ_LEGACY_TRACING && SpanNaming.instance().version() == 0,
-              "rabbit",
-              "rabbitmq");
+      Config.get().isTimeInQueueEnabled(!RABBITMQ_LEGACY_TRACING, "rabbit", "rabbitmq");
 
   private static final String LOCAL_SERVICE_NAME =
       RABBITMQ_LEGACY_TRACING ? "rabbitmq" : Config.get().getServiceName();

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -14,6 +14,7 @@ import com.rabbitmq.client.GetResponse
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.agent.test.utils.PortUtils
+import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
@@ -1008,6 +1009,11 @@ class RabbitMQLegacyTracingV1ForkedTest extends RabbitMQLegacyTracingV0ForkedTes
   @Override
   String operationForConsumer() {
     "amqp.process"
+  }
+
+  @Override
+  String service() {
+    Config.get().getServiceName()
   }
 
   @Override

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -113,6 +113,9 @@ public final class TracerConfig {
   public static final String TRACE_PEER_SERVICE_DEFAULTS_ENABLED =
       "trace.peer.service.defaults.enabled";
 
+  public static final String TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED =
+      "trace.remove.integration-service-names.enabled";
+
   public static final String TRACE_PEER_SERVICE_MAPPING = "trace.peer.service.mapping";
 
   private TracerConfig() {}

--- a/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
@@ -54,6 +54,13 @@ public interface NamingSchema {
    */
   ForPeerService peerService();
 
+  /**
+   * If true, the schema allows having service names != DD_SERVICE
+   *
+   * @return
+   */
+  boolean allowFakeServices();
+
   interface ForCache {
     /**
      * Calculate the operation name for a cache span.

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/CacheNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/CacheNamingV0.java
@@ -4,6 +4,13 @@ import datadog.trace.api.naming.NamingSchema;
 import javax.annotation.Nonnull;
 
 public class CacheNamingV0 implements NamingSchema.ForCache {
+
+  private final boolean allowsFakeServices;
+
+  public CacheNamingV0(boolean allowsFakeServices) {
+    this.allowsFakeServices = allowsFakeServices;
+  }
+
   @Nonnull
   @Override
   public String operation(@Nonnull String cacheSystem) {
@@ -25,6 +32,10 @@ public class CacheNamingV0 implements NamingSchema.ForCache {
   @Nonnull
   @Override
   public String service(@Nonnull String ddService, @Nonnull String cacheSystem) {
+    if (!allowsFakeServices) {
+      return ddService;
+    }
+
     if ("hazelcast".equals(cacheSystem)) {
       return "hazelcast-sdk";
     }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/ClientNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/ClientNamingV0.java
@@ -4,6 +4,7 @@ import datadog.trace.api.naming.NamingSchema;
 import javax.annotation.Nonnull;
 
 public class ClientNamingV0 implements NamingSchema.ForClient {
+
   @Nonnull
   @Override
   public String operationForProtocol(@Nonnull String protocol) {

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/CloudNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/CloudNamingV0.java
@@ -1,10 +1,17 @@
 package datadog.trace.api.naming.v0;
 
+import datadog.trace.api.Config;
 import datadog.trace.api.naming.NamingSchema;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class CloudNamingV0 implements NamingSchema.ForCloud {
+  private final boolean allowsFakeServices;
+
+  public CloudNamingV0(boolean allowsFakeServices) {
+    this.allowsFakeServices = allowsFakeServices;
+  }
+
   @Nonnull
   @Override
   public String operationForRequest(
@@ -19,6 +26,10 @@ public class CloudNamingV0 implements NamingSchema.ForCloud {
   @Override
   public String serviceForRequest(
       @Nonnull final String provider, @Nullable final String cloudService) {
+    if (!allowsFakeServices) {
+      return Config.get().getServiceName();
+    }
+
     // we only manage aws. Future switch for other cloud providers will be needed in the future
     if (cloudService == null) {
       return "java-aws-sdk";

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/DatabaseNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/DatabaseNamingV0.java
@@ -4,6 +4,13 @@ import datadog.trace.api.naming.NamingSchema;
 import javax.annotation.Nonnull;
 
 public class DatabaseNamingV0 implements NamingSchema.ForDatabase {
+
+  private final boolean allowsFakeServices;
+
+  public DatabaseNamingV0(boolean allowsFakeServices) {
+    this.allowsFakeServices = allowsFakeServices;
+  }
+
   @Override
   public String normalizedName(@Nonnull String rawName) {
     return rawName;
@@ -22,6 +29,9 @@ public class DatabaseNamingV0 implements NamingSchema.ForDatabase {
   @Nonnull
   @Override
   public String service(@Nonnull String ddService, @Nonnull String databaseType) {
-    return databaseType;
+    if (allowsFakeServices) {
+      return databaseType;
+    }
+    return ddService;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/MessagingNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/MessagingNamingV0.java
@@ -4,6 +4,12 @@ import datadog.trace.api.naming.NamingSchema;
 import javax.annotation.Nonnull;
 
 public class MessagingNamingV0 implements NamingSchema.ForMessaging {
+  private final boolean allowsFakeServices;
+
+  public MessagingNamingV0(boolean allowsFakeServices) {
+    this.allowsFakeServices = allowsFakeServices;
+  }
+
   @Nonnull
   @Override
   public String outboundOperation(@Nonnull final String messagingSystem) {
@@ -17,7 +23,10 @@ public class MessagingNamingV0 implements NamingSchema.ForMessaging {
   @Override
   public String outboundService(
       @Nonnull final String ddService, @Nonnull final String messagingSystem) {
-    return messagingSystem;
+    if (allowsFakeServices) {
+      return messagingSystem;
+    }
+    return ddService;
   }
 
   @Nonnull
@@ -37,7 +46,10 @@ public class MessagingNamingV0 implements NamingSchema.ForMessaging {
   @Override
   public String inboundService(
       @Nonnull final String ddService, @Nonnull final String messagingSystem) {
-    return messagingSystem;
+    if (allowsFakeServices) {
+      return messagingSystem;
+    }
+    return ddService;
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/NamingSchemaV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/NamingSchemaV0.java
@@ -5,11 +5,14 @@ import datadog.trace.api.naming.NamingSchema;
 import datadog.trace.api.naming.v1.PeerServiceNamingV1;
 
 public class NamingSchemaV0 implements NamingSchema {
-  private final NamingSchema.ForCache cacheNaming = new CacheNamingV0();
+
+  private final boolean allowsFakeServices = !Config.get().isRemoveIntegrationServiceNamesEnabled();
+  private final NamingSchema.ForCache cacheNaming = new CacheNamingV0(allowsFakeServices);
   private final NamingSchema.ForClient clientNaming = new ClientNamingV0();
-  private final NamingSchema.ForCloud cloudNaming = new CloudNamingV0();
-  private final NamingSchema.ForDatabase databaseNaming = new DatabaseNamingV0();
-  private final NamingSchema.ForMessaging messagingNaming = new MessagingNamingV0();
+  private final NamingSchema.ForCloud cloudNaming = new CloudNamingV0(allowsFakeServices);
+  private final NamingSchema.ForDatabase databaseNaming = new DatabaseNamingV0(allowsFakeServices);
+  private final NamingSchema.ForMessaging messagingNaming =
+      new MessagingNamingV0(allowsFakeServices);
   private final NamingSchema.ForPeerService peerServiceNaming =
       Config.get().isPeerServiceDefaultsEnabled()
           ? new PeerServiceNamingV1()
@@ -49,5 +52,10 @@ public class NamingSchemaV0 implements NamingSchema {
   @Override
   public ForPeerService peerService() {
     return peerServiceNaming;
+  }
+
+  @Override
+  public boolean allowFakeServices() {
+    return allowsFakeServices;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/NamingSchemaV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/NamingSchemaV1.java
@@ -42,6 +42,11 @@ public class NamingSchemaV1 implements NamingSchema {
   }
 
   @Override
+  public boolean allowFakeServices() {
+    return false;
+  }
+
+  @Override
   public ForServer server() {
     return serverNaming;
   }

--- a/internal-api/src/test/groovy/datadog/trace/api/naming/NamingV0ForkedTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/naming/NamingV0ForkedTest.groovy
@@ -1,0 +1,26 @@
+package datadog.trace.api.naming
+
+import datadog.trace.api.config.GeneralConfig
+import datadog.trace.api.config.TracerConfig
+import datadog.trace.test.util.DDSpecification
+
+class NamingV0ForkedTest extends DDSpecification {
+  def "v0 should use DD_SERVICE when DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED is true"() {
+    setup:
+    def ddService = "testService"
+    injectSysConfig(TracerConfig.TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED, "true")
+    injectSysConfig(GeneralConfig.SERVICE_NAME, ddService)
+
+    when:
+    def schema = SpanNaming.instance().namingSchema()
+
+    then:
+    assert SpanNaming.instance().version() == 0
+    assert !schema.allowFakeServices()
+    assert schema.messaging().inboundService(ddService, "anything") == ddService
+    assert schema.messaging().outboundService(ddService, "anything") == ddService
+    assert schema.database().service(ddService, "anything") == ddService
+    assert schema.cache().service(ddService, "anything") == ddService
+    assert schema.cloud().serviceForRequest("any", "anything") == ddService
+  }
+}


### PR DESCRIPTION
# What Does This Do

This PR allow to flatten every service name to `DD_SERVICE` also in v0 if the env `DD_TRACE_REMOVE_CLIENT_SERVICE_NAMES_ENABLED` is set to true

Please note that having this activated (like happening in v1) implies:
* legacy tracing disabled (otherwise we'll have fake services like `kafka`)
*  time in queue disabled (same reasons)

I took the time hence to refactor the way we determined if legacy tracing was enabled in the decorators by getting rid of checks like `schemaVersion == 0` that can cause nasty coupling

# Motivation

# Additional Notes
