### PR TITLE
Introduced separate global rate limiter for logs

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/ProbeRateLimiter.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/ProbeRateLimiter.java
@@ -7,30 +7,41 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 /** Rate limiter for sending snapshot to backend Use a global rate limiter and one per probe */
-public final class ProbeRateLimiter {
+public class ProbeRateLimiter {
+  public static final double DEFAULT_SNAPSHOT_RATE = 1.0;
+  public static final double DEFAULT_LOG_RATE = 5000.0;
   private static final Duration ONE_SECOND_WINDOW = Duration.of(1, ChronoUnit.SECONDS);
   private static final Duration TEN_SECONDS_WINDOW = Duration.of(10, ChronoUnit.SECONDS);
-  private static final double DEFAULT_RATE = 1.0;
-  private static final double DEFAULT_GLOBAL_RATE = DEFAULT_RATE * 100;
-  private static final ConcurrentMap<String, AdaptiveSampler> PROBE_SAMPLERS =
+  private static final double DEFAULT_GLOBAL_SNAPSHOT_RATE = DEFAULT_SNAPSHOT_RATE * 100;
+  private static final double DEFAULT_GLOBAL_LOG_RATE = 5000.0;
+  private static final ConcurrentMap<String, RateLimitInfo> PROBE_SAMPLERS =
       new ConcurrentHashMap<>();
-
-  private static AdaptiveSampler GLOBAL_SAMPLER = createSampler(DEFAULT_GLOBAL_RATE);
+  private static AdaptiveSampler GLOBAL_SNAPSHOT_SAMPLER =
+      createSampler(DEFAULT_GLOBAL_SNAPSHOT_RATE);
+  private static AdaptiveSampler GLOBAL_LOG_SAMPLER = createSampler(DEFAULT_GLOBAL_LOG_RATE);
 
   public static boolean tryProbe(String probeId) {
-    // rate limiter engaged at ~1 probe per second (1 probes per 1s time window)
-    if (GLOBAL_SAMPLER.sample()) {
-      return PROBE_SAMPLERS.computeIfAbsent(probeId, k -> createSampler(DEFAULT_RATE)).sample();
+    RateLimitInfo rateLimitInfo =
+        PROBE_SAMPLERS.computeIfAbsent(
+            probeId, k -> new RateLimitInfo(createSampler(DEFAULT_SNAPSHOT_RATE), true));
+    AdaptiveSampler globalSampler =
+        rateLimitInfo.isCaptureSnapshot ? GLOBAL_SNAPSHOT_SAMPLER : GLOBAL_LOG_SAMPLER;
+    if (globalSampler.sample()) {
+      return rateLimitInfo.sampler.sample();
     }
     return false;
   }
 
-  public static void setRate(String probeId, double rate) {
-    PROBE_SAMPLERS.put(probeId, createSampler(rate));
+  public static void setRate(String probeId, double rate, boolean isCaptureSnapshot) {
+    PROBE_SAMPLERS.put(probeId, new RateLimitInfo(createSampler(rate), isCaptureSnapshot));
   }
 
-  public static void setGlobalRate(double rate) {
-    GLOBAL_SAMPLER = createSampler(rate);
+  public static void setGlobalSnapshotRate(double rate) {
+    GLOBAL_SNAPSHOT_SAMPLER = createSampler(rate);
+  }
+
+  public static void setGlobalLogRate(double rate) {
+    GLOBAL_LOG_SAMPLER = createSampler(rate);
   }
 
   public static void resetRate(String probeId) {
@@ -38,7 +49,7 @@ public final class ProbeRateLimiter {
   }
 
   public static void resetGlobalRate() {
-    setGlobalRate(DEFAULT_GLOBAL_RATE);
+    setGlobalSnapshotRate(DEFAULT_GLOBAL_LOG_RATE);
   }
 
   private static AdaptiveSampler createSampler(double rate) {
@@ -47,5 +58,15 @@ public final class ProbeRateLimiter {
       return new AdaptiveSampler(TEN_SECONDS_WINDOW, intRate, 180, 16);
     }
     return new AdaptiveSampler(ONE_SECOND_WINDOW, (int) Math.round(rate), 180, 16);
+  }
+
+  private static class RateLimitInfo {
+    final AdaptiveSampler sampler;
+    final boolean isCaptureSnapshot;
+
+    public RateLimitInfo(AdaptiveSampler sampler, boolean isCaptureSnapshot) {
+      this.sampler = sampler;
+      this.isCaptureSnapshot = isCaptureSnapshot;
+    }
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1453,11 +1453,12 @@ public class CapturedSnapshotTest {
     DebuggerContext.initValueSerializer(new JsonSnapshotSerializer());
     for (LogProbe probe : logProbes) {
       if (probe.getSampling() != null) {
-        ProbeRateLimiter.setRate(probe.getId(), probe.getSampling().getSnapshotsPerSecond());
+        ProbeRateLimiter.setRate(
+            probe.getId(), probe.getSampling().getSnapshotsPerSecond(), probe.isCaptureSnapshot());
       }
     }
     if (configuration.getSampling() != null) {
-      ProbeRateLimiter.setGlobalRate(configuration.getSampling().getSnapshotsPerSecond());
+      ProbeRateLimiter.setGlobalSnapshotRate(configuration.getSampling().getSnapshotsPerSecond());
     }
     return listener;
   }


### PR DESCRIPTION
# What Does This Do
We need to store if the probe capture snapshot or not for choosing the right global rate limiter.

# Motivation
ProbeRateLimiter having only one global rate for snapshot, we need to have a separate one for logs with higher rate. 

# Additional Notes
