### PR TITLE
Handle when Servlet3 AsyncEvent was initialized without any ServletRequest

### DIFF
--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/FinishAsyncDispatchListener.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/FinishAsyncDispatchListener.java
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import javax.servlet.AsyncEvent;
 import javax.servlet.AsyncListener;
 import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
 
@@ -46,9 +47,12 @@ public class FinishAsyncDispatchListener implements AsyncListener, Runnable {
           DECORATE.onResponse(span, (HttpServletResponse) resp);
         }
       }
-      Object error = event.getSuppliedRequest().getAttribute(RequestDispatcher.ERROR_EXCEPTION);
-      if (error instanceof Throwable) {
-        DECORATE.onError(span, (Throwable) error);
+      ServletRequest req = event.getSuppliedRequest();
+      if (null != req) {
+        Object error = req.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
+        if (error instanceof Throwable) {
+          DECORATE.onError(span, (Throwable) error);
+        }
       }
       DECORATE.beforeFinish(span);
       span.finish();


### PR DESCRIPTION
The supplied request may be `null` according to the javadoc:

https://docs.oracle.com/javaee/7/api/javax/servlet/AsyncEvent.html#getSuppliedRequest--

> Returns:
> the ServletRequest that was used to initialize this AsyncEvent, or null if this AsyncEvent was initialized without any ServletRequest

The supplied response may also be `null`, but this is already covered by an `instanceof` check.