### PR TITLE
Update dynamic-config to reflect latest schema changes

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
@@ -16,6 +16,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.DynamicConfig;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import okio.Okio;
@@ -44,8 +45,6 @@ final class TracingConfigPoller {
   }
 
   final class Updater implements ProductListener {
-    private static final String CONFIG_OVERRIDES = "config_overrides";
-
     private final Moshi MOSHI = new Moshi.Builder().build();
 
     private final JsonAdapter<ConfigOverrides> CONFIG_OVERRIDES_ADAPTER =
@@ -64,25 +63,21 @@ final class TracingConfigPoller {
     @Override
     public void accept(ParsedConfigKey configKey, byte[] content, PollingRateHinter hinter)
         throws IOException {
-      if (CONFIG_OVERRIDES.equals(configKey.getConfigId())) {
 
-        ConfigOverrides overrides =
-            CONFIG_OVERRIDES_ADAPTER.fromJson(
-                Okio.buffer(Okio.source(new ByteArrayInputStream(content))));
+      ConfigOverrides overrides =
+          CONFIG_OVERRIDES_ADAPTER.fromJson(
+              Okio.buffer(Okio.source(new ByteArrayInputStream(content))));
 
-        if (null != overrides) {
-          applyConfigOverrides(overrides);
-        } else {
-          removeConfigOverrides();
-        }
+      if (null != overrides) {
+        applyConfigOverrides(overrides);
+      } else {
+        removeConfigOverrides();
       }
     }
 
     @Override
     public void remove(ParsedConfigKey configKey, PollingRateHinter hinter) {
-      if (CONFIG_OVERRIDES.equals(configKey.getConfigId())) {
-        removeConfigOverrides();
-      }
+      removeConfigOverrides();
     }
 
     @Override
@@ -111,9 +106,55 @@ final class TracingConfigPoller {
 
   static final class ConfigOverrides {
     @Json(name = "tracing_service_mapping")
-    public Map<String, String> serviceMapping;
+    public List<ServiceMappingEntry> serviceMapping;
 
     @Json(name = "tracing_header_tags")
-    public Map<String, String> headerTags;
+    public List<HeaderTagEntry> headerTags;
+  }
+
+  static final class ServiceMappingEntry implements Map.Entry<String, String> {
+    @Json(name = "from_name")
+    public String fromName;
+
+    @Json(name = "to_name")
+    public String toName;
+
+    @Override
+    public String getKey() {
+      return fromName;
+    }
+
+    @Override
+    public String getValue() {
+      return toName;
+    }
+
+    @Override
+    public String setValue(String value) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  static final class HeaderTagEntry implements Map.Entry<String, String> {
+    @Json(name = "header")
+    public String header;
+
+    @Json(name = "tag_name")
+    public String tagName;
+
+    @Override
+    public String getKey() {
+      return header;
+    }
+
+    @Override
+    public String getValue() {
+      return tagName;
+    }
+
+    @Override
+    public String setValue(String value) {
+      throw new UnsupportedOperationException();
+    }
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
@@ -5,6 +5,7 @@ import static datadog.trace.api.config.TracerConfig.HEADER_TAGS;
 import static datadog.trace.api.config.TracerConfig.SERVICE_MAPPING;
 import static datadog.trace.util.CollectionUtils.tryMakeImmutableMap;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -59,24 +60,40 @@ public final class DynamicConfig {
     }
 
     public Builder setServiceMapping(Map<String, String> serviceMapping) {
+      return setServiceMapping(serviceMapping.entrySet());
+    }
+
+    public Builder setHeaderTags(Map<String, String> headerTags) {
+      return setHeaderTags(headerTags.entrySet());
+    }
+
+    public Builder setBaggageMapping(Map<String, String> baggageMapping) {
+      return setBaggageMapping(baggageMapping.entrySet());
+    }
+
+    public Builder setServiceMapping(
+        Collection<? extends Map.Entry<String, String>> serviceMapping) {
       this.serviceMapping = cleanMapping(serviceMapping, false, false);
       return this;
     }
 
-    public Builder setHeaderTags(Map<String, String> headerTags) {
+    public Builder setHeaderTags(Collection<? extends Map.Entry<String, String>> headerTags) {
       this.headerTags = cleanMapping(headerTags, true, true);
       return this;
     }
 
-    public Builder setBaggageMapping(Map<String, String> baggageMapping) {
+    public Builder setBaggageMapping(
+        Collection<? extends Map.Entry<String, String>> baggageMapping) {
       this.baggageMapping = cleanMapping(baggageMapping, true, false);
       return this;
     }
 
     private Map<String, String> cleanMapping(
-        Map<String, String> mapping, boolean lowerCaseKeys, boolean lowerCaseValues) {
+        Collection<? extends Map.Entry<String, String>> mapping,
+        boolean lowerCaseKeys,
+        boolean lowerCaseValues) {
       final Map<String, String> cleanedMapping = new HashMap<>(mapping.size() * 4 / 3);
-      for (Map.Entry<String, String> association : mapping.entrySet()) {
+      for (Map.Entry<String, String> association : mapping) {
         String key = association.getKey().trim();
         if (lowerCaseKeys) {
           key = key.toLowerCase();


### PR DESCRIPTION
* config-id is now a hash and should be ignored
* service mapping and header tags are now passed as a series of structured entries rather than a map
  * we parse these into a collection of map entries and process as before, without needing to call to `entrySet`