### PR TITLE
Add telemetry to IAST advices

### DIFF
--- a/benchmark/load/insecure-bank/benchmark.json
+++ b/benchmark/load/insecure-bank/benchmark.json
@@ -18,18 +18,6 @@
         "JAVA_OPTS": "-javaagent:${TRACER}"
       }
     },
-    "profiling": {
-      "env": {
-        "VARIANT": "profiling",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.profiling.enabled=true"
-      }
-    },
-    "appsec": {
-      "env": {
-        "VARIANT": "appsec",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.appsec.enabled=true"
-      }
-    },
     "iast": {
       "env": {
         "VARIANT": "iast",

--- a/benchmark/load/insecure-bank/benchmark.json
+++ b/benchmark/load/insecure-bank/benchmark.json
@@ -47,6 +47,12 @@
         "VARIANT": "iast_INACTIVE",
         "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.iast.enabled=inactive"
       }
+    },
+    "iast_TELEMETRY_OFF": {
+      "env": {
+        "VARIANT": "iast_TELEMETRY_OFF",
+        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.iast.enabled=true -Ddd.iast.telemetry.verbosity=OFF"
+      }
     }
   }
 }

--- a/benchmark/startup/insecure-bank/benchmark.json
+++ b/benchmark/startup/insecure-bank/benchmark.json
@@ -29,6 +29,12 @@
         "VARIANT": "iast",
         "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.benchmark.output.dir=${OUTPUT_DIR}/iast -Ddd.iast.enabled=true"
       }
+    },
+    "iast_TELEMETRY_OFF": {
+      "env": {
+        "VARIANT": "iast_TELEMETRY_OFF",
+        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.benchmark.output.dir=${OUTPUT_DIR}/iast_TELEMETRY_OFF -Ddd.iast.enabled=true -Ddd.iast.telemetry.verbosity=OFF"
+      }
     }
   }
 }

--- a/benchmark/startup/insecure-bank/benchmark.json
+++ b/benchmark/startup/insecure-bank/benchmark.json
@@ -12,18 +12,6 @@
         "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.benchmark.output.dir=${OUTPUT_DIR}/tracing"
       }
     },
-    "profiling": {
-      "env": {
-        "VARIANT": "profiling",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.benchmark.output.dir=${OUTPUT_DIR}/profiling -Ddd.profiling.enabled=true"
-      }
-    },
-    "appsec": {
-      "env": {
-        "VARIANT": "appsec",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.benchmark.output.dir=${OUTPUT_DIR}/appsec -Ddd.appsec.enabled=true"
-      }
-    },
     "iast": {
       "env": {
         "VARIANT": "iast",

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -7,6 +7,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static net.bytebuddy.matcher.ElementMatchers.isSynthetic;
 
+import datadog.trace.agent.tooling.iast.IastPostProcessorFactory;
 import datadog.trace.agent.tooling.muzzle.Reference;
 import datadog.trace.agent.tooling.muzzle.ReferenceMatcher;
 import datadog.trace.agent.tooling.muzzle.ReferenceProvider;
@@ -24,6 +25,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import net.bytebuddy.asm.Advice;
 import net.bytebuddy.asm.AsmVisitorWrapper;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
@@ -115,6 +117,11 @@ public interface Instrumenter {
   /** Instrumentation that wants to apply additional structure checks after type matching. */
   interface WithTypeStructure {
     ElementMatcher<TypeDescription> structureMatcher();
+  }
+
+  /** Instrumentation that wants to apply additional structure checks after type matching. */
+  interface WithPostProcessor {
+    Advice.PostProcessor.Factory postProcessor();
   }
 
   /** Instrumentation that provides method advice. */
@@ -334,7 +341,7 @@ public interface Instrumenter {
 
   /** Parent class for all IAST related instrumentations */
   @SuppressForbidden
-  abstract class Iast extends Default {
+  abstract class Iast extends Default implements WithPostProcessor {
 
     private static final Logger log = LoggerFactory.getLogger(Instrumenter.Iast.class);
 
@@ -374,6 +381,11 @@ public interface Instrumenter {
     /** Get classes to force load* */
     public String[] getClassNamesToBePreloaded() {
       return null;
+    }
+
+    @Override
+    public Advice.PostProcessor.Factory postProcessor() {
+      return IastPostProcessorFactory.INSTANCE;
     }
   }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/iast/IastPostProcessorFactory.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/iast/IastPostProcessorFactory.java
@@ -1,0 +1,176 @@
+package datadog.trace.agent.tooling.iast;
+
+import static datadog.trace.api.iast.telemetry.IastMetric.EXECUTED_PROPAGATION;
+import static datadog.trace.api.iast.telemetry.IastMetric.EXECUTED_SINK;
+import static datadog.trace.api.iast.telemetry.IastMetric.EXECUTED_SOURCE;
+import static datadog.trace.api.iast.telemetry.IastMetric.INSTRUMENTED_PROPAGATION;
+import static datadog.trace.api.iast.telemetry.IastMetric.INSTRUMENTED_SINK;
+import static datadog.trace.api.iast.telemetry.IastMetric.INSTRUMENTED_SOURCE;
+import static net.bytebuddy.jar.asm.Opcodes.BIPUSH;
+import static net.bytebuddy.jar.asm.Opcodes.GETSTATIC;
+import static net.bytebuddy.jar.asm.Opcodes.ICONST_0;
+import static net.bytebuddy.jar.asm.Opcodes.ICONST_1;
+import static net.bytebuddy.jar.asm.Opcodes.ICONST_M1;
+import static net.bytebuddy.jar.asm.Opcodes.INVOKESTATIC;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.iast.Propagation;
+import datadog.trace.api.iast.Sink;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.telemetry.IastMetric;
+import datadog.trace.api.iast.telemetry.IastMetricCollector;
+import datadog.trace.api.iast.telemetry.Verbosity;
+import java.util.Collections;
+import javax.annotation.Nonnull;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.annotation.AnnotationDescription;
+import net.bytebuddy.description.annotation.AnnotationValue;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.PackageDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.implementation.bytecode.StackManipulation;
+import net.bytebuddy.implementation.bytecode.assign.Assigner;
+import net.bytebuddy.jar.asm.MethodVisitor;
+import net.bytebuddy.jar.asm.Type;
+
+public class IastPostProcessorFactory implements Advice.PostProcessor.Factory {
+
+  public static final Advice.PostProcessor.Factory INSTANCE;
+
+  static {
+    final Verbosity verbosity = Config.get().getIastTelemetryVerbosity();
+    INSTANCE = verbosity == Verbosity.OFF ? null : new IastPostProcessorFactory(verbosity);
+  }
+
+  private static final String IAST_ANNOTATIONS_PKG = Sink.class.getPackage().getName();
+  private static final String SINK_NAME = Sink.class.getSimpleName();
+  private static final String PROPAGATION_NAME = Propagation.class.getSimpleName();
+  private static final String SOURCE_NAME = Source.class.getSimpleName();
+
+  private static final String COLLECTOR_INTERNAL_NAME =
+      Type.getType(IastMetricCollector.class).getInternalName();
+  private static final String METRIC_INTERNAL_NAME =
+      Type.getType(IastMetric.class).getInternalName();
+  private static final String METRIC_DESCRIPTOR = "L" + METRIC_INTERNAL_NAME + ";";
+  private static final String ADD_DESCRIPTOR = "(" + METRIC_DESCRIPTOR + "I)V";
+  private static final String ADD_WITH_TAG_DESCRIPTOR = "(" + METRIC_DESCRIPTOR + "BI)V";
+
+  private final Verbosity verbosity;
+
+  public IastPostProcessorFactory(final Verbosity verbosity) {
+    this.verbosity = verbosity;
+  }
+
+  @Override
+  public @Nonnull Advice.PostProcessor make(
+      @Nonnull final MethodDescription.InDefinedShape advice, final boolean exit) {
+    for (final AnnotationDescription annotation : advice.getDeclaredAnnotations()) {
+      final TypeDescription typeDescr = annotation.getAnnotationType();
+      final PackageDescription pkgDescr = typeDescr.getPackage();
+      if (pkgDescr != null && IAST_ANNOTATIONS_PKG.equals(pkgDescr.getName())) {
+        final String typeName = typeDescr.getSimpleName();
+        if (SINK_NAME.equals(typeName)) {
+          final AnnotationValue<?, ?> tag = annotation.getValue("value");
+          return createPostProcessor(INSTRUMENTED_SINK, EXECUTED_SINK, tag.resolve(Byte.class));
+        } else if (SOURCE_NAME.equals(typeName)) {
+          final AnnotationValue<?, ?> tag = annotation.getValue("value");
+          return createPostProcessor(INSTRUMENTED_SOURCE, EXECUTED_SOURCE, tag.resolve(Byte.class));
+        } else if (PROPAGATION_NAME.equals(typeName)) {
+          return createPostProcessor(INSTRUMENTED_PROPAGATION, EXECUTED_PROPAGATION, null);
+        }
+      }
+    }
+    return Advice.PostProcessor.NoOp.INSTANCE;
+  }
+
+  private PostProcessor createPostProcessor(
+      final IastMetric instrumented, final IastMetric executed, final Byte tagValue) {
+    if (!executed.isEnabled(verbosity)) {
+      return new PostProcessor(instrumented, null, tagValue);
+    }
+    return new PostProcessor(instrumented, executed, tagValue);
+  }
+
+  private static class PostProcessor implements Advice.PostProcessor {
+
+    private final IastMetric instrumentation;
+    private final IastMetric runtime;
+    private final Byte tagValue;
+
+    private PostProcessor(
+        final IastMetric instrumentation, final IastMetric runtime, final Byte tagValue) {
+      this.instrumentation = instrumentation;
+      this.runtime = runtime;
+      this.tagValue = tagValue;
+    }
+
+    @Override
+    public @Nonnull StackManipulation resolve(
+        @Nonnull final TypeDescription instrumentedType,
+        @Nonnull final MethodDescription instrumentedMethod,
+        @Nonnull final Assigner assigner,
+        @Nonnull final Advice.ArgumentHandler argumentHandler,
+        @Nonnull final Advice.StackMapFrameHandler.ForPostProcessor stackMapFrameHandler,
+        @Nonnull final StackManipulation exceptionHandler) {
+      if (tagValue == null) {
+        IastMetricCollector.add(instrumentation, 1);
+      } else {
+        IastMetricCollector.add(instrumentation, (byte) tagValue, 1);
+      }
+      return runtime == null
+          ? StackManipulation.Trivial.INSTANCE
+          : new TelemetryStackManipulation(stackMapFrameHandler, runtime.name(), tagValue);
+    }
+  }
+
+  private static class TelemetryStackManipulation extends StackManipulation.AbstractBase {
+    private final Advice.StackMapFrameHandler.ForAdvice.ForPostProcessor stackMapFrameHandler;
+    private final String metricName;
+    private final Byte tagValue;
+
+    private TelemetryStackManipulation(
+        final Advice.StackMapFrameHandler.ForPostProcessor stackMapFrameHandler,
+        final String metricName,
+        final Byte tagValue) {
+      this.stackMapFrameHandler = stackMapFrameHandler;
+      this.metricName = metricName;
+      this.tagValue = tagValue;
+    }
+
+    @Override
+    public @Nonnull Size apply(
+        @Nonnull final MethodVisitor mv, @Nonnull final Implementation.Context ctx) {
+      stackMapFrameHandler.injectIntermediateFrame(mv, Collections.emptyList());
+      mv.visitFieldInsn(GETSTATIC, METRIC_INTERNAL_NAME, metricName, METRIC_DESCRIPTOR);
+      final String descriptor;
+      if (tagValue != null) {
+        visitTag(mv, tagValue);
+        descriptor = ADD_WITH_TAG_DESCRIPTOR;
+      } else {
+        descriptor = ADD_DESCRIPTOR;
+      }
+      mv.visitInsn(ICONST_1);
+      mv.visitMethodInsn(INVOKESTATIC, COLLECTOR_INTERNAL_NAME, "add", descriptor, false);
+      return new Size(0, tagValue != null ? 3 : 2);
+    }
+
+    private void visitTag(final MethodVisitor mv, final byte tagValue) {
+      switch (tagValue) {
+        case -1:
+          mv.visitInsn(ICONST_M1);
+          break;
+        case 0:
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+        case 5:
+          mv.visitInsn(ICONST_0 + tagValue);
+          break;
+        default:
+          mv.visitIntInsn(BIPUSH, tagValue);
+      }
+    }
+  }
+}

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/iast/IastPostProcessorFactoryTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/iast/IastPostProcessorFactoryTest.groovy
@@ -1,0 +1,83 @@
+package datadog.trace.agent.tooling.iast
+
+import datadog.trace.api.iast.telemetry.IastMetric
+import datadog.trace.api.iast.telemetry.IastMetricCollector
+import datadog.trace.test.util.DDSpecification
+import net.bytebuddy.asm.Advice
+import net.bytebuddy.description.method.MethodDescription
+import net.bytebuddy.description.type.TypeDescription
+import net.bytebuddy.implementation.Implementation
+import net.bytebuddy.implementation.bytecode.StackManipulation
+import net.bytebuddy.implementation.bytecode.assign.Assigner
+import net.bytebuddy.jar.asm.MethodVisitor
+import net.bytebuddy.jar.asm.Opcodes
+import net.bytebuddy.jar.asm.Type
+
+class IastPostProcessorFactoryTest extends DDSpecification {
+
+  private static final Type COLLECTOR_TYPE = Type.getType(IastMetricCollector)
+  private static final Type METRIC_TYPE = Type.getType(IastMetric)
+
+  static class NonAnnotatedAdvice {
+    @Advice.OnMethodExit
+    static void exit() {}
+  }
+
+  void 'test factory for non annotated'() {
+    given:
+    final method = new MethodDescription.ForLoadedMethod(NonAnnotatedAdvice.getDeclaredMethod('exit'))
+
+    when:
+    final result = IastPostProcessorFactory.INSTANCE.make(method, true)
+
+    then:
+    result == Advice.PostProcessor.NoOp.INSTANCE
+  }
+
+  void 'test factory for annotated advice'() {
+    given:
+    final collector = IastMetricCollector.get()
+    final method = new MethodDescription.ForLoadedMethod(IastAnnotatedAdvice.getDeclaredMethod('exit'))
+    final typeDescription = Mock(TypeDescription)
+    final methodDescription = Mock(MethodDescription)
+    final assigner = Mock(Assigner)
+    final argumentHandler = Mock(Advice.ArgumentHandler)
+    final forPostProcessor = Mock(Advice.StackMapFrameHandler.ForPostProcessor)
+    final stackManipulation = Mock(StackManipulation)
+    final methodVisitor = Mock(MethodVisitor)
+    final context = Mock(Implementation.Context)
+
+    when:
+    final postProcessor = IastPostProcessorFactory.INSTANCE.make(method, true)
+
+    then:
+    postProcessor != Advice.PostProcessor.NoOp.INSTANCE
+
+    when: 'a new advice is handled'
+    final manipulation = postProcessor.resolve(typeDescription, methodDescription, assigner, argumentHandler, forPostProcessor, stackManipulation)
+
+    then: 'a new method has been instrumented and the metric is generated'
+    manipulation != null
+    collector.prepareMetrics()
+    final metrics = collector.drain()
+    assert metrics.size() == 1
+    // one method has ben instrumented
+    metrics.first().with {
+      assert it.metric == IastMetric.INSTRUMENTED_SINK
+      assert it.tags == ['vulnerability_type:SQL_INJECTION']
+      assert it.value == 1L
+    }
+
+    when: 'the advice is used'
+    final size = manipulation.apply(methodVisitor, context)
+
+    then: 'the byte code to generate the metric during runtime is appended'
+    size.sizeImpact == 0 // stack remains the same
+    size.maximalSize == 3 // metric + tag + counter
+    1 * forPostProcessor.injectIntermediateFrame(methodVisitor, []) // new empty frame
+    1 * methodVisitor.visitFieldInsn(Opcodes.GETSTATIC, METRIC_TYPE.internalName, 'EXECUTED_SINK', 'L' + METRIC_TYPE.internalName + ';') // add executed metric to stack
+    1 * methodVisitor.visitInsn(Opcodes.ICONST_2) // add tag to stack: public static final byte SQL_INJECTION = 2
+    1 * methodVisitor.visitInsn(Opcodes.ICONST_1) // add counter to stack
+    1 * methodVisitor.visitMethodInsn(Opcodes.INVOKESTATIC, COLLECTOR_TYPE.internalName, 'add', '(L' + METRIC_TYPE.internalName + ';BI)V', false) // call increment
+  }
+}

--- a/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/iast/IastAnnotatedAdvice.java
+++ b/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/iast/IastAnnotatedAdvice.java
@@ -1,0 +1,11 @@
+package datadog.trace.agent.tooling.iast;
+
+import datadog.trace.api.iast.Sink;
+import datadog.trace.api.iast.VulnerabilityTypes;
+import net.bytebuddy.asm.Advice;
+
+public class IastAnnotatedAdvice {
+  @Advice.OnMethodExit
+  @Sink(VulnerabilityTypes.SQL_INJECTION)
+  static void exit() {}
+}

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateVariablesUrlHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateVariablesUrlHandlerInstrumentation.java
@@ -11,6 +11,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.iast.IastPostProcessorFactory;
 import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
@@ -32,7 +33,9 @@ import net.bytebuddy.matcher.ElementMatcher;
 /** Obtain template and matrix variables for AbstractUrlHandlerMapping */
 @AutoService(Instrumenter.class)
 public class TemplateVariablesUrlHandlerInstrumentation extends Instrumenter.Default
-    implements Instrumenter.ForSingleType {
+    implements Instrumenter.ForSingleType, Instrumenter.WithPostProcessor {
+
+  private Advice.PostProcessor.Factory postProcessorFactory;
 
   public TemplateVariablesUrlHandlerInstrumentation() {
     super("spring-web");
@@ -40,8 +43,11 @@ public class TemplateVariablesUrlHandlerInstrumentation extends Instrumenter.Def
 
   @Override
   public boolean isApplicable(Set<TargetSystem> enabledSystems) {
-    return enabledSystems.contains(TargetSystem.APPSEC)
-        || enabledSystems.contains(TargetSystem.IAST);
+    if (enabledSystems.contains(TargetSystem.IAST)) {
+      postProcessorFactory = IastPostProcessorFactory.INSTANCE;
+      return true;
+    }
+    return enabledSystems.contains(TargetSystem.APPSEC);
   }
 
   @Override
@@ -66,6 +72,11 @@ public class TemplateVariablesUrlHandlerInstrumentation extends Instrumenter.Def
             .and(takesArgument(1, named("javax.servlet.http.HttpServletResponse")))
             .and(takesArgument(2, Object.class)),
         TemplateVariablesUrlHandlerInstrumentation.class.getName() + "$InterceptorPreHandleAdvice");
+  }
+
+  @Override
+  public Advice.PostProcessor.Factory postProcessor() {
+    return postProcessorFactory;
   }
 
   public static class InterceptorPreHandleAdvice {

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java/datadog/trace/instrumentation/springweb6/TemplateAndMatrixVariablesInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java/datadog/trace/instrumentation/springweb6/TemplateAndMatrixVariablesInstrumentation.java
@@ -9,21 +9,29 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.iast.IastPostProcessorFactory;
 import java.util.Set;
+import net.bytebuddy.asm.Advice;
 import net.bytebuddy.matcher.ElementMatcher;
 
 /** Obtain template and matrix variables for RequestMappingInfoHandlerMapping. */
 @AutoService(Instrumenter.class)
 public class TemplateAndMatrixVariablesInstrumentation extends Instrumenter.Default
-    implements Instrumenter.ForSingleType {
+    implements Instrumenter.ForSingleType, Instrumenter.WithPostProcessor {
+
+  private Advice.PostProcessor.Factory postProcessorFactory;
+
   public TemplateAndMatrixVariablesInstrumentation() {
     super("spring-web");
   }
 
   @Override
   public boolean isApplicable(Set<TargetSystem> enabledSystems) {
-    return enabledSystems.contains(TargetSystem.APPSEC)
-        || enabledSystems.contains(TargetSystem.IAST);
+    if (enabledSystems.contains(TargetSystem.IAST)) {
+      postProcessorFactory = IastPostProcessorFactory.INSTANCE;
+      return true;
+    }
+    return enabledSystems.contains(TargetSystem.APPSEC);
   }
 
   @Override
@@ -57,5 +65,10 @@ public class TemplateAndMatrixVariablesInstrumentation extends Instrumenter.Defa
     return new String[] {
       packageName + ".PairList",
     };
+  }
+
+  @Override
+  public Advice.PostProcessor.Factory postProcessor() {
+    return postProcessorFactory;
   }
 }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteImplInstrumentation.java
@@ -8,12 +8,16 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.iast.IastPostProcessorFactory;
 import datadog.trace.agent.tooling.muzzle.Reference;
 import java.util.Set;
+import net.bytebuddy.asm.Advice;
 
 @AutoService(Instrumenter.class)
 public class RouteImplInstrumentation extends Instrumenter.Default
-    implements Instrumenter.ForKnownTypes {
+    implements Instrumenter.ForKnownTypes, Instrumenter.WithPostProcessor {
+
+  private Advice.PostProcessor.Factory postProcessorFactory;
 
   public RouteImplInstrumentation() {
     super("vertx", "vertx-4.0");
@@ -26,8 +30,11 @@ public class RouteImplInstrumentation extends Instrumenter.Default
 
   @Override
   public boolean isApplicable(Set<TargetSystem> enabledSystems) {
-    return enabledSystems.contains(TargetSystem.APPSEC)
-        || enabledSystems.contains(TargetSystem.IAST);
+    if (enabledSystems.contains(TargetSystem.IAST)) {
+      postProcessorFactory = IastPostProcessorFactory.INSTANCE;
+      return true;
+    }
+    return enabledSystems.contains(TargetSystem.APPSEC);
   }
 
   @Override
@@ -68,5 +75,10 @@ public class RouteImplInstrumentation extends Instrumenter.Default
             .and(takesArgument(2, boolean.class))
             .and(returns(boolean.class)),
         packageName + ".RouteMatchesAdvice$BooleanReturnVariant");
+  }
+
+  @Override
+  public Advice.PostProcessor.Factory postProcessor() {
+    return postProcessorFactory;
   }
 }


### PR DESCRIPTION
# What Does This Do
Adds a `net.bytebuddy.asm.Advice.PostProcessorFactory` to generate the required code to provide IAST related metrics in bytebuddy advices. 

The post processor does two things:

- Calls `IastMetricCollector.add(IastMetric.INSTRUMENTED_$TYPE, $TAG, 1)` whenever a new instrumentation point is detected.
- Injects the required bytecode to call `IastMetricCollector.add(IastMetric.EXECUTED_$TYPE, $TAG, 1)` when the actual code of the advice is executed at runtime.

# Motivation
From the IAST part we need very concrete metrics to understand if the vulnerability detection engine is working correctly. Having these kind of metrics allows us to check if customer spans that have certain operations (for instance a SQL call) are handled correctly by the engine.

# Additional Notes
