### PR TITLE
do not set error status on server spans when the user sets manually

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -291,7 +291,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
     // XXX: the logic is questionable: span.error becomes equivalent to status 5xx,
     // even if the server chooses not to respond with 5xx to an error.
     // Anyway, we def don't want it applied to blocked requests
-    if (!BlockingException.class.getName().equals(span.getTag("error.type"))) {
+    if (!BlockingException.class.getName().equals(span.getTag("error.type")) && !span.isError()) {
       span.setError(SERVER_ERROR_STATUSES.get(status));
     }
 

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
@@ -303,7 +303,10 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
       1 * this.span.setHttpStatusCode(status)
     }
     if (resp) {
-      1 * this.span.setError(error)
+      1 * this.span.isError() >> userErrored
+      if (!userErrored) {
+        1 * this.span.setError(error)
+      }
     }
     if (status == 404) {
       1 * this.span.setResourceName({ it as String == "404" }, ResourceNamePriorities.HTTP_404)
@@ -315,17 +318,17 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
     0 * _
 
     where:
-    status | resp           | error
-    200    | [status: 200]  | false
-    399    | [status: 399]  | false
-    400    | [status: 400]  | false
-    404    | [status: 404]  | false
-    404    | [status: 404]  | false
-    499    | [status: 499]  | false
-    500    | [status: 500]  | true
-    600    | [status: 600]  | false
-    null   | [status: null] | false
-    null   | null           | false
+    status | resp           | error | userErrored
+    200    | [status: 200]  | false | false
+    399    | [status: 399]  | false | false
+    400    | [status: 400]  | false | false
+    404    | [status: 404]  | true  | true
+    404    | [status: 404]  | false | false
+    499    | [status: 499]  | false | false
+    500    | [status: 500]  | true  | false
+    600    | [status: 600]  | false | false
+    null   | [status: null] | false | false
+    null   | null           | false | false
   }
 
   @Override

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowTest.groovy
@@ -190,6 +190,11 @@ class UndertowTest extends HttpServerTest<Undertow> {
   }
 
   @Override
+  boolean testBadUrl() {
+    false
+  }
+
+  @Override
   boolean testBlocking() {
     true
   }

--- a/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowDispatcherTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowDispatcherTest.groovy
@@ -163,6 +163,11 @@ class UndertowDispatcherTest extends HttpServerTest<Undertow> {
   }
 
   @Override
+  boolean testBadUrl() {
+    false
+  }
+
+  @Override
   boolean hasExtraErrorInformation() {
     true
   }

--- a/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowServletTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowServletTest.groovy
@@ -97,6 +97,11 @@ class UndertowServletTest extends HttpServerTest<Undertow> {
   }
 
   @Override
+  boolean testBadUrl() {
+    false
+  }
+
+  @Override
   boolean testExceptionBody() {
     false
   }

--- a/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.2/src/test/groovy/UndertowTest.groovy
@@ -166,6 +166,11 @@ class UndertowTest extends HttpServerTest<Undertow> {
   }
 
   @Override
+  boolean testBadUrl() {
+    false
+  }
+
+  @Override
   boolean testRequestBody() {
     // no low-level method to get Reader
     // see io.undertow.servlet.spec.HttpServletRequestImpl


### PR DESCRIPTION
# What Does This Do

Referring to a regression behavior introduced in 1.14.0, the ServerDecorator onResponseStatus always was setting the error flag. 

It may happen that the user it setting manually in the controller. Waiting a proper fix based on priorities (like resource naming), this workaround will avoid to clear the error flag is the user sets manually to true

# Motivation

# Additional Notes
