### PR TITLE
Fix NoClassDefFoundError due to OSGI/servlet issues in IAST

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteInstrumentation.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteInstrumentation.java
@@ -20,16 +20,11 @@ public abstract class CallSiteInstrumentation extends Instrumenter.Default
   }
 
   @Override
-  public String[] helperClassNames() {
-    return advices().getHelpers();
-  }
-
-  @Override
   public void adviceTransformations(final AdviceTransformation transformation) {}
 
   @Override
   public AdviceTransformer transformer() {
-    return new CallSiteTransformer(advices());
+    return new CallSiteTransformer(name(), advices());
   }
 
   protected abstract CallSiteSupplier callSites();

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/BaseCallSiteTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/BaseCallSiteTest.groovy
@@ -71,6 +71,9 @@ class BaseCallSiteTest extends DDSpecification {
         final Object[] args = params as Object[]
         adviceFinder.call(args[0] as String, args[1] as String, args[2] as String)
       }
+      getHelpers() >> {
+        helpers as String[]
+      }
     }
   }
 

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteInstrumentationTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteInstrumentationTest.groovy
@@ -38,20 +38,6 @@ class CallSiteInstrumentationTest extends BaseCallSiteTest {
     0 * mock._
   }
 
-  def 'test helper class names'() {
-    setup:
-    final advice1 = mockCallSites(Mock(InvokeAdvice), stringConcatPointcut(), 'foo.bar.Helper1')
-    final advice2 = mockCallSites(Mock(InvokeAdvice), messageDigestGetInstancePointcut(), 'foo.bar.Helper1', 'foo.bar.Helper2', 'foo.bar.Helper3')
-    final instrumentation = buildInstrumentation([advice1, advice2])
-
-    when:
-    final helpers = instrumentation.helperClassNames()
-
-    then:
-    helpers.length == 3
-    helpers.toList().containsAll('foo.bar.Helper1', 'foo.bar.Helper2', 'foo.bar.Helper3')
-  }
-
   def 'test fetch advices from spi with custom class'() {
     setup:
     final builder = Mock(DynamicType.Builder)

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/callsite/HttpServlet3RequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/callsite/HttpServlet3RequestCallSite.java
@@ -7,16 +7,17 @@ import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.source.WebModule;
 import java.util.Map;
-import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
 
 @CallSite(spi = IastCallSites.class)
-public class Servlet3RequestCallSite {
+public class HttpServlet3RequestCallSite {
 
   @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
-  @CallSite.After("java.util.Map javax.servlet.ServletRequest.getParameterMap()")
-  @CallSite.After("java.util.Map javax.servlet.ServletRequestWrapper.getParameterMap()")
+  @CallSite.After("java.util.Map javax.servlet.http.HttpServletRequest.getParameterMap()")
+  @CallSite.After("java.util.Map javax.servlet.http.HttpServletRequestWrapper.getParameterMap()")
   public static java.util.Map<java.lang.String, java.lang.String[]> afterGetParameterMap(
-      @CallSite.This final ServletRequest self, @CallSite.Return final Map<String, String[]> map) {
+      @CallSite.This final HttpServletRequest self,
+      @CallSite.Return final Map<String, String[]> map) {
     final WebModule module = InstrumentationBridge.WEB;
     if (module != null) {
       try {

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/Servlet3TestGetParameterInstrumentation.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/Servlet3TestGetParameterInstrumentation.groovy
@@ -1,15 +1,14 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.source.WebModule
+import foo.bar.smoketest.HttpServlet3TestSuite
+import foo.bar.smoketest.HttpServletWrapper3TestSuite
 import foo.bar.smoketest.Servlet3TestSuite
-import groovy.transform.CompileDynamic
-import spock.lang.Ignore
 
+import javax.servlet.ServletRequest
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletRequestWrapper
 
-@Ignore("https://github.com/DataDog/dd-trace-java/pull/5213")
-@CompileDynamic
 class Servlet3TestGetParameterInstrumentation extends AgentTestRunner {
 
   @Override
@@ -26,17 +25,21 @@ class Servlet3TestGetParameterInstrumentation extends AgentTestRunner {
     final iastModule = Mock(WebModule)
     InstrumentationBridge.registerIastModule(iastModule)
     final map = [param1: ['value1', 'value2'] as String[]]
-    final servletRequest = Mock(HttpServletRequest) {
+    final request = Mock(requestClass) {
       getParameterMap() >> map
     }
-    final wrapper = new HttpServletRequestWrapper(servletRequest)
-    final testSuite = new Servlet3TestSuite(wrapper)
 
     when:
-    final returnedMap = testSuite.getParameterMap()
+    final returnedMap = suite.getParameterMap(request)
 
     then:
     returnedMap == map
     1 * iastModule.onParameterValues(map)
+
+    where:
+    suite                              | requestClass
+    new Servlet3TestSuite()            | ServletRequest
+    new HttpServlet3TestSuite()        | HttpServletRequest
+    new HttpServletWrapper3TestSuite() | HttpServletRequestWrapper
   }
 }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/java/foo/bar/smoketest/HttpServlet3TestSuite.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/java/foo/bar/smoketest/HttpServlet3TestSuite.java
@@ -1,0 +1,12 @@
+package foo.bar.smoketest;
+
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+
+public class HttpServlet3TestSuite implements ServletSuite<HttpServletRequest> {
+
+  @Override
+  public Map<String, String[]> getParameterMap(HttpServletRequest request) {
+    return request.getParameterMap();
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/java/foo/bar/smoketest/HttpServletWrapper3TestSuite.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/java/foo/bar/smoketest/HttpServletWrapper3TestSuite.java
@@ -1,0 +1,12 @@
+package foo.bar.smoketest;
+
+import java.util.Map;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+public class HttpServletWrapper3TestSuite implements ServletSuite<HttpServletRequestWrapper> {
+
+  @Override
+  public Map<String, String[]> getParameterMap(HttpServletRequestWrapper request) {
+    return request.getParameterMap();
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/java/foo/bar/smoketest/Servlet3TestSuite.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/java/foo/bar/smoketest/Servlet3TestSuite.java
@@ -1,15 +1,12 @@
 package foo.bar.smoketest;
 
-import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
+import javax.servlet.ServletRequest;
 
-public class Servlet3TestSuite {
-  HttpServletRequest request;
+public class Servlet3TestSuite implements ServletSuite<ServletRequest> {
 
-  public Servlet3TestSuite(HttpServletRequest request) {
-    this.request = request;
-  }
-
-  public java.util.Map<java.lang.String, java.lang.String[]> getParameterMap() {
+  @Override
+  public Map<String, String[]> getParameterMap(ServletRequest request) {
     return request.getParameterMap();
   }
 }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/java/foo/bar/smoketest/ServletSuite.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/java/foo/bar/smoketest/ServletSuite.java
@@ -1,0 +1,9 @@
+package foo.bar.smoketest;
+
+import java.util.Map;
+import javax.servlet.ServletRequest;
+
+public interface ServletSuite<S extends ServletRequest> {
+
+  Map<String, String[]> getParameterMap(S request);
+}

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestInputStreamCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestInputStreamCallSite.java
@@ -1,0 +1,33 @@
+package datadog.trace.instrumentation.servlet5;
+
+import datadog.trace.agent.tooling.csi.CallSite;
+import datadog.trace.api.iast.IastCallSites;
+import datadog.trace.api.iast.IastCallSites.Propagation;
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.SourceTypes;
+import datadog.trace.api.iast.propagation.PropagationModule;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+
+@CallSite(spi = IastCallSites.class)
+public class JakartaHttpServletRequestInputStreamCallSite {
+
+  @Propagation
+  @CallSite.After(
+      "jakarta.servlet.ServletInputStream jakarta.servlet.http.HttpServletRequest.getInputStream()")
+  @CallSite.After(
+      "jakarta.servlet.ServletInputStream jakarta.servlet.http.HttpServletRequestWrapper.getInputStream()")
+  public static ServletInputStream afterGetInputStream(
+      @CallSite.This final HttpServletRequest self,
+      @CallSite.Return final ServletInputStream inputStream) {
+    final PropagationModule module = InstrumentationBridge.PROPAGATION;
+    if (module != null) {
+      try {
+        module.taint(SourceTypes.REQUEST_BODY, inputStream);
+      } catch (final Throwable e) {
+        module.onUnexpectedException("afterGetInputStream threw", e);
+      }
+    }
+    return inputStream;
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/request-5/src/test/java/foo/bar/smoketest/JakartaHttpServletRequestTestSuite.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/test/java/foo/bar/smoketest/JakartaHttpServletRequestTestSuite.java
@@ -1,7 +1,9 @@
 package foo.bar.smoketest;
 
 import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
 import java.util.Enumeration;
 
 public class JakartaHttpServletRequestTestSuite
@@ -36,5 +38,10 @@ public class JakartaHttpServletRequestTestSuite
   @Override
   public RequestDispatcher getRequestDispatcher(String path) {
     return request.getRequestDispatcher(path);
+  }
+
+  @Override
+  public ServletInputStream getInputStream() throws IOException {
+    return request.getInputStream();
   }
 }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/test/java/foo/bar/smoketest/JakartaHttpServletRequestWrapperTestSuite.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/test/java/foo/bar/smoketest/JakartaHttpServletRequestWrapperTestSuite.java
@@ -1,7 +1,9 @@
 package foo.bar.smoketest;
 
 import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequestWrapper;
+import java.io.IOException;
 import java.util.Enumeration;
 
 public class JakartaHttpServletRequestWrapperTestSuite
@@ -36,5 +38,10 @@ public class JakartaHttpServletRequestWrapperTestSuite
   @Override
   public RequestDispatcher getRequestDispatcher(String path) {
     return request.getRequestDispatcher(path);
+  }
+
+  @Override
+  public ServletInputStream getInputStream() throws IOException {
+    return request.getInputStream();
   }
 }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/test/java/foo/bar/smoketest/JakartaServletRequestTestSuite.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/test/java/foo/bar/smoketest/JakartaServletRequestTestSuite.java
@@ -1,7 +1,9 @@
 package foo.bar.smoketest;
 
 import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.ServletRequest;
+import java.io.IOException;
 import java.util.Enumeration;
 
 public class JakartaServletRequestTestSuite implements ServletRequestTestSuite<ServletRequest> {
@@ -35,5 +37,10 @@ public class JakartaServletRequestTestSuite implements ServletRequestTestSuite<S
   @Override
   public RequestDispatcher getRequestDispatcher(String path) {
     return request.getRequestDispatcher(path);
+  }
+
+  @Override
+  public ServletInputStream getInputStream() throws IOException {
+    return request.getInputStream();
   }
 }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/test/java/foo/bar/smoketest/JakartaServletRequestWrapperTestSuite.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/test/java/foo/bar/smoketest/JakartaServletRequestWrapperTestSuite.java
@@ -1,7 +1,9 @@
 package foo.bar.smoketest;
 
 import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.ServletRequestWrapper;
+import java.io.IOException;
 import java.util.Enumeration;
 
 public class JakartaServletRequestWrapperTestSuite
@@ -36,5 +38,10 @@ public class JakartaServletRequestWrapperTestSuite
   @Override
   public RequestDispatcher getRequestDispatcher(String path) {
     return request.getRequestDispatcher(path);
+  }
+
+  @Override
+  public ServletInputStream getInputStream() throws IOException {
+    return request.getInputStream();
   }
 }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/test/java/foo/bar/smoketest/ServletRequestTestSuite.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/test/java/foo/bar/smoketest/ServletRequestTestSuite.java
@@ -1,6 +1,8 @@
 package foo.bar.smoketest;
 
 import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletInputStream;
+import java.io.IOException;
 import java.util.Enumeration;
 
 public interface ServletRequestTestSuite<E> {
@@ -16,4 +18,6 @@ public interface ServletRequestTestSuite<E> {
   Enumeration getParameterNames();
 
   RequestDispatcher getRequestDispatcher(String path);
+
+  ServletInputStream getInputStream() throws IOException;
 }

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
@@ -6,9 +6,12 @@ import datadog.trace.api.iast.IastCallSites.Propagation;
 import datadog.trace.api.iast.IastCallSites.Source;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
+import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
 import datadog.trace.api.iast.source.WebModule;
 import datadog.trace.util.stacktrace.StackUtils;
+import java.io.BufferedReader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -140,5 +143,111 @@ public class HttpServletRequestCallSite {
       }
     }
     return queryString;
+  }
+
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
+  @CallSite.After(
+      "java.lang.String javax.servlet.http.HttpServletRequest.getParameter(java.lang.String)")
+  @CallSite.After(
+      "java.lang.String javax.servlet.http.HttpServletRequestWrapper.getParameter(java.lang.String)")
+  public static String afterGetParameter(
+      @CallSite.This final HttpServletRequest self,
+      @CallSite.Argument final String paramName,
+      @CallSite.Return final String paramValue) {
+    final WebModule module = InstrumentationBridge.WEB;
+    if (module != null) {
+      try {
+        module.onParameterValue(paramName, paramValue);
+      } catch (final Throwable e) {
+        module.onUnexpectedException("afterGetParameter threw", e);
+      }
+    }
+    return paramValue;
+  }
+
+  @Source(SourceTypes.REQUEST_PARAMETER_NAME)
+  @CallSite.After("java.util.Enumeration javax.servlet.http.HttpServletRequest.getParameterNames()")
+  @CallSite.After(
+      "java.util.Enumeration javax.servlet.http.HttpServletRequestWrapper.getParameterNames()")
+  public static Enumeration<String> afterGetParameterNames(
+      @CallSite.This final HttpServletRequest self,
+      @CallSite.Return final Enumeration<String> enumeration)
+      throws Throwable {
+    final WebModule module = InstrumentationBridge.WEB;
+    if (module == null) {
+      return enumeration;
+    }
+    try {
+      final List<String> parameterNames = new ArrayList<>();
+      while (enumeration.hasMoreElements()) {
+        final String paramName = enumeration.nextElement();
+        parameterNames.add(paramName);
+      }
+      try {
+        module.onParameterNames(parameterNames);
+      } catch (final Throwable e) {
+        module.onUnexpectedException("afterGetParameterNames threw", e);
+      }
+      return Collections.enumeration(parameterNames);
+    } catch (final Throwable e) {
+      module.onUnexpectedException(
+          "afterGetParameterNames threw while iterating parameter names", e);
+      throw StackUtils.filterFirstDatadog(e);
+    }
+  }
+
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
+  @CallSite.After(
+      "java.lang.String[] javax.servlet.http.HttpServletRequest.getParameterValues(java.lang.String)")
+  @CallSite.After(
+      "java.lang.String[] javax.servlet.http.HttpServletRequestWrapper.getParameterValues(java.lang.String)")
+  public static String[] afterGetParameterValues(
+      @CallSite.This final HttpServletRequest self,
+      @CallSite.Argument final String paramName,
+      @CallSite.Return final String[] parameterValues) {
+    if (null != parameterValues) {
+      final WebModule module = InstrumentationBridge.WEB;
+      if (module != null) {
+        try {
+          module.onParameterValues(paramName, parameterValues);
+        } catch (final Throwable e) {
+          module.onUnexpectedException("afterGetParameterValues threw", e);
+        }
+      }
+    }
+    return parameterValues;
+  }
+
+  @Propagation
+  @CallSite.After("java.io.BufferedReader javax.servlet.http.HttpServletRequest.getReader()")
+  @CallSite.After("java.io.BufferedReader javax.servlet.http.HttpServletRequestWrapper.getReader()")
+  public static BufferedReader afterGetReader(
+      @CallSite.This final HttpServletRequest self,
+      @CallSite.Return final BufferedReader bufferedReader) {
+    final PropagationModule module = InstrumentationBridge.PROPAGATION;
+    if (module != null) {
+      try {
+        module.taint(SourceTypes.REQUEST_BODY, bufferedReader);
+      } catch (final Throwable e) {
+        module.onUnexpectedException("afterGetReader threw", e);
+      }
+    }
+    return bufferedReader;
+  }
+
+  @IastCallSites.Sink(VulnerabilityTypes.UNVALIDATED_REDIRECT)
+  @CallSite.Before(
+      "javax.servlet.RequestDispatcher javax.servlet.http.HttpServletRequest.getRequestDispatcher(java.lang.String)")
+  @CallSite.Before(
+      "javax.servlet.RequestDispatcher javax.servlet.http.HttpServletRequestWrapper.getRequestDispatcher(java.lang.String)")
+  public static void beforeRequestDispatcher(@CallSite.Argument final String path) {
+    final UnvalidatedRedirectModule module = InstrumentationBridge.UNVALIDATED_REDIRECT;
+    if (module != null) {
+      try {
+        module.onRedirect(path);
+      } catch (final Throwable e) {
+        module.onUnexpectedException("beforeRequestDispatcher threw", e);
+      }
+    }
   }
 }

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestInputStreamCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestInputStreamCallSite.java
@@ -1,0 +1,33 @@
+package datadog.trace.instrumentation.servlet.request;
+
+import datadog.trace.agent.tooling.csi.CallSite;
+import datadog.trace.api.iast.IastCallSites;
+import datadog.trace.api.iast.IastCallSites.Propagation;
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.SourceTypes;
+import datadog.trace.api.iast.propagation.PropagationModule;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+
+@CallSite(spi = IastCallSites.class)
+public class HttpServletRequestInputStreamCallSite {
+
+  @Propagation
+  @CallSite.After(
+      "javax.servlet.ServletInputStream javax.servlet.http.HttpServletRequest.getInputStream()")
+  @CallSite.After(
+      "javax.servlet.ServletInputStream javax.servlet.http.HttpServletRequestWrapper.getInputStream()")
+  public static ServletInputStream afterGetInputStream(
+      @CallSite.This final HttpServletRequest self,
+      @CallSite.Return final ServletInputStream inputStream) {
+    final PropagationModule module = InstrumentationBridge.PROPAGATION;
+    if (module != null) {
+      try {
+        module.taint(SourceTypes.REQUEST_BODY, inputStream);
+      } catch (final Throwable e) {
+        module.onUnexpectedException("afterGetInputStream threw", e);
+      }
+    }
+    return inputStream;
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/ServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/ServletRequestCallSite.java
@@ -26,10 +26,6 @@ public class ServletRequestCallSite {
   @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
   @CallSite.After("java.lang.String javax.servlet.ServletRequest.getParameter(java.lang.String)")
   @CallSite.After(
-      "java.lang.String javax.servlet.http.HttpServletRequest.getParameter(java.lang.String)")
-  @CallSite.After(
-      "java.lang.String javax.servlet.http.HttpServletRequestWrapper.getParameter(java.lang.String)")
-  @CallSite.After(
       "java.lang.String javax.servlet.ServletRequestWrapper.getParameter(java.lang.String)")
   public static String afterGetParameter(
       @CallSite.This final ServletRequest self,
@@ -48,9 +44,6 @@ public class ServletRequestCallSite {
 
   @Source(SourceTypes.REQUEST_PARAMETER_NAME)
   @CallSite.After("java.util.Enumeration javax.servlet.ServletRequest.getParameterNames()")
-  @CallSite.After("java.util.Enumeration javax.servlet.http.HttpServletRequest.getParameterNames()")
-  @CallSite.After(
-      "java.util.Enumeration javax.servlet.http.HttpServletRequestWrapper.getParameterNames()")
   @CallSite.After("java.util.Enumeration javax.servlet.ServletRequestWrapper.getParameterNames()")
   public static Enumeration<String> afterGetParameterNames(
       @CallSite.This final ServletRequest self,
@@ -83,10 +76,6 @@ public class ServletRequestCallSite {
   @CallSite.After(
       "java.lang.String[] javax.servlet.ServletRequest.getParameterValues(java.lang.String)")
   @CallSite.After(
-      "java.lang.String[] javax.servlet.http.HttpServletRequest.getParameterValues(java.lang.String)")
-  @CallSite.After(
-      "java.lang.String[] javax.servlet.http.HttpServletRequestWrapper.getParameterValues(java.lang.String)")
-  @CallSite.After(
       "java.lang.String[] javax.servlet.ServletRequestWrapper.getParameterValues(java.lang.String)")
   public static String[] afterGetParameterValues(
       @CallSite.This final ServletRequest self,
@@ -108,10 +97,6 @@ public class ServletRequestCallSite {
   @Propagation
   @CallSite.After("javax.servlet.ServletInputStream javax.servlet.ServletRequest.getInputStream()")
   @CallSite.After(
-      "javax.servlet.ServletInputStream javax.servlet.http.HttpServletRequest.getInputStream()")
-  @CallSite.After(
-      "javax.servlet.ServletInputStream javax.servlet.http.HttpServletRequestWrapper.getInputStream()")
-  @CallSite.After(
       "javax.servlet.ServletInputStream javax.servlet.ServletRequestWrapper.getInputStream()")
   public static ServletInputStream afterGetInputStream(
       @CallSite.This final ServletRequest self,
@@ -129,8 +114,6 @@ public class ServletRequestCallSite {
 
   @Propagation
   @CallSite.After("java.io.BufferedReader javax.servlet.ServletRequest.getReader()")
-  @CallSite.After("java.io.BufferedReader javax.servlet.http.HttpServletRequest.getReader()")
-  @CallSite.After("java.io.BufferedReader javax.servlet.http.HttpServletRequestWrapper.getReader()")
   @CallSite.After("java.io.BufferedReader javax.servlet.ServletRequestWrapper.getReader()")
   public static BufferedReader afterGetReader(
       @CallSite.This final ServletRequest self,
@@ -149,10 +132,6 @@ public class ServletRequestCallSite {
   @Sink(VulnerabilityTypes.UNVALIDATED_REDIRECT)
   @CallSite.Before(
       "javax.servlet.RequestDispatcher javax.servlet.ServletRequest.getRequestDispatcher(java.lang.String)")
-  @CallSite.Before(
-      "javax.servlet.RequestDispatcher javax.servlet.http.HttpServletRequest.getRequestDispatcher(java.lang.String)")
-  @CallSite.Before(
-      "javax.servlet.RequestDispatcher javax.servlet.http.HttpServletRequestWrapper.getRequestDispatcher(java.lang.String)")
   @CallSite.Before(
       "javax.servlet.RequestDispatcher javax.servlet.ServletRequestWrapper.getRequestDispatcher(java.lang.String)")
   public static void beforeRequestDispatcher(@CallSite.Argument final String path) {


### PR DESCRIPTION
# What Does This Do
Separates call sites for `javax.servlet.ServletRequest` and `javax.servlet.http.HttpServletRequest` to prevent issues when classes are loaded in an OSGI environment.

# Motivation
A customer reported an exception during initialization:
```
Caused by: java.lang.ClassNotFoundException: javax.servlet.ServletRequest not found by security-connector-oauth2-client [328]
	at org.apache.felix.framework.BundleWiringImpl.findClassOrResourceByDelegation(BundleWiringImpl.java:1585)
	at org.apache.felix.framework.BundleWiringImpl.access$300(BundleWiringImpl.java:79)
	at org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.loadClass(BundleWiringImpl.java:1970)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 78 more
```
The Apache Felix driven class loader of the instrumented class is only able to load classes in the `javax.servlet.http` package but the call site was forcing a reference to `javax.servlet`

# Additional Notes
