### PR TITLE
Implement tests skipping for JUnit 4

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
@@ -98,8 +98,10 @@ public class TestEventsHandlerImpl implements TestEventsHandler {
 
   @Override
   public void onTestModuleFinish(boolean itrTestsSkipped) {
-    testModule.end(null, itrTestsSkipped);
-    testModule = null;
+    if (testModule != null) {
+      testModule.end(null, itrTestsSkipped);
+      testModule = null;
+    }
   }
 
   @Override

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/ItrFilter.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/ItrFilter.java
@@ -1,0 +1,39 @@
+package datadog.trace.instrumentation.junit4;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.civisibility.config.SkippableTest;
+import java.lang.reflect.Method;
+import java.util.Set;
+import org.junit.runner.Description;
+
+public class ItrFilter {
+
+  public static final ItrFilter INSTANCE = new ItrFilter();
+
+  private volatile boolean testsSkipped;
+
+  private ItrFilter() {}
+
+  public boolean skip(Description description) {
+    SkippableTest test = toSkippableTest(description);
+    Set<SkippableTest> skippableTests = Config.get().getCiVisibilitySkippableTests();
+    if (skippableTests.contains(test)) {
+      testsSkipped = true;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  private SkippableTest toSkippableTest(Description description) {
+    Method testMethod = JUnit4Utils.getTestMethod(description);
+    String suite = description.getClassName();
+    String name = JUnit4Utils.getTestName(description, testMethod);
+    String parameters = JUnit4Utils.getParameters(description);
+    return new SkippableTest(suite, name, parameters, null);
+  }
+
+  public boolean testsSkipped() {
+    return testsSkipped;
+  }
+}

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Instrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Instrumentation.java
@@ -34,7 +34,12 @@ public class JUnit4Instrumentation extends Instrumenter.CiVisibility
 
   @Override
   public String[] helperClassNames() {
-    return new String[] {packageName + ".TracingListener", packageName + ".JUnit4Utils"};
+    return new String[] {
+      packageName + ".TracingListener",
+      packageName + ".SkippedByItr",
+      packageName + ".JUnit4Utils",
+      packageName + ".ItrFilter",
+    };
   }
 
   @Override

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4ItrInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4ItrInstrumentation.java
@@ -1,0 +1,97 @@
+package datadog.trace.instrumentation.junit4;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Config;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Set;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.junit.Ignore;
+import org.junit.rules.RuleChain;
+import org.junit.runner.Description;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.ParentRunner;
+
+@AutoService(Instrumenter.class)
+public class JUnit4ItrInstrumentation extends Instrumenter.CiVisibility
+    implements Instrumenter.ForTypeHierarchy {
+
+  public JUnit4ItrInstrumentation() {
+    super("junit", "junit-4", "junit-4-itr");
+  }
+
+  @Override
+  public boolean isApplicable(Set<TargetSystem> enabledSystems) {
+    return super.isApplicable(enabledSystems) && Config.get().isCiVisibilityItrEnabled();
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "org.junit.runners.ParentRunner";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return extendsClass(named(hierarchyMarkerType()));
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".TracingListener",
+      packageName + ".SkippedByItr",
+      packageName + ".JUnit4Utils",
+      packageName + ".ItrFilter",
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("runChild")
+            .and(takesArguments(2))
+            .and(takesArgument(1, named("org.junit.runner.notification.RunNotifier"))),
+        JUnit4ItrInstrumentation.class.getName() + "$JUnit4ItrInstrumentationAdvice");
+  }
+
+  public static class JUnit4ItrInstrumentationAdvice {
+    @SuppressFBWarnings("NP_BOOLEAN_RETURN_NULL")
+    @Advice.OnMethodEnter(skipOn = Boolean.class)
+    public static Boolean runChild(
+        @Advice.This ParentRunner<?> runner,
+        @Advice.Argument(0) Object child,
+        @Advice.Argument(1) RunNotifier notifier) {
+      Description description = JUnit4Utils.getDescription(runner, child);
+      if (description == null || !description.isTest()) {
+        // ITR only skips individual tests
+        return null;
+      }
+
+      Ignore ignoreAnnotation = description.getAnnotation(Ignore.class);
+      if (ignoreAnnotation != null) {
+        // class is ignored, ITR not applicable
+        return null;
+      }
+
+      if (ItrFilter.INSTANCE.skip(description)) {
+        Description skippedDescription = JUnit4Utils.getSkippedDescription(description);
+        notifier.fireTestIgnored(skippedDescription);
+        return Boolean.FALSE;
+      } else {
+        return null;
+      }
+    }
+
+    // JUnit 4.10 and above
+    public static void muzzleCheck(final RuleChain ruleChain) {
+      ruleChain.apply(null, null);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4SuiteEventsInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4SuiteEventsInstrumentation.java
@@ -35,7 +35,12 @@ public class JUnit4SuiteEventsInstrumentation extends Instrumenter.CiVisibility
 
   @Override
   public String[] helperClassNames() {
-    return new String[] {packageName + ".TracingListener", packageName + ".JUnit4Utils"};
+    return new String[] {
+      packageName + ".TracingListener",
+      packageName + ".SkippedByItr",
+      packageName + ".JUnit4Utils",
+      packageName + ".ItrFilter",
+    };
   }
 
   @Override

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
@@ -5,7 +5,9 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.junit.Test;
@@ -13,6 +15,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.Description;
 import org.junit.runner.notification.RunListener;
 import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.ParentRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +27,21 @@ public abstract class JUnit4Utils {
 
   // Regex for the final brackets with its content in the test name. E.g. test_name[0] --> [0]
   private static final Pattern testNameNormalizerRegex = Pattern.compile("\\[[^\\[]*\\]$");
+
+  private static final Pattern METHOD_AND_CLASS_NAME_PATTERN =
+      Pattern.compile("([\\s\\S]*)\\((.*)\\)");
+
+  private static final Method DESCRIBE_CHILD = accesDescribeChildMethod();
+
+  private static Method accesDescribeChildMethod() {
+    try {
+      Method describeChild = ParentRunner.class.getDeclaredMethod("describeChild", Object.class);
+      describeChild.setAccessible(true);
+      return describeChild;
+    } catch (Exception e) {
+      return null;
+    }
+  }
 
   public static List<RunListener> runListenersFromRunNotifier(final RunNotifier runNotifier) {
     try {
@@ -253,5 +271,32 @@ public abstract class JUnit4Utils {
       }
     }
     return testMethods;
+  }
+
+  public static Description getDescription(ParentRunner runner, Object child) {
+    try {
+      if (DESCRIBE_CHILD != null) {
+        return (Description) DESCRIBE_CHILD.invoke(runner, child);
+      }
+    } catch (Exception e) {
+      log.error("Could not describe child: " + child, e);
+    }
+    return null;
+  }
+
+  public static Description getSkippedDescription(Description description) {
+    Collection<Annotation> annotations = description.getAnnotations();
+    Annotation[] updatedAnnotations = new Annotation[annotations.size() + 1];
+    int idx = 0;
+    for (Annotation annotation : annotations) {
+      updatedAnnotations[idx++] = annotation;
+    }
+    updatedAnnotations[idx] = new SkippedByItr();
+
+    String displayName = description.getDisplayName();
+    Matcher matcher = METHOD_AND_CLASS_NAME_PATTERN.matcher(displayName);
+    String name = matcher.matches() ? matcher.group(1) : getTestName(description, null);
+
+    return Description.createTestDescription(description.getTestClass(), name, updatedAnnotations);
   }
 }

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/SkippedByItr.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/SkippedByItr.java
@@ -1,0 +1,16 @@
+package datadog.trace.instrumentation.junit4;
+
+import java.lang.annotation.Annotation;
+import org.junit.Ignore;
+
+public final class SkippedByItr implements Ignore {
+  @Override
+  public String value() {
+    return "Skipped by Datadog Intelligent Test Runner";
+  }
+
+  @Override
+  public Class<? extends Annotation> annotationType() {
+    return Ignore.class;
+  }
+}

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.junit4;
 
 import datadog.trace.api.civisibility.InstrumentationBridge;
 import datadog.trace.api.civisibility.events.TestEventsHandler;
+import datadog.trace.util.AgentThreadFactory;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -17,6 +18,8 @@ import org.junit.runners.model.TestClass;
 
 public class TracingListener extends RunListener {
 
+  private static final String GRADLE_TEST_WORKER_ID_SYSTEM_PROP = "org.gradle.test.worker";
+
   private final TestEventsHandler testEventsHandler;
 
   public TracingListener() {
@@ -24,6 +27,25 @@ public class TracingListener extends RunListener {
     Path currentPath = Paths.get("").toAbsolutePath();
     testEventsHandler =
         InstrumentationBridge.createTestEventsHandler("junit", "junit4", version, currentPath);
+
+    boolean isRunByGradle = System.getProperty(GRADLE_TEST_WORKER_ID_SYSTEM_PROP) != null;
+    if (isRunByGradle) {
+      applyTestRunFinishedPatch();
+    }
+  }
+
+  /**
+   * Gradle uses its own custom JUnit 4 runner. The runner does not invoke
+   * org.junit.runner.notification.RunListener#testRunFinished, so we apply a "patch" to invoke it
+   * before the JVM is shutdown
+   */
+  private void applyTestRunFinishedPatch() {
+    Thread shutdownHook =
+        AgentThreadFactory.newAgentThread(
+            AgentThreadFactory.AgentThread.CI_GRADLE_JUNIT_SHUTDOWN_HOOK,
+            () -> testRunFinished(null),
+            false);
+    Runtime.getRuntime().addShutdownHook(shutdownHook);
   }
 
   @Override
@@ -33,7 +55,7 @@ public class TracingListener extends RunListener {
 
   @Override
   public void testRunFinished(Result result) {
-    testEventsHandler.onTestModuleFinish(false);
+    testEventsHandler.onTestModuleFinish(ItrFilter.INSTANCE.testsSkipped());
   }
 
   public void testSuiteStarted(final TestClass junitTestClass) {

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
@@ -1,8 +1,11 @@
 import datadog.trace.agent.test.asserts.ListWriterAssert
-import datadog.trace.civisibility.CiVisibilityTest
 import datadog.trace.api.DisableTestTrace
 import datadog.trace.api.civisibility.CIConstants
+import datadog.trace.api.civisibility.config.SkippableTest
+import datadog.trace.api.civisibility.config.SkippableTestsSerializer
+import datadog.trace.api.config.CiVisibilityConfig
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.civisibility.CiVisibilityTest
 import junit.runner.Version
 import org.example.TestAssumption
 import org.example.TestAssumptionAndSucceed
@@ -418,6 +421,67 @@ class JUnit4Test extends CiVisibilityTest {
 
     where:
     testTags_0 = [(Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"parameterized_test_succeed[0]"}}']
+    testTags_1 = [(Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"parameterized_test_succeed[1]"}}']
+  }
+
+  def "test ITR skipping"() {
+    setup:
+    injectSysConfig(CiVisibilityConfig.CIVISIBILITY_SKIPPABLE_TESTS, SkippableTestsSerializer.serialize([
+      new SkippableTest("org.example.TestFailedAndSucceed", "test_another_succeed", null, null),
+      new SkippableTest("org.example.TestFailedAndSucceed", "test_failed", null, null),
+    ]))
+    runner.run(TestFailedAndSucceed)
+
+    expect:
+    ListWriterAssert.assertTraces(TEST_WRITER, 4, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, CIConstants.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, "org.example.TestFailedAndSucceed", CIConstants.TEST_PASS)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_another_succeed", CIConstants.TEST_SKIP, testTags)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_failed", CIConstants.TEST_SKIP, testTags)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestFailedAndSucceed", "test_succeed", CIConstants.TEST_PASS)
+      }
+    })
+
+    where:
+    testTags = [(Tags.TEST_SKIP_REASON): "Skipped by Datadog Intelligent Test Runner"]
+  }
+
+  def "test ITR skipping for parameterized"() {
+    setup:
+    injectSysConfig(CiVisibilityConfig.CIVISIBILITY_SKIPPABLE_TESTS, SkippableTestsSerializer.serialize([
+      new SkippableTest("org.example.TestParameterized", "parameterized_test_succeed", testTags_0[Tags.TEST_PARAMETERS], null),
+    ]))
+    runner.run(TestParameterized)
+
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, CIConstants.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, "org.example.TestParameterized", CIConstants.TEST_PASS)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestParameterized", "parameterized_test_succeed", CIConstants.TEST_SKIP, testTags_0)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestParameterized", "parameterized_test_succeed", CIConstants.TEST_PASS, testTags_1)
+      }
+    })
+
+    where:
+    testTags_0 = [
+      (Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"parameterized_test_succeed[0]"}}',
+      (Tags.TEST_SKIP_REASON): "Skipped by Datadog Intelligent Test Runner"
+    ]
     testTags_1 = [(Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"parameterized_test_succeed[1]"}}']
   }
 

--- a/internal-api/src/main/java/datadog/trace/util/AgentThreadFactory.java
+++ b/internal-api/src/main/java/datadog/trace/util/AgentThreadFactory.java
@@ -47,6 +47,7 @@ public final class AgentThreadFactory implements ThreadFactory {
     CI_SHELL_COMMAND("dd-ci-shell-command"),
     CI_GIT_DATA_UPLOADER("dd-ci-git-data-uploader"),
     CI_GIT_DATA_SHUTDOWN_HOOK("dd-ci-git-data-shutdown-hook"),
+    CI_GRADLE_JUNIT_SHUTDOWN_HOOK("dd-ci-gradle-junit-shutdown-hook"),
     CI_PROJECT_CONFIGURATOR("dd-ci-project-configurator"),
     CI_SIGNAL_SERVER("dd-ci-signal-server");
 


### PR DESCRIPTION
# What Does This Do
Implements Intelligent Test Runner for JUnit 4: framework instrumentation is updated to skip test cases that were marked as skippable by the backend.

# Motivation
Intelligent Test Runner is a CI Visibility feature that allows skipping tests that are not relevant for a specific commit.

# Additional Notes
Requesting the list of skippable tests from the backend and passing it to JVM running the tests was implemented previously in a separate PR.
The changes in this PR simply use the already available list of skippable tests.
