### PR TITLE
Fix inserting line probe before for-loops

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/LineMap.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/LineMap.java
@@ -13,7 +13,11 @@ class LineMap {
   private final TreeMap<Integer, LabelNode> lineLabels = new TreeMap<>();
 
   void addLine(LineNumberNode lineNode) {
-    lineLabels.put(lineNode.line, lineNode.start);
+    // we are putting the line only the first time in the map.
+    // for-loops can generate 2 line nodes for the same line, 1 before the loop, 1 for the
+    // incrementation part.
+    // We consider here that we want to place the probe before the loop.
+    lineLabels.putIfAbsent(lineNode.line, lineNode.start);
   }
 
   LabelNode getLineLabel(int line) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1424,6 +1424,18 @@ public class CapturedSnapshotTest {
     }
   }
 
+  @Test
+  public void beforeForLoopLineProbe() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot02";
+    DebuggerTransformerTest.TestSnapshotListener listener =
+        installSingleProbe(CLASS_NAME, null, null, "46");
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "synchronizedBlock").get();
+    Assertions.assertEquals(76, result);
+    Snapshot snapshot = assertOneSnapshot(listener);
+    assertCaptureLocals(snapshot.getCaptures().getLines().get(46), "count", "int", "31");
+  }
+
   private DebuggerTransformerTest.TestSnapshotListener setupInstrumentTheWorldTransformer(
       String excludeFileName) {
     Config config = mock(Config.class);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/instrumentation/LineMapTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/instrumentation/LineMapTest.java
@@ -52,12 +52,12 @@ public class LineMapTest {
   }
 
   @Test
-  void AddingDifferentLabelsOverwriteLabel() {
+  void AddingDifferentLabelsDontOverwriteLabel() {
     LineMap map = new LineMap();
     LabelNode line1 = addLine(map, 1);
     LabelNode line1b = addLine(map, 1);
 
-    Assertions.assertEquals(line1b, map.getLineLabel(0));
-    Assertions.assertEquals(line1b, map.getLineLabel(1));
+    Assertions.assertEquals(line1, map.getLineLabel(0));
+    Assertions.assertEquals(line1, map.getLineLabel(1));
   }
 }


### PR DESCRIPTION
# What Does This Do
for loops generate 2 entries in LineNumberTable, 1 before the loop, 1 for the incrementation part. the second part was only kept into the line map (overwritten). We now always keep the first mapping.

# Motivation

# Additional Notes
