### PR TITLE
Stop using LZ4 via JNI, remove lz4-java native libraries

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/CompressingRequestBody.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/CompressingRequestBody.java
@@ -8,7 +8,9 @@ import java.io.OutputStream;
 import java.util.zip.GZIPOutputStream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import net.jpountz.lz4.LZ4Factory;
 import net.jpountz.lz4.LZ4FrameOutputStream;
+import net.jpountz.xxhash.XXHashFactory;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 import okio.BufferedSink;
@@ -20,6 +22,10 @@ import okio.Source;
  * data.
  */
 final class CompressingRequestBody extends RequestBody {
+
+  private static final LZ4Factory LZ4_FACTORY = LZ4Factory.fastestJavaInstance();
+  private static final XXHashFactory XXHASH_FACTORY = XXHashFactory.fastestJavaInstance();
+
   static final class MissingInputException extends IOException {
     public MissingInputException(String message) {
       super(message);
@@ -339,6 +345,9 @@ final class CompressingRequestBody extends RequestBody {
     return new LZ4FrameOutputStream(
         os,
         LZ4FrameOutputStream.BLOCKSIZE.SIZE_64KB,
+        -1L,
+        LZ4_FACTORY.fastCompressor(),
+        XXHASH_FACTORY.hash32(),
         // copy of the default flag(s) used by LZ4FrameOutputStream
         LZ4FrameOutputStream.FLG.Bits.BLOCK_INDEPENDENCE);
   }

--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -34,6 +34,8 @@ ext.generalShadowJarConfig = {
   exclude '**/META-INF/proguard/'
   exclude '**/META-INF/*.kotlin_module'
   exclude '**/module-info.class'
+  exclude '**/liblz4-java.so'
+  exclude '**/liblz4-java.dylib'
 
   // Prevents conflict with other SLF4J instances. Important for premain.
   relocate 'org.slf4j', 'datadog.slf4j'


### PR DESCRIPTION
# What Does This Do

Stops using the JNI implementations in lz4-java, and then removes the bundled native libraries. I have extensive experience with this library and have found that compressing large binaries via JNI is bad for time-to-safepoint, and that on more recent JDKs the Java code is very competitive with native code (LZ4 and XXHash32 are extremely simple algorithms).

# Motivation

Slightly reduces the agent jar size: 

before:
```
27180	dd-java-agent-1.16.0-SNAPSHOT.jar
inflated top level breakdown of contents:
45776	inst
19556	shared
12400	appsec
7016	profiling
3336	datadog
3224	metrics
1296	debugger
540	iast
452	ci-visibility
```

after:
```
26664	dd-java-agent-1.16.0-SNAPSHOT.jar
inflated top level breakdown of contents:
45776	inst
19556	shared
12400	appsec
5708	profiling
3340	datadog
3224	metrics
1304	debugger
540	iast
452	ci-visibility
```

It's likely that similar economies can be found elsewhere and part of the motivation is to encourage drive by reductions in jar size elsewhere.



# Additional Notes
