### PR TITLE
Fix null values for lists or maps

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/SerializerWithLimits.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/SerializerWithLimits.java
@@ -112,6 +112,9 @@ public class SerializerWithLimits {
   }
 
   public void serialize(Object value, String type, Limits limits) throws Exception {
+    if (type == null) {
+      throw new IllegalArgumentException("Type is required for serialization");
+    }
     tokenWriter.prologue(value, type);
     if (timeoutChecker.isTimedOut(System.currentTimeMillis())) {
       tokenWriter.notCaptured(NotCapturedReason.TIMEOUT);
@@ -355,7 +358,8 @@ public class SerializerWithLimits {
     int i = 0;
     while (i < maxSize) {
       Object val = objArray[i];
-      serialize(val, val != null ? val.getClass().getTypeName() : "java.lang.Object", newLimits);
+      serialize(
+          val, val != null ? val.getClass().getTypeName() : Object.class.getTypeName(), newLimits);
       i++;
     }
     return maxSize == objArray.length;
@@ -370,7 +374,8 @@ public class SerializerWithLimits {
     Iterator<?> it = collection.iterator(); // /!\ alien call /!\
     while (i < maxSize && it.hasNext()) { // /!\ alien call /!\
       Object val = it.next(); // /!\ alien call /!\
-      serialize(val, val != null ? val.getClass().getTypeName() : null, newLimits);
+      serialize(
+          val, val != null ? val.getClass().getTypeName() : Object.class.getTypeName(), newLimits);
       i++;
     }
     return maxSize == colSize;
@@ -388,8 +393,14 @@ public class SerializerWithLimits {
       tokenWriter.mapEntryPrologue(entry);
       Object keyObj = entry.getKey(); // /!\ alien call /!\
       Object valObj = entry.getValue(); // /!\ alien call /!\
-      serialize(keyObj, keyObj != null ? keyObj.getClass().getTypeName() : null, newLimits);
-      serialize(valObj, valObj != null ? valObj.getClass().getTypeName() : null, newLimits);
+      serialize(
+          keyObj,
+          keyObj != null ? keyObj.getClass().getTypeName() : Object.class.getTypeName(),
+          newLimits);
+      serialize(
+          valObj,
+          valObj != null ? valObj.getClass().getTypeName() : Object.class.getTypeName(),
+          newLimits);
       tokenWriter.mapEntryEpilogue(entry);
       i++;
     }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ValueScriptHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ValueScriptHelper.java
@@ -18,7 +18,10 @@ public class ValueScriptHelper {
     SerializerWithLimits serializer =
         new SerializerWithLimits(new StringTokenWriter(sb, status.getErrors()), timeoutChecker);
     try {
-      serializer.serialize(value, value != null ? value.getClass().getTypeName() : null, LIMITS);
+      serializer.serialize(
+          value,
+          value != null ? value.getClass().getTypeName() : Object.class.getTypeName(),
+          LIMITS);
     } catch (Exception ex) {
       status.addError(new EvaluationError(expr, ex.getMessage()));
     }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/StringTokenWriterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/StringTokenWriterTest.java
@@ -171,7 +171,8 @@ class StringTokenWriterTest {
         new SerializerWithLimits(
             new StringTokenWriter(sb, new ArrayList<>()),
             new TimeoutChecker(Duration.of(1, ChronoUnit.SECONDS)));
-    serializer.serialize(value, value != null ? value.getClass().getTypeName() : null, limits);
+    serializer.serialize(
+        value, value != null ? value.getClass().getTypeName() : Object.class.getTypeName(), limits);
     return sb.toString();
   }
 }


### PR DESCRIPTION
# What Does This Do
type is required should not be null when serializing. fallback is java.lang.Object

# Motivation

# Additional Notes
