### PR TITLE
Fix spark flaky test

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/test/groovy/SparkTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/test/groovy/SparkTest.groovy
@@ -113,6 +113,7 @@ class SparkTest extends AgentTestRunner {
     }
     catch (Exception ignored) {}
 
+    blockUntilChildSpansFinished(3)
     sparkSession.stop()
 
     expect:


### PR DESCRIPTION
# What Does This Do

The order in which spark is generating the spans is not deterministic, leading to flakiness in the `generate error tags in failed spans` test

Using `blockUntilChildSpansFinished` to finish the spans in a deterministic order
