### PR TITLE
Generate useful error that includes the bad agent URL instead of unhelpful NullPointerExceptions

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
+++ b/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
@@ -30,6 +30,9 @@ public class SharedCommunicationObjects {
     }
     if (agentUrl == null) {
       agentUrl = HttpUrl.parse(config.getAgentUrl());
+      if (agentUrl == null) {
+        throw new IllegalArgumentException("Bad agent URL: " + config.getAgentUrl());
+      }
     }
     if (okHttpClient == null) {
       String unixDomainSocket = SocketUtils.discoverApmSocket(config);

--- a/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
@@ -55,6 +55,7 @@ public class TelemetrySystem {
 
   public static void startTelemetry(
       Instrumentation instrumentation, SharedCommunicationObjects sco) {
+    sco.createRemaining(Config.get());
     DependencyService dependencyService = createDependencyService(instrumentation);
     TelemetryService telemetryService =
         new TelemetryService(sco.okHttpClient, new RequestBuilderSupplier(sco.agentUrl));


### PR DESCRIPTION
Before:
```
[dd-remote-config] DEBUG datadog.communication.ddagent.DDAgentFeaturesDiscovery - Error querying info at null
java.lang.NullPointerException
	at datadog.communication.ddagent.DDAgentFeaturesDiscovery.doDiscovery(DDAgentFeaturesDiscovery.java:137)
	at datadog.communication.ddagent.DDAgentFeaturesDiscovery.discoverIfOutdated(DDAgentFeaturesDiscovery.java:123)
	at datadog.communication.ddagent.DDAgentFeaturesDiscovery.discoverIfOutdated(DDAgentFeaturesDiscovery.java:112)
	at datadog.communication.ddagent.SharedCommunicationObjects$RetryConfigUrlSupplier.get(SharedCommunicationObjects.java:119)
	at datadog.communication.ddagent.SharedCommunicationObjects$RetryConfigUrlSupplier.get(SharedCommunicationObjects.java:102)
	at datadog.remoteconfig.ConfigurationPoller.initialize(ConfigurationPoller.java:224)
	at datadog.remoteconfig.ConfigurationPoller.poll(ConfigurationPoller.java:194)
	at datadog.trace.util.AgentTaskScheduler$PeriodicTask.run(AgentTaskScheduler.java:299)
	at datadog.trace.util.AgentTaskScheduler$Worker.run(AgentTaskScheduler.java:254)
	at java.lang.Thread.run(Thread.java:750)
```
variations of this message then repeat continually while the application is running

After:
```
[main] ERROR datadog.trace.bootstrap.Agent - Error starting remote config
...snip...
Caused by: java.lang.IllegalArgumentException: Bad agent URL: http://<some-bad:agent-url%:8126
	at datadog.communication.ddagent.SharedCommunicationObjects.createRemaining(SharedCommunicationObjects.java:34)
	at datadog.communication.ddagent.SharedCommunicationObjects.createPoller(SharedCommunicationObjects.java:63)
	at datadog.communication.ddagent.SharedCommunicationObjects.configurationPoller(SharedCommunicationObjects.java:51)
	... 20 more
```
the various tracer sub-systems now stop early rather than try to continue to parse the bad agent URL