### PR TITLE
Implement passing module execution results from children processes to parent process

### DIFF
--- a/dd-java-agent/agent-ci-visibility/build.gradle
+++ b/dd-java-agent/agent-ci-visibility/build.gradle
@@ -15,6 +15,7 @@ excludedClassesCoverage += [
   "datadog.trace.civisibility.DDTestSessionImpl",
   "datadog.trace.civisibility.DDTestSuiteImpl",
   "datadog.trace.civisibility.DDTestImpl",
+  "datadog.trace.civisibility.TestModuleRegistry",
   "datadog.trace.civisibility.ci.CIInfo",
   "datadog.trace.civisibility.ci.CIInfo.Builder",
   "datadog.trace.civisibility.communication.*",

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
@@ -31,6 +31,7 @@ import datadog.trace.civisibility.git.tree.GitClient;
 import datadog.trace.civisibility.git.tree.GitDataApi;
 import datadog.trace.civisibility.git.tree.GitDataUploader;
 import datadog.trace.civisibility.git.tree.GitDataUploaderImpl;
+import datadog.trace.civisibility.ipc.SignalServer;
 import datadog.trace.civisibility.source.BestEfforSourcePathResolver;
 import datadog.trace.civisibility.source.CompilerAidedSourcePathResolver;
 import datadog.trace.civisibility.source.MethodLinesResolver;
@@ -88,6 +89,7 @@ public class CiVisibilitySystem {
       MethodLinesResolver methodLinesResolver = new MethodLinesResolverImpl();
       Map<String, String> ciTags = new CITagsProvider().getCiTags(ciInfo);
       TestDecorator testDecorator = new TestDecoratorImpl(component, null, null, ciTags);
+      TestModuleRegistry testModuleRegistry = new TestModuleRegistry();
 
       GitDataUploader gitDataUploader = buildGitDataUploader(config, backendApi, repoRoot);
       gitDataUploader.startOrObserveGitDataUpload();
@@ -95,15 +97,21 @@ public class CiVisibilitySystem {
       ModuleExecutionSettingsFactory moduleExecutionSettingsFactory =
           buildModuleExecutionSettingsFactory(config, backendApi, gitDataUploader, repoRoot);
 
+      String signalServerHost = config.getCiVisibilitySignalServerHost();
+      int signalServerPort = config.getCiVisibilitySignalServerPort();
+      SignalServer signalServer = new SignalServer(signalServerHost, signalServerPort);
+
       return new DDTestSessionImpl(
           projectName,
           startTime,
           config,
+          testModuleRegistry,
           testDecorator,
           sourcePathResolver,
           codeowners,
           methodLinesResolver,
-          moduleExecutionSettingsFactory);
+          moduleExecutionSettingsFactory,
+          signalServer);
     };
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/TestModuleRegistry.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/TestModuleRegistry.java
@@ -1,0 +1,50 @@
+package datadog.trace.civisibility;
+
+import datadog.trace.api.DDTags;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.civisibility.ipc.ModuleExecutionResult;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestModuleRegistry {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TestModuleRegistry.class);
+
+  private final Map<Long, DDTestModuleImpl> testModuleById;
+
+  public TestModuleRegistry() {
+    this.testModuleById = new HashMap<>();
+  }
+
+  public void addModule(DDTestModuleImpl module) {
+    testModuleById.put(module.getId(), module);
+  }
+
+  public void removeModule(DDTestModuleImpl module) {
+    testModuleById.remove(module.getId());
+  }
+
+  public void onModuleExecutionResultReceived(ModuleExecutionResult result) {
+    long moduleId = result.getModuleId();
+    DDTestModuleImpl module = testModuleById.get(moduleId);
+    if (module == null) {
+      LOGGER.warn(
+          "Could not find module with ID {}, test execution result will be ignored: {}",
+          moduleId,
+          result);
+      return;
+    }
+
+    if (result.isCoverageEnabled()) {
+      module.setTag(Tags.TEST_CODE_COVERAGE_ENABLED, true);
+    }
+    if (result.isItrEnabled()) {
+      module.setTag(Tags.TEST_ITR_TESTS_SKIPPING_ENABLED, true);
+    }
+    if (result.isItrTestsSkipped()) {
+      module.setTag(DDTags.CI_ITR_TESTS_SKIPPED, true);
+    }
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/TestModuleRegistry.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/TestModuleRegistry.java
@@ -3,8 +3,8 @@ package datadog.trace.civisibility;
 import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.civisibility.ipc.ModuleExecutionResult;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,7 +15,7 @@ public class TestModuleRegistry {
   private final Map<Long, DDTestModuleImpl> testModuleById;
 
   public TestModuleRegistry() {
-    this.testModuleById = new HashMap<>();
+    this.testModuleById = new ConcurrentHashMap<>();
   }
 
   public void addModule(DDTestModuleImpl module) {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/BuildEventsHandlerImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/BuildEventsHandlerImpl.java
@@ -63,7 +63,7 @@ public class BuildEventsHandlerImpl<T> implements BuildEventsHandler<T> {
   }
 
   @Override
-  public ModuleAndSessionId onTestModuleStart(
+  public ModuleInfo onTestModuleStart(
       final T sessionKey,
       final String moduleName,
       String startCommand,
@@ -85,7 +85,7 @@ public class BuildEventsHandlerImpl<T> implements BuildEventsHandler<T> {
         new TestModuleDescriptor<>(sessionKey, moduleName);
     inProgressTestModules.put(testModuleDescriptor, testModule);
 
-    return ((DDTestModuleImpl) testModule).getModuleAndSessionId();
+    return ((DDTestModuleImpl) testModule).getModuleInfo();
   }
 
   @Override
@@ -135,7 +135,7 @@ public class BuildEventsHandlerImpl<T> implements BuildEventsHandler<T> {
               + " and module name "
               + moduleName);
     }
-    testModule.end(null);
+    testModule.end(null, false);
   }
 
   @Override

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
@@ -69,10 +69,12 @@ public class TestEventsHandlerImpl implements TestEventsHandler {
             moduleName,
             null,
             config,
+            null,
             testDecorator,
             sourcePathResolver,
             codeowners,
-            methodLinesResolver);
+            methodLinesResolver,
+            null);
   }
 
   @Override
@@ -85,16 +87,18 @@ public class TestEventsHandlerImpl implements TestEventsHandler {
               moduleName,
               null,
               config,
+              null,
               testDecorator,
               sourcePathResolver,
               codeowners,
-              methodLinesResolver);
+              methodLinesResolver,
+              null);
     }
   }
 
   @Override
-  public void onTestModuleFinish() {
-    testModule.end(null);
+  public void onTestModuleFinish(boolean itrTestsSkipped) {
+    testModule.end(null, itrTestsSkipped);
     testModule = null;
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityTest.groovy
@@ -18,6 +18,7 @@ import datadog.trace.civisibility.decorator.TestDecorator
 import datadog.trace.civisibility.decorator.TestDecoratorImpl
 import datadog.trace.civisibility.events.BuildEventsHandlerImpl
 import datadog.trace.civisibility.events.TestEventsHandlerImpl
+import datadog.trace.civisibility.ipc.SignalServer
 import datadog.trace.civisibility.source.MethodLinesResolver
 import datadog.trace.core.DDSpan
 import datadog.trace.util.Strings
@@ -74,15 +75,20 @@ abstract class CiVisibilityTest extends AgentTestRunner {
     CIVisibility.registerSessionFactory (String projectName, Path projectRoot, String component, Long startTime) -> {
       def ciTags = [(DUMMY_CI_TAG): DUMMY_CI_TAG_VALUE]
       TestDecorator testDecorator = new TestDecoratorImpl(component, null, null, ciTags)
+      TestModuleRegistry testModuleRegistry = new TestModuleRegistry()
+      SignalServer signalServer = new SignalServer()
       return new DDTestSessionImpl(
       projectName,
       startTime,
       Config.get(),
+      testModuleRegistry,
       testDecorator,
       sourcePathResolver,
       codeowners,
       methodLinesResolver,
-      moduleExecutionSettingsFactory)
+      moduleExecutionSettingsFactory,
+      signalServer
+      )
     }
   }
 

--- a/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleBuildListener.java
+++ b/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleBuildListener.java
@@ -155,7 +155,7 @@ public class GradleBuildListener extends BuildAdapter {
       Gradle gradle = project.getGradle();
       String taskPath = task.getPath();
       String startCommand = GradleUtils.recreateStartCommand(gradle.getStartParameter());
-      BuildEventsHandler.ModuleAndSessionId moduleAndSessionId =
+      BuildEventsHandler.ModuleInfo moduleInfo =
           buildEventsHandler.onTestModuleStart(gradle, taskPath, startCommand, null);
 
       Collection<GradleUtils.TestFramework> testFrameworks =
@@ -169,8 +169,10 @@ public class GradleBuildListener extends BuildAdapter {
 
       JavaForkOptions taskForkOptions = (JavaForkOptions) task;
       taskForkOptions.jvmArgs(
-          arg(CiVisibilityConfig.CIVISIBILITY_SESSION_ID, moduleAndSessionId.sessionId),
-          arg(CiVisibilityConfig.CIVISIBILITY_MODULE_ID, moduleAndSessionId.moduleId));
+          arg(CiVisibilityConfig.CIVISIBILITY_SESSION_ID, moduleInfo.sessionId),
+          arg(CiVisibilityConfig.CIVISIBILITY_MODULE_ID, moduleInfo.moduleId),
+          arg(CiVisibilityConfig.CIVISIBILITY_SIGNAL_SERVER_HOST, moduleInfo.signalServerHost),
+          arg(CiVisibilityConfig.CIVISIBILITY_SIGNAL_SERVER_PORT, moduleInfo.signalServerPort));
     }
 
     private String arg(String propertyName, Object value) {

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
@@ -33,7 +33,7 @@ public class TracingListener extends RunListener {
 
   @Override
   public void testRunFinished(Result result) {
-    testEventsHandler.onTestModuleFinish();
+    testEventsHandler.onTestModuleFinish(false);
   }
 
   public void testSuiteStarted(final TestClass junitTestClass) {

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/TracingListener.java
@@ -55,7 +55,7 @@ public class TracingListener implements TestExecutionListener {
 
   @Override
   public void testPlanExecutionFinished(final TestPlan testPlan) {
-    testEventsHandler.onTestModuleFinish();
+    testEventsHandler.onTestModuleFinish(false);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenExecutionListener.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenExecutionListener.java
@@ -82,7 +82,7 @@ public class MavenExecutionListener extends AbstractExecutionListener {
       Map<String, Object> additionalTags =
           Collections.singletonMap(Tags.TEST_EXECUTION, executionId);
 
-      BuildEventsHandler.ModuleAndSessionId moduleAndSessionId =
+      BuildEventsHandler.ModuleInfo moduleInfo =
           buildEventsHandler.onTestModuleStart(session, moduleName, startCommand, additionalTags);
 
       Collection<MavenUtils.TestFramework> testFrameworks =
@@ -107,12 +107,24 @@ public class MavenExecutionListener extends AbstractExecutionListener {
                 configuration,
                 Strings.propertyNameToSystemPropertyName(
                     CiVisibilityConfig.CIVISIBILITY_SESSION_ID),
-                moduleAndSessionId.sessionId);
+                moduleInfo.sessionId);
         configuration =
             setForkedVmSystemProperty(
                 configuration,
                 Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_MODULE_ID),
-                moduleAndSessionId.moduleId);
+                moduleInfo.moduleId);
+        configuration =
+            setForkedVmSystemProperty(
+                configuration,
+                Strings.propertyNameToSystemPropertyName(
+                    CiVisibilityConfig.CIVISIBILITY_SIGNAL_SERVER_HOST),
+                moduleInfo.signalServerHost);
+        configuration =
+            setForkedVmSystemProperty(
+                configuration,
+                Strings.propertyNameToSystemPropertyName(
+                    CiVisibilityConfig.CIVISIBILITY_SIGNAL_SERVER_PORT),
+                moduleInfo.signalServerPort);
 
         mojoExecution.setConfiguration(configuration);
       } else {
@@ -120,10 +132,10 @@ public class MavenExecutionListener extends AbstractExecutionListener {
         // that it shouldn't create its own module event
         System.setProperty(
             Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_SESSION_ID),
-            String.valueOf(moduleAndSessionId.sessionId));
+            String.valueOf(moduleInfo.sessionId));
         System.setProperty(
             Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_MODULE_ID),
-            String.valueOf(moduleAndSessionId.moduleId));
+            String.valueOf(moduleInfo.moduleId));
       }
     }
   }

--- a/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TracingListener.java
+++ b/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TracingListener.java
@@ -41,7 +41,7 @@ public class TracingListener extends TestNGClassListener
 
   @Override
   public void onExecutionFinish() {
-    testEventsHandler.onTestModuleFinish();
+    testEventsHandler.onTestModuleFinish(false);
   }
 
   @Override

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -41,6 +41,7 @@ public class DDTags {
   public static final String ORIGIN_KEY = "_dd.origin";
   public static final String LIBRARY_VERSION_TAG_KEY = "library_version";
   public static final String CI_ENV_VARS = "_dd.ci.env_vars";
+  public static final String CI_ITR_TESTS_SKIPPED = "_dd.ci.itr.tests_skipped";
   public static final String MEASURED = "_dd.measured";
   public static final String PID_TAG = "process_id";
   public static final String SCHEMA_VERSION_TAG_KEY = "_dd.trace_span_attribute_schema";

--- a/dd-trace-api/src/main/java/datadog/trace/api/civisibility/DDTestModule.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/civisibility/DDTestModule.java
@@ -55,8 +55,10 @@ public interface DDTestModule {
    *
    * @param endTime Optional finish time in microseconds. If {@code null} is supplied, current time
    *     will be assumed
+   * @param testsSkipped Flag indicating whether module contained tests that were skipped by
+   *     Intelligent Test Runner
    */
-  void end(@Nullable Long endTime);
+  void end(@Nullable Long endTime, boolean testsSkipped);
 
   /**
    * Marks the start of a new test suite in the module.

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -72,7 +72,7 @@ excludedClassesCoverage += [
   "datadog.trace.api.civisibility.coverage.TestReportFileEntry",
   "datadog.trace.api.civisibility.coverage.TestReportFileEntry.Segment",
   "datadog.trace.api.civisibility.InstrumentationBridge",
-  "datadog.trace.api.civisibility.events.BuildEventsHandler.ModuleAndSessionId",
+  "datadog.trace.api.civisibility.events.BuildEventsHandler.ModuleInfo",
   // POJO
   "datadog.trace.api.git.GitInfo",
   // POJO

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/events/BuildEventsHandler.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/events/BuildEventsHandler.java
@@ -19,7 +19,7 @@ public interface BuildEventsHandler<T> {
 
   void onTestSessionFinish(T sessionKey);
 
-  ModuleAndSessionId onTestModuleStart(
+  ModuleInfo onTestModuleStart(
       T sessionKey, String moduleName, String startCommand, Map<String, Object> additionalTags);
 
   void onModuleTestFrameworkDetected(
@@ -37,13 +37,18 @@ public interface BuildEventsHandler<T> {
     <U> BuildEventsHandler<U> create();
   }
 
-  final class ModuleAndSessionId {
+  final class ModuleInfo {
     public final long moduleId;
     public final long sessionId;
+    public final String signalServerHost;
+    public final int signalServerPort;
 
-    public ModuleAndSessionId(long moduleId, long sessionId) {
+    public ModuleInfo(
+        long moduleId, long sessionId, String signalServerHost, int signalServerPort) {
       this.moduleId = moduleId;
       this.sessionId = sessionId;
+      this.signalServerHost = signalServerHost;
+      this.signalServerPort = signalServerPort;
     }
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/events/TestEventsHandler.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/events/TestEventsHandler.java
@@ -10,7 +10,7 @@ public interface TestEventsHandler {
 
   void onTestModuleStart();
 
-  void onTestModuleFinish();
+  void onTestModuleFinish(boolean itrTestsSkipped);
 
   void onTestSuiteStart(
       String testSuiteName,

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
@@ -63,6 +63,8 @@ public class Tags {
   public static final String TEST_SESSION_ID = "test_session_id";
   public static final String TEST_MODULE_ID = "test_module_id";
   public static final String TEST_SUITE_ID = "test_suite_id";
+  public static final String TEST_CODE_COVERAGE_ENABLED = "test.code_coverage.enabled";
+  public static final String TEST_ITR_TESTS_SKIPPING_ENABLED = "test.itr.tests_skipping.enabled";
 
   public static final String CI_PROVIDER_NAME = "ci.provider.name";
   public static final String CI_PIPELINE_ID = "ci.pipeline.id";


### PR DESCRIPTION
# What Does This Do
Implements passing tests execution results from children processes (JVMs forked to run tests) to the parent process (Gradle or Maven).

# Motivation
The overall execution result (success or failure) is already available in the parent process, but for CI Visibility there's a need to pass more data (such as whether the tests were executed with code coverage, or if any of the test cases were skipped by Intelligent Test Runner).

# Additional Notes
The data is passed via TCP using `SignalServer` and`SignalClient` introduced for this purpose previously (in a separate PR).
