### PR TITLE
Unvalidated redirect not reported if Referer header is the source

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/UnvalidatedRedirectModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/UnvalidatedRedirectModuleImpl.java
@@ -5,10 +5,12 @@ import static com.datadog.iast.taint.Tainteds.canBeTainted;
 import com.datadog.iast.IastRequestContext;
 import com.datadog.iast.model.Evidence;
 import com.datadog.iast.model.Location;
+import com.datadog.iast.model.Range;
 import com.datadog.iast.model.Vulnerability;
 import com.datadog.iast.model.VulnerabilityType;
 import com.datadog.iast.overhead.Operations;
 import com.datadog.iast.taint.TaintedObject;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -20,18 +22,14 @@ public class UnvalidatedRedirectModuleImpl extends SinkModuleBase
     implements UnvalidatedRedirectModule {
 
   private static final String LOCATION_HEADER = "Location";
+  private static final String REFERER = "Referer";
 
   @Override
   public void onRedirect(final @Nullable String value) {
     if (!canBeTainted(value)) {
       return;
     }
-    final AgentSpan span = AgentTracer.activeSpan();
-    final IastRequestContext ctx = IastRequestContext.get(span);
-    if (ctx == null) {
-      return;
-    }
-    checkInjection(span, ctx, VulnerabilityType.UNVALIDATED_REDIRECT, value);
+    checkUnvalidatedRedirect(value);
   }
 
   @Override
@@ -39,6 +37,30 @@ public class UnvalidatedRedirectModuleImpl extends SinkModuleBase
     if (!canBeTainted(value)) {
       return;
     }
+    checkUnvalidatedRedirect(value, clazz, method);
+  }
+
+  @Override
+  public void onURIRedirect(@Nullable URI uri) {
+    if (uri == null) {
+      return;
+    }
+    checkUnvalidatedRedirect(uri);
+  }
+
+  @Override
+  public void onHeader(@Nonnull final String name, @Nullable final String value) {
+    if (value != null && LOCATION_HEADER.equalsIgnoreCase(name)) {
+      onRedirect(value);
+    }
+  }
+
+  private void checkUnvalidatedRedirect(@Nonnull final Object value) {
+    checkUnvalidatedRedirect(value, null, null);
+  }
+
+  private void checkUnvalidatedRedirect(
+      @Nonnull final Object value, @Nullable final String clazz, @Nullable final String method) {
     final AgentSpan span = AgentTracer.activeSpan();
     final IastRequestContext ctx = IastRequestContext.get(span);
     if (ctx == null) {
@@ -48,35 +70,32 @@ public class UnvalidatedRedirectModuleImpl extends SinkModuleBase
     if (taintedObject == null) {
       return;
     }
+    if (isRefererHeader(taintedObject.getRanges())) {
+      return;
+    }
     if (!overheadController.consumeQuota(Operations.REPORT_VULNERABILITY, span)) {
       return;
     }
-    final Evidence evidence = new Evidence(value, taintedObject.getRanges());
-    reporter.report(
-        span,
-        new Vulnerability(
-            VulnerabilityType.UNVALIDATED_REDIRECT,
-            Location.forSpanAndClassAndMethod(span.getSpanId(), clazz, method),
-            evidence));
+    final Evidence evidence = new Evidence(value.toString(), taintedObject.getRanges());
+    if (clazz != null && method != null) {
+      reporter.report(
+          span,
+          new Vulnerability(
+              VulnerabilityType.UNVALIDATED_REDIRECT,
+              Location.forSpanAndClassAndMethod(span.getSpanId(), clazz, method),
+              evidence));
+    } else {
+      report(span, VulnerabilityType.UNVALIDATED_REDIRECT, evidence);
+    }
   }
 
-  @Override
-  public void onURIRedirect(@Nullable URI uri) {
-    if (uri == null) {
-      return;
+  private boolean isRefererHeader(Range[] ranges) {
+    for (Range range : ranges) {
+      if (range.getSource().getOrigin() != SourceTypes.REQUEST_HEADER_VALUE
+          || !range.getSource().getName().equalsIgnoreCase(REFERER)) {
+        return false;
+      }
     }
-    final AgentSpan span = AgentTracer.activeSpan();
-    final IastRequestContext ctx = IastRequestContext.get(span);
-    if (ctx == null) {
-      return;
-    }
-    checkInjection(span, ctx, VulnerabilityType.UNVALIDATED_REDIRECT, uri);
-  }
-
-  @Override
-  public void onHeader(@Nonnull final String name, final String value) {
-    if (value != null && LOCATION_HEADER.equalsIgnoreCase(name)) {
-      onRedirect(value);
-    }
+    return true;
   }
 }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/UnvalidatedRedirectModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/UnvalidatedRedirectModuleTest.groovy
@@ -135,22 +135,9 @@ class UnvalidatedRedirectModuleTest extends IastModuleImplTestBase {
     0 * reporter.report(_, _)
   }
 
-  void 'If not all ranges from tainted element have referer header as source, is an unvalidated redirect'() {
+  void 'If not all ranges from tainted element have referer header as source, is an unvalidated redirect'(final String value, final Range[] ranges) {
     setup:
-    def value = 'test01'
-    Range[] ranges = [
-      new Range(0, 2, new Source(SourceTypes.REQUEST_HEADER_VALUE, 'referer', 'value')),
-      new Range(4, 1, new Source(SourceTypes.REQUEST_HEADER_VALUE, 'other', 'value'))
-    ]
     ctx.getTaintedObjects().taint(value, ranges)
-
-    def value2 = 'test02'
-    Range[] ranges2 = [
-      new Range(0, 2, new Source(SourceTypes.REQUEST_HEADER_VALUE, 'referer', 'value')),
-      new Range(4, 1, new Source(SourceTypes.REQUEST_PARAMETER_NAME, 'referer', 'value'))
-    ]
-    ctx.getTaintedObjects().taint(value2, ranges2)
-
 
     when:
     module.onRedirect(value)
@@ -158,11 +145,16 @@ class UnvalidatedRedirectModuleTest extends IastModuleImplTestBase {
     then:
     1 * reporter.report(_, _)
 
-    when:
-    module.onRedirect(value2)
-
-    then:
-    1 * reporter.report(_, _)
+    where:
+    value    | ranges
+    'test01' | [
+      new Range(0, 2, new Source(SourceTypes.REQUEST_HEADER_VALUE, 'referer', 'value')),
+      new Range(4, 1, new Source(SourceTypes.REQUEST_HEADER_VALUE, 'other', 'value'))
+    ]
+    'test02' | [
+      new Range(0, 2, new Source(SourceTypes.REQUEST_HEADER_VALUE, 'referer', 'value')),
+      new Range(4, 1, new Source(SourceTypes.REQUEST_PARAMETER_NAME, 'referer', 'value'))
+    ]
   }
 
 


### PR DESCRIPTION
# What Does This Do
Not report unvalidated redirect vulnerability if all tainted object ranges have header Referer as source

# Motivation
Avoid unvalidated redirect false positives

