### PR TITLE
Bump default max remote config payload size limit to 5Mb

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -115,7 +115,7 @@ public final class ConfigDefaults {
 
   static final boolean DEFAULT_REMOTE_CONFIG_ENABLED = true;
   static final boolean DEFAULT_REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED = false;
-  static final int DEFAULT_REMOTE_CONFIG_MAX_PAYLOAD_SIZE = 1024; // KiB
+  static final int DEFAULT_REMOTE_CONFIG_MAX_PAYLOAD_SIZE = 5120; // KiB
   static final int DEFAULT_REMOTE_CONFIG_POLL_INTERVAL_SECONDS = 5;
   static final String DEFAULT_REMOTE_CONFIG_TARGETS_KEY_ID =
       "5c4ece41241a1bb513f6e3e5df74ab7d5183dfffbd71bfd43127920d880569fd";


### PR DESCRIPTION
# What Does This Do
Bump the default maximum remote config payload size to 5Mb.

# Motivation
`ASM_DATA` to block IPs has increased our expectations for remote config payload sizes. While there might be upcoming changes to have lighter payloads, bumping the RC payload size limit to 5Mb should be enough to keep up with the limits that are currently tested for all tracers.

Note that RC esponses are cached, so payloads this big should not be seen at every polling interval.

# Additional Notes
