### PR TITLE
Support extending dynamic-config snapshots

### DIFF
--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -105,7 +105,7 @@ excludedClassesCoverage += [
   "datadog.trace.api.Config.RuntimeIdHolder",
   "datadog.trace.api.DynamicConfig",
   "datadog.trace.api.DynamicConfig.Builder",
-  "datadog.trace.api.DynamicConfig.State",
+  "datadog.trace.api.DynamicConfig.Snapshot",
   "datadog.trace.api.InstrumenterConfig",
   "datadog.trace.api.ResolverCacheConfig.*",
   // can't reliably force same identity hash for different instance to cover branch


### PR DESCRIPTION
# What Does This Do

This PR adds support for extending the type used to store snapshots of dynamic-config.

This lets us store more complex items alongside the dynamic-config they're derived from.

# Motivation

We want to dynamically configure the trace/span samplers. This PR means we can save the re-configured samplers, whose types are specific to `dd-trace-core`, alongside their related dynamic-config. This avoids the need for extra consistency checks whenever starting a new trace, since the dynamic-config and new samplers are contained in the same snapshot.