### PR TITLE
track time in FJP shared queues

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/QueueTimerHelper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/QueueTimerHelper.java
@@ -1,0 +1,34 @@
+package datadog.trace.bootstrap.instrumentation.java.concurrent;
+
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED_DEFAULT;
+import static datadog.trace.bootstrap.TaskWrapper.getUnwrappedType;
+
+import datadog.trace.api.profiling.QueueTiming;
+import datadog.trace.api.profiling.Timer;
+import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.jfr.InstrumentationBasedProfiling;
+
+public class QueueTimerHelper {
+
+  // don't use Config because it may use ThreadPoolExecutor to initialize itself
+  private static final boolean IS_PROFILING_QUEUEING_TIME_ENABLED =
+      ConfigProvider.getInstance()
+          .getBoolean(PROFILING_QUEUEING_TIME_ENABLED, PROFILING_QUEUEING_TIME_ENABLED_DEFAULT);
+
+  public static <T> void startQueuingTimer(
+      ContextStore<T, State> taskContextStore, Class<?> schedulerClass, T task) {
+    if (IS_PROFILING_QUEUEING_TIME_ENABLED && InstrumentationBasedProfiling.isJFRReady()) {
+      State state = taskContextStore.get(task);
+      if (task != null && state != null) {
+        QueueTiming timing =
+            (QueueTiming) AgentTracer.get().getTimer().start(Timer.TimerType.QUEUEING);
+        timing.setTask(getUnwrappedType(task));
+        timing.setScheduler(schedulerClass);
+        state.setTiming(timing);
+      }
+    }
+  }
+}

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/TPEHelper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/TPEHelper.java
@@ -1,20 +1,12 @@
 package datadog.trace.bootstrap.instrumentation.java.concurrent;
 
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED_DEFAULT;
-import static datadog.trace.bootstrap.TaskWrapper.getUnwrappedType;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.exclude;
 
 import datadog.trace.api.GenericClassValue;
 import datadog.trace.api.InstrumenterConfig;
-import datadog.trace.api.profiling.QueueTiming;
-import datadog.trace.api.profiling.Timer;
 import datadog.trace.bootstrap.ContextStore;
-import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.bootstrap.instrumentation.jfr.InstrumentationBasedProfiling;
 import java.util.Set;
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -125,24 +117,5 @@ public final class TPEHelper {
       return;
     }
     AdviceUtils.cancelTask(contextStore, task);
-  }
-
-  // don't use Config because it may use ThreadPoolExecutor to initialize itself
-  private static final boolean IS_PROFILING_QUEUEING_TIME_ENABLED =
-      ConfigProvider.getInstance()
-          .getBoolean(PROFILING_QUEUEING_TIME_ENABLED, PROFILING_QUEUEING_TIME_ENABLED_DEFAULT);
-
-  public static void startQueuingTimer(
-      ContextStore<Runnable, State> taskContextStore, ThreadPoolExecutor executor, Runnable task) {
-    if (IS_PROFILING_QUEUEING_TIME_ENABLED && InstrumentationBasedProfiling.isJFRReady()) {
-      State state = taskContextStore.get(task);
-      if (task != null && state != null) {
-        QueueTiming timing =
-            (QueueTiming) AgentTracer.get().getTimer().start(Timer.TimerType.QUEUEING);
-        timing.setTask(getUnwrappedType(task));
-        timing.setScheduler(executor.getClass());
-        state.setTiming(timing);
-      }
-    }
   }
 }

--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/NativeImageGeneratorRunnerInstrumentation.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/NativeImageGeneratorRunnerInstrumentation.java
@@ -77,6 +77,7 @@ public final class NativeImageGeneratorRunnerInstrumentation
               + "datadog.trace.bootstrap.instrumentation.java.concurrent.ConcurrentState:build_time,"
               + "datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter:build_time,"
               + "datadog.trace.bootstrap.instrumentation.java.concurrent.TPEHelper:build_time,"
+              + "datadog.trace.bootstrap.instrumentation.java.concurrent.QueueTimerHelper:build_time,"
               + "datadog.trace.bootstrap.instrumentation.traceannotation.TraceAnnotationConfigParser:build_time,"
               + "datadog.trace.logging.LoggingSettingsDescription:build_time,"
               + "datadog.trace.logging.simplelogger.SLCompatFactory:build_time,"

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorInstrumentation.java
@@ -20,6 +20,7 @@ import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.QueueTimerHelper;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.TPEHelper;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.Wrapper;
@@ -152,7 +153,7 @@ public final class ThreadPoolExecutorInstrumentation extends Instrumenter.Tracin
           ContextStore<Runnable, State> contextStore =
               InstrumentationContext.get(Runnable.class, State.class);
           TPEHelper.capture(contextStore, task);
-          TPEHelper.startQueuingTimer(contextStore, tpe, task);
+          QueueTimerHelper.startQueuingTimer(contextStore, tpe.getClass(), task);
         }
       }
     }

--- a/dd-smoke-tests/profiling-integration-tests/src/main/java/datadog/smoketest/profiling/ProfilingTestApplication.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/main/java/datadog/smoketest/profiling/ProfilingTestApplication.java
@@ -13,6 +13,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Future;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
@@ -24,8 +25,9 @@ public class ProfilingTestApplication {
   private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
 
   private static final ExecutorService EXECUTOR_SERVICE = Executors.newSingleThreadExecutor();
+  private static final ExecutorService FJP = new ForkJoinPool(4);
 
-  public static void main(final String[] args) throws InterruptedException, ExecutionException {
+  public static void main(final String[] args) throws Exception {
     ProfilingContextSetter foo = Profiling.get().createContextSetter("foo");
     long duration = -1;
     if (args.length > 0) {
@@ -33,6 +35,7 @@ public class ProfilingTestApplication {
     }
     setupDeadlock();
     submitWorkToTPE();
+    submitWorkToFJP();
     final long startTime = System.currentTimeMillis();
     int counter = 0;
     while (true) {
@@ -77,10 +80,20 @@ public class ProfilingTestApplication {
   }
 
   @Trace
-  private static void submitWorkToTPE() throws ExecutionException, InterruptedException {
+  private static void submitWorkToTPE() throws Exception {
+    submitWorkToExecutor(EXECUTOR_SERVICE);
+  }
+
+  @Trace
+  private static void submitWorkToFJP() throws Exception {
+    submitWorkToExecutor(FJP);
+  }
+
+  private static void submitWorkToExecutor(ExecutorService executorService)
+      throws ExecutionException, InterruptedException {
     AtomicInteger it = new AtomicInteger();
     for (int i = 0; i < 100; i++) {
-      EXECUTOR_SERVICE
+      executorService
           .submit(
               () -> {
                 try {
@@ -104,10 +117,10 @@ public class ProfilingTestApplication {
                           return it.getAndIncrement();
                         })
             .collect(Collectors.toList());
-    for (Future f : EXECUTOR_SERVICE.invokeAll(runnables)) {
+    for (Future f : executorService.invokeAll(runnables)) {
       f.get();
     }
-    System.out.println("incremented: " + it.get());
+    System.out.println(executorService.getClass() + " incremented: " + it.get());
   }
 
   private static void setupDeadlock() {


### PR DESCRIPTION
# What Does This Do

Tracks time spent in FJP queues and records it if a latency threshold is breached. Disabled by default, can be enabled with `-Ddd.profiling.experimental.queueing.time.enabled=true`

# Motivation

# Additional Notes
