### PR TITLE
Implement tests skipping for TestNG

### DIFF
--- a/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/ItrFilter.java
+++ b/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/ItrFilter.java
@@ -1,0 +1,37 @@
+package datadog.trace.instrumentation.testng;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.civisibility.config.SkippableTest;
+import java.lang.reflect.Method;
+import java.util.Set;
+
+public class ItrFilter {
+
+  public static final ItrFilter INSTANCE = new ItrFilter();
+
+  private volatile boolean testsSkipped;
+
+  private ItrFilter() {}
+
+  public boolean skip(Method method, Object instance, Object[] parameters) {
+    SkippableTest test = toSkippableTest(method, instance, parameters);
+    Set<SkippableTest> skippableTests = Config.get().getCiVisibilitySkippableTests();
+    if (skippableTests.contains(test)) {
+      testsSkipped = true;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  private SkippableTest toSkippableTest(Method method, Object instance, Object[] parameters) {
+    String testSuiteName = instance.getClass().getName();
+    String testName = method.getName();
+    String testParameters = TestNGUtils.getParameters(parameters);
+    return new SkippableTest(testSuiteName, testName, testParameters, null);
+  }
+
+  public boolean testsSkipped() {
+    return testsSkipped;
+  }
+}

--- a/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGInstrumentation.java
+++ b/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGInstrumentation.java
@@ -35,6 +35,7 @@ public class TestNGInstrumentation extends Instrumenter.CiVisibility
       packageName + ".TestNGUtils",
       packageName + ".TestNGSuiteListener",
       packageName + ".TestNGClassListener",
+      packageName + ".ItrFilter",
       packageName + ".TracingListener"
     };
   }

--- a/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGItrInstrumentation.java
+++ b/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGItrInstrumentation.java
@@ -1,0 +1,72 @@
+package datadog.trace.instrumentation.testng;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Config;
+import java.lang.reflect.Method;
+import java.util.Set;
+import net.bytebuddy.asm.Advice;
+import org.testng.SkipException;
+import org.testng.annotations.DataProvider;
+
+@AutoService(Instrumenter.class)
+public class TestNGItrInstrumentation extends Instrumenter.CiVisibility
+    implements Instrumenter.ForKnownTypes {
+  public TestNGItrInstrumentation() {
+    super("testng", "testng-itr");
+  }
+
+  @Override
+  public boolean isApplicable(Set<TargetSystem> enabledSystems) {
+    return super.isApplicable(enabledSystems) && Config.get().isCiVisibilityItrEnabled();
+  }
+
+  @Override
+  public String[] knownMatchingTypes() {
+    return new String[] {
+      "org.testng.internal.MethodInvocationHelper",
+      "org.testng.internal.invokers.MethodInvocationHelper"
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("invokeMethod")
+            .and(takesArguments(3))
+            .and(takesArgument(0, Method.class))
+            .and(takesArgument(1, Object.class))
+            .and(takesArgument(2, Object[].class)),
+        TestNGItrInstrumentation.class.getName() + "$InvokeMethodAdvice");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".TestNGUtils",
+      packageName + ".TestNGClassListener",
+      packageName + ".ItrFilter",
+    };
+  }
+
+  public static class InvokeMethodAdvice {
+    @Advice.OnMethodEnter
+    public static void invokeMethod(
+        @Advice.Argument(0) final Method method,
+        @Advice.Argument(1) final Object instance,
+        @Advice.Argument(2) final Object[] parameters) {
+      if (ItrFilter.INSTANCE.skip(method, instance, parameters)) {
+        throw new SkipException("Skipped by Datadog Intelligent Test Runner");
+      }
+    }
+
+    // TestNG 6.4 and above
+    public static void muzzleCheck(final DataProvider dataProvider) {
+      dataProvider.name();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGUtils.java
+++ b/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGUtils.java
@@ -40,20 +40,24 @@ public abstract class TestNGUtils {
   }
 
   public static String getParameters(final ITestResult result) {
-    if (result.getParameters() == null || result.getParameters().length == 0) {
+    return getParameters(result.getParameters());
+  }
+
+  public static String getParameters(Object[] parameters) {
+    if (parameters == null || parameters.length == 0) {
       return null;
     }
 
     // We build manually the JSON for test.parameters tag.
     // Example: {"arguments":{"0":"param1","1":"param2"}}
     final StringBuilder sb = new StringBuilder("{\"arguments\":{");
-    for (int i = 0; i < result.getParameters().length; i++) {
+    for (int i = 0; i < parameters.length; i++) {
       sb.append("\"")
           .append(i)
           .append("\":\"")
-          .append(Strings.escapeToJson(String.valueOf(result.getParameters()[i])))
+          .append(Strings.escapeToJson(String.valueOf(parameters[i])))
           .append("\"");
-      if (i != result.getParameters().length - 1) {
+      if (i != parameters.length - 1) {
         sb.append(",");
       }
     }

--- a/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TracingListener.java
+++ b/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TracingListener.java
@@ -41,7 +41,7 @@ public class TracingListener extends TestNGClassListener
 
   @Override
   public void onExecutionFinish() {
-    testEventsHandler.onTestModuleFinish(false);
+    testEventsHandler.onTestModuleFinish(ItrFilter.INSTANCE.testsSkipped());
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do
Implements Intelligent Test Runner for TestNG: framework instrumentation is updated to skip test cases that were marked as skippable by the backend.

# Motivation
Intelligent Test Runner is a CI Visibility feature that allows skipping tests that are not relevant for a specific commit.

# Additional Notes
Requesting the list of skippable tests from the backend and passing it to JVM running the tests was implemented previously in a separate PR.
The changes in this PR simply use the already available list of skippable tests.
