### PR TITLE
Avoid having infinite recursive loop serialization

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
@@ -12,15 +12,12 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Stores different kind of data (arguments, locals, fields, exception) for a specific location */
 public class CapturedContext implements ValueReferenceResolver {
   public static final CapturedContext EMPTY_CONTEXT = new CapturedContext(null);
   public static final CapturedContext EMPTY_CAPTURING_CONTEXT =
       new CapturedContext(ProbeImplementation.UNKNOWN);
-  private static final Logger LOGGER = LoggerFactory.getLogger(CapturedContext.class);
   private final transient Map<String, Object> extensions = new HashMap<>();
 
   private Map<String, CapturedValue> arguments;

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
@@ -12,12 +12,15 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Stores different kind of data (arguments, locals, fields, exception) for a specific location */
 public class CapturedContext implements ValueReferenceResolver {
   public static final CapturedContext EMPTY_CONTEXT = new CapturedContext(null);
   public static final CapturedContext EMPTY_CAPTURING_CONTEXT =
       new CapturedContext(ProbeImplementation.UNKNOWN);
+  private static final Logger LOGGER = LoggerFactory.getLogger(CapturedContext.class);
   private final transient Map<String, Object> extensions = new HashMap<>();
 
   private Map<String, CapturedValue> arguments;
@@ -72,6 +75,7 @@ public class CapturedContext implements ValueReferenceResolver {
     for (Status status : statusByProbeId.values()) {
       result |= status.isCapturing();
     }
+    result = result && DebuggerContext.checkAndSetInProbe();
     return result;
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
@@ -248,6 +248,14 @@ public class CapturedContextInstrumentor extends Instrumentor {
     LabelNode handlerLabel = new LabelNode();
     InsnList handler = new InsnList();
     handler.add(handlerLabel);
+    // stack [exception]
+    handler.add(new VarInsnNode(Opcodes.ALOAD, entryContextVar));
+    // stack [exception, capturedcontext]
+    LabelNode targetNode = new LabelNode();
+    invokeVirtual(handler, CAPTURED_CONTEXT_TYPE, "isCapturing", BOOLEAN_TYPE);
+    // stack [exception, boolean]
+    handler.add(new JumpInsnNode(Opcodes.IFEQ, targetNode));
+    // stack [exception]
     handler.add(collectCapturedContext(Snapshot.Kind.UNHANDLED_EXCEPTION, endLabel));
     // stack: [exception, capturedcontext]
     ldc(handler, Type.getObjectType(classNode.name));
@@ -272,6 +280,7 @@ public class CapturedContextInstrumentor extends Instrumentor {
     invokeStatic(handler, DEBUGGER_CONTEXT_TYPE, "disableInProbe", VOID_TYPE);
     // stack [exception]
     handler.add(commit());
+    handler.add(targetNode);
     // stack [exception]
     handler.add(new InsnNode(Opcodes.ATHROW));
     // stack: []

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
@@ -55,6 +55,7 @@ public class CapturedContextInstrumentor extends Instrumentor {
   private int exitContextVar = -1;
   private int timestampStartVar = -1;
   private int throwableListVar = -1;
+  private final List<FinallyBlock> finallyBlocks = new ArrayList<>();
 
   public CapturedContextInstrumentor(
       ProbeDefinition definition,
@@ -80,6 +81,15 @@ public class CapturedContextInstrumentor extends Instrumentor {
       instrumentTryCatchHandlers();
       processInstructions();
       addFinallyHandler(returnHandlerLabel);
+    }
+    installFinallyBlocks();
+  }
+
+  private void installFinallyBlocks() {
+    for (FinallyBlock finallyBlock : finallyBlocks) {
+      methodNode.tryCatchBlocks.add(
+          new TryCatchBlockNode(
+              finallyBlock.startLabel, finallyBlock.endLabel, finallyBlock.handlerLabel, null));
     }
   }
 
@@ -118,6 +128,8 @@ public class CapturedContextInstrumentor extends Instrumentor {
         // stack [boolean]
         LabelNode targetNode = new LabelNode();
         insnList.add(new JumpInsnNode(Opcodes.IFEQ, targetNode));
+        LabelNode inProbeStartLabel = new LabelNode();
+        insnList.add(inProbeStartLabel);
         // stack []
         insnList.add(collectCapturedContext(Snapshot.Kind.BEFORE, beforeLabel));
         // stack [capturedcontext]
@@ -137,6 +149,10 @@ public class CapturedContextInstrumentor extends Instrumentor {
             INT_TYPE,
             STRING_ARRAY_TYPE);
         // stack []
+        invokeStatic(insnList, DEBUGGER_CONTEXT_TYPE, "disableInProbe", VOID_TYPE);
+        LabelNode inProbeEndLabel = new LabelNode();
+        insnList.add(inProbeEndLabel);
+        createInProbeFinallyHandler(inProbeStartLabel, inProbeEndLabel);
         insnList.add(targetNode);
         methodNode.instructions.insertBefore(beforeLabel.getNext(), insnList);
       }
@@ -180,6 +196,7 @@ public class CapturedContextInstrumentor extends Instrumentor {
         METHOD_LOCATION_TYPE,
         STRING_ARRAY_TYPE);
     // stack [ret_value]
+    invokeStatic(insnList, DEBUGGER_CONTEXT_TYPE, "disableInProbe", VOID_TYPE);
     insnList.add(new JumpInsnNode(Opcodes.GOTO, gotoNode));
     insnList.add(targetNode);
     getStatic(insnList, CAPTURED_CONTEXT_TYPE, "EMPTY_CONTEXT");
@@ -252,13 +269,14 @@ public class CapturedContextInstrumentor extends Instrumentor {
         METHOD_LOCATION_TYPE,
         STRING_ARRAY_TYPE);
     // stack [exception]
+    invokeStatic(handler, DEBUGGER_CONTEXT_TYPE, "disableInProbe", VOID_TYPE);
+    // stack [exception]
     handler.add(commit());
     // stack [exception]
     handler.add(new InsnNode(Opcodes.ATHROW));
     // stack: []
     methodNode.instructions.add(handler);
-    methodNode.tryCatchBlocks.add(
-        new TryCatchBlockNode(contextInitLabel, endLabel, handlerLabel, null));
+    finallyBlocks.add(new FinallyBlock(contextInitLabel, endLabel, handlerLabel));
   }
 
   private void instrumentMethodEnter() {
@@ -272,50 +290,65 @@ public class CapturedContextInstrumentor extends Instrumentor {
     insnList.add(contextInitLabel);
     if (definition.getEvaluateAt() == MethodLocation.EXIT) {
       // if evaluation is at exit, skip collecting data at enter
-    } else {
-      pushProbesIds(insnList);
-      // stack [array]
-      invokeStatic(
-          insnList,
-          DEBUGGER_CONTEXT_TYPE,
-          "isReadyToCapture",
-          Type.BOOLEAN_TYPE,
-          STRING_ARRAY_TYPE);
-      // stack [boolean]
-      LabelNode targetNode = new LabelNode();
-      LabelNode gotoNode = new LabelNode();
-      insnList.add(new JumpInsnNode(Opcodes.IFEQ, targetNode));
-      // stack []
-      insnList.add(collectCapturedContext(Snapshot.Kind.ENTER, null));
-      // stack [capturedcontext]
-      ldc(insnList, Type.getObjectType(classNode.name));
-      // stack [capturedcontext, class]
-      ldc(insnList, -1L);
-      // stack [capturedcontext, class, long]
-      getStatic(insnList, METHOD_LOCATION_TYPE, "ENTRY");
-      // stack [capturedcontext, class, long, methodlocation]
-      pushProbesIds(insnList);
-      // stack [capturedcontext, class, long, methodlocation, array]
-      invokeStatic(
-          insnList,
-          DEBUGGER_CONTEXT_TYPE,
-          "evalContext",
-          VOID_TYPE,
-          CAPTURED_CONTEXT_TYPE,
-          CLASS_TYPE,
-          LONG_TYPE,
-          METHOD_LOCATION_TYPE,
-          STRING_ARRAY_TYPE);
-      // stack []
-      insnList.add(new JumpInsnNode(Opcodes.GOTO, gotoNode));
-      insnList.add(targetNode);
-      getStatic(insnList, CAPTURED_CONTEXT_TYPE, "EMPTY_CONTEXT");
-      // stack [capturedcontext]
-      insnList.add(new VarInsnNode(Opcodes.ASTORE, entryContextVar));
-      // stack []
-      insnList.add(gotoNode);
+      methodNode.instructions.insert(methodEnterLabel, insnList);
+      return;
     }
+    pushProbesIds(insnList);
+    // stack [array]
+    invokeStatic(
+        insnList, DEBUGGER_CONTEXT_TYPE, "isReadyToCapture", Type.BOOLEAN_TYPE, STRING_ARRAY_TYPE);
+    // stack [boolean]
+    LabelNode targetNode = new LabelNode();
+    LabelNode gotoNode = new LabelNode();
+    insnList.add(new JumpInsnNode(Opcodes.IFEQ, targetNode));
+    LabelNode inProbeStartLabel = new LabelNode();
+    insnList.add(inProbeStartLabel);
+    // stack []
+    insnList.add(collectCapturedContext(Snapshot.Kind.ENTER, null));
+    // stack [capturedcontext]
+    ldc(insnList, Type.getObjectType(classNode.name));
+    // stack [capturedcontext, class]
+    ldc(insnList, -1L);
+    // stack [capturedcontext, class, long]
+    getStatic(insnList, METHOD_LOCATION_TYPE, "ENTRY");
+    // stack [capturedcontext, class, long, methodlocation]
+    pushProbesIds(insnList);
+    // stack [capturedcontext, class, long, methodlocation, array]
+    invokeStatic(
+        insnList,
+        DEBUGGER_CONTEXT_TYPE,
+        "evalContext",
+        VOID_TYPE,
+        CAPTURED_CONTEXT_TYPE,
+        CLASS_TYPE,
+        LONG_TYPE,
+        METHOD_LOCATION_TYPE,
+        STRING_ARRAY_TYPE);
+    invokeStatic(insnList, DEBUGGER_CONTEXT_TYPE, "disableInProbe", VOID_TYPE);
+    LabelNode inProbeEndLabel = new LabelNode();
+    insnList.add(inProbeEndLabel);
+    // stack []
+    insnList.add(new JumpInsnNode(Opcodes.GOTO, gotoNode));
+    insnList.add(targetNode);
+    getStatic(insnList, CAPTURED_CONTEXT_TYPE, "EMPTY_CONTEXT");
+    // stack [capturedcontext]
+    insnList.add(new VarInsnNode(Opcodes.ASTORE, entryContextVar));
+    // stack []
+    insnList.add(gotoNode);
     methodNode.instructions.insert(methodEnterLabel, insnList);
+    createInProbeFinallyHandler(inProbeStartLabel, inProbeEndLabel);
+  }
+
+  private void createInProbeFinallyHandler(LabelNode inProbeStartLabel, LabelNode inProbeEndLabel) {
+    LabelNode handlerLabel = new LabelNode();
+    InsnList handler = new InsnList();
+    handler.add(handlerLabel);
+    // stack [exception]
+    invokeStatic(handler, DEBUGGER_CONTEXT_TYPE, "disableInProbe", VOID_TYPE);
+    // stack [exception]
+    handler.add(new InsnNode(Opcodes.ATHROW));
+    methodNode.instructions.add(handler);
+    finallyBlocks.add(new FinallyBlock(inProbeStartLabel, inProbeEndLabel, handlerLabel));
   }
 
   private void pushProbesIds(InsnList insnList) {
@@ -851,5 +884,17 @@ public class CapturedContextInstrumentor extends Instrumentor {
 
   private static void newInstance(InsnList insnList, Type type) {
     insnList.add(new TypeInsnNode(Opcodes.NEW, type.getInternalName()));
+  }
+
+  private static class FinallyBlock {
+    final LabelNode startLabel;
+    final LabelNode endLabel;
+    final LabelNode handlerLabel;
+
+    public FinallyBlock(LabelNode startLabel, LabelNode endLabel, LabelNode handlerLabel) {
+      this.startLabel = startLabel;
+      this.endLabel = endLabel;
+      this.handlerLabel = handlerLabel;
+    }
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -83,6 +83,7 @@ public class CapturedSnapshotTest {
       instr.removeTransformer(currentTransformer);
     }
     ProbeRateLimiter.resetGlobalRate();
+    Assertions.assertFalse(DebuggerContext.isInProbe());
   }
 
   @Test
@@ -1388,6 +1389,17 @@ public class CapturedSnapshotTest {
     assertTrue(arguments.containsKey("this"));
     assertTrue(arguments.containsKey("p1")); // this the hidden ordinal arg of an enum
     assertTrue(arguments.containsKey("strValue"));
+  }
+
+  @Test
+  public void recursiveCapture() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot24";
+    final String INNER_CLASS = CLASS_NAME + "$Holder";
+    DebuggerTransformerTest.TestSnapshotListener listener =
+        installProbes(INNER_CLASS, createProbe(PROBE_ID, INNER_CLASS, "size", null));
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "2").get();
+    Assertions.assertEquals(1, result);
   }
 
   private DebuggerTransformerTest.TestSnapshotListener setupInstrumentTheWorldTransformer(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1398,8 +1398,23 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener =
         installProbes(INNER_CLASS, createProbe(PROBE_ID, INNER_CLASS, "size", null));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
-    int result = Reflect.on(testClass).call("main", "2").get();
+    int result = Reflect.on(testClass).call("main", "").get();
     Assertions.assertEquals(1, result);
+  }
+
+  @Test
+  public void recursiveCaptureException() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot24";
+    final String INNER_CLASS = CLASS_NAME + "$HolderWithException";
+    DebuggerTransformerTest.TestSnapshotListener listener =
+        installProbes(INNER_CLASS, createProbe(PROBE_ID, INNER_CLASS, "size", null));
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    try {
+      Reflect.on(testClass).call("main", "exception").get();
+      Assertions.fail("should not reach this code");
+    } catch (ReflectException ex) {
+      Assertions.assertEquals("not supported", ex.getCause().getCause().getMessage());
+    }
   }
 
   private DebuggerTransformerTest.TestSnapshotListener setupInstrumentTheWorldTransformer(

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot24.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot24.java
@@ -1,0 +1,34 @@
+package com.datadog.debugger;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+
+public class CapturedSnapshot24 {
+
+  private Holder<String> holder = new Holder<>(this);
+
+  public static int main(String arg) {
+    CapturedSnapshot24 cs24 = new CapturedSnapshot24();
+    return cs24.doit(arg);
+  }
+
+  private int doit(String arg) {
+    holder.add("foo");
+    return holder.size();
+  }
+
+  static class Holder<T> extends ArrayList<T> {
+    private final CapturedSnapshot24 capturedSnapshot24;
+
+    public Holder(CapturedSnapshot24 capturedSnapshot24) {
+      this.capturedSnapshot24 = capturedSnapshot24;
+    }
+
+    @Override
+    public int size() {
+      return super.size();
+    }
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot24.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot24.java
@@ -8,15 +8,24 @@ import java.util.HashSet;
 public class CapturedSnapshot24 {
 
   private Holder<String> holder = new Holder<>(this);
+  private HolderWithException<String> holderWithException = new HolderWithException<>(this);
 
   public static int main(String arg) {
     CapturedSnapshot24 cs24 = new CapturedSnapshot24();
+    if ("exception".equals(arg)) {
+      return cs24.doItException(arg);
+    }
     return cs24.doit(arg);
   }
 
   private int doit(String arg) {
     holder.add("foo");
     return holder.size();
+  }
+
+  private int doItException(String arg) {
+    holderWithException.add("foo");
+    return holderWithException.size();
   }
 
   static class Holder<T> extends ArrayList<T> {
@@ -29,6 +38,19 @@ public class CapturedSnapshot24 {
     @Override
     public int size() {
       return super.size();
+    }
+  }
+
+  static class HolderWithException<T> extends ArrayList<T> {
+    private final CapturedSnapshot24 capturedSnapshot24;
+
+    public HolderWithException(CapturedSnapshot24 capturedSnapshot24) {
+      this.capturedSnapshot24 = capturedSnapshot24;
+    }
+
+    @Override
+    public int size() {
+      throw new UnsupportedOperationException("not supported");
     }
   }
 }


### PR DESCRIPTION
# What Does This Do
 Use a ThreadLocal storage for a boolean to avoid it.
# Motivation
in some case serialization can enter in an infinite loop
# Additional Notes
only support log/snapshot probes, will support other kind of probe later