### PR TITLE
Wait for traces to be published before exiting if CI Visibility is enabled

### DIFF
--- a/dd-trace-core/build.gradle
+++ b/dd-trace-core/build.gradle
@@ -25,7 +25,8 @@ excludedClassesCoverage += [
   'datadog.trace.core.Base64Encoder',
   'datadog.trace.core.CoreTracer.1',
   'datadog.trace.core.DDSpan.1',
-  'datadog.trace.core.tagprocessor.QueryObfuscator.1'
+  'datadog.trace.core.tagprocessor.QueryObfuscator.1',
+  'datadog.trace.common.writer.TraceProcessingWorker.NonDaemonTraceSerializingHandler'
 ]
 
 addTestSuite('traceAgentTest')

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceProcessingWorker.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceProcessingWorker.java
@@ -6,6 +6,7 @@ import static datadog.trace.util.AgentThreadFactory.newAgentThread;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import datadog.communication.ddagent.DroppingPolicy;
+import datadog.trace.api.Config;
 import datadog.trace.common.sampling.SingleSpanSampler;
 import datadog.trace.common.writer.ddagent.FlushEvent;
 import datadog.trace.common.writer.ddagent.Prioritization;
@@ -67,10 +68,15 @@ public class TraceProcessingWorker implements AutoCloseable {
             secondaryQueue,
             spanSamplingWorker.getSpanSamplingQueue(),
             droppingPolicy);
+
+    boolean runAsDaemon = !Config.get().isCiVisibilityEnabled();
     this.serializingHandler =
-        new TraceSerializingHandler(
-            primaryQueue, secondaryQueue, healthMetrics, dispatcher, flushInterval, timeUnit);
-    this.serializerThread = newAgentThread(TRACE_PROCESSOR, serializingHandler);
+        runAsDaemon
+            ? new DaemonTraceSerializingHandler(
+                primaryQueue, secondaryQueue, healthMetrics, dispatcher, flushInterval, timeUnit)
+            : new NonDaemonTraceSerializingHandler(
+                primaryQueue, secondaryQueue, healthMetrics, dispatcher, flushInterval, timeUnit);
+    this.serializerThread = newAgentThread(TRACE_PROCESSOR, serializingHandler, runAsDaemon);
   }
 
   public void start() {
@@ -121,7 +127,77 @@ public class TraceProcessingWorker implements AutoCloseable {
     return new MpscBlockingConsumerArrayQueue<>(capacity);
   }
 
-  public static class TraceSerializingHandler implements Runnable {
+  private static class DaemonTraceSerializingHandler extends TraceSerializingHandler {
+    public DaemonTraceSerializingHandler(
+        MpscBlockingConsumerArrayQueue<Object> primaryQueue,
+        MpscBlockingConsumerArrayQueue<Object> secondaryQueue,
+        HealthMetrics healthMetrics,
+        PayloadDispatcher payloadDispatcher,
+        long flushInterval,
+        TimeUnit timeUnit) {
+      super(
+          primaryQueue, secondaryQueue, healthMetrics, payloadDispatcher, flushInterval, timeUnit);
+    }
+
+    @Override
+    public void run() {
+      try {
+        runDutyCycle();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      log.debug("Datadog trace processor exited. Publishing traces stopped");
+    }
+
+    private void runDutyCycle() throws InterruptedException {
+      Thread thread = Thread.currentThread();
+      while (!thread.isInterrupted()) {
+        consumeFromPrimaryQueue();
+        consumeFromSecondaryQueue();
+        flushIfNecessary();
+      }
+    }
+  }
+
+  private static class NonDaemonTraceSerializingHandler extends TraceSerializingHandler {
+    private static final double SHUTDOWN_TIMEOUT_MILLIS = 5_000;
+    private Long shutdownSignalTimestamp;
+
+    public NonDaemonTraceSerializingHandler(
+        MpscBlockingConsumerArrayQueue<Object> primaryQueue,
+        MpscBlockingConsumerArrayQueue<Object> secondaryQueue,
+        HealthMetrics healthMetrics,
+        PayloadDispatcher payloadDispatcher,
+        long flushInterval,
+        TimeUnit timeUnit) {
+      super(
+          primaryQueue, secondaryQueue, healthMetrics, payloadDispatcher, flushInterval, timeUnit);
+    }
+
+    @Override
+    public void run() {
+      while (!shouldShutdown()) {
+        try {
+          consumeFromPrimaryQueue();
+          consumeFromSecondaryQueue();
+          flushIfNecessary();
+        } catch (InterruptedException e) {
+          if (shutdownSignalTimestamp == null) {
+            shutdownSignalTimestamp = System.currentTimeMillis();
+          }
+        }
+      }
+      log.debug("Datadog trace processor exited. Unpublished traces left: " + !queuesAreEmpty());
+    }
+
+    private boolean shouldShutdown() {
+      return shutdownSignalTimestamp != null
+          && (shutdownSignalTimestamp + SHUTDOWN_TIMEOUT_MILLIS <= System.currentTimeMillis()
+              || queuesAreEmpty());
+    }
+  }
+
+  public abstract static class TraceSerializingHandler implements Runnable {
 
     private final MpscBlockingConsumerArrayQueue<Object> primaryQueue;
     private final MpscBlockingConsumerArrayQueue<Object> secondaryQueue;
@@ -174,26 +250,7 @@ public class TraceProcessingWorker implements AutoCloseable {
       }
     }
 
-    @Override
-    public void run() {
-      try {
-        runDutyCycle();
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
-      log.debug("Datadog trace processor exited. Publishing traces stopped");
-    }
-
-    private void runDutyCycle() throws InterruptedException {
-      Thread thread = Thread.currentThread();
-      while (!thread.isInterrupted()) {
-        consumeFromPrimaryQueue();
-        consumeFromSecondaryQueue();
-        flushIfNecessary();
-      }
-    }
-
-    private void consumeFromPrimaryQueue() throws InterruptedException {
+    protected void consumeFromPrimaryQueue() throws InterruptedException {
       Object event = primaryQueue.poll(100, MILLISECONDS);
       if (null != event) {
         // there's a high priority trace, consume it,
@@ -203,7 +260,7 @@ public class TraceProcessingWorker implements AutoCloseable {
       }
     }
 
-    private void consumeFromSecondaryQueue() {
+    protected void consumeFromSecondaryQueue() {
       // if there's something there now, take it and try to fill a batch,
       // if not, it's the secondary queue so get back to polling the primary ASAP
       Object event = secondaryQueue.poll();
@@ -213,7 +270,7 @@ public class TraceProcessingWorker implements AutoCloseable {
       }
     }
 
-    private void flushIfNecessary() {
+    protected void flushIfNecessary() {
       if (shouldFlush()) {
         payloadDispatcher.flush();
       }
@@ -233,6 +290,10 @@ public class TraceProcessingWorker implements AutoCloseable {
 
     private void consumeBatch(MessagePassingQueue<Object> queue) {
       queue.drain(this::onEvent, queue.size());
+    }
+
+    protected boolean queuesAreEmpty() {
+      return primaryQueue.isEmpty() && secondaryQueue.isEmpty();
     }
   }
 }

--- a/internal-api/src/main/java/datadog/trace/util/AgentThreadFactory.java
+++ b/internal-api/src/main/java/datadog/trace/util/AgentThreadFactory.java
@@ -74,8 +74,13 @@ public final class AgentThreadFactory implements ThreadFactory {
    * @param runnable work to run on the new thread.
    */
   public static Thread newAgentThread(final AgentThread agentThread, final Runnable runnable) {
+    return newAgentThread(agentThread, runnable, true);
+  }
+
+  public static Thread newAgentThread(
+      final AgentThread agentThread, final Runnable runnable, boolean daemon) {
     final Thread thread = new Thread(AGENT_THREAD_GROUP, runnable, agentThread.threadName);
-    thread.setDaemon(true);
+    thread.setDaemon(daemon);
     thread.setContextClassLoader(null);
     thread.setUncaughtExceptionHandler(
         new Thread.UncaughtExceptionHandler() {


### PR DESCRIPTION
# What Does This Do
This PR changes the logic that publishes traces: if CI Visibility is enabled, the thread that does the publishing is not marked as daemon, and upon receiving an interrupt request the thread will wait up to 5 seconds to ensure all pending traces were published.

# Motivation
CI Visibility differs from production APM: when a customer shuts down a production service, it is acceptable for some operations that happened right before the shutdown to be missing in Datadog. When running tests, however, customers expect every executed test to be visible in Datadog. That means there's a need to wait until publishing is finished, even when all the tests have executed and JVM is ready to shut down.
