### PR TITLE
Update the live heap profiling config keys

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
@@ -14,12 +14,15 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILE
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_CSTACK;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_CSTACK_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_LIBPATH;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_LIVEHEAP_CAPACITY;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_LIVEHEAP_CAPACITY_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_LIVEHEAP_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_LIVEHEAP_ENABLED_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_LIVEHEAP_INTERVAL;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_LOG_LEVEL;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_LOG_LEVEL_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_MEMLEAK_CAPACITY;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_MEMLEAK_CAPACITY_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_MEMLEAK_ENABLED;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_MEMLEAK_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_MEMLEAK_INTERVAL;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_SAFEMODE;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_SAFEMODE_DEFAULT;
@@ -152,8 +155,9 @@ public class DatadogProfilerConfig {
   public static boolean isMemoryLeakProfilingEnabled(ConfigProvider configProvider) {
     return getBoolean(
         configProvider,
-        PROFILING_DATADOG_PROFILER_MEMLEAK_ENABLED,
-        PROFILING_DATADOG_PROFILER_MEMLEAK_ENABLED_DEFAULT);
+        PROFILING_DATADOG_PROFILER_LIVEHEAP_ENABLED,
+        PROFILING_DATADOG_PROFILER_LIVEHEAP_ENABLED_DEFAULT,
+        PROFILING_DATADOG_PROFILER_MEMLEAK_ENABLED);
   }
 
   public static boolean isMemoryLeakProfilingEnabled() {
@@ -165,7 +169,10 @@ public class DatadogProfilerConfig {
     long memleakIntervalDefault =
         maxheap <= 0 ? 1024 * 1024 : maxheap / Math.max(1, getMemleakCapacity());
     return getLong(
-        configProvider, PROFILING_DATADOG_PROFILER_MEMLEAK_INTERVAL, memleakIntervalDefault);
+        configProvider,
+        PROFILING_DATADOG_PROFILER_LIVEHEAP_INTERVAL,
+        memleakIntervalDefault,
+        PROFILING_DATADOG_PROFILER_MEMLEAK_INTERVAL);
   }
 
   public static long getMemleakInterval() {
@@ -175,12 +182,14 @@ public class DatadogProfilerConfig {
   public static int getMemleakCapacity(ConfigProvider configProvider) {
     return clamp(
         0,
-        // see https://github.com/DataDog/java-profiler/blob/main/src/memleakTracer.h
+        // see
+        // https://github.com/DataDog/java-profiler/blob/main/ddprof-lib/src/main/cpp/livenessTracker.h#L54
         8192,
         getInteger(
             configProvider,
-            PROFILING_DATADOG_PROFILER_MEMLEAK_CAPACITY,
-            PROFILING_DATADOG_PROFILER_MEMLEAK_CAPACITY_DEFAULT));
+            PROFILING_DATADOG_PROFILER_LIVEHEAP_CAPACITY,
+            PROFILING_DATADOG_PROFILER_LIVEHEAP_CAPACITY_DEFAULT,
+            PROFILING_DATADOG_PROFILER_MEMLEAK_CAPACITY));
   }
 
   public static int getMemleakCapacity() {
@@ -265,26 +274,29 @@ public class DatadogProfilerConfig {
   }
 
   public static boolean getBoolean(
-      ConfigProvider configProvider, String key, boolean defaultValue) {
+      ConfigProvider configProvider, String key, boolean defaultValue, String... aliases) {
     return configProvider.getBoolean(
-        key, configProvider.getBoolean(normalizeKey(key), defaultValue));
+        key, configProvider.getBoolean(normalizeKey(key), defaultValue), aliases);
   }
 
   public static boolean getBoolean(ConfigProvider configProvider, String key) {
     return configProvider.getBoolean(key, configProvider.getBoolean(normalizeKey(key), false));
   }
 
-  public static int getInteger(ConfigProvider configProvider, String key, int defaultValue) {
+  public static int getInteger(
+      ConfigProvider configProvider, String key, int defaultValue, String... aliases) {
     return configProvider.getInteger(
-        key, configProvider.getInteger(normalizeKey(key), defaultValue));
+        key, configProvider.getInteger(normalizeKey(key), defaultValue), aliases);
   }
 
   public static int getInteger(ConfigProvider configProvider, String key) {
     return configProvider.getInteger(key, configProvider.getInteger(normalizeKey(key), -1));
   }
 
-  public static long getLong(ConfigProvider configProvider, String key, long defaultValue) {
-    return configProvider.getLong(key, configProvider.getLong(normalizeKey(key), defaultValue));
+  public static long getLong(
+      ConfigProvider configProvider, String key, long defaultValue, String... aliases) {
+    return configProvider.getLong(
+        key, configProvider.getLong(normalizeKey(key), defaultValue), aliases);
   }
 
   public static long getLong(ConfigProvider configProvider, String key) {

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -116,14 +116,27 @@ public final class ProfilingConfig {
   public static final String PROFILING_DATADOG_PROFILER_SAFEMODE = "profiling.ddprof.safemode";
   public static final int PROFILING_DATADOG_PROFILER_SAFEMODE_DEFAULT =
       12; // POP_METHOD|UNWIND_NATIVE
+
+  @Deprecated
   public static final String PROFILING_DATADOG_PROFILER_MEMLEAK_ENABLED =
       "profiling.ddprof.memleak.enabled";
-  public static final boolean PROFILING_DATADOG_PROFILER_MEMLEAK_ENABLED_DEFAULT = false;
+
+  @Deprecated
   public static final String PROFILING_DATADOG_PROFILER_MEMLEAK_INTERVAL =
       "profiling.ddprof.memleak.interval";
+
+  @Deprecated
   public static final String PROFILING_DATADOG_PROFILER_MEMLEAK_CAPACITY =
       "profiling.ddprof.memleak.capacity";
-  public static final int PROFILING_DATADOG_PROFILER_MEMLEAK_CAPACITY_DEFAULT = 1024;
+
+  public static final String PROFILING_DATADOG_PROFILER_LIVEHEAP_ENABLED =
+      "profiling.ddprof.liveheap.enabled";
+  public static final boolean PROFILING_DATADOG_PROFILER_LIVEHEAP_ENABLED_DEFAULT = false;
+  public static final String PROFILING_DATADOG_PROFILER_LIVEHEAP_INTERVAL =
+      "profiling.ddprof.liveheap.interval";
+  public static final String PROFILING_DATADOG_PROFILER_LIVEHEAP_CAPACITY =
+      "profiling.ddprof.liveheap.capacity";
+  public static final int PROFILING_DATADOG_PROFILER_LIVEHEAP_CAPACITY_DEFAULT = 1024;
   public static final String PROFILING_ENDPOINT_COLLECTION_ENABLED =
       "profiling.endpoint.collection.enabled";
   public static final boolean PROFILING_ENDPOINT_COLLECTION_ENABLED_DEFAULT = true;


### PR DESCRIPTION
# What Does This Do
Updates the profiler config keys to be in sync with the final feature name.

# Motivation
The feature name changed from quite misleading ‘Memleak Profiler’ to more fitting ‘Live Heap Profiler’, yet we released several versions with ‘memleak’ in the config keys.

Although the releases were not public, there definitely may be deployments out there. Therefore it is required to keep the backward compatibility while changing the `memleak` part to `liveheap`.


