### PR TITLE
Add IAST telemetry annotations to bytebuddy advices

### DIFF
--- a/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/assertion/AdviceAssert.groovy
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/assertion/AdviceAssert.groovy
@@ -1,0 +1,18 @@
+package datadog.trace.plugin.csi.impl.assertion
+
+class AdviceAssert {
+  protected String owner
+  protected String method
+  protected String descriptor
+  protected Collection<String> statements
+
+  void pointcut(String owner, String method, String descriptor) {
+    assert owner == this.owner
+    assert method == this.method
+    assert descriptor == this.descriptor
+  }
+
+  void statements(String... values) {
+    assert values.toList() == statements
+  }
+}

--- a/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/assertion/AssertBuilder.groovy
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/assertion/AssertBuilder.groovy
@@ -1,0 +1,108 @@
+package datadog.trace.plugin.csi.impl.assertion
+
+import com.github.javaparser.JavaParser
+import com.github.javaparser.ParserConfiguration
+import com.github.javaparser.ast.CompilationUnit
+import com.github.javaparser.ast.Node
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration
+import com.github.javaparser.ast.body.MethodDeclaration
+import com.github.javaparser.ast.expr.MethodCallExpr
+import com.github.javaparser.symbolsolver.JavaSymbolSolver
+import datadog.trace.agent.tooling.csi.CallSites
+
+import java.lang.reflect.Executable
+import java.lang.reflect.Method
+
+import static datadog.trace.plugin.csi.impl.CallSiteFactory.typeResolver
+import static datadog.trace.plugin.csi.util.CallSiteUtils.classNameToType
+
+class AssertBuilder<C extends CallSiteAssert> {
+  private final File file
+
+  AssertBuilder(final File file) {
+    this.file = file
+  }
+
+  C build() {
+    final javaFile = parseJavaFile(file)
+    assert javaFile.parsed == Node.Parsedness.PARSED
+    final targetType = javaFile.primaryType.get().asClassOrInterfaceDeclaration()
+    final interfaces = getInterfaces(targetType)
+    def (enabled, enabledArgs) = getEnabledDeclaration(targetType, interfaces)
+    return (C) new CallSiteAssert([
+      interfaces : getInterfaces(targetType),
+      helpers    : getHelpers(targetType),
+      advices    : getAdvices(targetType),
+      enabled    : enabled,
+      enabledArgs: enabledArgs
+    ])
+  }
+
+  protected List<Class<?>> getInterfaces(final ClassOrInterfaceDeclaration type) {
+    return type.asClassOrInterfaceDeclaration().implementedTypes.collect {
+      final resolved = it.asClassOrInterfaceType().resolve()
+      return resolved.typeDeclaration.get().clazz
+    }
+  }
+
+  protected def getEnabledDeclaration(final ClassOrInterfaceDeclaration type, final List<Class<?>> interfaces) {
+    if (!interfaces.contains(CallSites.HasEnabledProperty)) {
+      return [null, null]
+    }
+    final isEnabled = type.getMethodsByName('isEnabled').first()
+    final returnStatement = isEnabled.body.get().statements.first.get().asReturnStmt()
+    final enabledMethodCall = returnStatement.expression.get().asMethodCallExpr()
+    final enabled = resolveMethod(enabledMethodCall)
+    final enabledArgs = enabledMethodCall.getArguments().collect { it.asStringLiteralExpr().asString() }
+    return [enabled, enabledArgs]
+  }
+
+  protected List<Class<?>> getHelpers(final ClassOrInterfaceDeclaration type) {
+    final acceptMethod = type.getMethodsByName('accept').first()
+    final methodCalls = getMethodCalls(acceptMethod)
+    return methodCalls.findAll {
+      it.nameAsString == 'addHelpers'
+    }.collectMany {
+      it.arguments
+    }.collect {
+      typeResolver().resolveType(classNameToType(it.asStringLiteralExpr().asString()))
+    }
+  }
+
+  protected List<AdviceAssert> getAdvices(final ClassOrInterfaceDeclaration type) {
+    final acceptMethod = type.getMethodsByName('accept').first()
+    return getMethodCalls(acceptMethod).findAll {
+      it.nameAsString == 'addAdvice'
+    }.collect {
+      def (owner, method, descriptor) =  it.arguments.subList(0, 3)*.asStringLiteralExpr()*.asString()
+      final handlerLambda = it.arguments[3].asLambdaExpr()
+      final advice = handlerLambda.body.asBlockStmt().statements*.toString()
+      return new AdviceAssert([
+        owner     : owner,
+        method    : method,
+        descriptor: descriptor,
+        statements: advice
+      ])
+    }
+  }
+
+  protected static List<MethodCallExpr> getMethodCalls(final MethodDeclaration method) {
+    return method.body.get().asBlockStmt().getStatements().findAll {
+      it.isExpressionStmt() && it.asExpressionStmt().getExpression().isMethodCallExpr()
+    }.collect {
+      it.asExpressionStmt().getExpression().asMethodCallExpr()
+    }
+  }
+
+  private static Executable resolveMethod(final MethodCallExpr methodCallExpr) {
+    final resolved = methodCallExpr.resolve()
+    return resolved.@method as Method
+  }
+
+  private static CompilationUnit parseJavaFile(final File file)
+    throws FileNotFoundException {
+    final JavaSymbolSolver solver = new JavaSymbolSolver(typeResolver());
+    final JavaParser parser = new JavaParser(new ParserConfiguration().setSymbolResolver(solver));
+    return parser.parse(file).getResult().get();
+  }
+}

--- a/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/assertion/CallSiteAssert.groovy
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/assertion/CallSiteAssert.groovy
@@ -1,0 +1,31 @@
+package datadog.trace.plugin.csi.impl.assertion
+
+import java.lang.reflect.Method
+
+class CallSiteAssert {
+
+  protected Collection<Class<?>> interfaces
+  protected Collection<Class<?>> helpers
+  protected Collection<AdviceAssert> advices
+  protected Method enabled
+  protected Collection<String> enabledArgs
+
+  void interfaces(Class<?>... values) {
+    assert values.toList() == interfaces
+  }
+
+  void helpers(Class<?>... values) {
+    assert values.toList() == helpers
+  }
+
+  void advices(int index, @DelegatesTo(AdviceAssert) Closure closure) {
+    final asserter = advices[index]
+    closure.delegate = asserter
+    closure(asserter)
+  }
+
+  void enabled(Method method, String... args) {
+    assert method == enabled
+    assert args.toList() == enabledArgs
+  }
+}

--- a/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/ext/IastExtensionTest.groovy
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/ext/IastExtensionTest.groovy
@@ -2,15 +2,16 @@ package datadog.trace.plugin.csi.impl.ext
 
 import com.github.javaparser.JavaParser
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration
-import com.github.javaparser.ast.body.MethodDeclaration
-import com.github.javaparser.ast.body.TypeDeclaration
-import datadog.trace.agent.tooling.csi.CallSiteAdvice
+import com.github.javaparser.ast.stmt.IfStmt
 import datadog.trace.agent.tooling.csi.CallSites
 import datadog.trace.plugin.csi.AdviceGenerator
 import datadog.trace.plugin.csi.PluginApplication.Configuration
 import datadog.trace.plugin.csi.impl.AdviceGeneratorImpl
 import datadog.trace.plugin.csi.impl.BaseCsiPluginTest
 import datadog.trace.plugin.csi.impl.CallSiteSpecification
+import datadog.trace.plugin.csi.impl.assertion.AdviceAssert
+import datadog.trace.plugin.csi.impl.assertion.AssertBuilder
+import datadog.trace.plugin.csi.impl.assertion.CallSiteAssert
 import datadog.trace.plugin.csi.impl.ext.tests.IastExtensionCallSite
 import groovy.transform.CompileDynamic
 import spock.lang.TempDir
@@ -69,17 +70,46 @@ class IastExtensionTest extends BaseCsiPluginTest {
     }
     final spec = buildClassSpecification(IastExtensionCallSite)
     final generator = buildAdviceGenerator(buildDir)
-    final callSite = generator.generate(spec)
-    if (!callSite.success) {
+    final result = generator.generate(spec)
+    if (!result.success) {
       throw new IllegalArgumentException("Error with call site ${IastExtensionCallSite}")
     }
     final extension = new IastExtension()
 
     when:
-    extension.apply(config, callSite)
+    extension.apply(config, result)
 
     then: 'the call site provider is modified with telemetry'
-    final callSiteType = parse(callSite.file)
+    assertNoErrors result
+    assertCallSites(result.file) {
+      advices(0) {
+        pointcut('javax/servlet/http/HttpServletRequest', 'getHeader', '(Ljava/lang/String;)Ljava/lang/String;')
+        instrumentedMetric('IastMetric.INSTRUMENTED_SOURCE') {
+          metricStatements('IastMetricCollector.add(IastMetric.INSTRUMENTED_SOURCE, "http.request.header.name", 1);')
+        }
+        executedMetric('IastMetric.EXECUTED_SOURCE') {
+          metricStatements(
+            'handler.field(net.bytebuddy.jar.asm.Opcodes.GETSTATIC, "datadog/trace/api/iast/telemetry/IastMetric", "EXECUTED_SOURCE", "Ldatadog/trace/api/iast/telemetry/IastMetric;");',
+            'handler.loadConstant("http.request.header.name");',
+            'handler.instruction(net.bytebuddy.jar.asm.Opcodes.ICONST_1);',
+            'handler.method(net.bytebuddy.jar.asm.Opcodes.INVOKESTATIC, "datadog/trace/api/iast/telemetry/IastMetricCollector", "add", "(Ldatadog/trace/api/iast/telemetry/IastMetric;Ljava/lang/String;I)V", false);'
+          )
+        }
+      }
+      advices(1) {
+        pointcut('javax/servlet/ServletRequest', 'getReader', '()Ljava/io/BufferedReader;')
+        instrumentedMetric('IastMetric.INSTRUMENTED_PROPAGATION') {
+          metricStatements('IastMetricCollector.add(IastMetric.INSTRUMENTED_PROPAGATION, 1);')
+        }
+        executedMetric('IastMetric.EXECUTED_PROPAGATION') {
+          metricStatements(
+            'handler.field(net.bytebuddy.jar.asm.Opcodes.GETSTATIC, "datadog/trace/api/iast/telemetry/IastMetric", "EXECUTED_PROPAGATION", "Ldatadog/trace/api/iast/telemetry/IastMetric;");',
+            'handler.instruction(net.bytebuddy.jar.asm.Opcodes.ICONST_1);',
+            'handler.method(net.bytebuddy.jar.asm.Opcodes.INVOKESTATIC, "datadog/trace/api/iast/telemetry/IastMetricCollector", "add", "(Ldatadog/trace/api/iast/telemetry/IastMetric;I)V", false);'
+          )
+        }
+      }
+    }
   }
 
   private static AdviceGenerator buildAdviceGenerator(final File targetFolder) {
@@ -94,5 +124,105 @@ class IastExtensionTest extends BaseCsiPluginTest {
   private static ClassOrInterfaceDeclaration parse(final File path) {
     final parsedAdvice = new JavaParser().parse(path).getResult().get()
     return parsedAdvice.primaryType.get().asClassOrInterfaceDeclaration()
+  }
+
+  private static void assertCallSites(final File generated, @DelegatesTo(IastExtensionCallSiteAssert) final Closure closure) {
+    final asserter = new IastExtensionAssertBuilder(generated).build()
+    closure.delegate = asserter
+    closure(asserter)
+  }
+
+  static class IastExtensionCallSiteAssert extends CallSiteAssert {
+
+    IastExtensionCallSiteAssert(CallSiteAssert base) {
+      interfaces = base.interfaces
+      helpers = base.helpers
+      advices = base.advices
+      enabled = base.enabled
+      enabledArgs = base.enabledArgs
+    }
+
+    void advices(int index, @DelegatesTo(IastExtensionAdviceAssert) Closure closure) {
+      final asserter = advices[index]
+      closure.delegate = asserter
+      closure(asserter)
+    }
+
+    void advices(@DelegatesTo(IastExtensionAdviceAssert) Closure closure) {
+      advices.each {
+        closure.delegate = it
+        closure(it)
+      }
+    }
+  }
+
+  static class IastExtensionAdviceAssert extends AdviceAssert {
+
+    protected IastExtensionMetricAsserter instrumented
+    protected IastExtensionMetricAsserter executed
+
+    void instrumentedMetric(final String metric, @DelegatesTo(IastExtensionMetricAsserter) Closure closure) {
+      assert metric == instrumented.metric
+      closure.delegate = instrumented
+      closure(instrumented)
+    }
+
+    void executedMetric(final String metric, @DelegatesTo(IastExtensionMetricAsserter) Closure closure) {
+      assert metric == executed.metric
+      closure.delegate = executed
+      closure(executed)
+    }
+  }
+
+  static class IastExtensionMetricAsserter {
+    protected String metric
+    protected Collection<String> statements
+
+    void metricStatements(String... values) {
+      assert values.toList() == statements
+    }
+  }
+
+  static class IastExtensionAssertBuilder extends AssertBuilder<IastExtensionCallSiteAssert> {
+
+    IastExtensionAssertBuilder(File file) {
+      super(file)
+    }
+
+    @Override
+    IastExtensionCallSiteAssert build() {
+      final base = super.build()
+      return new IastExtensionCallSiteAssert(base)
+    }
+
+    @Override
+    protected List<AdviceAssert> getAdvices(ClassOrInterfaceDeclaration type) {
+      final acceptMethod = type.getMethodsByName('accept').first()
+      return getMethodCalls(acceptMethod).findAll {
+        it.nameAsString == 'addAdvice'
+      }.collect {
+        def (owner, method, descriptor) = it.arguments.subList(0, 3)*.asStringLiteralExpr()*.asString()
+        final handlerLambda = it.arguments[3].asLambdaExpr()
+        final statements = handlerLambda.body.asBlockStmt().statements
+        final instrumentedStmt = statements.get(0).asIfStmt()
+        final executedStmt = statements.get(1).asIfStmt()
+        return new IastExtensionAdviceAssert([
+          owner     : owner,
+          method    : method,
+          descriptor: descriptor,
+          instrumented : buildMetricAsserter(instrumentedStmt),
+          executed: buildMetricAsserter(executedStmt),
+          statements: statements.findAll { !it.isIfStmt() }
+        ])
+      }
+    }
+
+    protected IastExtensionMetricAsserter buildMetricAsserter(final IfStmt ifStmt) {
+      final condition = ifStmt.getCondition().asMethodCallExpr()
+      return new IastExtensionMetricAsserter(
+        metric: condition.getScope().get().toString(),
+        statements: ifStmt.getThenStmt().asBlockStmt().statements*.toString()
+      )
+    }
   }
 }

--- a/buildSrc/call-site-instrumentation-plugin/src/test/java/datadog/trace/plugin/csi/impl/ext/tests/IastCallSites.java
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/java/datadog/trace/plugin/csi/impl/ext/tests/IastCallSites.java
@@ -1,41 +1,6 @@
 package datadog.trace.plugin.csi.impl.ext.tests;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
 public interface IastCallSites {
-
-  @Target({ElementType.METHOD, ElementType.TYPE})
-  @Retention(RetentionPolicy.RUNTIME)
-  @interface Propagation {
-    Kind kind() default Kind.PROPAGATION;
-  }
-
-  @Target({ElementType.METHOD, ElementType.TYPE})
-  @Retention(RetentionPolicy.RUNTIME)
-  @interface Sink {
-    /** Vulnerability type */
-    String value();
-
-    Kind kind() default Kind.SINK;
-  }
-
-  @Target({ElementType.METHOD, ElementType.TYPE})
-  @Retention(RetentionPolicy.RUNTIME)
-  @interface Source {
-    /** Source type */
-    byte value();
-
-    Kind kind() default Kind.SOURCE;
-  }
-
-  enum Kind {
-    PROPAGATION,
-    SINK,
-    SOURCE
-  }
 
   interface HasTelemetry {
     void setVerbosity(Object verbosity);

--- a/buildSrc/call-site-instrumentation-plugin/src/test/java/datadog/trace/plugin/csi/impl/ext/tests/IastExtensionCallSite.java
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/java/datadog/trace/plugin/csi/impl/ext/tests/IastExtensionCallSite.java
@@ -1,21 +1,28 @@
 package datadog.trace.plugin.csi.impl.ext.tests;
 
 import datadog.trace.agent.tooling.csi.CallSite;
-import datadog.trace.plugin.csi.impl.ext.tests.IastCallSites.Source;
+import java.io.BufferedReader;
+import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 
 @CallSite(spi = IastCallSites.class)
 public class IastExtensionCallSite {
 
-  @Source(SourceTypes.REQUEST_HEADER_VALUE)
+  @Source(SourceTypes.REQUEST_HEADER_NAME_STRING)
   @CallSite.After(
       "java.lang.String javax.servlet.http.HttpServletRequest.getHeader(java.lang.String)")
-  @CallSite.After(
-      "java.lang.String javax.servlet.http.HttpServletRequestWrapper.getHeader(java.lang.String)")
   public static String afterGetHeader(
       @CallSite.This final HttpServletRequest self,
       @CallSite.Argument final String headerName,
       @CallSite.Return final String headerValue) {
     return headerValue;
+  }
+
+  @Propagation
+  @CallSite.After("java.io.BufferedReader javax.servlet.ServletRequest.getReader()")
+  public static BufferedReader afterGetReader(
+      @CallSite.This final ServletRequest self,
+      @CallSite.Return final BufferedReader bufferedReader) {
+    return bufferedReader;
   }
 }

--- a/buildSrc/call-site-instrumentation-plugin/src/test/java/datadog/trace/plugin/csi/impl/ext/tests/Propagation.java
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/java/datadog/trace/plugin/csi/impl/ext/tests/Propagation.java
@@ -1,0 +1,10 @@
+package datadog.trace.plugin.csi.impl.ext.tests;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Propagation {}

--- a/buildSrc/call-site-instrumentation-plugin/src/test/java/datadog/trace/plugin/csi/impl/ext/tests/Source.java
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/java/datadog/trace/plugin/csi/impl/ext/tests/Source.java
@@ -1,0 +1,13 @@
+package datadog.trace.plugin.csi.impl.ext.tests;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Source {
+  /** Source type */
+  String value();
+}

--- a/buildSrc/call-site-instrumentation-plugin/src/test/java/datadog/trace/plugin/csi/impl/ext/tests/SourceTypes.java
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/java/datadog/trace/plugin/csi/impl/ext/tests/SourceTypes.java
@@ -2,5 +2,5 @@ package datadog.trace.plugin.csi.impl.ext.tests;
 
 public class SourceTypes {
 
-  public static final byte REQUEST_HEADER_VALUE = 4;
+  public static final String REQUEST_HEADER_NAME_STRING = "http.request.header.name";
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/telemetry/TelemetryRequestEndedHandler.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/telemetry/TelemetryRequestEndedHandler.java
@@ -50,9 +50,9 @@ public class TelemetryRequestEndedHandler
   private static void addMetricsToTrace(
       final TraceSegment trace, final Collection<IastMetricData> metrics) {
     for (final IastMetricData data : metrics) {
-      final IastMetric metric = data.metric;
+      final IastMetric metric = data.getMetric();
       if (metric.getScope() == REQUEST) {
-        final String tagValue = metric.getSpanTag();
+        final String tagValue = data.getSpanTag();
         trace.setTagTop(String.format(TRACE_METRIC_PATTERN, tagValue), data.counter);
       }
     }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/telemetry/taint/TaintedObjectsWithTelemetryTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/telemetry/taint/TaintedObjectsWithTelemetryTest.groovy
@@ -60,7 +60,7 @@ class TaintedObjectsWithTelemetryTest extends DDSpecification {
 
     then:
     if (IastMetric.REQUEST_TAINTED.isEnabled(verbosity)) {
-      1 * mockCollector.addMetric(IastMetric.REQUEST_TAINTED, tainteds.size())
+      1 * mockCollector.addMetric(IastMetric.REQUEST_TAINTED, null, tainteds.size())
     } else {
       0 * mockCollector.addMetric
     }
@@ -80,7 +80,7 @@ class TaintedObjectsWithTelemetryTest extends DDSpecification {
 
     then:
     if (IastMetric.EXECUTED_TAINTED.isEnabled(verbosity)) {
-      3 * mockCollector.addMetric(IastMetric.EXECUTED_TAINTED, 1) // two calls with one element
+      3 * mockCollector.addMetric(IastMetric.EXECUTED_TAINTED, null, 1) // two calls with one element
     } else {
       0 * mockCollector.addMetric
     }
@@ -100,7 +100,7 @@ class TaintedObjectsWithTelemetryTest extends DDSpecification {
 
     then:
     if (IastMetric.TAINTED_FLAT_MODE.isEnabled(verbosity) && taintedObjects.isFlat()) {
-      1 * mockCollector.addMetric(IastMetric.TAINTED_FLAT_MODE, _)
+      1 * mockCollector.addMetric(IastMetric.TAINTED_FLAT_MODE, null, _)
     } else {
       0 * mockCollector.addMetric
     }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/CookieDirectivesInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/CookieDirectivesInstrumentation.java
@@ -6,6 +6,8 @@ import akka.http.scaladsl.server.Directive;
 import akka.http.scaladsl.server.util.Tupler$;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.instrumentation.akkahttp.iast.helpers.TaintCookieFunction;
 import datadog.trace.instrumentation.akkahttp.iast.helpers.TaintOptionalCookieFunction;
 import net.bytebuddy.asm.Advice;
@@ -53,6 +55,7 @@ public class CookieDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintCookieAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive = directive.tmap(TaintCookieFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));
     }
@@ -60,6 +63,7 @@ public class CookieDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintOptionalCookieAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive =
           directive.tmap(TaintOptionalCookieFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/CookieHeaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/CookieHeaderInstrumentation.java
@@ -13,6 +13,8 @@ import akka.http.scaladsl.model.headers.HttpCookiePair;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.source.WebModule;
 import java.util.ArrayList;
@@ -51,6 +53,7 @@ public class CookieHeaderInstrumentation extends Instrumenter.Iast
 
   static class TaintAllCookiesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
     static void after(
         @Advice.This HttpHeader cookie, @Advice.Return Seq<HttpCookiePair> cookiePairs) {
       WebModule mod = InstrumentationBridge.WEB;

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/ExtractDirectivesInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/ExtractDirectivesInstrumentation.java
@@ -11,6 +11,8 @@ import akka.http.scaladsl.server.directives.BasicDirectives$;
 import akka.http.scaladsl.server.util.Tupler$;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.instrumentation.akkahttp.iast.helpers.TaintRequestContextFunction;
 import datadog.trace.instrumentation.akkahttp.iast.helpers.TaintRequestFunction;
 import datadog.trace.instrumentation.akkahttp.iast.helpers.TaintUriFunction;
@@ -70,6 +72,7 @@ public class ExtractDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintUriDirectiveAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_QUERY_STRING)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive = directive.tmap(TaintUriFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));
     }
@@ -77,6 +80,7 @@ public class ExtractDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintRequestDirectiveAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_BODY_STRING)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive = directive.tmap(TaintRequestFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));
     }
@@ -84,6 +88,7 @@ public class ExtractDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintRequestContextDirectiveAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_BODY_STRING)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive =
           directive.tmap(TaintRequestContextFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/FormFieldDirectivesInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/FormFieldDirectivesInstrumentation.java
@@ -14,6 +14,8 @@ import akka.http.scaladsl.server.directives.FormFieldDirectives;
 import akka.http.scaladsl.server.util.Tupler$;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.instrumentation.akkahttp.iast.helpers.TaintSingleParameterFunction;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.implementation.bytecode.assign.Assigner;
@@ -99,6 +101,7 @@ public class FormFieldDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintSingleFormFieldDirectiveOldScalaAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
     static void after(
         @Advice.Return(readOnly = false, typing = Assigner.Typing.DYNAMIC) Directive retval,
         @Advice.Argument(1) FormFieldDirectives.FieldMagnet fmag) {
@@ -113,6 +116,7 @@ public class FormFieldDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintSingleFormFieldDirectiveNewScalaAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
     static void after(
         @Advice.Return(readOnly = false, typing = Assigner.Typing.DYNAMIC) Directive retval,
         @Advice.Argument(0) FormFieldDirectives.FieldMagnet fmag) {

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HeaderNameCallSite.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HeaderNameCallSite.java
@@ -3,8 +3,8 @@ package datadog.trace.instrumentation.akkahttp.iast;
 import akka.http.javadsl.model.HttpHeader;
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Source;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.Taintable;
 import datadog.trace.api.iast.source.WebModule;
@@ -15,7 +15,7 @@ import java.util.Collections;
  * because there are many calls to {@link HttpHeader#name()} inside akka-http code that we don't
  * care about.
  */
-@Source(value = SourceTypes.REQUEST_HEADER_NAME)
+@Source(value = SourceTypes.REQUEST_HEADER_NAME_STRING)
 @CallSite(spi = IastCallSites.class)
 public class HeaderNameCallSite {
 

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HttpHeaderSubclassesInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HttpHeaderSubclassesInstrumentation.java
@@ -13,6 +13,7 @@ import akka.http.scaladsl.model.HttpRequest;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.Taintable;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
@@ -54,6 +55,7 @@ public class HttpHeaderSubclassesInstrumentation extends Instrumenter.Iast
 
   static class HttpHeaderSubclassesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Propagation
     static void onExit(@Advice.This HttpHeader h, @Advice.Return String retVal) {
 
       PropagationModule propagation = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HttpRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HttpRequestInstrumentation.java
@@ -14,6 +14,8 @@ import akka.http.scaladsl.model.HttpRequest;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.Taintable;
 import datadog.trace.api.iast.propagation.PropagationModule;
@@ -57,6 +59,7 @@ public class HttpRequestInstrumentation extends Instrumenter.Iast
   @SuppressFBWarnings("BC_IMPOSSIBLE_INSTANCEOF")
   static class RequestHeadersAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
     static void onExit(
         @Advice.This HttpRequest thiz, @Advice.Return(readOnly = false) Seq<HttpHeader> headers) {
       PropagationModule propagation = InstrumentationBridge.PROPAGATION;
@@ -91,6 +94,7 @@ public class HttpRequestInstrumentation extends Instrumenter.Iast
 
   static class EntityAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Propagation
     static void onExit(
         @Advice.This HttpRequest thiz,
         @Advice.Return(readOnly = false, typing = DYNAMIC) Object entity) {

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/MarshallingDirectivesInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/MarshallingDirectivesInstrumentation.java
@@ -13,6 +13,8 @@ import akka.http.scaladsl.unmarshalling.Unmarshaller;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.instrumentation.akkahttp.iast.helpers.TaintUnmarshaller;
 import net.bytebuddy.asm.Advice;
@@ -74,6 +76,7 @@ public class MarshallingDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintUnmarshallerInputOldScalaAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_BODY_STRING)
     static void before(@Advice.Argument(readOnly = false, value = 1) Unmarshaller unmarshaller) {
       PropagationModule mod = InstrumentationBridge.PROPAGATION;
       if (mod != null) {
@@ -84,6 +87,7 @@ public class MarshallingDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintUnmarshallerInputNewScalaAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_BODY_STRING)
     static void before(@Advice.Argument(readOnly = false, value = 0) Unmarshaller unmarshaller) {
       PropagationModule mod = InstrumentationBridge.PROPAGATION;
       if (mod != null) {

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/ParameterDirectivesInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/ParameterDirectivesInstrumentation.java
@@ -13,6 +13,8 @@ import akka.http.scaladsl.server.directives.ParameterDirectives;
 import akka.http.scaladsl.server.util.Tupler$;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.instrumentation.akkahttp.iast.helpers.TaintMapFunction;
 import datadog.trace.instrumentation.akkahttp.iast.helpers.TaintMultiMapFunction;
 import datadog.trace.instrumentation.akkahttp.iast.helpers.TaintSeqFunction;
@@ -98,6 +100,7 @@ public class ParameterDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintMultiMapDirectiveAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive = directive.tmap(TaintMultiMapFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));
     }
@@ -105,6 +108,7 @@ public class ParameterDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintMapDirectiveAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive = directive.tmap(TaintMapFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));
     }
@@ -112,6 +116,7 @@ public class ParameterDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintSeqDirectiveAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive = directive.tmap(TaintSeqFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));
     }
@@ -119,6 +124,7 @@ public class ParameterDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintSingleParameterDirectiveOldScalaAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
     static void after(
         @Advice.Return(readOnly = false) Object retval,
         @Advice.Argument(1) ParameterDirectives.ParamMagnet pmag) {
@@ -138,6 +144,7 @@ public class ParameterDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintSingleParameterDirectiveNewScalaAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
     static void after(
         @Advice.Return(readOnly = false) Object retval,
         @Advice.Argument(0) ParameterDirectives.ParamMagnet pmag) {

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/PathMatcherInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/PathMatcherInstrumentation.java
@@ -12,6 +12,8 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.source.WebModule;
 import net.bytebuddy.asm.Advice;
@@ -46,6 +48,7 @@ public class PathMatcherInstrumentation extends Instrumenter.Iast
   @RequiresRequestContext(RequestContextSlot.IAST)
   static class PathMatcherAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_PATH_PARAMETER_STRING)
     static void onExit(
         @Advice.Argument(1) Object extractions, @ActiveRequestContext RequestContext reqCtx) {
       if (!(extractions instanceof scala.Tuple1)) {

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/RequestContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/RequestContextInstrumentation.java
@@ -12,6 +12,7 @@ import akka.http.scaladsl.server.RequestContext;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.Taintable;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -44,6 +45,7 @@ public class RequestContextInstrumentation extends Instrumenter.Iast
   @SuppressFBWarnings("BC_IMPOSSIBLE_INSTANCEOF")
   static class GetRequestAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Propagation
     static void onExit(
         @Advice.This RequestContext requestContext, @Advice.Return HttpRequest request) {
 

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/UnmarshallerInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/UnmarshallerInstrumentation.java
@@ -14,6 +14,7 @@ import akka.http.javadsl.unmarshalling.Unmarshaller;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.instrumentation.akkahttp.iast.helpers.TaintFutureHelper;
 import net.bytebuddy.asm.Advice;
@@ -71,6 +72,7 @@ public class UnmarshallerInstrumentation extends Instrumenter.Iast
 
   static class PropagateTaintOnApplyAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Propagation
     static void after(
         @Advice.Return(readOnly = false) Future<?> result,
         @Advice.Argument(0) Object input,

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/UriInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/UriInstrumentation.java
@@ -12,6 +12,9 @@ import akka.http.scaladsl.model.Uri;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.source.WebModule;
 import java.util.Collections;
@@ -61,6 +64,7 @@ public class UriInstrumentation extends Instrumenter.Iast implements Instrumente
 
   static class TaintQueryStringAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Propagation
     static void after(@Advice.This Uri uri, @Advice.Return scala.Option<String> ret) {
       PropagationModule mod = InstrumentationBridge.PROPAGATION;
       if (mod == null || ret.isEmpty()) {
@@ -74,6 +78,7 @@ public class UriInstrumentation extends Instrumenter.Iast implements Instrumente
     // bind uri to a variable of type Object so that this advice can also
     // be used from FromDataInstrumentaton
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
     static void after(@Advice.This /*Uri*/ Object uri, @Advice.Return Uri.Query ret) {
       WebModule web = InstrumentationBridge.WEB;
       PropagationModule prop = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/akka-http-10.2-iast/src/main/java/datadog/trace/instrumentation/akkahttp102/iast/ParameterDirectivesImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.2-iast/src/main/java/datadog/trace/instrumentation/akkahttp102/iast/ParameterDirectivesImplInstrumentation.java
@@ -13,6 +13,8 @@ import akka.http.scaladsl.server.util.Tupler$;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.muzzle.Reference;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.instrumentation.akkahttp102.iast.helpers.TaintParametersFunction;
 import net.bytebuddy.asm.Advice;
 
@@ -67,6 +69,7 @@ public class ParameterDirectivesImplInstrumentation extends Instrumenter.Iast
 
   static class FilterAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
     static void after(
         @Advice.Argument(0) String paramName,
         @Advice.Return(readOnly = false) Directive /*<Tuple1<?>>*/ retval) {
@@ -81,6 +84,7 @@ public class ParameterDirectivesImplInstrumentation extends Instrumenter.Iast
 
   static class RepeatedFilterAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
     static void after(
         @Advice.Argument(0) String paramName,
         @Advice.Return(readOnly = false) Directive /*<Tuple1<Iterable<?>>>*/ retval) {

--- a/dd-java-agent/instrumentation/commons-codec-1/src/main/java/datadog/trace/instrumentation/commonscodec/Base64CallSite.java
+++ b/dd-java-agent/instrumentation/commons-codec-1/src/main/java/datadog/trace/instrumentation/commonscodec/Base64CallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.commonscodec;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Propagation;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.CodecModule;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/IastCommonsHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/IastCommonsHttpClientInstrumentation.java
@@ -8,6 +8,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
+import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.SsrfModule;
 import net.bytebuddy.asm.Advice;
 import org.apache.commons.httpclient.HttpMethod;
@@ -42,6 +44,7 @@ public class IastCommonsHttpClientInstrumentation extends Instrumenter.Iast
 
   public static class ExecAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.SSRF)
     public static void methodEnter(@Advice.Argument(1) final HttpMethod httpMethod) {
       final SsrfModule module = InstrumentationBridge.SSRF;
       if (module != null) {

--- a/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/IastHttpMethodBaseInstrumentation.java
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/IastHttpMethodBaseInstrumentation.java
@@ -8,6 +8,7 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
 
@@ -45,6 +46,7 @@ public class IastHttpMethodBaseInstrumentation extends Instrumenter.Iast
 
   public static class CtorAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Propagation
     public static void afterCtor(
         @Advice.This final Object self, @Advice.Argument(0) final Object argument) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/IastQueryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/main/java/datadog/trace/instrumentation/hibernate/core/v3_3/IastQueryInstrumentation.java
@@ -7,6 +7,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
+import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.SqlInjectionModule;
 import net.bytebuddy.asm.Advice;
 import org.hibernate.Query;
@@ -36,6 +38,7 @@ public class IastQueryInstrumentation extends Instrumenter.Iast
   public static class QueryMethodAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.SQL_INJECTION)
     public static void beforeMethod(@Advice.This final Query query) {
       final SqlInjectionModule module = InstrumentationBridge.SQL_INJECTION;
       if (module != null) {

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/IastQueryInstrumentation.java
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/main/java/datadog/trace/instrumentation/hibernate/core/v4_0/IastQueryInstrumentation.java
@@ -7,6 +7,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
+import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.SqlInjectionModule;
 import net.bytebuddy.asm.Advice;
 import org.hibernate.Query;
@@ -35,6 +37,7 @@ public class IastQueryInstrumentation extends Instrumenter.Iast
   public static class QueryMethodAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.SQL_INJECTION)
     public static void beforeMethod(@Advice.This final Query query) {
       final SqlInjectionModule module = InstrumentationBridge.SQL_INJECTION;
       if (module != null) {

--- a/dd-java-agent/instrumentation/jackson-core/jackson-core-1/src/main/java/datadog/trace/instrumentation/jackson/codehouse/core/Json1FactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/jackson-core/jackson-core-1/src/main/java/datadog/trace/instrumentation/jackson/codehouse/core/Json1FactoryInstrumentation.java
@@ -7,6 +7,8 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
+import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.sink.SsrfModule;
 import java.io.InputStream;
@@ -44,6 +46,7 @@ public class Json1FactoryInstrumentation extends Instrumenter.Iast
   public static class InstrumenterAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.SSRF) // SSRF takes priority over the propagation one
     public static void onExit(
         @Advice.Argument(0) final Object input, @Advice.Return final Object parser) {
       if (input != null) {

--- a/dd-java-agent/instrumentation/jackson-core/jackson-core-1/src/main/java/datadog/trace/instrumentation/jackson/codehouse/core/Json1ParserInstrumentation.java
+++ b/dd-java-agent/instrumentation/jackson-core/jackson-core-1/src/main/java/datadog/trace/instrumentation/jackson/codehouse/core/Json1ParserInstrumentation.java
@@ -13,6 +13,7 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -55,6 +56,7 @@ public class Json1ParserInstrumentation extends Instrumenter.Iast
   public static class JsonParserAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Propagation
     public static void onExit(@Advice.This JsonParser jsonParser, @Advice.Return String result) {
       if (jsonParser != null && result != null) {
         final PropagationModule module = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/jackson-core/src/main/java/datadog/trace/instrumentation/jackson/core/Json2FactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/jackson-core/src/main/java/datadog/trace/instrumentation/jackson/core/Json2FactoryInstrumentation.java
@@ -6,6 +6,8 @@ import static net.bytebuddy.matcher.ElementMatchers.*;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
+import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.sink.SsrfModule;
 import java.io.InputStream;
@@ -44,6 +46,7 @@ public class Json2FactoryInstrumentation extends Instrumenter.Iast
   public static class InstrumenterAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.SSRF) // it's both propagation and Sink but Sink takes priority
     public static void onExit(
         @Advice.Argument(0) final Object input, @Advice.Return final Object parser) {
       if (input != null) {

--- a/dd-java-agent/instrumentation/jackson-core/src/main/java/datadog/trace/instrumentation/jackson/core/Json2ParserInstrumentation.java
+++ b/dd-java-agent/instrumentation/jackson-core/src/main/java/datadog/trace/instrumentation/jackson/core/Json2ParserInstrumentation.java
@@ -13,6 +13,7 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor;
 import datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -74,6 +75,7 @@ public class Json2ParserInstrumentation extends Instrumenter.Iast
   public static class JsonParserAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Propagation
     public static void onExit(@Advice.This JsonParser jsonParser, @Advice.Return String result) {
       if (jsonParser != null && result != null) {
         final PropagationModule module = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/jackson-core/src/main/java/datadog/trace/instrumentation/jackson/core/TokenBufferInstrumentation.java
+++ b/dd-java-agent/instrumentation/jackson-core/src/main/java/datadog/trace/instrumentation/jackson/core/TokenBufferInstrumentation.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.util.TokenBuffer;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
 
@@ -43,6 +44,7 @@ public class TokenBufferInstrumentation extends Instrumenter.Iast
 
   public static class AsParserAdvice {
     @Advice.OnMethodExit
+    @Propagation
     public static void onExit(
         @Advice.This TokenBuffer tokenBuffer, @Advice.Return JsonParser parser) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/FileCallSite.java
+++ b/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/FileCallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.java.lang;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Sink;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.PathTraversalModule;
 import java.io.File;

--- a/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/FileInputStreamCallSite.java
+++ b/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/FileInputStreamCallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.java.lang;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Sink;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.PathTraversalModule;
 import javax.annotation.Nullable;

--- a/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/FileOutputStreamCallSite.java
+++ b/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/FileOutputStreamCallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.java.lang;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Sink;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.PathTraversalModule;
 import javax.annotation.Nullable;

--- a/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/InputStreamInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/InputStreamInstrumentation.java
@@ -8,6 +8,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import java.io.InputStream;
 import net.bytebuddy.asm.Advice;
@@ -49,6 +50,7 @@ public class InputStreamInstrumentation extends Instrumenter.Iast
   public static class InputStreamAdvice {
 
     @Advice.OnMethodExit
+    @Propagation
     public static void onExit(
         @Advice.This final InputStream self, @Advice.Argument(0) final InputStream param) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/PathCallSite.java
+++ b/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/PathCallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.java.lang;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Sink;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.PathTraversalModule;
 import javax.annotation.Nullable;

--- a/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/PathsCallSite.java
+++ b/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/PathsCallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.java.lang;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Sink;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.PathTraversalModule;
 import java.net.URI;

--- a/dd-java-agent/instrumentation/java-lang/java-lang-11/src/main/java/datadog/trace/instrumentation/java/lang/jdk11/StringCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/java-lang-11/src/main/java/datadog/trace/instrumentation/java/lang/jdk11/StringCallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.java.lang.jdk11;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Propagation;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.StringModule;
 
 @Propagation

--- a/dd-java-agent/instrumentation/java-lang/java-lang-9/src/main/java/datadog/trace/instrumentation/java/lang/invoke/StringConcatFactoryCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/java-lang-9/src/main/java/datadog/trace/instrumentation/java/lang/invoke/StringConcatFactoryCallSite.java
@@ -5,8 +5,8 @@ import static java.lang.invoke.StringConcatFactory.makeConcatWithConstants;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Propagation;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.StringModule;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.lang.invoke.ConstantCallSite;

--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/MathCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/MathCallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.java.lang;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Sink;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.WeakRandomnessModule;
 

--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/ProcessBuilderCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/ProcessBuilderCallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.java.lang;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Sink;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.CommandInjectionModule;
 import java.util.List;

--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/RuntimeCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/RuntimeCallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.java.lang;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Sink;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.CommandInjectionModule;
 import java.io.File;

--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringBuilderCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringBuilderCallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.java.lang;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Propagation;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.StringModule;
 import datadog.trace.util.stacktrace.StackUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;

--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringCallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.java.lang;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Propagation;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.CodecModule;
 import datadog.trace.api.iast.propagation.StringModule;
 import datadog.trace.util.stacktrace.StackUtils;

--- a/dd-java-agent/instrumentation/java-net/src/main/java/datadog/trace/instrumentation/java/net/URICallSite.java
+++ b/dd-java-agent/instrumentation/java-net/src/main/java/datadog/trace/instrumentation/java/net/URICallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.java.net;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Propagation;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import java.net.URI;
 import javax.annotation.Nonnull;

--- a/dd-java-agent/instrumentation/java-net/src/main/java/datadog/trace/instrumentation/java/net/URLCallSite.java
+++ b/dd-java-agent/instrumentation/java-net/src/main/java/datadog/trace/instrumentation/java/net/URLCallSite.java
@@ -2,9 +2,9 @@ package datadog.trace.instrumentation.java.net;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Propagation;
-import datadog.trace.api.iast.IastCallSites.Sink;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
+import datadog.trace.api.iast.Sink;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.sink.SsrfModule;

--- a/dd-java-agent/instrumentation/java-net/src/main/java/datadog/trace/instrumentation/java/net/URLDecoderCallSite.java
+++ b/dd-java-agent/instrumentation/java-net/src/main/java/datadog/trace/instrumentation/java/net/URLDecoderCallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.java.net;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Propagation;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.CodecModule;
 import javax.annotation.Nullable;
 

--- a/dd-java-agent/instrumentation/java-security/src/main/java/datadog/trace/instrumentation/java/security/WeakCipherInstrumentationCallSite.java
+++ b/dd-java-agent/instrumentation/java-security/src/main/java/datadog/trace/instrumentation/java/security/WeakCipherInstrumentationCallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.java.security;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Sink;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.WeakCipherModule;
 import java.security.Provider;

--- a/dd-java-agent/instrumentation/java-security/src/main/java/datadog/trace/instrumentation/java/security/WeakHashInstrumentationCallSite.java
+++ b/dd-java-agent/instrumentation/java-security/src/main/java/datadog/trace/instrumentation/java/security/WeakHashInstrumentationCallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.java.security;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Sink;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.WeakHashModule;
 import java.security.Provider;

--- a/dd-java-agent/instrumentation/java-util/src/main/java/datadog/trace/instrumentation/java/util/RandomCallSite.java
+++ b/dd-java-agent/instrumentation/java-util/src/main/java/datadog/trace/instrumentation/java/util/RandomCallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.java.util;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Sink;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.WeakRandomnessModule;
 import java.util.Random;

--- a/dd-java-agent/instrumentation/java-util/src/main/java/datadog/trace/instrumentation/java/util/concurrent/ThreadLocalRandomCallSite.java
+++ b/dd-java-agent/instrumentation/java-util/src/main/java/datadog/trace/instrumentation/java/util/concurrent/ThreadLocalRandomCallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.java.util.concurrent;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Sink;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.WeakRandomnessModule;
 import java.util.concurrent.ThreadLocalRandom;

--- a/dd-java-agent/instrumentation/javax-naming/src/main/java/datadog/trace/instrumentation/javax/naming/DirContextCallSite.java
+++ b/dd-java-agent/instrumentation/javax-naming/src/main/java/datadog/trace/instrumentation/javax/naming/DirContextCallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.javax.naming;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Sink;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.LdapInjectionModule;
 import javax.annotation.Nonnull;

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/IastConnectionCallSite.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/IastConnectionCallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.jdbc;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Sink;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.SqlInjectionModule;
 import datadog.trace.bootstrap.instrumentation.jdbc.DBInfo;

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/IastStatementCallSite.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/IastStatementCallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.jdbc;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Sink;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.SqlInjectionModule;
 import datadog.trace.bootstrap.instrumentation.jdbc.DBInfo;

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractFormProviderInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractFormProviderInstrumentation.java
@@ -7,6 +7,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.source.WebModule;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +36,7 @@ public class AbstractFormProviderInstrumentation extends Instrumenter.Iast
 
   public static class InstrumenterAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
     public static void onExit(@Advice.Return Map<String, List<String>> result) {
       final WebModule module = InstrumentationBridge.WEB;
       if (module != null) {

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractParamValueExtractorInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractParamValueExtractorInstrumentation.java
@@ -7,6 +7,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.source.WebModule;
 import net.bytebuddy.asm.Advice;
 
@@ -37,6 +38,7 @@ public class AbstractParamValueExtractorInstrumentation extends Instrumenter.Ias
 
   public static class InstrumenterAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Propagation
     public static void onExit(
         @Advice.Return(readOnly = true) Object result,
         @Advice.FieldValue("parameterName") String parameterName) {

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractStringReaderAdvice.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractStringReaderAdvice.java
@@ -1,11 +1,14 @@
-package datadog.trace.instrumentation.jersey3;
+package datadog.trace.instrumentation.jersey;
 
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.source.WebModule;
 import net.bytebuddy.asm.Advice;
 
 public class AbstractStringReaderAdvice {
   @Advice.OnMethodExit
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
   public static void onExit(@Advice.Return(readOnly = true) Object result) {
     if (result instanceof String) {
       final WebModule module = InstrumentationBridge.WEB;

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractStringReaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractStringReaderInstrumentation.java
@@ -1,4 +1,4 @@
-package datadog.trace.instrumentation.jersey3;
+package datadog.trace.instrumentation.jersey;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/CookieInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/CookieInstrumentation.java
@@ -8,6 +8,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
@@ -36,6 +37,7 @@ public class CookieInstrumentation extends Instrumenter.Iast implements Instrume
 
   public static class InstrumenterAdviceGetName {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_COOKIE_NAME_STRING)
     public static void onExit(@Advice.Return String cookieName, @Advice.This Object self) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
@@ -46,6 +48,7 @@ public class CookieInstrumentation extends Instrumenter.Iast implements Instrume
 
   public static class GetValueAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
     public static void onExit(
         @Advice.Return String cookieValue,
         @Advice.FieldValue("name") String name,

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/CookieParamValueFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/CookieParamValueFactoryInstrumentation.java
@@ -6,6 +6,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import net.bytebuddy.asm.Advice;
 
@@ -36,6 +37,7 @@ public class CookieParamValueFactoryInstrumentation extends Instrumenter.Iast
 
   public static class InstrumenterAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
     public static void onExit() {
       ThreadLocalSourceType.set(SourceTypes.REQUEST_COOKIE_VALUE);
     }

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/HeaderParamValueFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/HeaderParamValueFactoryInstrumentation.java
@@ -6,6 +6,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import net.bytebuddy.asm.Advice;
 
@@ -36,6 +37,7 @@ public class HeaderParamValueFactoryInstrumentation extends Instrumenter.Iast
 
   public static class InstrumenterAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
     public static void onExit() {
       ThreadLocalSourceType.set(SourceTypes.REQUEST_HEADER_VALUE);
     }

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/InboundMessageContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/InboundMessageContextInstrumentation.java
@@ -7,6 +7,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.source.WebModule;
@@ -41,6 +42,7 @@ public class InboundMessageContextInstrumentation extends Instrumenter.Iast
 
   public static class InstrumenterAdviceGetHeaders {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
     public static void onExit(@Advice.Return Map<String, List<String>> headers) {
       final WebModule module = InstrumentationBridge.WEB;
       if (module != null) {
@@ -56,6 +58,7 @@ public class InboundMessageContextInstrumentation extends Instrumenter.Iast
 
   public static class InstrumenterAdviceGetRequestCookies {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
     public static void onExit(@Advice.Return Map<String, Object> cookies) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/JakartaWSResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/JakartaWSResponseInstrumentation.java
@@ -8,6 +8,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
+import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
 import java.net.URI;
 import net.bytebuddy.asm.Advice;
@@ -44,6 +46,7 @@ public class JakartaWSResponseInstrumentation extends Instrumenter.Iast
 
   public static class HeaderAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.RESPONSE_HEADER)
     public static void onExit(
         @Advice.Argument(0) String headerName, @Advice.Argument(1) Object headerValue) {
       if (null != headerValue) {
@@ -57,6 +60,7 @@ public class JakartaWSResponseInstrumentation extends Instrumenter.Iast
 
   public static class RedirectionAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.UNVALIDATED_REDIRECT)
     public static void onEnter(@Advice.Argument(0) final URI location) {
       final UnvalidatedRedirectModule module = InstrumentationBridge.UNVALIDATED_REDIRECT;
       if (module != null) {

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/JavaxWSResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/JavaxWSResponseInstrumentation.java
@@ -8,6 +8,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
+import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
 import java.net.URI;
 import net.bytebuddy.asm.Advice;
@@ -44,6 +46,7 @@ public class JavaxWSResponseInstrumentation extends Instrumenter.Iast
 
   public static class HeaderAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.RESPONSE_HEADER)
     public static void onExit(
         @Advice.Argument(0) String headerName, @Advice.Argument(1) Object headerValue) {
       if (null != headerValue) {
@@ -57,6 +60,7 @@ public class JavaxWSResponseInstrumentation extends Instrumenter.Iast
 
   public static class RedirectionAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.UNVALIDATED_REDIRECT)
     public static void onEnter(@Advice.Argument(0) final URI location) {
       final UnvalidatedRedirectModule module = InstrumentationBridge.UNVALIDATED_REDIRECT;
       if (module != null) {

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/ParamValueFactoryWithSourceInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/ParamValueFactoryWithSourceInstrumentation.java
@@ -6,6 +6,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.SourceTypes;
 import net.bytebuddy.asm.Advice;
 
@@ -36,6 +37,7 @@ public class ParamValueFactoryWithSourceInstrumentation extends Instrumenter.Ias
 
   public static class InstrumenterAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Propagation
     public static void onExit(@Advice.FieldValue("parameterSource") Object parameterSource) {
       switch (parameterSource.toString()) {
         case "COOKIE":

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/PathParamValueFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/PathParamValueFactoryInstrumentation.java
@@ -5,6 +5,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import net.bytebuddy.asm.Advice;
 
@@ -35,6 +36,7 @@ public class PathParamValueFactoryInstrumentation extends Instrumenter.Iast
 
   public static class InstrumenterAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_PATH_PARAMETER_STRING)
     public static void onExit() {
       ThreadLocalSourceType.set(SourceTypes.REQUEST_PATH_PARAMETER);
     }

--- a/dd-java-agent/instrumentation/jose-jwt/src/main/java/datadog/trace/instrumentation/josejwt/JSONObjectUtilsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jose-jwt/src/main/java/datadog/trace/instrumentation/josejwt/JSONObjectUtilsInstrumentation.java
@@ -7,6 +7,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import java.util.Map;
@@ -35,6 +36,7 @@ public class JSONObjectUtilsInstrumentation extends Instrumenter.Iast
   public static class InstrumenterAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
     public static void onEnter(@Advice.Return Map<String, Object> map) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
 

--- a/dd-java-agent/instrumentation/jose-jwt/src/main/java/datadog/trace/instrumentation/josejwt/JWTParserInstrumentation.java
+++ b/dd-java-agent/instrumentation/jose-jwt/src/main/java/datadog/trace/instrumentation/josejwt/JWTParserInstrumentation.java
@@ -7,6 +7,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
@@ -34,6 +35,7 @@ public class JWTParserInstrumentation extends Instrumenter.Iast
   public static class InstrumenterAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
     public static void onEnter(@Advice.Argument(0) String json) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
 

--- a/dd-java-agent/instrumentation/netty-buffer-4/src/main/java/datadog/trace/instrumentation/netty40/buffer/ByteBufInputStreamInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-buffer-4/src/main/java/datadog/trace/instrumentation/netty40/buffer/ByteBufInputStreamInstrumentation.java
@@ -10,6 +10,7 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
 
@@ -46,6 +47,7 @@ public class ByteBufInputStreamInstrumentation extends Instrumenter.Iast
   public static class ConstructorAdvice {
 
     @Advice.OnMethodExit
+    @Propagation
     public static void onExit(
         @Advice.This final Object self, @Advice.Argument(0) final Object buffer) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/IastHttpUrlInstrumentation.java
+++ b/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/IastHttpUrlInstrumentation.java
@@ -10,6 +10,7 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import java.net.URL;
 import net.bytebuddy.asm.Advice;
@@ -70,6 +71,7 @@ public class IastHttpUrlInstrumentation extends Instrumenter.Iast
 
   public static class ParseAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Propagation
     public static void onParse(
         @Advice.Argument(0) final Object argument, @Advice.Return final Object result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
@@ -82,6 +84,7 @@ public class IastHttpUrlInstrumentation extends Instrumenter.Iast
   public static class PropagationAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    @Propagation
     public static void onPropagation(
         @Advice.This final Object self, @Advice.Return final Object result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/IastOkHttp2Instrumentation.java
+++ b/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/IastOkHttp2Instrumentation.java
@@ -6,6 +6,8 @@ import com.google.auto.service.AutoService;
 import com.squareup.okhttp.Interceptor;
 import com.squareup.okhttp.OkHttpClient;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.Sink;
+import datadog.trace.api.iast.VulnerabilityTypes;
 import net.bytebuddy.asm.Advice;
 
 @AutoService(Instrumenter.class)
@@ -36,6 +38,7 @@ public class IastOkHttp2Instrumentation extends Instrumenter.Iast
 
   public static class OkHttp2ClientAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.SSRF)
     public static void addIastInterceptor(@Advice.This final OkHttpClient client) {
       for (final Interceptor interceptor : client.interceptors()) {
         if (interceptor instanceof IastInterceptor) {

--- a/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/IastHttpUrlInstrumentation.java
+++ b/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/IastHttpUrlInstrumentation.java
@@ -10,6 +10,7 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import java.net.URL;
 import net.bytebuddy.asm.Advice;
@@ -70,6 +71,7 @@ public class IastHttpUrlInstrumentation extends Instrumenter.Iast
 
   public static class ParseAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Propagation
     public static void onParse(
         @Advice.Argument(0) final Object arg, @Advice.Return final Object result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/IastOkHttp3Instrumentation.java
+++ b/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/IastOkHttp3Instrumentation.java
@@ -6,6 +6,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.Sink;
+import datadog.trace.api.iast.VulnerabilityTypes;
 import net.bytebuddy.asm.Advice;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
@@ -39,6 +41,7 @@ public class IastOkHttp3Instrumentation extends Instrumenter.Iast
 
   public static class OkHttp3ClientAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.SSRF)
     public static void addIastInterceptor(@Advice.Argument(0) final OkHttpClient.Builder builder) {
       for (final Interceptor interceptor : builder.interceptors()) {
         if (interceptor instanceof IastInterceptor) {

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/CookieParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/CookieParamInjectorAdvice.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.resteasy;
 
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.source.WebModule;
 import java.util.Collection;
 import net.bytebuddy.asm.Advice;
@@ -8,6 +10,7 @@ import org.jboss.resteasy.core.CookieParamInjector;
 
 public class CookieParamInjectorAdvice {
   @Advice.OnMethodExit
+  @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
   public static void onExit(
       @Advice.This CookieParamInjector self,
       @Advice.Return(readOnly = true) Object result,

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/FormParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/FormParamInjectorAdvice.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.resteasy;
 
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.source.WebModule;
 import java.util.Collection;
 import net.bytebuddy.asm.Advice;
@@ -8,6 +10,7 @@ import org.jboss.resteasy.core.FormParamInjector;
 
 public class FormParamInjectorAdvice {
   @Advice.OnMethodExit
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
   public static void onExit(
       @Advice.This FormParamInjector self,
       @Advice.Return(readOnly = true) Object result,

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/HeaderParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/HeaderParamInjectorAdvice.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.resteasy;
 
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.source.WebModule;
 import java.util.Collection;
 import net.bytebuddy.asm.Advice;
@@ -8,6 +10,7 @@ import org.jboss.resteasy.core.HeaderParamInjector;
 
 public class HeaderParamInjectorAdvice {
   @Advice.OnMethodExit
+  @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
   public static void onExit(
       @Advice.This HeaderParamInjector self,
       @Advice.Return(readOnly = true) Object result,

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/JavaxWSResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/JavaxWSResponseInstrumentation.java
@@ -8,6 +8,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
+import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
 import java.net.URI;
 import net.bytebuddy.asm.Advice;
@@ -44,6 +46,7 @@ public class JavaxWSResponseInstrumentation extends Instrumenter.Iast
 
   public static class HeaderAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.RESPONSE_HEADER)
     public static void onExit(
         @Advice.Argument(0) String headerName, @Advice.Argument(1) Object headerValue) {
       if (headerValue instanceof String) {
@@ -57,6 +60,7 @@ public class JavaxWSResponseInstrumentation extends Instrumenter.Iast
 
   public static class RedirectionAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.UNVALIDATED_REDIRECT)
     public static void onEnter(@Advice.Argument(0) final URI location) {
       final UnvalidatedRedirectModule module = InstrumentationBridge.UNVALIDATED_REDIRECT;
       if (module != null) {

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/PathParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/PathParamInjectorAdvice.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.resteasy;
 
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.source.WebModule;
 import java.util.Collection;
 import net.bytebuddy.asm.Advice;
@@ -8,6 +10,7 @@ import org.jboss.resteasy.core.PathParamInjector;
 
 public class PathParamInjectorAdvice {
   @Advice.OnMethodExit
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
   public static void onExit(
       @Advice.This PathParamInjector self,
       @Advice.Return(readOnly = true) Object result,

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/QueryParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/QueryParamInjectorAdvice.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.resteasy;
 
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.source.WebModule;
 import java.util.Collection;
 import net.bytebuddy.asm.Advice;
@@ -8,6 +10,7 @@ import org.jboss.resteasy.core.QueryParamInjector;
 
 public class QueryParamInjectorAdvice {
   @Advice.OnMethodExit
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
   public static void onExit(
       @Advice.This QueryParamInjector self,
       @Advice.Return(readOnly = true) Object result,

--- a/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
@@ -12,6 +12,9 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
+import datadog.trace.api.iast.Sink;
+import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
 import net.bytebuddy.asm.Advice;
@@ -61,6 +64,7 @@ public final class HttpServletResponseInstrumentation extends Instrumenter.Iast
 
   public static class AddCookieAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.RESPONSE_HEADER)
     public static void onEnter(@Advice.Argument(0) final javax.servlet.http.Cookie cookie) {
       if (null != cookie) {
         InstrumentationBridge.RESPONSE_HEADER_MODULE.onCookie(
@@ -71,6 +75,7 @@ public final class HttpServletResponseInstrumentation extends Instrumenter.Iast
 
   public static class AddHeaderAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.RESPONSE_HEADER)
     public static void onEnter(
         @Advice.Argument(0) final String name, @Advice.Argument(1) String value) {
       if (null != value && value.length() > 0) {
@@ -81,6 +86,7 @@ public final class HttpServletResponseInstrumentation extends Instrumenter.Iast
 
   public static class SendRedirectAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.UNVALIDATED_REDIRECT)
     public static void onEnter(@Advice.Argument(0) final String location) {
       final UnvalidatedRedirectModule module = InstrumentationBridge.UNVALIDATED_REDIRECT;
       if (module != null) {
@@ -93,6 +99,7 @@ public final class HttpServletResponseInstrumentation extends Instrumenter.Iast
 
   public static class EncodeURLAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Propagation
     public static void onExit(@Advice.Argument(0) final String url, @Advice.Return String encoded) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/callsite/HttpServlet3RequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/callsite/HttpServlet3RequestCallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.servlet3.callsite;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Source;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.source.WebModule;
 import java.util.Map;
@@ -12,7 +12,7 @@ import javax.servlet.http.HttpServletRequest;
 @CallSite(spi = IastCallSites.class)
 public class HttpServlet3RequestCallSite {
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
   @CallSite.After("java.util.Map javax.servlet.http.HttpServletRequest.getParameterMap()")
   @CallSite.After("java.util.Map javax.servlet.http.HttpServletRequestWrapper.getParameterMap()")
   public static java.util.Map<java.lang.String, java.lang.String[]> afterGetParameterMap(

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/callsite/Servlet3RequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/callsite/Servlet3RequestCallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.servlet3.callsite;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Source;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.source.WebModule;
 import java.util.Map;
@@ -12,7 +12,7 @@ import javax.servlet.ServletRequest;
 @CallSite(spi = IastCallSites.class)
 public class Servlet3RequestCallSite {
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
   @CallSite.After("java.util.Map javax.servlet.ServletRequest.getParameterMap()")
   @CallSite.After("java.util.Map javax.servlet.ServletRequestWrapper.getParameterMap()")
   public static java.util.Map<java.lang.String, java.lang.String[]> afterGetParameterMap(

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestCallSite.java
@@ -2,9 +2,9 @@ package datadog.trace.instrumentation.servlet5;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Sink;
-import datadog.trace.api.iast.IastCallSites.Source;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
@@ -20,7 +20,7 @@ import java.util.Map;
 @CallSite(spi = IastCallSites.class)
 public class JakartaHttpServletRequestCallSite {
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
   @CallSite.After(
       "java.lang.String jakarta.servlet.http.HttpServletRequest.getParameter(java.lang.String)")
   @CallSite.After(
@@ -40,7 +40,7 @@ public class JakartaHttpServletRequestCallSite {
     return paramValue;
   }
 
-  @Source(SourceTypes.REQUEST_PARAMETER_NAME)
+  @Source(SourceTypes.REQUEST_PARAMETER_NAME_STRING)
   @CallSite.After(
       "java.util.Enumeration jakarta.servlet.http.HttpServletRequest.getParameterNames()")
   @CallSite.After(
@@ -72,7 +72,7 @@ public class JakartaHttpServletRequestCallSite {
     }
   }
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
   @CallSite.After(
       "java.lang.String[] jakarta.servlet.http.HttpServletRequest.getParameterValues(java.lang.String)")
   @CallSite.After(
@@ -94,7 +94,7 @@ public class JakartaHttpServletRequestCallSite {
     return parameterValues;
   }
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
   @CallSite.After("java.util.Map jakarta.servlet.http.HttpServletRequest.getParameterMap()")
   @CallSite.After("java.util.Map jakarta.servlet.http.HttpServletRequestWrapper.getParameterMap()")
   public static java.util.Map<java.lang.String, java.lang.String[]> afterGetParameterMap(

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestInputStreamCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestInputStreamCallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.servlet5;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Propagation;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import jakarta.servlet.ServletInputStream;
@@ -12,7 +12,7 @@ import jakarta.servlet.http.HttpServletRequest;
 @CallSite(spi = IastCallSites.class)
 public class JakartaHttpServletRequestInputStreamCallSite {
 
-  @Propagation
+  @Source(SourceTypes.REQUEST_BODY_STRING)
   @CallSite.After(
       "jakarta.servlet.ServletInputStream jakarta.servlet.http.HttpServletRequest.getInputStream()")
   @CallSite.After(

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletResponseInstrumentation.java
@@ -11,6 +11,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
+import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
 import net.bytebuddy.asm.Advice;
@@ -52,6 +54,7 @@ public final class JakartaHttpServletResponseInstrumentation extends Instrumente
 
   public static class AddCookieAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.RESPONSE_HEADER)
     public static void onEnter(@Advice.Argument(0) final jakarta.servlet.http.Cookie cookie) {
       if (cookie != null) {
         InstrumentationBridge.RESPONSE_HEADER_MODULE.onCookie(
@@ -62,6 +65,7 @@ public final class JakartaHttpServletResponseInstrumentation extends Instrumente
 
   public static class AddHeaderAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.RESPONSE_HEADER)
     public static void onEnter(
         @Advice.Argument(0) final String name, @Advice.Argument(1) String value) {
       if (null != value && value.length() > 0) {
@@ -72,6 +76,7 @@ public final class JakartaHttpServletResponseInstrumentation extends Instrumente
 
   public static class SendRedirectAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.UNVALIDATED_REDIRECT)
     public static void onEnter(@Advice.Argument(0) final String location) {
       final UnvalidatedRedirectModule module = InstrumentationBridge.UNVALIDATED_REDIRECT;
       if (module != null) {

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaServletRequestCallSite.java
@@ -2,9 +2,9 @@ package datadog.trace.instrumentation.servlet5;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Sink;
-import datadog.trace.api.iast.IastCallSites.Source;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
@@ -22,7 +22,7 @@ import java.util.Map;
 @CallSite(spi = IastCallSites.class)
 public class JakartaServletRequestCallSite {
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
   @CallSite.After("java.lang.String jakarta.servlet.ServletRequest.getParameter(java.lang.String)")
   @CallSite.After(
       "java.lang.String jakarta.servlet.ServletRequestWrapper.getParameter(java.lang.String)")
@@ -41,7 +41,7 @@ public class JakartaServletRequestCallSite {
     return paramValue;
   }
 
-  @Source(SourceTypes.REQUEST_PARAMETER_NAME)
+  @Source(SourceTypes.REQUEST_PARAMETER_NAME_STRING)
   @CallSite.After("java.util.Enumeration jakarta.servlet.ServletRequest.getParameterNames()")
   @CallSite.After("java.util.Enumeration jakarta.servlet.ServletRequestWrapper.getParameterNames()")
   public static Enumeration<String> afterGetParameterNames(
@@ -71,7 +71,7 @@ public class JakartaServletRequestCallSite {
     }
   }
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
   @CallSite.After(
       "java.lang.String[] jakarta.servlet.ServletRequest.getParameterValues(java.lang.String)")
   @CallSite.After(
@@ -93,7 +93,7 @@ public class JakartaServletRequestCallSite {
     return parameterValues;
   }
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
   @CallSite.After("java.util.Map jakarta.servlet.ServletRequest.getParameterMap()")
   @CallSite.After("java.util.Map jakarta.servlet.ServletRequestWrapper.getParameterMap()")
   public static java.util.Map<java.lang.String, java.lang.String[]> afterGetParameterMap(
@@ -125,7 +125,7 @@ public class JakartaServletRequestCallSite {
     }
   }
 
-  @IastCallSites.Propagation
+  @Source(SourceTypes.REQUEST_BODY_STRING)
   @CallSite.After(
       "jakarta.servlet.ServletInputStream jakarta.servlet.ServletRequest.getInputStream()")
   @CallSite.After(

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/CookieInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/CookieInstrumentation.java
@@ -8,6 +8,7 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
@@ -41,6 +42,7 @@ public class CookieInstrumentation extends Instrumenter.Iast implements Instrume
 
   public static class GetNameAdvice {
     @Advice.OnMethodExit
+    @Source(SourceTypes.REQUEST_COOKIE_NAME_STRING)
     public static void afterGetName(
         @Advice.This final Object self, @Advice.Return final String result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
@@ -57,6 +59,7 @@ public class CookieInstrumentation extends Instrumenter.Iast implements Instrume
   public static class GetValueAdvice {
 
     @Advice.OnMethodExit
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
     public static void afterGetValue(
         @Advice.This final Object self,
         @Advice.FieldValue("name") final String name,

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
@@ -2,9 +2,9 @@ package datadog.trace.instrumentation.servlet.request;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Propagation;
-import datadog.trace.api.iast.IastCallSites.Source;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
@@ -22,7 +22,7 @@ import javax.servlet.http.HttpServletRequest;
 @CallSite(spi = IastCallSites.class)
 public class HttpServletRequestCallSite {
 
-  @Source(SourceTypes.REQUEST_HEADER_VALUE)
+  @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
   @CallSite.After(
       "java.lang.String javax.servlet.http.HttpServletRequest.getHeader(java.lang.String)")
   @CallSite.After(
@@ -42,7 +42,7 @@ public class HttpServletRequestCallSite {
     return headerValue;
   }
 
-  @Source(SourceTypes.REQUEST_HEADER_VALUE)
+  @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
   @CallSite.After(
       "java.util.Enumeration javax.servlet.http.HttpServletRequest.getHeaders(java.lang.String)")
   @CallSite.After(
@@ -77,7 +77,7 @@ public class HttpServletRequestCallSite {
     }
   }
 
-  @Source(SourceTypes.REQUEST_HEADER_NAME)
+  @Source(SourceTypes.REQUEST_HEADER_NAME_STRING)
   @CallSite.After("java.util.Enumeration javax.servlet.http.HttpServletRequest.getHeaderNames()")
   @CallSite.After(
       "java.util.Enumeration javax.servlet.http.HttpServletRequestWrapper.getHeaderNames()")
@@ -110,7 +110,7 @@ public class HttpServletRequestCallSite {
     }
   }
 
-  @Propagation
+  @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
   @CallSite.After("javax.servlet.http.Cookie[] javax.servlet.http.HttpServletRequest.getCookies()")
   @CallSite.After(
       "javax.servlet.http.Cookie[] javax.servlet.http.HttpServletRequestWrapper.getCookies()")
@@ -129,7 +129,7 @@ public class HttpServletRequestCallSite {
     return cookies;
   }
 
-  @Source(SourceTypes.REQUEST_QUERY)
+  @Source(SourceTypes.REQUEST_QUERY_STRING)
   @CallSite.After("java.lang.String javax.servlet.http.HttpServletRequest.getQueryString()")
   @CallSite.After("java.lang.String javax.servlet.http.HttpServletRequestWrapper.getQueryString()")
   public static String afterGetQueryString(
@@ -145,7 +145,7 @@ public class HttpServletRequestCallSite {
     return queryString;
   }
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
   @CallSite.After(
       "java.lang.String javax.servlet.http.HttpServletRequest.getParameter(java.lang.String)")
   @CallSite.After(
@@ -165,7 +165,7 @@ public class HttpServletRequestCallSite {
     return paramValue;
   }
 
-  @Source(SourceTypes.REQUEST_PARAMETER_NAME)
+  @Source(SourceTypes.REQUEST_PARAMETER_NAME_STRING)
   @CallSite.After("java.util.Enumeration javax.servlet.http.HttpServletRequest.getParameterNames()")
   @CallSite.After(
       "java.util.Enumeration javax.servlet.http.HttpServletRequestWrapper.getParameterNames()")
@@ -196,7 +196,7 @@ public class HttpServletRequestCallSite {
     }
   }
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
   @CallSite.After(
       "java.lang.String[] javax.servlet.http.HttpServletRequest.getParameterValues(java.lang.String)")
   @CallSite.After(
@@ -218,7 +218,7 @@ public class HttpServletRequestCallSite {
     return parameterValues;
   }
 
-  @Propagation
+  @Source(SourceTypes.REQUEST_BODY_STRING)
   @CallSite.After("java.io.BufferedReader javax.servlet.http.HttpServletRequest.getReader()")
   @CallSite.After("java.io.BufferedReader javax.servlet.http.HttpServletRequestWrapper.getReader()")
   public static BufferedReader afterGetReader(
@@ -235,7 +235,7 @@ public class HttpServletRequestCallSite {
     return bufferedReader;
   }
 
-  @IastCallSites.Sink(VulnerabilityTypes.UNVALIDATED_REDIRECT)
+  @Sink(VulnerabilityTypes.UNVALIDATED_REDIRECT)
   @CallSite.Before(
       "javax.servlet.RequestDispatcher javax.servlet.http.HttpServletRequest.getRequestDispatcher(java.lang.String)")
   @CallSite.Before(

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestInputStreamCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestInputStreamCallSite.java
@@ -2,8 +2,8 @@ package datadog.trace.instrumentation.servlet.request;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Propagation;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import javax.servlet.ServletInputStream;
@@ -12,7 +12,7 @@ import javax.servlet.http.HttpServletRequest;
 @CallSite(spi = IastCallSites.class)
 public class HttpServletRequestInputStreamCallSite {
 
-  @Propagation
+  @Source(SourceTypes.REQUEST_BODY_STRING)
   @CallSite.After(
       "javax.servlet.ServletInputStream javax.servlet.http.HttpServletRequest.getInputStream()")
   @CallSite.After(

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/ServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/ServletRequestCallSite.java
@@ -2,10 +2,9 @@ package datadog.trace.instrumentation.servlet.request;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
-import datadog.trace.api.iast.IastCallSites.Propagation;
-import datadog.trace.api.iast.IastCallSites.Sink;
-import datadog.trace.api.iast.IastCallSites.Source;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
@@ -23,7 +22,7 @@ import javax.servlet.ServletRequest;
 @CallSite(spi = IastCallSites.class)
 public class ServletRequestCallSite {
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
   @CallSite.After("java.lang.String javax.servlet.ServletRequest.getParameter(java.lang.String)")
   @CallSite.After(
       "java.lang.String javax.servlet.ServletRequestWrapper.getParameter(java.lang.String)")
@@ -42,7 +41,7 @@ public class ServletRequestCallSite {
     return paramValue;
   }
 
-  @Source(SourceTypes.REQUEST_PARAMETER_NAME)
+  @Source(SourceTypes.REQUEST_PARAMETER_NAME_STRING)
   @CallSite.After("java.util.Enumeration javax.servlet.ServletRequest.getParameterNames()")
   @CallSite.After("java.util.Enumeration javax.servlet.ServletRequestWrapper.getParameterNames()")
   public static Enumeration<String> afterGetParameterNames(
@@ -72,7 +71,7 @@ public class ServletRequestCallSite {
     }
   }
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
   @CallSite.After(
       "java.lang.String[] javax.servlet.ServletRequest.getParameterValues(java.lang.String)")
   @CallSite.After(
@@ -94,7 +93,7 @@ public class ServletRequestCallSite {
     return parameterValues;
   }
 
-  @Propagation
+  @Source(SourceTypes.REQUEST_BODY_STRING)
   @CallSite.After("javax.servlet.ServletInputStream javax.servlet.ServletRequest.getInputStream()")
   @CallSite.After(
       "javax.servlet.ServletInputStream javax.servlet.ServletRequestWrapper.getInputStream()")
@@ -112,7 +111,7 @@ public class ServletRequestCallSite {
     return inputStream;
   }
 
-  @Propagation
+  @Source(SourceTypes.REQUEST_BODY_STRING)
   @CallSite.After("java.io.BufferedReader javax.servlet.ServletRequest.getReader()")
   @CallSite.After("java.io.BufferedReader javax.servlet.ServletRequestWrapper.getReader()")
   public static BufferedReader afterGetReader(

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/DataBufferAsInputStreamAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/DataBufferAsInputStreamAdvice.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.springwebflux.server.iast;
 import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import java.io.InputStream;
 import net.bytebuddy.asm.Advice;
@@ -12,6 +13,7 @@ import org.springframework.core.io.buffer.DataBuffer;
 public class DataBufferAsInputStreamAdvice {
 
   @Advice.OnMethodExit(suppress = Throwable.class)
+  @Propagation
   public static void after(@Advice.This DataBuffer dataBuffer, @Advice.Return InputStream is) {
     PropagationModule mod = InstrumentationBridge.PROPAGATION;
 

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/HandleMatchAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/HandleMatchAdvice.java
@@ -5,6 +5,8 @@ import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.source.WebModule;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -16,6 +18,7 @@ public class HandleMatchAdvice {
 
   @SuppressWarnings("Duplicates")
   @Advice.OnMethodExit(suppress = Throwable.class)
+  @Source(SourceTypes.REQUEST_PATH_PARAMETER_STRING)
   public static void after(
       @Advice.Argument(2) ServerWebExchange xchg, @ActiveRequestContext RequestContext reqCtx) {
 

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/Jackson2TokenizerApplyAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/Jackson2TokenizerApplyAdvice.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.util.TokenBuffer;
 import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
 import org.springframework.core.io.buffer.DataBuffer;
@@ -12,6 +14,7 @@ import reactor.core.publisher.Flux;
 @RequiresRequestContext(RequestContextSlot.IAST)
 class Jackson2TokenizerApplyAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
+  @Source(SourceTypes.REQUEST_BODY_STRING)
   public static void after(
       @Advice.Argument(0) DataBuffer dataBuffer,
       @Advice.Return(readOnly = false) Flux<TokenBuffer> flux) {

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/RequestHeaderMapResolveAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/RequestHeaderMapResolveAdvice.java
@@ -3,6 +3,8 @@ package datadog.trace.instrumentation.springwebflux.server.iast;
 import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.source.WebModule;
 import java.util.List;
 import java.util.Map;
@@ -13,6 +15,7 @@ import org.springframework.util.MultiValueMap;
 @RequiresRequestContext(RequestContextSlot.IAST)
 public class RequestHeaderMapResolveAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
+  @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
   public static void after(@Advice.Return(typing = Assigner.Typing.DYNAMIC) Map<String, ?> values) {
     WebModule module = InstrumentationBridge.WEB;
     if (module == null || values == null) {

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersGetAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersGetAdvice.java
@@ -3,6 +3,8 @@ package datadog.trace.instrumentation.springwebflux.server.iast;
 import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.source.WebModule;
 import java.util.List;
 import java.util.Locale;
@@ -12,6 +14,7 @@ import net.bytebuddy.asm.Advice;
 @RequiresRequestContext(RequestContextSlot.IAST)
 class TaintHttpHeadersGetAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
+  @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
   public static void after(@Advice.Argument(0) Object arg, @Advice.Return List<String> values) {
     WebModule module = InstrumentationBridge.WEB;
     if (module == null || values == null) {

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersGetFirstAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersGetFirstAdvice.java
@@ -3,6 +3,8 @@ package datadog.trace.instrumentation.springwebflux.server.iast;
 import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.source.WebModule;
 import net.bytebuddy.asm.Advice;
 
@@ -10,6 +12,7 @@ import net.bytebuddy.asm.Advice;
 @RequiresRequestContext(RequestContextSlot.IAST)
 class TaintHttpHeadersGetFirstAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
+  @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
   public static void after(@Advice.Argument(0) String arg, @Advice.Return String value) {
     WebModule module = InstrumentationBridge.WEB;
     if (module == null || arg == null || value == null) {

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersToSingleValueMapAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersToSingleValueMapAdvice.java
@@ -3,6 +3,8 @@ package datadog.trace.instrumentation.springwebflux.server.iast;
 import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.source.WebModule;
 import java.util.Map;
@@ -13,6 +15,7 @@ import org.springframework.http.HttpHeaders;
 @RequiresRequestContext(RequestContextSlot.IAST)
 class TaintHttpHeadersToSingleValueMapAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
+  @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
   public static void after(@Advice.Return Map<String, String> values) {
     PropagationModule propModule = InstrumentationBridge.PROPAGATION;
     WebModule module = InstrumentationBridge.WEB;

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintQueryParamsAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintQueryParamsAdvice.java
@@ -3,6 +3,8 @@ package datadog.trace.instrumentation.springwebflux.server.iast;
 import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.source.WebModule;
 import java.util.List;
 import java.util.Map;
@@ -14,6 +16,7 @@ class TaintQueryParamsAdvice {
 
   @SuppressWarnings("Duplicates")
   @Advice.OnMethodExit(suppress = Throwable.class)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
   public static void after(@Advice.Return MultiValueMap<String, String> queryParams) {
     WebModule module = InstrumentationBridge.WEB;
     if (module == null) {

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/InvocableHandlerMethodInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/InvocableHandlerMethodInstrumentation.java
@@ -6,6 +6,8 @@ import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
+import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
 import net.bytebuddy.asm.Advice;
 import org.springframework.web.method.support.InvocableHandlerMethod;
@@ -35,6 +37,7 @@ public final class InvocableHandlerMethodInstrumentation extends Instrumenter.Ia
   public static class ControllerAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.UNVALIDATED_REDIRECT)
     public static void checkReturnedObject(
         @Advice.Return Object returned, @Advice.This InvocableHandlerMethod self) {
       final UnvalidatedRedirectModule module = InstrumentationBridge.UNVALIDATED_REDIRECT;

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateAndMatrixVariablesInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateAndMatrixVariablesInstrumentation.java
@@ -17,6 +17,8 @@ import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.source.WebModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -83,6 +85,7 @@ public class TemplateAndMatrixVariablesInstrumentation extends Instrumenter.Defa
 
     @SuppressWarnings("Duplicates")
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+    @Source(SourceTypes.REQUEST_MATRIX_PARAMETER_STRING)
     public static void after(
         @Advice.Argument(2) final HttpServletRequest req,
         @Advice.Thrown(readOnly = false) Throwable t) {

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateVariablesUrlHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateVariablesUrlHandlerInstrumentation.java
@@ -17,6 +17,8 @@ import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.source.WebModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -72,6 +74,7 @@ public class TemplateVariablesUrlHandlerInstrumentation extends Instrumenter.Def
 
     @SuppressWarnings("Duplicates")
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+    @Source(SourceTypes.REQUEST_PATH_PARAMETER_STRING)
     public static void after(
         @Advice.Argument(0) final HttpServletRequest req,
         @Advice.Thrown(readOnly = false) Throwable t) {

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/HandleMatchAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/HandleMatchAdvice.java
@@ -9,6 +9,8 @@ import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.source.WebModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -27,6 +29,7 @@ public class HandleMatchAdvice {
 
   @SuppressWarnings("Duplicates")
   @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+  @Source(SourceTypes.REQUEST_PATH_PARAMETER_STRING)
   public static void after(
       @Advice.Argument(2) final HttpServletRequest req,
       @Advice.Thrown(readOnly = false) Throwable t) {

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/InterceptorPreHandleAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/InterceptorPreHandleAdvice.java
@@ -9,6 +9,8 @@ import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.source.WebModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -23,6 +25,7 @@ public class InterceptorPreHandleAdvice {
 
   @SuppressWarnings("Duplicates")
   @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+  @Source(SourceTypes.REQUEST_PATH_PARAMETER_STRING)
   public static void after(
       @Advice.Argument(0) final HttpServletRequest req,
       @Advice.Thrown(readOnly = false) Throwable t) {

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/AbstractHttpServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/AbstractHttpServerRequestInstrumentation.java
@@ -12,6 +12,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.muzzle.Reference;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
@@ -59,6 +60,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
     }
 
     @Advice.OnMethodExit
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
     public static void onExit(
         @Advice.Local("beforeParams") final Object beforeParams,
         @Advice.Return final Object multiMap) {
@@ -86,6 +88,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
     }
 
     @Advice.OnMethodExit
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
     public static void onExit(
         @Advice.Local("beforeAttributes") final Object beforeAttributes,
         @Advice.Return final Object multiMap) {
@@ -106,6 +109,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
   public static class DataAdvice {
 
     @Advice.OnMethodEnter
+    @Source(SourceTypes.REQUEST_BODY_STRING)
     public static void onExit(@Advice.Argument(0) final Object data) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/BufferInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/BufferInstrumentation.java
@@ -13,6 +13,7 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor;
 import datadog.trace.agent.tooling.muzzle.Reference;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
 
@@ -58,6 +59,7 @@ public class BufferInstrumentation extends Instrumenter.Iast implements Instrume
 
   public static class ToStringAdvice {
     @Advice.OnMethodExit
+    @Propagation
     public static void get(@Advice.This final Object self, @Advice.Return final String result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
@@ -72,6 +74,7 @@ public class BufferInstrumentation extends Instrumenter.Iast implements Instrume
 
   public static class GetByteBuffAdvice {
     @Advice.OnMethodExit
+    @Propagation
     public static void get(@Advice.This final Object self, @Advice.Return final Object result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
@@ -86,6 +89,7 @@ public class BufferInstrumentation extends Instrumenter.Iast implements Instrume
 
   public static class AppendBufferAdvice {
     @Advice.OnMethodExit
+    @Propagation
     public static void get(
         @Advice.Argument(0) final Object buffer, @Advice.Return final Object result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/CaseInsensitiveHeadersInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/CaseInsensitiveHeadersInstrumentation.java
@@ -14,6 +14,7 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor;
 import datadog.trace.agent.tooling.muzzle.Reference;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import java.util.Collection;
@@ -73,6 +74,7 @@ public class CaseInsensitiveHeadersInstrumentation extends Instrumenter.Iast
 
   public static class GetAdvice {
     @Advice.OnMethodExit
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
     public static void afterGet(
         @Advice.This final Object self,
         @Advice.Argument(0) final String name,
@@ -91,6 +93,7 @@ public class CaseInsensitiveHeadersInstrumentation extends Instrumenter.Iast
 
   public static class GetAllAdvice {
     @Advice.OnMethodExit
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
     public static void afterGetAll(
         @Advice.This final Object self,
         @Advice.Argument(0) final String name,
@@ -109,6 +112,7 @@ public class CaseInsensitiveHeadersInstrumentation extends Instrumenter.Iast
 
   public static class EntriesAdvice {
     @Advice.OnMethodExit
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
     public static void afterEntries(
         @Advice.This final Object self,
         @Advice.Return final List<Map.Entry<String, String>> result) {
@@ -125,6 +129,7 @@ public class CaseInsensitiveHeadersInstrumentation extends Instrumenter.Iast
 
   public static class NamesAdvice {
     @Advice.OnMethodExit
+    @Source(SourceTypes.REQUEST_PARAMETER_NAME_STRING)
     public static void afterNames(
         @Advice.This final Object self, @Advice.Return final Set<String> result) {
       final PropagationModule propagation = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/HeadersAdaptorInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/HeadersAdaptorInstrumentation.java
@@ -12,6 +12,7 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor;
 import datadog.trace.agent.tooling.muzzle.Reference;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import java.util.Collection;
@@ -65,6 +66,7 @@ public class HeadersAdaptorInstrumentation extends Instrumenter.Iast
 
   public static class GetAdvice {
     @Advice.OnMethodExit
+    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
     public static void afterGet(
         @Advice.This final Object self,
         @Advice.Argument(0) final CharSequence name,
@@ -86,6 +88,7 @@ public class HeadersAdaptorInstrumentation extends Instrumenter.Iast
 
   public static class GetAllAdvice {
     @Advice.OnMethodExit
+    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
     public static void afterGetAll(
         @Advice.This final Object self,
         @Advice.Argument(0) final CharSequence name,
@@ -107,6 +110,7 @@ public class HeadersAdaptorInstrumentation extends Instrumenter.Iast
 
   public static class EntriesAdvice {
     @Advice.OnMethodExit
+    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
     public static void afterEntries(
         @Advice.This final Object self,
         @Advice.Return final List<Map.Entry<String, String>> result) {
@@ -123,6 +127,7 @@ public class HeadersAdaptorInstrumentation extends Instrumenter.Iast
 
   public static class NamesAdvice {
     @Advice.OnMethodExit
+    @Source(SourceTypes.REQUEST_HEADER_NAME_STRING)
     public static void afterNames(
         @Advice.This final Object self, @Advice.Return final Set<String> result) {
       final PropagationModule propagation = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/Http2ServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/Http2ServerRequestInstrumentation.java
@@ -8,6 +8,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
@@ -45,6 +46,7 @@ public class Http2ServerRequestInstrumentation extends AbstractHttpServerRequest
     }
 
     @Advice.OnMethodExit
+    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
     public static void onExit(
         @Advice.Local("beforeHeaders") final Object beforeHeaders,
         @Advice.Return final Object multiMap) {

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/HttpServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/HttpServerRequestInstrumentation.java
@@ -9,6 +9,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
@@ -46,6 +47,7 @@ public class HttpServerRequestInstrumentation extends AbstractHttpServerRequestI
     }
 
     @Advice.OnMethodExit()
+    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
     public static void onExit(
         @Advice.Local("beforeHeaders") final Object beforeHeaders,
         @Advice.Return final Object multiMap) {

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/CookieImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/CookieImplInstrumentation.java
@@ -11,6 +11,7 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor;
 import datadog.trace.agent.tooling.muzzle.Reference;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import io.vertx.ext.web.Cookie;
@@ -51,6 +52,7 @@ public class CookieImplInstrumentation extends Instrumenter.Iast
 
   public static class GetNameAdvice {
     @Advice.OnMethodExit
+    @Source(SourceTypes.REQUEST_COOKIE_NAME_STRING)
     public static void afterGetName(
         @Advice.This final Cookie self, @Advice.Return final String result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
@@ -67,6 +69,7 @@ public class CookieImplInstrumentation extends Instrumenter.Iast
   public static class GetValueAdvice {
 
     @Advice.OnMethodExit
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
     public static void afterGetValue(
         @Advice.This final Cookie self, @Advice.Return final String result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/HttpServerResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/HttpServerResponseInstrumentation.java
@@ -10,6 +10,8 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.muzzle.Reference;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
+import datadog.trace.api.iast.VulnerabilityTypes;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -54,6 +56,7 @@ public class HttpServerResponseInstrumentation extends Instrumenter.Iast
 
   public static class PutHeaderAdvice1 {
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.RESPONSE_HEADER)
     public static void onEnter(
         @Advice.Argument(0) final CharSequence name, @Advice.Argument(1) CharSequence value) {
       if (null != name) {
@@ -64,6 +67,7 @@ public class HttpServerResponseInstrumentation extends Instrumenter.Iast
 
   public static class PutHeaderAdvice2 {
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.RESPONSE_HEADER)
     public static void onEnter(
         @Advice.Argument(0) final CharSequence name, @Advice.Argument(1) Iterable values) {
       if (null != values) {

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/IastRoutingContextImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/IastRoutingContextImplInstrumentation.java
@@ -10,7 +10,10 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.muzzle.Reference;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
+import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
 import java.util.Set;
@@ -50,6 +53,7 @@ public class IastRoutingContextImplInstrumentation extends Instrumenter.Iast
 
   public static class CookiesAdvice {
     @Advice.OnMethodExit
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
     public static void onCookies(@Advice.Return final Set<Object> cookies) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       try {
@@ -62,6 +66,7 @@ public class IastRoutingContextImplInstrumentation extends Instrumenter.Iast
 
   public static class GetCookieAdvice {
     @Advice.OnMethodExit
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
     public static void onGetCookie(@Advice.Return final Object cookie) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       try {
@@ -74,6 +79,7 @@ public class IastRoutingContextImplInstrumentation extends Instrumenter.Iast
 
   public static class RerouteAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.UNVALIDATED_REDIRECT)
     public static void onReroute(@Advice.Argument(1) final String path) {
       final UnvalidatedRedirectModule module = InstrumentationBridge.UNVALIDATED_REDIRECT;
       if (module != null) {

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RouteMatchesAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RouteMatchesAdvice.java
@@ -1,11 +1,14 @@
 package datadog.trace.instrumentation.vertx_3_4.server;
 
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import io.vertx.ext.web.RoutingContext;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 
 class RouteMatchesAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+  @Source(SourceTypes.REQUEST_PATH_PARAMETER_STRING)
   static void after(
       @Advice.Return int ret,
       @Advice.Argument(0) final RoutingContext ctx,
@@ -24,6 +27,7 @@ class RouteMatchesAdvice {
 
   static class BooleanReturnVariant {
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+    @Source(SourceTypes.REQUEST_PATH_PARAMETER_STRING)
     static void after(
         @Advice.Return boolean ret,
         @Advice.Argument(0) final RoutingContext ctx,

--- a/dd-java-agent/instrumentation/vertx-web-3.5/src/main/java/datadog/trace/instrumentation/vertx_3_5/core/VertxHttpHeadersInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.5/src/main/java/datadog/trace/instrumentation/vertx_3_5/core/VertxHttpHeadersInstrumentation.java
@@ -11,6 +11,7 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor;
 import datadog.trace.agent.tooling.muzzle.Reference;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import java.util.Collection;
@@ -71,6 +72,7 @@ public class VertxHttpHeadersInstrumentation extends Instrumenter.Iast
 
   public static class GetAdvice {
     @Advice.OnMethodExit
+    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
     public static void afterGet(
         @Advice.This final Object self,
         @Advice.Argument(0) final CharSequence name,
@@ -92,6 +94,7 @@ public class VertxHttpHeadersInstrumentation extends Instrumenter.Iast
 
   public static class GetAllAdvice {
     @Advice.OnMethodExit
+    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
     public static void afterGetAll(
         @Advice.This final Object self,
         @Advice.Argument(0) final CharSequence name,
@@ -113,6 +116,7 @@ public class VertxHttpHeadersInstrumentation extends Instrumenter.Iast
 
   public static class EntriesAdvice {
     @Advice.OnMethodExit
+    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
     public static void afterEntries(
         @Advice.This final Object self,
         @Advice.Return final List<Map.Entry<String, String>> result) {
@@ -129,6 +133,7 @@ public class VertxHttpHeadersInstrumentation extends Instrumenter.Iast
 
   public static class NamesAdvice {
     @Advice.OnMethodExit
+    @Source(SourceTypes.REQUEST_HEADER_NAME_STRING)
     public static void afterNames(
         @Advice.This final Object self, @Advice.Return final Set<String> result) {
       final PropagationModule propagation = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/vertx-web-3.9/src/main/java/datadog/trace/instrumentation/vertx_3_9/Vertx39HttpServertResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.9/src/main/java/datadog/trace/instrumentation/vertx_3_9/Vertx39HttpServertResponseInstrumentation.java
@@ -8,6 +8,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Sink;
+import datadog.trace.api.iast.VulnerabilityTypes;
 import io.vertx.core.http.Cookie;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -41,6 +43,7 @@ public class Vertx39HttpServertResponseInstrumentation extends Instrumenter.Iast
 
   public static class InstrumenterAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Sink(VulnerabilityTypes.RESPONSE_HEADER)
     public static void onEnter(@Advice.Argument(0) final Cookie cookie) {
       InstrumentationBridge.RESPONSE_HEADER_MODULE.onHeader("Set-Cookie", cookie.encode());
     }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/AbstractHttpServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/AbstractHttpServerRequestInstrumentation.java
@@ -12,6 +12,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.muzzle.Reference;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import java.util.Set;
@@ -68,6 +69,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
     }
 
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
     public static void onExit(
         @Advice.Local("beforeParams") final Object beforeParams,
         @Advice.Return final Object multiMap) {
@@ -91,6 +93,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
     }
 
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
     public static void onExit(
         @Advice.Local("beforeAttributes") final Object beforeAttributes,
         @Advice.Return final Object multiMap) {
@@ -107,6 +110,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
   public static class HeadersAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
     public static void onExit(@Advice.Return final Object multiMap) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
@@ -118,6 +122,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
   public static class DataAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_BODY_STRING)
     public static void onExit(@Advice.Argument(0) final Object data) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
@@ -129,6 +134,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
   public static class CookiesAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
     public static void onExit(@Advice.Return final Set<Object> cookies) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
@@ -140,6 +146,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
   public static class GetCookieAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
     public static void onExit(@Advice.Return final Object cookie) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/BufferInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/BufferInstrumentation.java
@@ -12,6 +12,7 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor;
 import datadog.trace.agent.tooling.muzzle.Reference;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
 
@@ -57,6 +58,7 @@ public class BufferInstrumentation extends Instrumenter.Iast implements Instrume
 
   public static class ToStringAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Propagation
     public static void get(@Advice.This final Object self, @Advice.Return final String result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
@@ -67,6 +69,7 @@ public class BufferInstrumentation extends Instrumenter.Iast implements Instrume
 
   public static class GetByteBuffAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Propagation
     public static void get(@Advice.This final Object self, @Advice.Return final Object result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
@@ -77,6 +80,7 @@ public class BufferInstrumentation extends Instrumenter.Iast implements Instrume
 
   public static class AppendBufferAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Propagation
     public static void get(
         @Advice.Argument(0) final Object buffer, @Advice.Return final Object result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/MultiMapInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/MultiMapInstrumentation.java
@@ -11,6 +11,7 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor;
 import datadog.trace.agent.tooling.muzzle.Reference;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.Taintable.Source;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import java.util.Collection;
@@ -65,6 +66,7 @@ public abstract class MultiMapInstrumentation extends Instrumenter.Iast {
 
   public static class GetAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Propagation
     public static void afterGet(
         @Advice.This final Object self,
         @Advice.Argument(0) final CharSequence name,
@@ -82,6 +84,7 @@ public abstract class MultiMapInstrumentation extends Instrumenter.Iast {
 
   public static class GetAllAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Propagation
     public static void afterGetAll(
         @Advice.This final Object self,
         @Advice.Argument(0) final CharSequence name,
@@ -99,6 +102,7 @@ public abstract class MultiMapInstrumentation extends Instrumenter.Iast {
 
   public static class EntriesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Propagation
     public static void afterEntries(
         @Advice.This final Object self,
         @Advice.Return final List<Map.Entry<String, String>> result) {
@@ -114,6 +118,7 @@ public abstract class MultiMapInstrumentation extends Instrumenter.Iast {
 
   public static class NamesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Propagation
     public static void afterNames(
         @Advice.This final Object self, @Advice.Return final Set<String> result) {
       final PropagationModule propagation = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/CookieImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/CookieImplInstrumentation.java
@@ -10,6 +10,7 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor;
 import datadog.trace.agent.tooling.muzzle.Reference;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import io.vertx.core.http.Cookie;
@@ -49,6 +50,7 @@ public class CookieImplInstrumentation extends Instrumenter.Iast
 
   public static class GetNameAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_COOKIE_NAME_STRING)
     public static void afterGetName(
         @Advice.This final Cookie self, @Advice.Return final String result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
@@ -61,6 +63,7 @@ public class CookieImplInstrumentation extends Instrumenter.Iast
   public static class GetValueAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
     public static void afterGetValue(
         @Advice.This final Cookie self, @Advice.Return final String result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteMatchesAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteMatchesAdvice.java
@@ -1,11 +1,14 @@
 package datadog.trace.instrumentation.vertx_4_0.server;
 
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
 import io.vertx.ext.web.RoutingContext;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 
 class RouteMatchesAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+  @Source(SourceTypes.REQUEST_PATH_PARAMETER_STRING)
   static void after(
       @Advice.Return int ret,
       @Advice.Argument(0) final RoutingContext ctx,
@@ -24,6 +27,7 @@ class RouteMatchesAdvice {
 
   static class BooleanReturnVariant {
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+    @Source(SourceTypes.REQUEST_PATH_PARAMETER_STRING)
     static void after(
         @Advice.Return boolean ret,
         @Advice.Argument(0) final RoutingContext ctx,

--- a/internal-api/src/main/java/datadog/trace/api/iast/IastCallSites.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/IastCallSites.java
@@ -1,34 +1,12 @@
 package datadog.trace.api.iast;
 
 import datadog.trace.api.iast.telemetry.Verbosity;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
 
 /**
  * Interface used to mark advice implementations using @CallSite so they are instrumented by
  * IastInstrumentation
  */
 public interface IastCallSites {
-
-  @Target({ElementType.METHOD, ElementType.TYPE})
-  @Retention(RetentionPolicy.CLASS)
-  @interface Propagation {}
-
-  @Target({ElementType.METHOD, ElementType.TYPE})
-  @Retention(RetentionPolicy.CLASS)
-  @interface Sink {
-    /** Vulnerability type */
-    String value();
-  }
-
-  @Target({ElementType.METHOD, ElementType.TYPE})
-  @Retention(RetentionPolicy.CLASS)
-  @interface Source {
-    /** Source type */
-    byte value();
-  }
 
   interface HasTelemetry {
     void setVerbosity(Verbosity verbosity);

--- a/internal-api/src/main/java/datadog/trace/api/iast/Propagation.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/Propagation.java
@@ -1,0 +1,10 @@
+package datadog.trace.api.iast;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Propagation {}

--- a/internal-api/src/main/java/datadog/trace/api/iast/Sink.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/Sink.java
@@ -1,0 +1,13 @@
+package datadog.trace.api.iast;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Sink {
+  /** Vulnerability type */
+  String value();
+}

--- a/internal-api/src/main/java/datadog/trace/api/iast/Source.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/Source.java
@@ -1,0 +1,13 @@
+package datadog.trace.api.iast;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Source {
+  /** Source type */
+  String value();
+}

--- a/internal-api/src/main/java/datadog/trace/api/iast/SourceTypes.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/SourceTypes.java
@@ -27,6 +27,23 @@ public abstract class SourceTypes {
   public static final byte REQUEST_MATRIX_PARAMETER = 10;
   public static final String REQUEST_MATRIX_PARAMETER_STRING = "http.request.matrix.parameter";
 
+  private static final String[] values = {
+    REQUEST_PARAMETER_NAME_STRING,
+    REQUEST_PARAMETER_VALUE_STRING,
+    REQUEST_HEADER_NAME_STRING,
+    REQUEST_HEADER_VALUE_STRING,
+    REQUEST_COOKIE_NAME_STRING,
+    REQUEST_COOKIE_VALUE_STRING,
+    REQUEST_BODY_STRING,
+    REQUEST_QUERY_STRING,
+    REQUEST_PATH_PARAMETER_STRING,
+    REQUEST_MATRIX_PARAMETER_STRING
+  };
+
+  public static String[] values() {
+    return values;
+  }
+
   public static String toString(final byte sourceType) {
     switch (sourceType) {
       case SourceTypes.REQUEST_PARAMETER_NAME:

--- a/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityTypes.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityTypes.java
@@ -15,4 +15,30 @@ public abstract class VulnerabilityTypes {
   public static final String NO_HTTPONLY_COOKIE = "NO_HTTPONLY_COOKIE";
   public static final String UNVALIDATED_REDIRECT = "UNVALIDATED_REDIRECT";
   public static final String WEAK_RANDOMNESS = "WEAK_RANDOMNESS";
+
+  /**
+   * Use for telemetry only, this is a special vulnerability type that is not reported, reported
+   * values will be {@link #RESPONSE_HEADER_TYPES}
+   */
+  public static final String RESPONSE_HEADER = "RESPONSE_HEADER";
+
+  public static final String[] RESPONSE_HEADER_TYPES = {UNVALIDATED_REDIRECT, INSECURE_COOKIE};
+
+  private static final String[] values = {
+    WEAK_CIPHER,
+    WEAK_HASH,
+    SQL_INJECTION,
+    COMMAND_INJECTION,
+    PATH_TRAVERSAL,
+    LDAP_INJECTION,
+    SSRF,
+    INSECURE_COOKIE,
+    NO_HTTPONLY_COOKIE,
+    UNVALIDATED_REDIRECT,
+    WEAK_RANDOMNESS
+  };
+
+  public static String[] values() {
+    return values;
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/telemetry/IastMetric.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/telemetry/IastMetric.java
@@ -1,235 +1,73 @@
 package datadog.trace.api.iast.telemetry;
 
-import static datadog.trace.api.iast.SourceTypes.REQUEST_BODY_STRING;
-import static datadog.trace.api.iast.SourceTypes.REQUEST_COOKIE_NAME_STRING;
-import static datadog.trace.api.iast.SourceTypes.REQUEST_COOKIE_VALUE_STRING;
-import static datadog.trace.api.iast.SourceTypes.REQUEST_HEADER_NAME_STRING;
-import static datadog.trace.api.iast.SourceTypes.REQUEST_HEADER_VALUE_STRING;
-import static datadog.trace.api.iast.SourceTypes.REQUEST_MATRIX_PARAMETER_STRING;
-import static datadog.trace.api.iast.SourceTypes.REQUEST_PARAMETER_NAME_STRING;
-import static datadog.trace.api.iast.SourceTypes.REQUEST_PARAMETER_VALUE_STRING;
-import static datadog.trace.api.iast.SourceTypes.REQUEST_PATH_PARAMETER_STRING;
-import static datadog.trace.api.iast.SourceTypes.REQUEST_QUERY_STRING;
-import static datadog.trace.api.iast.VulnerabilityTypes.COMMAND_INJECTION;
-import static datadog.trace.api.iast.VulnerabilityTypes.INSECURE_COOKIE;
-import static datadog.trace.api.iast.VulnerabilityTypes.LDAP_INJECTION;
-import static datadog.trace.api.iast.VulnerabilityTypes.PATH_TRAVERSAL;
-import static datadog.trace.api.iast.VulnerabilityTypes.SQL_INJECTION;
-import static datadog.trace.api.iast.VulnerabilityTypes.SSRF;
-import static datadog.trace.api.iast.VulnerabilityTypes.WEAK_CIPHER;
-import static datadog.trace.api.iast.VulnerabilityTypes.WEAK_HASH;
-import static datadog.trace.api.iast.VulnerabilityTypes.WEAK_RANDOMNESS;
-import static datadog.trace.api.iast.telemetry.IastMetric.Scope.GLOBAL;
-import static datadog.trace.api.iast.telemetry.IastMetric.Scope.REQUEST;
-import static datadog.trace.api.iast.telemetry.IastMetric.Tags.SOURCE_TYPE;
-import static datadog.trace.api.iast.telemetry.IastMetric.Tags.VULNERABILITY_TYPE;
-import static datadog.trace.api.iast.telemetry.Verbosity.DEBUG;
-import static datadog.trace.api.iast.telemetry.Verbosity.INFORMATION;
-import static datadog.trace.api.iast.telemetry.Verbosity.MANDATORY;
+import static datadog.trace.api.iast.VulnerabilityTypes.RESPONSE_HEADER;
+import static datadog.trace.api.iast.VulnerabilityTypes.RESPONSE_HEADER_TYPES;
 
-import de.thetaphi.forbiddenapis.SuppressForbidden;
-import java.util.Locale;
+import datadog.trace.api.iast.SourceTypes;
+import datadog.trace.api.iast.VulnerabilityTypes;
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Nonnull;
 
 public enum IastMetric {
-  INSTRUMENTED_PROPAGATION(MetricNames.INSTRUMENTED_PROPAGATION, true, GLOBAL, MANDATORY),
-  INSTRUMENTED_SOURCE_REQUEST_PARAMETER_NAME(
-      MetricNames.INSTRUMENTED_SOURCE,
-      true,
-      GLOBAL,
-      MANDATORY,
-      SOURCE_TYPE,
-      REQUEST_PARAMETER_NAME_STRING),
-  INSTRUMENTED_SOURCE_REQUEST_PARAMETER_VALUE(
-      MetricNames.INSTRUMENTED_SOURCE,
-      true,
-      GLOBAL,
-      MANDATORY,
-      SOURCE_TYPE,
-      REQUEST_PARAMETER_VALUE_STRING),
-  INSTRUMENTED_SOURCE_REQUEST_HEADER_NAME(
-      MetricNames.INSTRUMENTED_SOURCE,
-      true,
-      GLOBAL,
-      MANDATORY,
-      SOURCE_TYPE,
-      REQUEST_HEADER_NAME_STRING),
-  INSTRUMENTED_SOURCE_REQUEST_HEADER_VALUE(
-      MetricNames.INSTRUMENTED_SOURCE,
-      true,
-      GLOBAL,
-      MANDATORY,
-      SOURCE_TYPE,
-      REQUEST_HEADER_VALUE_STRING),
-  INSTRUMENTED_SOURCE_REQUEST_COOKIE_NAME(
-      MetricNames.INSTRUMENTED_SOURCE,
-      true,
-      GLOBAL,
-      MANDATORY,
-      SOURCE_TYPE,
-      REQUEST_COOKIE_NAME_STRING),
-  INSTRUMENTED_SOURCE_REQUEST_COOKIE_VALUE(
-      MetricNames.INSTRUMENTED_SOURCE,
-      true,
-      GLOBAL,
-      MANDATORY,
-      SOURCE_TYPE,
-      REQUEST_COOKIE_VALUE_STRING),
-  INSTRUMENTED_SOURCE_REQUEST_REQUEST_BODY(
-      MetricNames.INSTRUMENTED_SOURCE, true, GLOBAL, MANDATORY, SOURCE_TYPE, REQUEST_BODY_STRING),
-  INSTRUMENTED_SOURCE_REQUEST_QUERY(
-      MetricNames.INSTRUMENTED_SOURCE, true, GLOBAL, MANDATORY, SOURCE_TYPE, REQUEST_QUERY_STRING),
-  INSTRUMENTED_SOURCE_REQUEST_PATH_PARAMETER(
-      MetricNames.INSTRUMENTED_SOURCE,
-      true,
-      GLOBAL,
-      MANDATORY,
-      SOURCE_TYPE,
-      REQUEST_PATH_PARAMETER_STRING),
-  INSTRUMENTED_SOURCE_REQUEST_MATRIX_PARAMETER(
-      MetricNames.INSTRUMENTED_SOURCE,
-      true,
-      GLOBAL,
-      MANDATORY,
-      SOURCE_TYPE,
-      REQUEST_MATRIX_PARAMETER_STRING),
+  INSTRUMENTED_PROPAGATION("instrumented.propagation", true, Scope.GLOBAL, Verbosity.MANDATORY),
+  INSTRUMENTED_SOURCE(
+      "instrumented.source", true, Scope.GLOBAL, Tag.SOURCE_TYPE, Verbosity.MANDATORY),
+  INSTRUMENTED_SINK(
+      "instrumented.sink", true, Scope.GLOBAL, Tag.VULNERABILITY_TYPE, Verbosity.MANDATORY),
+  EXECUTED_PROPAGATION("executed.propagation", true, Scope.REQUEST, Verbosity.DEBUG),
+  EXECUTED_SOURCE("executed.source", true, Scope.REQUEST, Tag.SOURCE_TYPE, Verbosity.INFORMATION),
+  EXECUTED_SINK(
+      "executed.sink", true, Scope.REQUEST, Tag.VULNERABILITY_TYPE, Verbosity.INFORMATION),
+  EXECUTED_TAINTED("executed.tainted", true, Scope.REQUEST, Verbosity.DEBUG),
+  REQUEST_TAINTED("request.tainted", true, Scope.REQUEST, Verbosity.INFORMATION),
+  TAINTED_FLAT_MODE("tainted.flat.mode", false, Scope.REQUEST, Verbosity.INFORMATION);
 
-  INSTRUMENTED_SINK_WEAK_CIPHER(
-      MetricNames.INSTRUMENTED_SINK, true, GLOBAL, MANDATORY, VULNERABILITY_TYPE, WEAK_CIPHER),
-  INSTRUMENTED_SINK_WEAK_HASH(
-      MetricNames.INSTRUMENTED_SINK, true, GLOBAL, MANDATORY, VULNERABILITY_TYPE, WEAK_HASH),
-  INSTRUMENTED_SINK_SQL_INJECTION(
-      MetricNames.INSTRUMENTED_SINK, true, GLOBAL, MANDATORY, VULNERABILITY_TYPE, SQL_INJECTION),
-  INSTRUMENTED_SINK_COMMAND_INJECTION(
-      MetricNames.INSTRUMENTED_SINK,
-      true,
-      GLOBAL,
-      MANDATORY,
-      VULNERABILITY_TYPE,
-      COMMAND_INJECTION),
-  INSTRUMENTED_SINK_PATH_TRAVERSAL(
-      MetricNames.INSTRUMENTED_SINK, true, GLOBAL, MANDATORY, VULNERABILITY_TYPE, PATH_TRAVERSAL),
-  INSTRUMENTED_SINK_LDAP_INJECTION(
-      MetricNames.INSTRUMENTED_SINK, true, GLOBAL, MANDATORY, VULNERABILITY_TYPE, LDAP_INJECTION),
-  INSTRUMENTED_SINK_SSRF(
-      MetricNames.INSTRUMENTED_SINK, true, GLOBAL, MANDATORY, VULNERABILITY_TYPE, SSRF),
-  INSTRUMENTED_SINK_INSECURE_COOKIE(
-      MetricNames.INSTRUMENTED_SINK, true, GLOBAL, MANDATORY, VULNERABILITY_TYPE, INSECURE_COOKIE),
-  INSTRUMENTED_SINK_UNVALIDATED_REDIRECT(
-      MetricNames.INSTRUMENTED_SINK, true, GLOBAL, MANDATORY, VULNERABILITY_TYPE, INSECURE_COOKIE),
-  INSTRUMENTED_SINK_WEAK_RANDOMNESS(
-      MetricNames.INSTRUMENTED_SINK, true, GLOBAL, MANDATORY, VULNERABILITY_TYPE, WEAK_RANDOMNESS),
-  EXECUTED_PROPAGATION(MetricNames.EXECUTED_PROPAGATION, true, REQUEST, DEBUG),
-  EXECUTED_SOURCE_REQUEST_PARAMETER_NAME(
-      MetricNames.EXECUTED_SOURCE,
-      true,
-      REQUEST,
-      INFORMATION,
-      SOURCE_TYPE,
-      REQUEST_PARAMETER_NAME_STRING),
-  EXECUTED_SOURCE_REQUEST_PARAMETER_VALUE(
-      MetricNames.EXECUTED_SOURCE,
-      true,
-      REQUEST,
-      INFORMATION,
-      SOURCE_TYPE,
-      REQUEST_PARAMETER_VALUE_STRING),
-  EXECUTED_SOURCE_REQUEST_HEADER_NAME(
-      MetricNames.EXECUTED_SOURCE,
-      true,
-      REQUEST,
-      INFORMATION,
-      SOURCE_TYPE,
-      REQUEST_HEADER_NAME_STRING),
-  EXECUTED_SOURCE_REQUEST_HEADER_VALUE(
-      MetricNames.EXECUTED_SOURCE,
-      true,
-      REQUEST,
-      INFORMATION,
-      SOURCE_TYPE,
-      REQUEST_HEADER_VALUE_STRING),
-  EXECUTED_SOURCE_REQUEST_COOKIE_NAME(
-      MetricNames.EXECUTED_SOURCE,
-      true,
-      REQUEST,
-      INFORMATION,
-      SOURCE_TYPE,
-      REQUEST_COOKIE_NAME_STRING),
-  EXECUTED_SOURCE_REQUEST_COOKIE_VALUE(
-      MetricNames.EXECUTED_SOURCE,
-      true,
-      REQUEST,
-      INFORMATION,
-      SOURCE_TYPE,
-      REQUEST_COOKIE_VALUE_STRING),
-  EXECUTED_SOURCE_REQUEST_REQUEST_BODY(
-      MetricNames.EXECUTED_SOURCE, true, REQUEST, INFORMATION, SOURCE_TYPE, REQUEST_BODY_STRING),
-  EXECUTED_SOURCE_REQUEST_QUERY(
-      MetricNames.EXECUTED_SOURCE, true, REQUEST, INFORMATION, SOURCE_TYPE, REQUEST_QUERY_STRING),
-  EXECUTED_SOURCE_REQUEST_PATH_PARAMETER(
-      MetricNames.EXECUTED_SOURCE,
-      true,
-      REQUEST,
-      INFORMATION,
-      SOURCE_TYPE,
-      REQUEST_PATH_PARAMETER_STRING),
-  EXECUTED_SOURCE_REQUEST_MATRIX_PARAMETER(
-      MetricNames.EXECUTED_SOURCE,
-      true,
-      REQUEST,
-      INFORMATION,
-      SOURCE_TYPE,
-      REQUEST_MATRIX_PARAMETER_STRING),
+  private static final int COUNT;
 
-  EXECUTED_SINK_WEAK_CIPHER(
-      MetricNames.EXECUTED_SINK, true, REQUEST, INFORMATION, VULNERABILITY_TYPE, WEAK_CIPHER),
-  EXECUTED_SINK_WEAK_HASH(
-      MetricNames.EXECUTED_SINK, true, REQUEST, INFORMATION, VULNERABILITY_TYPE, WEAK_HASH),
-  EXECUTED_SINK_SQL_INJECTION(
-      MetricNames.EXECUTED_SINK, true, REQUEST, INFORMATION, VULNERABILITY_TYPE, SQL_INJECTION),
-  EXECUTED_SINK_COMMAND_INJECTION(
-      MetricNames.EXECUTED_SINK, true, REQUEST, INFORMATION, VULNERABILITY_TYPE, COMMAND_INJECTION),
-  EXECUTED_SINK_PATH_TRAVERSAL(
-      MetricNames.EXECUTED_SINK, true, REQUEST, INFORMATION, VULNERABILITY_TYPE, PATH_TRAVERSAL),
-  EXECUTED_SINK_LDAP_INJECTION(
-      MetricNames.EXECUTED_SINK, true, REQUEST, INFORMATION, VULNERABILITY_TYPE, LDAP_INJECTION),
-  EXECUTED_SINK_SSRF(
-      MetricNames.EXECUTED_SINK, true, REQUEST, INFORMATION, VULNERABILITY_TYPE, SSRF),
-  EXECUTED_SINK_INSECURE_COOKIE(
-      MetricNames.EXECUTED_SINK, true, REQUEST, INFORMATION, VULNERABILITY_TYPE, INSECURE_COOKIE),
-  EXECUTED_SINK_UNVALIDATED_REDIRECT(
-      MetricNames.EXECUTED_SINK, true, REQUEST, INFORMATION, VULNERABILITY_TYPE, INSECURE_COOKIE),
-  EXECUTED_SINK_WEAK_RANDOMNESS(
-      MetricNames.EXECUTED_SINK, true, REQUEST, INFORMATION, VULNERABILITY_TYPE, WEAK_RANDOMNESS),
-  EXECUTED_TAINTED(MetricNames.EXECUTED_TAINTED, true, REQUEST, DEBUG),
-  REQUEST_TAINTED(MetricNames.REQUEST_TAINTED, true, REQUEST, INFORMATION),
-  TAINTED_FLAT_MODE(MetricNames.TAINTED_FLAT_MODE, false, REQUEST, INFORMATION);
+  static {
+    int count = 0;
+    for (final IastMetric metric : values()) {
+      if (metric.tag == null) {
+        metric.index = count++;
+      } else {
+        metric.tagIndexes = new HashMap<>(metric.tag.getValues().length);
+        for (final String tagValue : metric.tag.getValues()) {
+          metric.tagIndexes.put(tagValue, count++);
+        }
+      }
+    }
+    COUNT = count;
+  }
+
+  public static int count() {
+    return COUNT;
+  }
 
   private final String name;
   private final boolean common;
   private final Scope scope;
-  private final String tagName;
-  private final String tagValue;
+  private final Tag tag;
   private final Verbosity verbosity;
+  private int index;
+  private Map<String, Integer> tagIndexes;
 
   IastMetric(
       final String name, final boolean common, final Scope scope, final Verbosity verbosity) {
-    this(name, common, scope, verbosity, null, null);
+    this(name, common, scope, null, verbosity);
   }
 
   IastMetric(
       final String name,
       final boolean common,
       final Scope scope,
-      final Verbosity verbosity,
-      final String tagName,
-      final String tagValue) {
+      final Tag tag,
+      final Verbosity verbosity) {
     this.name = name;
     this.common = common;
     this.scope = scope;
+    this.tag = tag;
     this.verbosity = verbosity;
-    this.tagName = tagName;
-    this.tagValue = tagValue;
   }
 
   public String getName() {
@@ -244,45 +82,76 @@ public enum IastMetric {
     return scope;
   }
 
-  public String getTag() {
-    return tagName == null ? null : String.format("%s:%s", tagName, tagValue);
-  }
-
-  public String getSpanTag() {
-    return tagName == null ? name : String.format("%s.%s", name, processTagValue(tagValue));
-  }
-
-  @SuppressForbidden
-  private static String processTagValue(final String tagValue) {
-    return tagValue.toLowerCase(Locale.ROOT).replaceAll("\\.", "_");
-  }
-
   public boolean isEnabled(@Nonnull final Verbosity verbosity) {
     return verbosity.isEnabled(this.verbosity);
   }
 
-  public abstract static class Tags {
-
-    private Tags() {}
-
-    public static final String VULNERABILITY_TYPE = "vulnerability_type";
-    public static final String SOURCE_TYPE = "source_type";
+  public Tag getTag() {
+    return tag;
   }
 
-  public enum Scope {
-    GLOBAL,
-    REQUEST
+  /**
+   * Returns the index for the particular tag to be used in the {@link
+   * java.util.concurrent.atomic.AtomicLongArray} of {@link IastMetricCollector}, returns -1 if the
+   * tag is not found
+   */
+  public int getIndex(final String value) {
+    if (tag == null) {
+      return index;
+    }
+    return tagIndexes.getOrDefault(value, -1);
   }
 
-  private static class MetricNames {
-    public static final String INSTRUMENTED_PROPAGATION = "instrumented.propagation";
-    public static final String INSTRUMENTED_SOURCE = "instrumented.source";
-    public static final String INSTRUMENTED_SINK = "instrumented.sink";
-    public static final String EXECUTED_PROPAGATION = "executed.propagation";
-    public static final String EXECUTED_SOURCE = "executed.source";
-    public static final String EXECUTED_SINK = "executed.sink";
-    public static final String EXECUTED_TAINTED = "executed.tainted";
-    public static final String REQUEST_TAINTED = "request.tainted";
-    public static final String TAINTED_FLAT_MODE = "tainted.flat.mode";
+  public static class Tag {
+
+    private static final String[] EMPTY = new String[0];
+
+    public static final Tag VULNERABILITY_TYPE =
+        new Tag("vulnerability_type", VulnerabilityTypes.values()) {
+          public String[] parse(final String tagValue) {
+            if (RESPONSE_HEADER.equals(tagValue)) {
+              return RESPONSE_HEADER_TYPES;
+            }
+            return EMPTY;
+          }
+        };
+
+    public static final Tag SOURCE_TYPE = new Tag("source_type", SourceTypes.values());
+
+    private final String name;
+    private final String[] values;
+
+    private Tag(final String name, final String... values) {
+      this.name = name;
+      this.values = values;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String[] getValues() {
+      return values;
+    }
+
+    public String[] parse(final String tagValue) {
+      return EMPTY;
+    }
+  }
+
+  public static final class Scope {
+
+    public static final Scope GLOBAL = new Scope("global");
+    public static final Scope REQUEST = new Scope("request");
+
+    private final String name;
+
+    private Scope(final String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return name;
+    }
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/telemetry/IastMetricCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/telemetry/IastMetricCollector.java
@@ -8,10 +8,12 @@ import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.telemetry.MetricCollector;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicLongArray;
@@ -20,35 +22,38 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("resource")
 public class IastMetricCollector implements MetricCollector<IastMetricCollector.IastMetricData> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IastMetricCollector.class);
 
-  private static final IastMetricCollector INSTANCE =
-      isEnabled() ? new IastMetricCollector() : new NoOpInstance();
-
   private static final String NAMESPACE = "iast";
+
+  private static final Verbosity VERBOSITY = Config.get().getIastTelemetryVerbosity();
+
+  private static final IastMetricCollector INSTANCE =
+      VERBOSITY != Verbosity.OFF ? new IastMetricCollector() : new NoOpInstance();
 
   public static IastMetricCollector get() {
     return INSTANCE;
   }
 
-  public static IastMetricCollector get(
-      @Nonnull final IastMetric metric, @Nullable RequestContext ctx) {
-    if (metric.getScope() == REQUEST) {
-      ctx = activeRequestContext(ctx);
-      if (ctx != null) {
-        final Object iastCtx = ctx.getData(RequestContextSlot.IAST);
-        if (iastCtx instanceof HasMetricCollector) {
-          final IastMetricCollector collector = ((HasMetricCollector) iastCtx).getMetricCollector();
-          if (collector != null) {
-            return collector;
-          }
+  private static IastMetricCollector get(@Nullable final RequestContext requestContext) {
+    if (VERBOSITY == Verbosity.OFF) {
+      return INSTANCE;
+    }
+    final RequestContext ctx = requestContext == null ? activeRequestContext() : requestContext;
+    if (ctx != null) {
+      final Object iastCtx = ctx.getData(RequestContextSlot.IAST);
+      if (iastCtx instanceof HasMetricCollector) {
+        final IastMetricCollector collector = ((HasMetricCollector) iastCtx).getMetricCollector();
+        if (collector != null) {
+          return collector;
         }
       }
     }
     // if no active request then forward to the global collector
-    return get();
+    return INSTANCE;
   }
 
   private final BlockingQueue<IastMetricData> rawMetricsQueue;
@@ -56,7 +61,7 @@ public class IastMetricCollector implements MetricCollector<IastMetricCollector.
   private final AtomicLongArray counters;
 
   public IastMetricCollector() {
-    this(new ArrayBlockingQueue<>(RAW_QUEUE_SIZE), new AtomicLongArray(IastMetric.values().length));
+    this(new ArrayBlockingQueue<>(RAW_QUEUE_SIZE), new AtomicLongArray(IastMetric.count()));
   }
 
   protected IastMetricCollector(
@@ -65,40 +70,73 @@ public class IastMetricCollector implements MetricCollector<IastMetricCollector.
     this.counters = counters;
   }
 
-  /** Prefer using {@link #add(IastMetric, long, RequestContext)} if possible */
-  public static void add(@Nonnull final IastMetric metric, final long value) {
+  /** Prefer using {@link #add(IastMetric, int, RequestContext)} if possible */
+  public static void add(@Nonnull final IastMetric metric, final int value) {
     add(metric, value, null);
   }
 
+  /** Prefer using {@link #add(IastMetric, String, int, RequestContext)} if possible */
+  public static void add(@Nonnull final IastMetric metric, final String tagValue, final int value) {
+    add(metric, tagValue, value, null);
+  }
+
   public static void add(
-      @Nonnull final IastMetric metric, final long value, @Nullable final RequestContext ctx) {
+      @Nonnull final IastMetric metric, final int value, @Nullable final RequestContext ctx) {
+    add(metric, null, value, ctx);
+  }
+
+  public static void add(
+      @Nonnull final IastMetric metric,
+      @Nullable final String tagValue,
+      final int value,
+      @Nullable final RequestContext ctx) {
     try {
-      final IastMetricCollector instance = get(metric, ctx);
-      instance.addMetric(metric, value);
+      final IastMetricCollector instance = metric.getScope() == REQUEST ? get(ctx) : INSTANCE;
+      instance.addMetric(metric, tagValue, value);
     } catch (final Throwable e) {
-      LOGGER.warn("Failed to add metric {}", metric, e);
+      LOGGER.warn("Failed to add metric {} with tag {}", metric, tagValue, e);
     }
   }
 
-  public void addMetric(final IastMetric metric, final long value) {
-    counters.addAndGet(metric.ordinal(), value);
+  public void addMetric(final IastMetric metric, final String tagValue, final int value) {
+    final int index = metric.getIndex(tagValue);
+    if (index < 0) {
+      // e.g.: VulnerabilityTypes.RESPONSE_HEADER
+      for (final String tag : metric.getTag().parse(tagValue)) {
+        counters.getAndAdd(metric.getIndex(tag), value);
+      }
+    } else {
+      counters.getAndAdd(index, value);
+    }
   }
 
   public void merge(final Collection<IastMetricData> metrics) {
     for (final IastMetricData data : metrics) {
       final IastMetric metric = data.metric;
+      final String tagValue = data.tagValue;
       final long value = data.counter;
-      counters.addAndGet(metric.ordinal(), value);
+      counters.getAndAdd(metric.getIndex(tagValue), value);
     }
   }
 
   @Override
   public void prepareMetrics() {
     for (final IastMetric metric : IastMetric.values()) {
-      final long value = counters.getAndSet(metric.ordinal(), 0);
-      if (value > 0) {
-        rawMetricsQueue.offer(new IastMetricData(metric, value));
+      if (metric.getTag() == null) {
+        prepareMetric(metric, null);
+      } else {
+        for (final String tagValue : metric.getTag().getValues()) {
+          prepareMetric(metric, tagValue);
+        }
       }
+    }
+  }
+
+  private void prepareMetric(final IastMetric metric, final String tagValue) {
+    final int index = metric.getIndex(tagValue);
+    final long value = counters.getAndSet(index, 0);
+    if (value > 0) {
+      rawMetricsQueue.offer(new IastMetricData(metric, tagValue, value));
     }
   }
 
@@ -116,18 +154,43 @@ public class IastMetricCollector implements MetricCollector<IastMetricCollector.
 
   public static class IastMetricData extends MetricCollector.Metric {
 
-    public final IastMetric metric;
+    private final IastMetric metric;
+    private final String tagValue;
 
-    public IastMetricData(final IastMetric metric, final long value) {
-      super(NAMESPACE, metric.isCommon(), metric.getName(), value, metric.getTag());
+    public IastMetricData(final IastMetric metric, final String tagValue, final long value) {
+      super(NAMESPACE, metric.isCommon(), metric.getName(), value, computeTag(metric, tagValue));
       this.metric = metric;
+      this.tagValue = tagValue;
+    }
+
+    public IastMetric getMetric() {
+      return metric;
+    }
+
+    public String getTagValue() {
+      return tagValue;
+    }
+
+    public String getSpanTag() {
+      return metric.getTag() == null
+          ? metric.getName()
+          : String.format("%s.%s", metric.getName(), processSpanTagValue(tagValue));
+    }
+
+    @SuppressForbidden
+    private static String processSpanTagValue(final String tagValue) {
+      return tagValue.toLowerCase(Locale.ROOT).replaceAll("\\.", "_");
+    }
+
+    public static String computeTag(final IastMetric metric, final String tagValue) {
+      if (metric.getTag() == null) {
+        return null;
+      }
+      return String.format("%s:%s", metric.getTag().getName(), tagValue);
     }
   }
 
-  private static RequestContext activeRequestContext(final RequestContext context) {
-    if (context != null) {
-      return context;
-    }
+  private static RequestContext activeRequestContext() {
     final AgentSpan span = AgentTracer.activeSpan();
     return span == null ? null : span.getRequestContext();
   }
@@ -139,7 +202,7 @@ public class IastMetricCollector implements MetricCollector<IastMetricCollector.
     }
 
     @Override
-    public void addMetric(final IastMetric metric, final long value) {}
+    public void addMetric(final IastMetric metric, final String tagValue, final int value) {}
 
     @Override
     public void merge(final Collection<IastMetricData> metrics) {}
@@ -151,11 +214,6 @@ public class IastMetricCollector implements MetricCollector<IastMetricCollector.
     public Collection<IastMetricData> drain() {
       return Collections.emptyList();
     }
-  }
-
-  private static boolean isEnabled() {
-    final Config config = Config.get();
-    return config.getIastTelemetryVerbosity() != Verbosity.OFF;
   }
 
   public interface HasMetricCollector {

--- a/internal-api/src/test/groovy/datadog/trace/api/iast/telemetry/IastMetricCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/iast/telemetry/IastMetricCollectorTest.groovy
@@ -2,6 +2,7 @@ package datadog.trace.api.iast.telemetry
 
 import datadog.trace.api.gateway.RequestContext
 import datadog.trace.api.gateway.RequestContextSlot
+import datadog.trace.api.iast.VulnerabilityTypes
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.test.util.DDSpecification
@@ -67,14 +68,17 @@ class IastMetricCollectorTest extends DDSpecification {
     final total = times * value
     final latch = new CountDownLatch(1)
     final requestCollector = new IastMetricCollector()
+    final random = new Random()
+    final metrics = IastMetric.values()
     iastCtx.getMetricCollector() >> requestCollector
 
     when:
     final futures = (1..times).collect { i ->
       executor.submit {
-        final metric = IastMetric.values()[i % IastMetric.values().length]
+        final metric = metrics[random.nextInt(metrics.length)]
+        final tag = metric.tag == null ? null : metric.tag.values[random.nextInt(metric.tag.values.length)]
         latch.await()
-        IastMetricCollector.add(metric, value)
+        IastMetricCollector.add(metric, tag, value)
       }
     }
     latch.countDown()
@@ -84,17 +88,21 @@ class IastMetricCollectorTest extends DDSpecification {
 
     then:
     IastMetricCollector.get().prepareMetrics()
-    final metrics = IastMetricCollector.get().drain()
-    final computedTotal = metrics*.counter.sum() as long
+    final result = IastMetricCollector.get().drain()
+    final computedTotal = result*.counter.sum() as long
     computedTotal == total
   }
 
   void 'test no op collector does nothing'() {
     setup:
     final collector = new NoOpInstance()
+    final metric = IastMetric.EXECUTED_PROPAGATION
+    final tag = null
+
+    when:
 
     when: 'adding a metric'
-    collector.addMetric(IastMetric.EXECUTED_PROPAGATION, 23)
+    collector.addMetric(metric, tag, 23)
     collector.prepareMetrics()
     final collectorMetrics = collector.drain()
 
@@ -102,7 +110,7 @@ class IastMetricCollectorTest extends DDSpecification {
     collectorMetrics.empty
 
     when: 'merging metrics'
-    collector.merge([new IastMetricCollector.IastMetricData(IastMetric.EXECUTED_PROPAGATION, 23)])
+    collector.merge([new IastMetricCollector.IastMetricData(metric, tag, 23)])
     collector.prepareMetrics()
     final mergedMetrics = collector.drain()
 
@@ -113,34 +121,73 @@ class IastMetricCollectorTest extends DDSpecification {
   void 'test global/request scoped metrics'() {
     given:
     final requestCollector = Mock(IastMetricCollector)
-    final globalMetric = IastMetric.INSTRUMENTED_SINK_SQL_INJECTION
-    final requestMetric = IastMetric.EXECUTED_SINK_SQL_INJECTION
-    final value = 1L
+    final globalMetric = IastMetric.INSTRUMENTED_SINK
+    final requestMetric = IastMetric.EXECUTED_SINK
+    final tag = VulnerabilityTypes.SQL_INJECTION
+    final value = 1
 
     when:
-    IastMetricCollector.add(globalMetric, value)
+    IastMetricCollector.add(globalMetric, tag, value)
 
     then: 'global metrics do not access the request context'
     0 * _
 
     when:
-    IastMetricCollector.add(requestMetric, value)
+    IastMetricCollector.add(requestMetric, tag, value)
 
     then: 'request metrics require access to the request context'
     1 * api.activeSpan() >> span
     1 * span.getRequestContext() >> ctx
     1 * ctx.getData(RequestContextSlot.IAST) >> iastCtx
     1 * iastCtx.getMetricCollector() >> requestCollector
-    1 * requestCollector.addMetric(requestMetric, value)
+    1 * requestCollector.addMetric(requestMetric, tag, value)
     0 * _
 
     when:
-    IastMetricCollector.add(requestMetric, value, ctx)
+    IastMetricCollector.add(requestMetric, tag, value, ctx)
 
     then: 'if request context is provided no access to the active span is needed'
     1 * ctx.getData(RequestContextSlot.IAST) >> iastCtx
     1 * iastCtx.getMetricCollector() >> requestCollector
-    1 * requestCollector.addMetric(requestMetric, value)
+    1 * requestCollector.addMetric(requestMetric, tag, value)
     0 * _
+  }
+
+  void 'test metric tags/span tags'() {
+    given:
+    final metric = IastMetric.INSTRUMENTED_SINK
+    final tag = VulnerabilityTypes.SQL_INJECTION
+
+    when:
+    final withTag = new IastMetricCollector.IastMetricData(metric, tag, 1)
+
+    then:
+    withTag.tags == ["${metric.tag.name}:${tag}"]
+    withTag.spanTag == "${metric.name}.${tag.toLowerCase().replaceAll('\\.', '_')}"
+  }
+
+  void 'test metrics with multiple tags'() {
+    given:
+    final collector = new IastMetricCollector()
+    final metric = IastMetric.INSTRUMENTED_SINK
+    final tag = VulnerabilityTypes.RESPONSE_HEADER
+    final value = 1
+
+    when:
+    collector.addMetric(metric, tag, value)
+    collector.prepareMetrics()
+    final result = collector.drain()
+
+    then: 'multiple data points are added'
+
+    result.size() == 2
+    final grouped = result.groupBy { it.tags.first() }
+    VulnerabilityTypes.RESPONSE_HEADER_TYPES.each {
+      final tagValue = "${metric.tag.name}:${it}"
+      final data = grouped[tagValue].first()
+      assert data.metric == metric
+      assert data.counter == value
+      assert data.tags == [tagValue]
+    }
   }
 }

--- a/internal-api/src/test/groovy/datadog/trace/api/iast/telemetry/IastMetricTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/iast/telemetry/IastMetricTest.groovy
@@ -1,6 +1,8 @@
 package datadog.trace.api.iast.telemetry
 
 import datadog.trace.api.Config
+import datadog.trace.api.iast.SourceTypes
+import datadog.trace.api.iast.VulnerabilityTypes
 import spock.lang.Specification
 
 
@@ -17,18 +19,6 @@ class IastMetricTest extends Specification {
     name != null
 
     when:
-    final tag = metric.tag
-
-    then:
-    tag == metric.tagName == null ? null : "${metric.tagName}:${metric.tagValue}"
-
-    when:
-    final spanTag = metric.spanTag
-
-    then:
-    spanTag == metric.tagName == null ? null : "${metric.tagName}.${metric.tagValue}".toLowerCase().replaceAll('\\_', '.')
-
-    when:
     final enabled = metric.isEnabled(verbosity)
 
     then:
@@ -36,5 +26,19 @@ class IastMetricTest extends Specification {
 
     where:
     metric << (IastMetric.values() as List<IastMetric>)
+  }
+
+  void 'test parsing of tags'() {
+    when:
+    final result = metricTag.parse(tag)
+
+    then:
+    result == expected
+
+    where:
+    metricTag                         | tag                                        | expected
+    IastMetric.Tag.VULNERABILITY_TYPE | VulnerabilityTypes.RESPONSE_HEADER         | VulnerabilityTypes.RESPONSE_HEADER_TYPES
+    IastMetric.Tag.VULNERABILITY_TYPE | VulnerabilityTypes.SQL_INJECTION           | new String[0]
+    IastMetric.Tag.SOURCE_TYPE        | SourceTypes.REQUEST_PARAMETER_VALUE_STRING | new String[0]
   }
 }

--- a/telemetry/src/test/groovy/datadog/telemetry/metric/IastMetricPeriodicActionTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/metric/IastMetricPeriodicActionTest.groovy
@@ -2,6 +2,7 @@ package datadog.telemetry.metric
 
 import datadog.telemetry.TelemetryService
 import datadog.telemetry.api.Metric
+import datadog.trace.api.iast.SourceTypes
 import datadog.trace.api.iast.telemetry.IastMetric
 import datadog.trace.api.iast.telemetry.IastMetricCollector
 import groovy.transform.CompileDynamic
@@ -15,7 +16,7 @@ class IastMetricPeriodicActionTest extends Specification {
     final action = new IastMetricPeriodicAction()
     final service = Mock(TelemetryService)
     final iastMetric = IastMetric.EXECUTED_TAINTED
-    final value = 23L
+    final value = 23
 
     when:
     IastMetricCollector.add(iastMetric, value)
@@ -31,16 +32,17 @@ class IastMetricPeriodicActionTest extends Specification {
     given:
     final action = new IastMetricPeriodicAction()
     final service = Mock(TelemetryService)
-    final iastMetric = IastMetric.INSTRUMENTED_SOURCE_REQUEST_PARAMETER_VALUE
-    final value = 23L
+    final iastMetric = IastMetric.INSTRUMENTED_SOURCE
+    final tag = SourceTypes.REQUEST_PARAMETER_VALUE_STRING
+    final value = 23
 
     when:
-    IastMetricCollector.add(iastMetric, value)
+    IastMetricCollector.add(iastMetric, tag, value)
     IastMetricCollector.get().prepareMetrics()
     action.doIteration(service)
 
     then:
-    1 * service.addMetric({ matches(it, iastMetric, value, ["${iastMetric.tagName}:${iastMetric.tagValue}"]) })
+    1 * service.addMetric({ matches(it, iastMetric, value, ["${iastMetric.tag.name}:${tag}"]) })
     0 * _
   }
 


### PR DESCRIPTION
# What Does This Do
Add IAST related annotations to bytebuddy advices so latter we can apply telemetry callbacks to them

# Motivation

# Additional Notes
