### PR TITLE
Fix unvalidated redirect detection in Jetty

### DIFF
--- a/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
@@ -5,6 +5,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.im
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.not;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
@@ -49,8 +50,13 @@ public final class HttpServletResponseInstrumentation extends Instrumenter.Iast
         namedOneOf("setHeader", "addHeader").and(takesArguments(String.class, String.class)),
         getClass().getName() + "$AddHeaderAdvice");
     transformation.applyAdvice(
-        namedOneOf("encodeRedirectURL", "encodeURL"), getClass().getName() + "$EncodeURLAdvice");
-    transformation.applyAdvice(named("sendRedirect"), getClass().getName() + "$SendRedirectAdvice");
+        namedOneOf("encodeRedirectURL", "encodeURL")
+            .and(takesArgument(0, String.class))
+            .and(returns(String.class)),
+        getClass().getName() + "$EncodeURLAdvice");
+    transformation.applyAdvice(
+        named("sendRedirect").and(takesArgument(0, String.class)),
+        getClass().getName() + "$SendRedirectAdvice");
   }
 
   public static class AddCookieAdvice {

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletResponseInstrumentation.java
@@ -5,6 +5,8 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.im
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.not;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
@@ -39,8 +41,13 @@ public final class JakartaHttpServletResponseInstrumentation extends Instrumente
     transformation.applyAdvice(
         namedOneOf("setHeader", "addHeader"), getClass().getName() + "$AddHeaderAdvice");
     transformation.applyAdvice(
-        namedOneOf("encodeRedirectURL", "encodeURL"), getClass().getName() + "$EncodeURLAdvice");
-    transformation.applyAdvice(named("sendRedirect"), getClass().getName() + "$SendRedirectAdvice");
+        namedOneOf("encodeRedirectURL", "encodeURL")
+            .and(takesArgument(0, String.class))
+            .and(returns(String.class)),
+        getClass().getName() + "$EncodeURLAdvice");
+    transformation.applyAdvice(
+        named("sendRedirect").and(takesArgument(0, String.class)),
+        getClass().getName() + "$SendRedirectAdvice");
   }
 
   public static class AddCookieAdvice {


### PR DESCRIPTION
# What Does This Do
Make method matchers in IAST instrumenter for servlet more precise. Avoids matching the wrong methods in Jetty.

# Motivation
Some unvalidated redirects were not detected in Jetty.

# Additional Notes
