### PR TITLE
Apply any dynamically overridden header-tags to response headers as well

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -3,6 +3,7 @@ package datadog.trace.bootstrap.instrumentation.decorator;
 import static datadog.trace.api.cache.RadixTreeCache.UNSET_STATUS;
 import static datadog.trace.api.gateway.Events.EVENTS;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourceDecorator.HTTP_RESOURCE_DECORATOR;
 
 import datadog.appsec.api.blocking.BlockingException;
@@ -309,7 +310,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
       AgentPropagation.ContextVisitor<RESPONSE> getter = responseGetter();
       if (getter != null) {
         ResponseHeaderTagClassifier tagger =
-            ResponseHeaderTagClassifier.create(span, Config.get().getResponseHeaderTags());
+            ResponseHeaderTagClassifier.create(span, traceConfig(span).getResponseHeaderTags());
         if (tagger != null) {
           getter.forEachKey(response, tagger);
         }

--- a/dd-trace-core/src/jmh/java/datadog/trace/core/propagation/ExtractorBenchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/propagation/ExtractorBenchmark.java
@@ -87,7 +87,7 @@ public class ExtractorBenchmark {
     System.setProperty("dd.propagation.style.extract", propagations.toString());
     DynamicConfig dynamicConfig =
         DynamicConfig.create()
-            .setTaggedHeaders(Collections.emptyMap())
+            .setHeaderTags(Collections.emptyMap())
             .setBaggageMapping(Collections.emptyMap())
             .apply();
     extractor = HttpCodec.createExtractor(Config.get(), dynamicConfig::captureTraceConfig);

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -499,7 +499,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     this.dynamicConfig =
         DynamicConfig.create()
             .setServiceMapping(serviceNameMappings)
-            .setTaggedHeaders(taggedHeaders)
+            .setHeaderTags(taggedHeaders)
             .setBaggageMapping(baggageMapping)
             .apply();
     this.sampler = sampler;

--- a/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
@@ -92,7 +92,7 @@ final class TracingConfigPoller {
   void applyConfigOverrides(ConfigOverrides overrides) {
     DynamicConfig.Builder builder = dynamicConfig.initial();
     maybeOverride(builder::setServiceMapping, overrides.serviceMapping, SERVICE_MAPPING);
-    maybeOverride(builder::setTaggedHeaders, overrides.taggedHeaders, HEADER_TAGS);
+    maybeOverride(builder::setHeaderTags, overrides.headerTags, HEADER_TAGS);
     builder.apply();
     log.debug("Applied APM_TRACING overrides");
   }
@@ -114,6 +114,6 @@ final class TracingConfigPoller {
     public Map<String, String> serviceMapping;
 
     @Json(name = "tracing_header_tags")
-    public Map<String, String> taggedHeaders;
+    public Map<String, String> headerTags;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -34,7 +34,7 @@ import java.util.TreeMap;
 public abstract class ContextInterpreter implements AgentPropagation.KeyClassifier {
   private TraceConfig traceConfig;
 
-  protected Map<String, String> taggedHeaders;
+  protected Map<String, String> headerTags;
   protected Map<String, String> baggageMapping;
 
   protected DDTraceId traceId;
@@ -175,11 +175,11 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
   }
 
   protected final boolean handleTags(String key, String value) {
-    if (taggedHeaders.isEmpty() || value == null) {
+    if (headerTags.isEmpty() || value == null) {
       return false;
     }
     final String lowerCaseKey = toLowerCase(key);
-    final String mappedKey = taggedHeaders.get(lowerCaseKey);
+    final String mappedKey = headerTags.get(lowerCaseKey);
     if (null != mappedKey) {
       if (tags.isEmpty()) {
         tags = new TreeMap<>();
@@ -221,7 +221,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
     collectIpHeaders =
         this.clientIpWithoutAppSec
             || this.clientIpResolutionEnabled && ActiveSubsystems.APPSEC_ACTIVE;
-    taggedHeaders = traceConfig.getTaggedHeaders();
+    headerTags = traceConfig.getHeaderTags();
     baggageMapping = traceConfig.getBaggageMapping();
     return this;
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -175,7 +175,7 @@ class CoreTracerTest extends DDCoreSpecification {
     when:
     def tracer = tracerBuilder().build()
     // Datadog extractor gets placed first
-    def taggedHeaders = tracer.extractor.extractors[0].traceConfigSupplier.get().getHeaderTags
+    def taggedHeaders = tracer.extractor.extractors[0].traceConfigSupplier.get().headerTags
 
     then:
     tracer.defaultSpanTags == map

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -175,7 +175,7 @@ class CoreTracerTest extends DDCoreSpecification {
     when:
     def tracer = tracerBuilder().build()
     // Datadog extractor gets placed first
-    def taggedHeaders = tracer.extractor.extractors[0].traceConfigSupplier.get().taggedHeaders
+    def taggedHeaders = tracer.extractor.extractors[0].traceConfigSupplier.get().getHeaderTags
 
     then:
     tracer.defaultSpanTags == map

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpExtractorTest.groovy
@@ -24,7 +24,7 @@ class B3HttpExtractorTest extends DDSpecification {
 
   void setup() {
     dynamicConfig = DynamicConfig.create()
-      .setTaggedHeaders(["SOME_HEADER": "some-tag"])
+      .setHeaderTags(["SOME_HEADER": "some-tag"])
       .setBaggageMapping([:])
       .apply()
     extractor = B3HttpCodec.newExtractor(Config.get(), { dynamicConfig.captureTraceConfig() })

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpInjectorTest.groovy
@@ -88,7 +88,7 @@ class B3HttpInjectorTest extends DDCoreSpecification {
       (SPAN_ID_KEY.toUpperCase()) : spanId,
     ]
     DynamicConfig dynamicConfig = DynamicConfig.create()
-      .setTaggedHeaders([:])
+      .setHeaderTags([:])
       .setBaggageMapping([:])
       .apply()
     HttpCodec.Extractor extractor = B3HttpCodec.newExtractor(Config.get(), { dynamicConfig.captureTraceConfig() })

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpExtractorTest.groovy
@@ -36,7 +36,7 @@ class DatadogHttpExtractorTest extends DDSpecification {
 
   void setup() {
     dynamicConfig = DynamicConfig.create()
-      .setTaggedHeaders(["SOME_HEADER": "some-tag"])
+      .setHeaderTags(["SOME_HEADER": "some-tag"])
       .setBaggageMapping(["SOME_CUSTOM_BAGGAGE_HEADER": "some-baggage", "SOME_CUSTOM_BAGGAGE_HEADER_2": "some-CaseSensitive-baggage"])
       .apply()
     origAppSecActive = ActiveSubsystems.APPSEC_ACTIVE

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HaystackHttpExtractorTest.groovy
@@ -27,7 +27,7 @@ class HaystackHttpExtractorTest extends DDSpecification {
 
   void setup() {
     DynamicConfig dynamicConfig = DynamicConfig.create()
-      .setTaggedHeaders(["SOME_HEADER": "some-tag"])
+      .setHeaderTags(["SOME_HEADER": "some-tag"])
       .setBaggageMapping(["SOME_CUSTOM_BAGGAGE_HEADER": "some-baggage", "SOME_CUSTOM_BAGGAGE_HEADER_2": "some-CaseSensitive-baggage"])
       .apply()
     extractor = HaystackHttpCodec.newExtractor(Config.get(), { dynamicConfig.captureTraceConfig() })

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpExtractorTest.groovy
@@ -24,7 +24,7 @@ class HttpExtractorTest extends DDSpecification {
       getTracePropagationStylesToExtract() >> styles
     }
     DynamicConfig dynamicConfig = DynamicConfig.create()
-      .setTaggedHeaders(["SOME_HEADER": "some-tag"])
+      .setHeaderTags(["SOME_HEADER": "some-tag"])
       .setBaggageMapping([:])
       .apply()
     HttpCodec.Extractor extractor = HttpCodec.createExtractor(config, { dynamicConfig.captureTraceConfig() })

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/W3CHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/W3CHttpExtractorTest.groovy
@@ -41,7 +41,7 @@ class W3CHttpExtractorTest extends DDSpecification {
 
   void setup() {
     dynamicConfig = DynamicConfig.create()
-      .setTaggedHeaders(["SOME_HEADER": "some-tag"])
+      .setHeaderTags(["SOME_HEADER": "some-tag"])
       .setBaggageMapping(["SOME_CUSTOM_BAGGAGE_HEADER": "some-baggage", "SOME_CUSTOM_BAGGAGE_HEADER_2": "some-CaseSensitive-baggage"])
       .apply()
     origAppSecActive = ActiveSubsystems.APPSEC_ACTIVE

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/XRayHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/XRayHttpExtractorTest.groovy
@@ -22,7 +22,7 @@ class XRayHttpExtractorTest extends DDSpecification {
 
   void setup() {
     dynamicConfig = DynamicConfig.create()
-      .setTaggedHeaders(["SOME_HEADER": "some-tag"])
+      .setHeaderTags(["SOME_HEADER": "some-tag"])
       .setBaggageMapping(["SOME_CUSTOM_BAGGAGE_HEADER": "some-baggage", "SOME_CUSTOM_BAGGAGE_HEADER_2": "some-CaseSensitive-baggage"])
       .apply()
     extractor = XRayHttpCodec.newExtractor(Config.get(), { dynamicConfig.captureTraceConfig() })

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/XRayHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/XRayHttpInjectorTest.groovy
@@ -81,7 +81,7 @@ class XRayHttpInjectorTest extends DDCoreSpecification {
       'X-Amzn-Trace-Id' : "Root=1-00000000-00000000${traceId.padLeft(16, '0')};Parent=${spanId.padLeft(16, '0')}"
     ]
     DynamicConfig dynamicConfig = DynamicConfig.create()
-      .setTaggedHeaders([:])
+      .setHeaderTags([:])
       .setBaggageMapping([:])
       .apply()
     HttpCodec.Extractor extractor = XRayHttpCodec.newExtractor(Config.get(), { dynamicConfig.captureTraceConfig() })

--- a/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
@@ -43,17 +43,17 @@ public final class DynamicConfig {
   public final class Builder {
 
     Map<String, String> serviceMapping;
-    Map<String, String> taggedHeaders;
+    Map<String, String> headerTags;
     Map<String, String> baggageMapping;
 
     Builder(State state) {
       if (null == state) {
         this.serviceMapping = Collections.emptyMap();
-        this.taggedHeaders = Collections.emptyMap();
+        this.headerTags = Collections.emptyMap();
         this.baggageMapping = Collections.emptyMap();
       } else {
         this.serviceMapping = state.serviceMapping;
-        this.taggedHeaders = state.taggedHeaders;
+        this.headerTags = state.headerTags;
         this.baggageMapping = state.baggageMapping;
       }
     }
@@ -63,8 +63,8 @@ public final class DynamicConfig {
       return this;
     }
 
-    public Builder setTaggedHeaders(Map<String, String> taggedHeaders) {
-      this.taggedHeaders = cleanMapping(taggedHeaders, true, true);
+    public Builder setHeaderTags(Map<String, String> headerTags) {
+      this.headerTags = cleanMapping(headerTags, true, true);
       return this;
     }
 
@@ -101,7 +101,7 @@ public final class DynamicConfig {
         currentState = newState;
         Map<String, Object> update = new HashMap<>();
         update.put(SERVICE_MAPPING, newState.serviceMapping);
-        update.put(HEADER_TAGS, newState.taggedHeaders);
+        update.put(HEADER_TAGS, newState.headerTags);
         update.put(BAGGAGE_MAPPING, newState.baggageMapping);
         ConfigCollector.get().putAll(update);
       }
@@ -113,12 +113,12 @@ public final class DynamicConfig {
   static final class State implements TraceConfig {
 
     final Map<String, String> serviceMapping;
-    final Map<String, String> taggedHeaders;
+    final Map<String, String> headerTags;
     final Map<String, String> baggageMapping;
 
     State(Builder builder) {
       this.serviceMapping = builder.serviceMapping;
-      this.taggedHeaders = builder.taggedHeaders;
+      this.headerTags = builder.headerTags;
       this.baggageMapping = builder.baggageMapping;
     }
 
@@ -126,8 +126,8 @@ public final class DynamicConfig {
       return serviceMapping;
     }
 
-    public Map<String, String> getTaggedHeaders() {
-      return taggedHeaders;
+    public Map<String, String> getHeaderTags() {
+      return headerTags;
     }
 
     public Map<String, String> getBaggageMapping() {

--- a/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
@@ -92,7 +92,7 @@ public final class DynamicConfig {
 
     /** Overwrites the current configuration with a new snapshot. */
     public DynamicConfig apply() {
-      State newState = new State(this);
+      State newState = new State(this, initialState);
       State oldState = currentState;
       if (null == oldState) {
         initialState = newState; // captured when constructing the dynamic config
@@ -116,20 +116,33 @@ public final class DynamicConfig {
     final Map<String, String> headerTags;
     final Map<String, String> baggageMapping;
 
-    State(Builder builder) {
+    private final boolean overrideResponseTags;
+
+    State(Builder builder, State initialState) {
       this.serviceMapping = builder.serviceMapping;
       this.headerTags = builder.headerTags;
       this.baggageMapping = builder.baggageMapping;
+
+      // also apply headerTags to response headers if the initial reference has been overridden
+      this.overrideResponseTags = null != initialState && headerTags != initialState.headerTags;
     }
 
+    @Override
     public Map<String, String> getServiceMapping() {
       return serviceMapping;
     }
 
+    @Override
     public Map<String, String> getHeaderTags() {
       return headerTags;
     }
 
+    @Override
+    public Map<String, String> getResponseHeaderTags() {
+      return overrideResponseTags ? headerTags : Config.get().getResponseHeaderTags();
+    }
+
+    @Override
     public Map<String, String> getBaggageMapping() {
       return baggageMapping;
     }

--- a/internal-api/src/main/java/datadog/trace/api/TraceConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/TraceConfig.java
@@ -9,5 +9,7 @@ public interface TraceConfig {
 
   Map<String, String> getHeaderTags();
 
+  Map<String, String> getResponseHeaderTags();
+
   Map<String, String> getBaggageMapping();
 }

--- a/internal-api/src/main/java/datadog/trace/api/TraceConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/TraceConfig.java
@@ -7,7 +7,7 @@ public interface TraceConfig {
 
   Map<String, String> getServiceMapping();
 
-  Map<String, String> getTaggedHeaders();
+  Map<String, String> getHeaderTags();
 
   Map<String, String> getBaggageMapping();
 }


### PR DESCRIPTION
Follow-up to https://github.com/DataDog/dd-trace-java/pull/5154 but for response header processing.

Note: users can still statically configure separate tag mappings for request and response headers 