### PR TITLE
Fix TestNG integration for TESTS parallel mode

### DIFF
--- a/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGUtils.java
+++ b/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGUtils.java
@@ -132,7 +132,8 @@ public abstract class TestNGUtils {
           XML_TEST_GET_PARALLEL != null
               ? XML_TEST_GET_PARALLEL.invoke(testClass.getXmlTest())
               : null;
-      return parallel != null && "methods".equals(parallel.toString());
+      return parallel != null
+          && ("methods".equals(parallel.toString()) || "tests".equals(parallel.toString()));
     } catch (Exception e) {
       return false;
     }

--- a/dd-java-agent/instrumentation/testng/testng-7.5/src/main/java/datadog/trace/instrumentation/testng75/TestNGClassListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/testng/testng-7.5/src/main/java/datadog/trace/instrumentation/testng75/TestNGClassListenerInstrumentation.java
@@ -63,7 +63,8 @@ public class TestNGClassListenerInstrumentation extends Instrumenter.CiVisibilit
 
       XmlTest xmlTest = testClass.getXmlTest();
       XmlSuite.ParallelMode parallel = xmlTest.getParallel();
-      boolean parallelized = parallel == XmlSuite.ParallelMode.METHODS;
+      boolean parallelized =
+          parallel == XmlSuite.ParallelMode.METHODS || parallel == XmlSuite.ParallelMode.TESTS;
 
       TestNGClassListener listener = TestNGUtils.getTestNGClassListener(testContext);
       listener.invokeBeforeClass(testClass, parallelized);


### PR DESCRIPTION
# What Does This Do
Fixes Test NG integration for cases when parallel execution mode is set to `tests` and when XML configuration is used.

# Motivation
There are clients who use CI Visibility with Test NG in `tests` parallel mode and with explicit XML configuration.

# Additional Notes
When Test NG is configured explicitly using XML (rather than when Maven/Gradle plugins create an implicit `XmlSuite` instance), some of the assumptions made previously do not hold: it is possible to have multiple `ITestClass` instances for the same Java class and multiple `ITestMethod` instances for the same test case method.
