### PR TITLE
[system-tests] Tests parametric on migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ instrumentation_modules: &instrumentation_modules "dd-java-agent/instrumentation
 debugger_modules: &debugger_modules "dd-java-agent/agent-debugger|dd-java-agent/agent-bootstrap|dd-java-agent/agent-builder|internal-api|communication|dd-trace-core"
 profiling_modules: &profiling_modules "dd-java-agent/agent-profiling"
 
-default_system_tests_commit: &default_system_tests_commit 733e06a4e535c970fc62a33c7eca7c00b52a730c
+default_system_tests_commit: &default_system_tests_commit ea123afecf8142319955e52b5972368afa86961a
 
 parameters:
   gradle_flags:


### PR DESCRIPTION
# What Does This Do
Test if changes made on system-tests/parametric generates error on dd-trace-java default circleci pipeline

# Motivation

# Additional Notes
