### PR TITLE
Fix mixing global and per probe rate limiting

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/ProbeRateLimiter.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/ProbeRateLimiter.java
@@ -19,10 +19,10 @@ public final class ProbeRateLimiter {
 
   public static boolean tryProbe(String probeId) {
     // rate limiter engaged at ~1 probe per second (1 probes per 1s time window)
-    boolean result =
-        PROBE_SAMPLERS.computeIfAbsent(probeId, k -> createSampler(DEFAULT_RATE)).sample();
-    result &= GLOBAL_SAMPLER.sample();
-    return result;
+    if (GLOBAL_SAMPLER.sample()) {
+      return PROBE_SAMPLERS.computeIfAbsent(probeId, k -> createSampler(DEFAULT_RATE)).sample();
+    }
+    return false;
   }
 
   public static void setRate(String probeId, double rate) {


### PR DESCRIPTION
# What Does This Do

# Motivation
Global rate limiter (more permissive) should be test before the per probe one and condition the test of the second on the validity of the first

# Additional Notes
