### PR TITLE
Implement tests skipping for JUnit 5

### DIFF
--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/ItrFilter.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/ItrFilter.java
@@ -1,0 +1,52 @@
+package datadog.trace.instrumentation.junit5;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.civisibility.config.SkippableTest;
+import java.util.Set;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.MethodSource;
+
+public class ItrFilter {
+
+  public static final ItrFilter INSTANCE = new ItrFilter();
+
+  private volatile boolean testsSkipped;
+
+  private ItrFilter() {}
+
+  public boolean skip(TestDescriptor testDescriptor) {
+    SkippableTest test = toSkippableTest(testDescriptor);
+    Set<SkippableTest> skippableTests = Config.get().getCiVisibilitySkippableTests();
+    if (skippableTests.contains(test)) {
+      testsSkipped = true;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  private SkippableTest toSkippableTest(TestDescriptor testDescriptor) {
+    TestSource testSource = testDescriptor.getSource().orElse(null);
+    if (!(testSource instanceof MethodSource)) {
+      return null;
+    }
+
+    MethodSource methodSource = (MethodSource) testSource;
+    String testSuitName = methodSource.getClassName();
+
+    String displayName = testDescriptor.getDisplayName();
+    UniqueId uniqueId = testDescriptor.getUniqueId();
+    String testEngineId = uniqueId.getEngineId().orElse(null);
+    String testName = TestFrameworkUtils.getTestName(displayName, methodSource, testEngineId);
+
+    String testParameters = TestFrameworkUtils.getParameters(methodSource, displayName);
+
+    return new SkippableTest(testSuitName, testName, testParameters, null);
+  }
+
+  public boolean testsSkipped() {
+    return testsSkipped;
+  }
+}

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5Instrumentation.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5Instrumentation.java
@@ -38,7 +38,10 @@ public class JUnit5Instrumentation extends Instrumenter.CiVisibility
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".TestFrameworkUtils", packageName + ".TracingListener",
+      packageName + ".JUnit5Utils",
+      packageName + ".TestFrameworkUtils",
+      packageName + ".ItrFilter",
+      packageName + ".TracingListener",
     };
   }
 
@@ -59,7 +62,17 @@ public class JUnit5Instrumentation extends Instrumenter.CiVisibility
         @Advice.This LauncherConfig config,
         @Advice.Return(readOnly = false) Collection<TestExecutionListener> listeners) {
 
-      Collection<TestEngine> testEngines = TestFrameworkUtils.getTestEngines(config);
+      if (JUnit5Utils.isTestInProgress()) {
+        // a test case that is in progress starts a new JUnit instance.
+        // It might be done in order to achieve classloader isolation
+        // (for example, spring-boot uses this technique).
+        // We are already tracking the active test case,
+        // and do not want to report the "embedded" JUnit execution
+        // as a separate module
+        return;
+      }
+
+      Collection<TestEngine> testEngines = JUnit5Utils.getTestEngines(config);
       final TracingListener listener = new TracingListener(testEngines);
 
       Collection<TestExecutionListener> modifiedListeners = new ArrayList<>(listeners);

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5ItrInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5ItrInstrumentation.java
@@ -1,0 +1,77 @@
+package datadog.trace.instrumentation.junit5;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Config;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Set;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.support.hierarchical.Node;
+import org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService;
+
+@AutoService(Instrumenter.class)
+public class JUnit5ItrInstrumentation extends Instrumenter.CiVisibility
+    implements Instrumenter.ForTypeHierarchy {
+
+  public JUnit5ItrInstrumentation() {
+    super("junit", "junit-5");
+  }
+
+  @Override
+  public boolean isApplicable(Set<TargetSystem> enabledSystems) {
+    return super.isApplicable(enabledSystems) && Config.get().isCiVisibilityItrEnabled();
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "org.junit.platform.engine.support.hierarchical.Node";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return implementsInterface(named(hierarchyMarkerType()))
+        .and(implementsInterface(named("org.junit.platform.engine.TestDescriptor")));
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".TestFrameworkUtils", packageName + ".ItrFilter",
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("shouldBeSkipped").and(takesArguments(1)),
+        JUnit5ItrInstrumentation.class.getName() + "$JUnit5ItrAdvice");
+  }
+
+  public static class JUnit5ItrAdvice {
+
+    @SuppressFBWarnings(
+        value = "UC_USELESS_OBJECT",
+        justification = "skipResult is the return value of the instrumented method")
+    @Advice.OnMethodExit
+    public static void shouldBeSkipped(
+        @Advice.This TestDescriptor testDescriptor,
+        @Advice.Return(readOnly = false) Node.SkipResult skipResult) {
+
+      if (!skipResult.isSkipped() && ItrFilter.INSTANCE.skip(testDescriptor)) {
+        skipResult = Node.SkipResult.skip("Skipped by Datadog Intelligent Test Runner");
+      }
+    }
+
+    // JUnit 5.3.0 and above
+    public static void muzzleCheck(final SameThreadHierarchicalTestExecutorService service) {
+      service.invokeAll(null);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5Utils.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5Utils.java
@@ -1,0 +1,88 @@
+package datadog.trace.instrumentation.junit5;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.ServiceLoader;
+import java.util.Set;
+import org.junit.platform.commons.util.ClassLoaderUtils;
+import org.junit.platform.engine.TestEngine;
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.support.descriptor.ClassSource;
+import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.core.LauncherConfig;
+
+public abstract class JUnit5Utils {
+
+  public static Class<?> getJavaClass(TestIdentifier testIdentifier) {
+    TestSource testSource = testIdentifier.getSource().orElse(null);
+    if (testSource instanceof ClassSource) {
+      ClassSource classSource = (ClassSource) testSource;
+      return classSource.getJavaClass();
+
+    } else if (testSource instanceof MethodSource) {
+      MethodSource methodSource = (MethodSource) testSource;
+      return TestFrameworkUtils.getTestClass(methodSource);
+
+    } else {
+      return null;
+    }
+  }
+
+  /*
+   * JUnit5 considers parameterized or factory test cases as containers.
+   * We need to differentiate this type of containers from "regular" ones, that are test classes
+   */
+  public static boolean isTestCase(TestIdentifier testIdentifier) {
+    return testIdentifier.isContainer() && getMethodSourceOrNull(testIdentifier) != null;
+  }
+
+  public static boolean isRootContainer(TestIdentifier testIdentifier) {
+    return !testIdentifier.getParentId().isPresent();
+  }
+
+  private static MethodSource getMethodSourceOrNull(TestIdentifier testIdentifier) {
+    return (MethodSource)
+        testIdentifier.getSource().filter(s -> s instanceof MethodSource).orElse(null);
+  }
+
+  public static boolean isAssumptionFailure(Throwable throwable) {
+    switch (throwable.getClass().getName()) {
+      case "org.junit.AssumptionViolatedException":
+      case "org.junit.internal.AssumptionViolatedException":
+      case "org.opentest4j.TestAbortedException":
+      case "org.opentest4j.TestSkippedException":
+        // If the test assumption fails, one of the following exceptions will be thrown.
+        // The consensus is to treat "assumptions failure" as skipped tests.
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  public static Collection<TestEngine> getTestEngines(LauncherConfig config) {
+    Set<TestEngine> engines = new LinkedHashSet<>();
+    if (config.isTestEngineAutoRegistrationEnabled()) {
+      ClassLoader defaultClassLoader = ClassLoaderUtils.getDefaultClassLoader();
+      ServiceLoader.load(TestEngine.class, defaultClassLoader).forEach(engines::add);
+    }
+    engines.addAll(config.getAdditionalTestEngines());
+    return engines;
+  }
+
+  public static boolean isTestInProgress() {
+    AgentScope activeScope = AgentTracer.activeScope();
+    if (activeScope == null) {
+      return false;
+    }
+    AgentSpan span = activeScope.span();
+    if (span == null) {
+      return false;
+    }
+    return InternalSpanTypes.TEST.toString().equals(span.getSpanType());
+  }
+}

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
@@ -1,8 +1,11 @@
 import datadog.trace.agent.test.asserts.ListWriterAssert
-import datadog.trace.civisibility.CiVisibilityTest
 import datadog.trace.api.DisableTestTrace
 import datadog.trace.api.civisibility.CIConstants
+import datadog.trace.api.civisibility.config.SkippableTest
+import datadog.trace.api.civisibility.config.SkippableTestsSerializer
+import datadog.trace.api.config.CiVisibilityConfig
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.civisibility.CiVisibilityTest
 import org.example.TestAssumption
 import org.example.TestAssumptionAndSucceed
 import org.example.TestAssumptionLegacy
@@ -566,6 +569,68 @@ class JUnit5Test extends CiVisibilityTest {
 
     where:
     testTags = [(Tags.TEST_SKIP_REASON): "Ignore reason in class"]
+  }
+
+  def "test ITR skipping"() {
+    setup:
+    injectSysConfig(CiVisibilityConfig.CIVISIBILITY_SKIPPABLE_TESTS, SkippableTestsSerializer.serialize([
+      new SkippableTest("org.example.TestFailedAndSucceed", "test_another_succeed", null, null),
+      new SkippableTest("org.example.TestFailedAndSucceed", "test_failed", null, null),
+    ]))
+    runTestClasses(TestFailedAndSucceed)
+
+    expect:
+    ListWriterAssert.assertTraces(TEST_WRITER, 4, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, CIConstants.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, "org.example.TestFailedAndSucceed", CIConstants.TEST_PASS)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_another_succeed", CIConstants.TEST_SKIP, testTags)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_failed", CIConstants.TEST_SKIP, testTags)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_succeed", CIConstants.TEST_PASS)
+      }
+    })
+
+    where:
+    testTags = [(Tags.TEST_SKIP_REASON): "Skipped by Datadog Intelligent Test Runner"]
+  }
+
+  def "test ITR skipping for parameterized tests"() {
+    setup:
+    injectSysConfig(CiVisibilityConfig.CIVISIBILITY_SKIPPABLE_TESTS, SkippableTestsSerializer.serialize([
+      new SkippableTest("org.example.TestParameterized", "test_parameterized", testTags_0[Tags.TEST_PARAMETERS], null),
+    ]))
+    runTestClasses(TestParameterized)
+
+    expect:
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, CIConstants.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, "org.example.TestParameterized", CIConstants.TEST_PASS)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestParameterized", "test_parameterized", CIConstants.TEST_SKIP, testTags_0)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestParameterized", "test_parameterized", CIConstants.TEST_PASS, testTags_1)
+      }
+    })
+
+    where:
+    testTags_0 = [
+      (Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"[1] 0, 0, 0, some:\\\"parameter\\\""}}',
+      (Tags.TEST_SKIP_REASON): "Skipped by Datadog Intelligent Test Runner"
+    ]
+    testTags_1 = [(Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"[2] 1, 1, 2, some:\\\"parameter\\\""}}']
   }
 
   private static void runTestClasses(Class<?>... classes) {


### PR DESCRIPTION
# What Does This Do
Implements Intelligent Test Runner for JUnit 5: framework instrumentation is updated to skip test cases that were marked as skippable by the backend.

# Motivation
Intelligent Test Runner is a CI Visibility feature that allows skipping tests that are not relevant for a specific commit.

# Additional Notes
Requesting the list of skippable tests from the backend and passing it to JVM running the tests was implemented previously in a separate PR.
The changes in this PR simply use the already available list of skippable tests.
