### PR TITLE
Upgrade to ddprof 0.47.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.46.0",
+    ddprof        : "0.47.0",
     asm           : "9.5"
   ]
 


### PR DESCRIPTION
# What Does This Do

Links libstdc++ statically, which was erroneously undone in 0.46.0.

# Motivation

# Additional Notes
