### PR TITLE
upgrade ddprof 0.49.0, disable on OpenJDK8/aarch64

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.48.0",
+    ddprof        : "0.49.0",
     asm           : "9.5"
   ]
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -2047,6 +2047,12 @@ public class Config {
   public static boolean isDatadogProfilerSafeInCurrentEnvironment() {
     // don't want to put this logic (which will evolve) in the public ProfilingConfig, and can't
     // access Platform there
+    if (!Platform.isJ9() && Platform.isJavaVersion(8)) {
+      String arch = System.getProperty("os.arch");
+      if ("aarch64".equalsIgnoreCase(arch) || "arm64".equalsIgnoreCase(arch)) {
+        return false;
+      }
+    }
     boolean result =
         Platform.isJ9()
             || !Platform.isJavaVersion(18) // missing AGCT fixes


### PR DESCRIPTION
# What Does This Do

* Changes the thread state when contention is detected in wallclock samples from BLOCKED to CONTENDED
* Disables Datadog profiler on OpenJDK8/aarch64 because we saw some AsyncGetCallTrace crashes in testing

# Motivation

# Additional Notes
