### PR TITLE
Break potentially circular dependency between Config and TPEHelper

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/TPEHelper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/TPEHelper.java
@@ -128,8 +128,8 @@ public final class TPEHelper {
   @SuppressWarnings("deprecation")
   public static void startQueuingTimer(
       ContextStore<Runnable, State> taskContextStore, ThreadPoolExecutor executor, Runnable task) {
-    if (Config.get().isProfilingQueueingTimeEnabled()
-        && InstrumentationBasedProfiling.isJFRReady()) {
+    if (InstrumentationBasedProfiling.isJFRReady()
+        && Config.get().isProfilingQueueingTimeEnabled()) {
       State state = taskContextStore.get(task);
       if (task != null && state != null) {
         QueueTiming timing =

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/TPEHelper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/TPEHelper.java
@@ -1,15 +1,17 @@
 package datadog.trace.bootstrap.instrumentation.java.concurrent;
 
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED_DEFAULT;
 import static datadog.trace.bootstrap.TaskWrapper.getUnwrappedType;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.exclude;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.GenericClassValue;
 import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.api.profiling.QueueTiming;
 import datadog.trace.api.profiling.Timer;
 import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.jfr.InstrumentationBasedProfiling;
@@ -125,11 +127,14 @@ public final class TPEHelper {
     AdviceUtils.cancelTask(contextStore, task);
   }
 
-  @SuppressWarnings("deprecation")
+  // don't use Config because it may use ThreadPoolExecutor to initialize itself
+  private static final boolean IS_PROFILING_QUEUEING_TIME_ENABLED =
+      ConfigProvider.getInstance()
+          .getBoolean(PROFILING_QUEUEING_TIME_ENABLED, PROFILING_QUEUEING_TIME_ENABLED_DEFAULT);
+
   public static void startQueuingTimer(
       ContextStore<Runnable, State> taskContextStore, ThreadPoolExecutor executor, Runnable task) {
-    if (InstrumentationBasedProfiling.isJFRReady()
-        && Config.get().isProfilingQueueingTimeEnabled()) {
+    if (IS_PROFILING_QUEUEING_TIME_ENABLED && InstrumentationBasedProfiling.isJFRReady()) {
       State state = taskContextStore.get(task);
       if (task != null && state != null) {
         QueueTiming timing =

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -211,8 +211,6 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_PASSWORD;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_PORT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_PORT_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_USERNAME;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_START_DELAY;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_START_DELAY_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_START_FORCE_FIRST;
@@ -547,8 +545,6 @@ public class Config {
   private final boolean profilingExcludeAgentThreads;
   private final boolean profilingUploadSummaryOn413Enabled;
   private final boolean profilingRecordExceptionMessage;
-
-  private final boolean profilingQueueingTimeEnabled;
 
   private final boolean crashTrackingAgentless;
   private final Map<String, String> crashTrackingTags;
@@ -1238,10 +1234,6 @@ public class Config {
     profilingRecordExceptionMessage =
         configProvider.getBoolean(
             PROFILING_EXCEPTION_RECORD_MESSAGE, PROFILING_EXCEPTION_RECORD_MESSAGE_DEFAULT);
-
-    profilingQueueingTimeEnabled =
-        configProvider.getBoolean(
-            PROFILING_QUEUEING_TIME_ENABLED, PROFILING_QUEUEING_TIME_ENABLED_DEFAULT);
 
     profilingUploadSummaryOn413Enabled =
         configProvider.getBoolean(
@@ -2038,10 +2030,6 @@ public class Config {
 
   public boolean isDatadogProfilerEnabled() {
     return isDatadogProfilerEnabled;
-  }
-
-  public boolean isProfilingQueueingTimeEnabled() {
-    return profilingQueueingTimeEnabled;
   }
 
   public static boolean isDatadogProfilerSafeInCurrentEnvironment() {


### PR DESCRIPTION
# What Does This Do

This resolves a circular dependency where `TPEHelper` depends on `Config` for a feature flag check, but `Config.<clinit>` depends on `Runtime.exec` to get the hostname, which depends on `ThreadPoolExecutor` which depends on `TPEHelper` once instrumented. All of this has been set up by the time `InstrumentationBasedProfiling`'s flag is flipped.

# Motivation

# Additional Notes
