### PR TITLE
Accept any telemetry 2xx response as successful, not just 202

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
@@ -243,7 +243,7 @@ public class TelemetryService {
         log.debug("Telemetry endpoint is disabled, dropping {} message", type);
         return SendResult.NOT_FOUND;
       }
-      if (response.code() != 202) {
+      if (!response.isSuccessful()) {
         log.debug(
             "Telemetry message {} failed with: {} {} ", type, response.code(), response.message());
         return SendResult.FAILURE;

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
@@ -49,7 +49,7 @@ class TelemetryServiceSpecification extends DDSpecification {
   }
 
   def okResponse = mockResponse(202)
-  def okButNotReallyResponse = mockResponse(200)
+  def continueResponse = mockResponse(100)
   def notFoundResponse = mockResponse(404)
   def serverErrorResponse = mockResponse(500)
 
@@ -239,7 +239,7 @@ class TelemetryServiceSpecification extends DDSpecification {
       p.dependencies.isEmpty()
       p.integrations.isEmpty()
     })
-    1 * httpClient.newCall(_) >> okButNotReallyResponse
+    1 * httpClient.newCall(_) >> continueResponse
     0 * _
 
     when: 'attempt with success'


### PR DESCRIPTION
# Motivation

While the real agent/intake currently responds to telemetry submissions with 202, the test agent uses 200

It seems odd to classify 200 as unsuccessful, so I'm widening the check to consider all 2xx responses as successful