### PR TITLE
Ensure safe class loading in instrumentation

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -205,7 +205,7 @@ public class ConfigurationUpdater
   private void retransformClasses(List<Class<?>> classesToBeTransformed) {
     for (Class<?> clazz : classesToBeTransformed) {
       try {
-        LOGGER.info("Re-transforming {}", clazz.getCanonicalName());
+        LOGGER.info("Re-transforming class: {}", clazz.getTypeName());
         instrumentation.retransformClasses(clazz);
       } catch (Exception ex) {
         ExceptionHelper.logException(LOGGER, ex, "Re-transform error:");

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -154,7 +154,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
       // e.g. Main.java contains Main & TopLevel class, line numbers are in TopLevel class
       log.info(
           "type {} matched but no transformation for definitions: {}", classFilePath, definitions);
-    } catch (Exception ex) {
+    } catch (Throwable ex) {
       log.warn("Cannot transform: ", ex);
     }
     return null;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
@@ -103,6 +103,37 @@ public class ASMHelper {
     return new Type(mainType, genericTypes);
   }
 
+  /**
+   * Makes sure that the class we want to load is not the one that we are currently transforming
+   * otherwise it will lead into a LinkageError
+   *
+   * @param className class name to load in '.' format (Java)
+   * @param currentClassTransformed in '.' format (Java)
+   * @param classLoader use for loading the class
+   * @return the loaded class
+   */
+  public static Class<?> ensureSafeClassLoad(
+      String className, String currentClassTransformed, ClassLoader classLoader) {
+    if (currentClassTransformed == null) {
+      // This is requires to make sure we are not loading class being transformed during
+      // transformation as it will generate a LinkageError with
+      // "attempted duplicate class definition"
+      throw new IllegalArgumentException(
+          "Cannot ensure loading class: "
+              + className
+              + " safely as current class being transformed is not provided (null)");
+    }
+    if (className.equals(currentClassTransformed)) {
+      throw new IllegalArgumentException(
+          "Cannot load class " + className + " as this is the class being currently transformed");
+    }
+    try {
+      return Class.forName(className, true, classLoader);
+    } catch (Throwable t) {
+      throw new RuntimeException("Cannot load class " + className, t);
+    }
+  }
+
   /** Wraps ASM's {@link org.objectweb.asm.Type} with associated generic types */
   public static class Type {
     private final org.objectweb.asm.Type mainType;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
@@ -107,15 +107,15 @@ public class ASMHelper {
    * Makes sure that the class we want to load is not the one that we are currently transforming
    * otherwise it will lead into a LinkageError
    *
-   * @param className class name to load in '.' format (Java)
-   * @param currentClassTransformed in '.' format (Java)
+   * @param className class name to load in '.' format (com.foo.bar.Class$InnerClass)
+   * @param currentClassTransformed in '.' format (com.foo.bar.Class$InnerClass)
    * @param classLoader use for loading the class
    * @return the loaded class
    */
   public static Class<?> ensureSafeClassLoad(
       String className, String currentClassTransformed, ClassLoader classLoader) {
     if (currentClassTransformed == null) {
-      // This is requires to make sure we are not loading class being transformed during
+      // This is required to make sure we are not loading the class being transformed during
       // transformation as it will generate a LinkageError with
       // "attempted duplicate class definition"
       throw new IllegalArgumentException(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
@@ -1,12 +1,14 @@
 package com.datadog.debugger.instrumentation;
 
 import static com.datadog.debugger.instrumentation.ASMHelper.decodeSignature;
+import static com.datadog.debugger.instrumentation.ASMHelper.ensureSafeClassLoad;
 import static com.datadog.debugger.instrumentation.ASMHelper.invokeInterface;
 import static com.datadog.debugger.instrumentation.ASMHelper.invokeStatic;
 import static com.datadog.debugger.instrumentation.ASMHelper.invokeVirtual;
 import static com.datadog.debugger.instrumentation.ASMHelper.isStaticField;
 import static com.datadog.debugger.instrumentation.ASMHelper.ldc;
 import static com.datadog.debugger.instrumentation.Types.*;
+import static datadog.trace.util.Strings.getClassName;
 
 import com.datadog.debugger.el.InvalidValueException;
 import com.datadog.debugger.el.Visitor;
@@ -676,7 +678,9 @@ public class MetricInstrumentor extends Instrumentor {
           }
         } else {
           className = currentType.getClassName();
-          clazz = Class.forName(className, true, instrumentor.classLoader);
+          clazz =
+              ensureSafeClassLoad(
+                  className, getClassName(instrumentor.classNode.name), instrumentor.classLoader);
           Field declaredField = clazz.getDeclaredField(fieldName); // no parent fields!
           isAccessible = declaredField.isAccessible();
           fieldDesc = Type.getDescriptor(declaredField.getType());

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/instrumentation/ASMHelperTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/instrumentation/ASMHelperTest.java
@@ -1,0 +1,32 @@
+package com.datadog.debugger.instrumentation;
+
+import static com.datadog.debugger.instrumentation.ASMHelper.ensureSafeClassLoad;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class ASMHelperTest {
+
+  @Test
+  public void ensureSafeLoadClass() {
+    IllegalArgumentException illegalArgumentException =
+        assertThrows(IllegalArgumentException.class, () -> ensureSafeClassLoad("", null, null));
+    assertEquals(
+        "Cannot ensure loading class:  safely as current class being transformed is not provided (null)",
+        illegalArgumentException.getMessage());
+    illegalArgumentException =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                ensureSafeClassLoad(
+                    "com.datadog.debugger.MyClass", "com.datadog.debugger.MyClass", null));
+    assertEquals(
+        "Cannot load class com.datadog.debugger.MyClass as this is the class being currently transformed",
+        illegalArgumentException.getMessage());
+    Class<?> clazz =
+        ensureSafeClassLoad(
+            ASMHelperTest.class.getTypeName(), "", ASMHelperTest.class.getClassLoader());
+    assertEquals(ASMHelperTest.class, clazz);
+  }
+}


### PR DESCRIPTION

# What Does This Do
We introduced a helper method that require to provide the name of the class currently being transformed to ensure it is not the same. We also catch Throwable in transform method to ensure whatever happens during transformation we do not bubble up to the user code and load the original class

# Motivation
Loading a class during transformation/instrumentation MUST not be the current class being transformed otherwise a LinkageError happen with message "attempted duplicate class definition" because we have loaded the class before it was transformed, so when transformation finish the original load of the class is happening and boom! 
# Additional Notes
