### PR TITLE
[Spark] Compute available executor time per stage

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
@@ -338,9 +338,9 @@ public class DatadogSparkListener extends SparkListener {
 
     if (taskEnd.taskMetrics() != null) {
       // Record the runtime in each active stage in order to allocate the available executor time
-      long executorRunTime = taskEnd.taskMetrics().executorRunTime();
+      long taskRunTime = SparkAggregatedTaskMetrics.computeTaskRunTime(taskEnd.taskMetrics());
       for (SparkAggregatedTaskMetrics aggMetrics : stageMetrics.values()) {
-        aggMetrics.recordExecutorRunTime(executorRunTime);
+        aggMetrics.recordTotalTaskRunTime(taskRunTime);
       }
     }
 

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
@@ -116,14 +116,11 @@ public class DatadogSparkListener extends SparkListener {
       applicationSpan.setTag(DDTags.ERROR_STACK, lastJobFailedStackTrace);
     }
 
-    for (SparkListenerExecutorAdded executor : liveExecutors.values()) {
-      availableExecutorTime += (time - executor.time()) * executor.executorInfo().totalCores();
-    }
-
     applicationMetrics.setSpanMetrics(applicationSpan, "spark_application_metrics");
     applicationSpan.setMetric("spark_application_metrics.max_executor_count", maxExecutorCount);
     applicationSpan.setMetric(
-        "spark_application_metrics.available_executor_time", availableExecutorTime);
+        "spark_application_metrics.available_executor_time",
+        computeCurrentAvailableExecutorTime(time));
 
     applicationSpan.finish(time * 1000);
   }
@@ -255,6 +252,11 @@ public class DatadogSparkListener extends SparkListener {
       submissionTimeMs = System.currentTimeMillis();
     }
 
+    long stageSpanKey = stageSpanKey(stageId, stageAttemptId);
+    stageMetrics.put(
+        stageSpanKey,
+        new SparkAggregatedTaskMetrics(computeCurrentAvailableExecutorTime(submissionTimeMs)));
+
     AgentSpan stageSpan =
         buildSparkSpan("spark.stage")
             .asChildOf(jobSpan.context())
@@ -298,6 +300,18 @@ public class DatadogSparkListener extends SparkListener {
 
     stageInfo.rddInfos().foreach(rdd -> span.setTag("rdd." + rdd.name(), rdd.toString()));
 
+    long completionTimeMs;
+    if (stageCompleted.stageInfo().completionTime().isDefined()) {
+      completionTimeMs = (long) stageCompleted.stageInfo().completionTime().get();
+    } else {
+      completionTimeMs = System.currentTimeMillis();
+    }
+
+    long currentAvailableExecutorTime = computeCurrentAvailableExecutorTime(completionTimeMs);
+    for (SparkAggregatedTaskMetrics metric : stageMetrics.values()) {
+      metric.allocateAvailableExecutorTime(currentAvailableExecutorTime);
+    }
+
     SparkAggregatedTaskMetrics stageMetric = stageMetrics.remove(stageSpanKey);
     if (stageMetric != null) {
       stageMetric.setSpanMetrics(span, "spark_stage_metrics");
@@ -308,29 +322,27 @@ public class DatadogSparkListener extends SparkListener {
           .accumulateStageMetrics(stageMetric);
     }
 
-    long completionTimeMs;
-    if (stageCompleted.stageInfo().completionTime().isDefined()) {
-      completionTimeMs = (long) stageCompleted.stageInfo().completionTime().get();
-    } else {
-      completionTimeMs = System.currentTimeMillis();
-    }
-
     span.finish(completionTimeMs * 1000);
   }
 
   @Override
   public void onTaskEnd(SparkListenerTaskEnd taskEnd) {
-    if (jobMetrics.size() > MAX_COLLECTION_SIZE || stageMetrics.size() > MAX_COLLECTION_SIZE) {
-      return;
-    }
-
     int stageId = taskEnd.stageId();
     int stageAttemptId = taskEnd.stageAttemptId();
     long stageSpanKey = stageSpanKey(stageId, stageAttemptId);
 
-    stageMetrics
-        .computeIfAbsent(stageSpanKey, k -> new SparkAggregatedTaskMetrics())
-        .addTaskMetrics(taskEnd);
+    SparkAggregatedTaskMetrics stageMetric = stageMetrics.get(stageSpanKey);
+    if (stageMetric != null) {
+      stageMetric.addTaskMetrics(taskEnd);
+    }
+
+    if (taskEnd.taskMetrics() != null) {
+      // Record the runtime in each active stage in order to allocate the available executor time
+      long executorRunTime = taskEnd.taskMetrics().executorRunTime();
+      for (SparkAggregatedTaskMetrics aggMetrics : stageMetrics.values()) {
+        aggMetrics.recordExecutorRunTime(executorRunTime);
+      }
+    }
 
     // Only sending failing tasks
     if (!(taskEnd.reason() instanceof TaskFailedReason)) {
@@ -453,5 +465,16 @@ public class DatadogSparkListener extends SparkListener {
     }
 
     return errorMessage;
+  }
+
+  private long computeCurrentAvailableExecutorTime(long time) {
+    long currentAvailableExecutorTime = availableExecutorTime;
+
+    for (SparkListenerExecutorAdded executor : liveExecutors.values()) {
+      currentAvailableExecutorTime +=
+          (time - executor.time()) * executor.executorInfo().totalCores();
+    }
+
+    return currentAvailableExecutorTime;
   }
 }

--- a/dd-java-agent/instrumentation/spark/src/test/groovy/SparkListenerTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/test/groovy/SparkListenerTest.groovy
@@ -1,13 +1,28 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.instrumentation.spark.DatadogSparkListener
 import org.apache.spark.SparkConf
+import org.apache.spark.Success$
+import org.apache.spark.executor.TaskMetrics
+import org.apache.spark.scheduler.JobSucceeded$
 import org.apache.spark.scheduler.SparkListenerApplicationEnd
 import org.apache.spark.scheduler.SparkListenerApplicationStart
 import org.apache.spark.scheduler.SparkListenerExecutorAdded
 import org.apache.spark.scheduler.SparkListenerExecutorRemoved
+import org.apache.spark.scheduler.SparkListenerJobEnd
+import org.apache.spark.scheduler.SparkListenerJobStart
+import org.apache.spark.scheduler.SparkListenerStageCompleted
+import org.apache.spark.scheduler.SparkListenerStageSubmitted
+import org.apache.spark.scheduler.SparkListenerTaskEnd
+import org.apache.spark.scheduler.StageInfo
+import org.apache.spark.scheduler.TaskInfo
+import org.apache.spark.scheduler.TaskLocality
 import org.apache.spark.scheduler.cluster.ExecutorInfo
+import org.apache.spark.storage.RDDInfo
 import scala.Option
 import scala.collection.immutable.HashMap
+import scala.collection.immutable.Seq
+
+import scala.collection.JavaConverters
 
 class SparkListenerTest extends AgentTestRunner {
 
@@ -40,6 +55,105 @@ class SparkListenerTest extends AgentTestRunner {
       )
   }
 
+  private jobStartEvent(Integer jobId, Long time, ArrayList<Integer> stageIds) {
+    def stageInfos = stageIds.collect { stageId ->
+      createStageInfo(stageId)
+    }
+
+    return new SparkListenerJobStart(
+      jobId,
+      time,
+      JavaConverters.asScalaBuffer(stageInfos).toSeq(),
+      null
+      )
+  }
+
+  private createStageInfo(Integer stageId) {
+    if (TestSparkComputation.getSparkVersion() < "3") {
+      return new StageInfo(
+        stageId,
+        0,
+        "stage_name",
+        0,
+        JavaConverters.asScalaBuffer([]).toSeq() as Seq<RDDInfo>,
+        JavaConverters.asScalaBuffer([]).toSeq() as Seq<Integer>,
+        "stage_details",
+        null as TaskMetrics,
+        null
+        )
+    }
+
+    return new StageInfo(
+      stageId,
+      0,
+      "stage_name",
+      0,
+      JavaConverters.asScalaBuffer([]).toSeq() as Seq<RDDInfo>,
+      JavaConverters.asScalaBuffer([]).toSeq() as Seq<Integer>,
+      "stage_details",
+      null as TaskMetrics,
+      null,
+      Option.apply(),
+      0,
+      false,
+      0
+      )
+  }
+
+  private jobEndEvent(Integer jobId, Long time) {
+    return new SparkListenerJobEnd(jobId, time, JobSucceeded$.MODULE$)
+  }
+
+  private stageSubmittedEvent(Integer stageId, Long time) {
+    def stageInfo = createStageInfo(stageId)
+    stageInfo.submissionTime = Option.apply(time)
+
+    return new SparkListenerStageSubmitted(stageInfo, null)
+  }
+
+  private stageCompletedEvent(Integer stageId, Long time) {
+    def stageInfo = createStageInfo(stageId)
+    stageInfo.completionTime = Option.apply(time)
+    return new SparkListenerStageCompleted(stageInfo)
+  }
+
+  private taskEndEvent(Integer stageId, Long launchTime, Long runTime) {
+    def taskInfo = new TaskInfo(
+      0,
+      0,
+      0,
+      launchTime,
+      "some_executor_id",
+      "some_host",
+      TaskLocality.PROCESS_LOCAL(),
+      false
+      )
+
+    def taskMetrics = new TaskMetrics()
+    taskMetrics.setExecutorRunTime(runTime)
+
+    if (TestSparkComputation.getSparkVersion() < "3") {
+      return new SparkListenerTaskEnd(
+        stageId,
+        0,
+        "task_type",
+        Success$.MODULE$,
+        taskInfo,
+        taskMetrics
+        )
+    }
+
+    return new SparkListenerTaskEnd(
+      stageId,
+      0,
+      "task_type",
+      Success$.MODULE$,
+      taskInfo,
+      null,
+      taskMetrics
+      )
+  }
+
   private executorAddedEvent(time=0L, executorId="executor-0", totalCores=0) {
     new SparkListenerExecutorAdded(
       time,
@@ -60,7 +174,7 @@ class SparkListenerTest extends AgentTestRunner {
       )
   }
 
-  def "compute available executor time"() {
+  def "compute available executor time for the whole application"() {
     setup:
     def listener = getTestDatadogSparkListener()
 
@@ -80,6 +194,88 @@ class SparkListenerTest extends AgentTestRunner {
           operationName "spark.application"
           spanType "spark"
           assert span.tags["spark_application_metrics.available_executor_time"] == expectedExecutorTime
+        }
+      }
+    }
+  }
+
+  def "compute available executor time for each stage and job"() {
+    setup:
+    def listener = getTestDatadogSparkListener()
+    listener.onApplicationStart(applicationStartEvent(1000L))
+
+    listener.onExecutorAdded(executorAddedEvent(1100L, "executor-1", 4))
+    listener.onJobStart(jobStartEvent(1, 2000L, [1, 2, 3]))
+    listener.onStageSubmitted(stageSubmittedEvent(1, 2000L))
+    listener.onTaskEnd(taskEndEvent(1, 2000L, 100L))
+    listener.onStageCompleted(stageCompletedEvent(1, 2100L))
+
+    listener.onStageSubmitted(stageSubmittedEvent(2, 2100L))
+    listener.onStageSubmitted(stageSubmittedEvent(3, 2100L))
+
+    listener.onTaskEnd(taskEndEvent(2, 2100L, 500L))
+    listener.onTaskEnd(taskEndEvent(2, 2100L, 500L))
+    listener.onTaskEnd(taskEndEvent(3, 2100L, 500L))
+    listener.onTaskEnd(taskEndEvent(3, 2100L, 500L))
+
+    listener.onStageCompleted(stageCompletedEvent(2, 2600L))
+
+    listener.onTaskEnd(taskEndEvent(3, 2600L, 400L))
+    listener.onTaskEnd(taskEndEvent(3, 2600L, 500L))
+
+    listener.onStageCompleted(stageCompletedEvent(3, 3100L))
+
+    listener.onJobEnd(jobEndEvent(1, 3100L))
+    listener.onApplicationEnd(new SparkListenerApplicationEnd(3100L))
+
+    expect:
+    /*
+     This spark application is composed of one executor of 4 cores available during 2000 units of time.
+     The test is generating the following scenario where each character represents 100 units of time
+     of a core, that can be executing a task of the corresponding stage id or be idle
+     Core1: .........12222233333
+     Core2: ..........222223333.
+     Core3: ..........33333.....
+     Core4: ..........33333.....
+     */
+    assertTraces(1) {
+      trace(5) {
+        span {
+          operationName "spark.application"
+          assert span.tags["spark_application_metrics.available_executor_time"] == 8000L
+          assert span.tags["spark_application_metrics.executor_run_time"] == 3000L
+          spanType "spark"
+        }
+        span {
+          operationName "spark.job"
+          assert span.tags["spark_job_metrics.available_executor_time"] == 4400L
+          assert span.tags["spark_job_metrics.executor_run_time"] == 3000L
+          spanType "spark"
+          childOf(span(0))
+        }
+        span {
+          operationName "spark.stage"
+          assert span.tags["stage_id"] == 3
+          assert span.tags["spark_stage_metrics.available_executor_time"] == 3000L
+          assert span.tags["spark_stage_metrics.executor_run_time"] == 1900L
+          spanType "spark"
+          childOf(span(1))
+        }
+        span {
+          operationName "spark.stage"
+          assert span.tags["stage_id"] == 2
+          assert span.tags["spark_stage_metrics.available_executor_time"] == 1000L
+          assert span.tags["spark_stage_metrics.executor_run_time"] == 1000L
+          spanType "spark"
+          childOf(span(1))
+        }
+        span {
+          operationName "spark.stage"
+          assert span.tags["stage_id"] == 1
+          assert span.tags["spark_stage_metrics.available_executor_time"] == 400L
+          assert span.tags["spark_stage_metrics.executor_run_time"] == 100L
+          spanType "spark"
+          childOf(span(1))
         }
       }
     }


### PR DESCRIPTION
# What Does This Do

The available executor time is defined as `sum(executor uptime * number of cores)` it is already computed for the whole spark application

This PR introduce the computation to attribute it for each stage
- when only one stage is running, the executor time of the full executor time is attributed to the stage
- when multiple stages are running at the same time, the executor time attribution is weighted by the run time of each stage 

![executor_time_attribution](https://github.com/DataDog/dd-trace-java/assets/99249445/749f3495-4393-4e1b-9176-d872149d2012)