### PR TITLE
Less verbose AppSec start log

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/AppSecSystem.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/AppSecSystem.java
@@ -92,7 +92,11 @@ public class AppSecSystem {
     STARTED.set(true);
 
     String startedAppSecModules = Strings.join(", ", STARTED_MODULES_INFO.values());
-    log.info("AppSec is {} with {}", appSecEnabledConfig, startedAppSecModules);
+    if (appSecEnabledConfig == ProductActivation.FULLY_ENABLED) {
+      log.info("AppSec is {} with {}", appSecEnabledConfig, startedAppSecModules);
+    } else {
+      log.debug("AppSec is {} with {}", appSecEnabledConfig, startedAppSecModules);
+    }
   }
 
   private static RateLimiter getRateLimiter(Config config, Monitoring monitoring) {


### PR DESCRIPTION


# What Does This Do
By default (AppSec inactive), log to debug instead of info. This prevents getting an uninteresting (by default) early log line with:

>  AppSec is ENABLED_INACTIVE with powerwaf(libddwaf: 1.10.0)

# Motivation

# Additional Notes
