### PR TITLE
Apply APM tracing overrides from remote-config

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/TracerInstaller.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/TracerInstaller.java
@@ -21,6 +21,7 @@ public class TracerInstaller {
             CoreTracer.builder()
                 .sharedCommunicationObjects(sharedCommunicationObjects)
                 .profilingContextIntegration(profilingContextIntegration)
+                .pollForTracingConfiguration()
                 .build());
       } else {
         log.debug("GlobalTracer already registered.");

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -141,6 +141,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   /** Nanosecond offset to counter clock drift */
   private volatile long counterDrift;
 
+  private final TracingConfigPoller tracingConfigPoller;
+
   private final PendingTraceBuffer pendingTraceBuffer;
 
   /** Default service name if none provided on the trace or span */
@@ -267,6 +269,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     private DataStreamsMonitoring dataStreamsMonitoring;
     private ProfilingContextIntegration profilingContextIntegration =
         ProfilingContextIntegration.NoOp.INSTANCE;
+    private boolean pollForTracingConfiguration;
 
     public CoreTracerBuilder serviceName(String serviceName) {
       this.serviceName = serviceName;
@@ -385,6 +388,11 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       return this;
     }
 
+    public CoreTracerBuilder pollForTracingConfiguration() {
+      this.pollForTracingConfiguration = true;
+      return this;
+    }
+
     public CoreTracerBuilder() {
       // Apply the default values from config.
       config(Config.get());
@@ -442,7 +450,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
           instrumentationGateway,
           timeSource,
           dataStreamsMonitoring,
-          profilingContextIntegration);
+          profilingContextIntegration,
+          pollForTracingConfiguration);
     }
   }
 
@@ -470,7 +479,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       final InstrumentationGateway instrumentationGateway,
       final TimeSource timeSource,
       final DataStreamsMonitoring dataStreamsMonitoring,
-      final ProfilingContextIntegration profilingContextIntegration) {
+      final ProfilingContextIntegration profilingContextIntegration,
+      final boolean pollForTracingConfiguration) {
 
     assert localRootSpanTags != null;
     assert defaultSpanTags != null;
@@ -553,6 +563,11 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     }
     sharedCommunicationObjects.monitoring = monitoring;
     sharedCommunicationObjects.createRemaining(config);
+
+    tracingConfigPoller = new TracingConfigPoller(dynamicConfig);
+    if (pollForTracingConfiguration) {
+      tracingConfigPoller.start(config, sharedCommunicationObjects);
+    }
 
     if (writer == null) {
       this.writer =
@@ -1127,6 +1142,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
   @Override
   public void close() {
+    tracingConfigPoller.stop();
     pendingTraceBuffer.close();
     writer.close();
     statsDClient.close();

--- a/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
@@ -1,0 +1,119 @@
+package datadog.trace.core;
+
+import static datadog.trace.api.config.TracerConfig.HEADER_TAGS;
+import static datadog.trace.api.config.TracerConfig.SERVICE_MAPPING;
+
+import com.squareup.moshi.Json;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+import datadog.communication.ddagent.SharedCommunicationObjects;
+import datadog.remoteconfig.ConfigurationChangesListener.PollingRateHinter;
+import datadog.remoteconfig.ConfigurationPoller;
+import datadog.remoteconfig.Product;
+import datadog.remoteconfig.state.ParsedConfigKey;
+import datadog.remoteconfig.state.ProductListener;
+import datadog.trace.api.Config;
+import datadog.trace.api.DynamicConfig;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.Consumer;
+import okio.Okio;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class TracingConfigPoller {
+  private static final Logger log = LoggerFactory.getLogger(TracingConfigPoller.class);
+
+  private final DynamicConfig dynamicConfig;
+
+  private Runnable stopPolling;
+
+  public TracingConfigPoller(DynamicConfig dynamicConfig) {
+    this.dynamicConfig = dynamicConfig;
+  }
+
+  public void start(Config config, SharedCommunicationObjects sco) {
+    stopPolling = new Updater().register(config, sco);
+  }
+
+  public void stop() {
+    if (null != stopPolling) {
+      stopPolling.run();
+    }
+  }
+
+  final class Updater implements ProductListener {
+    private static final String CONFIG_OVERRIDES = "config_overrides";
+
+    private final Moshi MOSHI = new Moshi.Builder().build();
+
+    private final JsonAdapter<ConfigOverrides> CONFIG_OVERRIDES_ADAPTER =
+        MOSHI.adapter(ConfigOverrides.class);
+
+    public Runnable register(Config config, SharedCommunicationObjects sco) {
+      ConfigurationPoller poller = sco.configurationPoller(config);
+      if (null != poller) {
+        poller.addListener(Product.APM_TRACING, this);
+        return poller::stop;
+      } else {
+        return null;
+      }
+    }
+
+    @Override
+    public void accept(ParsedConfigKey configKey, byte[] content, PollingRateHinter hinter)
+        throws IOException {
+      if (CONFIG_OVERRIDES.equals(configKey.getConfigId())) {
+
+        ConfigOverrides overrides =
+            CONFIG_OVERRIDES_ADAPTER.fromJson(
+                Okio.buffer(Okio.source(new ByteArrayInputStream(content))));
+
+        if (null != overrides) {
+          applyConfigOverrides(overrides);
+        } else {
+          removeConfigOverrides();
+        }
+      }
+    }
+
+    @Override
+    public void remove(ParsedConfigKey configKey, PollingRateHinter hinter) {
+      if (CONFIG_OVERRIDES.equals(configKey.getConfigId())) {
+        removeConfigOverrides();
+      }
+    }
+
+    @Override
+    public void commit(PollingRateHinter hinter) {}
+  }
+
+  void applyConfigOverrides(ConfigOverrides overrides) {
+    DynamicConfig.Builder builder = dynamicConfig.initial();
+    maybeOverride(builder::setServiceMapping, overrides.serviceMapping, SERVICE_MAPPING);
+    maybeOverride(builder::setTaggedHeaders, overrides.taggedHeaders, HEADER_TAGS);
+    builder.apply();
+    log.debug("Applied APM_TRACING overrides");
+  }
+
+  void removeConfigOverrides() {
+    dynamicConfig.resetTraceConfig();
+    log.debug("Removed APM_TRACING overrides");
+  }
+
+  private <T> void maybeOverride(Consumer<T> setter, T override, String key) {
+    if (null != override) {
+      setter.accept(override);
+      log.debug("Overriding dd.{} with {}", key, override);
+    }
+  }
+
+  static final class ConfigOverrides {
+    @Json(name = "tracing_service_mapping")
+    public Map<String, String> serviceMapping;
+
+    @Json(name = "tracing_header_tags")
+    public Map<String, String> taggedHeaders;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
@@ -8,12 +8,13 @@ import java.util.Map;
 
 /** Manages dynamic configuration for a particular {@link Tracer} instance. */
 public final class DynamicConfig {
+  private State initialState;
   private volatile State currentState;
 
   private DynamicConfig() {}
 
   public static Builder create() {
-    return new DynamicConfig().prepare();
+    return new DynamicConfig().initial();
   }
 
   /** Captures a snapshot of the configuration at the start of a trace. */
@@ -21,8 +22,19 @@ public final class DynamicConfig {
     return currentState;
   }
 
-  public Builder prepare() {
+  /** Start building a new configuration based on its initial state. */
+  public Builder initial() {
+    return new Builder(initialState);
+  }
+
+  /** Start building a new configuration based on its current state. */
+  public Builder current() {
     return new Builder(currentState);
+  }
+
+  /** Reset the configuration to its initial state. */
+  public void resetTraceConfig() {
+    currentState = initialState;
   }
 
   public final class Builder {
@@ -77,7 +89,10 @@ public final class DynamicConfig {
 
     /** Overwrites the current configuration with a new snapshot. */
     public DynamicConfig apply() {
-      DynamicConfig.this.currentState = new State(this);
+      currentState = new State(this);
+      if (null == initialState) {
+        initialState = currentState; // captured when constructing the dynamic config
+      }
       return DynamicConfig.this;
     }
   }

--- a/remote-config/src/main/java/datadog/remoteconfig/Product.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/Product.java
@@ -2,6 +2,7 @@ package datadog.remoteconfig;
 
 /* The order of these products is the same as the order in which they're processed */
 public enum Product {
+  APM_TRACING,
   LIVE_DEBUGGING,
   ASM_DD,
   ASM,


### PR DESCRIPTION
# Additional Notes

Activation of remote-config's shared poller now occurs earlier than before, because it is now activated when installing the tracer rather than when setting up AppSec (note the remote-config poller is used even when AppSec is inactive, to allow users to fully activate AppSec.) This shows up in the benchmarks below where the `GlobalTracer` phase has increased by ~50ms while the `AppSec` phase has decreased by the same amount. The overall startup time however has remained the same.