### PR TITLE
Fold stacktrace for exception

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ExceptionHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ExceptionHelper.java
@@ -1,6 +1,9 @@
 package com.datadog.debugger.util;
 
 import datadog.trace.relocate.api.RatelimitedLogger;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.util.Arrays;
 import org.slf4j.Logger;
 
@@ -31,6 +34,26 @@ public class ExceptionHelper {
       logException(log, ex, message, params);
     } else {
       ratelimitedLogger.warn(message + " " + ex.toString(), params);
+    }
+  }
+
+  public static String foldExceptionStackTrace(Throwable t) {
+    StringWriter writer = new StringWriter();
+    t.printStackTrace(new NoNewLinePrintWriter(writer));
+    return writer.toString();
+  }
+
+  private static class NoNewLinePrintWriter extends PrintWriter {
+    public NoNewLinePrintWriter(Writer out) {
+      super(out);
+    }
+
+    @Override
+    public void println() {}
+
+    @Override
+    public void write(String s, int off, int len) {
+      super.write(s.replace('\t', ' '), off, len);
     }
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
@@ -408,7 +408,10 @@ public class MoshiSnapshotHelper {
 
       @Override
       public void handleFieldException(Exception ex, Field field) {
-        LOG.debug("Exception when extracting field={}", field.getName(), ex);
+        LOG.debug(
+            "Exception when extracting field={} exception={}",
+            field.getName(),
+            ExceptionHelper.foldExceptionStackTrace(ex));
         String fieldName = field.getName();
         try {
           jsonWriter.name(fieldName);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ExceptionHelperTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ExceptionHelperTest.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
@@ -64,6 +65,17 @@ public class ExceptionHelperTest {
         "Error {} {}",
         "param1",
         "param2");
+  }
+
+  @Test
+  public void foldExceptionStackTrace() {
+    String strStackTrace = ExceptionHelper.foldExceptionStackTrace(new Exception());
+    assertTrue(
+        strStackTrace.startsWith(
+            "java.lang.Exception at com.datadog.debugger.util.ExceptionHelperTest.foldExceptionStackTrace(ExceptionHelperTest.java:72) at "));
+    assertFalse(strStackTrace.contains("\n"));
+    assertFalse(strStackTrace.contains("\t"));
+    assertFalse(strStackTrace.contains("\r"));
   }
 
   private Object logDebug(InvocationOnMock invocation) {


### PR DESCRIPTION
when trying access fields during capture/serialization and debug logs
# What Does This Do

# Motivation

# Additional Notes
