### PR TITLE
upgrade to ddprof 0.46.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.45.0",
+    ddprof        : "0.46.0",
     asm           : "9.5"
   ]
 


### PR DESCRIPTION
# What Does This Do

Upgrades to [ddprof 0.46.0](https://github.com/DataDog/java-profiler/releases/tag/v_0.46.0) to pick up bug fixes

# Motivation

# Additional Notes
