### PR TITLE
Added NPE checkers in Instrumentation Gateway

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -218,6 +218,13 @@ public class GatewayBridge {
                 pathParamsSubInfo =
                     producerService.getDataSubscribers(KnownAddresses.REQUEST_PATH_PARAMS);
               }
+              if (pathParamsSubInfo == null) {
+                log.warn("Subscriptions is null for REQUEST_PATH_PARAMS event");
+                return NoopFlow.INSTANCE;
+              }
+              if (pathParamsSubInfo.isEmpty()) {
+                return NoopFlow.INSTANCE;
+              }
               DataBundle bundle =
                   new SingletonDataBundle<>(KnownAddresses.REQUEST_PATH_PARAMS, data);
               try {
@@ -245,6 +252,10 @@ public class GatewayBridge {
               if (rawRequestBodySubInfo == null) {
                 rawRequestBodySubInfo =
                     producerService.getDataSubscribers(KnownAddresses.REQUEST_BODY_RAW);
+              }
+              if (pathParamsSubInfo == null) {
+                log.warn("Subscriptions is null for REQUEST_BODY_DONE event");
+                return NoopFlow.INSTANCE;
               }
               if (rawRequestBodySubInfo.isEmpty()) {
                 return NoopFlow.INSTANCE;
@@ -286,6 +297,10 @@ public class GatewayBridge {
               if (requestBodySubInfo == null) {
                 requestBodySubInfo =
                     producerService.getDataSubscribers(KnownAddresses.REQUEST_BODY_OBJECT);
+              }
+              if (requestBodySubInfo == null) {
+                log.warn("Subscriptions is null for REQUEST_BODY_CONVERTED event");
+                return NoopFlow.INSTANCE;
               }
               if (requestBodySubInfo.isEmpty()) {
                 return NoopFlow.INSTANCE;
@@ -365,6 +380,10 @@ public class GatewayBridge {
             if (grpcServerRequestMsgSubInfo == null) {
               grpcServerRequestMsgSubInfo =
                   producerService.getDataSubscribers(KnownAddresses.GRPC_SERVER_REQUEST_MESSAGE);
+            }
+            if (grpcServerRequestMsgSubInfo == null) {
+              log.warn("Subscriptions is null for GRPC_SERVER_REQUEST_MESSAGE event");
+              return NoopFlow.INSTANCE;
             }
             if (grpcServerRequestMsgSubInfo.isEmpty()) {
               return Flow.ResultFlow.empty();


### PR DESCRIPTION
# What Does This Do
The temporary solution. Added Null checker to avoid NPE.

# Motivation
Reported NPE:
```
java.lang.NullPointerException: Cannot invoke "com.datadog.appsec.event.EventDispatcher$DataSubscriberInfoImpl.isEventDispatcher(com.datadog.appsec.event.EventDispatcher)" 
because "subscribers" is null. 
	at com.datadog.appsec.event.EventDispatcher.publishDataEvent(EventDispatcher.java:185)
	at com.datadog.appsec.event.ReplaceableEventProducerService.publishDataEvent(ReplaceableEventProducerService.java:33)
	at com.datadog.appsec.gateway.GatewayBridge.lambda$init$5(GatewayBridge.java:224)
	at com.datadog.appsec.gateway.GatewayBridge$$Lambda$151 (Source)
	at datadog.trace.api.gateway.InstrumentationGateway$6.apply(InstrumentationGateway.java:255)
	at datadog.trace.api.gateway.InstrumentationGateway$6.apply(InstrumentationGateway.java:250)
	at org.glassfish.jersey.server.internal.routing.UriRoutingContext.getPathParameters(UriRoutingContext.java:319)
	at org.glassfish.jersey.server.internal.routing.UriRoutingContext.getPathParameters(UriRoutingContext.java:297)
	at com.fsmatic.launcher.JettyEnvironment.decorateRequest(JettyEnvironment.java:284)
	at com.fsmatic.launcher.JettyEnvironment$2.decorateRequest(JettyEnvironment.java:341)
	at io.opentracing.contrib.jaxrs2.server.ServerTracingFilter.filter(ServerTracingFilter.java:78)
	at org.glassfish.jersey.server.ContainerFilteringStage.apply(ContainerFilteringStage.java:132)
	at org.glassfish.jersey.server.ContainerFilteringStage.apply(ContainerFilteringStage.java:68)
	at org.glassfish.jersey.process.internal.Stages.process(Stages.java:197)
	at org.glassfish.jersey.server.ServerRuntime$1run(ServerRuntime.java:269)
```

# Additional Notes
This is a temporary fix, while we are investigating the root of issue. It seems, there are something is wrong with the jersey instrumentation, that cause the problem.
