### PR TITLE
enable contextual allocation profiler by default

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
@@ -1,10 +1,11 @@
 package com.datadog.profiling.ddprof;
 
 import static datadog.trace.api.Platform.isJ9;
+import static datadog.trace.api.Platform.isJavaVersionAtLeast;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_ALLOCATION_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_CONTEXT_ATTRIBUTES;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_CONTEXT_ATTRIBUTES_SPAN_NAME_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_ALLOC_ENABLED;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_ALLOC_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_ALLOC_INTERVAL;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_ALLOC_INTERVAL_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_CPU_ENABLED;
@@ -128,10 +129,13 @@ public class DatadogProfilerConfig {
   }
 
   public static boolean isAllocationProfilingEnabled(ConfigProvider configProvider) {
+    // switch on if the datadog allocation profiler is enabled,
+    // or if generic allocation profiling has been enabled,
+    // or on any JDK >= 11
     return getBoolean(
         configProvider,
         PROFILING_DATADOG_PROFILER_ALLOC_ENABLED,
-        PROFILING_DATADOG_PROFILER_ALLOC_ENABLED_DEFAULT);
+        getBoolean(configProvider, PROFILING_ALLOCATION_ENABLED, isJavaVersionAtLeast(11)));
   }
 
   public static boolean isAllocationProfilingEnabled() {


### PR DESCRIPTION
# What Does This Do

Enables our new allocation profiler by default on any JDK >= 11 or when any allocation profiling is explicitly enabled.

# Motivation

# Additional Notes
