### PR TITLE
Add distribution metric for StatsDClient

### DIFF
--- a/communication/src/main/java/datadog/communication/monitor/DDAgentStatsDClient.java
+++ b/communication/src/main/java/datadog/communication/monitor/DDAgentStatsDClient.java
@@ -55,6 +55,18 @@ final class DDAgentStatsDClient implements StatsDClient {
   }
 
   @Override
+  public void distribution(String metricName, long value, String... tags) {
+    connection.statsd.recordDistributionValue(
+        nameMapping.apply(metricName), value, tagMapping.apply(tags));
+  }
+
+  @Override
+  public void distribution(String metricName, double value, String... tags) {
+    connection.statsd.recordDistributionValue(
+        nameMapping.apply(metricName), value, tagMapping.apply(tags));
+  }
+
+  @Override
   public void serviceCheck(
       final String serviceCheckName,
       final String status,

--- a/communication/src/main/java/datadog/communication/monitor/LoggingStatsDClient.java
+++ b/communication/src/main/java/datadog/communication/monitor/LoggingStatsDClient.java
@@ -17,6 +17,7 @@ public final class LoggingStatsDClient implements StatsDClient {
   private static final String COUNT_FORMAT = "{}:{}|c{}";
   private static final String GAUGE_FORMAT = "{}:{}|g{}";
   private static final String HISTOGRAM_FORMAT = "{}:{}|h{}";
+  private static final String DISTRIBUTION_FORMAT = "{}:{}|d{}";
   private static final String SERVICE_CHECK_FORMAT = "_sc|{}|{}{}{}";
 
   private static final DecimalFormat DECIMAL_FORMAT;
@@ -68,6 +69,21 @@ public final class LoggingStatsDClient implements StatsDClient {
   public void histogram(final String metricName, final double value, final String... tags) {
     log.info(
         HISTOGRAM_FORMAT,
+        nameMapping.apply(metricName),
+        DECIMAL_FORMAT.format(value),
+        join(tagMapping.apply(tags)));
+  }
+
+  @Override
+  public void distribution(String metricName, long value, String... tags) {
+    log.info(
+        DISTRIBUTION_FORMAT, nameMapping.apply(metricName), value, join(tagMapping.apply(tags)));
+  }
+
+  @Override
+  public void distribution(String metricName, double value, String... tags) {
+    log.info(
+        DISTRIBUTION_FORMAT,
         nameMapping.apply(metricName),
         DECIMAL_FORMAT.format(value),
         join(tagMapping.apply(tags)));

--- a/communication/src/test/groovy/datadog/communication/monitor/DDAgentStatsDClientTest.groovy
+++ b/communication/src/test/groovy/datadog/communication/monitor/DDAgentStatsDClientTest.groovy
@@ -62,6 +62,20 @@ class DDAgentStatsDClientTest extends DDSpecification {
     client.histogram(metricName, Math.PI, tags)
     server.waitForMessage().startsWith("$expectedMetricName:3.141593|h|#$expectedTags")
 
+    client.distribution(metricName, Integer.MIN_VALUE, tags)
+    server.waitForMessage().startsWith("$expectedMetricName:-2147483648|d|#$expectedTags")
+    client.distribution(metricName, Integer.MAX_VALUE, tags)
+    server.waitForMessage().startsWith("$expectedMetricName:2147483647|d|#$expectedTags")
+    client.distribution(metricName, Long.MIN_VALUE, tags)
+    server.waitForMessage().startsWith("$expectedMetricName:-9223372036854775808|d|#$expectedTags")
+    client.distribution(metricName, Long.MAX_VALUE, tags)
+    server.waitForMessage().startsWith("$expectedMetricName:9223372036854775807|d|#$expectedTags")
+
+    client.distribution(metricName, -Math.E, tags)
+    server.waitForMessage().startsWith("$expectedMetricName:-2.718282|d|#$expectedTags")
+    client.distribution(metricName, Math.PI, tags)
+    server.waitForMessage().startsWith("$expectedMetricName:3.141593|d|#$expectedTags")
+
     client.serviceCheck(checkName, "OK", null, tags)
     server.waitForMessage().startsWith("_sc|$expectedCheckName|0|#$expectedTags")
     client.serviceCheck(checkName, "WARN", null, tags)

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/DebuggerMetrics.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/DebuggerMetrics.java
@@ -67,6 +67,16 @@ public class DebuggerMetrics implements StatsDClient {
   }
 
   @Override
+  public void distribution(String metricName, long value, String... tags) {
+    statsd.distribution(metricName, value, tags);
+  }
+
+  @Override
+  public void distribution(String metricName, double value, String... tags) {
+    statsd.distribution(metricName, value, tags);
+  }
+
+  @Override
   public void serviceCheck(String serviceCheckName, String status, String message, String... tags) {
     statsd.serviceCheck(serviceCheckName, status, message, tags);
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
@@ -433,6 +433,24 @@ class HealthMetricsTest extends DDSpecification {
     }
 
     @Override
+    void distribution(String metricName, long value, String... tags) {
+      try {
+        delegate.distribution(metricName, value, tags)
+      } finally {
+        latch.countDown()
+      }
+    }
+
+    @Override
+    void distribution(String metricName, double value, String... tags) {
+      try {
+        delegate.distribution(metricName, value, tags)
+      } finally {
+        latch.countDown()
+      }
+    }
+
+    @Override
     void serviceCheck(String serviceCheckName, String status, String message, String... tags) {
       try {
         delegate.serviceCheck(serviceCheckName, status, message, tags)

--- a/internal-api/src/main/java/datadog/trace/api/NoOpStatsDClient.java
+++ b/internal-api/src/main/java/datadog/trace/api/NoOpStatsDClient.java
@@ -21,6 +21,12 @@ final class NoOpStatsDClient implements StatsDClient {
   public void histogram(final String metricName, final double value, final String... tags) {}
 
   @Override
+  public void distribution(String metricName, long value, String... tags) {}
+
+  @Override
+  public void distribution(String metricName, double value, String... tags) {}
+
+  @Override
   public void serviceCheck(
       final String serviceCheckName,
       final String status,

--- a/internal-api/src/main/java/datadog/trace/api/StatsDClient.java
+++ b/internal-api/src/main/java/datadog/trace/api/StatsDClient.java
@@ -17,6 +17,10 @@ public interface StatsDClient extends Closeable {
 
   void histogram(String metricName, double value, String... tags);
 
+  void distribution(String metricName, long value, String... tags);
+
+  void distribution(String metricName, double value, String... tags);
+
   void serviceCheck(String serviceCheckName, String status, String message, String... tags);
 
   void error(Exception error);


### PR DESCRIPTION
# What Does This Do

# Motivation
Allow to provide distribution metrics for Dynamic Instrumentation probes

# Additional Notes
