### PR TITLE
Fix handling of local variable table

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
@@ -447,7 +447,7 @@ public class CapturedContextInstrumentor extends Instrumentor {
     int slot = isStatic ? 0 : 1;
     for (Type argType : argTypes) {
       String currentArgName = null;
-      if (localVarsBySlot.length > 0) {
+      if (slot < localVarsBySlot.length) {
         LocalVariableNode localVarNode = localVarsBySlot[slot];
         currentArgName = localVarNode != null ? localVarNode.name : null;
       }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
@@ -87,14 +87,16 @@ public abstract class Instrumentor {
     // as stated into the JVM spec:
     // https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-2.html#jvms-2.6.1
     // so we reassigned local var in arg slots if they are empty
-    int slot = isStatic ? 0 : 1;
-    int localVarTableIdx = slot;
-    for (Type t : argTypes) {
-      if (localVars[slot] == null) {
-        localVars[slot] = sortedLocalVars.get(localVarTableIdx);
+    if (argTypes.length < localVars.length) {
+      int slot = isStatic ? 0 : 1;
+      int localVarTableIdx = slot;
+      for (Type t : argTypes) {
+        if (localVars[slot] == null && localVarTableIdx < sortedLocalVars.size()) {
+          localVars[slot] = sortedLocalVars.get(localVarTableIdx);
+        }
+        slot += t.getSize();
+        localVarTableIdx++;
       }
-      slot += t.getSize();
-      localVarTableIdx++;
     }
     return localVars;
   }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1372,6 +1372,24 @@ public class CapturedSnapshotTest {
         snapshot.getEvaluationErrors().get(1).getMessage());
   }
 
+  @Test
+  public void enumConstructorArgs() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot23";
+    final String ENUM_CLASS = CLASS_NAME + "$MyEnum";
+    DebuggerTransformerTest.TestSnapshotListener listener =
+        installProbes(ENUM_CLASS, createProbe(PROBE_ID, ENUM_CLASS, "<init>", null));
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "2").get();
+    Assertions.assertEquals(2, result);
+    assertSnapshots(listener, 3, PROBE_ID);
+    Map<String, CapturedContext.CapturedValue> arguments =
+        listener.snapshots.get(0).getCaptures().getEntry().getArguments();
+    assertEquals(3, arguments.size());
+    assertTrue(arguments.containsKey("this"));
+    assertTrue(arguments.containsKey("p1")); // this the hidden ordinal arg of an enum
+    assertTrue(arguments.containsKey("strValue"));
+  }
+
   private DebuggerTransformerTest.TestSnapshotListener setupInstrumentTheWorldTransformer(
       String excludeFileName) {
     Config config = mock(Config.class);

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot23.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot23.java
@@ -1,0 +1,33 @@
+package com.datadog.debugger;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+
+public class CapturedSnapshot23 {
+  enum MyEnum {
+    ONE("1"),
+    TWO("2"),
+    THREE("3");
+
+    private final String strValue;
+
+    MyEnum(String strValue) {
+      this.strValue = strValue;
+    }
+
+    public String getStrValue() {
+      return strValue;
+    }
+  }
+
+  private int doit(String arg) {
+    return Integer.parseInt(MyEnum.TWO.getStrValue());
+  }
+
+  public static int main(String arg) {
+    CapturedSnapshot23 cs23 = new CapturedSnapshot23();
+    return cs23.doit(arg);
+  }
+}


### PR DESCRIPTION
# What Does This Do
Add protection about array out of bounds

# Motivation
in some cases there is no match between method arguments and local variable tables (hidden arg, inherited method with no info in local variable table)

# Additional Notes
