### PR TITLE
Upgrade ddprof to 0.53.0 to unlink libgcc

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.52.0",
+    ddprof        : "0.53.0",
     asm           : "9.5"
   ]
 


### PR DESCRIPTION
# What Does This Do

# Motivation

# Additional Notes
