### PR TITLE
Run parametric tests on larger instance with newer JVM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ instrumentation_modules: &instrumentation_modules "dd-java-agent/instrumentation
 debugger_modules: &debugger_modules "dd-java-agent/agent-debugger|dd-java-agent/agent-bootstrap|dd-java-agent/agent-builder|internal-api|communication|dd-trace-core"
 profiling_modules: &profiling_modules "dd-java-agent/agent-profiling"
 
-default_system_tests_commit: &default_system_tests_commit 1aab7b726729ed4fea324169f66c36340b246558
+default_system_tests_commit: &default_system_tests_commit eadec7e06840b1148a47ee4752fe348041dfed07
 
 parameters:
   gradle_flags:
@@ -814,7 +814,7 @@ jobs:
     machine:
       # https://support.circleci.com/hc/en-us/articles/360007324514-How-can-I-use-Docker-volume-mounting-on-CircleCI-
       image: ubuntu-2004:current
-    resource_class: large
+    resource_class: xlarge
     steps:
       - setup_system_tests
 
@@ -841,7 +841,8 @@ jobs:
           command: |
             cd system-tests/parametric
             export CLIENTS_ENABLED=java
-            ./run.sh
+            export PYTEST_WORKER_COUNT=8
+            ./run.sh --log-cli-level=DEBUG --durations=30
 
 build_test_jobs: &build_test_jobs
   - build:


### PR DESCRIPTION
# What Does This Do

Speeds up the parametric tests by running them on a larger instance with more concurrency as well as switching to a Java 17

# Motivation

Slow tests are slow

# Additional Notes
