### PR TITLE
Fix Collection/Map serialization

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
@@ -402,14 +402,14 @@ public class MoshiSnapshotHelper {
       }
 
       @Override
-      public void mapEpilogue(Map<?, ?> map, boolean isComplete) throws Exception {
+      public void mapEpilogue(boolean isComplete, int size) throws Exception {
         jsonWriter.endArray();
         if (!isComplete) {
           jsonWriter.name(NOT_CAPTURED_REASON);
           jsonWriter.value(COLLECTION_SIZE_REASON);
         }
         jsonWriter.name(SIZE);
-        jsonWriter.value(String.valueOf(map.size()));
+        jsonWriter.value(String.valueOf(size));
       }
 
       @Override
@@ -425,6 +425,7 @@ public class MoshiSnapshotHelper {
 
       @Override
       public void handleFieldException(Exception ex, Field field) {
+        LOG.debug("Exception when extracting field={}", field.getName(), ex);
         String fieldName = field.getName();
         try {
           jsonWriter.name(fieldName);
@@ -468,6 +469,12 @@ public class MoshiSnapshotHelper {
           default:
             throw new RuntimeException("Unsupported NotCapturedReason: " + reason);
         }
+      }
+
+      @Override
+      public void notCaptured(String reason) throws Exception {
+        jsonWriter.name(NOT_CAPTURED_REASON);
+        jsonWriter.value(reason);
       }
     }
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/StringTokenWriter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/StringTokenWriter.java
@@ -109,7 +109,7 @@ public class StringTokenWriter implements SerializerWithLimits.TokenWriter {
   }
 
   @Override
-  public void mapEpilogue(Map<?, ?> map, boolean isComplete) {
+  public void mapEpilogue(boolean isComplete, int size) {
     sb.append(isComplete ? "}" : ", ...}");
     inCollection = false;
   }
@@ -158,5 +158,10 @@ public class StringTokenWriter implements SerializerWithLimits.TokenWriter {
       default:
         throw new RuntimeException("Unsupported NotCapturedReason: " + reason);
     }
+  }
+
+  @Override
+  public void notCaptured(String reason) throws Exception {
+    sb.append("(Error: ").append(reason).append(")");
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
@@ -723,7 +723,7 @@ public class SnapshotSerializationTest {
     JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
     Snapshot snapshot = createSnapshot();
     CapturedContext context = new CapturedContext();
-    CapturedContext.CapturedValue mapField =
+    CapturedContext.CapturedValue listField =
         CapturedContext.CapturedValue.of(
             "listField",
             List.class.getTypeName(),
@@ -733,7 +733,7 @@ public class SnapshotSerializationTest {
                 throw new UnsupportedOperationException();
               }
             });
-    context.addFields(new CapturedContext.CapturedValue[] {mapField});
+    context.addFields(new CapturedContext.CapturedValue[] {listField});
     snapshot.setExit(context);
     String buffer = adapter.toJson(snapshot);
     System.out.println(buffer);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/MoshiSnapshotTestHelper.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/MoshiSnapshotTestHelper.java
@@ -178,6 +178,11 @@ public class MoshiSnapshotTestHelper {
               capturedContext.addFields(fromJsonCapturedValues(jsonReader));
               break;
             }
+          case NOT_CAPTURED_REASON:
+            {
+              jsonReader.nextString();
+              break;
+            }
           default:
             throw new IllegalArgumentException("Unknown field name for 'this' object: " + name);
         }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/StringTokenWriterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/StringTokenWriterTest.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.Test;
 
@@ -95,6 +96,32 @@ class StringTokenWriterTest {
     String serializedStr = serializeValue(map, Limits.DEFAULT);
     assertTrue(serializedStr.contains("[foo1=bar1]"));
     assertTrue(serializedStr.contains("[null=null]"));
+  }
+
+  @Test
+  public void arrayListSizeThrows() throws Exception {
+    class MyArrayList<T> extends ArrayList<T> {
+      @Override
+      public int size() {
+        throw new UnsupportedOperationException("size");
+      }
+    }
+    assertEquals(
+        "[](Error: java.lang.UnsupportedOperationException: size)",
+        serializeValue(new MyArrayList<>(), Limits.DEFAULT));
+  }
+
+  @Test
+  public void entrySetThrows() throws Exception {
+    class MyMap<K, V> extends HashMap<K, V> {
+      @Override
+      public Set<Entry<K, V>> entrySet() {
+        throw new UnsupportedOperationException("entrySet");
+      }
+    }
+    assertEquals(
+        "{}(Error: java.lang.UnsupportedOperationException: entrySet)",
+        serializeValue(new MyMap<String, String>(), Limits.DEFAULT));
   }
 
   static class Person {


### PR DESCRIPTION

# What Does This Do
Catch exception and report it safely into the snapshot

# Motivation
Some implementation of collections or maps may throw exceptions in somce situations which can happen during our serialization process 


# Additional Notes
