### PR TITLE
Add feature-flag to control tagging of search request body/parameters

### DIFF
--- a/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchRestClientDecorator.java
+++ b/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchRestClientDecorator.java
@@ -18,6 +18,7 @@ import org.apache.http.HttpEntity;
 import org.elasticsearch.client.Response;
 
 public class ElasticsearchRestClientDecorator extends DBTypeProcessingDatabaseClientDecorator {
+  private static final int MAX_ELASTICSEARCH_BODY_CONTENT_LENGTH = 25000;
 
   private static final String SERVICE_NAME =
       SpanNaming.instance()
@@ -36,7 +37,7 @@ public class ElasticsearchRestClientDecorator extends DBTypeProcessingDatabaseCl
 
   @Override
   protected String[] instrumentationNames() {
-    return new String[] {"elasticsearch"};
+    return new String[]{"elasticsearch"};
   }
 
   @Override
@@ -98,18 +99,26 @@ public class ElasticsearchRestClientDecorator extends DBTypeProcessingDatabaseCl
       final Map<String, String> parameters) {
     span.setTag(Tags.HTTP_METHOD, method);
     span.setTag(Tags.HTTP_URL, endpoint);
-    if (entity != null) {
-      span.setTag("elasticsearch.body", getElasticsearchRequestBody(entity));
-    }
-    if (parameters != null) {
-      StringBuilder queryParametersStringBuilder = new StringBuilder();
-      for (Map.Entry<String, String> parameter : parameters.entrySet()) {
-        queryParametersStringBuilder.append(parameter.getKey() + "=" + parameter.getValue() + "&");
+    if (Config.get().isElasticsearchBodyAndParamsEnabled()) {
+      if (entity != null) {
+        long contentLength = entity.getContentLength();
+        if (contentLength <= MAX_ELASTICSEARCH_BODY_CONTENT_LENGTH) {
+          span.setTag("elasticsearch.body", getElasticsearchRequestBody(entity));
+        } else {
+          span.setTag("elasticsearch.body", "<body size " + contentLength + " exceeds limit of " +
+              MAX_ELASTICSEARCH_BODY_CONTENT_LENGTH + ">");
+        }
       }
-      if (queryParametersStringBuilder.length() >= 1) {
-        queryParametersStringBuilder.deleteCharAt(queryParametersStringBuilder.length() - 1);
+      if (parameters != null) {
+        StringBuilder queryParametersStringBuilder = new StringBuilder();
+        for (Map.Entry<String, String> parameter : parameters.entrySet()) {
+          queryParametersStringBuilder.append(parameter.getKey() + "=" + parameter.getValue() + "&");
+        }
+        if (queryParametersStringBuilder.length() >= 1) {
+          queryParametersStringBuilder.deleteCharAt(queryParametersStringBuilder.length() - 1);
+        }
+        span.setTag("elasticsearch.params", queryParametersStringBuilder.toString());
       }
-      span.setTag("elasticsearch.params", queryParametersStringBuilder.toString());
     }
     return HTTP_RESOURCE_DECORATOR.withClientPath(span, method, endpoint);
   }

--- a/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchRestClientDecorator.java
+++ b/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchRestClientDecorator.java
@@ -37,7 +37,7 @@ public class ElasticsearchRestClientDecorator extends DBTypeProcessingDatabaseCl
 
   @Override
   protected String[] instrumentationNames() {
-    return new String[]{"elasticsearch"};
+    return new String[] {"elasticsearch"};
   }
 
   @Override
@@ -105,14 +105,20 @@ public class ElasticsearchRestClientDecorator extends DBTypeProcessingDatabaseCl
         if (contentLength <= MAX_ELASTICSEARCH_BODY_CONTENT_LENGTH) {
           span.setTag("elasticsearch.body", getElasticsearchRequestBody(entity));
         } else {
-          span.setTag("elasticsearch.body", "<body size " + contentLength + " exceeds limit of " +
-              MAX_ELASTICSEARCH_BODY_CONTENT_LENGTH + ">");
+          span.setTag(
+              "elasticsearch.body",
+              "<body size "
+                  + contentLength
+                  + " exceeds limit of "
+                  + MAX_ELASTICSEARCH_BODY_CONTENT_LENGTH
+                  + ">");
         }
       }
       if (parameters != null) {
         StringBuilder queryParametersStringBuilder = new StringBuilder();
         for (Map.Entry<String, String> parameter : parameters.entrySet()) {
-          queryParametersStringBuilder.append(parameter.getKey() + "=" + parameter.getValue() + "&");
+          queryParametersStringBuilder.append(
+              parameter.getKey() + "=" + parameter.getValue() + "&");
         }
         if (queryParametersStringBuilder.length() >= 1) {
           queryParametersStringBuilder.deleteCharAt(queryParametersStringBuilder.length() - 1);

--- a/dd-java-agent/instrumentation/opensearch/src/main/java/datadog/trace/instrumentation/opensearch/OpensearchRestClientDecorator.java
+++ b/dd-java-agent/instrumentation/opensearch/src/main/java/datadog/trace/instrumentation/opensearch/OpensearchRestClientDecorator.java
@@ -35,7 +35,7 @@ public class OpensearchRestClientDecorator extends DBTypeProcessingDatabaseClien
 
   @Override
   protected String[] instrumentationNames() {
-    return new String[]{"opensearch"};
+    return new String[] {"opensearch"};
   }
 
   @Override
@@ -97,20 +97,27 @@ public class OpensearchRestClientDecorator extends DBTypeProcessingDatabaseClien
       final Map<String, String> parameters) {
     span.setTag(Tags.HTTP_METHOD, method);
     span.setTag(Tags.HTTP_URL, endpoint);
-    if (Config.get().isElasticsearchBodyAndParamsEnabled()) {  // Elasticsearch also controls Opensearch
+    if (Config.get()
+        .isElasticsearchBodyAndParamsEnabled()) { // Elasticsearch also controls Opensearch
       if (entity != null) {
         long contentLength = entity.getContentLength();
         if (contentLength <= MAX_OPENSEARCH_BODY_CONTENT_LENGTH) {
           span.setTag("opensearch.body", getOpensearchRequestBody(entity));
         } else {
-          span.setTag("opensearch.body", "<body size " + contentLength + " exceeds limit of " +
-              MAX_OPENSEARCH_BODY_CONTENT_LENGTH + ">");
+          span.setTag(
+              "opensearch.body",
+              "<body size "
+                  + contentLength
+                  + " exceeds limit of "
+                  + MAX_OPENSEARCH_BODY_CONTENT_LENGTH
+                  + ">");
         }
       }
       if (parameters != null) {
         StringBuilder queryParametersStringBuilder = new StringBuilder();
         for (Map.Entry<String, String> parameter : parameters.entrySet()) {
-          queryParametersStringBuilder.append(parameter.getKey() + "=" + parameter.getValue() + "&");
+          queryParametersStringBuilder.append(
+              parameter.getKey() + "=" + parameter.getValue() + "&");
         }
         if (queryParametersStringBuilder.length() >= 1) {
           queryParametersStringBuilder.deleteCharAt(queryParametersStringBuilder.length() - 1);

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -168,7 +168,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_TRACE_LONG_RUNNING_ENABLED = false;
   static final long DEFAULT_TRACE_LONG_RUNNING_FLUSH_INTERVAL = 300; // seconds -> 5 minutes
 
-  static final boolean DEFAULT_ELASTICSEARCH_BODY_AND_PARAMS_ENABLED = false;
+  static final boolean DEFAULT_ELASTICSEARCH_BODY_AND_PARAMS_ENABLED = true;
 
   private ConfigDefaults() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -168,5 +168,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_TRACE_LONG_RUNNING_ENABLED = false;
   static final long DEFAULT_TRACE_LONG_RUNNING_FLUSH_INTERVAL = 300; // seconds -> 5 minutes
 
+  static final boolean DEFAULT_ELASTICSEARCH_BODY_AND_PARAMS_ENABLED = false;
+
   private ConfigDefaults() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -110,6 +110,8 @@ public final class TraceInstrumentationConfig {
   public static final String RESOLVER_USE_LOADCLASS = "resolver.use.loadclass";
   public static final String RESOLVER_RESET_INTERVAL = "resolver.reset.interval";
   public static final String RESOLVER_NAMES_ARE_UNIQUE = "resolver.names.are.unique";
+  public static final String ELASTICSEARCH_BODY_AND_PARAMS_ENABLED =
+      "trace.elasticsearch.body-and-params.enabled";
 
   private TraceInstrumentationConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -36,6 +36,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_UPLOAD_FLUSH_INT
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_UPLOAD_TIMEOUT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_VERIFY_BYTECODE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DOGSTATSD_START_DELAY;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_ELASTICSEARCH_BODY_AND_PARAMS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_GRPC_CLIENT_ERROR_STATUSES;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_GRPC_SERVER_ERROR_STATUSES;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HEALTH_METRICS_ENABLED;
@@ -267,6 +268,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ASYNC_
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_PRINCIPAL_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ROOT_CONTEXT_SERVICE_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SPRING_DATA_REPOSITORY_INTERFACE_RESOURCE_NAME;
+import static datadog.trace.api.config.TraceInstrumentationConfig.ELASTICSEARCH_BODY_AND_PARAMS_ENABLED;
 import static datadog.trace.api.config.TracerConfig.AGENT_HOST;
 import static datadog.trace.api.config.TracerConfig.AGENT_NAMED_PIPE;
 import static datadog.trace.api.config.TracerConfig.AGENT_PORT_LEGACY;
@@ -696,6 +698,7 @@ public class Config {
 
   private final boolean longRunningTraceEnabled;
   private final long longRunningTraceFlushInterval;
+  private final boolean elasticsearchBodyAndParamsEnabled;
 
   // Read order: System Properties -> Env Variables, [-> properties file], [-> default value]
   private Config() {
@@ -755,7 +758,8 @@ public class Config {
     } else {
       secureRandom = configProvider.getBoolean(SECURE_RANDOM, DEFAULT_SECURE_RANDOM);
     }
-
+    elasticsearchBodyAndParamsEnabled = configProvider.getBoolean(ELASTICSEARCH_BODY_AND_PARAMS_ENABLED,
+        DEFAULT_ELASTICSEARCH_BODY_AND_PARAMS_ENABLED);
     String strategyName = configProvider.getString(ID_GENERATION_STRATEGY);
     trace128bitTraceIdGenerationEnabled =
         configProvider.getBoolean(
@@ -2492,6 +2496,10 @@ public class Config {
     return grpcClientErrorStatuses;
   }
 
+  public boolean isElasticsearchBodyAndParamsEnabled(){
+    return elasticsearchBodyAndParamsEnabled;
+  }
+
   /** @return A map of tags to be applied only to the local application root span. */
   public Map<String, Object> getLocalRootSpanTags() {
     final Map<String, String> runtimeTags = getRuntimeTags();
@@ -3509,6 +3517,8 @@ public class Config {
         + longRunningTraceEnabled
         + ", longRunningTraceFlushInterval="
         + longRunningTraceFlushInterval
+        + ", elasticsearchBodyAndParamsEnabled="
+        + elasticsearchBodyAndParamsEnabled
         + '}';
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -238,6 +238,7 @@ import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_URL;
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX;
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_DBM_PROPAGATION_MODE_MODE;
+import static datadog.trace.api.config.TraceInstrumentationConfig.ELASTICSEARCH_BODY_AND_PARAMS_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_CLIENT_ERROR_STATUSES;
 import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_IGNORED_INBOUND_METHODS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_IGNORED_OUTBOUND_METHODS;
@@ -268,7 +269,6 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ASYNC_
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_PRINCIPAL_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ROOT_CONTEXT_SERVICE_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SPRING_DATA_REPOSITORY_INTERFACE_RESOURCE_NAME;
-import static datadog.trace.api.config.TraceInstrumentationConfig.ELASTICSEARCH_BODY_AND_PARAMS_ENABLED;
 import static datadog.trace.api.config.TracerConfig.AGENT_HOST;
 import static datadog.trace.api.config.TracerConfig.AGENT_NAMED_PIPE;
 import static datadog.trace.api.config.TracerConfig.AGENT_PORT_LEGACY;
@@ -758,8 +758,9 @@ public class Config {
     } else {
       secureRandom = configProvider.getBoolean(SECURE_RANDOM, DEFAULT_SECURE_RANDOM);
     }
-    elasticsearchBodyAndParamsEnabled = configProvider.getBoolean(ELASTICSEARCH_BODY_AND_PARAMS_ENABLED,
-        DEFAULT_ELASTICSEARCH_BODY_AND_PARAMS_ENABLED);
+    elasticsearchBodyAndParamsEnabled =
+        configProvider.getBoolean(
+            ELASTICSEARCH_BODY_AND_PARAMS_ENABLED, DEFAULT_ELASTICSEARCH_BODY_AND_PARAMS_ENABLED);
     String strategyName = configProvider.getString(ID_GENERATION_STRATEGY);
     trace128bitTraceIdGenerationEnabled =
         configProvider.getBoolean(
@@ -2496,7 +2497,7 @@ public class Config {
     return grpcClientErrorStatuses;
   }
 
-  public boolean isElasticsearchBodyAndParamsEnabled(){
+  public boolean isElasticsearchBodyAndParamsEnabled() {
     return elasticsearchBodyAndParamsEnabled;
   }
 


### PR DESCRIPTION
# What Does This Do

Adds a feature-flag to control tagging of search request body/parameters to the Elasticsearch & Opensearch instrumentations (default: enabled). Limits tagging of search request bodies to those below 25,000 characters.

# Additional Notes

Starting the Java trace agent with the JVM option `-Ddd.trace.elasticsearch.body-and-params.enabled=false` or setting `DD_TRACE_ELASTICSEARCH_BODY_AND_PARAMETERS_ENABLED=false` in the environment will disable the inclusion of body and params fields in Elasticsearch/Opensearch traces.