### PR TITLE
Add special support for enum values

### DIFF
--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1387,7 +1387,7 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener =
         installProbes(ENUM_CLASS, createProbe(PROBE_ID, ENUM_CLASS, "<init>", null));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
-    int result = Reflect.on(testClass).call("main", "2").get();
+    int result = Reflect.on(testClass).call("main", "").get();
     Assertions.assertEquals(2, result);
     assertSnapshots(listener, 3, PROBE_ID);
     Map<String, CapturedContext.CapturedValue> arguments =
@@ -1396,6 +1396,21 @@ public class CapturedSnapshotTest {
     assertTrue(arguments.containsKey("this"));
     assertTrue(arguments.containsKey("p1")); // this the hidden ordinal arg of an enum
     assertTrue(arguments.containsKey("strValue"));
+  }
+
+  @Test
+  public void enumValues() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot23";
+    DebuggerTransformerTest.TestSnapshotListener listener =
+        installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, "convert", null));
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "2").get();
+    Assertions.assertEquals(2, result);
+    Snapshot snapshot = assertOneSnapshot(listener);
+    assertCaptureReturnValue(
+        snapshot.getCaptures().getReturn(),
+        "com.datadog.debugger.CapturedSnapshot23$MyEnum",
+        "TWO");
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
@@ -843,6 +843,28 @@ public class SnapshotSerializationTest {
     Assertions.assertEquals(TIMEOUT_REASON, json.get(NOT_CAPTURED_REASON));
   }
 
+  enum MyEnum {
+    ONE,
+    TWO,
+    THREE;
+  }
+
+  @Test
+  public void enumValues() throws IOException {
+    JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
+    Snapshot snapshot = createSnapshot();
+    CapturedContext context = new CapturedContext();
+    CapturedContext.CapturedValue enumValue =
+        CapturedContext.CapturedValue.of("enumValue", MyEnum.class.getTypeName(), MyEnum.TWO);
+    context.addLocals(new CapturedContext.CapturedValue[] {enumValue});
+    snapshot.setExit(context);
+    String buffer = adapter.toJson(snapshot);
+    System.out.println(buffer);
+    Map<String, Object> locals = getLocalsFromJson(buffer);
+    Map<String, Object> enumValueJson = (Map<String, Object>) locals.get("enumValue");
+    assertEquals("TWO", enumValueJson.get("value"));
+  }
+
   private Map<String, Object> doFieldCount(int maxFieldCount) throws IOException {
     JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
     Snapshot snapshot = createSnapshotForFieldCount(maxFieldCount);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/MoshiSnapshotTestHelper.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/MoshiSnapshotTestHelper.java
@@ -448,7 +448,7 @@ public class MoshiSnapshotTestHelper {
         case "java.lang.String":
           return strValue;
       }
-      return null;
+      return strValue;
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot23.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot23.java
@@ -23,7 +23,20 @@ public class CapturedSnapshot23 {
   }
 
   private int doit(String arg) {
-    return Integer.parseInt(MyEnum.TWO.getStrValue());
+    if ("".equals(arg)) {
+      return Integer.parseInt(MyEnum.TWO.getStrValue());
+    }
+    return Integer.parseInt(convert(arg).getStrValue());
+  }
+
+  private MyEnum convert(String value) {
+    switch (value) {
+      case "1": return MyEnum.ONE;
+      case "2": return MyEnum.TWO;
+      case "3": return MyEnum.THREE;
+      default:
+        throw new IllegalArgumentException("Unknown value: " + value);
+    }
   }
 
   public static int main(String arg) {


### PR DESCRIPTION
# What Does This Do
We are serializing then the enum constant name in the snapshot instead of handling enum as regular complex class

# Motivation
Enum in java are in fact regular classes with a special treatment by the java compiler. from the POV of the JVM there is no difference. From user perspective however it would be nice to have constant name as enum values.

# Additional Notes
