### PR TITLE
Ensure lambda instrumentation only notifies extension once.

### DIFF
--- a/dd-java-agent/instrumentation/aws-lambda-handler/build.gradle
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/build.gradle
@@ -1,3 +1,10 @@
+muzzle {
+  pass {
+    group = 'com.amazonaws'
+    module = 'aws-lambda-java-core'
+    versions = '[1.2.1,)'
+  }
+}
 
 apply from: "$rootDir/gradle/java.gradle"
 
@@ -16,5 +23,6 @@ latestDepTest {
 }
 
 dependencies {
+  compileOnly group: 'com.amazonaws', name: 'aws-lambda-java-core', version: '1.2.1'
   testImplementation group: 'com.amazonaws', name: 'aws-lambda-java-core', version: '1.2.1'
 }

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaHandler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaHandler.java
@@ -56,6 +56,7 @@ public class LambdaHandler {
       new Moshi.Builder()
           // we need to bypass abstract Classes as we can't JSON serialize them
           .add(SkipUnsupportedTypeJsonAdapter.newFactory())
+          .add(ReadFromInputStreamJsonAdapter.newFactory())
           .build()
           .adapter(Object.class);
 

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaHandler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaHandler.java
@@ -10,6 +10,7 @@ import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.core.propagation.ExtractedContext;
 import datadog.trace.core.propagation.PropagationTags;
+import java.io.ByteArrayInputStream;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -54,9 +55,8 @@ public class LambdaHandler {
   private static final MediaType jsonMediaType = MediaType.parse("application/json");
   private static final JsonAdapter<Object> adapter =
       new Moshi.Builder()
-          // we need to bypass abstract Classes as we can't JSON serialize them
+          .add(ByteArrayInputStream.class, new ReadFromInputStreamJsonAdapter())
           .add(SkipUnsupportedTypeJsonAdapter.newFactory())
-          .add(ReadFromInputStreamJsonAdapter.newFactory())
           .build()
           .adapter(Object.class);
 

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/ReadFromInputStreamJsonAdapter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/ReadFromInputStreamJsonAdapter.java
@@ -1,0 +1,51 @@
+package datadog.trace.lambda;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import com.squareup.moshi.Moshi;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Set;
+import okio.BufferedSink;
+
+public final class ReadFromInputStreamJsonAdapter<T> extends JsonAdapter<T> {
+
+  @Override
+  public T fromJson(JsonReader reader) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void toJson(JsonWriter writer, T value) throws IOException {
+    BufferedSink sink = writer.valueSink();
+    byte[] bytes = getInputBytes(value);
+    sink.write(bytes);
+    sink.flush();
+  }
+
+  private byte[] getInputBytes(T value) throws IOException {
+    ByteArrayInputStream inputStream = (ByteArrayInputStream) value;
+    inputStream.mark(0);
+    byte[] bytes = new byte[inputStream.available()];
+    inputStream.read(bytes);
+    inputStream.reset();
+    return bytes;
+  }
+
+  public static Factory newFactory() {
+    return new Factory() {
+      @Override
+      public JsonAdapter<?> create(
+          Type requestedType, Set<? extends Annotation> annotations, Moshi moshi) {
+        if (requestedType == ByteArrayInputStream.class) {
+          return new ReadFromInputStreamJsonAdapter<>();
+        }
+        return moshi.nextAdapter(this, requestedType, annotations);
+      }
+    };
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/ReadFromInputStreamJsonAdapter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/ReadFromInputStreamJsonAdapter.java
@@ -5,7 +5,6 @@ import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.JsonWriter;
 import com.squareup.moshi.Moshi;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/ReadFromInputStreamJsonAdapter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/ReadFromInputStreamJsonAdapter.java
@@ -3,48 +3,32 @@ package datadog.trace.lambda;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.JsonWriter;
-import com.squareup.moshi.Moshi;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Type;
-import java.util.Set;
 import okio.BufferedSink;
 
-public final class ReadFromInputStreamJsonAdapter<T> extends JsonAdapter<T> {
+public final class ReadFromInputStreamJsonAdapter extends JsonAdapter<ByteArrayInputStream> {
 
   @Override
-  public T fromJson(JsonReader reader) throws IOException {
+  public ByteArrayInputStream fromJson(JsonReader reader) throws IOException {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public void toJson(JsonWriter writer, T value) throws IOException {
-    BufferedSink sink = writer.valueSink();
-    byte[] bytes = getInputBytes(value);
-    sink.write(bytes);
-    sink.flush();
+  public void toJson(JsonWriter writer, ByteArrayInputStream inputStream) throws IOException {
+    if (inputStream != null) {
+      BufferedSink sink = writer.valueSink();
+      byte[] bytes = getInputBytes(inputStream);
+      sink.write(bytes);
+      sink.flush();
+    }
   }
 
-  private byte[] getInputBytes(T value) throws IOException {
-    ByteArrayInputStream inputStream = (ByteArrayInputStream) value;
+  private byte[] getInputBytes(ByteArrayInputStream inputStream) throws IOException {
     inputStream.mark(0);
     byte[] bytes = new byte[inputStream.available()];
     inputStream.read(bytes);
     inputStream.reset();
     return bytes;
-  }
-
-  public static Factory newFactory() {
-    return new Factory() {
-      @Override
-      public JsonAdapter<?> create(
-          Type requestedType, Set<? extends Annotation> annotations, Moshi moshi) {
-        if (requestedType == ByteArrayInputStream.class) {
-          return new ReadFromInputStreamJsonAdapter<>();
-        }
-        return moshi.nextAdapter(this, requestedType, annotations);
-      }
-    };
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/lambda/LambdaHandlerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/lambda/LambdaHandlerTest.groovy
@@ -11,6 +11,7 @@ import com.amazonaws.services.lambda.runtime.events.SNSEvent
 import com.amazonaws.services.lambda.runtime.events.S3Event
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
 import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification
+import java.io.ByteArrayInputStream
 
 import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
 
@@ -222,5 +223,17 @@ class LambdaHandlerTest extends DDCoreSpecification {
 
     then:
     result == "{\"body\":\"bababango\",\"httpMethod\":\"POST\"}"
+  }
+
+  def "test moshi toJson InputStream"() {
+    given:
+    def body = "{\"body\":\"bababango\",\"httpMethod\":\"POST\"}"
+    def myEvent = new ByteArrayInputStream(body.getBytes())
+
+    when:
+    def result = LambdaHandler.writeValueAsString(myEvent)
+
+    then:
+    result == body
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/lambda/LambdaHandlerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/lambda/LambdaHandlerTest.groovy
@@ -11,7 +11,6 @@ import com.amazonaws.services.lambda.runtime.events.SNSEvent
 import com.amazonaws.services.lambda.runtime.events.S3Event
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
 import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification
-import java.io.ByteArrayInputStream
 
 import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
 


### PR DESCRIPTION
# What Does This Do

Prevent calling `start-invocation` and `end-invocation` on the aws lambda extension multiple times.

The lambda event needs to be serialized to json and shared with the extension. This event was properly serialized for the second wrapping, but not for the first. This means that once the extra handler wrapping is ignored, only one `aws.lambda` span is being created, but the lack of event json means we won't be able to create inferred spans or properly handle trace context.

The solution for this second problem is to add a new json adapter to serialize these types.

# Motivation

In the most recent version of the java tracing layer for aws lambda, the request handler is being wrapped at least twice.

```log
[dd.trace 2023-05-18 21:41:20:530 +0000] [main] DEBUG datadog.trace.agent.tooling.InstrumenterState - Instrumentation applied - instrumentation.names=[aws-lambda] instrumentation.class=datadog.trace.instrumentation.aws.v1.lambda.LambdaHandlerInstrumentation instrumentation.target.classloader=lambdainternal.CustomerClassLoader@4d2a1da3

[dd.trace 2023-05-18 21:41:21:649 +0000] [main] DEBUG datadog.trace.agent.tooling.InstrumenterState - Instrumentation applied - instrumentation.names=[aws-lambda] instrumentation.class=datadog.trace.instrumentation.aws.v1.lambda.LambdaHandlerInstrumentation instrumentation.target.classloader=jdk.internal.loader.ClassLoaders$AppClassLoader@2626b418
```

This double wrapping is causing the tracer to make calls to `start-invocation` and `end-invocation` multiple times. A `aws.lambda` root span is created in the extension for every call to these endpoints.

# Additional Notes
