### PR TITLE
Fix NullPointerException in map/list serialization

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/SerializerWithLimits.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/SerializerWithLimits.java
@@ -345,7 +345,7 @@ public class SerializerWithLimits {
     Iterator<?> it = collection.iterator();
     while (i < maxSize && it.hasNext()) {
       Object val = it.next();
-      serialize(val, val.getClass().getTypeName(), newLimits);
+      serialize(val, val != null ? val.getClass().getTypeName() : null, newLimits);
       i++;
     }
     return maxSize == colSize;
@@ -363,8 +363,8 @@ public class SerializerWithLimits {
       tokenWriter.mapEntryPrologue(entry);
       Object keyObj = entry.getKey();
       Object valObj = entry.getValue();
-      serialize(keyObj, keyObj.getClass().getTypeName(), newLimits);
-      serialize(valObj, valObj.getClass().getTypeName(), newLimits);
+      serialize(keyObj, keyObj != null ? keyObj.getClass().getTypeName() : null, newLimits);
+      serialize(valObj, valObj != null ? valObj.getClass().getTypeName() : null, newLimits);
       tokenWriter.mapEntryEpilogue(entry);
       i++;
     }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/StringTokenWriterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/StringTokenWriterTest.java
@@ -5,6 +5,7 @@ import static datadog.trace.bootstrap.debugger.Limits.DEFAULT_FIELD_COUNT;
 import static datadog.trace.bootstrap.debugger.Limits.DEFAULT_LENGTH;
 import static datadog.trace.bootstrap.debugger.Limits.DEFAULT_REFERENCE_DEPTH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import datadog.trace.bootstrap.debugger.Limits;
 import datadog.trace.bootstrap.debugger.util.TimeoutChecker;
@@ -75,6 +76,25 @@ class StringTokenWriterTest {
         serializeValue(
             new LeafClass(),
             new Limits(DEFAULT_REFERENCE_DEPTH, DEFAULT_COLLECTION_SIZE, DEFAULT_LENGTH, 2)));
+  }
+
+  @Test
+  public void collections() throws Exception {
+    List<String> list = new ArrayList<>();
+    list.add("foo");
+    list.add("bar");
+    list.add(null);
+    assertEquals("[foo, bar, null]", serializeValue(list, Limits.DEFAULT));
+  }
+
+  @Test
+  public void maps() throws Exception {
+    HashMap<String, String> map = new HashMap<>();
+    map.put("foo1", "bar1");
+    map.put(null, null);
+    String serializedStr = serializeValue(map, Limits.DEFAULT);
+    assertTrue(serializedStr.contains("[foo1=bar1]"));
+    assertTrue(serializedStr.contains("[null=null]"));
   }
 
   static class Person {


### PR DESCRIPTION
# What Does This Do

# Motivation
if null elements are present in map or collections, serialization was throwing NullPointerException

# Additional Notes
