### PR TITLE
get stack depth from Throwable stackTrace to avoid copy

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionProfiling.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionProfiling.java
@@ -42,13 +42,13 @@ public final class ExceptionProfiling {
     this.recordExceptionMessage = recordExceptionMessage;
   }
 
-  public ExceptionSampleEvent process(final Throwable t) {
+  public ExceptionSampleEvent process(final Throwable t, final int stackDepth) {
     // always record the exception in histogram
     final boolean firstHit = histogram.record(t);
 
     final boolean sampled = sampler.sample();
     if (firstHit || sampled) {
-      return new ExceptionSampleEvent(t, sampled, firstHit);
+      return new ExceptionSampleEvent(t, stackDepth, sampled, firstHit);
     }
     return null;
   }

--- a/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionSampleEvent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionSampleEvent.java
@@ -34,7 +34,8 @@ public class ExceptionSampleEvent extends Event implements ContextualEvent {
   @Label("Span Id")
   private long spanId;
 
-  public ExceptionSampleEvent(Throwable e, boolean sampled, boolean firstOccurrence) {
+  public ExceptionSampleEvent(
+      Throwable e, final int stackDepth, boolean sampled, boolean firstOccurrence) {
     /*
      * TODO: we should have some tests for this class.
      * Unfortunately at the moment this is not easily possible because we cannot build tests with groovy that
@@ -43,7 +44,7 @@ public class ExceptionSampleEvent extends Event implements ContextualEvent {
      */
     this.type = e.getClass().getName();
     this.message = getMessage(e);
-    this.stackDepth = getStackDepth(e);
+    this.stackDepth = stackDepth;
     this.sampled = sampled;
     this.firstOccurrence = firstOccurrence;
     captureContext();
@@ -58,15 +59,6 @@ public class ExceptionSampleEvent extends Event implements ContextualEvent {
       }
     }
     return null;
-  }
-
-  private static int getStackDepth(Throwable t) {
-    try {
-      return t.getStackTrace().length;
-    } catch (Throwable ignored) {
-      // be defensive about exceptions choking on a call to getStackTrace()
-    }
-    return 0;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/exception-profiling/src/main/java/datadog/exceptions/instrumentation/ThrowableInstrumentation.java
+++ b/dd-java-agent/instrumentation/exception-profiling/src/main/java/datadog/exceptions/instrumentation/ThrowableInstrumentation.java
@@ -1,15 +1,21 @@
 package datadog.exceptions.instrumentation;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.declaresField;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.Platform;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
 
 /** Provides instrumentation of {@linkplain Throwable} constructor. */
 @AutoService(Instrumenter.class)
 public final class ThrowableInstrumentation extends Instrumenter.Profiling
-    implements Instrumenter.ForBootstrap, Instrumenter.ForSingleType {
+    implements Instrumenter.ForBootstrap,
+        Instrumenter.ForSingleType,
+        Instrumenter.WithTypeStructure {
 
   public ThrowableInstrumentation() {
     super("throwables");
@@ -23,6 +29,11 @@ public final class ThrowableInstrumentation extends Instrumenter.Profiling
   @Override
   public String instrumentedType() {
     return "java.lang.Throwable";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> structureMatcher() {
+    return declaresField(named("stackTrace"));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/exception-profiling/src/main/java11/datadog/exceptions/instrumentation/ThrowableInstanceAdvice.java
+++ b/dd-java-agent/instrumentation/exception-profiling/src/main/java11/datadog/exceptions/instrumentation/ThrowableInstanceAdvice.java
@@ -11,7 +11,9 @@ import net.bytebuddy.asm.Advice;
 
 public class ThrowableInstanceAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
-  public static void onExit(@Advice.This final Throwable t) {
+  public static void onExit(
+      @Advice.This final Throwable t,
+      @Advice.FieldValue("stackTrace") StackTraceElement[] stackTrace) {
     if (t.getClass().getName().endsWith(".ResourceLeakDetector$TraceRecord")) {
       return;
     }
@@ -45,7 +47,8 @@ public class ThrowableInstanceAdvice {
        * JFR will assign the stacktrace depending on the place where the event is committed.
        * Therefore we need to commit the event here, right in the 'Exception' constructor
        */
-      final ExceptionSampleEvent event = ExceptionProfiling.getInstance().process(t);
+      final ExceptionSampleEvent event =
+          ExceptionProfiling.getInstance().process(t, stackTrace == null ? 0 : stackTrace.length);
       if (event != null && event.shouldCommit()) {
         event.commit();
       }


### PR DESCRIPTION
# What Does This Do

This addresses a fairly large source of overhead in exception profiling when applications throw lots of exceptions: 
<img width="976" alt="Screenshot 2023-06-09 at 18 59 55" src="https://github.com/DataDog/dd-trace-java/assets/16439049/ee11ac9d-e49f-4e2a-99e6-7e8266aaeda2">

The instrumentation will only activate if the `Throwable` class has a field called `stackTrace` (rather than crash) which means exception profiling would be unavailable, but this is unlikely ever to happen.


# Motivation

# Additional Notes
