### PR TITLE
Run parametric tests with the standard runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ instrumentation_modules: &instrumentation_modules "dd-java-agent/instrumentation
 debugger_modules: &debugger_modules "dd-java-agent/agent-debugger|dd-java-agent/agent-bootstrap|dd-java-agent/agent-builder|internal-api|communication|dd-trace-core"
 profiling_modules: &profiling_modules "dd-java-agent/agent-profiling"
 
-default_system_tests_commit: &default_system_tests_commit 733e06a4e535c970fc62a33c7eca7c00b52a730c
+default_system_tests_commit: &default_system_tests_commit ce9a727fa56ca09b573aaa779f19355943a6cdfd
 
 parameters:
   gradle_flags:
@@ -860,17 +860,18 @@ jobs:
           name: Run
           command: |
             set -e
-            cd system-tests/parametric
-            mkdir -p test-results
-            export CLIENTS_ENABLED=java
+            cd system-tests
+            export TEST_LIBRARY=java
             export PYTEST_WORKER_COUNT=8
-            ./run.sh --log-cli-level=DEBUG --durations=30 -vv --junitxml=test-results/junit.xml
+            ./build.sh -i runner
+            ./run.sh PARAMETRIC --log-cli-level=DEBUG --durations=30 -vv
 
       - store_test_results:
-          path: system-tests/parametric/test-results
+          path: system-tests/logs_parametric
 
       - store_artifacts:
-          path: system-tests/parametric/test-results
+          path: system-tests/logs_parametric
+
 
 build_test_jobs: &build_test_jobs
   - build:


### PR DESCRIPTION
# What Does This Do

Runs the `parametric` tests with the standard top level `run.sh` script.

# Motivation

DataDog/system-tests#1279 changed to using the top level `run.sh` for `parametric` tests as well as moved the test result files so they weren't added to CI.