### PR TITLE
byte-buddy 1.14.5

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
   implementation(gradleApi())
   implementation(localGroovy())
 
-  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.14.3")
+  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.14.5")
 
   implementation("org.eclipse.aether", "aether-connector-basic", "1.1.0")
   implementation("org.eclipse.aether", "aether-transport-http", "1.1.0")

--- a/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
+++ b/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
@@ -23,7 +23,7 @@ class InstrumentPluginTest extends Specification {
     }
 
     dependencies {
-      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.3' // just to build TestPlugin
+      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.5' // just to build TestPlugin
     }
 
     apply plugin: 'instrument'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -14,7 +14,7 @@ final class CachedData {
     groovy        : groovyVer,
     junit5        : "5.9.2",
     logback       : "1.2.3",
-    bytebuddy     : "1.14.3",
+    bytebuddy     : "1.14.5",
     scala         : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)
     scala210      : "2.10.7",
     scala211      : "2.11.12",


### PR DESCRIPTION
[Byte Buddy 1.14.5](https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.14.5)
* Avoid use of location if agent argument separator is contained
* Allow failure of member substitution if no element is separated
* Allow retry in case of parallel class injection

^ this last improvement might help avoid some of the "duplicate class definition" errors we've seen in the past

[Byte Buddy 1.14.4](https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.14.4)
* Include instrumented type and auxiliary types in TypePool that is passed to TypeWriter