### PR TITLE
Do not send empty test suite spans

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestSessionImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestSessionImpl.java
@@ -80,7 +80,8 @@ public class DDTestSessionImpl implements DDTestSession {
 
   @Override
   public void end(@Nullable Long endTime) {
-    span.setTag(Tags.TEST_STATUS, context.getStatus());
+    String status = context.getStatus();
+    span.setTag(Tags.TEST_STATUS, status != null ? status : CIConstants.TEST_SKIP);
     testDecorator.beforeFinish(span);
 
     if (endTime != null) {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestSuiteImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestSuiteImpl.java
@@ -143,13 +143,16 @@ public class DDTestSuiteImpl implements DDTestSuite {
     testDecorator.beforeFinish(span);
 
     String status = context.getStatus();
-    span.setTag(Tags.TEST_STATUS, status);
-    moduleContext.reportChildStatus(status);
+    if (status != null) {
+      // do not report test suite if no execution took place
+      span.setTag(Tags.TEST_STATUS, status);
+      moduleContext.reportChildStatus(status);
 
-    if (endTime != null) {
-      span.finish(endTime);
-    } else {
-      span.finish();
+      if (endTime != null) {
+        span.finish(endTime);
+      } else {
+        span.finish();
+      }
     }
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/context/AbstractTestContext.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/context/AbstractTestContext.java
@@ -4,18 +4,23 @@ import datadog.trace.api.civisibility.CIConstants;
 
 abstract class AbstractTestContext implements TestContext {
 
-  private String status = CIConstants.TEST_SKIP;
+  private String status;
 
   @Override
   public synchronized void reportChildStatus(String childStatus) {
     switch (childStatus) {
       case CIConstants.TEST_PASS:
-        if (CIConstants.TEST_SKIP.equals(status)) {
+        if (status == null || CIConstants.TEST_SKIP.equals(status)) {
           status = CIConstants.TEST_PASS;
         }
         break;
       case CIConstants.TEST_FAIL:
         status = CIConstants.TEST_FAIL;
+        break;
+      case CIConstants.TEST_SKIP:
+        if (status == null) {
+          status = CIConstants.TEST_SKIP;
+        }
         break;
       default:
         break;


### PR DESCRIPTION
# What Does This Do
Adds a check to avoid reporting empty test suite spans.
A test suite span is considered empty if it has no children (i.e. suite does not include test cases) and it was not explicitly reported by the test framework as skipped or failed.

# Motivation
In certain edge cases a test framework might report a test suite as started, and then all of suite's children might be skipped by Intelligent Test Runner (this happens with parameterized tests in JUnit 5 - the list of test cases is not known in advance, so when suite is started there is no way to know if it will be skipped entirely or not).
These empty suites are confusing for the product's users and must not be reported.
