### PR TITLE
omit dylibs unless building to run on a MacOS laptop

### DIFF
--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -35,6 +35,10 @@ ext.generalShadowJarConfig = {
   exclude '**/META-INF/*.kotlin_module'
   exclude '**/module-info.class'
 
+  if (!project.hasProperty("targetMacOs")) {
+    exclude '**/*.dylib'
+  }
+
   // Prevents conflict with other SLF4J instances. Important for premain.
   relocate 'org.slf4j', 'datadog.slf4j'
   // rewrite dependencies calling Logger.getLogger


### PR DESCRIPTION
# What Does This Do

Unless a developer builds with the property `targetMacOs`, native dylibs are excluded from the build, which reduces deployment size by about 1MiB. This assumes that customers do not use appsec on laptops.

before:
```
26312	dd-java-agent-1.16.0-SNAPSHOT.jar
45776	inst
19556	shared
12400	appsec
7016	profiling
3340	datadog
3224	metrics
1304	debugger
540	iast
452	ci-visibility
```

after:
```
25500	dd-java-agent-1.16.0-SNAPSHOT.jar
45776	inst
19556	shared
9620	appsec
6860	profiling   <-- double counts the dylib excluded by the profiling-specific PR
3340	datadog
3224	metrics
1304	debugger
540	iast
452	ci-visibility
```

# Motivation

# Additional Notes
